### PR TITLE
[backend] get obsgendiff working

### DIFF
--- a/src/backend/BSSched/BuildJob.pm
+++ b/src/backend/BSSched/BuildJob.pm
@@ -1162,7 +1162,9 @@ sub create {
     $binfo->{'logidlelimit'} = $bconf->{'buildflags:logidlelimit'} if $bconf->{'buildflags:logidlelimit'};
     $binfo->{'genbuildreqs'} = $genbuildreqs->[0] if $genbuildreqs;
     if ($bconf->{'buildflags:obsgendiff'} && @{$ctx->{'repo'}->{'releasetarget'} || []}) {
-      $binfo->{'obsgendiff'} = $ctx->{'repo'}->{'releasetarget'}->[0];
+       $binfo->{'obsgendiff'} = { 'project' => $ctx->{'repo'}->{'releasetarget'}->[0]->{'project'},
+                                  'repository' => $ctx->{'repo'}->{'releasetarget'}->[0]->{'repository'} };
+
     }
   }
   $ctx->writejob($job, $binfo, $reason);

--- a/src/backend/BSSched/BuildJob.pm
+++ b/src/backend/BSSched/BuildJob.pm
@@ -1162,8 +1162,9 @@ sub create {
     $binfo->{'logidlelimit'} = $bconf->{'buildflags:logidlelimit'} if $bconf->{'buildflags:logidlelimit'};
     $binfo->{'genbuildreqs'} = $genbuildreqs->[0] if $genbuildreqs;
     if ($bconf->{'buildflags:obsgendiff'} && @{$ctx->{'repo'}->{'releasetarget'} || []}) {
-       $binfo->{'obsgendiff'} = { 'project' => $ctx->{'repo'}->{'releasetarget'}->[0]->{'project'},
-                                  'repository' => $ctx->{'repo'}->{'releasetarget'}->[0]->{'repository'} };
+       my $releasetarget = $ctx->{'repo'}->{'releasetarget'}->[0];
+       $binfo->{'obsgendiff'} = { 'project' => $releasetarget->{'project'},
+                                  'repository' => $releasetarget->{'repository'} };
 
     }
   }

--- a/src/backend/BSXML.pm
+++ b/src/backend/BSXML.pm
@@ -548,7 +548,7 @@ our $buildinfo = [
 	'genbuildreqs',	# internal
       [ 'obsgendiff' =>
 	    'project',
-	    'package',
+	    'repository',
       ],		# internal
       [ 'dep' ],
      [[ 'bdep' =>

--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -4334,7 +4334,7 @@ my $dispatches = [
   '!worker /getpackagebinaryversionlist $project $repository $arch $package* withcode:bool? workerid?' => \&getpackagebinaryversionlist,
   '!worker /badpackagebinaryversionlist $project $repository $arch $package* workerid?' => \&badpackagebinaryversionlist,
   '!worker /getpreinstallimageinfos $prpa+ match:? workerid?' => \&getpreinstallimageinfos,
-  '/getobsgendiffdata $project $repository $arch workerid?' => \&getobsgendiffdata,
+  '/getobsgendiffdata $project $repository $arch jobid? workerid?' => \&getobsgendiffdata,
 
   # published files
   '/published' => \&publisheddir,

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -5412,7 +5412,7 @@ sub getobsgendiffdata {
     'ignorestatus' => 1,
     'receiver' => \&BSServer::reply_receiver,
   };
-  BSWatcher::rpc($param, undef, BSRPC::args($cgi, 'project', 'repository', 'arch', 'workerid'));
+  BSWatcher::rpc($param, undef, BSRPC::args($cgi, 'project', 'repository', 'arch', 'jobid', 'workerid'));
   return undef;
 }
 
@@ -6660,7 +6660,7 @@ my $dispatches = [
   '/getsslcert $project autoextend:bool? workerid? signtype:?' => \&getsslcert,
   '/getbinaries $project $repository $arch binaries: nometa:bool? workerid? module*' => \&worker_getbinaries,
   '/getbinaryversions $project $repository $arch binaries: nometa:bool? workerid? module*' => \&worker_getbinaryversions,
-  '/getobsgendiffdata $project $repository $arch workerid?' => \&getobsgendiffdata,
+  '/getobsgendiffdata $project $repository $arch jobid? workerid?' => \&getobsgendiffdata,
 
   # publisher/signer calls
   '/getsignkey $project withpubkey:bool? autoextend:bool? withalgo:bool?' => \&getsignkey,

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -1093,7 +1093,8 @@ sub getobsgendiffdata {
     'uri' => "$server/getobsgendiffdata",
     'directory' => $dir,
     'timeout' => $gettimeout,
-  }, $BSXML::dir, "project=$obsgendiff->{'project'}", "repository=$obsgendiff->{'repository'}", "arch=$buildinfo->{'arch'}", "jobid=$buildinfo->{'jobid'}");
+    'receiver' => \&BSHTTP::cpio_receiver,
+  }, undef, "project=$obsgendiff->{'project'}", "repository=$obsgendiff->{'repository'}", "arch=$buildinfo->{'arch'}", "jobid=$buildinfo->{'jobid'}");
   return $res;
 }
 


### PR DESCRIPTION
<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
