### PR TITLE
Refactor validator test

### DIFF
--- a/src/api/test/unit/active_support_test_case_extensions.rb
+++ b/src/api/test/unit/active_support_test_case_extensions.rb
@@ -1,0 +1,60 @@
+
+# We monkey patch ActiveSupport::TestCase in test/test_helper.rb
+# This test covers the added methods
+class ActiveSupportTestCaseTest < ActiveSupport::TestCase
+  def test_assert_xml_tag
+    xml = <<-XML
+      <services>
+        <service name="download_url">
+          <param name="host">blahfasel</param>
+        </service>
+        <service name="download_files" />
+        <service name="set_version">
+          <param name="version">0815</param>
+        </service>
+      </services>
+    XML
+    assert_xml_tag xml, tag: 'service', attributes: { name: 'download_url', not_present_tag: nil }
+    assert_xml_tag xml, before: { attributes: { name: 'set_version' } }, attributes: { name: 'download_files' }
+    assert_xml_tag xml, after: { attributes: { name: 'download_url' } }, attributes: { name: 'download_files' }
+    assert_xml_tag xml, sibling: { attributes: { name: 'download_url' } }, attributes: { name: 'set_version' }
+    assert_xml_tag xml, ancestor: { tag: 'services' }, content: '0815'
+    assert_xml_tag xml, descendant: { content: '0815' }
+    assert_no_xml_tag xml, descendant: { content: '0815' }, tag: 'param', attributes: { name: 'host' }
+    assert_xml_tag xml, tag: 'services', children: { count: 3, only: { tag: 'service' } }
+    assert_xml_tag xml, tag: 'service', attributes: { name: 'download_files' }
+    assert_xml_tag xml, parent: { tag: 'service', attributes: { name: 'download_url' } },
+                        tag: 'param', attributes: { name: 'host' },
+                        content: 'blahfasel'
+    assert_xml_tag xml, parent: { tag: 'service', attributes: { name: 'set_version' } },
+                        tag: 'param', attributes: { name: 'version' },
+                        content: '0815'
+    assert_no_xml_tag xml, parent: { tag: 'service', attributes: { name: 'set_version' } },
+                           tag: 'param', attributes: { name: 'version' },
+                           content: '0816'
+    assert_xml_tag xml, child: { tag: 'param' }, attributes: { name: 'download_url' }
+  end
+
+  def test_assert_no_xml_tag
+    xml = <<-XML
+      <project name="home:Iggy:branches:BaseDistro">
+        <package project="home:Iggy:branches:BaseDistro" name="pack1">
+        </package>
+        <package project="home:Iggy:branches:BaseDistro" name="pack_new">
+        </package>
+      </project>
+    XML
+    assert_no_xml_tag xml, parent: { tag: 'issue' }
+
+    xml = <<-XML
+      <person>
+        <login>tom</login>
+        <email>tschmidt@example.com</email>
+        <realname>Freddy Cool</realname>
+        <watchlist>
+        </watchlist>
+      </person>
+    XML
+    assert_no_xml_tag xml, tag: 'person', child: { tag: 'globalrole', content: 'Admin' }
+  end
+end

--- a/src/api/test/unit/validator_test.rb
+++ b/src/api/test/unit/validator_test.rb
@@ -3,7 +3,7 @@ require File.expand_path(File.dirname(__FILE__) + '/..') + '/test_helper'
 require 'opensuse/validator'
 
 class ValidatorTest < ActiveSupport::TestCase
-  def test_validator
+  def test_arguments
     exception = assert_raise ArgumentError do
       Suse::Validator.validate 'notthere'
     end
@@ -20,111 +20,66 @@ class ValidatorTest < ActiveSupport::TestCase
       Suse::Validator.validate controller: :project
     end
     assert_match('wrong number of arguments (given 1, expected 2)', exception.message)
-
-    request = ActionController::TestRequest.create({})
-    exception = assert_raise Suse::ValidationError do
-      Suse::Validator.validate 'link', request.raw_post.to_s
-    end
-    assert_match(/Document is empty/, exception.message)
-
-    request.env['RAW_POST_DATA'] = '<link test="invalid"/>'
-    exception = assert_raise Suse::ValidationError do
-      Suse::Validator.validate 'link', request.raw_post.to_s
-    end
-    assert_match(/Invalid attribute test for element link/, exception.message)
-
-    request.env['RAW_POST_DATA'] = '<link test"invalid"/>'
-    exception = assert_raise Suse::ValidationError do
-      Suse::Validator.validate 'link', request.raw_post.to_s
-    end
-    assert_match(/Extra content at the end of the document/, exception.message)
-
-    request.env['RAW_POST_DATA'] = '<link test="invalid">'
-    exception = assert_raise Suse::ValidationError do
-      Suse::Validator.validate 'link', request.raw_post.to_s
-    end
-    assert_match(/Premature end of data in tag link/, exception.message)
-
-    request.env['RAW_POST_DATA'] = '<link test="invalid"></ink>'
-    exception = assert_raise Suse::ValidationError do
-      Suse::Validator.validate 'link', request.raw_post.to_s
-    end
-    assert_match(/Opening and ending tag mismatch/, exception.message)
-
-    request.env['RAW_POST_DATA'] = '<link test="invalid" fun="foo"/>'
-    exception = assert_raise Suse::ValidationError do
-      Suse::Validator.validate 'link', request.raw_post.to_s
-    end
-    assert_match(/Invalid attribute test for element link/, exception.message)
-
-    request.env['RAW_POST_DATA'] = '<link test="invalid">foo</link>'
-    exception = assert_raise Suse::ValidationError do
-      Suse::Validator.validate 'link', request.raw_post.to_s
-    end
-    assert_match(/Did not expect text in element link content/, exception.message)
-
-    request.env['RAW_POST_DATA'] = '<link test="invalid"><foo/></link>'
-    exception = assert_raise Suse::ValidationError do
-      Suse::Validator.validate 'link', request.raw_post.to_s
-    end
-    assert_match(/Did not expect element foo there/, exception.message)
-
-    # projects can be anything
-    request.env['RAW_POST_DATA'] = '<link project="invalid"/>'
-    assert_equal true, Suse::Validator.validate('link', request.raw_post.to_s)
   end
 
