### PR TITLE
Prevent staging a request with errors

### DIFF
--- a/src/api/spec/cassettes/Staging_StagedRequestsController/POST_create/when_providing_two_request/and_none_is_excluded/with_the_same_package/1_2_9_1_1_2.yml
+++ b/src/api/spec/cassettes/Staging_StagedRequestsController/POST_create/when_providing_two_request/and_none_is_excluded/with_the_same_package/1_2_9_1_1_2.yml
@@ -40,14 +40,14 @@ http_interactions:
           <person userid="permitted_user" role="maintainer"/>
         </project>
     http_version: 
-  recorded_at: Wed, 20 Nov 2019 17:11:57 GMT
+  recorded_at: Fri, 03 Jan 2020 17:43:37 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:permitted_user/_project/_staging_workflow?user=permitted_user
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:permitted_user" managers="staging-workflow-managers-17">
+        <workflow project="home:permitted_user" managers="staging-workflow-managers-4">
           <staging_project name="home:permitted_user:Staging:A"/>
         </workflow>
     headers:
@@ -73,15 +73,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="33">
-          <srcmd5>98f8bcabb4295ca82639e40c9a391462</srcmd5>
-          <time>1574269917</time>
+        <revision rev="67">
+          <srcmd5>18c157519aff432594c6a090a274aba7</srcmd5>
+          <time>1578073417</time>
           <user>permitted_user</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 20 Nov 2019 17:11:58 GMT
+  recorded_at: Fri, 03 Jan 2020 17:43:37 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:permitted_user:Staging:A/_meta?user=permitted_user
@@ -91,7 +91,7 @@ http_interactions:
         <project name="home:permitted_user:Staging:A">
           <title/>
           <description/>
-          <group groupid="staging-workflow-managers-17" role="maintainer"/>
+          <group groupid="staging-workflow-managers-4" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -112,24 +112,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '174'
+      - '173'
     body:
       encoding: UTF-8
       string: |
         <project name="home:permitted_user:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="staging-workflow-managers-17" role="maintainer"/>
+          <group groupid="staging-workflow-managers-4" role="maintainer"/>
         </project>
     http_version: 
-  recorded_at: Wed, 20 Nov 2019 17:11:58 GMT
+  recorded_at: Fri, 03 Jan 2020 17:43:37 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:permitted_user/_project/_staging_workflow?user=permitted_user
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:permitted_user" managers="staging-workflow-managers-17">
+        <workflow project="home:permitted_user" managers="staging-workflow-managers-4">
           <staging_project name="home:permitted_user:Staging:A"/>
           <staging_project name="home:permitted_user:Staging:B"/>
         </workflow>
@@ -156,15 +156,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="34">
-          <srcmd5>d58c349c3e414222fa2866fa875627c8</srcmd5>
-          <time>1574269918</time>
+        <revision rev="68">
+          <srcmd5>ad46b5f3713410d48ff8bd3925f28689</srcmd5>
+          <time>1578073417</time>
           <user>permitted_user</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 20 Nov 2019 17:11:58 GMT
+  recorded_at: Fri, 03 Jan 2020 17:43:37 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:permitted_user:Staging:B/_meta?user=permitted_user
@@ -174,7 +174,7 @@ http_interactions:
         <project name="home:permitted_user:Staging:B">
           <title/>
           <description/>
-          <group groupid="staging-workflow-managers-17" role="maintainer"/>
+          <group groupid="staging-workflow-managers-4" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -195,17 +195,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '174'
+      - '173'
     body:
       encoding: UTF-8
       string: |
         <project name="home:permitted_user:Staging:B">
           <title></title>
           <description></description>
-          <group groupid="staging-workflow-managers-17" role="maintainer"/>
+          <group groupid="staging-workflow-managers-4" role="maintainer"/>
         </project>
     http_version: 
-  recorded_at: Wed, 20 Nov 2019 17:11:58 GMT
+  recorded_at: Fri, 03 Jan 2020 17:43:37 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:permitted_user/_meta?user=permitted_user
@@ -216,7 +216,7 @@ http_interactions:
           <title/>
           <description/>
           <person userid="permitted_user" role="maintainer"/>
