### PR TITLE
Fix some RuboCop style offenses with autocorrect

### DIFF
--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -788,17 +788,6 @@ Style/AccessModifierDeclarations:
     - 'test/functional/read_permission_test.rb'
     - 'test/functional/source_controller_test.rb'
 
-# Offense count: 6
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: prefer_alias, prefer_alias_method
-Style/Alias:
-  Exclude:
-    - 'app/models/attrib.rb'
-    - 'app/models/cloud/backend/upload_job.rb'
-    - 'app/models/role.rb'
-    - 'test/test_helper.rb'
-
 # Offense count: 132
 # Cop supports --auto-correct.
 # Configuration parameters: AutoCorrect, EnforcedStyle.

--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -944,19 +944,6 @@ Style/PercentLiteralDelimiters:
     - 'app/models/obs_factory/openqa_job.rb'
     - 'app/presenters/obs_factory/obs_project_presenter.rb'
 
-# Offense count: 9
-# Cop supports --auto-correct.
-Style/RedundantBegin:
-  Exclude:
-    - 'app/controllers/public_controller.rb'
-    - 'app/controllers/webui/package_controller.rb'
-    - 'app/jobs/consistency_check_job.rb'
-    - 'app/mixins/build_log_support.rb'
-    - 'app/models/obs_factory/distribution.rb'
-    - 'app/models/package.rb'
-    - 'db/checker.rb'
-    - 'script/start_test_backend'
-
 # Offense count: 2
 # Cop supports --auto-correct.
 Style/RedundantCondition:

--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -804,17 +804,6 @@ Style/ClassVars:
     - 'test/functional/branch_publish_flag_test.rb'
     - 'test/test_helper.rb'
 
-# Offense count: 6
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, AllowInnerBackticks.
-# SupportedStyles: backticks, percent_x, mixed
-Style/CommandLiteral:
-  Exclude:
-    - 'config/initializers/git.rb'
-    - 'lib/memory_debugger.rb'
-    - 'lib/tasks/databases.rake'
-    - 'script/import_database.rb'
-
 # Offense count: 1
 # Cop supports --auto-correct.
 # Configuration parameters: Keywords.

--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -851,21 +851,6 @@ Style/EmptyLiteral:
     - 'app/models/obs_factory/openqa_job.rb'
     - 'app/presenters/obs_factory/staging_project_presenter.rb'
 
-# Offense count: 11
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: each, for
-Style/For:
-  Exclude:
-    - 'app/models/bs_request_action_maintenance_release.rb'
-    - 'app/models/project.rb'
-    - 'app/views/webui/feeds/news.rss.builder'
-    - 'db/attribute_descriptions.rb'
-    - 'test/functional/attributes_test.rb'
-    - 'test/unit/build_flag_test.rb'
-    - 'test/unit/debug_flag_test.rb'
-    - 'test/unit/publish_flag_test.rb'
-
 # Offense count: 1297
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.

--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -944,13 +944,6 @@ Style/PercentLiteralDelimiters:
     - 'app/models/obs_factory/openqa_job.rb'
     - 'app/presenters/obs_factory/obs_project_presenter.rb'
 
-# Offense count: 2
-# Cop supports --auto-correct.
-Style/RedundantCondition:
-  Exclude:
-    - 'app/models/binary_release.rb'
-    - 'script/import_database.rb'
-
 # Offense count: 56
 # Cop supports --auto-correct.
 # Configuration parameters: AllowMultipleReturnValues.

--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -878,19 +878,6 @@ Style/IdenticalConditionalBranches:
 Style/IfUnlessModifier:
   Enabled: false
 
-# Offense count: 9
-# Cop supports --auto-correct.
-# Configuration parameters: InverseMethods, InverseBlocks.
-Style/InverseMethods:
-  Exclude:
-    - 'app/models/bs_request.rb'
-    - 'app/models/bs_request_action_submit.rb'
-    - 'app/models/bs_request_permission_check.rb'
-    - 'app/models/package.rb'
-    - 'app/models/project.rb'
-    - 'app/views/source/_common_issues.xml.builder'
-    - 'test/functional/request_events_test.rb'
-
 # Offense count: 1
 # Cop supports --auto-correct.
 # Configuration parameters: IgnoredMethods.

--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -1015,14 +1015,6 @@ Style/SymbolProc:
 
 # Offense count: 1
 # Cop supports --auto-correct.
