### PR TITLE
Remove dead routes from project

### DIFF
--- a/src/api/app/controllers/statistics_controller.rb
+++ b/src/api/app/controllers/statistics_controller.rb
@@ -5,7 +5,7 @@ class StatisticsController < ApplicationController
 
   before_action :get_limit, only: [
     :highest_rated, :most_active_packages, :most_active_projects, :latest_added, :latest_updated,
-    :latest_built, :download_counter
+    :download_counter
   ]
 
   def index

--- a/src/api/config/routes/api_routes.rb
+++ b/src/api/config/routes/api_routes.rb
@@ -71,7 +71,6 @@ OBSApi::Application.routes.draw do
     post 'trigger/webhook' => 'services/webhooks#create'
 
     ### /issue_trackers
-    get 'issue_trackers/issues_in' => 'issue_trackers#issues_in'
     resources :issue_trackers, only: [:index, :show, :create, :update, :destroy] do
       resources :issues, only: [:show] # Nested route
     end

--- a/src/api/config/routes/api_routes.rb
+++ b/src/api/config/routes/api_routes.rb
@@ -148,7 +148,6 @@ OBSApi::Application.routes.draw do
       get 'statistics/latest_added' => :latest_added
       get 'statistics/latest_updated' => :latest_updated
       get 'statistics/global_counters' => :global_counters
-      get 'statistics/latest_built' => :latest_built
 
       get 'statistics/active_request_creators/:project' => :active_request_creators, constraints: cons
       get 'statistics/maintenance_statistics/:project' => 'statistics/maintenance_statistics#index', constraints: cons,

--- a/src/api/config/routes/api_routes.rb
+++ b/src/api/config/routes/api_routes.rb
@@ -40,9 +40,6 @@ OBSApi::Application.routes.draw do
     get 'service/:service' => 'service#index_service', constraints: cons
 
     ### /source
-
-    get 'source/:project/:package/_tags' => 'tag#package_tags', constraints: cons
-    get 'source/:project/_tags' => 'tag#project_tags', constraints: cons
     get 'source/:project/_keyinfo' => 'source/key_info#show', constraints: cons
 
     resources :about, only: :index
@@ -78,43 +75,6 @@ OBSApi::Application.routes.draw do
     resources :issue_trackers, only: [:index, :show, :create, :update, :destroy] do
       resources :issues, only: [:show] # Nested route
     end
-
-    ### /tag
-
-    # routes for tagging support
-    #
-    # get 'tag/_all' => 'tag',
-    #  action: 'list_xml'
-    # Get/put tags by object
-    ### moved to source section
-
-    # Get objects by tag.
-    controller :tag do
-      get 'tag/:tag/_projects' => :get_projects_by_tag
-      get 'tag/:tag/_packages' => :get_packages_by_tag
-      get 'tag/:tag/_all' => :get_objects_by_tag
-
-      get 'tag/get_tagged_projects_by_user' => :get_tagged_projects_by_user
-      get 'tag/get_tagged_packages_by_user' => :get_tagged_packages_by_user
-      get 'tag/get_tags_by_user' => :get_tags_by_user
-      get 'tag/tags_by_user_and_object' => :tags_by_user_and_object
-      get 'tag/get_tags_by_user_and_project' => :get_tags_by_user_and_project
-      get 'tag/get_tags_by_user_and_package' => :get_tags_by_user_and_package
-      get 'tag/most_popular_tags' => :most_popular_tags
-      get 'tag/most_recent_tags' => :most_recent_tags
-      get 'tag/get_taglist' => :get_taglist
-      get 'tag/project_tags' => :project_tags
-      get 'tag/package_tags' => :package_tags
-    end
-
-    ### /user
-
-    # Get objects tagged by user. (objects with tags)
-    get 'user/:user/tags/_projects' => 'tag#get_tagged_projects_by_user', constraints: cons
-    get 'user/:user/tags/_packages' => 'tag#get_tagged_packages_by_user', constraints: cons
-
-    # Get tags for a certain object by user.
-    match 'user/:user/tags/:project(/:package)' => 'tag#tags_by_user_and_object', constraints: cons, via: [:get, :post, :put, :delete]
 
     ### /statistics
     # Routes for statistics

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -4,10 +4,6 @@ OBSApi::Application.routes.draw do
   constraints(WebuiMatcher) do
     root 'webui/main#index'
 
-    controller 'webui/main' do
-      get 'main/systemstatus' => :systemstatus
-    end
-
     resources :status_messages, only: [:create, :destroy], controller: 'webui/status_messages'
 
     controller 'webui/feeds' do
@@ -99,7 +95,6 @@ OBSApi::Application.routes.draw do
         get 'package/attributes/:project/:package', to: redirect('/attribs/%{project}/%{package}'), constraints: cons
         # For backward compatibility
         get 'package/repositories/:project/:package', to: redirect('/repositories/%{project}/%{package}'), constraints: cons
-        get 'package/import_spec/:project/:package' => :import_spec, constraints: cons
         # For backward compatibility
         get 'package/files/:project/:package' => :show, constraints: cons
       end
@@ -197,18 +192,13 @@ OBSApi::Application.routes.draw do
       post 'project/restore' => :restore, constraints: cons, as: 'projects_restore'
       patch 'project/update' => :update, constraints: cons
       delete 'project/destroy' => :destroy
-      get 'project/packages/:project' => :packages, constraints: cons
       get 'project/requests/:project' => :requests, constraints: cons, as: 'project_requests'
-      post 'project/save_path_element' => :save_path_element
       post 'project/remove_target_request' => :remove_target_request, as: 'project_remove_target_request'
       post 'project/remove_path_from_target' => :remove_path_from_target, as: 'remove_repository_path'
-      post 'project/release_repository/:project/:repository' => :release_repository, constraints: cons
       post 'project/move_path/:project' => :move_path, as: 'move_repository_path'
       post 'project/save_person/:project' => :save_person, constraints: cons, as: 'project_save_person'
       post 'project/save_group/:project' => :save_group, constraints: cons, as: 'project_save_group'
       post 'project/remove_role/:project' => :remove_role, constraints: cons, as: 'project_remove_role'
-      post 'project/remove_person/:project' => :remove_person, constraints: cons
-      post 'project/remove_group/:project' => :remove_group, constraints: cons
       get 'project/monitor/:project' => :monitor, constraints: cons, as: 'project_monitor'
       # For backward compatibility
       get 'project/monitor', to: redirect { |_path_parameters, request|


### PR DESCRIPTION
The routes are unusable, since the corresponding controller
methods do not exists. They are most likely leftovers
from refactored views.

Fixes #7003

It's still WIP because I'm not yet complete checking the routes for leftovers.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
