### PR TITLE
Fix the API docs involving the directory schema

### DIFF
--- a/docs/api/api/api.txt
+++ b/docs/api/api/api.txt
@@ -507,7 +507,7 @@ Parameters:
   repository: string, for view=info: parse buildinfo for this repository, optinal
   product: string, limit the product view to a given product
 
-XmlResult: package directory.xsd
+XmlResult: directory_filelist directory.xsd
 
 
 GET /source/<project>/<package>/_meta

--- a/docs/api/api/directory.xsd
+++ b/docs/api/api/directory.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
   elementFormDefault="qualified">
 
   <xs:annotation>
@@ -20,7 +20,9 @@
         <xs:element ref="linkinfo" minOccurs="0" maxOccurs="unbounded"/>
         <xs:element ref="serviceinfo" minOccurs="0" maxOccurs="unbounded"/>
       </xs:sequence>
+      <xs:attribute name="name" type="xs:string"/>
       <xs:attribute name="rev" type="xs:string"/>
+      <xs:attribute name="vrev" type="xs:string"/>
       <xs:attribute name="srcmd5" type="xs:string"/>
       <xs:attribute name="count" type="xs:int"/>
     </xs:complexType>

--- a/docs/api/api/directory_filelist.xml
+++ b/docs/api/api/directory_filelist.xml
@@ -1,0 +1,10 @@
+<directory name="notmuch" rev="54" vrev="57" srcmd5="230b02edd1c26728721ae0b03d5b5283">
+  <linkinfo project="openSUSE:Factory" package="notmuch" srcmd5="9e47261dc1fd93ce2744131619671fbc" baserev="9e47261dc1fd93ce2744131619671fbc" xsrcmd5="f516416f687b247b04d3c313a5b70e6c" lsrcmd5="230b02edd1c26728721ae0b03d5b5283"/>
+  <entry name="_link" md5="c69b492d162910ea13be95b90b21d675" size="124" mtime="1578437805"/>
+  <entry name="database-v1.tar.xz" md5="934228459565fbd7956a2eb2d0f64c53" size="204876" mtime="1551092319"/>
+  <entry name="notmuch-0.29.3.tar.xz" md5="d2697458d1ae087ee385a9912db29c95" size="660536" mtime="1574936762"/>
+  <entry name="notmuch-0.29.3.tar.xz.asc" md5="5595358fce14489e688868d287b28247" size="833" mtime="1574936762"/>
+  <entry name="notmuch.changes" md5="39d8bd04680c8ee4bb2405a1feb87c14" size="15247" mtime="1578351012"/>
+  <entry name="notmuch.keyring" md5="bffffb2323097035476d87fc2f7b0ce2" size="13400" mtime="1573125108"/>
+  <entry name="notmuch.spec" md5="dcd69f2a2f1d86bbde53dc3d712d98f8" size="7746" mtime="1578412371"/>
+</directory>

--- a/src/api/test/functional/backend_test.rb
+++ b/src/api/test/functional/backend_test.rb
@@ -13,7 +13,7 @@ class BackendTests < ActionDispatch::IntegrationTest
       # map schema names
       if ['about', 'activity', 'added_timestamp', 'announcement', 'announcements', 'new_announcement', 'architecture', 'attrib', 'attrib_type',
           'attrib_namespace', 'attribute_namespace_meta', 'collection_objects_by_tag',
-          'collection_objects_with_tags_by_user', 'configuration', 'directory_view', 'download_counter',
+          'collection_objects_with_tags_by_user', 'configuration', 'directory_filelist', 'directory_view', 'download_counter',
           'download_counter_summary', 'download_stats', 'group', 'highest_rated', 'issue_tracker',
           'latest_added', 'latest_updated', 'message', 'messages', 'most_active_packages', 'most_active_projects', 'newest_stats',
           'packageresult', 'projectresult', 'projects', 'rating', 'redirect_stats', 'status_message',


### PR DESCRIPTION
- The directory element can contain the `vrev` attribute
- The example for the `/source/<project>/<package>` route is a `_meta` and not the list of files as would be expected.