-          <group groupid="staging-workflow-managers-17" role="reviewer"/>
+          <group groupid="staging-workflow-managers-4" role="reviewer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -237,7 +237,7 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '216'
+      - '215'
     body:
       encoding: UTF-8
       string: |
@@ -245,10 +245,10 @@ http_interactions:
           <title></title>
           <description></description>
           <person userid="permitted_user" role="maintainer"/>
-          <group groupid="staging-workflow-managers-17" role="reviewer"/>
+          <group groupid="staging-workflow-managers-4" role="reviewer"/>
         </project>
     http_version: 
-  recorded_at: Wed, 20 Nov 2019 17:11:58 GMT
+  recorded_at: Fri, 03 Jan 2020 17:43:37 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:permitted_user/target_package/_meta?user=permitted_user
@@ -256,8 +256,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="home:permitted_user">
-          <title>If Not Now, When?</title>
-          <description>Optio incidunt et necessitatibus.</description>
+          <title>Number the Stars</title>
+          <description>Quas blanditiis placeat quibusdam.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -283,11 +283,11 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="home:permitted_user">
-          <title>If Not Now, When?</title>
-          <description>Optio incidunt et necessitatibus.</description>
+          <title>Number the Stars</title>
+          <description>Quas blanditiis placeat quibusdam.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 20 Nov 2019 17:11:58 GMT
+  recorded_at: Fri, 03 Jan 2020 17:43:38 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_meta?user=permitted_user
@@ -295,7 +295,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>In Death Ground</title>
+          <title>Cabbages and Kings</title>
           <description/>
         </project>
     headers:
@@ -317,16 +317,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '106'
+      - '109'
     body:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>In Death Ground</title>
+          <title>Cabbages and Kings</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Wed, 20 Nov 2019 17:11:58 GMT
+  recorded_at: Fri, 03 Jan 2020 17:43:38 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/source_package/_meta?user=permitted_user
@@ -334,8 +334,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>A Glass of Blessings</title>
-          <description>Officia quibusdam voluptatum libero.</description>
+          <title>Have His Carcase</title>
+          <description>Molestias explicabo hic sit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -356,16 +356,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '172'
+      - '160'
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>A Glass of Blessings</title>
-          <description>Officia quibusdam voluptatum libero.</description>
+          <title>Have His Carcase</title>
+          <description>Molestias explicabo hic sit.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 20 Nov 2019 17:11:58 GMT
+  recorded_at: Fri, 03 Jan 2020 17:43:38 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package?expand=1
@@ -398,7 +398,7 @@ http_interactions:
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
     http_version: 
-  recorded_at: Wed, 20 Nov 2019 17:11:58 GMT
+  recorded_at: Fri, 03 Jan 2020 17:43:39 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:permitted_user:Staging:A/target_package/_meta?user=permitted_user
@@ -437,7 +437,7 @@ http_interactions:
           <description></description>
         </package>
     http_version: 
-  recorded_at: Wed, 20 Nov 2019 17:11:58 GMT
+  recorded_at: Fri, 03 Jan 2020 17:43:39 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:permitted_user:Staging:A/target_package/_link?user=permitted_user
@@ -464,18 +464,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '214'
+      - '216'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="4" vrev="4">
+        <revision rev="24" vrev="24">
           <srcmd5>d5e16cac42930eeb8421736378202c08</srcmd5>
           <version>unknown</version>
-          <time>1574269918</time>
+          <time>1578073419</time>
           <user>permitted_user</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 20 Nov 2019 17:11:58 GMT
+  recorded_at: Fri, 03 Jan 2020 17:43:39 GMT
 recorded_with: VCR 5.0.0

--- a/src/api/spec/cassettes/Staging_StagedRequestsController/POST_create/when_providing_two_request/and_none_is_excluded/with_the_same_package/1_2_9_1_1_3.yml
+++ b/src/api/spec/cassettes/Staging_StagedRequestsController/POST_create/when_providing_two_request/and_none_is_excluded/with_the_same_package/1_2_9_1_1_3.yml
@@ -40,14 +40,14 @@ http_interactions:
           <person userid="permitted_user" role="maintainer"/>
         </project>
     http_version: 
