### PR TITLE
Enable responsive_ux for development environment

### DIFF
--- a/src/api/lib/tasks/dev.rake
+++ b/src/api/lib/tasks/dev.rake
@@ -55,8 +55,8 @@ namespace :dev do
       puts 'Configure default signing'
       Rake::Task['assets:clobber'].invoke
       ::Configuration.update(enforce_project_keys: true)
-      # we enable bootstrap as default
-      Flipper[:bootstrap].enable
+      # we enable responsive_ux as default
+      Flipper[:responsive_ux].enable
     end
   end
 


### PR DESCRIPTION
As default the development environment will be running with `responsive_ux`
toggle enabled.