### PR TITLE
Harmonize display of broken packages

### DIFF
--- a/src/api/app/helpers/webui/staging/project_helper.rb
+++ b/src/api/app/helpers/webui/staging/project_helper.rb
@@ -12,4 +12,14 @@ module Webui::Staging::ProjectHelper
     return 'fa-eye text-info' if check.pending?
     'fa-exclamation-circle text-danger'
   end
+
+  def merge_broken_packages(packages)
+    problems = {}
+    packages.each do |package|
+      problems[package[:package]] ||= {}
+      problems[package[:package]][package[:state]] ||= []
+      problems[package[:package]][package[:state]] << { repository: package[:repository], arch: package[:arch] }
+    end
+    problems.sort
+  end
 end

--- a/src/api/app/helpers/webui/webui_helper.rb
+++ b/src/api/app/helpers/webui/webui_helper.rb
@@ -341,5 +341,19 @@ module Webui::WebuiHelper
   def home_title
     @configuration ? @configuration['title'] : 'Open Build Service'
   end
+
+  def pick_max_problems(remaining_checks, remaining_build_problems, max_shown)
+    show_checks = [max_shown, remaining_checks.length].min
+    show_builds = [max_shown - show_checks, remaining_build_problems.length].min
+    # always prefer one build fail
+    if show_builds == 0 && remaining_build_problems.present?
+      show_builds += 1
+      show_checks -= 1
+    end
+
+    checks = remaining_checks.shift(show_checks)
+    build_problems = remaining_build_problems.shift(show_builds)
+    return checks, build_problems, remaining_checks, remaining_build_problems
+  end
 end
 # rubocop:enable Metrics/ModuleLength

--- a/src/api/app/views/webui/staging/projects/_broken_packages.html.haml
+++ b/src/api/app/views/webui/staging/projects/_broken_packages.html.haml
@@ -1,0 +1,24 @@
+- problems = merge_broken_packages(staging_project.broken_packages)
+
+%td.p-2.w-25.font-weight-bold
+  %i.mr-2.fas{ class: problems.empty? ? 'fa-check-circle text-primary' : 'fa-exclamation-triangle text-warning' }
+  Broken Packages
+%td.p-2
+  - if problems.empty?
+    None
+  - else
+    - problems.each do |name, states|
+      = link_to("#{name}:", package_show_path(package: name, project: staging_project))
+      - states.each do |state, values|
+        = state
+        = surround '(', ')' do
+          - values.each do |value|
+            - comma = ', ' unless values.last == value
+            = succeed comma do
+              - if ['unresolvable', 'broken'].include?(state)
+                = value[:arch]
+              - else
+                = link_to(value[:arch], package_live_build_log_path(package: name,
+                                                                    repository: value[:repository],
+                                                                    project: staging_project,
+                                                                    arch: value[:arch]))

--- a/src/api/app/views/webui/staging/projects/_status_items.html.haml
+++ b/src/api/app/views/webui/staging/projects/_status_items.html.haml
@@ -16,6 +16,4 @@
           when 'building_repositories'
             link_to("#{item['repository']}-#{item['arch']} (#{item['state']})",
                     project_repository_state_path(project: @staging_project.name, repository: item['repository']))
-          when 'broken_packages'
-            link_to("#{item[:package]} (#{item[:state]})", package_show_path(project: item[:project], package: item[:package]))
           end

--- a/src/api/app/views/webui/staging/projects/show.html.haml
+++ b/src/api/app/views/webui/staging/projects/show.html.haml
@@ -28,8 +28,8 @@
               = render partial: 'status_items',
                        locals: { staging_project: @staging_project, items: @staging_project.building_repositories, type: 'building_repositories' }
             %tr
-              = render partial: 'status_items',
-                       locals: { staging_project: @staging_project, items: @staging_project.broken_packages, type: 'broken_packages' }
+              = render partial: 'broken_packages',
+                       locals: { staging_project: @staging_project }
             %tr
               = render partial: 'checks',
                        locals: { checks: @staging_project.checks, missing_checks: @staging_project.missing_checks }

--- a/src/api/app/views/webui/staging/workflows/_problems.html.haml
+++ b/src/api/app/views/webui/staging/workflows/_problems.html.haml
@@ -3,7 +3,7 @@
   project_class = staging_project.name.tr(':.', '_')
   item_project_class = 'hidden-item-' + project_class
   checks_problems = staging_project.checks.failed
-  build_problems = staging_project.problems
+  build_problems = merge_broken_packages(staging_project.broken_packages)
   total_problems = checks_problems.length + build_problems.length
 
 - if total_problems == 0

--- a/src/api/app/views/webui/staging/workflows/_problems.html.haml
+++ b/src/api/app/views/webui/staging/workflows/_problems.html.haml
@@ -2,30 +2,27 @@
   max_shown = 5
   project_class = staging_project.name.tr(':.', '_')
   item_project_class = 'hidden-item-' + project_class