-  recorded_at: Fri, 03 Jan 2020 17:43:25 GMT
+  recorded_at: Fri, 03 Jan 2020 17:43:29 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:permitted_user/_project/_staging_workflow?user=permitted_user
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:permitted_user" managers="staging-workflow-managers-1">
+        <workflow project="home:permitted_user" managers="staging-workflow-managers-2">
           <staging_project name="home:permitted_user:Staging:A"/>
         </workflow>
     headers:
@@ -73,15 +73,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="61">
-          <srcmd5>9dcb5cf420daed4d036a384bfeb64efb</srcmd5>
-          <time>1578073405</time>
+        <revision rev="63">
+          <srcmd5>5aa91688e74e53b49343157a65da71e6</srcmd5>
+          <time>1578073409</time>
           <user>permitted_user</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Fri, 03 Jan 2020 17:43:25 GMT
+  recorded_at: Fri, 03 Jan 2020 17:43:30 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:permitted_user:Staging:A/_meta?user=permitted_user
@@ -91,7 +91,7 @@ http_interactions:
         <project name="home:permitted_user:Staging:A">
           <title/>
           <description/>
-          <group groupid="staging-workflow-managers-1" role="maintainer"/>
+          <group groupid="staging-workflow-managers-2" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -119,17 +119,17 @@ http_interactions:
         <project name="home:permitted_user:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="staging-workflow-managers-1" role="maintainer"/>
+          <group groupid="staging-workflow-managers-2" role="maintainer"/>
         </project>
     http_version: 
-  recorded_at: Fri, 03 Jan 2020 17:43:25 GMT
+  recorded_at: Fri, 03 Jan 2020 17:43:30 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:permitted_user/_project/_staging_workflow?user=permitted_user
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:permitted_user" managers="staging-workflow-managers-1">
+        <workflow project="home:permitted_user" managers="staging-workflow-managers-2">
           <staging_project name="home:permitted_user:Staging:A"/>
           <staging_project name="home:permitted_user:Staging:B"/>
         </workflow>
@@ -156,15 +156,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="62">
-          <srcmd5>55c0e52fdb04d9dffcf1ab79dc2ec54c</srcmd5>
-          <time>1578073405</time>
+        <revision rev="64">
+          <srcmd5>6b66a2ec580136385a4db14d7d083dd7</srcmd5>
+          <time>1578073410</time>
           <user>permitted_user</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Fri, 03 Jan 2020 17:43:25 GMT
+  recorded_at: Fri, 03 Jan 2020 17:43:30 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:permitted_user:Staging:B/_meta?user=permitted_user
@@ -174,7 +174,7 @@ http_interactions:
         <project name="home:permitted_user:Staging:B">
           <title/>
           <description/>
-          <group groupid="staging-workflow-managers-1" role="maintainer"/>
+          <group groupid="staging-workflow-managers-2" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -202,10 +202,10 @@ http_interactions:
         <project name="home:permitted_user:Staging:B">
           <title></title>
           <description></description>
-          <group groupid="staging-workflow-managers-1" role="maintainer"/>
+          <group groupid="staging-workflow-managers-2" role="maintainer"/>
         </project>
     http_version: 
-  recorded_at: Fri, 03 Jan 2020 17:43:25 GMT
+  recorded_at: Fri, 03 Jan 2020 17:43:30 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:permitted_user/_meta?user=permitted_user
@@ -216,7 +216,7 @@ http_interactions:
           <title/>
           <description/>
           <person userid="permitted_user" role="maintainer"/>
-          <group groupid="staging-workflow-managers-1" role="reviewer"/>
+          <group groupid="staging-workflow-managers-2" role="reviewer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -245,10 +245,10 @@ http_interactions:
           <title></title>
           <description></description>
           <person userid="permitted_user" role="maintainer"/>
