### PR TITLE
[2.10 Backport] Add support for handling modules (Fedora Modularity)

### DIFF
--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -112,6 +112,7 @@ BuildRequires:  perl-Socket-MsgHdr
 BuildRequires:  perl-TimeDate
 BuildRequires:  perl-XML-Parser
 BuildRequires:  perl-XML-Simple
+BuildRequires:  perl-YAML-LibYAML
 BuildRequires:  procps
 BuildRequires:  timezone
 BuildRequires:  perl(Devel::Cover)
@@ -159,6 +160,7 @@ Requires:       perl-Net-SSLeay
 Requires:       perl-Socket-MsgHdr
 Requires:       perl-XML-Parser
 Requires:       perl-XML-Simple
+Requires:       perl-YAML-LibYAML
 
 Obsoletes:      obs-productconverter < 2.9
 Obsoletes:      obs-source_service < 2.9

--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -120,7 +120,7 @@ BuildRequires:  perl(Test::Simple) > 1
 PreReq:         /usr/sbin/useradd /usr/sbin/groupadd
 BuildArch:      noarch
 Requires(pre):  obs-common
-Requires:       build >= 20181031
+Requires:       build >= 20191114
 Requires:       perl-BSSolv >= 0.28
 Requires:       perl(Date::Parse)
 # Required by source server

