### PR TITLE
start storing build stats whenever possible.

### DIFF
--- a/src/backend/BSSched/BuildJob.pm
+++ b/src/backend/BSSched/BuildJob.pm
@@ -774,7 +774,7 @@ sub addbuildstats {
   my $lay = $BSXML::buildstatslay;
   my $bstat_ = flat_hash('stats_buildstatistics', $bstat);
   my $jobhist_ = flat_hash('stats', $jobhist);
-  BSFileDB::fdb_add("$dst/stats", $lay, {%$jobhist_, %$bstat_});
+  BSFileDB::fdb_add("$dst/.stats", $lay, {%$jobhist_, %$bstat_});
 }
 
 =head2 makejobhist - return jobhistlay comaptible hash

--- a/src/backend/BSSched/BuildResult.pm
+++ b/src/backend/BSSched/BuildResult.pm
@@ -440,7 +440,7 @@ sub update_dst_full {
   } elsif ($new_full_handling || !$importarch) {
     # get old state: oldfiles, oldbininfo, oldrepo
     my @oldfiles = sort(ls($dst));
-    @oldfiles = grep {$_ ne 'stats' && $_ ne 'history' && $_ ne 'logfile' && $_ ne 'meta' && $_ ne 'status' && $_ ne 'reason' && $_ ne '.bininfo' && $_ ne '.meta.success'} @oldfiles;
+    @oldfiles = grep {$_ ne '.stats' && $_ ne 'history' && $_ ne 'logfile' && $_ ne 'meta' && $_ ne 'status' && $_ ne 'reason' && $_ ne '.bininfo' && $_ ne '.meta.success'} @oldfiles;
     mkdir_p($dst);
     my $oldbininfo = read_bininfo($dst);
     delete $oldbininfo->{'.bininfo'};   # delete new version marker

--- a/src/backend/BSSched/BuildResult.pm
+++ b/src/backend/BSSched/BuildResult.pm
@@ -440,7 +440,7 @@ sub update_dst_full {
   } elsif ($new_full_handling || !$importarch) {
     # get old state: oldfiles, oldbininfo, oldrepo
     my @oldfiles = sort(ls($dst));
-    @oldfiles = grep {$_ ne 'history' && $_ ne 'logfile' && $_ ne 'meta' && $_ ne 'status' && $_ ne 'reason' && $_ ne '.bininfo' && $_ ne '.meta.success'} @oldfiles;
+    @oldfiles = grep {$_ ne 'stats' && $_ ne 'history' && $_ ne 'logfile' && $_ ne 'meta' && $_ ne 'status' && $_ ne 'reason' && $_ ne '.bininfo' && $_ ne '.meta.success'} @oldfiles;
     mkdir_p($dst);
     my $oldbininfo = read_bininfo($dst);
     delete $oldbininfo->{'.bininfo'};   # delete new version marker

--- a/src/backend/BSSched/PublishRepo.pm
+++ b/src/backend/BSSched/PublishRepo.pm
@@ -204,7 +204,7 @@ sub prpfinished {
     next if $all{'.preinstallimage'};
     my $debian = grep {/\.dsc$/} @all;
     my $nosourceaccess = $all{'.nosourceaccess'};
-    @all = grep {$_ ne 'stats' && $_ ne 'history' && $_ ne 'logfile' && $_ ne 'rpmlint.log' && $_ ne '_statistics' && $_ ne '_buildenv' && $_ ne '_channel' && $_ ne 'meta' && $_ ne 'status' && $_ ne 'reason' && !/^\./} @all;
+    @all = grep {$_ ne '.stats' && $_ ne 'history' && $_ ne 'logfile' && $_ ne 'rpmlint.log' && $_ ne '_statistics' && $_ ne '_buildenv' && $_ ne '_channel' && $_ ne 'meta' && $_ ne 'status' && $_ ne 'reason' && !/^\./} @all;
     my $taken;
     for my $bin (@all) {
       next if $bin =~ /^::import::/;

--- a/src/backend/BSSched/PublishRepo.pm
+++ b/src/backend/BSSched/PublishRepo.pm
@@ -204,7 +204,7 @@ sub prpfinished {
     next if $all{'.preinstallimage'};
     my $debian = grep {/\.dsc$/} @all;
     my $nosourceaccess = $all{'.nosourceaccess'};
-    @all = grep {$_ ne 'history' && $_ ne 'logfile' && $_ ne 'rpmlint.log' && $_ ne '_statistics' && $_ ne '_buildenv' && $_ ne '_channel' && $_ ne 'meta' && $_ ne 'status' && $_ ne 'reason' && !/^\./} @all;
+    @all = grep {$_ ne 'stats' && $_ ne 'history' && $_ ne 'logfile' && $_ ne 'rpmlint.log' && $_ ne '_statistics' && $_ ne '_buildenv' && $_ ne '_channel' && $_ ne 'meta' && $_ ne 'status' && $_ ne 'reason' && !/^\./} @all;
     my $taken;
     for my $bin (@all) {
       next if $bin =~ /^::import::/;

--- a/src/backend/BSXML.pm
+++ b/src/backend/BSXML.pm
@@ -1801,6 +1801,75 @@ our $buildstatistics = [
       ],
 ];
 
+# This array is an outcome of following perl snippet
+# our $buildstatslay = [
+#     'stats' =>
+#        $buildstatistics,
+#        @$jobhistlay,
+# ];
+# 
+#  
+# sub flat_arr {
+#     my $first = shift @_;
+#     return [] if ! defined($first);
+#     my $second = [map { ref eq 'ARRAY' ? @{flat_arr(@$_)} : $_ } @_];
+#     return [map { join '_',$first, $_  } @$second];
+# }
+#
+# $buildstatslay = flat_arr(@$buildstatslay)
+#  
+# adding new elements to the buildstatistics array should get a new entry in this array 
+# otherwise that entry will not saved to the stats file 
+
+
+our $buildstatslay = [
+    'stats_buildstatistics_disk_usage_size_unit',
+    'stats_buildstatistics_disk_usage_size__content',
+    'stats_buildstatistics_disk_usage_io_requests',
+    'stats_buildstatistics_disk_usage_io_sectors',
+    'stats_buildstatistics_memory_usage_size_unit',
+    'stats_buildstatistics_memory_usage_size__content',
+    'stats_buildstatistics_times_total_time_unit',
+    'stats_buildstatistics_times_total_time__content',
+    'stats_buildstatistics_times_preinstall_time_unit',
+    'stats_buildstatistics_times_preinstall_time__content',
+    'stats_buildstatistics_times_install_time_unit',
+    'stats_buildstatistics_times_install_time__content',
+    'stats_buildstatistics_times_main_time_unit',
+    'stats_buildstatistics_times_main_time__content',
+    'stats_buildstatistics_times_postchecks_time_unit',
+    'stats_buildstatistics_times_postchecks_time__content',
+    'stats_buildstatistics_times_rpmlint_time_unit',
+    'stats_buildstatistics_times_rpmlint_time__content',
+    'stats_buildstatistics_times_buildcmp_time_unit',
+    'stats_buildstatistics_times_buildcmp_time__content',
+    'stats_buildstatistics_times_deltarpms_time_unit',
+    'stats_buildstatistics_times_deltarpms_time__content',
+    'stats_buildstatistics_times_download_time_unit',
+    'stats_buildstatistics_times_download_time__content',
+    'stats_buildstatistics_download_size_unit',
+    'stats_buildstatistics_download_size__content',
+    'stats_buildstatistics_download_binaries',
+    'stats_buildstatistics_download_cachehits',
+    'stats_buildstatistics_download_preinstallimage',
+    'stats_package',
+    'stats_rev',
+    'stats_srcmd5',
+    'stats_versrel',
+    'stats_bcnt',
+    'stats_readytime',
+    'stats_starttime',
+    'stats_endtime',
+    'stats_code',
+    'stats_uri',
+    'stats_workerid',
+    'stats_hostarch',
+    'stats_reason',
+    'stats_verifymd5'
+];
+
+
+
 our $notifications = [
     'notifications' =>
 	'next',

--- a/src/backend/bs_check_consistency
+++ b/src/backend/bs_check_consistency
@@ -262,6 +262,8 @@ sub check_package_dir {
       # unchecked for now
     } elsif ($ent eq "_statistics") {
       # unchecked for now
+    } elsif ($ent eq ".stats") {
+      # unchecked for now
     } elsif ($ent eq "_buildenv") {
       # unchecked for now
     } elsif ($ent eq "_channel") {


### PR DESCRIPTION
THe stats are stored in the simple file format, so external processsing
can be easy. This allows changes to the format and structure. The
xml from _statistics file parsed into an hash and is flattened into an
array. This xml template used to parse the _statistics file is also
flattened into an array. This array acts as an overlay to store the
stats.
Since the same xml template is used to parse xml and as layout of
storage, this patch acts like a converter from xml to tabular format.

A simple and implementation independent file format is chosen to allow
easy enhancement to the schema without affecting the application code

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
