### PR TITLE
Fix some other RuboCop offenses with autocorrect

### DIFF
--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -352,17 +352,6 @@ RSpec/DescribedClass:
 RSpec/EmptyLineAfterFinalLet:
   Enabled: false
 
-# Offense count: 12
-# Cop supports --auto-correct.
-RSpec/EmptyLineAfterSubject:
-  Exclude:
-    - 'spec/models/backend_info_spec.rb'
-    - 'spec/models/bs_request/find_for/user_spec.rb'
-    - 'spec/models/bs_request_spec.rb'
-    - 'spec/models/download_repository_spec.rb'
-    - 'spec/models/review_spec.rb'
-    - 'spec/support/shared_examples/features/flags_tables.rb'
-
 # Offense count: 217
 # Configuration parameters: Max.
 RSpec/ExampleLength:

--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -385,17 +385,6 @@ RSpec/ExpectInHook:
     - 'spec/controllers/webui/project_controller_spec.rb'
     - 'spec/features/webui/projects_spec.rb'
 
-# Offense count: 7
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: implicit, each, example
-RSpec/HookArgument:
-  Exclude:
-    - 'spec/models/branch_package_spec.rb'
-    - 'spec/models/group_spec.rb'
-    - 'spec/rails_helper.rb'
-    - 'spec/support/database_cleaner.rb'
-
 # Offense count: 45
 # Configuration parameters: AssignmentOnly.
 RSpec/InstanceVariable:

--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -19,14 +19,6 @@ Capybara/CurrentPathExpectation:
 Capybara/FeatureMethods:
   Enabled: false
 
-# Offense count: 3
-# Cop supports --auto-correct.
-Layout/ClosingHeredocIndentation:
-  Exclude:
-    - 'db/seeds.rb'
-    - 'spec/helpers/webui/flash_helper_spec.rb'
-    - 'spec/models/project_spec.rb'
-
 # Offense count: 17
 # Cop supports --auto-correct.
 Layout/ClosingParenthesisIndentation:

--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -19,15 +19,6 @@ Capybara/CurrentPathExpectation:
 Capybara/FeatureMethods:
   Enabled: false
 
-# Offense count: 17
-# Cop supports --auto-correct.
-Layout/ClosingParenthesisIndentation:
-  Exclude:
-    - 'spec/controllers/webui/package_controller_spec.rb'
-    - 'spec/models/bs_request_spec.rb'
-    - 'test/unit/package_test.rb'
-    - 'test/unit/project_test.rb'
-
 # Offense count: 93
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.

--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -57,29 +57,10 @@ Layout/EndAlignment:
     - 'app/controllers/webui/webui_controller.rb'
     - 'app/models/obs_factory/distribution.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: squiggly, active_support, powerpack, unindent
-Layout/HeredocIndentation:
-  Exclude:
-    - 'spec/controllers/source_project_package_meta_controller_spec.rb'
-
 # Offense count: 19
 # Cop supports --auto-correct.
 Layout/LeadingEmptyLines:
   Enabled: false
-
-# Offense count: 6
-# Cop supports --auto-correct.
-# Configuration parameters: AllowForAlignment, EnforcedStyleForExponentOperator.
-# SupportedStylesForExponentOperator: space, no_space
-Layout/SpaceAroundOperators:
-  Exclude:
-    - 'spec/controllers/webui/search_controller_spec.rb'
-    - 'spec/features/webui/packages_spec.rb'
-    - 'test/functional/attributes_test.rb'
-    - 'test/functional/search_controller_test.rb'
 
 # Offense count: 23
 # Cop supports --auto-correct.

--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -59,13 +59,6 @@ Layout/EndAlignment:
 
 # Offense count: 1
 # Cop supports --auto-correct.
-# Configuration parameters: AllowForAlignment, AllowBeforeTrailingComments, ForceEqualSignAlignment.
-Layout/ExtraSpacing:
-  Exclude:
-    - 'test/functional/maintenance_test.rb'
-
-# Offense count: 1
-# Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: squiggly, active_support, powerpack, unindent
 Layout/HeredocIndentation:

--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -121,12 +121,6 @@ Lint/RedundantCopDisableDirective:
     - 'test/functional/read_permission_test.rb'
     - 'test/functional/zzz_post_consistency_test.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-Lint/RedundantCopEnableDirective:
-  Exclude:
-    - 'test/unit/schema_test.rb'
-
 # Offense count: 5
 Lint/RescueException:
   Exclude:

--- a/src/api/db/seeds.rb
+++ b/src/api/db/seeds.rb
@@ -38,7 +38,7 @@ Configuration.first_or_create(name: 'private', title: 'Open Build Service') do |
     <a href="http://wiki.opensuse.org/openSUSE:Build_Service_installations">this wiki page</a>.
     Have fun and fast build times!
   </p>
-EOT
+  EOT
 end
 
 puts 'Seeding roles table...'

--- a/src/api/spec/controllers/source_project_package_meta_controller_spec.rb
+++ b/src/api/spec/controllers/source_project_package_meta_controller_spec.rb
@@ -38,10 +38,10 @@ RSpec.describe SourceProjectPackageMetaController, vcr: true do
       let(:meta) do
         # rubocop: disable Layout/IndentHeredoc
         <<~META
-        <package name="foo" project="#{project_with_package.name}">
-          <title>My cool package</title>
-          <description/>
-        </package>
+          <package name="foo" project="#{project_with_package.name}">
+            <title>My cool package</title>
+            <description/>
+          </package>
         META
         # rubocop: enable Layout/IndentHeredoc
       end

--- a/src/api/spec/controllers/webui/package_controller_spec.rb
+++ b/src/api/spec/controllers/webui/package_controller_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe Webui::PackageController, vcr: true do
                  target_package: package.name,
                  type: 'submit',
                  source_rev: 2
-        )).to exist
+               )).to exist
       end
     end
 

--- a/src/api/spec/controllers/webui/search_controller_spec.rb
+++ b/src/api/spec/controllers/webui/search_controller_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Webui::SearchController, vcr: true do
       collection = file_fixture('owner_search_collection.xml').read
       stub_request(:post, "#{CONFIG['source_url']}/search/published/binary/id?match=(@name='package'%20and%20(@project='home:Iggy'))").and_return(body: collection)
       get :owner, params: { search_text: 'package', owner: 1 }
-      expect(assigns(:results)[0].users).to eq('maintainer'=>[user])
+      expect(assigns(:results)[0].users).to eq('maintainer' => [user])
     end
   end
 

--- a/src/api/spec/features/webui/packages_spec.rb
+++ b/src/api/spec/features/webui/packages_spec.rb
@@ -154,9 +154,9 @@ RSpec.feature 'Packages', type: :feature, js: true, vcr: true do
       stub_request(:get, result_path + "arch=i586&package=#{package}&repository=#{repository.name}&view=status")
         .and_return(body: result)
       stub_request(:get, "#{CONFIG['source_url']}/build/#{user.home_project}/#{repository.name}/i586/#{package}/_log?view=entry")
-        .and_return(headers: { 'Content-Type'=> 'text/plain' }, body: '<directory><entry size="1"/></directory>')
+        .and_return(headers: { 'Content-Type' => 'text/plain' }, body: '<directory><entry size="1"/></directory>')
       stub_request(:get, "#{CONFIG['source_url']}/build/#{user.home_project}/#{repository.name}/i586/#{package}/_log")
-        .and_return(headers: { 'Content-Type'=> 'text/plain' }, body: '[1] this is my dummy logfile -> ümlaut')
+        .and_return(headers: { 'Content-Type' => 'text/plain' }, body: '[1] this is my dummy logfile -> ümlaut')
       path = "#{CONFIG['source_url']}/build/#{user.home_project}/#{repository.name}/i586/_builddepinfo?package=#{package}&view=revpkgnames"
       stub_request(:get, path).and_return(body: '<builddepinfo />')
     end

