### PR TITLE
Refactor create expand package

### DIFF
--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -463,7 +463,7 @@ class BsRequestAction < ApplicationRecord
 
       # overwrite target if defined
       tprj = Project.get_by_name(target_project) if target_project
-      raise UnknownTargetProject, 'target project does not exist' unless tprj || is_maintenance_release?
+      raise UnknownTargetProject unless tprj || is_maintenance_release?
 
       # do not allow release requests without binaries
       if is_maintenance_release? && pkg.is_patchinfo? && data && !opts[:ignore_build_state]
@@ -548,7 +548,7 @@ class BsRequestAction < ApplicationRecord
             new_packages << pkg
             next
           elsif !is_maintenance_incident? && !is_submit?
-            raise UnknownTargetPackage, 'target package does not exist'
+            raise UnknownTargetPackage
           end
         end
       end

--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -522,13 +522,11 @@ class BsRequestAction < ApplicationRecord
             repo.release_targets.each do |rt|
               next if rt.trigger != 'maintenance'
               next unless rt.target_repository.project.is_maintenance_release?
-              if release_target && release_target != rt.target_repository.project
-                raise InvalidReleaseTarget, 'Multiple release target projects are not supported'
-              end
+              raise MultipleReleaseTargets if release_target && release_target != rt.target_repository.project
               release_target = rt.target_repository.project
             end
           end
-          raise InvalidReleaseTarget, 'Can not release to a maintenance incident project' unless release_target
+          raise InvalidReleaseTarget unless release_target
           tprj = release_target
         end
       end

--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -550,6 +550,7 @@ class BsRequestAction < ApplicationRecord
           raise UnknownTargetPackage if !is_maintenance_incident? && !is_submit?
         end
       end
+      # call dup to work on a copy of self
       new_action = dup
       new_action.source_package = pkg.name
       if is_maintenance_incident?

--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -405,10 +405,9 @@ class BsRequestAction < ApplicationRecord
   def create_expand_package(packages, opts = {})
     newactions = []
     incident_suffix = ''
-    if is_maintenance_release?
-      # The maintenance ID is always the sub project name of the maintenance project
-      incident_suffix = '.' + source_project.gsub(/.*:/, '')
-    end
+
+    # The maintenance ID is always the sub project name of the maintenance project
+    incident_suffix = '.' + source_project.gsub(/.*:/, '') if is_maintenance_release?
 
     found_patchinfo = false
     new_packages = []

--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -546,9 +546,8 @@ class BsRequestAction < ApplicationRecord
             end
             new_packages << pkg
             next
-          elsif !is_maintenance_incident? && !is_submit?
-            raise UnknownTargetPackage
           end
+          raise UnknownTargetPackage if !is_maintenance_incident? && !is_submit?
         end
       end
       new_action = dup

--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -563,15 +563,15 @@ class BsRequestAction < ApplicationRecord
       if is_maintenance_release?
         if pkg.is_channel?
           # create submit request for possible changes in the _channel file
-          sumbit_action = BsRequestActionSubmit.new
-          sumbit_action.source_project = new_action.source_project
-          sumbit_action.source_package = new_action.source_package
-          sumbit_action.source_rev = new_action.source_rev
-          sumbit_action.target_project = tprj.name
-          sumbit_action.target_package = tpkg
+          submit_action = BsRequestActionSubmit.new
+          submit_action.source_project = new_action.source_project
+          submit_action.source_package = new_action.source_package
+          submit_action.source_rev = new_action.source_rev
+          submit_action.target_project = tprj.name
+          submit_action.target_package = tpkg
           # replace the new action
           new_action.destroy
-          new_action = sumbit_action
+          new_action = submit_action
         else # non-channel package
           next unless maintenance_trigger?(pkg.project.repositories, tprj.repositories)
           unless pkg.project.can_be_released_to_project?(tprj)

--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -428,14 +428,14 @@ class BsRequestAction < ApplicationRecord
 
       while tprj == pkg.project
         data = Directory.hashed(project: tprj.name, package: ltpkg)
-        e = data['linkinfo']
+        data_linkinfo = data['linkinfo']
 