-  def test_assert_xml
-    xml = <<-EOS
-      <services>
-        <service name="download_url">
-          <param name="host">blahfasel</param>
-        </service>
-        <service name="download_files" />
-        <service name="set_version">
-          <param name="version">0815</param>
-        </service>
-      </services>
-    EOS
-    assert_xml_tag xml, tag: 'service', attributes: { name: 'download_url', not_present_tag: nil }
-    assert_xml_tag xml, before: { attributes: { name: 'set_version' } }, attributes: { name: 'download_files' }
-    assert_xml_tag xml, after: { attributes: { name: 'download_url' } }, attributes: { name: 'download_files' }
-    assert_xml_tag xml, sibling: { attributes: { name: 'download_url' } }, attributes: { name: 'set_version' }
-    assert_xml_tag xml, ancestor: { tag: 'services' }, content: '0815'
-    assert_xml_tag xml, descendant: { content: '0815' }
-    assert_no_xml_tag xml, descendant: { content: '0815' }, tag: 'param', attributes: { name: 'host' }
-    assert_xml_tag xml, tag: 'services', children: { count: 3, only: { tag: 'service' } }
-    assert_xml_tag xml, tag: 'service', attributes: { name: 'download_files' }
-    assert_xml_tag xml, parent: { tag: 'service', attributes: { name: 'download_url' } },
-                        tag: 'param', attributes: { name: 'host' },
-                        content: 'blahfasel'
-    assert_xml_tag xml, parent: { tag: 'service', attributes: { name: 'set_version' } },
-                        tag: 'param', attributes: { name: 'version' },
-                        content: '0815'
-    assert_no_xml_tag xml, parent: { tag: 'service', attributes: { name: 'set_version' } },
-                           tag: 'param', attributes: { name: 'version' },
-                           content: '0816'
-    assert_xml_tag xml, child: { tag: 'param' }, attributes: { name: 'download_url' }
+  def test_empty_data
+    request = ActionController::TestRequest.create({})
+    assert_raise Suse::ValidationError do
+      Suse::Validator.validate 'link', request.raw_post.to_s
+    end
+  end
 
-    xml = <<-EOS
-      <project name="home:Iggy:branches:BaseDistro">
-        <package project="home:Iggy:branches:BaseDistro" name="pack1">
-        </package>
-        <package project="home:Iggy:branches:BaseDistro" name="pack_new">
-        </package>
-      </project>
-    EOS
-    assert_no_xml_tag xml, parent: { tag: 'issue' }
+  def test_invalid_attribute_name
+    request = ActionController::TestRequest.create({})
+    request.env['RAW_POST_DATA'] = '<link test="invalid"/>'
+    assert_raise Suse::ValidationError do
+      Suse::Validator.validate 'link', request.raw_post.to_s
+    end
+  end
 
-    xml = <<-EOS
-      <person>
-        <login>tom</login>
-        <email>tschmidt@example.com</email>
-        <realname>Freddy Cool</realname>
-        <watchlist>
-        </watchlist>
-      </person>
-    EOS
-    assert_no_xml_tag xml, tag: 'person', child: { tag: 'globalrole', content: 'Admin' }
+  def test_invalid_attribute_syntax
+    request = ActionController::TestRequest.create({})
+    request.env['RAW_POST_DATA'] = '<link project"invalid"/>'
+    assert_raise Suse::ValidationError do
+      Suse::Validator.validate 'link', request.raw_post.to_s
+    end
+  end
+
+  def test_unclosed_element
+    request = ActionController::TestRequest.create({})
+    request.env['RAW_POST_DATA'] = '<link test="invalid">'
+    assert_raise Suse::ValidationError do
+      Suse::Validator.validate 'link', request.raw_post.to_s
+    end
+  end
+
+  def test_ending_tag_mismatch
+    request = ActionController::TestRequest.create({})
+    request.env['RAW_POST_DATA'] = '<link test="invalid"></ink>'
+    assert_raise Suse::ValidationError do
+      Suse::Validator.validate 'link', request.raw_post.to_s
+    end
+  end
+
+  def test_unexpected_text_content
+    request = ActionController::TestRequest.create({})
+    request.env['RAW_POST_DATA'] = '<link project="invalid">foo</link>'
+    assert_raise Suse::ValidationError do
+      Suse::Validator.validate 'link', request.raw_post.to_s
+    end
+  end
+
+  def test_unexpected_element
+    request = ActionController::TestRequest.create({})
+    request.env['RAW_POST_DATA'] = '<link test="invalid"><foo/></link>'
+    assert_raise Suse::ValidationError do
+      Suse::Validator.validate 'link', request.raw_post.to_s
+    end
+  end
+
+  def test_valid_data
+    request = ActionController::TestRequest.create({})
+    request.env['RAW_POST_DATA'] = '<link project="some:project"/>'
+    assert_equal true, Suse::Validator.validate('link', request.raw_post.to_s)
   end
 end


### PR DESCRIPTION
Instead of testing for specific Nokogiri error messages, that change from
version to version, let's test what is important for us: That invalid things
don't go through the validator.

Also move out the ActiveSupport::TestCase monkey patch tests to their own file.
They have little to do with the validator.

Fixes #8934

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
