### PR TITLE
Add Query objects to Package model

### DIFF
--- a/src/api/app/queries/packages_finder.rb
+++ b/src/api/app/queries/packages_finder.rb
@@ -1,0 +1,84 @@
+class PackagesFinder
+  def initialize(relation = Package.all)
+    @relation = relation
+  end
+
+  def by_package_and_project(package, project)
+    @relation.where(name: package, projects: { name: project }).includes(:project)
+  end
+
+  def find_by_attribute_type(attrib_type, package = nil)
+    # One sql statement is faster than a ruby loop
+    # attribute match in package or project
+    sql = build_sql_find_by_attribute(package)
+    finder_arguments = if package
+                         [sql, attrib_type.id.to_s, attrib_type.id.to_s, package]
+                       else
+                         [sql, attrib_type.id.to_s, attrib_type.id.to_s]
+                       end
+    find_package(finder_arguments)
+  end
+
+  def find_by_attribute_type_and_value(attrib_type, value, package = nil)
+    # One sql statement is faster than a ruby loop
+    sql = build_sql_find_by_attribute_and_value(package)
+    finder_arguments = if package
+                         [sql, attrib_type.id.to_s, value.to_s, package]
+                       else
+                         [sql, attrib_type.id.to_s, value.to_s]
+                       end
+    find_package(finder_arguments)
+  end
+
+  def forbidden_packages
+    @relation.where(project_id: Relationship.forbidden_project_ids)
+  end
+
+  def dirty_backend_packages
+    @relation.joins('left outer join backend_packages on backend_packages.package_id = packages.id').
+      where('backend_packages.package_id is null')
+  end
+
+  private
+
+  def find_package(args)
+    Package.find_by_sql(args).keep_if { |p| Package.check_access?(p) }
+  end
+
+  def base_query
+    <<-END_SQL
+      SELECT pack.* FROM packages pack
+      LEFT OUTER JOIN attribs attr ON pack.id = attr.package_id
+    END_SQL
+  end
+
+  def find_by_attribute
+    <<-END_SQL
+      LEFT OUTER JOIN attribs attrprj ON pack.project_id = attrprj.project_id
+      WHERE ( attr.attrib_type_id = ? or attrprj.attrib_type_id = ? )
+    END_SQL
+  end
+
+  def build_sql_find_by_attribute(package = nil)
+    if package
+      base_query + find_by_attribute + ' AND pack.name = ? GROUP by pack.id'
+    else
+      base_query + find_by_attribute + ' GROUP by pack.id'
+    end
+  end
+
+  def find_by_attribute_and_value
+    <<-END_SQL
+      LEFT OUTER JOIN attrib_values val ON attr.id = val.attrib_id
+      WHERE attr.attrib_type_id = ? AND val.value = ?
+    END_SQL
+  end
+
+  def build_sql_find_by_attribute_and_value(package = nil)
+    if package
+      base_query + find_by_attribute_and_value + ' AND pack.name = ?'
+    else
+      base_query + find_by_attribute_and_value + ' GROUP by pack.id'
+    end
+  end
+end

--- a/src/api/spec/cassettes/PackagesFinder/_by_package_and_project/package_and_project_exist/1_1_1_1.yml
+++ b/src/api/spec/cassettes/PackagesFinder/_by_package_and_project/package_and_project_exist/1_1_1_1.yml
@@ -1,0 +1,81 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/foo/_meta?user=user_9
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="foo">
+          <title>For a Breath I Tarry</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '100'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="foo">
+          <title>For a Breath I Tarry</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 20 Jan 2020 11:00:07 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/foo/foo_pack/_meta?user=user_10
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="foo_pack" project="foo">
+          <title>The Sun Also Rises</title>
+          <description>Error facere optio nesciunt.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '145'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="foo_pack" project="foo">
+          <title>The Sun Also Rises</title>
+          <description>Error facere optio nesciunt.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 20 Jan 2020 11:00:07 GMT
+recorded_with: VCR 5.0.0

--- a/src/api/spec/cassettes/PackagesFinder/_by_package_and_project/package_or_project_doesn_t_exist/1_1_2_1.yml
+++ b/src/api/spec/cassettes/PackagesFinder/_by_package_and_project/package_or_project_doesn_t_exist/1_1_2_1.yml
@@ -1,0 +1,81 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/foo/_meta?user=user_7
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="foo">
+          <title>Fair Stood the Wind for France</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '110'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="foo">
+          <title>Fair Stood the Wind for France</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 20 Jan 2020 11:00:06 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/foo/foo_pack/_meta?user=user_8
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="foo_pack" project="foo">
+          <title>Look to Windward</title>
+          <description>Molestiae voluptatum sequi sint.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '147'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="foo_pack" project="foo">
+          <title>Look to Windward</title>
+          <description>Molestiae voluptatum sequi sint.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 20 Jan 2020 11:00:06 GMT
+recorded_with: VCR 5.0.0

