### PR TITLE
Refactor code related to issue models 

### DIFF
--- a/src/api/app/models/issue.rb
+++ b/src/api/app/models/issue.rb
@@ -49,10 +49,6 @@ class Issue < ApplicationRecord
     end
   end
 
-  def self.valid_name?(tracker, name)
-    tracker.show_label_for(name).match?(tracker.regex)
-  end
-
   def fetch_issues
     IssueTrackerFetchIssuesJob.perform_later(issue_tracker.id)
   end

--- a/src/api/app/models/issue.rb
+++ b/src/api/app/models/issue.rb
@@ -1,9 +1,7 @@
 require 'api_error'
 
 class Issue < ApplicationRecord
-  class NotFoundError < APIError
-    setup 'issue_not_found', 404, 'Issue not found'
-  end
+  include Issue::Errors
 
   has_many :package_issues, foreign_key: 'issue_id', dependent: :delete_all
 

--- a/src/api/app/models/issue/errors.rb
+++ b/src/api/app/models/issue/errors.rb
@@ -1,0 +1,9 @@
+module Issue::Errors
+  extend ActiveSupport::Concern
+
+  class NotFoundError < APIError
+    setup 'issue_not_found', 404, 'Issue not found'
+  end
+
+  class InvalidName < APIError; end
+end

--- a/src/api/app/models/issue_tracker.rb
+++ b/src/api/app/models/issue_tracker.rb
@@ -6,7 +6,6 @@ class IssueTracker < ApplicationRecord
   class NotFoundError < APIError
     setup 'issue_tracker_not_found', 404, 'Issue Tracker not found'
   end
-  class InvalidIssueName < APIError; end
 
   validates :name, :regex, :url, :kind, presence: true
   validates :name, :regex, uniqueness: true
@@ -22,10 +21,6 @@ class IssueTracker < ApplicationRecord
 
   before_validation(on: :create) do
     self.issues_updated ||= Time.now
-  end
-
-  def valid_issue_name?(name)
-    Issue.valid_name?(self, name)
   end
 
   # Checks if the given issue belongs to this issue tracker

--- a/src/api/app/models/issue_tracker.rb
+++ b/src/api/app/models/issue_tracker.rb
@@ -24,10 +24,6 @@ class IssueTracker < ApplicationRecord
     self.issues_updated ||= Time.now
   end
 
-  def cve?
-    kind == 'cve'
-  end
-
   def valid_issue_name?(name)
     Issue.valid_name?(self, name)
   end

