### PR TITLE
Show action column when user is logged in

### DIFF
--- a/src/api/app/views/webui/shared/user_or_groups_roles/_index.html.haml
+++ b/src/api/app/views/webui/shared/user_or_groups_roles/_index.html.haml
@@ -21,7 +21,8 @@
           %td Username
           - roles.each do |role|
             %td= role.title.capitalize
-          %td
+          - if User.session
+            %td
       %tbody
         = render partial: 'webui/shared/user_or_groups_roles/list',
                  locals: { records: users, roles: roles, type: 'user',
@@ -47,7 +48,7 @@
           %td Group name
           - roles.each do |role|
             %td= role.title.capitalize
-          - if user_is_maintainer
+          - if User.session
             %td
       %tbody
         = render partial: 'webui/shared/user_or_groups_roles/list',

--- a/src/api/app/views/webui/shared/user_or_groups_roles/_list.html.haml
+++ b/src/api/app/views/webui/shared/user_or_groups_roles/_list.html.haml
@@ -18,12 +18,13 @@
           - if package && project.send("#{type}_has_role?", record, role)
             = link_to(project_users_path(project: project)) do
               %i.fa.fa-cubes.text-secondary{ title: 'inherited from project' }
-    %td.text-nowrap
-      - if mail_subject && record.email
-        = mail_to(record.email, subject: mail_subject) do
-          %i.far.fa-envelope{ title: "Send email to #{type}" }
-      - if user_is_maintainer
-        = link_to('#', class: "remove-#{type}",
-          data: { toggle: 'modal', target: '#delete-role-modal',
-          action: user_or_groups_roles_delete_path(project, type, record, package), type: type, object: record.to_s }) do
-          %i.fas.fa-times-circle.text-danger{ title: "Delete all roles for #{type}" }
+    - if User.session
+      %td.text-nowrap
+        - if mail_subject && record.email
+          = mail_to(record.email, subject: mail_subject) do
+            %i.far.fa-envelope{ title: "Send email to #{type}" }
+        - if user_is_maintainer
+          = link_to('#', class: "remove-#{type}",
+            data: { toggle: 'modal', target: '#delete-role-modal',
+            action: user_or_groups_roles_delete_path(project, type, record, package), type: type, object: record.to_s }) do
+            %i.fas.fa-times-circle.text-danger{ title: "Delete all roles for #{type}" }


### PR DESCRIPTION
Datatable javascript was raising an exception because the action column was missing the column header.

The action column is now rendered when a user is logged in.

Fixes #8681.

Co-authored-by: David Kang <dkang@suse.com>