### PR TITLE
[2.10] [dist] Update rake version to 12.3.3 in bundled gems spec

### DIFF
--- a/dist/obs-bundled-gems.spec
+++ b/dist/obs-bundled-gems.spec
@@ -50,7 +50,7 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 This package bundles all the gems required by the Open Build Service
 to make it easier to deploy the obs-server package.
 
-%define rake_version 12.3.2
+%define rake_version 12.3.3
 %define rack_version 2.0.8
 
 %package -n obs-api-deps


### PR DESCRIPTION
When the `selenium-webdriver` gem was updated in 80e6a5d15c271a20c529b5c187a9090a023bc598,
`rake` was updated from 12.3.2 to 12.3.3. However, the `obs-bundled-gems`
RPM spec was not updated along with the `rake` update in the `Gemfile.lock`
to reference the newer `rake` version, so package builds began to fail.

This change fixes that by updating the `%rake_version` macro to the
correct version in the `obs-bundled-gems` RPM spec file.
