### PR TITLE
Provide the url to get the required data for the form prefilling

### DIFF
--- a/src/api/app/views/webui/package/_revision_diff_footer.html.haml
+++ b/src/api/app/views/webui/package/_revision_diff_footer.html.haml
@@ -9,7 +9,11 @@
 - if submit_message && show_link
   %ul.list-inline
     %li.list-inline-item
-      = link_to('#', class: 'nav-link', data: { toggle: 'modal', target: '#submit-request-modal' }) do
+      = link_to('#',
+          class: 'nav-link',
+          data: { toggle: 'modal',
+                  target: '#submit-request-modal',
+                  url: package_branch_diff_info_path(project.name, package.name) }) do
         %i.fas.fa-share-square.text-warning
         = submit_message
 


### PR DESCRIPTION
The url to ask the data to prefill was not provided and so the form was unable to work properly.

Fixes #7551

Here is a screenshot of how it looks:

Note the target project, target package, supersede request check and package clean up check in the screenshots below

**Before**
![image](https://user-images.githubusercontent.com/2650/73667425-877e3e80-46a4-11ea-99db-cdefbfc51f20.png)


**After**
![image](https://user-images.githubusercontent.com/2650/73667373-76353200-46a4-11ea-8b17-59262a8de8a3.png)