-# Configuration parameters: ExactNameMatch, AllowPredicates, AllowDSLWriters, IgnoreClassMethods, AllowedMethods.
-# AllowedMethods: to_ary, to_a, to_c, to_enum, to_h, to_hash, to_i, to_int, to_io, to_open, to_path, to_proc, to_r, to_regexp, to_str, to_s, to_sym
-Style/TrivialAccessors:
-  Exclude:
-    - 'test/test_helper.rb'
-
-# Offense count: 1
-# Cop supports --auto-correct.
 Style/UnlessElse:
   Exclude:
     - 'app/models/obs_factory/openqa_job.rb'

--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -851,14 +851,6 @@ Style/EmptyLiteral:
     - 'app/models/obs_factory/openqa_job.rb'
     - 'app/presenters/obs_factory/staging_project_presenter.rb'
 
-# Offense count: 3
-# Cop supports --auto-correct.
-Style/ExpandPathArguments:
-  Exclude:
-    - 'bin/bundle'
-    - 'spec/rails_helper.rb'
-    - 'test/test_helper.rb'
-
 # Offense count: 11
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.

--- a/src/api/app/controllers/public_controller.rb
+++ b/src/api/app/controllers/public_controller.rb
@@ -202,12 +202,10 @@ class PublicController < ApplicationController
     # generic access checks
     key = 'public_package:' + project_name + ':' + package_name
     allowed = Rails.cache.fetch(key, expires_in: 30.minutes) do
-      begin
-        Package.get_by_project_and_name(project_name, package_name, use_source: false)
-        true
-      rescue Exception
-        false
-      end
+      Package.get_by_project_and_name(project_name, package_name, use_source: false)
+      true
+    rescue Exception
+      false
     end
     raise Package::UnknownObjectError, "#{project_name} / #{package_name} " unless allowed
   end

--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -274,17 +274,15 @@ class Webui::PackageController < Webui::WebuiController
     supersede_errors = []
     if params[:supersede_request_numbers]
       params[:supersede_request_numbers].each do |request_number|
-        begin
-          r = BsRequest.find_by_number!(request_number)
-          opts = {
-            newstate: 'superseded',
-            reason: "Superseded by request #{req.number}",
-            superseded_by: req.number
-          }
-          r.change_state(opts)
-        rescue APIError => e
-          supersede_errors << e.message.to_s
-        end
+        r = BsRequest.find_by_number!(request_number)
+        opts = {
+          newstate: 'superseded',
+          reason: "Superseded by request #{req.number}",
+          superseded_by: req.number
+        }
+        r.change_state(opts)
+      rescue APIError => e
+        supersede_errors << e.message.to_s
       end
     end
 
@@ -776,13 +774,11 @@ class Webui::PackageController < Webui::WebuiController
   end
 
   def rpmlint_log
-    begin
-      @log = Backend::Api::BuildResults::Binaries.rpmlint_log(params[:project], params[:package], params[:repository], params[:architecture])
-      @log.encode!(xml: :text)
-      render partial: 'rpmlint_log'
-    rescue Backend::NotFoundError
-      render plain: 'No rpmlint log'
-    end
+    @log = Backend::Api::BuildResults::Binaries.rpmlint_log(params[:project], params[:package], params[:repository], params[:architecture])
+    @log.encode!(xml: :text)
+    render partial: 'rpmlint_log'
+  rescue Backend::NotFoundError
+    render plain: 'No rpmlint log'
   end
 
   def meta

--- a/src/api/app/jobs/consistency_check_job.rb
+++ b/src/api/app/jobs/consistency_check_job.rb
@@ -214,17 +214,15 @@ class ConsistencyCheckJob < ApplicationJob
       if fix
         # restore from backend
         diff.each do |package|
-          begin
-            meta = Backend::Api::Sources::Project.meta(project.name)
-            pkg = project.packages.new(name: package)
-            pkg.commit_opts = { no_backend_write: 1 }
-            pkg.update_from_xml(Xmlhash.parse(meta), true) # ignore locked project
-            pkg.save!
-          rescue ActiveRecord::RecordInvalid,
-                 Backend::NotFoundError
-            Backend::Api::Sources::Package.delete(project.name, package)
-            errors << "DELETED in backend due to invalid data #{project.name}/#{package}\n"
-          end
+          meta = Backend::Api::Sources::Project.meta(project.name)
+          pkg = project.packages.new(name: package)
+          pkg.commit_opts = { no_backend_write: 1 }
+          pkg.update_from_xml(Xmlhash.parse(meta), true) # ignore locked project
+          pkg.save!
+        rescue ActiveRecord::RecordInvalid,
+               Backend::NotFoundError
+          Backend::Api::Sources::Package.delete(project.name, package)
+          errors << "DELETED in backend due to invalid data #{project.name}/#{package}\n"
         end
       end
     end

