### PR TITLE
Show the correct user in Pulse page

### DIFF
--- a/src/api/app/views/webui/projects/pulse/_pulse_list_requests.html.haml
+++ b/src/api/app/views/webui/projects/pulse/_pulse_list_requests.html.haml
@@ -7,11 +7,15 @@
       = link_to(request_show_path(request.number), title: request.description) do
         = request.number
       - if request.request_history_elements.any?
-        = request.request_history_elements.last.description.gsub('Request', '')
+        - history_element = request.request_history_elements.last
+        = history_element.description.gsub('Request', '')
+        by
+        = link_to(user_path(history_element.user)) do
+          = history_element.user
       - else
         was created
-      by
-      = link_to(user_path(request.creator)) do
-        = request.creator
+        by
+        = link_to(user_path(request.creator)) do
+          = request.creator
       = fuzzy_time(request.updated_at)
 


### PR DESCRIPTION
The list of requests in the Pulse page was always showing the creator
instead of the user who performed the action (accept, revoke, etc.).

Now this is fixed and closes #8656

As an example, all the requests were created by scp, but the first was accepted by Admin, the second revoked by scp and the last one declined by Admin as well:

![Screenshot_2019-11-27 Open Build Service(3)](https://user-images.githubusercontent.com/2581944/69682012-4f5ced00-10b0-11ea-9dee-a2eeb5855196.png)
 
<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
