### PR TITLE
Use correct policies in StagedRequestController

### DIFF
--- a/src/api/app/controllers/staging/staged_requests_controller.rb
+++ b/src/api/app/controllers/staging/staged_requests_controller.rb
@@ -13,7 +13,7 @@ class Staging::StagedRequestsController < Staging::StagingController
   end
 
   def create
-    authorize @staging_project, :update?
+    authorize @staging_workflow, policy_class: Staging::StagedRequestPolicy
 
     if params[:remove_exclusion]
       ::Staging::RequestExcluder
@@ -33,7 +33,7 @@ class Staging::StagedRequestsController < Staging::StagingController
   end
 
   def destroy
-    authorize @staging_workflow, :update?
+    authorize @staging_workflow, policy_class: Staging::StagedRequestPolicy
 
     result = ::Staging::StagedRequests.new(
       request_numbers: @request_numbers,

--- a/src/api/app/policies/staging/staged_request_policy.rb
+++ b/src/api/app/policies/staging/staged_request_policy.rb
@@ -1,0 +1,11 @@
+class Staging::StagedRequestPolicy < ApplicationPolicy
+  def create?
+    group = record.managers_group
+    user.groups_users.where(group: group).exists? ||
+      ProjectPolicy.new(user, record.project).update?
+  end
+
+  def destroy?
+    create?
+  end
+end

--- a/src/api/spec/policies/staging/staged_request_policy_spec.rb
+++ b/src/api/spec/policies/staging/staged_request_policy_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe Staging::StagedRequestPolicy do
+  let(:admin) { create(:admin_user) }
+  let(:authorized_user) { create(:confirmed_user, login: 'Tom') }
+  let(:unauthorized_user) { create(:confirmed_user, login: 'Jerry') }
+  let!(:staging_workflow) { create(:staging_workflow_with_staging_projects, project: admin.home_project) }
+  let!(:add_member) { create(:groups_user, user: authorized_user, group: staging_workflow.managers_group) }
+
+  subject { Staging::StagedRequestPolicy }
+
+  permissions :create?, :destroy? do
+    it { is_expected.not_to permit(unauthorized_user, staging_workflow) }
+    it { is_expected.to permit(admin, staging_workflow) }
+    it { is_expected.to permit(authorized_user, staging_workflow) }
+  end
+end


### PR DESCRIPTION
The users of the manager group could unstaged the requests if they
weren't added as maintainers. Now we use a specific policy for staged an
unstaged a request.

Fix: #8784