### PR TITLE
 Show 0% of tests done where there are no checks 

### DIFF
--- a/src/api/app/helpers/webui/staging/workflow_helper.rb
+++ b/src/api/app/helpers/webui/staging/workflow_helper.rb
@@ -23,11 +23,12 @@ module Webui::Staging::WorkflowHelper
   end
 
   def testing_progress(staging_project)
-    notdone = staging_project.checks.pending.size
-    allchecks = staging_project.checks.size + staging_project.missing_checks.size
+    return 0 if staging_project.checks.size.zero?
 
-    return 100 if allchecks == 0
-    100 - notdone * 100 / allchecks
+    not_done = staging_project.checks.pending.size + staging_project.missing_checks.size
+    all_checks = staging_project.checks.size + staging_project.missing_checks.size
+
+    100 - not_done * 100 / all_checks
   end
 
   def progress(staging_project)


### PR DESCRIPTION
The [original piece of code](https://github.com/openSUSE/open-build-service/blob/675c1238d2c467f6720f9dd8e78f22c3841454d7/src/api/app/presenters/obs_factory/staging_project_presenter.rb#L133) returns 0% when there are no checks.

Also refactor a little piece of code.

Fixes #8794.

