### PR TITLE
Replace "Your Home" by "Profile"

### DIFF
--- a/src/api/app/views/webui/main/_user_proceed-list.html.haml
+++ b/src/api/app/views/webui/main/_user_proceed-list.html.haml
@@ -1,9 +1,9 @@
 - if User.session
   .col
-    = link_to(user_path(User.session!), class: 'btn btn-default', title: 'Go to your home') do
-      %i.fas.fa-home.fa-2x.text-dark
+    = link_to(user_path(User.session!), class: 'btn btn-default', title: 'Go to your profile') do
+      %i.fas.fa-user.fa-2x.text-dark
       %br
-      Your Home
+      Profile
 .col
   = link_to(projects_path, class: 'btn btn-default', title: 'See all projects') do
     %i.fas.fa-list.fa-2x.text-muted

--- a/src/api/app/views/webui/user/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui/user/_breadcrumb_items.html.haml
@@ -13,7 +13,7 @@
 - when 'show'
   = render partial: 'webui/main/breadcrumb_items'
   %li.breadcrumb-item.active{ 'aria-current' => 'page' }
-    Home of #{@displayed_user}
+    Profile of #{@displayed_user}
 - when 'register_user'
   = render partial: 'webui/configuration/breadcrumb_items'
   %li.breadcrumb-item

--- a/src/api/app/views/webui/users/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui/users/_breadcrumb_items.html.haml
@@ -10,7 +10,7 @@
   - when 'show'
     = render partial: 'webui/main/breadcrumb_items'
     %li.breadcrumb-item.active{ 'aria-current' => 'page' }
-      Home of #{@displayed_user}
+      Profile of #{@displayed_user}
   - when 'edit'
     = render partial: 'webui/configuration/breadcrumb_items'
     %li.breadcrumb-item

--- a/src/api/app/views/webui/users/show.html.haml
+++ b/src/api/app/views/webui/users/show.html.haml
@@ -1,5 +1,5 @@
 :ruby
-  @pagetitle = "Home of #{@displayed_user}"
+  @pagetitle = "Profile of #{@displayed_user}"
 
   content_for(:meta_title, @pagetitle)
   content_for(:meta_image, gravatar_url(@displayed_user.email))


### PR DESCRIPTION
To avoid confusion between the concepts "Your Home" and "Your Home Project",
the first one has been renamed to "Profile".

The icon for "Profile" is now a user icon instead of a house, which
is commonly used for the main page (a.k.a landing or home page).

![Welcome   Open Build Service(2)](https://user-images.githubusercontent.com/2581944/73856403-b2e46300-4835-11ea-9259-32dcf4174d89.png)

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