--- a/src/api/spec/helpers/webui/flash_helper_spec.rb
+++ b/src/api/spec/helpers/webui/flash_helper_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Webui::FlashHelper do
             <li>error 2 content 2</li>
           </ul>
         </ul>
-       EOF
+      EOF
     end
 
     let(:flash) { 'example: \\n<i>error 1</i> <b>content</b>' }

--- a/src/api/spec/models/backend_info_spec.rb
+++ b/src/api/spec/models/backend_info_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe BackendInfo, type: :model do
 
   describe '.setter' do
     subject { BackendInfo.where(key: :lastnotification_nr).first.value.to_i }
+
     it 'will set the assigned value' do
       BackendInfo.lastnotification_nr = 100
       expect(subject).to eq(100)

--- a/src/api/spec/models/branch_package_spec.rb
+++ b/src/api/spec/models/branch_package_spec.rb
@@ -29,12 +29,12 @@ RSpec.describe BranchPackage, vcr: true do
       XML
     end
 
-    before(:each) do
+    before do
       login(user)
       update_project_attrib
     end
 
-    after(:each) do
+    after do
       Project.where('name LIKE ?', "#{user.home_project}:branches:%").destroy_all
     end
 

--- a/src/api/spec/models/bs_request/find_for/user_spec.rb
+++ b/src/api/spec/models/bs_request/find_for/user_spec.rb
@@ -114,12 +114,14 @@ RSpec.describe BsRequest::FindFor::User do
 
         context 'submitted as array' do
           subject { klass.new(user: user.login, review_states: [:accepted, :new]).all }
+
           it { expect(subject).to include(request) }
           it { expect(subject).to include(another_request) }
         end
 
         context 'submitted as symbol' do
           subject { klass.new(user: user.login, review_states: :accepted).all }
+
           it { expect(subject).to include(request) }
           it { expect(subject).not_to include(another_request) }
         end

--- a/src/api/spec/models/bs_request_spec.rb
+++ b/src/api/spec/models/bs_request_spec.rb
@@ -111,6 +111,7 @@ RSpec.describe BsRequest, vcr: true do
     end
 
     subject { Review.last }
+
     let(:history_element) { HistoryElement::RequestReviewAdded.last }
 
     it { expect(subject.state).to eq(:new) }

--- a/src/api/spec/models/bs_request_spec.rb
+++ b/src/api/spec/models/bs_request_spec.rb
@@ -557,7 +557,7 @@ RSpec.describe BsRequest, vcr: true do
                  target_package: target_package.name,
                  source_project: target_package.project.name,
                  source_package: target_package.name
-        )).to exist
+               )).to exist
       end
 
       it 'does not set the sourceupdate' do

--- a/src/api/spec/models/download_repository_spec.rb
+++ b/src/api/spec/models/download_repository_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe DownloadRepository do
   describe 'validations' do
     subject(:download_repository) { create(:download_repository) }
+
     it { is_expected.to validate_presence_of(:url) }
     it { is_expected.to validate_presence_of(:arch) }
     it { is_expected.to validate_presence_of(:repotype) }
@@ -16,6 +17,7 @@ RSpec.describe DownloadRepository do
 
     describe 'architecture_inclusion validation' do
       subject(:download_repository) { create(:download_repository) }