--- a/src/api/app/mixins/build_log_support.rb
+++ b/src/api/app/mixins/build_log_support.rb
@@ -8,15 +8,13 @@ module BuildLogSupport
     log = raw_log_chunk(project, package, repo, arch, start, theend)
     log.encode!(invalid: :replace, undef: :replace, cr_newline: true)
     log.gsub(/([^a-zA-Z0-9&;<>\/\n\r \t()])/) do |c|
-      begin
-        if c.ord < 32
-          ''
-        else
-          c
-        end
-      rescue ArgumentError
+      if c.ord < 32
         ''
+      else
+        c
       end
+    rescue ArgumentError
+      ''
     end
   end
 

--- a/src/api/app/models/attrib.rb
+++ b/src/api/app/models/attrib.rb
@@ -121,7 +121,7 @@ class Attrib < ApplicationRecord
   end
 
   #### Alias of methods
-  alias_method :values_addable?, :values_removeable?
+  alias values_addable? values_removeable?
 
   private
 

--- a/src/api/app/models/binary_release.rb
+++ b/src/api/app/models/binary_release.rb
@@ -222,7 +222,7 @@ class BinaryRelease < ApplicationRecord
   end
 
   def update_for_product
-    repository.product_update_repositories.map { |i| i.product if i.product }.uniq
+    repository.product_update_repositories.map(&:product).uniq
   end
 
   #### Alias of methods

--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -323,11 +323,11 @@ class BsRequest < ApplicationRecord
   end
 
   def check_supersede_state
-    if state == :superseded && (!superseded_by.is_a?(Numeric) || !(superseded_by > 0))
+    if state == :superseded && (!superseded_by.is_a?(Numeric) || superseded_by <= 0)
       errors.add(:superseded_by, 'Superseded_by should be set')
     end
 
-    return unless superseded_by && !(state == :superseded)
+    return unless superseded_by && state != :superseded
     errors.add(:superseded_by, 'Superseded_by should not be set')
   end
 

--- a/src/api/app/models/bs_request_action_maintenance_release.rb
+++ b/src/api/app/models/bs_request_action_maintenance_release.rb
@@ -158,7 +158,7 @@ class BsRequestActionMaintenanceRelease < BsRequestAction
           raise ArchitectureOrderMissmatch, "Repository '#{repo.name}' and releasetarget " \
                                             "'#{rt.target_repository.name}' have different architectures"
         end
-        for i in 1..(repo.architectures.size)
+        (1..(repo.architectures.size)).each do |i|
           unless repo.architectures[i - 1] == rt.target_repository.architectures[i - 1]
             raise ArchitectureOrderMissmatch, "Repository and releasetarget don't have the same architecture " \
                                               "on position #{i}: #{prj.name} / #{repo.name}"

--- a/src/api/app/models/bs_request_action_submit.rb
+++ b/src/api/app/models/bs_request_action_submit.rb
@@ -86,7 +86,7 @@ class BsRequestActionSubmit < BsRequestAction
     target_package.sources_changed
 
     # cleanup source project