--- a/src/api/spec/cassettes/PackagesFinder/_find_by_attribute_type/when_package_is_invalid/1_2_3_1.yml
+++ b/src/api/spec/cassettes/PackagesFinder/_find_by_attribute_type/when_package_is_invalid/1_2_3_1.yml
@@ -1,0 +1,163 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/foo/_meta?user=user_5
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="foo">
+          <title>O Jerusalem!</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '92'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="foo">
+          <title>O Jerusalem!</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 20 Jan 2020 11:00:06 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/foo/foo_pack/_meta?user=user_6
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="foo_pack" project="foo">
+          <title>Far From the Madding Crowd</title>
+          <description>Voluptatem quis aut illum.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '151'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="foo_pack" project="foo">
+          <title>Far From the Madding Crowd</title>
+          <description>Voluptatem quis aut illum.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 20 Jan 2020 11:00:06 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:superbad/_meta?user=superbad
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:superbad">
+          <title/>
+          <description/>
+          <person userid="superbad" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '138'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:superbad">
+          <title></title>
+          <description></description>
+          <person userid="superbad" role="maintainer"/>
+        </project>
+    http_version: 
+  recorded_at: Mon, 20 Jan 2020 11:00:06 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/foo/foo_pack/_attribute?meta=1&user=superbad
+    body:
+      encoding: UTF-8
+      string: |
+        <attributes>
+          <attribute name="Maintained" namespace="OBS"/>
+        </attributes>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '171'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="38">
+          <srcmd5>55ef65ad1891b298d275654ab7159a13</srcmd5>
+          <time>1579518006</time>
+          <user>superbad</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Mon, 20 Jan 2020 11:00:06 GMT
+recorded_with: VCR 5.0.0

--- a/src/api/spec/cassettes/PackagesFinder/_find_by_attribute_type/when_package_is_nil/1_2_1_1.yml
+++ b/src/api/spec/cassettes/PackagesFinder/_find_by_attribute_type/when_package_is_nil/1_2_1_1.yml
@@ -1,0 +1,163 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/foo/_meta?user=user_1
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="foo">
+          <title>Rosemary Sutcliff</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '97'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="foo">
+          <title>Rosemary Sutcliff</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 20 Jan 2020 11:00:04 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/foo/foo_pack/_meta?user=user_2
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="foo_pack" project="foo">
+          <title>Some Buried Caesar</title>
+          <description>Sit enim exercitationem illum.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '147'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="foo_pack" project="foo">
+          <title>Some Buried Caesar</title>
+          <description>Sit enim exercitationem illum.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 20 Jan 2020 11:00:04 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:superbad/_meta?user=superbad
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:superbad">
+          <title/>
+          <description/>
+          <person userid="superbad" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '138'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:superbad">
+          <title></title>
+          <description></description>
+          <person userid="superbad" role="maintainer"/>
+        </project>
+    http_version: 
+  recorded_at: Mon, 20 Jan 2020 11:00:05 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/foo/foo_pack/_attribute?meta=1&user=superbad
+    body:
+      encoding: UTF-8
+      string: |
+        <attributes>
+          <attribute name="Maintained" namespace="OBS"/>
+        </attributes>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '171'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="34">
+          <srcmd5>db05b515efb88bf87f3aa1711acf7507</srcmd5>
+          <time>1579518005</time>
+          <user>superbad</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Mon, 20 Jan 2020 11:00:05 GMT
+recorded_with: VCR 5.0.0