-          <group groupid="staging-workflow-managers-1" role="reviewer"/>
+          <group groupid="staging-workflow-managers-2" role="reviewer"/>
         </project>
     http_version: 
-  recorded_at: Fri, 03 Jan 2020 17:43:25 GMT
+  recorded_at: Fri, 03 Jan 2020 17:43:30 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:permitted_user/target_package/_meta?user=permitted_user
@@ -256,8 +256,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="home:permitted_user">
-          <title>Fame Is the Spur</title>
-          <description>Id fugiat iusto ab.</description>
+          <title>A Many-Splendoured Thing</title>
+          <description>Pariatur maiores non cum.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -278,16 +278,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '156'
+      - '170'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="home:permitted_user">
-          <title>Fame Is the Spur</title>
-          <description>Id fugiat iusto ab.</description>
+          <title>A Many-Splendoured Thing</title>
+          <description>Pariatur maiores non cum.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 03 Jan 2020 17:43:26 GMT
+  recorded_at: Fri, 03 Jan 2020 17:43:30 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_meta?user=permitted_user
@@ -295,7 +295,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Vanity Fair</title>
+          <title>Time of our Darkness</title>
           <description/>
         </project>
     headers:
@@ -317,16 +317,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '102'
+      - '111'
     body:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Vanity Fair</title>
+          <title>Time of our Darkness</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Fri, 03 Jan 2020 17:43:26 GMT
+  recorded_at: Fri, 03 Jan 2020 17:43:30 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/source_package/_meta?user=permitted_user
@@ -334,8 +334,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>Absalom, Absalom!</title>
-          <description>Illum dolorum adipisci est.</description>
+          <title>The Wives of Bath</title>
+          <description>Eos ut esse est.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -356,16 +356,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '160'
+      - '149'
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>Absalom, Absalom!</title>
-          <description>Illum dolorum adipisci est.</description>
+          <title>The Wives of Bath</title>
+          <description>Eos ut esse est.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 03 Jan 2020 17:43:26 GMT
+  recorded_at: Fri, 03 Jan 2020 17:43:30 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package?expand=1
@@ -398,7 +398,7 @@ http_interactions:
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
     http_version: 
-  recorded_at: Fri, 03 Jan 2020 17:43:28 GMT
+  recorded_at: Fri, 03 Jan 2020 17:43:32 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:permitted_user:Staging:A/target_package/_meta?user=permitted_user
@@ -437,7 +437,7 @@ http_interactions:
           <description></description>
         </package>
     http_version: 
-  recorded_at: Fri, 03 Jan 2020 17:43:28 GMT
+  recorded_at: Fri, 03 Jan 2020 17:43:32 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:permitted_user:Staging:A/target_package/_link?user=permitted_user
@@ -468,14 +468,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="21" vrev="21">
+        <revision rev="22" vrev="22">
           <srcmd5>d5e16cac42930eeb8421736378202c08</srcmd5>
           <version>unknown</version>
-          <time>1578073408</time>
+          <time>1578073412</time>
           <user>permitted_user</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Fri, 03 Jan 2020 17:43:28 GMT
+  recorded_at: Fri, 03 Jan 2020 17:43:32 GMT
 recorded_with: VCR 5.0.0

--- a/src/api/spec/cassettes/Staging_StagedRequestsController/POST_create/when_providing_two_request/and_none_is_excluded/with_the_same_package/1_2_9_1_1_4.yml
+++ b/src/api/spec/cassettes/Staging_StagedRequestsController/POST_create/when_providing_two_request/and_none_is_excluded/with_the_same_package/1_2_9_1_1_4.yml
@@ -40,14 +40,14 @@ http_interactions:
           <person userid="permitted_user" role="maintainer"/>
         </project>
     http_version: 
-  recorded_at: Fri, 03 Jan 2020 17:43:25 GMT
+  recorded_at: Fri, 03 Jan 2020 17:43:33 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:permitted_user/_project/_staging_workflow?user=permitted_user
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:permitted_user" managers="staging-workflow-managers-1">
+        <workflow project="home:permitted_user" managers="staging-workflow-managers-3">
           <staging_project name="home:permitted_user:Staging:A"/>
         </workflow>
     headers:
@@ -73,15 +73,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="61">
-          <srcmd5>9dcb5cf420daed4d036a384bfeb64efb</srcmd5>
-          <time>1578073405</time>
+        <revision rev="65">
+          <srcmd5>602e8e3284f67812365e97e2880b3ef9</srcmd5>
+          <time>1578073413</time>
           <user>permitted_user</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Fri, 03 Jan 2020 17:43:25 GMT
+  recorded_at: Fri, 03 Jan 2020 17:43:33 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:permitted_user:Staging:A/_meta?user=permitted_user
@@ -91,7 +91,7 @@ http_interactions:
         <project name="home:permitted_user:Staging:A">
           <title/>
           <description/>
-          <group groupid="staging-workflow-managers-1" role="maintainer"/>
+          <group groupid="staging-workflow-managers-3" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -119,17 +119,17 @@ http_interactions:
         <project name="home:permitted_user:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="staging-workflow-managers-1" role="maintainer"/>
+          <group groupid="staging-workflow-managers-3" role="maintainer"/>
         </project>
     http_version: 
-  recorded_at: Fri, 03 Jan 2020 17:43:25 GMT
+  recorded_at: Fri, 03 Jan 2020 17:43:33 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:permitted_user/_project/_staging_workflow?user=permitted_user
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:permitted_user" managers="staging-workflow-managers-1">
+        <workflow project="home:permitted_user" managers="staging-workflow-managers-3">
           <staging_project name="home:permitted_user:Staging:A"/>
           <staging_project name="home:permitted_user:Staging:B"/>
         </workflow>
@@ -156,15 +156,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="62">
-          <srcmd5>55c0e52fdb04d9dffcf1ab79dc2ec54c</srcmd5>
-          <time>1578073405</time>
+        <revision rev="66">
+          <srcmd5>2b5b5658007e8ef89a0cbc4576bcef05</srcmd5>
+          <time>1578073413</time>
           <user>permitted_user</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Fri, 03 Jan 2020 17:43:25 GMT
+  recorded_at: Fri, 03 Jan 2020 17:43:33 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:permitted_user:Staging:B/_meta?user=permitted_user
@@ -174,7 +174,7 @@ http_interactions:
         <project name="home:permitted_user:Staging:B">
           <title/>
           <description/>
-          <group groupid="staging-workflow-managers-1" role="maintainer"/>
+          <group groupid="staging-workflow-managers-3" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -202,10 +202,10 @@ http_interactions:
         <project name="home:permitted_user:Staging:B">
           <title></title>
           <description></description>
-          <group groupid="staging-workflow-managers-1" role="maintainer"/>
+          <group groupid="staging-workflow-managers-3" role="maintainer"/>
         </project>
     http_version: 
-  recorded_at: Fri, 03 Jan 2020 17:43:25 GMT
+  recorded_at: Fri, 03 Jan 2020 17:43:34 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:permitted_user/_meta?user=permitted_user
@@ -216,7 +216,7 @@ http_interactions:
           <title/>
           <description/>
           <person userid="permitted_user" role="maintainer"/>
-          <group groupid="staging-workflow-managers-1" role="reviewer"/>
+          <group groupid="staging-workflow-managers-3" role="reviewer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -245,10 +245,10 @@ http_interactions:
           <title></title>
           <description></description>
           <person userid="permitted_user" role="maintainer"/>
-          <group groupid="staging-workflow-managers-1" role="reviewer"/>
+          <group groupid="staging-workflow-managers-3" role="reviewer"/>
         </project>
     http_version: 