--- a/src/backend/BSRepServer/Checker.pm
+++ b/src/backend/BSRepServer/Checker.pm
@@ -97,6 +97,7 @@ sub preparepool {
   my $pool = BSSolv::pool->new();
   $pool->settype('deb') if $bconf->{'binarytype'} eq 'deb';
   $pool->settype('arch') if $bconf->{'binarytype'} eq 'arch';
+  $pool->setmodules($bconf->{'modules'}) if $bconf->{'modules'} && defined &BSSolv::pool::setmodules;
   $ctx->{'pool'} = $pool;
 
   if ($ldepfile) {

--- a/src/backend/BSSched/BuildJob.pm
+++ b/src/backend/BSSched/BuildJob.pm
@@ -769,6 +769,7 @@ sub create_jobdata {
   $binfo->{'nodbgpkgs'} = $info->{'nodbgpkgs'} if $info->{'nodbgpkgs'};
   $binfo->{'nosrcpkgs'} = $info->{'nosrcpkgs'} if $info->{'nosrcpkgs'};
   $binfo->{'hostarch'} = $bconf->{'hostarch'} if $bconf->{'hostarch'};
+  $binfo->{'module'} = $bconf->{'modules'} if $bconf->{'modules'};
   my $obsname = $gctx->{'obsname'};
   $binfo->{'disturl'} = "obs://$obsname/$projid/$repoid/$pdata->{'srcmd5'}-$packid" if defined($obsname) && defined($packid);
   if (defined($packid) && exists($pdata->{'versrel'})) {

--- a/src/backend/BSSched/BuildJob/Docker.pm
+++ b/src/backend/BSSched/BuildJob/Docker.pm
@@ -204,6 +204,8 @@ sub check {
 
   my $pool = BSSolv::pool->new();
   $pool->settype('deb') if $bconf->{'binarytype'} eq 'deb';
+  $pool->settype('arch') if $bconf->{'binarytype'} eq 'arch';
+  $pool->setmodules($bconf->{'modules'}) if $bconf->{'modules'} && defined &BSSolv::pool::setmodules;
 
   my $delayed_errors = '';
   for my $aprp (@aprps) {

--- a/src/backend/BSSched/BuildJob/KiwiImage.pm
+++ b/src/backend/BSSched/BuildJob/KiwiImage.pm
@@ -105,6 +105,7 @@ sub check {
 
   my $pool = BSSolv::pool->new();
   $pool->settype('deb') if $bconf->{'binarytype'} eq 'deb';
+  $pool->setmodules($bconf->{'modules'}) if $bconf->{'modules'} && defined &BSSolv::pool::setmodules;
 
   my $delayed_errors = '';
   for my $aprp (@aprps) {

--- a/src/backend/BSSched/BuildJob/KiwiProduct.pm
+++ b/src/backend/BSSched/BuildJob/KiwiProduct.pm
@@ -155,6 +155,7 @@ sub check {
     # calculate packages needed for building
     $pool = BSSolv::pool->new();
     $pool->settype('deb') if $bconf->{'binarytype'} eq 'deb';
+    $pool->setmodules($bconf->{'modules'}) if $bconf->{'modules'} && defined &BSSolv::pool::setmodules;
     my $delayed_errors = '';
     for my $aprp (@bprps) {
       if (!$ctx->checkprpaccess($aprp)) {

--- a/src/backend/BSSched/BuildRepo.pm
+++ b/src/backend/BSSched/BuildRepo.pm
@@ -994,7 +994,7 @@ sub addrepo_scan {
   return undef unless $r;
   # write solv file (unless alien arch)
   if ($dirty && $arch eq $gctx->{'arch'}) {
-    @bins = BSSched::DoD::clean_obsolete_dodpackages($r, $dir, @bins) if $doddata;
+    @bins = BSSched::DoD::clean_obsolete_dodpackages($pool, $r, $dir, @bins) if $doddata;
     writesolv("$dir.solv.new", "$dir.solv", $r);
   }
   $repocache->setcache($prp, $arch) if $repocache;

--- a/src/backend/BSSched/Checker.pm
+++ b/src/backend/BSSched/Checker.pm
@@ -389,6 +389,7 @@ sub preparepool {
   my $pool = BSSolv::pool->new();
   $pool->settype('deb') if $bconf->{'binarytype'} eq 'deb';
   $pool->settype('arch') if $bconf->{'binarytype'} eq 'arch';
+  $pool->setmodules($bconf->{'modules'}) if $bconf->{'modules'} && defined &BSSolv::pool::setmodules;
   $ctx->{'pool'} = $pool;
 
   my $prpsearchpath = $ctx->{'prpsearchpath'};

--- a/src/backend/BSSched/DoD.pm
+++ b/src/backend/BSSched/DoD.pm
@@ -141,7 +141,13 @@ sub dodcheck {
     next unless $p && ($pool->pkg2pkgid($p) || '') eq 'd0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0';
     # ohhh, we have to download
     my $prp = $pool->pkg2reponame($p);
-    $ctx->{'doddownloads'}->{"$prp/$arch"}->{$pkg} = 1;
+    my @modules;
+    @modules = $pool->getmodules() if defined &BSSolv::pool::getmodules;
+    if (@modules) {
+      $ctx->{'doddownloads'}->{"$prp/$arch/".join('/', @modules)}->{$pkg} = 1;
+    } else {
+      $ctx->{'doddownloads'}->{"$prp/$arch"}->{$pkg} = 1;
+    }
     $todownload{$pkg} = 1;
   }
   return unless %todownload;
@@ -180,11 +186,12 @@ sub dodfetch {
   return unless $doddownloads;
   my $gctx = $ctx->{'gctx'};
   my $remoteprojs = $gctx->{'remoteprojs'};
-  for my $prpa (sort(keys %$doddownloads)) {
-    my @pkgs = sort(keys %{$doddownloads->{$prpa} || {}});
+  for my $prpam (sort(keys %$doddownloads)) {
+    my @pkgs = sort(keys %{$doddownloads->{$prpam} || {}});
     next unless @pkgs;
+    my ($projid, $repoid, $arch, @modules) = split('/', $prpam);
+    my $prpa = "$projid/$repoid/$arch";
     print "    requesting ".@pkgs." dod packages from $prpa\n";
-    my ($projid, $repoid, $arch) = split('/', $prpa, 3);
     my $server = $BSConfig::reposerver || $BSConfig::srcserver;
     if ($remoteprojs->{$projid}) {
       $server = $BSConfig::srcserver;
@@ -199,8 +206,11 @@ sub dodfetch {
         '_prpa' => $prpa,
       },
     };
+    my @args = 'view=binaryversions';
+    push @args, map {"module=$_"} @modules;
+    push @args, map {"binary=$_"} @pkgs;
     eval {
-      $ctx->xrpc("dodfetch/$prpa", $param, undef, "view=binaryversions", map {"binary=$_"} @pkgs);
+      $ctx->xrpc("dodfetch/$prpa", $param, undef, @args);
     };
     if ($@) {
       warn($@);

--- a/src/backend/BSSched/DoD.pm
+++ b/src/backend/BSSched/DoD.pm
@@ -105,14 +105,13 @@ sub clean_obsolete_dodpackages {
   return @bins unless defined &BSSolv::repo::pkgpaths;
   my %paths = $cache->pkgpaths();
   if (defined(&BSSolv::repo::mayhavemodules) && $cache->mayhavemodules()) {
-    # find all modules 
     my @modules;
-    my @nbins = @bins;
-    while (@nbins) {
-      my (undef, $id) = splice(@nbins, 0, 2);
-      push @modules, $pool->pkg2modules($id);
+    if (defined(&BSSolv::repo::modulesfrombins)) {
+      @modules = $cache->modulesfrombins(@bins);
+    } else {
+      @modules = $cache->getmodules();
     }
-    print "clean_obsolete_dodpackages: @modules\n";
+    print "    clean_obsolete_dodpackages: @modules\n";
     if (@modules) {
       my @oldpoolmodules = $pool->getmodules();
       for my $module (sort(BSUtil::unify(@modules))) {

--- a/src/backend/BSVerify.pm
+++ b/src/backend/BSVerify.pm
@@ -535,6 +535,9 @@ sub verify_multibuild {
   }
 }
 
+sub verify_module {
+}
+
 our $verifiers = {
   'project' => \&verify_projid,
   'package' => \&verify_packid,
@@ -558,6 +561,7 @@ our $verifiers = {
   'workerid' => \&verify_workerid,
   'regrepo' => \&verify_regrepo,
   'regtag' => \&verify_regtag,
+  'module' => \&verify_module,
 };
 
 1;

--- a/src/backend/BSXML.pm
+++ b/src/backend/BSXML.pm
@@ -593,6 +593,7 @@ our $buildinfo = [
 	'followupfile',	# for two-stage builds
 	'masterdispatched',	# dispatched through a master dispatcher
 	'nounchanged',	# do not check for "unchanged" builds
+      [ 'module' ],	# list of modules to use
 
       [ 'preinstallimage' =>
 	    'project',

--- a/src/backend/bs_dodup
+++ b/src/backend/bs_dodup
@@ -27,6 +27,7 @@ use Build::Repo;
 use Build::Rpmmd;
 use Build::Deb;
 use Build::Rpm;
+use Build::Modules;
 
 use strict;
 
@@ -238,12 +239,22 @@ sub dod_rpmmd {
   unlink("$file.repomd");
   my $primaryfile = (grep {$_->{'type'} eq 'primary' && defined($_->{'location'})} @files)[0];
   die("no primary file in repomd.xml\n") unless $primaryfile;
-  die("primary file has no checksum\n") if $doddata->{'pubkey'}&& !$primaryfile->{'checksum'};
+  die("primary file has no checksum\n") if $doddata->{'pubkey'} && !$primaryfile->{'checksum'};
   fetch("${url}$primaryfile->{'location'}", $sslfingerprint, $timeout_large, $file);
   chkverify($file, $primaryfile->{'checksum'}) if $primaryfile->{'checksum'};
   uncompress($file, $primaryfile->{'location'});
   my $moduleinfo;
-  $moduleinfo = {} if grep {$_->{'type'} eq 'modules'} @files;
+  my $moduleinfofile = (grep {$_->{'type'} eq 'modules' && defined($_->{'location'})} @files)[0];
+  if ($moduleinfofile) {
+    die("module file has no checksum\n") if $doddata->{'pubkey'} && !$moduleinfofile->{'checksum'};
+    my $tmp = "$file.tmp";
+    fetch("${url}$moduleinfofile->{'location'}", $sslfingerprint, $timeout_large, $tmp);
+    chkverify($tmp, $moduleinfofile->{'checksum'}) if $moduleinfofile->{'checksum'};
+    uncompress($tmp, $moduleinfofile->{'location'});
+    $moduleinfo = {};
+    Build::Modules::parse($tmp, $moduleinfo);
+    unlink($tmp);
+  }
   return ($newcookie, $url, $moduleinfo);
 }
 
@@ -375,13 +386,24 @@ sub addpkg {
   my ($cache, $p, $archfilter, $moduleinfo) = @_; 
 
   return unless $p->{'location'} && $p->{'name'} && $p->{'arch'};
-  return if $moduleinfo && $p->{'release'} && $p->{'release'} =~ /\.module_/;
   return if $archfilter && !$archfilter->{$p->{'arch'}};
   if ($BSConfig::dodupblacklist) {
     return if grep {$p->{'name'} =~ /^$_/s } @$BSConfig::dodupblacklist;
   }
   $p->{'path'} = delete $p->{'location'};
-  my $key = "$p->{'name'}.$p->{'arch'}";
+  my $name = $p->{'name'};
+  my $arch = $p->{'arch'};
+  my $key = "$name.$arch";
+  if ($moduleinfo) {
+    my $evr = $p->{'epoch'} ? "$p->{'epoch'}:$p->{'version'}" : $p->{'version'};
+    $evr .= "-$p->{'release'}" if defined $p->{'release'};
+    if ($moduleinfo->{"$name-$evr.$arch"}) {
+      $p->{'modules'} = $moduleinfo->{"$name-$evr.$arch"};
+      $key = "$name-$evr.$arch";
+    } else {
+      return if $p->{'release'} && $p->{'release'} =~ /\.module_/;
+    }
+  }
   return if $cache->{$key} && cmppkg($cache->{$key}, $p) > 0;   # highest version only
   $cache->{$key} = $p; 
 }

--- a/src/backend/bs_getbinariesproxy
+++ b/src/backend/bs_getbinariesproxy
@@ -188,6 +188,7 @@ sub getbinaries {
     push @args, "repository=$repoid";
     push @args, "arch=$arch";
     push @args, "nometa" if $nometa;
+    push @args, map {"module=$_"} @{$cgi->{'module'} || []};
     push @args, "binaries=".join(',', @missingbvs);
     my $bvl;
     eval {
@@ -300,6 +301,7 @@ sub getbinaries {
     push @args, "project=$projid";
     push @args, "repository=$repoid";
     push @args, "arch=$arch";
+    push @args, map {"module=$_"} @{$cgi->{'module'} || []};
     my $res = BSRPC::rpc({
       'uri' => "$server/getbinaries",
       'directory' => $cachetmpdir,
@@ -406,7 +408,7 @@ sub hello {
 
 my $dispatches = [
   '/' => \&hello,
-  '/getbinaries $project $repository $arch binaries: nometa:bool? metaonly:bool? workerid? server:' => \&getbinaries,
+  '/getbinaries $project $repository $arch binaries: nometa:bool? metaonly:bool? module* workerid? server:' => \&getbinaries,
   '/getpreinstallimage $prpa $hdrmd5:md5 path: sizek:num? workerid? server:' => \&getpreinstallimage,
 ];
 

--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -134,22 +134,20 @@ sub fetchdodbinary {
   die("$path has an unsupported suffix\n") unless $path =~ /\.($binsufsre)$/;
   my $suf = $1;
   my $pkgname = $pool->pkg2name($p);
+  if (defined(&BSSolv::pool::pkg2inmodule) && $pool->pkg2inmodule($p)) {
+    $pkgname .= '-' . $pool->pkg2evr($p) . '.' . $pool->pkg2arch($p);
+  }
+  $pkgname .= ".$suf";
   BSVerify::verify_filename($pkgname);
   BSVerify::verify_simple($pkgname);
-  my $localname = "$reporoot/$reponame/$arch/:full/$pkgname.$suf";
-  if (defined(&BSSolv::pool::pkg2inmodule) && $pool->pkg2inmodule($p)) {
-    # use nevra for module packages
-    my $evr = $pool->pkg2evr($p);
-    my $arch = $pool->pkg2arch($p);
-    $localname = "$reporoot/$reponame/$arch/:full/$pkgname-$evr.$arch.$suf";
-  }
+  my $localname = "$reporoot/$reponame/$arch/:full/$pkgname";
   return $localname if -e $localname;
   # we really need to download, handoff to ajax if not already done
   BSHandoff::handoff(@$handoff) if $handoff && !$BSStdServer::isajax;
   my $url = $repo->dodurl();
   $url .= '/' unless $url =~ /\/$/;
   $url .= $pool->pkg2path($p);
-  my $tmp = "$reporoot/$reponame/$arch/:full/.dod.$$.$pkgname.$suf";
+  my $tmp = "$reporoot/$reponame/$arch/:full/.dod.$$.$pkgname";
   #print "fetching: $url\n";
   my $param = {'uri' => $url, 'filename' => $tmp, 'receiver' => \&BSHTTP::file_receiver, 'proxy' => $proxy};
   $param->{'maxredirects'} = $maxredirects if defined $maxredirects;

--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -137,6 +137,12 @@ sub fetchdodbinary {
   BSVerify::verify_filename($pkgname);
   BSVerify::verify_simple($pkgname);
   my $localname = "$reporoot/$reponame/$arch/:full/$pkgname.$suf";
+  if (defined(&BSSolv::pool::pkg2inmodule) && $pool->pkg2inmodule($p)) {
+    # use nevra for module packages
+    my $evr = $pool->pkg2evr($p);
+    my $arch = $pool->pkg2arch($p);
+    $localname = "$reporoot/$reponame/$arch/:full/$pkgname-$evr.$arch.$suf";
+  }
   return $localname if -e $localname;
   # we really need to download, handoff to ajax if not already done
   BSHandoff::handoff(@$handoff) if $handoff && !$BSStdServer::isajax;
@@ -228,6 +234,7 @@ sub getbinaryversions {
   $serial = BSWatcher::serialize("$reporoot/$projid/$repoid/$arch") if $BSStdServer::isajax;
   return if $BSStdServer::isajax && !defined $serial;
   my $pool = BSSolv::pool->new();
+  $pool->setmodules($cgi->{'module'} || []) if defined &BSSolv::pool::setmodules;
   my $repo = BSRepServer::addrepo_scan($pool, $prp, $arch);
   my %names = $repo ? $repo->pkgnames() : ();
   @bins = sort keys %names if !@bins && !defined $cgi->{'binaries'};
@@ -247,9 +254,9 @@ sub getbinaryversions {
     if ($dodurl && $hdrmd5 eq 'd0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0') {
       my @handoff;
       if (defined $cgi->{'binaries'}) {
-	@handoff = ('/getbinaryversions', undef, "project=$projid", "repository=$repoid", "arch=$arch", "binaries=$cgi->{'binaries'}");
+	@handoff = ('/getbinaryversions', undef, "project=$projid", "repository=$repoid", "arch=$arch", BSRPC::args($cgi, 'binaries', 'module'));
       } else {
-	@handoff = ("/build/$projid/$repoid/$arch/_repository", undef, 'view=binaryversions', map {"binary=$_"} @{$cgi->{'binary'} || []});
+	@handoff = ("/build/$projid/$repoid/$arch/_repository", undef, 'view=binaryversions', BSRPC::args($cgi, 'binary', 'module'));
       }
       $path = fetchdodbinary($pool, $repo, $p, $arch, 3, \@handoff);
       return unless defined $path;
@@ -434,6 +441,7 @@ sub getbinaries {
   $serial = BSWatcher::serialize("$reporoot/$projid/$repoid/$arch") if $BSStdServer::isajax;
   return if $BSStdServer::isajax && !defined $serial;
   my $pool = BSSolv::pool->new();
+  $pool->setmodules($cgi->{'module'} || []) if defined &BSSolv::pool::setmodules;
   my $repo = BSRepServer::addrepo_scan($pool, $prp, $arch);
   my %names = $repo ? $repo->pkgnames() : ();
   my @send;
@@ -447,7 +455,7 @@ sub getbinaries {
     }
     my $path = "$reporoot/".$pool->pkg2fullpath($p, $arch);
     if ($dodurl && $pool->pkg2pkgid($p) eq 'd0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0') {
-      my @handoff = ('/getbinaries', undef, "project=$projid", "repository=$repoid", "arch=$arch", "binaries=$cgi->{'binaries'}");
+      my @handoff = ('/getbinaries', undef, "project=$projid", "repository=$repoid", "arch=$arch", BSRPC::args($cgi, 'binaries', 'module'));
       $path = fetchdodbinary($pool, $repo, $p, $arch, 3, \@handoff);
       return unless defined $path;
       $needscan = 1;
@@ -526,7 +534,7 @@ sub getrpmheaders {
 }
 
 sub getavailable {
-my ($projid, $repoid, $arch, $available, $available_pattern, $available_product) = @_;
+  my ($projid, $repoid, $arch, $available, $available_pattern, $available_product) = @_;
   my $pool = BSSolv::pool->new();
   my $dir = "$reporoot/$projid/$repoid/$arch/:full";
   my $repo;
@@ -644,7 +652,7 @@ sub getbinarylist_repository {
   my $view = $cgi->{'view'} || '';
 
   if (($view eq 'cache' || $view eq 'cpio' || $view eq 'solvstate') && !$BSStdServer::isajax && !$cgi->{'noajax'}) {
-    my @args = BSRPC::args($cgi, 'view', 'binary');
+    my @args = BSRPC::args($cgi, 'view', 'binary', 'module');
     BSHandoff::handoff("/build/$projid/$repoid/$arch/_repository", undef, @args);
   }
 
@@ -704,45 +712,86 @@ sub getbinarylist_repository {
       'name' => 'repositorystate',
       'data' => XMLout($BSXML::repositorystate, $repostate),
     };
-    my $fd = gensym;
+    my $fd;
     if (-s "$reporoot/$prp/$arch/:full.solv") {
       my @s = stat(_);
       my $id64 = pack("a64", "$s[9]/$s[7]/$s[1]");
-      if (open($fd, '<', "$reporoot/$prp/$arch/:full.xcache")) {
+      my $xcachefile = "$reporoot/$prp/$arch/:full.xcache";
+
+      my @modules = @{$cgi->{'module'} || []};
+      # can we use the xcache?
+      if (!@modules && open($fd, '<', $xcachefile)) {
 	my $id;
 	if (sysread($fd, $id, 64) == 64 && $id eq $id64) {
           push @files, { 'name' => 'repositorycache', 'filename' => $fd, 'offset' => 64 };
 	  BSWatcher::reply_cpio(\@files);
 	  return undef;
 	}
-	unlink("$reporoot/$prp/$arch/:full.xcache");
+	unlink($xcachefile);
+	close($fd);
+	undef $fd;
       }
+
       my $pool = BSSolv::pool->new();
       my $repo = BSRepServer::addrepo_scan($pool, $prp, $arch);
-      if ($repo) {
-        my %data = $repo->pkgnames();
-        for my $p (values %data) {
-	  $p = $pool->pkg2data($p);
-	  if ($p->{'annotation'}) {
-	    $p->{'annotationdata'} = export_annotation($p->{'annotation'});
-	    $p->{'annotation'} = create_legacy_annotation($p->{'annotationdata'});
-	  }
-        }
-	if (keys(%data) < 100 && $s[7] < 10000) {
-	  # small repo, feed from memory
-	  push @files, { 'name' => 'repositorycache', 'data' => BSUtil::tostorable(\%data) };
-	} else {
-	  # cache result
-	  my $tmpname = "$reporoot/$prp/$arch/:full.xcache.$$";
-	  open($fd, '+>', $tmpname) || die("$tmpname: $!\n");
-	  # Storable uses PerlIO_write, so we have to use print instead of syswrite here
-	  print $fd $id64;
-	  Storable::nstore_fd(\%data, $fd) || die("nstore_fd $tmpname: $!\n");
-	  $fd->flush();
-	  BSUtil::do_fdatasync(fileno($fd)) if $BSUtil::fdatasync_before_rename;
-	  rename($tmpname, "$reporoot/$prp/$arch/:full.xcache");
+      if (!$repo) {
+        undef $pool;
+        BSWatcher::reply_cpio(\@files);
+        return undef;
+      }
+
+      my @repomodules;	# modules known in this repo
+      if (@modules) {
+	@repomodules = $repo->getmodules() if defined &BSSolv::pool::getmodules;
+	# reduce requested modules to the modules known in this repo
+	my %repomodules = map {$_ => 1} @repomodules;
+	@modules = grep {$repomodules{$_}} @modules;
+      }
+
+      # can we now use the xcache?
+      if (!@repomodules && open($fd, '<', $xcachefile)) {
+	my $id;
+	if (sysread($fd, $id, 64) == 64 && $id eq $id64) {
+	  undef $repo;
+	  undef $pool;
 	  push @files, { 'name' => 'repositorycache', 'filename' => $fd, 'offset' => 64 };
+	  BSWatcher::reply_cpio(\@files);
+	  return undef;
 	}
+	unlink($xcachefile);
+	close($fd);
+	undef $fd;
+      }
+
+      $pool->setmodules(\@modules) if @modules && defined &BSSolv::pool::setmodules;
+      my %data = $repo->pkgnames();
+      for my $p (values %data) {
+	$p = $pool->pkg2data($p);
+	if ($p->{'annotation'}) {
+	  $p->{'annotationdata'} = export_annotation($p->{'annotation'});
+	  $p->{'annotation'} = create_legacy_annotation($p->{'annotationdata'});
+	}
+      }
+      # return known modules if some module was requested
+      $data{'/modules'} = \@repomodules if @repomodules;
+      if (keys(%data) < 100 && $s[7] < 10000) {
+	# small repo, feed from memory
+	push @files, { 'name' => 'repositorycache', 'data' => BSUtil::tostorable(\%data) };
+      } else {
+	# cache result
+	my $tmpname = "$xcachefile.$$";
+	open($fd, '+>', $tmpname) || die("$tmpname: $!\n");
+	# Storable uses PerlIO_write, so we have to use print instead of syswrite here
+	print $fd $id64;
+	Storable::nstore_fd(\%data, $fd) || die("nstore_fd $tmpname: $!\n");
+	$fd->flush();
+	BSUtil::do_fdatasync(fileno($fd)) if $BSUtil::fdatasync_before_rename;
+	if (@repomodules) {
+	  unlink($tmpname);
+	} else {
+	  rename($tmpname, $xcachefile);
+	}
+	push @files, { 'name' => 'repositorycache', 'filename' => $fd, 'offset' => 64 };
       }
       undef $repo;
       undef $pool;
@@ -758,6 +807,7 @@ sub getbinarylist_repository {
 
   if ($view eq 'cpioheaders') {
     my $pool = BSSolv::pool->new();
+    $pool->setmodules($cgi->{'module'} || []) if defined &BSSolv::pool::setmodules;
     my $repo = BSRepServer::addrepo_scan($pool, $prp, $arch);
     my %names = $repo ? $repo->pkgnames() : ();
     my @bins = $cgi->{'binary'} ? @{$cgi->{'binary'}} : sort keys %names;
@@ -795,6 +845,7 @@ sub getbinarylist_repository {
     return if $BSStdServer::isajax && !defined $serial;
     my @files;
     my $pool = BSSolv::pool->new();
+    $pool->setmodules($cgi->{'module'} || []) if defined &BSSolv::pool::setmodules;
     my $repo = BSRepServer::addrepo_scan($pool, $prp, $arch);
     my %names = $repo ? $repo->pkgnames() : ();
     my @bins = $cgi->{'binary'} ? @{$cgi->{'binary'}} : sort keys %names;
@@ -808,7 +859,7 @@ sub getbinarylist_repository {
       }
       my $path = "$reporoot/".$pool->pkg2fullpath($p, $arch);
       if ($dodurl && $pool->pkg2pkgid($p) eq 'd0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0') {
-	my @handoff = ("/build/$projid/$repoid/$arch/_repository", undef, "view=$view", map {"binary=$_"} @{$cgi->{'binary'} || []});
+	my @handoff = ("/build/$projid/$repoid/$arch/_repository", undef, BSRPC::args($cgi, 'view', 'binary', 'module'));
         $path = fetchdodbinary($pool, $repo, $p, $arch, 3, \@handoff);
         return unless defined $path;
         $needscan = 1;
@@ -863,13 +914,14 @@ sub getbinarylist_repository {
   $serial = BSWatcher::serialize("$reporoot/$projid/$repoid/$arch") if $BSStdServer::isajax;
   return if $BSStdServer::isajax && !defined $serial;
   my $pool = BSSolv::pool->new();
+  $pool->setmodules($cgi->{'module'} || []) if defined &BSSolv::pool::setmodules;
   my $repo = BSRepServer::addrepo_scan($pool, $prp, $arch);
   my %names = $repo ? $repo->pkgnames() : ();
   my @bins = $cgi->{'binary'} ? @{$cgi->{'binary'}} : sort keys %names;
   my @res;
   my $needscan;
   my $dodurl = $repo->dodurl();
-  my @handoff = ("/build/$projid/$repoid/$arch/_repository", undef, BSRPC::args($cgi, 'view', 'binary'));
+  my @handoff = ("/build/$projid/$repoid/$arch/_repository", undef, BSRPC::args($cgi, 'view', 'binary', 'module'));
   for my $bin (@bins) {
     my $p = $names{$bin};
     if (!$p) {
@@ -1328,6 +1380,7 @@ sub getbinary_info {
     my $pool = BSSolv::pool->new();
     $pool->settype('deb') if $bconf->{'binarytype'} eq 'deb';
     $pool->settype('arch') if $bconf->{'binarytype'} eq 'arch';
+    $pool->setmodules($bconf->{'modules'}) if $bconf->{'modules'} && defined &BSSolv::pool::setmodules;
     for my $prp (@prp) {
       my ($rprojid, $rrepoid) = split('/', $prp, 2);
       my $r;
@@ -1386,6 +1439,7 @@ sub getbinary_repository {
   if (! -f $path) {
     # return by name
     my $pool = BSSolv::pool->new();
+    $pool->setmodules($cgi->{'module'} || []) if defined &BSSolv::pool::setmodules;
     my $repo = BSRepServer::addrepo_scan($pool, "$projid/$repoid", $arch);
     my $dodurl = $repo->dodurl();
     my %rnames = $repo ? $repo->pkgnames() : ();
@@ -1399,7 +1453,7 @@ sub getbinary_repository {
     die("404 no such binary '$bin'\n") unless $p;
     $path = "$reporoot/".$pool->pkg2fullpath($p, $arch);
     if ($dodurl && $pool->pkg2pkgid($p) eq 'd0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0') {
-      my @handoff = ("/build/$projid/$repoid/$arch/_repository/$bin", undef, $view ? ("view=$view") : ());
+      my @handoff = ("/build/$projid/$repoid/$arch/_repository/$bin", undef, BSRPC::args($cgi, 'view', 'module'));
       $path = fetchdodbinary($pool, $repo, $p, $arch, 3, \@handoff);
       return unless defined $path;
       $needscan = 1;
@@ -4236,7 +4290,7 @@ my $dispatches = [
   '/build/$project/$repository/$arch/_relsync' => \&getrelsync,
   'POST:/build/$project/$repository/$arch/$package cmd=copy oproject:project? opackage:package? orepository:repository? setupdateinfoid:? resign:bool? setrelease:?' => \&copybuild,
   'POST:/build/$project/$repository/$arch/$package' => \&uploadbuild,
-  '!worker,rw /build/$project/$repository/$arch/$package:package_repository view:? binary:filename* nometa:bool? noajax:bool? nosource:bool? noimport:bool? withmd5:bool?' => \&getbinarylist,
+  '!worker,rw /build/$project/$repository/$arch/$package:package_repository view:? binary:filename* nometa:bool? noajax:bool? nosource:bool? noimport:bool? withmd5:bool? module*' => \&getbinarylist,
   'POST:/build/$project/$repository/$arch/$package_repository/_buildinfo add:* internal:bool? debug:bool? deps:bool?' => \&getbuildinfo_post,
   '/build/$project/$repository/$arch/$package/_buildinfo add:* internal:bool? debug:bool? deps:bool?' => \&getbuildinfo,
   '/build/$project/$repository/$arch/$package/_reason' => \&getbuildreason,
@@ -4244,7 +4298,7 @@ my $dispatches = [
   '/build/$project/$repository/$arch/$package/_jobstatus' => \&getjobstatus,
   '/build/$project/$repository/$arch/$package/_history limit:num?' => \&getbuildhistory,
   '/build/$project/$repository/$arch/$package/_log nostream:bool? start:intnum? end:num? handoff:bool? last:bool? view:?' => \&getlogfile,
-  '/build/$project/$repository/$arch/$package:package_repository/$filename view:?' => \&getbinary,
+  '/build/$project/$repository/$arch/$package:package_repository/$filename view:? module*' => \&getbinary,
   'PUT:/build/$project/$repository/$arch/_repository/$filename ignoreolder:bool? wipe:bool?' => \&putbinary,
   'DELETE:/build/$project/$repository/$arch/_repository/$filename' => \&delbinary,
   '/search/published/binary/id $match:' => \&search_published_binary_id,
@@ -4265,8 +4319,8 @@ my $dispatches = [
   '!worker /getworkercode' => \&getworkercode,
   '!worker POST:/putjob $arch $job $jobid $code:? now:num? kiwitree:bool? workerid?' => \&putjob,
   '!worker POST:/workerdispatched $arch $job $jobid hostarch:arch port workerid?' => \&workerdispatched,
-  '!worker /getbinaries $project $repository $arch binaries: nometa:bool? metaonly:bool? workerid?' => \&getbinaries,
-  '!worker /getbinaryversions $project $repository $arch binaries: nometa:bool? workerid?' => \&getbinaryversions,
+  '!worker /getbinaries $project $repository $arch binaries: nometa:bool? metaonly:bool? workerid? module*' => \&getbinaries,
+  '!worker /getbinaryversions $project $repository $arch binaries: nometa:bool? workerid? module*' => \&getbinaryversions,
   '!worker /getjobdata $arch $job $jobid workerid?' => \&getjobdata,
   '!worker /getpackagebinaryversionlist $project $repository $arch $package* withcode:bool? workerid?' => \&getpackagebinaryversionlist,
   '!worker /badpackagebinaryversionlist $project $repository $arch $package* workerid?' => \&badpackagebinaryversionlist,
@@ -4320,11 +4374,11 @@ my $dispatches_ajax = [
   '/' => \&hello,
   '/ajaxstatus' => \&getajaxstatus,
   '/build/$project/$repository/$arch/$package/_log nostream:bool? last:bool? start:intnum? end:num? view:?' => \&getlogfile,
-  '/build/$project/$repository/$arch/$package:package_repository view:? binary:filename* nosource:bool?' => \&getbinarylist,
-  '/build/$project/$repository/$arch/$package:package_repository/$filename view:?' => \&getbinary,
+  '/build/$project/$repository/$arch/$package:package_repository view:? binary:filename* nosource:bool? module*' => \&getbinarylist,
+  '/build/$project/$repository/$arch/$package:package_repository/$filename view:? module*' => \&getbinary,
   '/_result $prpa+ oldstate:md5? package* code:* withbinarylist:bool? withstats:bool? summary:bool? withversrel:bool?' => \&getresult,
-  '/getbinaries $project $repository $arch binaries: nometa:bool? metaonly:bool?' => \&getbinaries,
-  '/getbinaryversions $project $repository $arch binaries: nometa:bool?' => \&getbinaryversions,
+  '/getbinaries $project $repository $arch binaries: nometa:bool? metaonly:bool? module*' => \&getbinaries,
+  '/getbinaryversions $project $repository $arch binaries: nometa:bool? module*' => \&getbinaryversions,
 ];
 
 my $conf = {

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -6637,8 +6637,8 @@ my $dispatches = [
   '/getsources $project $package $srcmd5:md5 workerid?' => \&getsources,
   '/getconfig $project $repository path:prp* workerid?' => \&getbuildconfig,
   '/getsslcert $project autoextend:bool? workerid?' => \&getsslcert,
-  '/getbinaries $project $repository $arch binaries: nometa:bool? workerid?' => \&worker_getbinaries,
-  '/getbinaryversions $project $repository $arch binaries: nometa:bool? workerid?' => \&worker_getbinaryversions,
+  '/getbinaries $project $repository $arch binaries: nometa:bool? workerid? module*' => \&worker_getbinaries,
+  '/getbinaryversions $project $repository $arch binaries: nometa:bool? workerid? module*' => \&worker_getbinaryversions,
 
   # publisher/signer calls
   '/getsignkey $project withpubkey:bool? autoextend:bool? withalgo:bool?' => \&getsignkey,

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -4060,7 +4060,7 @@ sub getbinarylist {
   my $view = $cgi->{'view'};
   my $nosource = $cgi->{'nosource'};
   my $reposerver = $BSConfig::partitioning ? BSSrcServer::Partition::projid2reposerver($projid) : $BSConfig::reposerver;
-  my @args = BSRPC::args($cgi, 'view', 'nosource', 'withmd5', 'binary');
+  my @args = BSRPC::args($cgi, 'view', 'nosource', 'withmd5', 'binary', 'module');
   if ($view && ($view eq 'cache' || $view eq 'cpio' || $view eq 'solv' || $view eq 'solvstate')) {
     # do not check arch in interconnect mode
     my $proj = checkprojrepoarch($projid, $repoid, undef, 1);
@@ -4079,6 +4079,7 @@ sub getbinarylist {
 	push @args, "repository=$repoid";
 	push @args, "arch=$arch";
 	push @args, "binaries=".join(',', @{$cgi->{'binary'} || []});
+	push @args, map {"module=$_"} @{$cgi->{'module'} || []};
 	BSHandoff::handoff('/getbinaries', undef, @args);
       }
       BSHandoff::handoff("/build/$projid/$repoid/$arch/$packid", undef, @args);
@@ -4113,6 +4114,7 @@ sub getbinarylist {
       push @args, "arch=$arch";
       push @args, 'nometa=1' if $cgi->{'nometa'};
       push @args, "binaries=".join(',', @{$cgi->{'binary'} || []});
+      push @args, map {"module=$_"} @{$cgi->{'module'} || []};
       BSHandoff::handoff('/getbinaryversions', undef, @args);
     }
     if (!$BSStdServer::isajax && $packid eq '_repository') {
@@ -4162,6 +4164,7 @@ sub getbinary {
     push @args, "arch=$arch";
     push @args, "binaries=$filename";
     push @args, "raw=1";
+    push @args, map {"module=$_"} @{$cgi->{'module'} || []};
     BSHandoff::handoff('/getbinaries', undef, @args);
   }
   if ($view eq 'publishedpath') {
@@ -5350,13 +5353,14 @@ sub worker_getbinaries {
     push @args, "repository=$repoid";
     push @args, "arch=$arch";
     push @args, "binaries=$cgi->{'binaries'}";
+    push @args, map {"module=$_"} @{$cgi->{'module'} || []};
     BSHandoff::handoff('/getbinaries', undef, @args);
   }
   my @binaries = split(',', $cgi->{'binaries'});
   my $proj = findremote($projid);
-  my $binarylist = BSSrcServer::Remote::getremotebinarylist($proj, $projid, $repoid, $arch, \@binaries);
+  my $binarylist = BSSrcServer::Remote::getremotebinarylist($proj, $projid, $repoid, $arch, \@binaries, $cgi->{'module'});
   return undef unless $binarylist;
-  my $reply = BSSrcServer::Remote::getremotebinaries($proj, $projid, $repoid, $arch, \@binaries, $binarylist);
+  my $reply = BSSrcServer::Remote::getremotebinaries($proj, $projid, $repoid, $arch, \@binaries, $binarylist, $cgi->{'module'});
   return undef unless $reply;
   if ($cgi->{'raw'}) {
     die("can only transport one binary in raw mode\n") unless @$reply == 1;
@@ -5380,11 +5384,12 @@ sub worker_getbinaryversions {
     push @args, "arch=$arch";
     push @args, "binaries=$cgi->{'binaries'}";
     push @args, "nometa=1" if $cgi->{'nometa'};
+    push @args, map {"module=$_"} @{$cgi->{'module'} || []};
     BSHandoff::handoff('/getbinaryversions', undef, @args);
   }
   my @binaries = split(',', $cgi->{'binaries'});
   my $proj = findremote($projid);
-  my $binaryversions = BSSrcServer::Remote::getremotebinaryversions($proj, $projid, $repoid, $arch, \@binaries);
+  my $binaryversions = BSSrcServer::Remote::getremotebinaryversions($proj, $projid, $repoid, $arch, \@binaries, $cgi->{'module'});
   return undef unless $binaryversions;
   my $bvl = {};
   $bvl->{'binary'} = [ map {$binaryversions->{$_}} @binaries];
@@ -6690,7 +6695,7 @@ my $dispatches = [
   'POST:/build/$project/$repository/$arch/_repository match:' =>  \&postrepo,
   'POST:/build/$project/$repository/$arch/$package cmd=copy oproject:project? opackage:package? orepository:repository? setupdateinfoid:? resign:bool? setrelease:? multibuild:bool?' => \&copybuild,
   'POST:/build/$project/$repository/$arch/$package' => \&uploadbuild,
-  '/build/$project/$repository/$arch/$package_repository view:? binary:filename* nometa:bool? nosource:bool? withmd5:bool?' => \&getbinarylist,
+  '/build/$project/$repository/$arch/$package_repository view:? binary:filename* nometa:bool? nosource:bool? withmd5:bool? module*' => \&getbinarylist,
   'POST:/build/$project/$repository/$arch/$package_repository/_buildinfo add:* debug:bool?' => \&getbuildinfo_post,
   '/build/$project/$repository/$arch/$package/_buildinfo add:* internal:bool? debug:bool?' => \&getbuildinfo,
   '/build/$project/$repository/$arch/$package/_jobstatus' => \&getjobstatus,
@@ -6698,7 +6703,7 @@ my $dispatches = [
   '/build/$project/$repository/$arch/$package/_reason' => \&getbuildreason,
   '/build/$project/$repository/$arch/$package/_status' => \&getbuildstatus,
   '/build/$project/$repository/$arch/$package/_history limit:num?' => \&getbuildhistory,
-  '/build/$project/$repository/$arch/$package_repository/$filename view:?' => \&getbinary,
+  '/build/$project/$repository/$arch/$package_repository/$filename view:? module*' => \&getbinary,
   'PUT:/build/$project/$repository/$arch/_repository/$filename ignoreolder:bool? wipe:bool?' => \&putbinary,
   'DELETE:/build/$project/$repository/$arch/_repository/$filename' => \&delbinary,
 
@@ -6746,9 +6751,9 @@ my $dispatches_ajax = [
   '/build/$project/_result oldstate:md5? view:resultview* repository* arch* package* code:*' => \&getresult,
   '/build/$project/$repository/$arch package* view:?' => \&getpackagelist_build,
   '/build/$project/$repository/$arch/$package/_log nostream:bool? last:bool? start:intnum? end:num?' => \&getlogfile,
-  '/build/$project/$repository/$arch/$package_repository view:? binary:filename* nometa:bool? nosource:bool? withmd5:bool?' => \&getbinarylist,
-  '/getbinaries $project $repository $arch binaries: nometa:bool? raw:bool?' => \&worker_getbinaries,
-  '/getbinaryversions $project $repository $arch binaries: nometa:bool?' => \&worker_getbinaryversions,
+  '/build/$project/$repository/$arch/$package_repository view:? binary:filename* nometa:bool? nosource:bool? withmd5:bool? module*' => \&getbinarylist,
+  '/getbinaries $project $repository $arch binaries: nometa:bool? raw:bool? module*' => \&worker_getbinaries,
+  '/getbinaryversions $project $repository $arch binaries: nometa:bool? module*' => \&worker_getbinaryversions,
   '/lastevents $filter:* start:num? obsname:?' => \&lastevents,
   '/lasteventsproxy $filter:* start:num? remoteurl: client:?' => \&lasteventsproxy,
   '/lastnotifications start:num? view:? block:bool?' => \&lastnotifications,

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -4172,8 +4172,7 @@ sub getbinary {
     return published_path($cgi, $projid, $repoid);
   }
   my $reposerver = $BSConfig::partitioning ? BSSrcServer::Partition::projid2reposerver($projid) : $BSConfig::reposerver;
-  my @args;
-  push @args, "view=$view" if $view;
+  my @args = BSRPC::args($cgi, 'view', 'module');
   my $param = {
     'uri' => "$reposerver/build/$projid/$repoid/$arch/$packid/$filename",
     'ignorestatus' => 1,

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -1920,6 +1920,7 @@ sub getpreinstallimage {
     push @args, "repository=$repo->{'repository'}";
     push @args, "arch=$buildinfo->{'arch'}";
     push @args, "nometa" if $nometa;
+    push @args, map {"module=$_"} @{$buildinfo->{'module'} || []};
     push @args, "binaries=".join(',', @bins);
     my $bvl;
     eval {
@@ -2161,6 +2162,7 @@ sub getbinaries_buildenv {
       push @args, "repository=$repo->{'repository'}";
       push @args, "arch=$arch";
       push @args, 'nometa';
+      push @args, map {"module=$_"} @{$buildinfo->{'module'} || []};
       push @args, "binaries=".join(',', @needed_names);
       my $bvl;
       eval {
@@ -2233,6 +2235,7 @@ sub getbinaries_buildenv {
       my $projid = $repo->{'project'};
       my $repoid = $repo->{'repository'};
       my $param;
+      my @args;
       unlink("$dir/$bv->{'name'}");
       if ($bv->{'package'}) {
 	$param = {
@@ -2242,6 +2245,7 @@ sub getbinaries_buildenv {
 	  'filename' => "$dir/$bv->{'name'}",
 	};
       } else {
+	push @args, map {"module=$_"} @{$buildinfo->{'module'} || []};
 	$param = {
           'uri' => "$server/build/$projid/$repoid/$arch/_repository/$bv->{'name'}",
           'timeout' => $gettimeout,
@@ -2250,7 +2254,7 @@ sub getbinaries_buildenv {
 	};
       }
       eval {
-        BSRPC::rpc($param);
+        BSRPC::rpc($param, undef, @args);
       };
       if ($@) {
 	warn($@);

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -1272,7 +1272,7 @@ sub trygetbinariesproxy_preinstallimage {
 }
 
 sub getbinaries_cache {
-  my ($dir, $server, $projid, $repoid, $arch, $nometa, $bins, $bvl) = @_;
+  my ($dir, $server, $projid, $repoid, $arch, $nometa, $bins, $modules, $bvl) = @_;
 
   importbuild() unless defined &Build::queryhdrmd5;
   if (! -d $dir) {
@@ -1299,6 +1299,7 @@ sub getbinaries_cache {
     push @args, "repository=$repoid";
     push @args, "arch=$arch";
     push @args, "nometa" if $nometa;
+    push @args, map {"module=$_"} @{$modules || []};
     push @args, "binaries=".join(',', @$bins);
     eval {
       $bvl = BSRPC::rpc({
@@ -1388,6 +1389,7 @@ sub getbinaries_cache {
     push @args, "project=$projid";
     push @args, "repository=$repoid";
     push @args, "arch=$arch";
+    push @args, map {"module=$_"} @{$modules || []};
     my $res;
     $res = trygetbinariesproxy($server, $dir, \@downloadbins, \%bv, @args) if $getbinariesproxy;
     eval {
@@ -1495,12 +1497,13 @@ sub getbinaries_kiwiproduct {
   mkdir_p($dir);
 
   # fetch packages needed for product building
+  my $modules = $buildinfo->{'module'};
   for my $repo (@{$buildinfo->{'syspath'} || $buildinfo->{'path'} || []}) {
     last if !@kdeps;
     my $repoarch = $buildinfo->{'arch'};
     $repoarch = $BSConfig::localarch if $repoarch eq 'local' && $BSConfig::localarch;
     my $server = $repo->{'server'} || $buildinfo->{'reposerver'};
-    my $got = getbinaries_cache($dir, $server, $repo->{'project'}, $repo->{'repository'}, $repoarch, 1, \@kdeps);
+    my $got = getbinaries_cache($dir, $server, $repo->{'project'}, $repo->{'repository'}, $repoarch, 1, \@kdeps, $modules);
     @kdeps = grep {!$got->{$_}} @kdeps;
   }
   die("getbinaries_kiwiproduct: missing packages: @kdeps\n") if @kdeps;
@@ -2314,6 +2317,7 @@ sub getbinaries {
   my $packid = $buildinfo->{'package'};
   my $projid = $buildinfo->{'project'};
   my $repoid = $buildinfo->{'repository'};
+  my $modules = $buildinfo->{'module'};
 
   if ($kiwimode && $buildinfo->{'syspath'}) {
     # two path mode: fetch environment
@@ -2321,7 +2325,7 @@ sub getbinaries {
     for my $repo (@{$buildinfo->{'syspath'} || []}) {
       last if !@todo;
       my $server = $repo->{'server'} || $buildinfo->{'reposerver'};
-      my $got = getbinaries_cache($dir, $server, $repo->{'project'}, $repo->{'repository'}, $buildinfo->{'arch'}, 1, \@todo);
+      my $got = getbinaries_cache($dir, $server, $repo->{'project'}, $repo->{'repository'}, $buildinfo->{'arch'}, 1, \@todo, $modules);
       @todo = grep {!$got->{$_}} @todo;
     }
     die("getbinaries: missing packages: @todo\n") if @todo;
@@ -2380,7 +2384,7 @@ sub getbinaries {
     $nometa = 1 if $kiwimode || $repo->{'project'} ne $projid || $repo->{'repository'} ne $repoid;
     $nometa = 1 if $buildinfo->{'file'} eq '_preinstallimage';
     my $server = $repo->{'server'} || $buildinfo->{'reposerver'};
-    my $got = getbinaries_cache($ddir, $server, $repo->{'project'}, $repo->{'repository'}, $buildinfo->{'arch'}, $nometa, \@todo_repo, $bvls{"$repoprp/$buildinfo->{'arch'}"});
+    my $got = getbinaries_cache($ddir, $server, $repo->{'project'}, $repo->{'repository'}, $buildinfo->{'arch'}, $nometa, \@todo_repo, $modules, $bvls{"$repoprp/$buildinfo->{'arch'}"});
     for (sort keys %$got) {
       my $gotpkg = $got->{$_};
       $done{$_} = $gotpkg->{'name'};
@@ -2923,7 +2927,7 @@ sub dobuild {
       'verifymd5' => $buildinfo->{'verifymd5'} || $buildinfo->{'srcmd5'},
       'bdep' => [],
     };
-    for ('versrel', 'bcnt', 'release') {
+    for ('versrel', 'bcnt', 'release', 'module') {
       $buildinfo->{'outbuildinfo'}->{$_} = $buildinfo->{$_} if defined $buildinfo->{$_};
     }
   }


### PR DESCRIPTION
This pull request backports the changes needed to support using modules on OBS 2.10 from git master. Thus, this still has the same quirks as the support in OBS git master (no module dependency resolution, ignorance of content shadowing, no build environment property propagation, etc.). Essentially, modules are treated _solely_ as sub repositories (similar to sections in Debian repositories).

<strike>This PR is marked as draft because I'm still testing the functionality with my internal instance. Moreover, there's no released version of [perl-BSSolv](https://github.com/openSUSE/perl-BSSolv) with module support.</strike>

**EDIT: The only thing missing now is a released version of [perl-BSSolv](https://github.com/openSUSE/perl-BSSolv) with module support.**

This is derived from the following PRs to git master:

* PR #8637 
* PR #8633 
* PR #8662 
* PR #8670 
* PR #8717
* PR #8854

(cc: @sgallagher, @ignatenkobrain, @whitel, @mattdm, @dmach)