### PR TITLE
Remove not needed/used "responders" ruby gem

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -41,8 +41,6 @@ gem 'sanitize'
 gem 'pundit'
 # for password hashing
 gem 'bcrypt'
-#
-gem 'responders', '~> 3.0'
 # for threaded comments
 gem 'acts_as_tree'
 # js plotting (OBS monitor)

--- a/src/api/app/controllers/distributions_controller.rb
+++ b/src/api/app/controllers/distributions_controller.rb
@@ -5,8 +5,6 @@ class DistributionsController < ApplicationController
   validate_action index: { method: :get, response: :distributions }
   validate_action upload: { method: :put, request: :distributions, response: :status }
 
-  respond_to :xml, :json
-
   # GET /distributions
   # GET /distributions.xml
   def index

--- a/src/api/app/controllers/mail_handler_controller.rb
+++ b/src/api/app/controllers/mail_handler_controller.rb
@@ -2,8 +2,6 @@ class MailHandlerController < ApplicationController
   skip_before_action :extract_user
   skip_before_action :require_login
 
-  respond_to :xml, :json
-
   def upload
     # UNIMPLEMENTED STUB JUST FOR TESTING
     render_ok

--- a/src/api/app/controllers/webui/obs_factory/distributions_controller.rb
+++ b/src/api/app/controllers/webui/obs_factory/distributions_controller.rb
@@ -1,7 +1,5 @@
 module Webui::ObsFactory
   class DistributionsController < Webui::ObsFactory::ApplicationController
-    respond_to :html
-
     before_action :require_distribution, :require_dashboard
 
     def show

--- a/src/api/app/controllers/webui/obs_factory/staging_projects_controller.rb
+++ b/src/api/app/controllers/webui/obs_factory/staging_projects_controller.rb
@@ -1,7 +1,5 @@
 module Webui::ObsFactory
   class StagingProjectsController < Webui::ObsFactory::ApplicationController
-    respond_to :json, :html
-
     before_action :require_distribution
     before_action :require_project_name, only: [:show]
 

--- a/src/api/spec/controllers/public_controller_spec.rb
+++ b/src/api/spec/controllers/public_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe PublicController, vcr: true do
       get :source_file, params: { project: project.name, package: package.name, filename: 'somefile.txt' }
     end
 
-    it { is_expected.to respond_with(:success) }
+    it { expect(response).to have_http_status(:success) }
     it { expect(response.body).to eq(package.source_file('somefile.txt')) }
   end
 
@@ -27,7 +27,7 @@ RSpec.describe PublicController, vcr: true do
       get :build, params: { project: project.name }
     end
 
-    it { is_expected.to respond_with(:success) }
+    it { expect(response).to have_http_status(:success) }
     it { expect(a_request(:get, /.*\/build\/public_controller_project/)).to have_been_made.once }
   end
 
@@ -37,7 +37,7 @@ RSpec.describe PublicController, vcr: true do
         get :configuration_show, params: { format: :json }
       end
 
-      it { is_expected.to respond_with(:success) }
+      it { expect(response).to have_http_status(:success) }
       it { expect(assigns(:configuration)).to eq(Configuration.first) }
     end
 
@@ -46,7 +46,7 @@ RSpec.describe PublicController, vcr: true do
         get :configuration_show
       end
 
-      it { is_expected.to respond_with(:success) }
+      it { expect(response).to have_http_status(:success) }
       it { expect(assigns(:configuration)).to eq(Configuration.first) }
     end
   end
@@ -56,7 +56,7 @@ RSpec.describe PublicController, vcr: true do
       get :project_meta, params: { project: project.name }
     end
 
-    it { is_expected.to respond_with(:success) }
+    it { expect(response).to have_http_status(:success) }
     it { expect(response.body).to match(/<project name="public_controller_project">/) }
     it { expect(a_request(:get, /.*\/source\/public_controller_project\/_meta/)).to have_been_made.once }
   end
@@ -69,7 +69,7 @@ RSpec.describe PublicController, vcr: true do
       end
 
       it { expect(assigns(:project)).to eq(project) }
-      it { is_expected.to respond_with(:success) }
+      it { expect(response).to have_http_status(:success) }
       it { expect(response.body).to match(/<entry name="public_controller_package"/) }
       it { expect(a_request(:get, /.*\/source\/public_controller_project\?expand=1&noorigins=1/)).to have_been_made.once }
     end
@@ -80,7 +80,7 @@ RSpec.describe PublicController, vcr: true do
           get :project_index, params: { project: project.name, view: 'info', nofilename: 'filename' }
         end
 
