### PR TITLE
Fixes releasing for multiple targets via trigger

### DIFF
--- a/src/api/app/controllers/trigger_controller.rb
+++ b/src/api/app/controllers/trigger_controller.rb
@@ -3,7 +3,7 @@ class TriggerController < ApplicationController
   validate_action release: { method: :post, response: :status }
   validate_action runservice: { method: :post, response: :status }
 
-  before_action :require_project_param, only: [:release]
+  before_action :disallow_project_param, only: [:release]
 
   before_action :extract_auth_from_request, :validate_auth_token, :require_valid_token
   #
@@ -62,8 +62,8 @@ class TriggerController < ApplicationController
     URI(path + build_query_from_hash(params, [:cmd, :comment, :user])).to_s
   end
 
-  def require_project_param
-    render_error(message: 'Token must define the release package', status: 403, errorcode: 'no_permission') if params[:project].present?
+  def disallow_project_param
+    render_error(message: 'You specified a project, but the token defines the project/package to release', status: 403, errorcode: 'no_permission') if params[:project].present?
   end
 
   def extract_auth_from_request


### PR DESCRIPTION
Triggering package release via a token did only release one project,
because .any? does not continue after first successful evaluation.

Also remove superflous permission check for target, release_package does that
already. And throw a 404 if the project has no release targets.

Co-authored-by: Stefan Seyfried <stefan.seyfried@sap.com>

Supersedes #8945  
<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