+
       it {
         expect { download_repository.update_attributes!(arch: 's390x') }.to raise_error(
           ActiveRecord::RecordInvalid, 'Validation failed: Architecture has to be available via repository association'

--- a/src/api/spec/models/group_spec.rb
+++ b/src/api/spec/models/group_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Group do
     end
 
     context 'with invalid user input' do
-      before(:each) do
+      before do
         group.users << user
         @before = group.users
       end

--- a/src/api/spec/models/project_spec.rb
+++ b/src/api/spec/models/project_spec.rb
@@ -223,7 +223,7 @@ RSpec.describe Project, vcr: true do
             <arch>x86_64</arch>
           </repository>
         </project>
-      XML_DATA
+        XML_DATA
       end
 
       before do

--- a/src/api/spec/models/review_spec.rb
+++ b/src/api/spec/models/review_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe Review do
     include_context 'some assigned reviews and some unassigned reviews'
 
     subject { Review.assigned }
+
     it { is_expected.to match_array([review_assigned1, review_assigned2]) }
   end
 
@@ -59,6 +60,7 @@ RSpec.describe Review do
     include_context 'some assigned reviews and some unassigned reviews'
 
     subject { Review.unassigned }
+
     it { is_expected.to match_array([review_unassigned1, review_unassigned2]) }
   end
 

--- a/src/api/spec/rails_helper.rb
+++ b/src/api/spec/rails_helper.rb
@@ -40,11 +40,11 @@ RSpec.configure do |config|
 
   # Wrap each test in Bullet api.
   if Bullet.enable?
-    config.before(:each) do
+    config.before do
       Bullet.start_request
     end
 
-    config.after(:each) do
+    config.after do
       Bullet.perform_out_of_channel_notifications if Bullet.notification?
       Bullet.end_request
     end

--- a/src/api/spec/support/database_cleaner.rb
+++ b/src/api/spec/support/database_cleaner.rb
@@ -14,7 +14,7 @@ RSpec.configure do |config|
     DatabaseCleaner.clean_with(:truncation, except: STATIC_TABLES)
   end
 
-  config.before(:each) do |example|
+  config.before do |example|
     # For feature test we use truncation instead of transactions because the
     # test suite and the capybara driver do not use the same server thread.
     if example.metadata[:type] == :feature || example.metadata[:type] == :migration || example.metadata[:thinking_sphinx] == true
@@ -40,7 +40,7 @@ RSpec.configure do |config|
     Configuration.update(allow_user_to_create_home_project: false)
   end
 
-  config.after(:each) do
+  config.after do
     DatabaseCleaner.clean
     User.session = nil
   end

--- a/src/api/spec/support/shared_examples/features/flags_tables.rb
+++ b/src/api/spec/support/shared_examples/features/flags_tables.rb
@@ -105,12 +105,14 @@ RSpec.shared_examples 'tests for sections with flag tables' do
     describe '#flag_table_build' do
       let(:flag_type) { 'build' }
       subject { find('#flag_table_build') }
+
       it_behaves_like 'a flag table'
     end
 
     describe '#flag_table_publish' do
       let(:flag_type) { 'publish' }
       subject { find('#flag_table_publish') }
+
       it_behaves_like 'a flag table'
     end
 
@@ -123,12 +125,14 @@ RSpec.shared_examples 'tests for sections with flag tables' do
       end
 
       subject { find('#flag_table_debuginfo') }
+
       it_behaves_like 'a flag table'
     end
 
     describe '#flag_table_useforbuild' do
       let(:flag_type) { 'useforbuild' }
       subject { find('#flag_table_useforbuild') }
+
       it_behaves_like 'a flag table'
     end
   end

--- a/src/api/test/functional/attributes_test.rb
+++ b/src/api/test/functional/attributes_test.rb
@@ -338,7 +338,7 @@ ription</description>
     assert_response :success
     get '/source/home:tom/_attribute/OBS:Maintained'
     assert_response :success
-    assert_equal({ 'attribute'=>{ 'name' => 'Maintained', 'namespace' => 'OBS' } }, Xmlhash.parse(@response.body))
+    assert_equal({ 'attribute' => { 'name' => 'Maintained', 'namespace' => 'OBS' } }, Xmlhash.parse(@response.body))
 
     get '/source/NOT_EXISTING/_attribute'
     assert_response 404
@@ -468,7 +468,7 @@ ription</description>
     assert_response :success
     get '/source/kde4/kdelibs/kdelibs-devel/_attribute/OBS:Maintained'
     assert_response :success
-    assert_equal({ 'attribute'=>{ 'name' => 'Maintained', 'namespace' => 'OBS', 'binary' => 'kdelibs-devel' } }, Xmlhash.parse(@response.body))
+    assert_equal({ 'attribute' => { 'name' => 'Maintained', 'namespace' => 'OBS', 'binary' => 'kdelibs-devel' } }, Xmlhash.parse(@response.body))
 
     get '/source/kde4/NOT_EXISTING/_attribute'
     assert_response 404

--- a/src/api/test/functional/maintenance_test.rb
+++ b/src/api/test/functional/maintenance_test.rb
@@ -2563,7 +2563,8 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     assert_not_nil srcmd5
     assert_equal originsrcmd5, srcmd5
     expectedvrev = "#{originvrev.to_i + 1}.1" # the origin gets incremented by one, but also extended to avoid that it can become
-    assert_equal expectedvrev, vrev.to_s        # newer than the origin project at any time later.
+    # newer than the origin project at any time later.
+    assert_equal expectedvrev, vrev.to_s
     assert_equal version, originversion
     assert_not_equal time, origintime
     assert_equal 'king', last_revision(history).value('user')

--- a/src/api/test/functional/search_controller_test.rb
+++ b/src/api/test/functional/search_controller_test.rb
@@ -376,7 +376,7 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
 
     get '/search/request', params: { match: "(action/target/@project='Apache' and action/@type='submit' and state/@name='review' ) or (action/target/@project='Apache' and action/@type='maintenance_release' and state/@name='review' )" }
     assert_response :success
-    assert_xml_tag tag: 'collection', attributes: { 'matches'=> '1' }
+    assert_xml_tag tag: 'collection', attributes: { 'matches' => '1' }
     assert_xml_tag tag: 'request', children: { count: 3, only: { tag: 'review' } }
 
     get '/search/request', params: { match: '[@id=1]' }

--- a/src/api/test/unit/package_test.rb
+++ b/src/api/test/unit/package_test.rb
@@ -144,7 +144,7 @@ class PackageTest < ActiveSupport::TestCase
                                    <description></description>
                                    <devel project='Notexistant'/>
                                  </package>"
-      ))
+                               ))
     end
     assert_raise Package::SaveError do
       @package.update_from_xml(Xmlhash.parse(
@@ -153,7 +153,7 @@ class PackageTest < ActiveSupport::TestCase
                                    <description></description>
                                    <devel project='home:Iggy' package='nothing'/>
                                  </package>"
-      ))
+                               ))
     end
 
     assert_raise NotFoundError do