-    if relink_source && !(sourceupdate == 'noupdate')
+    if relink_source && sourceupdate != 'noupdate'
       # source package got used as devel package, link it to the target
       # re-create it via branch , but keep current content...
       options = { comment: "initialized devel package after accepting #{bs_request.number}",

--- a/src/api/app/models/bs_request_permission_check.rb
+++ b/src/api/app/models/bs_request_permission_check.rb
@@ -67,7 +67,7 @@ class BsRequestPermissionCheck
     unless by_user || by_group || by_package || by_project
       raise ReviewNotSpecified, 'The review must specified via by_user, by_group or by_project(by_package) argument.'
     end
-    if by_user && !(User.session! == by_user)
+    if by_user && User.session! != by_user
       raise ReviewChangeStateNoPermission, "review state change is not permitted for #{User.session!.login}"
     end
     if by_group && !User.session!.is_in_group?(by_group)

--- a/src/api/app/models/cloud/backend/upload_job.rb
+++ b/src/api/app/models/cloud/backend/upload_job.rb
@@ -19,8 +19,8 @@ module Cloud
                      :arch,
                      :filename,
                      :size
-      alias_method :id, :name
-      alias_method :architecture, :arch
+      alias id name
+      alias architecture arch
       validate :validate_xml
 
       def self.create(params)
@@ -54,7 +54,7 @@ module Cloud
       def created
         Time.at(xml_object.created.to_i)
       end
-      alias_method :created_at, :created
+      alias created_at created
 
       private
 

--- a/src/api/app/models/obs_factory/distribution.rb
+++ b/src/api/app/models/obs_factory/distribution.rb
@@ -105,12 +105,10 @@ module ObsFactory
     # @return [String] version string
     def source_version
       Rails.cache.fetch("source_version_for_#{name}", expires_in: 10.minutes) do
-        begin
-          p = Xmlhash.parse(Backend::Api::Sources::Package.file(name, SOURCE_VERSION_FILE[:package_name], SOURCE_VERSION_FILE[:filename]))
-          p.get('products').get('product').get('version')
-        rescue Backend::NotFoundError
-          nil
-        end
+        p = Xmlhash.parse(Backend::Api::Sources::Package.file(name, SOURCE_VERSION_FILE[:package_name], SOURCE_VERSION_FILE[:filename]))
+        p.get('products').get('product').get('version')
+      rescue Backend::NotFoundError
+        nil
       end
     end
 

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -480,13 +480,11 @@ class Package < ApplicationRecord
     if is_patchinfo?
       xml = Patchinfo.new.read_patchinfo_xmlhash(self)
       xml.elements('issue') do |i|
-        begin
-          current_issues['kept'] ||= []
-          current_issues['kept'] << Issue.find_or_create_by_name_and_tracker(i['id'], i['tracker'])
-        rescue IssueTracker::NotFoundError => e
-          # if the issue is invalid, we ignore it
-          Rails.logger.debug e
-        end
+        current_issues['kept'] ||= []
+        current_issues['kept'] << Issue.find_or_create_by_name_and_tracker(i['id'], i['tracker'])
+      rescue IssueTracker::NotFoundError => e
+        # if the issue is invalid, we ignore it
+        Rails.logger.debug e
       end
     else
       # onlyissues backend call gets the issues from .changes files

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -1235,7 +1235,7 @@ class Package < ApplicationRecord
 
   def self.verify_file!(pkg, name, content)
     # Prohibit dotfiles (files with leading .) and files with a / character in the name
-    raise IllegalFileName, "'#{name}' is not a valid filename" if name.blank? || !(name =~ /^[^\.\/][^\/]+$/)
+    raise IllegalFileName, "'#{name}' is not a valid filename" if name.blank? || name !~ /^[^\.\/][^\/]+$/
 
     # file is an ActionDispatch::Http::UploadedFile and Suse::Validator.validate
     # will call to_s therefore we have to read the content first

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -1220,7 +1220,7 @@ class Project < ApplicationRecord
     projects = []
     unused = 0
 
-    for i in 1..atoms.length do
+    (1..atoms.length).each do |i|
       p = atoms.slice(0, i).join(':')
       r = atoms.slice(unused, i - unused).join(':')
       if Project.where(name: p).exists? # ignore remote projects here

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -354,7 +354,7 @@ class Project < ApplicationRecord
     # replace links to this project repositories with links to the "deleted" repository
     find_repos(:linking_repositories) do |linking_repository|
       linking_repository.path_elements.includes(:link).each do |path_element|
-        next unless path_element.link.db_project_id == id && !(path_element.repository.db_project_id == id)
+        next unless path_element.link.db_project_id == id && path_element.repository.db_project_id != id
         if linking_repository.path_elements.find_by_repository_id(Repository.deleted_instance)
           # repository has already a path to deleted repo
           path_element.destroy
@@ -582,7 +582,7 @@ class Project < ApplicationRecord
       errors.add(:base, 'is not locked')
     end
 
-    !errors.any?
+    errors.none?
   end
 
   def update_from_xml!(xmlhash, force = nil)

--- a/src/api/app/models/role.rb
+++ b/src/api/app/models/role.rb
@@ -77,7 +77,7 @@ class Role < ApplicationRecord
   def to_s
     title
   end
-  alias_method :to_param, :to_s
+  alias to_param to_s
 end
 
 # == Schema Information

--- a/src/api/app/views/source/_common_issues.xml.builder
+++ b/src/api/app/views/source/_common_issues.xml.builder
@@ -9,6 +9,6 @@ issues.each do |i|
     # self.owner must not by used, since it is reserved by rails
     o = User.find i.issue.owner_id
   end
-  next if @login && (!o || !(@login == o.login))
+  next if @login && (!o || @login != o.login)
   i.issue.render_body(builder, change)
 end

--- a/src/api/app/views/webui/feeds/news.rss.builder
+++ b/src/api/app/views/webui/feeds/news.rss.builder
@@ -4,7 +4,7 @@ xml.rss version: '2.0' do
     xml.description 'Recent news'
     xml.link url_for only_path: false, controller: 'main', action: 'index'
 
-    for message in @news
+    @news.each do |message|
       xml.item do
         xml.title message.message
         xml.pubDate message.created_at

--- a/src/api/bin/bundle
+++ b/src/api/bin/bundle
@@ -1,3 +1,3 @@
 #!/usr/bin/ruby.ruby2.5
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 load Gem.bin_path('bundler', 'bundle')

--- a/src/api/config/initializers/git.rb
+++ b/src/api/config/initializers/git.rb
@@ -3,7 +3,7 @@ module Git
     COMMIT = File.open(File.join(Rails.root, 'last_deploy'), 'r') { |f| GIT_REVISION = f.gets.try(:chomp) }
     LAST_DEPLOYMENT = File.new(File.join(Rails.root, 'last_deploy')).mtime
   else
-    COMMIT = %x(SHA1=$(git rev-parse --short HEAD 2> /dev/null); if [ $SHA1 ]; then echo $SHA1; else echo ''; fi).chomp
+    COMMIT = `SHA1=$(git rev-parse --short HEAD 2> /dev/null); if [ $SHA1 ]; then echo $SHA1; else echo ''; fi`.chomp
     LAST_DEPLOYMENT = ''.freeze
   end
 end

--- a/src/api/db/attribute_descriptions.rb
+++ b/src/api/db/attribute_descriptions.rb
@@ -30,7 +30,7 @@ def update_all_attrib_type_descriptions
   }
   # rubocop:enable Layout/LineLength
 
