### PR TITLE
Tell the proxy where to redirect to after login

### DIFF
--- a/src/api/app/helpers/proxy_mode_helper.rb
+++ b/src/api/app/helpers/proxy_mode_helper.rb
@@ -1,0 +1,16 @@
+module ProxyModeHelper
+  # last visited url in our app, unless it's the login/sign up path
+  def return_to_location
+    return root_path unless request.env['HTTP_REFERER'].to_s.start_with?(base_url)
+    return root_path if request.env['HTTP_REFERER'].to_s.end_with?(new_session_path, new_user_path)
+    request.env['HTTP_REFERER'].delete_prefix(base_url)
+  end
+
+  private
+
+  def base_url
+    url = "#{request.protocol}#{request.host}"
+    url += ":#{request.port}" if request.port.present?
+    url
+  end
+end

--- a/src/api/app/views/webui/session/_form.html.haml
+++ b/src/api/app/views/webui/session/_form.html.haml
@@ -5,6 +5,7 @@
     = hidden_field_tag(:context, 'default')
     = hidden_field_tag(:proxypath, 'reserve')
     = hidden_field_tag(:message, 'Please log in')
+    = hidden_field_tag(:url, return_to_location)
   .form-group
     = label_tag(:username, 'Username')
     = text_field_tag(:username, nil, placeholder: 'User Name', required: true, id: 'user-login', class: 'form-control')


### PR DESCRIPTION
Fixes #8399

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
