### PR TITLE
WorkerStatus refactoring

### DIFF
--- a/src/api/app/queries/project_names_finder.rb
+++ b/src/api/app/queries/project_names_finder.rb
@@ -1,0 +1,10 @@
+class ProjectNamesFinder
+  def initialize(projects, relation = Project.all)
+    @relation = relation
+    @projects = projects
+  end
+
+  def call
+    @relation.where(name: @projects).pluck(:name)
+  end
+end

--- a/src/api/spec/models/worker_status_spec.rb
+++ b/src/api/spec/models/worker_status_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+RSpec.describe WorkerStatus do
+  describe '.hidden' do
+    before do
+      allow(Backend::Api::BuildResults::Worker).to receive(:status).and_return(xml_response)
+    end
+
+    subject { Xmlhash.parse(WorkerStatus.hidden.to_xml) }
+
+    context 'no hidden project' do
+      let(:project) { create(:project_with_repository, name: 'openSUSE:Factory') }
+      let(:xml_response) do
+        <<-HEREDOC
+          <workerstatus clients="1">
+          <building workerid="build01/2" hostarch="i586" project="#{project.name}" repository="nada" package="bdpack" arch="i586" starttime="0" />
+          <waiting arch="i586" jobs="1" />
+          <buildavg arch="i586" buildavg="1200" />
+          <partition>
+            <daemon type="scheduler" arch="i586" state="dead">
+            <queue high="0" med="0" low="3" next="0" />
+            </daemon>
+            <daemon type="publisher" state="dead" />
+          </partition>
+          </workerstatus>
+        HEREDOC
+      end
+
+      it { expect(subject['building']['project']).to eq(project.name) }
+    end
+
+    context 'XPATH filter matches more projects' do
+      let(:xml_response) do
+        <<-HEREDOC
+          <workerstatus clients="1">
+          <building workerid="build01/2" hostarch="i586" project="BinaryprotectedProject" repository="nada" package="bdpack" arch="i586" starttime="0" />
+          <waiting arch="i586" jobs="1" />
+          <buildavg arch="i586" buildavg="1200" />
+          <partition>
+            <daemon type="scheduler" arch="i586" state="dead">
+            <queue high="0" med="0" low="3" next="0" />
+            </daemon>
+            <daemon type="publisher" state="dead" />
+          </partition>
+          </workerstatus>
+        HEREDOC
+      end
+
+      it { expect(subject['building']['project']).to eq('---') }
+    end
+
+    context 'project name is hidden' do
+      let(:xml_response) do
+        <<-HEREDOC
+          <workerstatus clients="1">
+          <building workerid="build01/2" hostarch="i586" project="BinaryprotectedProject" repository="nada" package="bdpack" arch="i586" starttime="0" />
+          <building workerid="build01/3" hostarch="i586" project="BinaryprotectedProject" repository="nada" package="bdpack" arch="i586" starttime="0" />
+          <building workerid="build01/4" hostarch="i586" project="BinaryprotectedProject" repository="nada" package="bdpack" arch="i586" starttime="0" />
+          <building workerid="build01/5" hostarch="i586" project="BinaryprotectedProject" repository="nada" package="bdpack" arch="i586" starttime="0" />
+          <waiting arch="i586" jobs="1" />
+          <buildavg arch="i586" buildavg="1200" />
+          <partition>
+            <daemon type="scheduler" arch="i586" state="dead">
+            <queue high="0" med="0" low="3" next="0" />
+            </daemon>
+            <daemon type="publisher" state="dead" />
+          </partition>
+          </workerstatus>
+        HEREDOC
+      end
+
+      it { expect(subject['building'].count).to eq(4) }
+      it { expect(subject['building'].map { |x| x['project'] }).to all(eq('---')) }
+    end
+  end
+end


### PR DESCRIPTION
Related with https://github.com/openSUSE/open-build-service/pull/9010

Refactoring and improvements being done in the model `WorkerStatus`:

- Focus on the method `WorkerStatus.hidden`
- Added spec for it
- Extracted sql query to a query object
- Instead of loop through all entries on worker_status trying to match for a name, filter the results using "XML XPATH"
- Extract small methods from it
