### PR TITLE
[api] move api routes from webui to api definitions

### DIFF
--- a/src/api/config/routes/api_routes.rb
+++ b/src/api/config/routes/api_routes.rb
@@ -364,4 +364,33 @@ OBSApi::Application.routes.draw do
     get 'project/sitemap' => :projects
     get 'package/sitemap(/:project_name)' => :packages
   end
+
+  ### /worker
+  get 'worker/_status' => 'worker/status#index', as: :worker_status
+  get 'build/_workerstatus' => 'worker/status#index', as: :build_workerstatus # For backward compatibility
+  get 'worker/:worker' => 'worker/capability#show'
+  post 'worker' => 'worker/command#run'
+
+  ### /build
+  get 'build/:project/:repository/:arch/:package/_log' => 'build#logfile', constraints: cons, as: :raw_logfile
+  match 'build/:project/:repository/:arch/:package/_buildinfo' => 'build#buildinfo', constraints: cons, via: [:get, :post]
+  match 'build/:project/:repository/:arch/:package/_status' => 'build#index', constraints: cons, via: [:get, :post]
+  match 'build/:project/:repository/:arch/:package/_history' => 'build#index', constraints: cons, via: [:get, :post]
+  get 'build/:project/:repository/:arch/:package/:filename' => 'build/file#show', constraints: cons
+  put 'build/:project/:repository/:arch/:package/:filename' => 'build/file#update', constraints: cons
+  delete 'build/:project/:repository/:arch/:package/:filename' => 'build/file#destroy', constraints: cons
+  match 'build/:project/:repository/:arch/_builddepinfo' => 'build#builddepinfo', via: [:get, :post], constraints: cons
+  match 'build/:project/:repository/_buildconfig' => 'build#index', constraints: cons, via: [:get, :post]
+  match 'build/:project/:repository/:arch(/:package)' => 'build#index', constraints: cons, via: [:get, :post]
+  get 'build/:project/_result' => 'build#result', constraints: cons
+  match 'build/:project/:repository' => 'build#index', constraints: cons, via: [:get, :post]
+  match 'build/:project' => 'build#project_index', constraints: cons, via: [:get, :post, :put]
+  get 'build' => 'source#index'
+
+  ### /published
+
+  # :arch can be also a ymp for a pattern :/
+  get 'published/:project(/:repository(/:arch(/:binary)))' => 'published#index', constraints: cons
+  get 'published/' => 'source#index', via: :get
+
 end

--- a/src/api/config/routes/api_routes.rb
+++ b/src/api/config/routes/api_routes.rb
@@ -392,5 +392,4 @@ OBSApi::Application.routes.draw do
   # :arch can be also a ymp for a pattern :/
   get 'published/:project(/:repository(/:arch(/:binary)))' => 'published#index', constraints: cons
   get 'published/' => 'source#index', via: :get
-
 end

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -345,34 +345,6 @@ OBSApi::Application.routes.draw do
     end
   end
 
-  ### /worker
-  get 'worker/_status' => 'worker/status#index', as: :worker_status
-  get 'build/_workerstatus' => 'worker/status#index', as: :build_workerstatus # For backward compatibility
-  get 'worker/:worker' => 'worker/capability#show'
-  post 'worker' => 'worker/command#run'
-
-  ### /build
-  get 'build/:project/:repository/:arch/:package/_log' => 'build#logfile', constraints: cons, as: :raw_logfile
-  match 'build/:project/:repository/:arch/:package/_buildinfo' => 'build#buildinfo', constraints: cons, via: [:get, :post]
-  match 'build/:project/:repository/:arch/:package/_status' => 'build#index', constraints: cons, via: [:get, :post]
-  match 'build/:project/:repository/:arch/:package/_history' => 'build#index', constraints: cons, via: [:get, :post]
-  get 'build/:project/:repository/:arch/:package/:filename' => 'build/file#show', constraints: cons
-  put 'build/:project/:repository/:arch/:package/:filename' => 'build/file#update', constraints: cons
-  delete 'build/:project/:repository/:arch/:package/:filename' => 'build/file#destroy', constraints: cons
-  match 'build/:project/:repository/:arch/_builddepinfo' => 'build#builddepinfo', via: [:get, :post], constraints: cons
-  match 'build/:project/:repository/_buildconfig' => 'build#index', constraints: cons, via: [:get, :post]
-  match 'build/:project/:repository/:arch(/:package)' => 'build#index', constraints: cons, via: [:get, :post]
-  get 'build/:project/_result' => 'build#result', constraints: cons
-  match 'build/:project/:repository' => 'build#index', constraints: cons, via: [:get, :post]
-  match 'build/:project' => 'build#project_index', constraints: cons, via: [:get, :post, :put]
-  get 'build' => 'source#index'
-
-  ### /published
-
-  # :arch can be also a ymp for a pattern :/
-  get 'published/:project(/:repository(/:arch(/:binary)))' => 'published#index', constraints: cons
-  get 'published/' => 'source#index', via: :get
-
   resources :staging_workflows, except: :index, controller: 'webui/staging/workflows', param: :workflow_project, constraints: cons do
     member do
       resources :staging_projects, only: [:create, :destroy, :show], controller: 'webui/staging/projects',


### PR DESCRIPTION
<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