--- a/src/api/spec/cassettes/PackagesFinder/_find_by_attribute_type/when_package_is_valid/1_2_2_1.yml
+++ b/src/api/spec/cassettes/PackagesFinder/_find_by_attribute_type/when_package_is_valid/1_2_2_1.yml
@@ -1,0 +1,163 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/foo/_meta?user=user_3
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="foo">
+          <title>Brandy of the Damned</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '100'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="foo">
+          <title>Brandy of the Damned</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 20 Jan 2020 11:00:06 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/foo/foo_pack/_meta?user=user_4
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="foo_pack" project="foo">
+          <title>Little Hands Clapping</title>
+          <description>Aut molestiae natus dolorum.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '148'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="foo_pack" project="foo">
+          <title>Little Hands Clapping</title>
+          <description>Aut molestiae natus dolorum.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 20 Jan 2020 11:00:06 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:superbad/_meta?user=superbad
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:superbad">
+          <title/>
+          <description/>
+          <person userid="superbad" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '138'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:superbad">
+          <title></title>
+          <description></description>
+          <person userid="superbad" role="maintainer"/>
+        </project>
+    http_version: 
+  recorded_at: Mon, 20 Jan 2020 11:00:06 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/foo/foo_pack/_attribute?meta=1&user=superbad
+    body:
+      encoding: UTF-8
+      string: |
+        <attributes>
+          <attribute name="Maintained" namespace="OBS"/>
+        </attributes>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '171'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="36">
+          <srcmd5>89a9d970e8f96bc20a030e6f085a572c</srcmd5>
+          <time>1579518006</time>
+          <user>superbad</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Mon, 20 Jan 2020 11:00:06 GMT
+recorded_with: VCR 5.0.0

--- a/src/api/spec/cassettes/PackagesFinder/find_by_attribute_type_and_value/when_package_is_nil/1_3_1_1.yml
+++ b/src/api/spec/cassettes/PackagesFinder/find_by_attribute_type_and_value/when_package_is_nil/1_3_1_1.yml
@@ -1,0 +1,165 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/foo/_meta?user=user_1
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="foo">
+          <title>A Farewell to Arms</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '98'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="foo">
+          <title>A Farewell to Arms</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 20 Jan 2020 14:38:21 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/foo/foo_pack/_meta?user=user_2
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="foo_pack" project="foo">
+          <title>The Golden Apples of the Sun</title>
+          <description>Voluptas repellat mollitia facilis.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '162'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="foo_pack" project="foo">
+          <title>The Golden Apples of the Sun</title>
+          <description>Voluptas repellat mollitia facilis.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 20 Jan 2020 14:38:21 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:superbad/_meta?user=superbad
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:superbad">
+          <title/>
+          <description/>
+          <person userid="superbad" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '138'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:superbad">
+          <title></title>
+          <description></description>
+          <person userid="superbad" role="maintainer"/>
+        </project>
+    http_version: 
+  recorded_at: Mon, 20 Jan 2020 14:38:21 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/foo/foo_pack/_attribute?meta=1&user=superbad
+    body:
+      encoding: UTF-8
+      string: |
+        <attributes>
+          <attribute name="EmbargoDate" namespace="OBS">
+            <value>2021-11-11</value>
+          </attribute>
+        </attributes>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '171'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="60">
+          <srcmd5>a9632a4f9cda0a71fee350b061101c06</srcmd5>
+          <time>1579531101</time>
+          <user>superbad</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Mon, 20 Jan 2020 14:38:21 GMT
+recorded_with: VCR 5.0.0

--- a/src/api/spec/cassettes/PackagesFinder/find_by_attribute_type_and_value/when_package_is_nil/1_3_1_2.yml
+++ b/src/api/spec/cassettes/PackagesFinder/find_by_attribute_type_and_value/when_package_is_nil/1_3_1_2.yml
@@ -1,0 +1,165 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/foo/_meta?user=user_3
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="foo">
+          <title>Endless Night</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="foo">
+          <title>Endless Night</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 20 Jan 2020 14:38:22 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/foo/foo_pack/_meta?user=user_4
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="foo_pack" project="foo">
+          <title>Number the Stars</title>
+          <description>Culpa cum accusamus temporibus.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '146'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="foo_pack" project="foo">
+          <title>Number the Stars</title>
+          <description>Culpa cum accusamus temporibus.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 20 Jan 2020 14:38:22 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:superbad/_meta?user=superbad
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:superbad">
+          <title/>
+          <description/>
+          <person userid="superbad" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '138'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:superbad">
+          <title></title>
+          <description></description>
+          <person userid="superbad" role="maintainer"/>
+        </project>
+    http_version: 
+  recorded_at: Mon, 20 Jan 2020 14:38:22 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/foo/foo_pack/_attribute?meta=1&user=superbad
+    body:
+      encoding: UTF-8
+      string: |
+        <attributes>
+          <attribute name="EmbargoDate" namespace="OBS">
+            <value>2021-11-11</value>
+          </attribute>
+        </attributes>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '171'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="62">
+          <srcmd5>2785a1bc832ce000f6078301a33f4548</srcmd5>
+          <time>1579531102</time>
+          <user>superbad</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Mon, 20 Jan 2020 14:38:22 GMT
+recorded_with: VCR 5.0.0

