### PR TITLE
Show project title in staging projects table

### DIFF
--- a/src/api/app/assets/stylesheets/webui/staging-workflow.scss
+++ b/src/api/app/assets/stylesheets/webui/staging-workflow.scss
@@ -31,11 +31,17 @@ ul .table-list-group-item {
   }
 
   &.project {
+    @extend .w-25;
+
     > span.badge {
       @extend .w-100;
 
       > span.badge {
         @extend .m-1;
+        overflow-wrap: break-word;
+        word-wrap: break-word;
+        display: inline-block;
+        white-space: normal;
       }
     }
 

--- a/src/api/app/assets/stylesheets/webui/staging-workflow.scss
+++ b/src/api/app/assets/stylesheets/webui/staging-workflow.scss
@@ -31,15 +31,17 @@ ul .table-list-group-item {
   }
 
   &.project {
-    @extend .w-25;
+    min-width: 9rem;
 
     > span.badge {
-      @extend .w-100;
+      width: 100%;
 
       > span.badge {
         @extend .m-1;
+        max-width: 15rem;
         overflow-wrap: break-word;
         word-wrap: break-word;
+        word-break: keep-all;
         display: inline-block;
         white-space: normal;
       }
@@ -89,10 +91,7 @@ ul .table-list-group-item {
       }
     }
   }
-
   &.requests {
-    min-width: 50%;
-
     span.badge {
       margin-left: 10px;
 

--- a/src/api/app/assets/stylesheets/webui/staging-workflow.scss
+++ b/src/api/app/assets/stylesheets/webui/staging-workflow.scss
@@ -34,14 +34,13 @@ ul .table-list-group-item {
     min-width: 9rem;
 
     > span.badge {
-      width: 100%;
+      @extend .w-100;
 
       > span.badge {
         @extend .m-1;
         max-width: 15rem;
         overflow-wrap: break-word;
         word-wrap: break-word;
-        word-break: keep-all;
         display: inline-block;
         white-space: normal;
       }
@@ -92,6 +91,8 @@ ul .table-list-group-item {
     }
   }
   &.requests {
+    .request-elements { min-width: 20rem; }
+
     span.badge {
       margin-left: 10px;
 
@@ -144,6 +145,7 @@ ul .table-list-group-item {
       float: left;
     }
   }
+  .problem-elements { min-width: 12rem; }
 }
 
 li.missing-check {

--- a/src/api/app/decorators/staging/project_decorator.rb
+++ b/src/api/app/decorators/staging/project_decorator.rb
@@ -1,0 +1,15 @@
+module Staging
+  class ProjectDecorator < BaseDecorator
+    # If the staging project has a title we use the title.
+    # If the staging project has no title and is a subproject of the workflow
+    # project we remove the workflow project name from the string.
+    # And if the staging project has no title and is not a subproject then we
+    # show the name.
+    def title
+      return model.title if model.title.present?
+
+      workflow_project = model.staging_workflow.project
+      model.name.delete_prefix("#{workflow_project}:")
+    end
+  end
+end

--- a/src/api/app/views/webui/staging/workflows/_empty_projects_list.html.haml
+++ b/src/api/app/views/webui/staging/workflows/_empty_projects_list.html.haml
@@ -4,4 +4,5 @@
   %ul.pl-4
     - projects.sort.each do |project|
       %li
-        = link_to(project.name, staging_workflow_staging_project_path(staging_workflow.project, project.name))
+        = link_to(Staging::ProjectDecorator.new(project).title,
+                  staging_workflow_staging_project_path(staging_workflow.project, project.name))

--- a/src/api/app/views/webui/staging/workflows/_overall_state.html.haml
+++ b/src/api/app/views/webui/staging/workflows/_overall_state.html.haml
@@ -1,6 +1,6 @@
 %span.badge{ class: "state-#{staging_project.overall_state}" }
   %span.badge.badge-light
-    = link_to(staging_project.title.presence || staging_project.name,
+    = link_to(Staging::ProjectDecorator.new(staging_project).title,
               staging_workflow_staging_project_path(staging_workflow.project, staging_project.name),
               data: { content: staging_project.description, placement: 'bottom', toggle: 'popover' })
   %span

--- a/src/api/app/views/webui/staging/workflows/_overall_state.html.haml
+++ b/src/api/app/views/webui/staging/workflows/_overall_state.html.haml
@@ -1,7 +1,8 @@
 %span.badge{ class: "state-#{staging_project.overall_state}" }
   %span.badge.badge-light
     = link_to(staging_project.title.presence || staging_project.name,
-              staging_workflow_staging_project_path(staging_workflow.project, staging_project.name))
+              staging_workflow_staging_project_path(staging_workflow.project, staging_project.name),
+              data: { content: staging_project.description, placement: 'bottom', toggle: 'popover' })
   %span
     %br
     = staging_project.overall_state

--- a/src/api/app/views/webui/staging/workflows/_overall_state.html.haml
+++ b/src/api/app/views/webui/staging/workflows/_overall_state.html.haml
@@ -1,6 +1,7 @@
 %span.badge{ class: "state-#{staging_project.overall_state}" }
   %span.badge.badge-light
-    = link_to(staging_project.name, staging_workflow_staging_project_path(staging_workflow.project, staging_project.name))
+    = link_to(staging_project.title.presence || staging_project.name,
+              staging_workflow_staging_project_path(staging_workflow.project, staging_project.name))
   %span
     %br
     = staging_project.overall_state

--- a/src/api/app/views/webui/staging/workflows/_staging_project.html.haml
+++ b/src/api/app/views/webui/staging/workflows/_staging_project.html.haml
@@ -6,7 +6,8 @@
     .card-header.bg-light.p-2
       .d-flex.w-100.justify-content-between
         .col-10.p-0
-          = link_to(staging_project.name, staging_workflow_staging_project_path(staging_workflow.project, staging_project.name))
+          = link_to(Staging::ProjectDecorator.new(staging_project).title,
+                    staging_workflow_staging_project_path(staging_workflow.project, staging_project.name))
         .col-2.p-0.text-right
           %span.mr-1
             = link_to(preview_copy_staging_workflow_staging_project_path(staging_workflow.project, staging_project), title: 'Copy Staging Project') do

--- a/src/api/app/views/webui/staging/workflows/_staging_projects_table.html.haml
+++ b/src/api/app/views/webui/staging/workflows/_staging_projects_table.html.haml
@@ -10,10 +10,12 @@
         %td.project
           = render partial: 'overall_state', locals: { staging_workflow: staging_workflow, staging_project: staging_project }
         %td.requests
-          = render partial: 'webui/staging/shared/packages_list', locals: { staging_project: staging_project,
-                                                                            users_hash: users_hash, groups_hash: groups_hash }
+          .request-elements
+            = render partial: 'webui/staging/shared/packages_list', locals: { staging_project: staging_project,
+                                                                              users_hash: users_hash, groups_hash: groups_hash }
         %td
-          = render partial: 'problems', locals: { staging_project: staging_project }
+          .problem-elements
+            = render partial: 'problems', locals: { staging_project: staging_project }
 
 - content_for :ready_function do
   :plain

--- a/src/api/app/views/webui/staging/workflows/_staging_projects_table.html.haml
+++ b/src/api/app/views/webui/staging/workflows/_staging_projects_table.html.haml
@@ -24,5 +24,10 @@
       searching: false,
       info: false,
       stateSave: true,
-      stateDuration: #{2.days}
+      stateDuration: #{2.days},
+      columnDefs: [
+        { width: null, targets: 0 },
+        { width: '75%', targets: 1 },
+        { width: '25%', targets: 2 },
+      ]
     });

--- a/src/api/spec/decorators/staging/project_decorator_spec.rb
+++ b/src/api/spec/decorators/staging/project_decorator_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe Staging::ProjectDecorator do
+  let(:workflow_project) { create(:project, name: 'SUSE') }
+  let(:staging_workflow) { create(:staging_workflow_with_staging_projects, project: workflow_project) }
+  let(:staging_project) { staging_workflow.staging_projects.first }
+
+  subject do
+    Staging::ProjectDecorator.new(staging_project)
+  end
+
+  context 'when the project has a title' do
+    before do
+      staging_project.update_attributes(title: 'A')
+    end
+
+    it 'returns the title' do
+      expect(subject.title).to eql('A')
+    end
+  end
+
+  context 'when the project does not have a title' do
+    context 'and the project is a subproject of the workflow project' do
+      it 'returns the project name without the workflow part' do
+        expect(subject.title).to eql('Staging:A')
+      end
+    end
+
+    context 'and the project is not a subproject of the workflow project' do
+      let(:staging_project) { create(:project, title: '', name: 'OpenSUSE') }
+
+      before do
+        staging_workflow.staging_projects << staging_project
+      end
+
+      it 'returns the project name' do
+        expect(subject.title).to eql('OpenSUSE')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #8787  

Showing the full project name again in the staging projects
table is redundant and usually not needed.
Now in case a project title is set, it will use it in the staging projects table instead of
the project name. This allows the staging managers to customize the naming.

Also, since some staging projects are meant for specific packages the description
of the project is now shown in a tooltip when hovering over the link to the staging project 
in the table. This makes it easier to get an quick overview.

![Screenshot_2020-01-09 Open Build Service](https://user-images.githubusercontent.com/22001671/72089357-30d34e00-330c-11ea-85e4-cfcdef2fe225.png)
![Screenshot_2020-01-09_18-06-36](https://user-images.githubusercontent.com/22001671/72089364-33ce3e80-330c-11ea-900a-11ae520da7e7.png)

### staging projects without title
![Screenshot_2020-01-20 Open Build Service(2)](https://user-images.githubusercontent.com/1212806/72739650-5b42c800-3ba4-11ea-8f38-3aefe3377373.png)

### staging projects with title
![Screenshot_2020-01-20 Open Build Service](https://user-images.githubusercontent.com/1212806/72739613-3f3f2680-3ba4-11ea-831f-9cf7fc887d6c.png)

### staging projects with title: A,B,C,...
![Screenshot_2020-01-20 Open Build Service(3)](https://user-images.githubusercontent.com/1212806/72756724-67dc1600-3bce-11ea-917a-f91763fb8167.png)
