### PR TITLE
[backend] support container architecture variants

### DIFF
--- a/src/backend/BSPublisher/Registry.pm
+++ b/src/backend/BSPublisher/Registry.pm
@@ -441,6 +441,7 @@ sub push_containers {
 
       # see if a already have this arch/os combination
       my $platformstr = "architecture:$config->{'architecture'} os:$config->{'os'}";
+      $platformstr .= "variant: $config->{'variant'}" if $config->{'variant'};
       if ($multiplatforms{$platformstr}) {
 	print "ignoring $containerinfo->{'file'}, already have $platformstr\n";
 	close $tarfd if $tarfd;
@@ -497,6 +498,7 @@ sub push_containers {
 	'digest' => $mani_id,
 	'platform' => {'architecture' => $config->{'architecture'}, 'os' => $config->{'os'}},
       };
+      $multimani->{'platform'}->{'variant'} = $config->{'variant'} if $config->{'variant'};
       push @multimanifests, $multimani;
 
       my $imginfo = {
@@ -505,6 +507,7 @@ sub push_containers {
         'goos' => $config->{'os'},
 	'distmanifest' => $mani_id,
       };
+      $imginfo->{'govariant'} = $containerinfo->{'govariant'} if $containerinfo->{'govariant'};
       $imginfo->{'package'} = $containerinfo->{'_origin'} if $containerinfo->{'_origin'};
       $imginfo->{'disturl'} = $containerinfo->{'disturl'} if $containerinfo->{'disturl'};
       $imginfo->{'buildtime'} = $containerinfo->{'buildtime'} if $containerinfo->{'buildtime'};

--- a/src/backend/BSRepServer/Containertar.pm
+++ b/src/backend/BSRepServer/Containertar.pm
@@ -67,7 +67,7 @@ sub normalize_container {
   $containerinfo->{'imageid'} =~ s/^sha256://;
   $containerinfo->{'goarch'} = $config->{'architecture'};
   $containerinfo->{'goos'} = $config->{'os'};
-  # XXX: should add a variant for arm
+  $containerinfo->{'govariant'} = $config->{'variant'} if $config->{'variant'};
   BSRepServer::Containerinfo::writecontainerinfo("$dir/.$containerinfo_file", "$dir/$containerinfo_file", $containerinfo);
 
   if ($deletetar) {

--- a/src/backend/BSRepServer/Registry.pm
+++ b/src/backend/BSRepServer/Registry.pm
@@ -28,8 +28,9 @@ use strict;
 my $uploaddir = "$BSConfig::bsdir/upload";
 
 sub select_manifest {
-  my ($mani, $goarch, $goos) = @_;
+  my ($mani, $goarch, $goos, $govariant) = @_;
   for my $m (@{$mani->{'manifests'} || []}) {
+    next if $govariant && $m->{'platform'}->{'variant'} && $m->{'platform'}->{'variant'} ne $govariant;
     return $m->{'digest'} if $m->{'platform'} && $m->{'platform'}->{'architecture'} eq $goarch && $m->{'platform'}->{'os'} eq $goos;
   }
   return undef;

--- a/src/backend/bs_regpush
+++ b/src/backend/bs_regpush
@@ -553,6 +553,7 @@ for my $tarfile (@tarfiles) {
   if ($multiarch) {
     # see if a already have this arch/os combination
     my $platformstr = "architecture:$config->{'architecture'} os:$config->{'os'}";
+    $platformstr .= " variant:$config->{'variant'}" if $config->{'variant'};
     if ($multiplatforms{$platformstr}) {
       print "ignoring $tarfile, already have $platformstr\n";
       close $tarfd if $tarfd;
@@ -626,6 +627,7 @@ for my $tarfile (@tarfiles) {
       'digest' => 'sha256:'.Digest::SHA::sha256_hex($mani_json),
       'platform' => {'architecture' => $config->{'architecture'}, 'os' => $config->{'os'}},
     };
+    $multimani->{'platform'}->{'variant'} = $config->{'variant'} if $config->{'variant'};
     push @multimanifests, $multimani;
   } else {
     manifest_upload_tags($mani_json, \@tags);


### PR DESCRIPTION
Esp. to avoid armv6 and v7 conflicts

The kiwi/umoci/docker/podman tooling seems not to support it yet, but that are independend bugs.
Could not test it for real therefore yet.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
