### PR TITLE
Display an icon based on the state of a check

### DIFF
--- a/src/api/app/assets/stylesheets/webui/staging-workflow.scss
+++ b/src/api/app/assets/stylesheets/webui/staging-workflow.scss
@@ -140,3 +140,8 @@ ul .table-list-group-item {
     }
   }
 }
+
+li.missing-check {
+  margin-left: 1.25rem;
+  list-style: disc;
+}

--- a/src/api/app/helpers/webui/staging/project_helper.rb
+++ b/src/api/app/helpers/webui/staging/project_helper.rb
@@ -6,4 +6,10 @@ module Webui::Staging::ProjectHelper
     return 'fa-check-circle text-primary' if checks.all?(&:success?)
     'fa-exclamation-circle text-danger'
   end
+
+  def icon_for_check(check)
+    return 'fa-check-circle text-primary' if check.success?
+    return 'fa-eye text-info' if check.pending?
+    'fa-exclamation-circle text-danger'
+  end
 end

--- a/src/api/app/views/webui/staging/projects/_checks.html.haml
+++ b/src/api/app/views/webui/staging/projects/_checks.html.haml
@@ -5,12 +5,13 @@
   - if checks.blank? && missing_checks.blank?
     None
   - else
-    %ul
+    %ul.pl-0.list-unstyled
       - missing_checks.each do |name|
-        %li
-          %span.check-pending
+        %li.missing-check
+          %span
             #{name} (Expected - Waiting for status to be reported)
       - checks.each do |check|
         %li
-          = link_to "#{check.name} (#{check.state} - #{time_ago_in_words(check.updated_at)} ago)", check.url,
-                    class: "check-#{check.state}", title: "#{check.short_description} (#{check.updated_at})"
+          = link_to(check.url, class: "check-#{check.state}", title: "#{check.short_description} (#{check.updated_at})") do
+            %i.fas{ class: icon_for_check(check) }
+            #{check.name} (#{check.state} - #{time_ago_in_words(check.updated_at)} ago)


### PR DESCRIPTION
Closes #8741

Preview:
![issue-8741-2nd](https://user-images.githubusercontent.com/1102934/69716440-4993f580-110a-11ea-8005-a2dd9a5d5771.png)

It's not directly related to the issue, but I'm wondering if we should sort the checks by state... Any thoughts? 