-  recorded_at: Fri, 03 Jan 2020 17:43:25 GMT
+  recorded_at: Fri, 03 Jan 2020 17:43:34 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:permitted_user/target_package/_meta?user=permitted_user
@@ -256,8 +256,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="home:permitted_user">
-          <title>Fame Is the Spur</title>
-          <description>Id fugiat iusto ab.</description>
+          <title>A Time to Kill</title>
+          <description>Enim aut debitis molestias.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -278,16 +278,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '156'
+      - '162'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="home:permitted_user">
-          <title>Fame Is the Spur</title>
-          <description>Id fugiat iusto ab.</description>
+          <title>A Time to Kill</title>
+          <description>Enim aut debitis molestias.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 03 Jan 2020 17:43:26 GMT
+  recorded_at: Fri, 03 Jan 2020 17:43:34 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_meta?user=permitted_user
@@ -295,7 +295,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Vanity Fair</title>
+          <title>The Moving Toyshop</title>
           <description/>
         </project>
     headers:
@@ -317,16 +317,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '102'
+      - '109'
     body:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Vanity Fair</title>
+          <title>The Moving Toyshop</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Fri, 03 Jan 2020 17:43:26 GMT
+  recorded_at: Fri, 03 Jan 2020 17:43:34 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/source_package/_meta?user=permitted_user
@@ -334,8 +334,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>Absalom, Absalom!</title>
-          <description>Illum dolorum adipisci est.</description>
+          <title>A Scanner Darkly</title>
+          <description>Ipsa neque similique aliquam.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -356,16 +356,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '160'
+      - '161'
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>Absalom, Absalom!</title>
-          <description>Illum dolorum adipisci est.</description>
+          <title>A Scanner Darkly</title>
+          <description>Ipsa neque similique aliquam.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 03 Jan 2020 17:43:26 GMT
+  recorded_at: Fri, 03 Jan 2020 17:43:34 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package?expand=1
@@ -398,7 +398,7 @@ http_interactions:
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
     http_version: 
-  recorded_at: Fri, 03 Jan 2020 17:43:28 GMT
+  recorded_at: Fri, 03 Jan 2020 17:43:36 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:permitted_user:Staging:A/target_package/_meta?user=permitted_user
@@ -437,7 +437,7 @@ http_interactions:
           <description></description>
         </package>
     http_version: 
-  recorded_at: Fri, 03 Jan 2020 17:43:28 GMT
+  recorded_at: Fri, 03 Jan 2020 17:43:36 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:permitted_user:Staging:A/target_package/_link?user=permitted_user
@@ -468,14 +468,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="21" vrev="21">
+        <revision rev="23" vrev="23">
           <srcmd5>d5e16cac42930eeb8421736378202c08</srcmd5>
           <version>unknown</version>
-          <time>1578073408</time>
+          <time>1578073416</time>
           <user>permitted_user</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Fri, 03 Jan 2020 17:43:28 GMT
+  recorded_at: Fri, 03 Jan 2020 17:43:36 GMT
 recorded_with: VCR 5.0.0

--- a/src/api/spec/controllers/staging/staged_requests_controller_spec.rb
+++ b/src/api/spec/controllers/staging/staged_requests_controller_spec.rb
@@ -210,16 +210,6 @@ RSpec.describe Staging::StagedRequestsController do
           }
         end
         let(:body) { "<requests><request id='#{bs_request.number}'/><request id='#{another_bs_request.number}'/></requests>" }
-        let(:another_bs_request) do
-          create(:bs_request_with_submit_action,
-                 state: :review,
-                 creator: other_user,
-                 target_package: target_package,
-                 source_package: source_package,
-                 description: 'BsRequest 2',
-                 number: 2,
-                 review_by_group: group)
-        end
 
         before { subject }
 
@@ -237,6 +227,8 @@ RSpec.describe Staging::StagedRequestsController do
 
           it { expect(response).to have_http_status(:bad_request) }
           it { expect(response.body).to match(/Can't stage request '#{another_bs_request.number}'/) }
+          it { expect(staging_project.staged_requests).to include(bs_request) }
+          it { expect(staging_project.staged_requests).not_to include(another_bs_request) }
         end
 
         context 'with another package' do


### PR DESCRIPTION
In #8736 an error was thrown when a second request for the same target package wanted to be added, preventing the creation of the linked package. But the request was still staged.

Now both, the linked package and the staged request are not created.

Fixes #8730.

Co-authored-by: David Kang <dkang@suse.com>