### PR TITLE
[backend] allow publishing of empty repository

### DIFF
--- a/src/backend/BSSched/PublishRepo.pm
+++ b/src/backend/BSSched/PublishRepo.pm
@@ -172,6 +172,9 @@ sub prpfinished {
     $seen_binary = {};
   }
 
+  # Let the publisher decide about empty repositories
+  $changed = 1 if $bconf && $bconf->{'publishflags:create_empty'} && ! -e "$reporoot/$prp/:repoinfo";
+
   my %newchecksums;
   # sort like in the full tree
   for my $packid (BSSched::ProjPacks::orderpackids($projpacks->{$projid}, @$packs)) {

--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -1772,6 +1772,8 @@ sub publish {
     my $r = "$reporoot/$prp/$arch/:repo";
     $found_repo = 1 if -e $r;
   }
+  # no published binary found, but we may want an empty repo nevertheless?
+  $found_repo = 1 if $config->{'publishflags:create_empty'};
   if (!defined($found_repo)) {
     deleterepo($projid, $repoid);
     return;


### PR DESCRIPTION
First part as a proposal. Usecase are esp :Update repositories which must be there from the beging but can be empty. Otherwise QA checks for the distro my fail.

This rule allows the publisher to create a repo neverthless even though there are now binaries. Second part would be to trigger the publish from scheduler if that flag is set.

I think @bugfinder will love that feature and be done just by setting up the publish rule in prjconf altogether with the rest....