### PR TITLE
[api] Log server name to test log for backend log messages.

### DIFF
--- a/src/api/script/start_test_backend
+++ b/src/api/script/start_test_backend
@@ -106,11 +106,12 @@ srcsrv = Thread.new do
     begin
       line = srcsrv_out.gets
       break if line.nil?
-      logger.debug line.strip unless line.empty?
+      logger.debug 'bs_srcserver: ' + line.strip unless line.empty?
     rescue IOError
       break
     end
   end
+  logger.debug 'bs_srcserver stopped'
 end
 
 puts 'Starting backend repserver...'
@@ -121,11 +122,12 @@ reposrv = Thread.new do
     begin
       line = reposrv_out.gets
       break if line.nil?
-      logger.debug line.strip unless line.empty?
+      logger.debug 'bs_repserver: ' + line.strip unless line.empty?
     rescue IOError
       break
     end
   end
+  logger.debug 'bs_repserver stopped'
 end
 
 until dienow
@@ -161,11 +163,12 @@ servicesrv = Thread.new do
     begin
       line = servicesrv_out.gets
       break if line.nil?
-      logger.debug line.strip unless line.empty?
+      logger.debug 'bs_service: ' + line.strip unless line.empty?
     rescue IOError
       break
     end
   end
+  logger.debug 'bs_service stopped'
 end
 
 puts 'Starting backend service dispatcher...'
@@ -190,10 +193,11 @@ while publishsrv_out && !dienow
   begin
     line = publishsrv_out.gets
     break if line.nil?
-    logger.debug line.strip unless line.empty?
+    logger.debug 'bs_publish: ' + line.strip unless line.empty?
   rescue IOError
     break
   end
+  logger.debug 'bs_publish stopped'
 end
 
 until dienow


### PR DESCRIPTION
Test log produced by testsuite contains messages from frontend and backend.
Sometimes it's not obvious which backend server produced some message.
This change makes log messages produced by backend during tests
to be prefixed by the name of the server which produced the message.
Also, a message is logged when backend server has stopped running.

Signed-off-by: Oleg Girko <ol@infoserver.lv>

