### PR TITLE
Prevent an exception to be raised in auto cleanup

### DIFF
--- a/src/api/app/jobs/project_create_auto_cleanup_requests.rb
+++ b/src/api/app/jobs/project_create_auto_cleanup_requests.rb
@@ -23,7 +23,7 @@ Such requests get not created for projects with open requests or if you remove t
 
   def autoclean_project(prj)
     # project may be locked?
-    return if prj.nil? || prj.is_locked?
+    return if prj.nil? || prj.is_locked? || !prj.check_weak_dependencies?
 
     # open requests do block the cleanup
     open_requests_count = BsRequest.in_states([:new, :review, :declined]).

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -537,8 +537,8 @@ class Project < ApplicationRecord
   def check_weak_dependencies?
     begin
       check_weak_dependencies!
-    rescue DeleteError
-      false
+    rescue DeleteError, Package::Errors::DeleteError
+      return false
     end
     # Get all my repositories and linking_repositories and check if I can modify the
     # associated projects

--- a/src/api/spec/cassettes/ProjectCreateAutoCleanupRequests/_perform/with_devel_package_inside_the_project/does_not_create_a_deletion_request.yml
+++ b/src/api/spec/cassettes/ProjectCreateAutoCleanupRequests/_perform/with_devel_package_inside_the_project/does_not_create_a_deletion_request.yml
@@ -1,0 +1,204 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/ProjectA/_meta?user=Admin
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="ProjectA">
+          <title>A Time of Gifts</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '100'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="ProjectA">
+          <title>A Time of Gifts</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Tue, 26 Nov 2019 14:37:55 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/ProjectA/_project/_attribute?meta=1&user=Admin
+    body:
+      encoding: UTF-8
+      string: |
+        <attributes>
+          <attribute name="AutoCleanup" namespace="OBS">
+            <value>14</value>
+          </attribute>
+        </attributes>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '168'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="21">
+          <srcmd5>30e59f75d1a05114a70eb2731feaf3d0</srcmd5>
+          <time>1574779075</time>
+          <user>Admin</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Tue, 26 Nov 2019 14:37:55 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/ProjectA/DevelPackage/_meta?user=Admin
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="DevelPackage" project="ProjectA">
+          <title>Death Be Not Proud</title>
+          <description>Similique at nisi quis.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '149'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="DevelPackage" project="ProjectA">
+          <title>Death Be Not Proud</title>
+          <description>Similique at nisi quis.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 26 Nov 2019 14:37:55 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/ProjectB/_meta?user=Admin
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="ProjectB">
+          <title>By Grand Central Station I Sat Down and Wept</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '129'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="ProjectB">
+          <title>By Grand Central Station I Sat Down and Wept</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Tue, 26 Nov 2019 14:37:55 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/ProjectB/AnotherPackage/_meta?user=Admin
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="AnotherPackage" project="ProjectB">
+          <title>Blood's a Rover</title>
+          <description>Deleniti aut sit id.</description>
+          <devel project="ProjectA" package="DevelPackage"/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '198'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="AnotherPackage" project="ProjectB">
+          <title>Blood's a Rover</title>
+          <description>Deleniti aut sit id.</description>
+          <devel project="ProjectA" package="DevelPackage"/>
+        </package>
+    http_version: 
+  recorded_at: Tue, 26 Nov 2019 14:37:55 GMT
+recorded_with: VCR 5.0.0

--- a/src/api/spec/cassettes/ProjectCreateAutoCleanupRequests/_perform/with_project_without_dependencies/sets_a_deletion_request_on_the_project.yml
+++ b/src/api/spec/cassettes/ProjectCreateAutoCleanupRequests/_perform/with_project_without_dependencies/sets_a_deletion_request_on_the_project.yml
@@ -1,0 +1,85 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/ProjectA/_meta?user=Admin
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="ProjectA">
+          <title>Far From the Madding Crowd</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '111'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="ProjectA">
+          <title>Far From the Madding Crowd</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Tue, 26 Nov 2019 14:37:55 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/ProjectA/_project/_attribute?meta=1&user=Admin
+    body:
+      encoding: UTF-8
+      string: |
+        <attributes>
+          <attribute name="AutoCleanup" namespace="OBS">
+            <value>14</value>
+          </attribute>
+        </attributes>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '168'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="19">
+          <srcmd5>0038532d850ef9974cdc76a9fcdf61c6</srcmd5>
+          <time>1574779075</time>
+          <user>Admin</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Tue, 26 Nov 2019 14:37:55 GMT
+recorded_with: VCR 5.0.0

--- a/src/api/spec/factories/attribs.rb
+++ b/src/api/spec/factories/attribs.rb
@@ -48,6 +48,12 @@ FactoryBot.define do
       values { [build(:attrib_value, value: Faker::Lorem.sentence)] }
     end
 
+    factory :auto_cleanup_attrib do
+      attrib_type { AttribType.find_by_namespace_and_name!('OBS', 'AutoCleanup') }
+
+      values { [build(:attrib_value, value: 14)] }
+    end
+
     factory :attrib_with_default_value do
       attrib_type { create(:attrib_type_with_default_value) }
     end

--- a/src/api/spec/jobs/project_create_auto_cleanup_requests_job_spec.rb
+++ b/src/api/spec/jobs/project_create_auto_cleanup_requests_job_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+require 'webmock/rspec'
+
+RSpec.describe ProjectCreateAutoCleanupRequests, type: :job, vcr: true do
+  include ActiveJob::TestHelper
+
+  describe '#perform' do
+    let(:admin) { create(:admin_user, login: 'Admin') }
+    let(:project) { create(:project, name: 'ProjectA') }
+    let(:attribute) { create(:auto_cleanup_attrib, project: project) }
+
+    subject { ProjectCreateAutoCleanupRequests.new.perform }
+
+    before do
+      allow(::Configuration).to receive(:cleanup_after_days).and_return(3)
+      login(admin)
+      attribute
+    end
+
+    context 'with project without dependencies' do
+      it 'sets a deletion request on the project' do
+        subject
+        expect(project.target_of_bs_request_actions.where(type: 'delete').count).to eq(1)
+      end
+    end
+
+    context 'with devel_package inside the project' do
+      let(:another_project) { create(:project, name: 'ProjectB') }
+      let!(:develpackage) { create(:package, project: project, name: 'DevelPackage') }
+      let!(:another_package) { create(:package, project: another_project, name: 'AnotherPackage', develpackage: develpackage) }
+
+      it 'does not create a deletion request' do
+        subject
+        expect(project.target_of_bs_request_actions.where(type: 'delete').count).to eq(0)
+      end
+    end
+  end
+end

--- a/src/api/spec/support/delayed_job.rb
+++ b/src/api/spec/support/delayed_job.rb
@@ -1,5 +1,7 @@
-# Disabling the delay on delayed jobs
 RSpec.configure do |config|
+  config.include ModelsAuthentication, type: :job
+
+  # Disabling the delay on delayed jobs
   config.before do
     Delayed::Worker.delay_jobs = false
   end


### PR DESCRIPTION
The performance of the auto cleanup delayed job failed because the check of dependencies raised an exception. So the delayed job was retried again and again.

The exception was caused by a project with a develpackage inside, that couldn't be removed.

Now, instead of raising an exception, the dependencies are correctly checked.

Fixes: #8762

Co-authored-by: David Kang <dkang@suse.com>
Co-authored-by: Eduardo Navarro <enavarro@suse.com>

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
