### PR TITLE
adding appstream.xml and appstream-icons to match appstream-generator requirements

### DIFF
--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -659,7 +659,10 @@ sub createrepo_rpmmd {
     if (-e "$extrep/repodata/appdata.xml") {
       print "    adding appdata.xml to repodata\n";
       qsystem($modifyrepo_bin, "$extrep/repodata/appdata.xml", "$extrep/repodata", @legacyargs) && die("    modifyrepo failed: $?\n");
-      unlink("$extrep/repodata/appdata.xml");
+      rename("$extrep/repodata/appdata.xml", "$extrep/repodata/appstream.xml");
+      print "    adding appstream.xml to repodata\n";
+      qsystem($modifyrepo_bin, "$extrep/repodata/appstream.xml", "$extrep/repodata", @legacyargs) && die("    modifyrepo failed: $?\n");
+      unlink("$extrep/repodata/appstream.xml");
     }
     if (-e "$extrep/repodata/app-icons.tar") {
       print "    adding app-icons.tar to repodata\n";
@@ -667,7 +670,10 @@ sub createrepo_rpmmd {
       rename("$extrep/repodata/app-icons.tar", "$extrep/repodata/appdata-icons.tar");
       print "    adding appdata-icons.tar to repodata\n";
       qsystem($modifyrepo_bin, "$extrep/repodata/appdata-icons.tar", "$extrep/repodata", @legacyargs) && die("    modifyrepo failed: $?\n");
-      unlink("$extrep/repodata/appdata-icons.tar");
+      rename("$extrep/repodata/appdata-icons.tar", "$extrep/repodata/appstream-icons.tar");
+      print "    adding appstream-icons.tar to repodata\n";
+      qsystem($modifyrepo_bin, "$extrep/repodata/appstream-icons.tar", "$extrep/repodata", @legacyargs) && die("    modifyrepo failed: $?\n");
+      unlink("$extrep/repodata/appstream-icons.tar");
     }
   }
 


### PR DESCRIPTION
Fixing publisher code to also generate the appstream.xml and appstream-icons.gz files, to match what appstream-generator and everything that uses appdata look for (like Gnome Software) in recent releases.
We're also changing the way Leap 15.2 and Tumbleweed look for appdata to match this, as proposed in https://github.com/DimStar77/openSUSE-appstream/pull/2

As discussed in https://github.com/openSUSE/open-build-service/issues/8999 .