@@ -163,7 +163,7 @@ class PackageTest < ActiveSupport::TestCase
                                    <description></description>
                                    <person userid='alice' role='maintainer'/>
                                  </package>"
-      ))
+                               ))
     end
 
     assert_raise HasRelationships::SaveError do
@@ -173,7 +173,7 @@ class PackageTest < ActiveSupport::TestCase
                                    <description></description>
                                    <person userid='tom' role='coolman'/>
                                  </package>"
-      ))
+                               ))
     end
 
     assert_equal orig, Xmlhash.parse(@package.to_axml)
@@ -184,7 +184,7 @@ class PackageTest < ActiveSupport::TestCase
                                         <person userid='fred' role='bugowner'/>
                                         <person userid='Iggy' role='maintainer'/>
                                       </package>"
-    ))
+                                    ))
   end
 
   def test_add_user

--- a/src/api/test/unit/project_test.rb
+++ b/src/api/test/unit/project_test.rb
@@ -389,7 +389,7 @@ class ProjectTest < ActiveSupport::TestCase
                                <arch>i586</arch>
                              </repository>
                            </project>"
-    ))
+                         ))
 
     xml = prj.to_axml
     assert_xml_tag xml, tag: :download, attributes: { arch: 'i586', url: 'http://me.org', repotype: 'rpmmd' }
