### PR TITLE
[backend] add support for buildflags:obsgendiff for diff generation

### DIFF
--- a/src/backend/BSSched/BuildJob.pm
+++ b/src/backend/BSSched/BuildJob.pm
@@ -1097,6 +1097,9 @@ sub create {
     my $genbuildreqs = ($ctx->{'genbuildreqs'} || {})->{$packid};
     $binfo->{'logidlelimit'} = $bconf->{'buildflags:logidlelimit'} if $bconf->{'buildflags:logidlelimit'};
     $binfo->{'genbuildreqs'} = $genbuildreqs->[0] if $genbuildreqs;
+    if ($bconf->{'buildflags:obsgendiff'} && @{$ctx->{'repo'}->{'releasetarget'} || []}) {
+      $binfo->{'obsgendiff'} = $ctx->{'repo'}->{'releasetarget'}->[0];
+    }
   }
   $ctx->writejob($job, $binfo, $reason);
 

--- a/src/backend/BSXML.pm
+++ b/src/backend/BSXML.pm
@@ -546,6 +546,10 @@ our $buildinfo = [
 	'logidlelimit',	# internal
 	'logsizelimit',	# internal
 	'genbuildreqs',	# internal
+      [ 'obsgendiff' =>
+	    'project',
+	    'package',
+      ],		# internal
       [ 'dep' ],
      [[ 'bdep' =>
 	'name',

--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -1780,6 +1780,17 @@ sub getpreinstallimageinfos {
   return ($answer, 'Content-Type: application/octet-stream');
 }
 
+sub getobsgendiffdata {
+  my ($cgi, $projid, $repoid, $arch) = @_;
+  my $dir = "$reporoot/$projid/$repoid/$arch/:repo";
+  my @files;
+  for my $f (grep {/[^\.].*\.obsgendiff$/} sort(ls($dir))) {
+    push @files, {'name' => $f, 'filename' => "$dir/$f"};
+  }
+  BSWatcher::reply_cpio(\@files);
+  return undef;
+}
+
 sub dirty {
   my ($projid, $repoid, $arch) = @_;
 
@@ -4323,6 +4334,7 @@ my $dispatches = [
   '!worker /getpackagebinaryversionlist $project $repository $arch $package* withcode:bool? workerid?' => \&getpackagebinaryversionlist,
   '!worker /badpackagebinaryversionlist $project $repository $arch $package* workerid?' => \&badpackagebinaryversionlist,
   '!worker /getpreinstallimageinfos $prpa+ match:? workerid?' => \&getpreinstallimageinfos,
+  '/getobsgendiffdata $project $repository $arch workerid?' => \&getobsgendiffdata,
 
   # published files
   '/published' => \&publisheddir,

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -5403,6 +5403,19 @@ sub worker_getbinaryversions {
   return ($bvl, $BSXML::binaryversionlist);
 }
 
+sub getobsgendiffdata {
+  my ($cgi, $projid, $repoid, $arch) = @_;
+  checkprojrepoarch($projid, $repoid, $arch);
+  my $reposerver = $BSConfig::partitioning ? BSSrcServer::Partition::projid2reposerver($projid) : $BSConfig::reposerver;
+  my $param = {
+    'uri' => "$reposerver/getobsgendiffdata",
+    'ignorestatus' => 1,
+    'receiver' => \&BSServer::reply_receiver,
+  };
+  BSWatcher::rpc($param, undef, BSRPC::args($cgi, 'project', 'repository', 'arch', 'workerid'));
+  return undef;
+}
+
 ####################################################################
 
 # this is shared for AJAX requests
@@ -6647,6 +6660,7 @@ my $dispatches = [
   '/getsslcert $project autoextend:bool? workerid? signtype:?' => \&getsslcert,
   '/getbinaries $project $repository $arch binaries: nometa:bool? workerid? module*' => \&worker_getbinaries,
   '/getbinaryversions $project $repository $arch binaries: nometa:bool? workerid? module*' => \&worker_getbinaryversions,
+  '/getobsgendiffdata $project $repository $arch workerid?' => \&getobsgendiffdata,
 
   # publisher/signer calls
   '/getsignkey $project withpubkey:bool? autoextend:bool? withalgo:bool?' => \&getsignkey,

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -1084,6 +1084,19 @@ sub getfollowupsources {
   }, undef, "rev=$buildinfo->{'srcmd5'}");
 }
 
+sub getobsgendiffdata {
+  my ($buildinfo, $dir) = @_;
+  my $obsgendiff = $buildinfo->{'obsgendiff'};
+  return undef unless $obsgendiff;
+  my $server = $buildinfo->{'srcserver'} || $srcserver;
+  my $res = BSRPC::rpc({
+    'uri' => "$server/getobsgendiffdata",
+    'directory' => $dir,
+    'timeout' => $gettimeout,
+  }, $BSXML::dir, "project=$obsgendiff->{'project'}", "repository=$obsgendiff->{'repository'}", "arch=$buildinfo->{'arch'}", "jobid=$buildinfo->{'jobid'}");
+  return $res;
+}
+
 sub getsslcert {
   my ($buildinfo, $dir, $signtype) = @_;
   my $server = $buildinfo->{'srcserver'} || $srcserver;
@@ -3037,6 +3050,7 @@ sub dobuild {
 	close F;
       }
     }
+    getobsgendiffdata($buildinfo, $srcdir) if $buildinfo->{'obsgendiff'};
     getsslcert($buildinfo, $srcdir, $needappxsslcert ? 'appx' : undef) if $needsslcert || $needappxsslcert;
     readbuildenv($buildinfo, $srcdir);
     print "packages, ";


### PR DESCRIPTION
If the "obsgendiff" build flag is set and the repository has at
least one release target, we get all published files with the
suffix ".obsgendiff" from the first target.

It is up to the build job to do the diff and create new .obsgendiff
files.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
