### PR TITLE
Add uniqueness validation on Issue

### DIFF
--- a/src/api/app/models/issue.rb
+++ b/src/api/app/models/issue.rb
@@ -9,6 +9,7 @@ class Issue < ApplicationRecord
   belongs_to :owner, class_name: 'User'
 
   validate :name_validation, on: :create
+  validates :name, uniqueness: { scope: :issue_tracker_id }
 
   scope :stateless, -> { where(state: nil) }
 

--- a/src/api/app/models/patchinfo.rb
+++ b/src/api/app/models/patchinfo.rb
@@ -89,7 +89,7 @@ class Patchinfo
     data.elements('issue').each do |i|
       tracker = IssueTracker.find_by_name(i['tracker'])
       raise TrackerNotFound, "Tracker #{i['tracker']} is not registered in this OBS instance" unless tracker
-      issue = Issue.new(name: i['id'], issue_tracker: tracker)
+      issue = Issue.find_or_initialize_by(name: i['id'], issue_tracker: tracker)
       raise Issue::InvalidName, issue.errors.full_messages.to_sentence unless issue.valid?
     end
     # are releasetargets specified ? validate that this project is actually defining them.

--- a/src/api/spec/models/attrib_spec.rb
+++ b/src/api/spec/models/attrib_spec.rb
@@ -150,6 +150,7 @@ RSpec.describe Attrib, type: :model do
 
       subject { build(:attrib, project: project, attrib_type: attrib_type, issues: [issue]) }
 
+      it { expect(subject).to be_invalid }
       it { expect(subject.errors.full_messages).to match_array(["Issues can't have issues"]) }
     end
 

--- a/src/api/spec/models/issue_spec.rb
+++ b/src/api/spec/models/issue_spec.rb
@@ -42,5 +42,16 @@ RSpec.describe Issue do
     it 'CVE-XXXX-YYYY should be an invalid name' do
       expect { issue_cve.save! }.to raise_error(ActiveRecord::RecordInvalid, /does not match defined regex/)
     end
+
+    context 'with duplicated issues' do
+      let(:duplicated_issue) { build(:issue, name: '1234', issue_tracker: issue_tracker) }
+
+      it { expect(duplicated_issue).to be_invalid }
+
+      it 'has a proper error' do
+        duplicated_issue.save
+        expect(duplicated_issue.errors.full_messages).to match_array(['Name has already been taken'])
+      end
+    end
   end
 end

--- a/src/api/test/unit/attrib_test.rb
+++ b/src/api/test/unit/attrib_test.rb
@@ -124,18 +124,6 @@ class AttribTest < ActiveSupport::TestCase
     assert_equal 'One', attrib.values.first.value
   end
 
-  test 'should have no issues' do
-    attrib_type = AttribType.new(attrib_namespace: @namespace, name: 'AttribIssues')
-    attrib = Attrib.new(attrib_type: attrib_type, project: Project.first)
-
-    bnc = IssueTracker.find_by_name('bnc')
-    attrib.issues << Issue.new(name: '12345', issue_tracker: bnc)
-    assert_not attrib.valid?
-    assert_equal ["can't have issues"], attrib.errors.messages[:issues]
-    attrib_type.issue_list = true
-    assert attrib.valid?, "attrib should be valid: #{attrib.errors.messages}"
-  end
-
   test 'find_by_container_and_fullname' do
     project = Project.find_by(name: 'BaseDistro2.0')
     attrib = Attrib.find_by_container_and_fullname(project, 'OBS:UpdateProject')


### PR DESCRIPTION
The creation of an issue should be unique regarding the `name` and the
`issue_tracker_id`.

Fix #4044

Co-authored-by: Eduardo Navarro <enavarro@suse.com>

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
