### PR TITLE
Fix staging tab link

### DIFF
--- a/src/api/app/views/webui/project/_tabs.html.haml
+++ b/src/api/app/views/webui/project/_tabs.html.haml
@@ -36,14 +36,15 @@
       - if project.staging_project?
         %li.nav-item
           = tab_link('Staging', staging_workflow_path(project.staging_workflow.project), active)
-      - elsif policy(project.staging || Staging::Workflow.new(project: project)).create?
-        %li.nav-item
-          = tab_link('Staging', new_staging_workflow_path(project: project), active)
-      - elsif project.staging.persisted?
-        -# If Staging::Workflow.new(...) is executed above, project.staging will be a new object.
+      - elsif project.staging && project.staging.persisted?
+        -# If Staging::Workflow.new(...) is executed below, project.staging will be a new object.
            It will be persisted if the project is really a staging workflow project.
         %li.nav-item
           = tab_link('Staging', staging_workflow_path(project), active)
+      - elsif policy(Staging::Workflow.new(project: project)).create?
+        %li.nav-item
+          = tab_link('Staging', new_staging_workflow_path(project: project), active)
+
     %li.nav-item.dropdown
       %a.nav-link.dropdown-toggle{ href: '#', 'data-toggle': 'dropdown', 'role': 'button', 'aria-expanded': 'false', 'aria-haspopup': 'true' }
       .dropdown-menu.dropdown-menu-right


### PR DESCRIPTION
It should only point to new_staging_workflow_path if there isn't a staging
workflow.

Fixes #8951

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
