### PR TITLE
Move errors from BsRequestPermissionCheck to BsRequest::Errors

### DIFF
--- a/src/api/app/models/bs_request/errors.rb
+++ b/src/api/app/models/bs_request/errors.rb
@@ -16,4 +16,41 @@ module BsRequest::Errors
   class SaveError < APIError
     setup 'request_save_error'
   end
+  class AddReviewNotPermitted < APIError
+    setup 403
+  end
+
+  class NotExistingTarget < APIError
+    setup 404
+  end
+
+  class SourceChanged < APIError
+  end
+
+  class ReleaseTargetNoPermission < APIError
+    setup 403
+  end
+
+  class ProjectLocked < APIError
+    setup 403, 'The target project is locked'
+  end
+
+  class TargetNotMaintenance < APIError
+    setup 404
+  end
+
+  class SourceMissing < APIError
+    setup 'unknown_package', 404
+  end
+
+  class SetPriorityNoPermission < APIError
+    setup 403
+  end
+
+  class ReviewChangeStateNoPermission < APIError
+    setup 403
+  end
+
+  class ReviewNotSpecified < APIError
+  end
 end

--- a/src/api/app/models/bs_request_permission_check.rb
+++ b/src/api/app/models/bs_request_permission_check.rb
@@ -1,41 +1,5 @@
 class BsRequestPermissionCheck
-  class AddReviewNotPermitted < APIError
-    setup 403
-  end
-
-  class NotExistingTarget < APIError
-    setup 404
-  end
-
-  class SourceChanged < APIError
-  end
-
-  class ReleaseTargetNoPermission < APIError
-    setup 403
-  end
-
-  class ProjectLocked < APIError
-    setup 403, 'The target project is locked'
-  end
-
-  class TargetNotMaintenance < APIError
-    setup 404
-  end
-
-  class SourceMissing < APIError
-    setup 'unknown_package', 404
-  end
-
-  class SetPriorityNoPermission < APIError
-    setup 403
-  end
-
-  class ReviewChangeStateNoPermission < APIError
-    setup 403
-  end
-
-  class ReviewNotSpecified < APIError
-  end
+  include BsRequest::Errors
 
   def cmd_addreview_permissions(permissions_granted)
     unless req.state.in?([:review, :new])


### PR DESCRIPTION
Follow-up from #8835 