### PR TITLE
[backend] bs_getbinariesproxy: clean up downloaded files if there is …

### DIFF
--- a/src/backend/bs_getbinariesproxy
+++ b/src/backend/bs_getbinariesproxy
@@ -302,44 +302,52 @@ sub getbinaries {
     push @args, "repository=$repoid";
     push @args, "arch=$arch";
     push @args, map {"module=$_"} @{$cgi->{'module'} || []};
-    my $res = BSRPC::rpc({
-      'uri' => "$server/getbinaries",
-      'directory' => $cachetmpdir,
-      'map' => $tmpprefix,
-      'timeout' => $gettimeout,
-      'receiver' => \&BSHTTP::cpio_receiver,
-    }, undef, @args, 'binaries='.join(',', @downloadbins));
-    my %havemeta;
-    for my $r (@$res) {
-      if ($r->{'name'} =~ /^\Q$tmpprefix\E(.*)\.($binsufsre)$/) {
-	my $n = $1;
-	my $suf = $2;
-	next unless $downloadbins{$n};
-	my @s = stat("$cachetmpdir/$r->{'name'}");
-	die unless @s;
-	my $id = Build::queryhdrmd5("$cachetmpdir/$r->{'name'}");
-	$r->{'hdrmd5'} = $id; 
-	if (!$metaonly && !$toomany) {
-	  my $fd = gensym;
-	  open($fd, '<', "$cachetmpdir/$r->{'name'}") || die;
-	  push @cpio, {'name' => "$n.$suf", 'filename' => $fd};
-	  $openfds++;
+    my $res;
+    eval {
+      $res = BSRPC::rpc({
+	'uri' => "$server/getbinaries",
+	'directory' => $cachetmpdir,
+	'map' => $tmpprefix,
+	'timeout' => $gettimeout,
+	'receiver' => \&BSHTTP::cpio_receiver,
+      }, undef, @args, 'binaries='.join(',', @downloadbins));
+      for my $r (@$res) {
+	if ($r->{'name'} =~ /^\Q$tmpprefix\E(.*)\.($binsufsre)$/) {
+	  my $n = $1;
+	  my $suf = $2;
+	  next unless $downloadbins{$n};
+	  my @s = stat("$cachetmpdir/$r->{'name'}");
+	  die unless @s;
+	  my $id = Build::queryhdrmd5("$cachetmpdir/$r->{'name'}");
+	  $r->{'hdrmd5'} = $id; 
+	  if (!$metaonly && !$toomany) {
+	    my $fd = gensym;
+	    open($fd, '<', "$cachetmpdir/$r->{'name'}") || die;
+	    push @cpio, {'name' => "$n.$suf", 'filename' => $fd};
+	    $openfds++;
+	  }
+	  my $cacheid =  Digest::MD5::md5_hex("$projid/$repoid/$arch/$id");
+	  push @cachenew, [$cacheid, $s[7], "$cachetmpdir/$r->{'name'}"];
+	} elsif ($r->{'name'} =~ /^\Q$tmpprefix\E(.*)\.meta$/) {
+	  my $n = $1;
+	  next unless $downloadbins{$n};
+	  if (!$nometa && !$toomany) {
+	    my $fd = gensym;
+	    open($fd, '<', "$cachetmpdir/$r->{'name'}") || die;
+	    push @cpio, {'name' => "$n.meta", 'filename' => $fd};
+	    $openfds++;
+	  }
 	}
-	my $cacheid =  Digest::MD5::md5_hex("$projid/$repoid/$arch/$id");
-	push @cachenew, [$cacheid, $s[7], "$cachetmpdir/$r->{'name'}"];
-      } elsif ($r->{'name'} =~ /^\Q$tmpprefix\E(.*)\.meta$/) {
-	my $n = $1;
-	next unless $downloadbins{$n};
-	if (!$nometa && !$toomany) {
-	  my $fd = gensym;
-	  open($fd, '<', "$cachetmpdir/$r->{'name'}") || die;
-	  push @cpio, {'name' => "$n.meta", 'filename' => $fd};
-	  $openfds++;
-	}
+	$toomany = 1 if $openfds + 16 > $maxopen;		# sorry
       }
-      $toomany = 1 if $openfds + 16 > $maxopen;		# sorry
+      manage_cache($cachesize, \@cacheold, \@cachenew);
+    };
+    if ($@) {
+      # clean up downloaded files
+      my $err = $@;
+      unlink("$cachetmpdir/$_") for grep {/^\Q$tmpprefix\E/} ls($cachetmpdir);
+      die($err);
     }
-    manage_cache($cachesize, \@cacheold, \@cachenew);
     # clean up
     for my $r (@$res) {
       unlink("$cachetmpdir/$r->{'name'}");


### PR DESCRIPTION
…a download error

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
