### PR TITLE
[backend] support milestone publishing using macros

### DIFF
--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -1634,14 +1634,16 @@ sub deleterepo {
 }
 
 sub mapsleimage {
-  my ($rdir, $rbin, $p, $media) = @_;
+  my ($config, $rdir, $rbin, $p, $media) = @_;
   if ($p =~ /-Build\d+/) {
     $rbin =~ s/\.sha256$//;
-    $rbin =~ s/\.xz$//;
-    $rbin =~ s/\.(iso|packages|raw|qcow2|vhdx|vmdk|vagrant\..*\.box)$//;
+    $rbin =~ s/\.(?:bz2|gz|xz|zst)$//;
+    $rbin =~ s/\.(iso|packages|raw|tbz|tgz|tar|qcow2|vhdx|vmdk|vagrant\..*\.box)$//;
     my $milestone = readstr("$rdir/$rbin.milestone", 1);
     chomp $milestone;
     $milestone ||= 'GM';
+    $milestone = Build::Rpm::expandmacros($config, $milestone) if $milestone =~ /%/;
+    $milestone =~ s/[\/\n]/_/sg;
     $p =~ s/-Build\d+(\.\d+)?/-$milestone/;
   }
   $p =~ s/-Media/-DVD/ if $media eq 'dvd';
@@ -1907,13 +1909,13 @@ sub publish {
 	if ($bin =~ /\.iso(?:\.sha256)?$/) {
 	  $p = "iso/$bin";
 	  $kiwimedium = "$arch/$1" if $bin =~ /(.+)\.iso$/;
-	  $p = mapsleimage("$reporoot/$prp/$arch/:repo", $rbin, $p, $sleimage) if $sleimage;
+    	  $p = mapsleimage($config, "$reporoot/$prp/$arch/:repo", $rbin, $p, $sleimage) if $sleimage;
 	} elsif ($bin =~ /ONIE\.bin(?:\.sha256)?$/) {
 	  $p = "onie/$bin";
 	  $kiwimedium = "$arch/$1" if $bin =~ /(.+)ONIE\.bin$/;
 	} elsif ($bin =~ /\.raw(?:\.install)?(?:\.(?:gz|bz2|xz))?(?:\.sha256)?$/) {
 	  $p = $bin;
-	  $p = mapsleimage("$reporoot/$prp/$arch/:repo", $rbin, $p, $sleimage) if $sleimage;
+	  $p = mapsleimage($config, "$reporoot/$prp/$arch/:repo", $rbin, $p, $sleimage) if $sleimage;
 	} elsif ($bin =~ /\.containerinfo$/) {
 	  # handle the case where there is a containerinfo with no tar file
 	  my @s = stat("$r/$bin");
@@ -1951,7 +1953,7 @@ sub publish {
 	      undef $containerinfo if $3;
 	    }
 	  } else {
-	    $p = mapsleimage("$reporoot/$prp/$arch/:repo", $rbin, $p, $sleimage) if $sleimage;
+	    $p = mapsleimage($config, "$reporoot/$prp/$arch/:repo", $rbin, $p, $sleimage) if $sleimage;
 	  }
 	} elsif ($bin =~ /(.*)\.tar(?:\.(?:gz|bz2|xz))?(\.sha256)?$/) {
           # Dockerfile case
@@ -1987,10 +1989,10 @@ sub publish {
         } elsif ($bin =~ /^(.*)\.(?:box|json|ovf|phar|qcow2|vdi|vhdfixed|vmx|vmdk|vhdx)(?:\.xz)?(\.sha256)?$/) {
 	  $p = $bin;
           $kiwimedium = "$arch/$1" if !$2 && -e "$r/$1.packages";
-          $p = mapsleimage("$reporoot/$prp/$arch/:repo", $rbin, $p, $sleimage) if $sleimage;
+          $p = mapsleimage($config, "$reporoot/$prp/$arch/:repo", $rbin, $p, $sleimage) if $sleimage;
         } elsif ($bin =~ /\.packages$/) {
 	  $p = $bin;
-	  $p = mapsleimage("$reporoot/$prp/$arch/:repo", $rbin, $p, $sleimage) if $sleimage;
+	  $p = mapsleimage($config, "$reporoot/$prp/$arch/:repo", $rbin, $p, $sleimage) if $sleimage;
         } elsif ($bin =~ /^(.*)\.report$/) {
 	  # collect reports
 	  $kiwireport{"$arch/$1"} = readxml("$r/$rbin", $BSXML::report, 1) if $do_packtrack;


### PR DESCRIPTION
Makes it possible to define project global milestones in prjconf

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
