### PR TITLE
[backend] generate _statistics file when the result is no-change

### DIFF
--- a/src/backend/BSSched/BuildJob.pm
+++ b/src/backend/BSSched/BuildJob.pm
@@ -544,11 +544,12 @@ sub jobfinished {
     }
     # Add a comment to logfile from last real build
     BSUtil::appendstr("$dst/logfile", "\nRetried build at ".localtime(time())." returned same result, skipped\n");
+    my $jobhist = makejobhist($info, $status, $js, 'unchanged');
+    addbuildstats($jobdatadir, $dst, $jobhist) if $all{'_statistics'};
     unlink("$gdst/:logfiles.fail/$packid");
     rename($meta, "$gdst/:meta/$packid") if $meta;
     unlink($_) for @all;
     rmdir($jobdatadir);
-    my $jobhist = makejobhist($info, $status, $js, 'unchanged');
     addjobhist($gctx, $prp, $jobhist);
     $status->{'status'} = 'succeeded';
     writexml("$dst/.status", "$dst/status", $status, $BSXML::buildstatus);

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -3258,6 +3258,13 @@ sub dobuild {
     if (($buildinfo->{'reason'} || '') eq "rebuild counter sync") {
       $ret = 0;
     } else {
+      if ($vm =~ /(xen|kvm|zvm|emulator|pvm|openstack)/) {
+        my $statsfile = "$buildroot/.mount/.build.packages/OTHER/_statistics";
+        updatestatsfromfile($stats, $statsfile) if -e $statsfile;
+      }
+      $stats->{'times'}->{'total'}->{'time'} = { 'unit' => 's', '_content' => (time() - $starttime) };
+      mkdir_p("$buildroot/.build.packages/OTHER");
+      writexml("$buildroot/.build.packages/OTHER/_statistics.new", "$buildroot/.build.packages/OTHER/_statistics", $stats, $BSXML::buildstatistics);
       return 2;
     }
   } elsif ($ret == 3 * 256) {
@@ -3292,10 +3299,42 @@ sub dobuild {
     symlink('.', "$buildroot/.build.packages/DEBS");
     symlink('.', "$buildroot/.build.packages/KIWI");
     # convert build statistics into xml
-    if (-e "$buildroot/.build.packages/OTHER/_statistics") {
+    my $statsfile = "$buildroot/.build.packages/OTHER/_statistics";
+    updatestatsfromfile($stats, $statsfile) if -e $statsfile;
+  }
+  $stats->{'times'}->{'total'}->{'time'} = { 'unit' => 's', '_content' => (time() - $starttime) };
+  mkdir_p("$buildroot/.build.packages/OTHER");
+  writexml("$buildroot/.build.packages/OTHER/_statistics.new", "$buildroot/.build.packages/OTHER/_statistics", $stats, $BSXML::buildstatistics);
+
+  if ($buildinfo->{'outbuildinfo'}) {
+    writexml("$buildroot/.build.packages/OTHER/_buildenv", undef, $buildinfo->{'outbuildinfo'}, $BSXML::buildinfo);
+  }
+
+  if (!$followupmode && $kiwiorigins) {
+    $buildinfo->{'buildtime'} = time();
+    if (!$kiwimode) {
+      # some builds like python-venv also write a .packages file
+      createreport($buildinfo, "$buildroot/.build.packages/OTHER", $kiwiorigins, $srcdir);
+    } elsif ($kiwimode ne 'product') {
+      createreport($buildinfo, "$buildroot/.build.packages/KIWI", $kiwiorigins, $srcdir);
+    } else {
+      # as a special service we also create a channel file from the report files
+      createchannel($buildinfo, "$buildroot/.build.packages/OTHER", $kiwiorigins, $srcdir);
+    }
+  }
+
+  if (%$followupcopy) {
+    writestr("$buildroot/.build.packages/OTHER/$_", undef, $followupcopy->{$_}) for keys %$followupcopy;
+  }
+  return 0;
+}
+
+
+sub updatestatsfromfile {
+  my ($stats, $filepath) = @_;
       my $iosectors = 0;
       my $iorequests = 0;
-      open(FILE, "<", "$buildroot/.build.packages/OTHER/_statistics") || die;
+      open(FILE, "<", $filepath) || die;
       my %timekeys = (
 	'TIME_preinstall' => 'preinstall',
 	'TIME_install' => 'install',
@@ -3323,33 +3362,6 @@ sub dobuild {
         }
       }
       close FILE;
-    }
-  }
-  $stats->{'times'}->{'total'}->{'time'} = { 'unit' => 's', '_content' => (time() - $starttime) };
-  mkdir_p("$buildroot/.build.packages/OTHER");
-  writexml("$buildroot/.build.packages/OTHER/_statistics.new", "$buildroot/.build.packages/OTHER/_statistics", $stats, $BSXML::buildstatistics);
-
-  if ($buildinfo->{'outbuildinfo'}) {
-    writexml("$buildroot/.build.packages/OTHER/_buildenv", undef, $buildinfo->{'outbuildinfo'}, $BSXML::buildinfo);
-  }
-
-  if (!$followupmode && $kiwiorigins) {
-    $buildinfo->{'buildtime'} = time();
-    if (!$kiwimode) {
-      # some builds like python-venv also write a .packages file
-      createreport($buildinfo, "$buildroot/.build.packages/OTHER", $kiwiorigins, $srcdir);
-    } elsif ($kiwimode ne 'product') {
-      createreport($buildinfo, "$buildroot/.build.packages/KIWI", $kiwiorigins, $srcdir);
-    } else {
-      # as a special service we also create a channel file from the report files
-      createchannel($buildinfo, "$buildroot/.build.packages/OTHER", $kiwiorigins, $srcdir);
-    }
-  }
-
-  if (%$followupcopy) {
-    writestr("$buildroot/.build.packages/OTHER/$_", undef, $followupcopy->{$_}) for keys %$followupcopy;
-  }
-  return 0;
 }
 
 sub buildkiwitree {
@@ -4018,6 +4030,8 @@ if (!$ex) {
 } elsif ($ex == 2) {
   print "build succeeded, but does not differ from old build result...\n";
   $code = 'unchanged';
+  my $statsfile = "$buildroot/.build.packages/OTHER/_statistics";
+  push @send, {name => '_statistics', filename => $statsfile} if -e $statsfile;
 } elsif ($ex == 3 && $buildinfo->{'nobadhost'}) {
   print "build failed (ignored bad build host flag)...\n";
   BSUtil::appendstr("$buildroot/.build.log", "\n$buildinfo->{'nobadhost'}\n");


### PR DESCRIPTION
this patch moves some of the code around into a new function . It adds a
few lines for the real work of creating file when there is no change.
The code for the new function `updatestatsfromfile` add stats to the
passed in hash after reading it from file. The function is not
responsible for checking the existence of file and its format.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