@@ -441,7 +441,7 @@ class ProjectTest < ActiveSupport::TestCase
                              <description/>
                              <repository name='sp0_ga' />
                            </project>"
-    ))
+                         ))
     prj = Project.new(name: 'Enterprise-SP0:Update')
     prj.update_from_xml!(Xmlhash.parse(
                            "<project name='Enterprise-SP0:Update' kind='maintenance_release'>
@@ -451,7 +451,7 @@ class ProjectTest < ActiveSupport::TestCase
                                <path project='Enterprise-SP0:GA' repository='sp0_ga' />
                              </repository>
                            </project>"
-    ))
+                         ))
     prj = Project.new(name: 'Enterprise-SP1:GA')
     prj.update_from_xml!(Xmlhash.parse(
                            "<project name='Enterprise-SP1:GA'>
@@ -461,7 +461,7 @@ class ProjectTest < ActiveSupport::TestCase
                                <path project='Enterprise-SP0:GA' repository='sp0_ga' />
                              </repository>
                            </project>"
-    ))
+                         ))
     prj = Project.new(name: 'Enterprise-SP1:Update')
     prj.update_from_xml!(Xmlhash.parse(
                            "<project name='Enterprise-SP1:Update' kind='maintenance_release'>
@@ -472,7 +472,7 @@ class ProjectTest < ActiveSupport::TestCase
                                <path project='Enterprise-SP0:Update' repository='sp0_update' />
                              </repository>
                            </project>"
-    ))
+                         ))
     prj = Project.new(name: 'Enterprise-SP1:Channel:Server')
     prj.update_from_xml!(Xmlhash.parse(
                            "<project name='Enterprise-SP1:Channel:Server'>
@@ -482,7 +482,7 @@ class ProjectTest < ActiveSupport::TestCase
                                <path project='Enterprise-SP1:Update' repository='sp1_update' />
                              </repository>
                            </project>"
-    ))
+                         ))
     # this is what the classic add_repository call is producing:
     prj = Project.new(name: 'My:Branch')
     prj.update_from_xml!(Xmlhash.parse(
@@ -499,7 +499,7 @@ class ProjectTest < ActiveSupport::TestCase
                                <path project='Enterprise-SP1:Update' repository='sp1_update' />
                              </repository>
                            </project>"
-    ))
+                         ))
     # however, this is not correct, because my:branch (or an incident)
     # is providing in this situation often a package in SP0:Update which
     # must be used for building the package in sp1 repo.
@@ -564,7 +564,7 @@ class ProjectTest < ActiveSupport::TestCase
                                <title/>
                                <description/>
                              </project>"
-    ))
+                           ))
     prj_a.save!
     prj_b = Project.new(name: 'Project:B')
     prj_b.update_from_xml!(Xmlhash.parse(
@@ -573,7 +573,7 @@ class ProjectTest < ActiveSupport::TestCase
                                <description/>
                                <link project='Project:A'/>
                              </project>"
-    ))
+                           ))
     prj_b.save!
     prj_a.update_from_xml!(Xmlhash.parse(
                              "<project name='Project:A'>
@@ -581,7 +581,7 @@ class ProjectTest < ActiveSupport::TestCase
                                <description/>
                                <link project='Project:B'/>
                              </project>"
-    ))
+                           ))
     prj_a.save!
 
     assert_equal [], prj_a.expand_all_packages

--- a/src/api/test/unit/schema_test.rb
+++ b/src/api/test/unit/schema_test.rb
@@ -20,7 +20,6 @@ class SchemaTest < ActiveSupport::TestCase
       testresult = io.read
       io.close
       assert $CHILD_STATUS == 0, "#{testfile} does not validate against #{f} -> #{testresult}"
-      # rubocop:enable Style/NumericPredicate
     end
   end
 end


### PR DESCRIPTION
Fix some RuboCop cops' offenses with: rake task dev:lint:rubocop:auto_correct. These RuboCop cops' offenses are not related with style cops.