### PR TITLE
Remove unnecessary require call

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -1,5 +1,3 @@
-require 'project'
-
 class Webui::PackageController < Webui::WebuiController
   require_dependency 'opensuse/validator'
   include ParsePackageDiff


### PR DESCRIPTION
`require 'project'` was unnecessary and dubious 