-  for k in d.keys do
+  d.keys.each do |k|
     at = ans.attrib_types.where(name: k).first
     next unless at # might be called in older migrations
     at.description = d[k]

--- a/src/api/db/checker.rb
+++ b/src/api/db/checker.rb
@@ -96,14 +96,12 @@ module DB
         User.session = User.find_by_login('_nobody_')
         projects = {}
         Package.where('develpackage_id is not null').each do |package|
-          begin
-            package.resolve_devel_package
-            print step(:ok)
-          rescue Package::CycleError => e
-            projects[package.project.name] ||= []
-            projects[package.project.name] << [package.name, e.message]
-            print step(:fail)
-          end
+          package.resolve_devel_package
+          print step(:ok)
+        rescue Package::CycleError => e
+          projects[package.project.name] ||= []
+          projects[package.project.name] << [package.name, e.message]
+          print step(:fail)
         end
         puts summary(projects.empty? ? :ok : :fail)
         projects.keys.sort.each do |project|

--- a/src/api/lib/memory_debugger.rb
+++ b/src/api/lib/memory_debugger.rb
@@ -37,7 +37,7 @@ class MemoryDebugger
   def call(env)
     logger = Rails.logger
     GC.start
-    before = %x(ps -orss= -p#{$PROCESS_ID}).to_i
+    before = `ps -orss= -p#{$PROCESS_ID}`.to_i
     file = File.new("/tmp/memprof-#{$PROCESS_ID}.log", 'w')
     ret = Memprof.dump(file.path) do
       ret = @app.call(env)
@@ -45,7 +45,7 @@ class MemoryDebugger
       ret
     end
     file.close
-    after = %x(ps -orss= -p#{$PROCESS_ID}).to_i
+    after = `ps -orss= -p#{$PROCESS_ID}`.to_i
     logger.debug "memory diff #{after - before} from #{before} to #{after}"
     file = File.new("/tmp/memprof-#{$PROCESS_ID}.log", 'r')
     ids = {}

--- a/src/api/lib/tasks/databases.rake
+++ b/src/api/lib/tasks/databases.rake
@@ -102,7 +102,7 @@ namespace :db do
     task verify_no_bigint: :environment do
       puts 'Checking db/structure.sql for bigint'
 
-      bigint_lines = %x(grep "bigint" #{Rails.root}/db/structure.sql)
+      bigint_lines = `grep "bigint" #{Rails.root}/db/structure.sql`
 
       if bigint_lines.present?
         abort <<-STR

--- a/src/api/script/import_database.rb
+++ b/src/api/script/import_database.rb
@@ -71,7 +71,7 @@ def load_dump
   end
 
   puts 'Downloading database backup ...'
-  `scp -v -P #{port ? port : 22} #{username}@#{server}:#{File.join(location, filename)} #{@data_path}`
+  `scp -v -P #{port || 22} #{username}@#{server}:#{File.join(location, filename)} #{@data_path}`
 end
 
 def import_dump

--- a/src/api/script/import_database.rb
+++ b/src/api/script/import_database.rb
@@ -71,7 +71,7 @@ def load_dump
   end
 
   puts 'Downloading database backup ...'
-  %x(scp -v -P #{port ? port : 22} #{username}@#{server}:#{File.join(location, filename)} #{@data_path})
+  `scp -v -P #{port ? port : 22} #{username}@#{server}:#{File.join(location, filename)} #{@data_path}`
 end
 
 def import_dump
@@ -94,7 +94,7 @@ def import_dump
   cmds << "mysql -u#{username} -p#{password} -h#{host} #{database}"
 
   puts "Extracting and importing data from #{filename}..."
-  %x(#{cmds.join(' | ')})
+  `#{cmds.join(' | ')}`
   puts "Completed loading #{filename}."
 end
 

--- a/src/api/script/start_test_backend
+++ b/src/api/script/start_test_backend
@@ -36,14 +36,12 @@ end
 
 # check for still running daemons from former run
 [port_src_server, port_rep_server, port_service_server].each do |port|
-  begin
-    Net::HTTP.start(CONFIG['source_host'], port) { |http| http.get('/') }
-    puts "ERROR Port #{port} is already in use, maybe from former unclean shutdown, aborting ..."
-    exit 1
-  rescue Errno::ECONNREFUSED, Errno::ENETUNREACH, Errno::EADDRNOTAVAIL
-    # Connect failed, good :)
-    next
-  end
+  Net::HTTP.start(CONFIG['source_host'], port) { |http| http.get('/') }
+  puts "ERROR Port #{port} is already in use, maybe from former unclean shutdown, aborting ..."
+  exit 1
+rescue Errno::ECONNREFUSED, Errno::ENETUNREACH, Errno::EADDRNOTAVAIL
+  # Connect failed, good :)
+  next
 end
 
 schedulerdone_file = Rails.root.join('tmp', 'scheduler.done')

--- a/src/api/spec/rails_helper.rb
+++ b/src/api/spec/rails_helper.rb
@@ -11,7 +11,7 @@ if ENV['CLEAN_UNUSED_CASSETTES']
 end
 
 ENV['RAILS_ENV'] ||= 'test'
-require File.expand_path('../../config/environment', __FILE__)
+require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 # as our base helper

--- a/src/api/test/functional/attributes_test.rb
+++ b/src/api/test/functional/attributes_test.rb
@@ -202,7 +202,7 @@ ription</description>
     assert_response :success
     get '/attribute/TEST/Dummy/_meta'
     assert_response :success
-    for i in ['count', 'description', 'default', 'allowed', 'count', 'modifiable_by'] do
+    ['count', 'description', 'default', 'allowed', 'count', 'modifiable_by'].each do |i|
       assert_equal(Xmlhash.parse(data)[i], Xmlhash.parse(@response.body)[i])
     end
     login_Iggy

--- a/src/api/test/functional/request_events_test.rb
+++ b/src/api/test/functional/request_events_test.rb
@@ -14,7 +14,7 @@ class RequestEventsTest < ActionDispatch::IntegrationTest
 
   def verify_email(fixture_name, myid, email)
     should = load_fixture("event_mailer/#{fixture_name}").gsub('REQUESTID', myid).chomp
-    assert_equal should, email.encoded.lines.map(&:chomp).select { |l| l !~ %r{^Date:} }.join("\n")
+    assert_equal should, email.encoded.lines.map(&:chomp).reject { |l| l =~ %r{^Date:} }.join("\n")
   end
 
   def test_request_event

--- a/src/api/test/test_helper.rb
+++ b/src/api/test/test_helper.rb
@@ -218,9 +218,7 @@ module Webui
       prepare_request_with_user(user, password)
     end
 
-    def current_user
-      @current_user
-    end
+    attr_reader :current_user
 
     self.use_transactional_tests = true
     fixtures :all

--- a/src/api/test/test_helper.rb
+++ b/src/api/test/test_helper.rb
@@ -26,7 +26,7 @@ if ENV['DO_COVERAGE']
   end
 end
 
-require File.expand_path('../../config/environment', __FILE__)
+require File.expand_path('../config/environment', __dir__)
 require_relative 'test_consistency_helper'
 
 require 'rails/test_help'

--- a/src/api/test/test_helper.rb
+++ b/src/api/test/test_helper.rb
@@ -160,7 +160,7 @@ module ActionDispatch
         headers
       end
 
-      alias_method :real_process, :process
+      alias real_process process
 
       def process(http_method, path, params: nil, headers: nil, env: nil, xhr: false, as: nil)
         CONFIG['global_write_through'] = true

--- a/src/api/test/unit/build_flag_test.rb
+++ b/src/api/test/unit/build_flag_test.rb
@@ -18,7 +18,7 @@ class BuildFlagTest < ActiveSupport::TestCase
     assert_equal 2, @project.flags.of_type('build').size
 
     # create two new flags and save it.
-    for i in 1..2 do
+    (1..2).each do |i|
       f = Flag.new(repo: "9.#{i}", status: 'enable', flag: 'build')
       f.architecture = @arch
       @project.flags << f
@@ -53,7 +53,7 @@ class BuildFlagTest < ActiveSupport::TestCase
     assert_equal 2, @package.flags.of_type('build').size
 
     # create two new flags and save it.
-    for i in 1..2 do
+    (1..2).each do |i|
       f = Flag.new(repo: "9.#{i}", status: 'disable', flag: 'build')
       f.architecture = @arch
       @package.flags << f

--- a/src/api/test/unit/debug_flag_test.rb
+++ b/src/api/test/unit/debug_flag_test.rb
@@ -18,7 +18,7 @@ class DebuginfoFlagTest < ActiveSupport::TestCase
     assert_equal 2, @project.flags.of_type('debuginfo').size
 
     # create two new flags and save it.
-    for i in 1..2 do
+    (1..2).each do |i|
       f = Flag.new(repo: "9.#{i}", status: 'enable', position: i + 2, flag: 'debuginfo')
       f.architecture = @arch
       @project.flags << f
@@ -55,7 +55,7 @@ class DebuginfoFlagTest < ActiveSupport::TestCase
     assert_equal 1, @package.flags.of_type('debuginfo').size
 
     # create two new flags and save it.
-    for i in 1..2 do
+    (1..2).each do |i|
       f = Flag.new(repo: "10.#{i}", status: 'disable', position: i + 1, flag: 'debuginfo')
       f.architecture = @arch
       @package.flags << f

--- a/src/api/test/unit/publish_flag_test.rb
+++ b/src/api/test/unit/publish_flag_test.rb
@@ -17,7 +17,7 @@ class PublishFlagTest < ActiveSupport::TestCase
     assert_equal 2, @project.flags.of_type('publish').size
 
     # create two new flags and save it.
-    for i in 1..2 do
+    (1..2).each do |i|
       @project.flags.create(repo: "9.#{i}", status: 'enable', position: i + 2, flag: 'publish', architecture: @arch)
     end
 
@@ -52,7 +52,7 @@ class PublishFlagTest < ActiveSupport::TestCase
     assert_equal 1, @package.flags.of_type('publish').size
 
     # create two new flags and save it.
-    for i in 1..2 do
+    (1..2).each do |i|
       @package.flags.create(repo: "10.#{i}", status: 'disable', position: i + 1, flag: 'publish', architecture: @arch)
     end
 


### PR DESCRIPTION
Fix some style RuboCop cops' offenses with: `rake task dev:lint:rubocop:auto_correct`.

To make it easier to review, fixes of the cops' offenses are included in separate commits.

There are more cops that can be autocorrected, but to not create a very big pull request I leave those for other pull requests. And most of the cops left will only fix code related to the about to be deprecated obs_factory.