### PR TITLE
Fix yet another random test suite failure

### DIFF
--- a/src/api/app/models/kiwi/image/xml_parser.rb
+++ b/src/api/app/models/kiwi/image/xml_parser.rb
@@ -56,7 +56,7 @@ module Kiwi
           prefer_license = repository.attribute('prefer-license')&.value
           attributes['prefer_license'] = prefer_license == 'true' unless prefer_license.nil?
 
-          Repository.new(attributes)
+          Kiwi::Repository.new(attributes)
         end
       end
 


### PR DESCRIPTION
Avoid relying on autoload to figure that Repository is in the kiwi namespace

As seen on https://circleci.com/gh/openSUSE/open-build-service/34716
