### PR TITLE
Allow a package maintainer to rebuild packages

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -706,7 +706,9 @@ class Webui::PackageController < Webui::WebuiController
   def trigger_rebuild
     authorize @package, :update?
 
-    if @package.rebuild(params)
+    allowed_params = [:project, :package, :repository, :arch]
+
+    if @package.rebuild(params.slice(*allowed_params).permit!.to_h)
       flash[:success] = "Triggered rebuild for #{@project.name}/#{@package.name} successfully."
       redirect_to package_show_path(project: @project, package: @package)
     else

--- a/src/api/spec/cassettes/Webui_PackageController/POST_trigger_rebuild/when_triggering_a_rebuild_fails/1_14_3_1.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/POST_trigger_rebuild/when_triggering_a_rebuild_fails/1_14_3_1.yml
@@ -1,0 +1,83 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/foo_project/_meta?user=foo
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="foo_project">
+          <title>Pale Kings and Princes</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '110'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="foo_project">
+          <title>Pale Kings and Princes</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Wed, 11 Dec 2019 20:48:09 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/foo_project/package_2/_meta?user=foo
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_2" project="foo_project">
+          <title>Taming a Sea Horse</title>
+          <description>Nihil et saepe vitae.</description>
+          <person userid="foo" role="maintainer"/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '190'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_2" project="foo_project">
+          <title>Taming a Sea Horse</title>
+          <description>Nihil et saepe vitae.</description>
+          <person userid="foo" role="maintainer"/>
+        </package>
+    http_version: 
+  recorded_at: Wed, 11 Dec 2019 20:48:09 GMT
+recorded_with: VCR 5.0.0

--- a/src/api/spec/cassettes/Webui_PackageController/POST_trigger_rebuild/when_triggering_a_rebuild_fails/1_14_3_2.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/POST_trigger_rebuild/when_triggering_a_rebuild_fails/1_14_3_2.yml
@@ -1,0 +1,83 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/foo_project/_meta?user=foo
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="foo_project">
+          <title>When the Green Woods Laugh</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '114'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="foo_project">
+          <title>When the Green Woods Laugh</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Wed, 11 Dec 2019 20:48:08 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/foo_project/package_1/_meta?user=foo
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_1" project="foo_project">
+          <title>A Catskill Eagle</title>
+          <description>Rerum est sit saepe.</description>
+          <person userid="foo" role="maintainer"/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '187'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_1" project="foo_project">
+          <title>A Catskill Eagle</title>
+          <description>Rerum est sit saepe.</description>
+          <person userid="foo" role="maintainer"/>
+        </package>
+    http_version: 
+  recorded_at: Wed, 11 Dec 2019 20:48:08 GMT
+recorded_with: VCR 5.0.0

--- a/src/api/spec/cassettes/Webui_PackageController/POST_trigger_rebuild/when_triggering_a_rebuild_with_maintainer_of_package/1_14_3_1.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/POST_trigger_rebuild/when_triggering_a_rebuild_with_maintainer_of_package/1_14_3_1.yml
@@ -1,0 +1,167 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/foo_project/_meta?user=foo
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="foo_project">
+          <title>The Grapes of Wrath</title>
+          <description/>
+          <person userid="foo" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '150'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="foo_project">
+          <title>The Grapes of Wrath</title>
+          <description></description>
+          <person userid="foo" role="maintainer"/>
+        </project>
+    http_version: 
+  recorded_at: Thu, 12 Dec 2019 20:18:25 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/foo_project/package_1/_meta?user=foo
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_1" project="foo_project">
+          <title>No Longer at Ease</title>
+          <description>Ipsam consequatur cumque porro.</description>
+          <person userid="bar" role="maintainer"/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '199'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_1" project="foo_project">
+          <title>No Longer at Ease</title>
+          <description>Ipsam consequatur cumque porro.</description>
+          <person userid="bar" role="maintainer"/>
+        </package>
+    http_version: 
+  recorded_at: Thu, 12 Dec 2019 20:18:26 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/foo_project/_meta?user=foo
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="foo_project">
+          <title>The Grapes of Wrath</title>
+          <description/>
+          <person userid="foo" role="maintainer"/>
+          <repository name="openSUSE_Leap_15.1">
+            <arch>i586</arch>
+          </repository>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '229'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="foo_project">
+          <title>The Grapes of Wrath</title>
+          <description></description>
+          <person userid="foo" role="maintainer"/>
+          <repository name="openSUSE_Leap_15.1">
+            <arch>i586</arch>
+          </repository>
+        </project>
+    http_version: 
+  recorded_at: Thu, 12 Dec 2019 20:18:26 GMT
+- request:
+    method: post
+    uri: http://backend:5352/build/foo_project?arch=i586&cmd=rebuild&package=package_1&repository=openSUSE_Leap_15.1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Thu, 12 Dec 2019 20:18:26 GMT
+recorded_with: VCR 5.0.0

--- a/src/api/spec/controllers/webui/package_controller_spec.rb
+++ b/src/api/spec/controllers/webui/package_controller_spec.rb
@@ -1193,6 +1193,37 @@ RSpec.describe Webui::PackageController, vcr: true do
       it { expect(flash[:success]).to eq("Triggered rebuild for #{source_project.name}/#{source_package.name} successfully.") }
       it { expect(response).to redirect_to(package_show_path(project: source_project, package: source_package)) }
     end
+
+    context 'when triggering a rebuild with maintainer of package' do
+      let(:user) { create(:confirmed_user, login: 'foo') }
+      let(:other_user) { create(:confirmed_user, login: 'bar') }
+      let!(:project) { create(:project, name: 'foo_project', maintainer: user) }
+      let!(:repository) { create(:repository, project: project, architectures: ['i586'], name: 'openSUSE_Leap_15.1') }
+      let!(:package_with_maintainer) { create(:package_with_maintainer, maintainer: other_user, project: project, name: 'package_1') }
+
+      before do
+        login other_user
+        project.store
+        post :trigger_rebuild, params: { project: project, package: package_with_maintainer,
+                                         repository: repository.name, arch: 'i586' }
+      end
+
+      it { expect(flash[:success]).not_to be_nil }
+    end
+
+    context 'when triggering a rebuild fails' do
+      let(:user) { create(:confirmed_user, login: 'foo') }
+      let(:other_user) { create(:confirmed_user, login: 'bar') }
+      let(:project) { create(:project, name: 'foo_project') }
+      let!(:package_with_maintainer) { create(:package_with_maintainer, maintainer: user, project: project) }
+      before do
+        login other_user
+        post :trigger_rebuild, params: { project: project, package: package_with_maintainer }
+      end
+
+      it { expect(flash[:success]).to be_nil }
+      it { expect(flash[:error]).not_to be_nil }
+    end
   end
 
   describe 'POST #abort_build' do

--- a/src/api/spec/factories/packages.rb
+++ b/src/api/spec/factories/packages.rb
@@ -15,6 +15,17 @@ FactoryBot.define do
       end
     end
 
+    factory :package_with_maintainer do
+      transient do
+        maintainer { build(:confirmed_user) }
+      end
+
+      after(:build) do |package, evaluator|
+        role = Role.find_by_title('maintainer')
+        package.relationships.build(user: evaluator.maintainer, role: role)
+      end
+    end
+
     factory :package_with_revisions do
       transient do
         revision_count { 2 }


### PR DESCRIPTION
Fix #6758 

Let package maintainers to trigger rebuild.

Use just `pundit` as authorization avoiding any second model authorization. 