### PR TITLE
[backend] support rpm's %include statement

### DIFF
--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -925,6 +925,23 @@ sub readbuildenv {
   }
 }
 
+sub rpm_includecallback {
+  my ($rev, $files, $fn) = @_;
+  my %files = map {$_ => $_} keys %$files;
+  if ($files{'_service'}) {
+    for (sort keys %files) {
+      next unless /^_service:.*:(.*?)$/s;
+      $files{$1} = delete($files{$_}) if $files{$_};
+    }
+  }
+  $fn =~ s/.*\///;
+  $fn = $files{$fn};
+  return undef unless $fn;
+  my @s = BSRevision::revstat($rev, $fn, $files->{$fn});
+  return undef if !@s || $s[7] > 100000;
+  return BSRevision::revreadstr($rev, $fn, $files->{$fn});
+}
+
 sub getprojpack {
   my ($cgi, $projids, $repoids, $packids, $arch) = @_;
   local *oldbsrpc = *BSRPC::rpc;
@@ -1613,6 +1630,7 @@ sub getprojpack {
 	      $conf->{'buildflavor'} = $2;
 	    }
 	    my $d;
+	    local $Build::Rpm::includecallback = sub { rpm_includecallback($rev, $files, @_) };
 	    eval {
 	      $d = Build::parse_typed($conf, BSRevision::revfilename($rev, $file, $files->{$file}), $buildtype);
 	    };
@@ -5866,6 +5884,7 @@ sub sourceinfo {
     $bconf->{'buildflavor'} = $2;
   }
   
+  local $Build::Rpm::includecallback = sub { rpm_includecallback($rev, $files, @_) };
   my $d;
   eval {
     $d = Build::parse_typed($bconf, BSRevision::revfilename($rev, $file, $files->{$file}), $buildtype);


### PR DESCRIPTION
<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