--- a/src/api/app/models/issue_tracker/issue_summary.rb
+++ b/src/api/app/models/issue_tracker/issue_summary.rb
@@ -10,15 +10,15 @@ class IssueTracker::IssueSummary
     @issue_tracker && bug.match?(/^#{@issue_tracker.regex}$/)
   end
 
-  def bug
-    @issue_id.starts_with?('CVE-') ? @issue_id : @issue_tracker.name + '#' + @issue_id
-  end
-
   def issue_summary
     belongs_bug_to_tracker? ? fetch_issue_summary.gsub(/\\|'/, '') : nil
   end
 
   private
+
+  def bug
+    @issue_id.starts_with?('CVE-') ? @issue_id : @issue_tracker.name + '#' + @issue_id
+  end
 
   def fetch_issue_summary
     issue = find_or_create_by_name_and_tracker

--- a/src/api/app/models/issue_tracker/issue_tracker_helper.rb
+++ b/src/api/app/models/issue_tracker/issue_tracker_helper.rb
@@ -19,14 +19,6 @@ class IssueTracker::IssueTrackerHelper
     !@issue_id.nil?
   end
 
-  def cve?
-    @tracker == 'cve'
-  end
-
-  def not_cve?
-    !cve?
-  end
-
   def to_a
     [@tracker, @issue_id, url, summary]
   end

--- a/src/api/app/models/issue_tracker/issue_tracker_helper.rb
+++ b/src/api/app/models/issue_tracker/issue_tracker_helper.rb
@@ -11,10 +11,6 @@ class IssueTracker::IssueTrackerHelper
     end
   end
 
-  def bug
-    @issue_id.starts_with?('CVE-') ? @issue_id : @tracker + '#' + @issue_id
-  end
-
   def valid?
     !@issue_id.nil?
   end

--- a/src/api/app/models/patchinfo.rb
+++ b/src/api/app/models/patchinfo.rb
@@ -89,7 +89,8 @@ class Patchinfo
     data.elements('issue').each do |i|
       tracker = IssueTracker.find_by_name(i['tracker'])
       raise TrackerNotFound, "Tracker #{i['tracker']} is not registered in this OBS instance" unless tracker
-      raise Issue::InvalidName, "The issue name is not supported: #{i['id']}" unless Issue.valid_name?(tracker, i['id'])
+      issue = Issue.new(name: i['id'], issue_tracker: tracker)
+      raise Issue::InvalidName, issue.errors.full_messages.to_sentence unless issue.valid?
     end
     # are releasetargets specified ? validate that this project is actually defining them.
     data.elements('releasetarget') { |r| check_releasetarget!(r) }

--- a/src/api/app/models/patchinfo.rb
+++ b/src/api/app/models/patchinfo.rb
@@ -89,7 +89,7 @@ class Patchinfo
     data.elements('issue').each do |i|
       tracker = IssueTracker.find_by_name(i['tracker'])
       raise TrackerNotFound, "Tracker #{i['tracker']} is not registered in this OBS instance" unless tracker
-      raise IssueTracker::InvalidIssueName, "The issue name is not supported: #{i['id']}" unless tracker.valid_issue_name?(i['id'])
+      raise Issue::InvalidName, "The issue name is not supported: #{i['id']}" unless Issue.valid_name?(tracker, i['id'])
     end
     # are releasetargets specified ? validate that this project is actually defining them.
     data.elements('releasetarget') { |r| check_releasetarget!(r) }

--- a/src/api/spec/models/issue_tracker/issue_summary_spec.rb
+++ b/src/api/spec/models/issue_tracker/issue_summary_spec.rb
@@ -1,16 +1,38 @@
 require 'rails_helper'
 
-RSpec.describe IssueTracker::IssueSummary, vcr: true do
+RSpec.describe IssueTracker::IssueSummary do
   let(:issue_tracker) { create(:issue_tracker) }
-  let(:issue_tracker_instance) { IssueTracker::IssueSummary.new('github', '31337') }
+  let(:issue_tracker_instance) { IssueTracker::IssueSummary.new(issue_tracker.name, issue_id) }
 
-  describe 'valid input' do
-    before do
-      allow(IssueTracker).to receive(:find_by).and_return(issue_tracker)
+  describe '#belongs_bug_to_tracker?' do
+    context 'CVE ids' do
+      let(:issue_tracker) { create(:issue_tracker, regex: '(?:cve|CVE)-(\\d\\d\\d\\d-\\d+)') }
+
+      context 'with a valid issue id' do
+        let(:issue_id) { 'CVE-3133-7' }
+
+        it { expect(issue_tracker_instance).to be_belongs_bug_to_tracker }
+      end
+
+      context 'with an invalid issue id' do
+        let(:issue_id) { 'CVE-A31337' }
+
+        it { expect(issue_tracker_instance).not_to be_belongs_bug_to_tracker }
+      end
     end
 
-    it { expect(issue_tracker_instance).not_to be_nil }
-    it { expect(issue_tracker_instance.bug).to eq("#{issue_tracker.name}#31337") }
-    it { expect(issue_tracker_instance).to be_belongs_bug_to_tracker }
+    context 'rest of the ids' do
+      context 'with a valid issue id' do
+        let(:issue_id) { '31337' }
+
+        it { expect(issue_tracker_instance).to be_belongs_bug_to_tracker }
+      end
+
+      context 'with an invalid issue id' do
+        let(:issue_id) { 'A31337' }
+
+        it { expect(issue_tracker_instance).not_to be_belongs_bug_to_tracker }
+      end
+    end
   end
 end

--- a/src/api/spec/models/issue_tracker/issue_tracker_helper_spec.rb
+++ b/src/api/spec/models/issue_tracker/issue_tracker_helper_spec.rb
@@ -11,10 +11,6 @@ RSpec.describe IssueTracker::IssueTrackerHelper do
     describe '#tracker' do
       it { expect(issue.tracker).to eq('cve') }
     end
-
-    describe '#bug' do
-      it { expect(issue.bug).to eq('CVE-2010-31337') }
-    end
   end
 
   context 'other tracker' do
@@ -26,10 +22,6 @@ RSpec.describe IssueTracker::IssueTrackerHelper do
 
     describe '#tracker' do
       it { expect(issue.tracker).to eq('bnc') }
-    end
-
-    describe '#bug' do
-      it { expect(issue.bug).to eq('bnc#31337') }
     end
   end
 end

--- a/src/api/spec/models/issue_tracker/issue_tracker_helper_spec.rb
+++ b/src/api/spec/models/issue_tracker/issue_tracker_helper_spec.rb
@@ -15,10 +15,6 @@ RSpec.describe IssueTracker::IssueTrackerHelper do
     describe '#bug' do
       it { expect(issue.bug).to eq('CVE-2010-31337') }
     end
-
-    describe '#cve?' do
-      it { expect(issue).to be_cve }
-    end
   end
 
   context 'other tracker' do
@@ -34,10 +30,6 @@ RSpec.describe IssueTracker::IssueTrackerHelper do
 
     describe '#bug' do
       it { expect(issue.bug).to eq('bnc#31337') }
-    end
-
-    describe '#cve?' do
-      it { expect(issue).not_to be_cve }
     end
   end
 end

--- a/src/api/test/unit/patchinfo_test.rb
+++ b/src/api/test/unit/patchinfo_test.rb
@@ -45,7 +45,7 @@ blub
                  </description>
                  <summary>Security update for someone</summary>
                </patchinfo>"
-    assert_raise IssueTracker::InvalidIssueName do
+    assert_raise Issue::InvalidName do
       Patchinfo.new.verify_data(Project.first, content)
     end
   end


### PR DESCRIPTION
We realized that the issues' models had unused code. In order to have a better codebase we decided to cleanup the unused code and refactor.

Have a look at the commits' descriptions for a more detailed explanation.

Co-authored-by: David Kang <dkang@suse.com>
Co-authored-by: Saray Cabrera Padrón <scabrerapadron@suse.de>