### PR TITLE
Use the whole screen instead of using only a half

### DIFF
--- a/src/api/app/assets/stylesheets/webui/staging-workflow.scss
+++ b/src/api/app/assets/stylesheets/webui/staging-workflow.scss
@@ -85,7 +85,7 @@ ul .table-list-group-item {
   }
 
   &.requests {
-    @extend .w-50;
+    min-width: 50%;
 
     span.badge {
       margin-left: 10px;


### PR DESCRIPTION
Fixes #7352 partially, not the part of paginating the history.

This is how it will look like:

![Screenshot from 2020-01-17 17-22-06](https://user-images.githubusercontent.com/24919/72628168-1291d180-394e-11ea-8fc0-8ebac0adfc0b.png)

