### PR TITLE
[backend] add some more memory debugging aids

### DIFF
--- a/src/backend/BSSched/EventHandler.pm
+++ b/src/backend/BSSched/EventHandler.pm
@@ -69,6 +69,7 @@ our %event_handlers = (
   'suspendproject'  => \&BSSched::EventHandler::event_suspendproject,
   'resumeproject'   => \&BSSched::EventHandler::event_resumeproject,
   'memstats'        => \&BSSched::EventHandler::event_memstats,
+  'dumppmat'        => \&BSSched::EventHandler::event_dumppmat,
   'dispatchdetails' => \&BSSched::EventHandler::event_dispatchdetails,
   'force_publish'   => \&BSSched::EventHandler::event_force_publish,
 );
@@ -625,6 +626,10 @@ sub event_uploadbuildimport_delay {
 
 sub event_memstats {
   my ($ectx, $ev) = @_;
+  eval {
+    require Devel::Mallinfo;
+    print Devel::Mallinfo::malloc_info_string(0);
+  };
   my $gctx = $ectx->{'gctx'};
   my %gctx = %$gctx;
   %$gctx = ();
@@ -654,6 +659,18 @@ sub event_memstats {
   };
   warn($@) if $@;
   %$gctx = %gctx;
+}
+
+sub event_dumppmat {
+  my ($ectx, $ev) = @_;
+  my $gctx = $ectx->{'gctx'};
+  my $myarch = $gctx->{'arch'};
+  my $rundir = $gctx->{'rundir'};
+  eval {
+    require Devel::MAT::Dumper;
+    Devel::MAT::Dumper::dump("$rundir/bs_sched.$myarch.pmat");
+  };
+  warn($@) if $@;
 }
 
 sub event_dispatchdetails {

--- a/src/backend/bs_admin
+++ b/src/backend/bs_admin
@@ -215,6 +215,7 @@ Debug Options
    Show delta store statistics
 
  --dump-memstats <architecture> [what]
+ --dump-pmat <architecture>
 
 Backend Configuration
 =====================
@@ -536,6 +537,11 @@ sub dump_memstats {
   write_event( undef, undef, $arch, 'memstats', undef, $job );
 }
 
+sub dump_pmat {
+  my ($arch) = @_;
+  write_event( undef, undef, $arch, 'dumppmat' );
+}
+
 sub shutdown_scheduler {
   my ($arch) = @_;
   write_event( '', undef, $arch, 'exitcomplete' );
@@ -712,6 +718,10 @@ while (@ARGV) {
     my $arch = shift @ARGV;
     my $job = shift @ARGV if @ARGV;
     dump_memstats($arch, $job);
+  } elsif ($arg eq "--dump-pmat") {
+    die("ERROR: need architecture as argument!\n") if @ARGV < 1;
+    my $arch = shift @ARGV;
+    dump_pmat($arch);
   } elsif ($arg eq "--dump-project-from-state") {
     die("ERROR: need project as argument!\n") if @ARGV < 1;
     my $project = shift @ARGV;


### PR DESCRIPTION
The scheduler can how write a Devel::MAT pmat file. The memstats
event also includes statistics from glibc's malloc implementation.
(You need the Devel::MAT::Dumper and Devel::Mallinfo modules for
this, respectively.)

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
