### PR TITLE
Drop mysql workaround

### DIFF
--- a/dist/obs-bundled-gems.spec
+++ b/dist/obs-bundled-gems.spec
@@ -102,7 +102,6 @@ mkdir -p vendor/cache
 cp %{_sourcedir}/vendor/cache/*.gem vendor/cache
 export GEM_HOME=~/.gems
 bundle config build.ffi --enable-system-libffi
-bundle config build.mysql2 --with-cflags='%{optflags} -Wno-return-type'
 bundle config build.nokogiri --use-system-libraries
 bundle config build.sassc --disable-march-tune-native
 


### PR DESCRIPTION
[dist] revert workaround for mysql from commit
88e0ddaf9306c4f2ed2bb5c2e639a0d263c4959c
now that rubygem-mysql 0.5.3 is out