-        if e
-          suffix = ltpkg.gsub(/^#{Regexp.escape(e['package'])}/, '')
-          ltpkg = e['package']
-          tprj = Project.get_by_name(e['project'])
+        if data_linkinfo
+          suffix = ltpkg.gsub(/^#{Regexp.escape(data_linkinfo['package'])}/, '')
+          ltpkg = data_linkinfo['package']
+          tprj = Project.get_by_name(data_linkinfo['project'])
 
-          missing_ok_link = true if e['missingok']
+          missing_ok_link = true if data_linkinfo['missingok']
         else
           tprj = nil
         end
@@ -450,8 +450,8 @@ class BsRequestAction < ApplicationRecord
              elsif tprj.try(:is_maintenance_incident?) && is_maintenance_release?
                # fallback, how can we get rid of it?
                data = Directory.hashed(project: tprj.name, package: ltpkg)
-               e = data['linkinfo']
-               e['package'] if e
+               data_linkinfo = data['linkinfo']
+               data_linkinfo['package'] if data_linkinfo
              else
                # we need to get rid of it again ...
                tpkg.gsub(/#{Regexp.escape(suffix)}$/, '') # strip distro specific extension
@@ -537,7 +537,7 @@ class BsRequestAction < ApplicationRecord
       unless missing_ok_link
         # check if the main package container exists in target.
         # take into account that an additional local link with spec file might got added
-        unless e && tprj && tprj.exists_package?(ltpkg, follow_project_links: true, allow_remote_packages: false)
+        unless data_linkinfo && tprj && tprj.exists_package?(ltpkg, follow_project_links: true, allow_remote_packages: false)
           if is_maintenance_release?
             pkg.project.repositories.includes(:release_targets).each do |repo|
               repo.release_targets.each do |rt|

--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -430,15 +430,12 @@ class BsRequestAction < ApplicationRecord
         data = Directory.hashed(project: tprj.name, package: ltpkg)
         data_linkinfo = data['linkinfo']
 
-        if data_linkinfo
-          suffix = ltpkg.gsub(/^#{Regexp.escape(data_linkinfo['package'])}/, '')
-          ltpkg = data_linkinfo['package']
-          tprj = Project.get_by_name(data_linkinfo['project'])
-
-          missing_ok_link = true if data_linkinfo['missingok']
-        else
-          tprj = nil
-        end
+        tprj = if data_linkinfo
+                 suffix = ltpkg.gsub(/^#{Regexp.escape(data_linkinfo['package'])}/, '')
+                 ltpkg = data_linkinfo['package']
+                 missing_ok_link = true if data_linkinfo['missingok']
+                 Project.get_by_name(data_linkinfo['project'])
+               end
       end
 
       tpkg = if target_package

--- a/src/api/app/models/bs_request_action/errors.rb
+++ b/src/api/app/models/bs_request_action/errors.rb
@@ -7,7 +7,10 @@ module BsRequestAction::Errors
     setup 'remote_source', 400, 'No support for auto expanding from remote instance. You need to submit a full specified request in that case.'
   end
   class RemoteTarget < APIError; end
-  class InvalidReleaseTarget < APIError; end
+  class InvalidReleaseTarget < APIError
+    setup 'invalid_release_target', 400, 'Can not release to a maintenance incident project'
+  end
+  class MultipleReleaseTargets < APIError; setup 'Multiple release target projects are not supported'; end
   class LackingMaintainership < APIError
     setup 'lacking_maintainership', 403, 'Creating a submit request action with options requires maintainership in source package'
   end

--- a/src/api/app/models/bs_request_action/errors.rb
+++ b/src/api/app/models/bs_request_action/errors.rb
@@ -21,7 +21,9 @@ module BsRequestAction::Errors
   class UnknownRole < APIError; setup 404; end
   class IllegalRequest < APIError; end
   class BuildNotFinished < APIError; end
-  class UnknownTargetProject < APIError; end
+  class UnknownTargetProject < APIError
+    setup 'unknown_target_project', 400, 'target project does not exist'
+  end
   class UnknownTargetPackage < APIError; end
   class WrongLinkedPackageSource < APIError; end
   class MissingPatchinfo < APIError


### PR DESCRIPTION
Follow-up PR of #8861 and #8848 

Cleaned the method `create_expand_package` little bit leading to a reduction in the `Metrics/PerceivedComplexity` score (From 73 to 65) and `Metrics/CyclomaticComplexity` score (from 67 to 61). Both are still far from threshold (45) allowed by Rubocop.