### PR TITLE
Also set https_proxy if missing

### DIFF
--- a/src/api/app/models/project/remote_url.rb
+++ b/src/api/app/models/project/remote_url.rb
@@ -7,6 +7,9 @@ class Project::RemoteURL
     if ENV['http_proxy'].blank?
       ENV['http_proxy'] = Configuration.first.http_proxy
     end
+    if ENV['https_proxy'].blank?
+      ENV['https_proxy'] = Configuration.first.http_proxy
+    end
     if ENV['no_proxy'].blank?
       ENV['no_proxy'] = Configuration.first.no_proxy
     end


### PR DESCRIPTION
As apache does not have proxy env vars with systemd #6810, http_proxy is broken is some places: #3143 #3133 #3935 #2958

Current code does try to workaround the issue by settings http_proxy env when it is missing. However, it is not used by https:// URI. Accessing https://api.opensuse.org (when adding a new repo) generates:

```
I, [2020-01-15T18:55:36.628560 #4291]  INFO -- : [a76ce02a-fb1a-4bcc-b9af-7716766173c0] [4291:998.17] method=GET path=/project/add_repository_from_default_list/tresc format=html controller=Webui::RepositoriesController action=distributions status=500 error='Errno::EHOSTUNREACH: Failed to open TCP connection to api.opensuse.org:443 (No route to host - connect(2) for "api.opensuse.org" port 443)' duration=193.70 view=0.00 db=5.02 params={"project"=>"tresc"} host=10.9.200.2 time=1055.49 backend=0 user=luizluca
F, [2020-01-15T18:55:36.640626 #4291] FATAL -- : [a76ce02a-fb1a-4bcc-b9af-7716766173c0] [4291:998.18]   
F, [2020-01-15T18:55:36.641691 #4291] FATAL -- : [a76ce02a-fb1a-4bcc-b9af-7716766173c0] [4291:998.18] Errno::EHOSTUNREACH (Failed to open TCP connection to api.opensuse.org:443 (No route to host - connect(2) for "api.opensuse.org" port 443)):
F, [2020-01-15T18:55:36.642033 #4291] FATAL -- : [a76ce02a-fb1a-4bcc-b9af-7716766173c0] [4291:998.18]   
F, [2020-01-15T18:55:36.642231 #4291] FATAL -- : [a76ce02a-fb1a-4bcc-b9af-7716766173c0] [4291:998.18] app/models/project/remote_url.rb:14:in `load'
```

This patch should be backported to 2.10.x

And please, would it be possible to not close proxy issues with "set /etc/sysconfig/proxy". It is not working with systemd.
 