### PR TITLE
Show excluded request description on info list

### DIFF
--- a/src/api/app/controllers/webui/staging/workflows_controller.rb
+++ b/src/api/app/controllers/webui/staging/workflows_controller.rb
@@ -45,7 +45,7 @@ class Webui::Staging::WorkflowsController < Webui::WebuiController
     @more_unassigned_requests = @staging_workflow.unassigned_requests.count - @unassigned_requests.size
     @ready_requests = @staging_workflow.ready_requests.first(5)
     @more_ready_requests = @staging_workflow.ready_requests.count - @ready_requests.size
-    @excluded_requests = @staging_workflow.excluded_requests.first(5)
+    @excluded_requests = @staging_workflow.excluded_requests.includes(:request_exclusion).first(5)
     @more_excluded_requests = @staging_workflow.excluded_requests.count - @excluded_requests.size
     @empty_projects = @staging_workflow.staging_projects.without_staged_requests
     @managers = @staging_workflow.managers_group

--- a/src/api/app/helpers/webui/staging/workflow_helper.rb
+++ b/src/api/app/helpers/webui/staging/workflow_helper.rb
@@ -103,4 +103,9 @@ module Webui::Staging::WorkflowHelper
       safe_join(requests_links[requests_visible_by_default..-1])
     end
   end
+
+  def info_link(request, excluded = false)
+    options = { data: { content: request.request_exclusion.description, placement: 'top', toggle: 'popover' } } if excluded
+    link_to(elide(request.first_target_package, 19), request_show_path(request.number), options)
+  end
 end

--- a/src/api/app/views/webui/staging/workflows/_infos.html.haml
+++ b/src/api/app/views/webui/staging/workflows/_infos.html.haml
@@ -17,4 +17,4 @@
       %dd= render 'requests_list', requests: ready_requests, more_requests: more_ready_requests
 
       %dt= link_to('Excluded:', staging_workflow_excluded_requests_path(staging_workflow_id: staging_workflow))
-      %dd= render 'requests_list', requests: excluded_requests, more_requests: more_excluded_requests
+      %dd= render 'requests_list', requests: excluded_requests, more_requests: more_excluded_requests, excluded: true

--- a/src/api/app/views/webui/staging/workflows/_requests_list.html.haml
+++ b/src/api/app/views/webui/staging/workflows/_requests_list.html.haml
@@ -1,9 +1,11 @@
+- excluded ||= false
+
 %ul.pl-2.list-unstyled
   - if requests.empty?
     %li
       Empty
   - else
     - requests.each do |request|
-      %li= link_to(elide(request.first_target_package, 19), request_show_path(request.number))
+      %li= info_link(request, excluded)
     - unless more_requests.zero?
       %li ... #{more_requests} more


### PR DESCRIPTION
The reason for the request exclusion is shown in the info list.

### Staging Info section
![excluded_description](https://user-images.githubusercontent.com/1212806/72143887-d41d7500-3397-11ea-9305-9b05b53eee36.png)

### Excluded List

![Screenshot_2020-01-10 Open Build Service](https://user-images.githubusercontent.com/1212806/72143877-d089ee00-3397-11ea-853a-c58c40973ca7.png)
