### PR TITLE
Revert "Add uniqueness validation on Issue"

### DIFF
--- a/src/api/app/models/issue.rb
+++ b/src/api/app/models/issue.rb
@@ -9,7 +9,6 @@ class Issue < ApplicationRecord
   belongs_to :owner, class_name: 'User'
 
   validate :name_validation, on: :create
-  validates :name, uniqueness: { scope: :issue_tracker_id }
 
   scope :stateless, -> { where(state: nil) }
 

--- a/src/api/app/models/patchinfo.rb
+++ b/src/api/app/models/patchinfo.rb
@@ -89,7 +89,7 @@ class Patchinfo
     data.elements('issue').each do |i|
       tracker = IssueTracker.find_by_name(i['tracker'])
       raise TrackerNotFound, "Tracker #{i['tracker']} is not registered in this OBS instance" unless tracker
-      issue = Issue.find_or_initialize_by(name: i['id'], issue_tracker: tracker)
+      issue = Issue.new(name: i['id'], issue_tracker: tracker)
       raise Issue::InvalidName, issue.errors.full_messages.to_sentence unless issue.valid?
     end
     # are releasetargets specified ? validate that this project is actually defining them.

--- a/src/api/spec/models/attrib_spec.rb
+++ b/src/api/spec/models/attrib_spec.rb
@@ -150,7 +150,6 @@ RSpec.describe Attrib, type: :model do
 
       subject { build(:attrib, project: project, attrib_type: attrib_type, issues: [issue]) }
 
-      it { expect(subject).to be_invalid }
       it { expect(subject.errors.full_messages).to match_array(["Issues can't have issues"]) }
     end
 

--- a/src/api/spec/models/issue_spec.rb
+++ b/src/api/spec/models/issue_spec.rb
@@ -42,16 +42,5 @@ RSpec.describe Issue do
     it 'CVE-XXXX-YYYY should be an invalid name' do
       expect { issue_cve.save! }.to raise_error(ActiveRecord::RecordInvalid, /does not match defined regex/)
     end
-
-    context 'with duplicated issues' do
-      let(:duplicated_issue) { build(:issue, name: '1234', issue_tracker: issue_tracker) }
-
-      it { expect(duplicated_issue).to be_invalid }
-
-      it 'has a proper error' do
-        duplicated_issue.save
-        expect(duplicated_issue.errors.full_messages).to match_array(['Name has already been taken'])
-      end
-    end
   end
 end

--- a/src/api/test/unit/attrib_test.rb
+++ b/src/api/test/unit/attrib_test.rb
@@ -124,6 +124,18 @@ class AttribTest < ActiveSupport::TestCase
     assert_equal 'One', attrib.values.first.value
   end
 
+  test 'should have no issues' do
+    attrib_type = AttribType.new(attrib_namespace: @namespace, name: 'AttribIssues')
+    attrib = Attrib.new(attrib_type: attrib_type, project: Project.first)
+
+    bnc = IssueTracker.find_by_name('bnc')
+    attrib.issues << Issue.new(name: '12345', issue_tracker: bnc)
+    assert_not attrib.valid?
+    assert_equal ["can't have issues"], attrib.errors.messages[:issues]
+    attrib_type.issue_list = true
+    assert attrib.valid?, "attrib should be valid: #{attrib.errors.messages}"
+  end
+
   test 'find_by_container_and_fullname' do
     project = Project.find_by(name: 'BaseDistro2.0')
     attrib = Attrib.find_by_container_and_fullname(project, 'OBS:UpdateProject')


### PR DESCRIPTION
Reverts openSUSE/open-build-service#8796

This PR broke the patchinfo generation for the Maintenance Team. Reverting it