### PR TITLE
Remove unneeded default sorting of project results

### DIFF
--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -380,9 +380,9 @@ class Webui::ProjectController < Webui::WebuiController
     when 'sibling project'
       @project.siblingprojects
     when 'subproject'
-      @project.subprojects.order(:name)
+      @project.subprojects
     when 'parent project'
-      @project.ancestors.order(:name)
+      @project.ancestors
     end
   end
 


### PR DESCRIPTION
This is already handled by column sorting in datatables.

Fixes #8328.