-        it { is_expected.to respond_with(400) }
+        it { expect(response).to have_http_status(400) }
         it { expect(a_request(:get, /.*\/source\/public_controller_project\?nofilename=1&view=info/)).not_to have_been_made }
       end
 
@@ -90,7 +90,7 @@ RSpec.describe PublicController, vcr: true do
         end
 
         it { expect(assigns(:project)).to eq(project) }
-        it { is_expected.to respond_with(:success) }
+        it { expect(response).to have_http_status(:success) }
         it { expect(a_request(:get, /.*\/source\/public_controller_project\?nofilename=1&view=info/)).to have_been_made.once }
       end
     end
@@ -101,7 +101,7 @@ RSpec.describe PublicController, vcr: true do
       end
 
       it { expect(assigns(:project)).to eq(project) }
-      it { is_expected.to respond_with(:success) }
+      it { expect(response).to have_http_status(:success) }
       it { expect(assigns(:products)).to eq(Product.all_products(project, 0)) }
       it { expect(subject).to render_template('source/verboseproductlist') }
     end
@@ -112,7 +112,7 @@ RSpec.describe PublicController, vcr: true do
       end
 
       it { expect(assigns(:project)).to eq(project) }
-      it { is_expected.to respond_with(:success) }
+      it { expect(response).to have_http_status(:success) }
       it { expect(assigns(:products)).to eq(Product.all_products(project, 0)) }
       it { expect(subject).to render_template('source/productlist') }
     end
@@ -123,7 +123,7 @@ RSpec.describe PublicController, vcr: true do
       get :project_file, params: { project: project.name }
     end
 
-    it { is_expected.to respond_with(:success) }
+    it { expect(response).to have_http_status(:success) }
     it { expect(a_request(:get, /.*\/source\/public_controller_project\/_config/)).to have_been_made }
     it { expect(response.body).to eq(project.source_file('_config')) }
   end
@@ -133,7 +133,7 @@ RSpec.describe PublicController, vcr: true do
       get :package_index, params: { project: project.name, package: package.name }
     end
 
-    it { is_expected.to respond_with(:success) }
+    it { expect(response).to have_http_status(:success) }
     it { expect(response.body).to match(/name="somefile.txt"/) }
     it { expect(a_request(:get, /.*\/source\/public_controller_project\/public_controller_package/)).to have_been_made.once }
   end
@@ -143,7 +143,7 @@ RSpec.describe PublicController, vcr: true do
       get :package_meta, params: { project: project.name, package: package.name }
     end
 
-    it { is_expected.to respond_with(:success) }
+    it { expect(response).to have_http_status(:success) }
     it { expect(response.body).to match(/<package name="public_controller_package" project="public_controller_project">/) }
     it { expect(a_request(:get, /.*\/source\/public_controller_project\/public_controller_package\/_meta/)).to have_been_made.once }
   end
@@ -153,7 +153,7 @@ RSpec.describe PublicController, vcr: true do
       get :distributions, params: { format: :xml }
     end
 
-    it { is_expected.to respond_with(:success) }
+    it { expect(response).to have_http_status(:success) }
     it { expect(assigns(:distributions)).to eq(Distribution.all_as_hash) }
   end
 
@@ -164,7 +164,7 @@ RSpec.describe PublicController, vcr: true do
       get :show_request, params: { number: request.number }
     end
 
-    it { is_expected.to respond_with(:success) }
+    it { expect(response).to have_http_status(:success) }
     it { expect(response.body).to eq(request.reload.render_xml) }
   end
 
@@ -173,7 +173,7 @@ RSpec.describe PublicController, vcr: true do
       get :binary_packages, params: { project: project.name, package: package.name }
     end
 
-    it { is_expected.to respond_with(:success) }
+    it { expect(response).to have_http_status(:success) }
     it { expect(assigns(:pkg)).to eq(package) }
   end
 
@@ -184,7 +184,7 @@ RSpec.describe PublicController, vcr: true do
         @revisions = Nokogiri::XML(response.body, &:strict).xpath('//revision')
       end
 
-      it { is_expected.to respond_with(:success) }
+      it { expect(response).to have_http_status(:success) }
       it { expect(@revisions.count).to be > 1 }
     end
 
@@ -194,7 +194,7 @@ RSpec.describe PublicController, vcr: true do
         @revisions = Nokogiri::XML(response.body, &:strict).xpath('//revision')
       end
 
-      it { is_expected.to respond_with(:success) }
+      it { expect(response).to have_http_status(:success) }
       it { expect(@revisions.count).to eq(1) }
     end
   end

