### PR TITLE
Save the bs_request factory always as the creator

### DIFF
--- a/src/api/spec/controllers/staging/staged_requests_controller_spec.rb
+++ b/src/api/spec/controllers/staging/staged_requests_controller_spec.rb
@@ -26,8 +26,10 @@ RSpec.describe Staging::StagedRequestsController do
 
   describe 'GET #index' do
     before do
+      login(user)
       bs_request.staging_project = staging_project
       bs_request.save
+      logout
       get :index, params: { staging_workflow_project: staging_workflow.project.name, staging_project_name: staging_project.name, format: :xml }
     end
 
@@ -365,10 +367,12 @@ RSpec.describe Staging::StagedRequestsController do
     let(:review_by_project) { create(:review, by_project: staging_project) }
 
     before do
+      login(group.users.first)
       bs_request.staging_project = staging_project
       bs_request.reviews << review_by_project
       bs_request.save
       bs_request.change_review_state(:accepted, by_group: group.title, comment: 'accepted')
+      logout
     end
 
     context 'invalid user' do

--- a/src/api/spec/factories/bs_requests.rb
+++ b/src/api/spec/factories/bs_requests.rb
@@ -1,5 +1,14 @@
 FactoryBot.define do
   factory :bs_request do
+    # Monkeypatch how we create BsRequests to avoid errors caused by permission checks
+    # made in BsRequestPermissionCheck that depend on a logged in user.
+    to_create do |instance|
+      creator = User.find_by!(login: instance.creator)
+      creator.run_as do
+        instance.save!
+      end
+    end
+
     description { Faker::Lorem.paragraph }
     commenter do
       creator
@@ -98,10 +107,7 @@ FactoryBot.define do
       end
     end
 
-    after(:build) do |request, evaluator|
-      # Monkeypatch to avoid errors caused by permission checks made
-      # in user and bs_request model
-      User.session = evaluator.creating_user
+    after(:build) do |request|
       request[:state] ||= 'new'
     end
 

--- a/src/api/spec/factories/staging_workflow.rb
+++ b/src/api/spec/factories/staging_workflow.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :staging_workflow, class: 'Staging::Workflow' do
     project
-    association :managers_group, factory: :staging_workflow_group
+    association :managers_group, factory: :group_with_user
 
     after(:build) do |workflow|
       workflow.commit_user ||= build(:confirmed_user)

--- a/src/api/spec/jobs/bs_request_action_webui_infos_job_spec.rb
+++ b/src/api/spec/jobs/bs_request_action_webui_infos_job_spec.rb
@@ -48,7 +48,9 @@ RSpec.describe BsRequestActionWebuiInfosJob, type: :job, vcr: true do
                         target_project: 'does-not-exist',
                         target_package: target_package.name)
         request.skip_sanitize
-        request.save!
+        User.find_by!(login: request.creator).run_as do
+          request.save!
+        end
         request
       end
       let(:request_action) { request.bs_request_actions.first }
@@ -65,7 +67,9 @@ RSpec.describe BsRequestActionWebuiInfosJob, type: :job, vcr: true do
                         source_package: source_package.name,
                         target_package: target_package)
         request.skip_sanitize
-        request.save!
+        User.find_by!(login: request.creator).run_as do
+          request.save!
+        end
         request
       end
       let(:request_action) { request.bs_request_actions.first }

--- a/src/api/spec/models/bs_request_spec.rb
+++ b/src/api/spec/models/bs_request_spec.rb
@@ -712,7 +712,9 @@ RSpec.describe BsRequest, vcr: true do
     before do
       bs_request.skip_sanitize
       allow(bs_request).to receive(:sanitize!)
-      bs_request.save!
+      User.find_by!(login: bs_request.creator).run_as do
+        bs_request.save!
+      end
     end
 
     it { expect(bs_request).not_to have_received(:sanitize!) }


### PR DESCRIPTION
Do not set the session in a factory. Especially if you don't reset it afterward! This is something you should do inside your test. I ran into weird permission problems in another factory because User.session changed to some random user...
