### PR TITLE
[backend] fix handling of marked-as-done events in bs_redis

### DIFF
--- a/src/backend/bs_redis
+++ b/src/backend/bs_redis
@@ -155,6 +155,10 @@ sub forwarddata {
     my $len = length($_);
     die("bad line\n") unless chop($_) eq "\n";
     my @line = split('\|', $_);
+    if (!@line || !$line[0]) {
+      $markoff += $len;		# empty or marked as done
+      next;
+    }
     next unless @line && $line[0];
     s/%([a-fA-F0-9]{2})/chr(hex($1))/ge for @line;
     my $cmd = shift @line;
@@ -163,6 +167,7 @@ sub forwarddata {
     if ($cmd eq 'deleteresult') {
       unshift @line, 'EVAL', $lua_deleteresult, 2, "result.$prpa", "jobs.$prpa";
     } elsif ($cmd eq 'updateresult') {
+      die("odd number of arguments in $cmd\n") if scalar(@line) % 2;
       if (@line) {
         unshift @line, 'EVAL', $lua_updateresult, 2, "result.$prpa", "jobs.$prpa";
       } else {


### PR DESCRIPTION
We did not account for the length of such events, leading to
corrupt data if another error happened.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
