### PR TITLE
[api] fix /trigger/release to release all projects

### DIFF
--- a/src/api/app/controllers/trigger_controller.rb
+++ b/src/api/app/controllers/trigger_controller.rb
@@ -28,7 +28,12 @@ class TriggerController < ApplicationController
   def release
     raise NoPermissionForPackage.setup('no_permission', 403, "no permission for package #{@pkg} in project #{@pkg.project}") unless policy(@pkg).update?
 
-    matched_repo = @pkg.project.repositories.includes(:release_targets).any? { |repo| matched_repo?(repo) }
+    matched_repo = false
+    @pkg.project.repositories.includes(:release_targets).each do |repo|
+      if matched_repo?(repo) then
+        matched_repo = true
+      end
+    end
 
     raise NoPermissionForPackage.setup('not_found', 404, "no repository from #{@pkg.project} could get released") unless matched_repo
 


### PR DESCRIPTION
Triggering package release with a token via /trigger/release path did
only release one project, because .any? returns after first successful
iteration.

See https://lists.opensuse.org/opensuse-buildservice/2020-01/msg00048.html for the gory details.