### PR TITLE
Specify namespace of class

### DIFF
--- a/src/api/app/models/cloud/ec2/params.rb
+++ b/src/api/app/models/cloud/ec2/params.rb
@@ -6,7 +6,7 @@ module Cloud
 
       attr_accessor :region, :ami_name, :vpc_subnet_id
       validates :region, presence: true, inclusion: {
-        in: Configuration::REGIONS.map(&:second), message: "'%{value}' is not a valid EC2 region"
+        in: Cloud::Ec2::Configuration::REGIONS.map(&:second), message: "'%{value}' is not a valid EC2 region"
       }
       validates :ami_name, presence: true, length: { maximum: 100 }
       validate :valid_ami_name


### PR DESCRIPTION
Avoid relying on autoload to figure the class is in the same namespace

Fixes #8812