-  checks_problems = staging_project.checks.failed
   build_problems = merge_broken_packages(staging_project.broken_packages)
-  total_problems = checks_problems.length + build_problems.length
+  checks, build_problems, remaining_checks, remaining_build_problems =
+    pick_max_problems(staging_project.checks.failed.to_a, build_problems, max_shown)
 
-- if total_problems == 0
+- if checks.empty? && build_problems.empty?
   .text-center
     %i.fas.fa-check-circle.text-success
 - else
-  :ruby
-    rendered_checks_problems = [max_shown - 1, checks_problems.length].min
-    rendered_build_problems = max_shown - rendered_checks_problems
   %ul.list-group.list-group-flush
-    - checks_problems[0..(rendered_checks_problems - 1)].each do |check|
+    - checks.each do |check|
       = render partial: 'status_problems', locals: { check: check }
-    - build_problems[0..(rendered_build_problems - 1)].each do |name, states|
+    - build_problems.each do |name, states|
       = render partial: 'build_problems', locals: { name: name, states: states, staging_project: staging_project }
-    - if total_problems > max_shown
-      - number = total_problems - max_shown
+    - remain_count = remaining_checks.length + remaining_build_problems.length
+    - if remain_count > 0
       %span.collapse{ 'id': item_project_class }
-        - checks_problems[rendered_checks_problems..-1].each do |check|
+        - remaining_checks.each do |check|
           = render partial: 'status_problems', locals: { check: check }
-        - build_problems[rendered_build_problems..-1].each do |name, states|
+        - remaining_build_problems.each do |name, states|
           = render partial: 'build_problems', locals: { name: name, states: states, staging_project: staging_project }
       %li.list-group-item.table-list-group-item
         %a{ 'data-toggle': 'collapse', href: "##{item_project_class}", 'aria-expanded': 'false' }
-          %span.expander See #{number} more
-          %span.collapser See #{number} less
+          %span.expander See #{remain_count} more
+          %span.collapser See #{remain_count} less

--- a/src/api/spec/controllers/staging/staging_projects_controller_spec.rb
+++ b/src/api/spec/controllers/staging/staging_projects_controller_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe Staging::StagingProjectsController do
             assert_select 'obsolete_requests', 0
             assert_select 'missing_reviews', 0
             assert_select 'broken_packages', 1 do
-              assert_select 'package', 1
+              assert_select 'package', 2
             end
             assert_select 'checks', 1
             assert_select 'history', 0
@@ -221,7 +221,7 @@ RSpec.describe Staging::StagingProjectsController do
               assert_select 'review', 1
             end
             assert_select 'broken_packages', 1 do
-              assert_select 'package', 1
+              assert_select 'package', 2
             end
             assert_select 'history', 1
           end

--- a/src/api/spec/helpers/webui/webui_helper_spec.rb
+++ b/src/api/spec/helpers/webui/webui_helper_spec.rb
@@ -248,4 +248,37 @@ RSpec.describe Webui::WebuiHelper do
       it { expect(toggle_sliced_text(big_text)).to match(/(.+)#{sliced_text}(.+)\[\+\](.+)#{big_text}(.+)\[\-\](.+)/) }
     end
   end
+
+  describe '#pick_max_problems' do
+    let(:max_shown) { 5 }
+    subject { pick_max_problems(checks, builds, max_shown) }
+
+    context 'with no failed checks' do
+      let(:checks) { [] }
+
+      context 'with no fails' do
+        let(:builds) { [] }
+        it { is_expected.to eq([[], [], [], []]) }
+      end
+
+      context 'with 7 fails' do
+        let(:builds) { [1, 2, 3, 4, 5, 6, 7] }
+        it { is_expected.to eq([[], [1, 2, 3, 4, 5], [], [6, 7]]) }
+      end
+    end
+
+    context 'with 7 checks' do
+      let(:checks) { [1, 2, 3, 4, 5, 6, 7] }
+
+      context 'with no fails' do
+        let(:builds) { [] }
+        it { is_expected.to eq([[1, 2, 3, 4, 5], [], [6, 7], []]) }
+      end
+
+      context 'with 7 fails' do
+        let(:builds) { [1, 2, 3, 4, 5, 6, 7] }
+        it { is_expected.to eq([[1, 2, 3, 4], [1], [5, 6, 7], [2, 3, 4, 5, 6, 7]]) }
+      end
+    end
+  end
 end


### PR DESCRIPTION
workflow#show used a different way than project#show leading to fixes for one broke the other.

So this moves the `problems` function from the model to a helper that can is used by both views

Reverts parts of #8521, fixes #7362 differently and fixes #8802