--- a/src/api/spec/factories/attribs.rb
+++ b/src/api/spec/factories/attribs.rb
@@ -54,6 +54,11 @@ FactoryBot.define do
       values { [build(:attrib_value, value: (Time.now - 14.days).to_s)] }
     end
 
+    factory :embargo_date_attrib do
+      attrib_type { AttribType.find_by_namespace_and_name!('OBS', 'EmbargoDate') }
+      values { [build(:attrib_value, value: '2021-11-11')] }
+    end
+
     factory :attrib_with_default_value do
       attrib_type { create(:attrib_type_with_default_value) }
     end

--- a/src/api/spec/queries/packages_finder_spec.rb
+++ b/src/api/spec/queries/packages_finder_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+RSpec.describe PackagesFinder, vcr: true do
+  describe '#by_package_and_project' do
+    let(:project) { create(:project, name: 'foo') }
+    let!(:package) { create(:package, name: 'foo_pack', project: project) }
+
+    context 'package and project exist' do
+      subject { PackagesFinder.new.by_package_and_project(package.name, project.name) }
+
+      it { expect(subject).not_to be_empty }
+    end
+
+    context 'package or project doesn\'t exist' do
+      subject { PackagesFinder.new.by_package_and_project('foo_pack', 'fooa') }
+
+      it { expect(subject).to be_empty }
+    end
+  end
+
+  describe '#find_by_attribute_type' do
+    let(:admin_user) { create(:admin_user, login: 'superbad') }
+    let(:project) { create(:project, name: 'foo') }
+    let!(:package) { create(:package, name: 'foo_pack', project: project) }
+    let(:maintained_attrib) { create(:maintained_attrib, project: project, package: package) }
+    context 'when package is nil' do
+      before do
+        User.session = admin_user
+      end
+
+      subject { PackagesFinder.new.find_by_attribute_type(maintained_attrib.attrib_type) }
+
+      it { expect(subject).not_to be_empty }
+    end
+
+    context 'when package is valid' do
+      before do
+        User.session = admin_user
+      end
+
+      subject { PackagesFinder.new.find_by_attribute_type(maintained_attrib.attrib_type, package.name) }
+
+      it { expect(subject).not_to be_empty }
+    end
+
+    context 'when package is invalid' do
+      before do
+        User.session = admin_user
+      end
+
+      subject { PackagesFinder.new.find_by_attribute_type(maintained_attrib.attrib_type, 'xoo') }
+
+      it { expect(subject).to be_empty }
+    end
+  end
+
+  describe 'find_by_attribute_type_and_value' do
+    let(:admin_user) { create(:admin_user, login: 'superbad') }
+    let(:project) { create(:project, name: 'foo') }
+    let!(:package) { create(:package, name: 'foo_pack', project: project) }
+    let!(:embargo_date_attrib_type) do
+      AttribType.create(name: 'EmbargoDate',
+                        attrib_namespace: AttribNamespace.find_by!(name: 'OBS'), value_count: 1)
+    end
+    let(:embargo_date_attrib) { create(:embargo_date_attrib, project: project, package: package) }
+    context 'when package is nil' do
+      before do
+        User.session = admin_user
+      end
+
+      subject { PackagesFinder.new.find_by_attribute_type_and_value(embargo_date_attrib.attrib_type, '2021-11-11') }
+
+      it { expect(subject).not_to be_empty }
+      it { expect(subject).to include(package) }
+    end
+  end
+end


### PR DESCRIPTION
In the quest of reduce the complexity and size of controllers and models, we introduced long time ago services objects, which reside in `app/services`, now following the design patterns, we are introducing the query object pattern, which the implementation will be located under `app/queries`.

The idea is to extract complex SQL queries or scopes to it's own PORO class, where we can better manage and test, removing some code which the implementation isn't so relevant to the models or controllers. 

The reasoning behind it is to use the battle tested design patterns to try to keep the base sane and avoid 700+ lines of models/controllers. 

References: 
https://www.martinfowler.com/eaaCatalog/queryObject.html
https://mkdev.me/en/posts/how-to-use-query-objects-to-refactor-rails-sql-queries 
https://github.com/infinum/rails-handbook/blob/master/Design%20Patterns/Query%20Objects.md