--- a/src/api/spec/controllers/source/key_info_controller_controller_spec.rb
+++ b/src/api/spec/controllers/source/key_info_controller_controller_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Source::KeyInfoController, type: :controller do
       get :show, params: { format: :xml, project: project.name }
     end
 
-    it { is_expected.to respond_with(:success) }
+    it { expect(response).to have_http_status(:success) }
     it { expect(response.body).to eq(keyinfo_response) }
   end
 end

--- a/src/api/spec/controllers/statistics/maintenance_statistics_controller_spec.rb
+++ b/src/api/spec/controllers/statistics/maintenance_statistics_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Statistics::MaintenanceStatisticsController, type: :controller do
           get :index, params: { format: :xml, project: project.name }
         end
 
-        it { is_expected.to respond_with(:success) }
+        it { expect(response).to have_http_status(:success) }
 
         it 'assigns the project to an instance variable' do
           expect(assigns[:project]).to be_a(Project)
@@ -68,7 +68,7 @@ RSpec.describe Statistics::MaintenanceStatisticsController, type: :controller do
         get :index, params: { format: :xml, project: 'NonExistantProject' }
       end
 
-      it { is_expected.to respond_with(:not_found) }
+      it { expect(response).to have_http_status(:not_found) }
     end
   end
 end

--- a/src/api/spec/controllers/status_project_controller_spec.rb
+++ b/src/api/spec/controllers/status_project_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe StatusProjectController, vcr: true do
         get :show, params: { project: project.name, format: :xml }
       end
 
-      it { is_expected.to respond_with(:success) }
+      it { expect(response).to have_http_status(:success) }
       it { expect(response.body).to include("project=\"#{project.name}\"") }
       it { expect(response.body).to include("name=\"#{package.name}\"") }
       it { expect(response.body).to include('srcmd5=') }

--- a/src/api/spec/controllers/trigger_controller_spec.rb
+++ b/src/api/spec/controllers/trigger_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe TriggerController, vcr: true do
         post :rebuild, params: { format: :xml }
       end
 
-      it { is_expected.to respond_with(:forbidden) }
+      it { expect(response).to have_http_status(:forbidden) }
     end
 
     context 'when token is valid and packet rebuild' do
@@ -39,7 +39,7 @@ RSpec.describe TriggerController, vcr: true do
         post :rebuild, params: { format: :xml }
       end
 
-      it { is_expected.to respond_with(:success) }
+      it { expect(response).to have_http_status(:success) }
     end
   end
 
@@ -49,7 +49,7 @@ RSpec.describe TriggerController, vcr: true do
         post :release, params: { project: 'foo', format: :xml }
       end
 
-      it { is_expected.to respond_with(:forbidden) }
+      it { expect(response).to have_http_status(:forbidden) }
     end
 
     context 'when token is valid and package exists' do
@@ -68,7 +68,7 @@ RSpec.describe TriggerController, vcr: true do
         post :release, params: { package: package, format: :xml }
       end
 
-      it { is_expected.to respond_with(:success) }
+      it { expect(response).to have_http_status(:success) }
     end
 
     context 'when user has no rights for source' do
@@ -99,7 +99,7 @@ RSpec.describe TriggerController, vcr: true do
         post :release, params: { package: package, format: :xml }
       end
 
-      it { is_expected.to respond_with(403) }
+      it { expect(response).to have_http_status(403) }
       it { expect(response.body).to include("No permission to modify project 'target_project' for user 'mrfluffy'") }
     end
 
@@ -129,6 +129,6 @@ RSpec.describe TriggerController, vcr: true do
       post :runservice, params: { package: package, format: :xml }
     end
 
-    it { is_expected.to respond_with(:success) }
+    it { expect(response).to have_http_status(:success) }
   end
 end

--- a/src/api/spec/controllers/webui/image_templates_controller_spec.rb
+++ b/src/api/spec/controllers/webui/image_templates_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Webui::ImageTemplatesController, type: :controller do
       end
 
       it { is_expected.to render_template('webui/image_templates/index') }
-      it { is_expected.to respond_with(:success) }
+      it { expect(response).to have_http_status(:success) }
       it { expect(assigns(:projects)).to eq([]) }
     end
 
@@ -25,7 +25,7 @@ RSpec.describe Webui::ImageTemplatesController, type: :controller do
         get :index
       end
 
-      it { is_expected.to respond_with(:success) }
+      it { expect(response).to have_http_status(:success) }
       it { expect(assigns(:projects)).to eq([leap_project]) }
       it { is_expected.to render_template('webui/image_templates/index') }
 


### PR DESCRIPTION
The gem was only used in the tests, as rails 4.2 was introduced.

