### PR TITLE
Prevent duplicate issues in patchinfo

### DIFF
--- a/src/api/app/assets/javascripts/webui/patchinfo.js
+++ b/src/api/app/assets/javascripts/webui/patchinfo.js
@@ -20,6 +20,19 @@ function addIssuesAjaxBefore() {
 
     issues = $.unique(issues.replace(/ /g, '').split(','));
 
+    var currentIssues = $('[name="patchinfo[issueid][]"]').map(function(_, element) {
+      var issueId = element.id;
+      if (issueId.startsWith('issueid_cve')) {
+        return issueId.replace('issueid_cve_', '');
+      } else {
+        return issueId.replace('issueid_', '').replace('_', '#');
+      }
+    }).toArray();
+
+    issues = issues.filter(function(issue) {
+      return currentIssues.indexOf(issue) === -1;
+    });
+
     element.data('params', { issues: issues, project: element.data('project') });
   });
 }


### PR DESCRIPTION
Closes #8798

Submitting at once the same issue multiple times by separating its instance with commas does remove the duplicates which were entered by the user. However, as described in the issue, it was possible to add the same issue multiple times by adding them one by one. These changes prevent this.

Nothing changed visually... so no screenshots.