### PR TITLE
[backend] bs_dispatch: speed up nativeonly handling

### DIFF
--- a/src/backend/bs_dispatch
+++ b/src/backend/bs_dispatch
@@ -1129,7 +1129,9 @@ while (1) {
   @jobprpas = sort {$scales{$a} * $load->{$a} <=> $scales{$b} * $load->{$b}} @jobprpas;
 
   my %checkconstraintscache;
+  my %nativeonlycache;
   #BSUtil::printlog("assigning jobs");
+
   while (@jobprpas) {
     my $prpa = shift @jobprpas;
     my $arch = (split('/', $prpa))[2];
@@ -1207,6 +1209,7 @@ while (1) {
     }
 
     my $rerun;
+    my $nativeonly = $nativeonlycache{$arch};
     for my $job (@b) {
       my $info = $ic->{$job};
       next unless $info && $info->{'file'} && $info->{'file'} ne '_aggregate';
@@ -1221,6 +1224,11 @@ while (1) {
       }
       my @idle = List::Util::shuffle(@{$idlearch{$info->{'hostarch'} || $arch} || []});
       last unless @idle;
+      if ($nativeonly) {
+	# remove nativeonly hosts that cannot build this job
+	@idle = grep {!$nativeonly->{$_}} @idle;
+	last unless @idle;
+      }
       if (@idle > 1) {
         # sort by worker load
         my %idleload;
@@ -1295,8 +1303,7 @@ while (1) {
         my $worker = $workerinfo{$idle};
 	if (!$worker) {
 	  my @s = stat("$workersdir/idle/$idle");
-	  next unless @s;
-	  $worker = readxml("$workersdir/idle/$idle", $BSXML::worker, 1);
+	  $worker = readxml("$workersdir/idle/$idle", $BSXML::worker, 1) if @s;
 	  if (!$worker) {
 	    for (@{$cando{$harch} || []}) { 
 	       $idlearch{$_} = [ grep {$_ ne $idle} @{$idlearch{$_}} ];
@@ -1311,6 +1318,8 @@ while (1) {
 	}
         # is a helper needed for personality change?
         if ($harchcando{"$harch/$arch"} && $worker->{hardware} && exists($worker->{hardware}->{nativeonly})) {
+	  $nativeonly = $nativeonlycache{$arch} = {} unless $nativeonly;
+	  $nativeonly->{$idle} = 1;
           next;	# worker is not supporting the needed personality change
         }
 	if ($constraints) {
@@ -1332,7 +1341,10 @@ while (1) {
 	    }
 	  }
 	}
-	last unless -e "$jobsdir/$arch/$job";
+	if (!-e "$jobsdir/$arch/$job") {
+	  $haveassigned = 1;		# hack: disable constrains check
+	  last;
+	}
 	last if $assigned && $tries >= 5;
 	$tries++;
 	my $res = assignjob($job, $idle, $arch);


### PR DESCRIPTION
The nativeonly flag was checked in the body of two nested loops,
taking way too much time if there are many jobs and many idle
workers. Add a cache so that we can prune workers that we know
cannot build the job.

Also remove the worker from the idle list if its file is gone.
Not removing it led to lots of unneccessary constrain checks.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
