### PR TITLE
Get rid of systemV

### DIFF
--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -188,7 +188,7 @@ BuildRequires: obs-server-macros
 
 %if 0%{?suse_version:1}
 BuildRequires:  fdupes
-PreReq:         %insserv_prereq permissions pwdutils
+Requires(pre):  shadow
 %endif
 
 %if 0%{?suse_version:1}
@@ -227,9 +227,6 @@ Provides:       obs-source_service = %version
 
 Recommends:     obs-service-download_url
 Recommends:     obs-service-verify_file
-%if 0%{?suse_version} >= 1550
-Requires:       insserv-compat
-%endif
 
 BuildRequires:  systemd-rpm-macros
 
@@ -262,9 +259,6 @@ Group:          Productivity/Networking/Web/Utilities
 Requires:       util-linux >= 2.16
 # the following may not even exist depending on the architecture
 Recommends:     powerpc32
-%if 0%{?suse_version} >= 1550
-Requires:       insserv-compat
-%endif
 
 %description -n obs-worker
 This is the obs build host, to be installed on each machine building
@@ -276,7 +270,7 @@ Summary:        The Open Build Service -- base configuration files
 Group:          Productivity/Networking/Web/Utilities
 %if 0%{?suse_version}
 Requires(pre):  shadow
-PreReq:         %fillup_prereq
+Requires(pre):  %fillup_prereq
 %endif
 
 %description -n obs-common
@@ -653,9 +647,6 @@ rmdir %{obs_backend_data_dir} 2> /dev/null || :
 %service_del_postun -r obsclouduploadworker.service
 %service_del_postun -r obsclouduploadserver.service
 
-%verifyscript -n obs-server
-%verify_permissions
-
 %pre -n obs-api
 getent passwd obsapidelayed >/dev/null || \
   /usr/sbin/useradd -r -s /bin/bash -c "User for build service api delayed jobs" -d %{__obs_api_prefix} -g %{apache_group} obsapidelayed
@@ -678,7 +669,7 @@ fi
 %post -n obs-common
 %service_add_post obsstoragesetup.service
 %if 0%{?suse_version}
-%{fillup_and_insserv -n obs-server}
+%{fillup_only -n obs-server}
 %endif
 
 %post -n obs-api
@@ -724,7 +715,6 @@ if [ -e %{_rundir}/start_obs-api-support.target ];then
 fi
 
 %postun -n obs-api
-%insserv_cleanup
 %service_del_postun %{obs_api_support_scripts}
 %service_del_postun -r apache2
 

--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -453,7 +453,6 @@ popd
 
 %if 0%{?fedora} || 0%{?rhel} || 0%{?centos}
 [-d $RPM_BUILD_ROOT/etc/sysconfig] || mkdir -p $RPM_BUILD_ROOT/etc/sysconfig
-cp dist/rc.status $RPM_BUILD_ROOT/etc
 install -m 0644 dist/sysconfig.obs-server $RPM_BUILD_ROOT/etc/sysconfig/obs-server
 %else
 mkdir -p $RPM_BUILD_ROOT/%{_fillupdir}
@@ -981,9 +980,6 @@ usermod -a -G docker obsservicerun
 /usr/sbin/obsstoragesetup
 %if 0%{?suse_version}
 /usr/sbin/rcobsstoragesetup
-%endif
-%if 0%{?fedora} || 0%{?rhel} || 0%{?centos}
-/etc/rc.status
 %endif
 
 %files -n obs-utils

--- a/dist/obsscheduler
+++ b/dist/obsscheduler
@@ -3,8 +3,6 @@
 #
 # Author: adrian@suse.de
 
-. /etc/rc.status
-
 . /etc/sysconfig/obs-server
 
 # Determine the base and follow a runlevel link name.
@@ -42,10 +40,8 @@ if test -z "$OBS_SCHEDULER_ARCHITECTURES" ; then
 fi
 
 
-rc_reset
 case "$1" in
 	start)
-		echo -n "Initializing obsscheduler"
 		mkdir -p "$rundir" "$logdir"
 		chown obsrun:obsrun "$logdir" "$rundir"
 		cd "$obsdir"
@@ -54,10 +50,8 @@ case "$1" in
 		for i in $OBS_SCHEDULER_ARCHITECTURES; do
 		        $OBS_SCHEDULER_WRAPPER ./bs_sched $i >> "$logdir"/scheduler_$i.log 2>&1 &
 		done
-		rc_status -v
 	;;
-	stop|shutdown)
-		echo -n "Shutting down obsscheduler"
+	stop)
 		if checkproc bs_sched; then
 			for i in $OBS_SCHEDULER_ARCHITECTURES; do
 			 	$obsdir/bs_admin --shutdown-scheduler "$i"
@@ -70,32 +64,9 @@ case "$1" in
 				killall bs_sched
 			fi
 		fi
-		rc_status -v
-	;;
-	restart)
-		$0 stop	
-		$0 start
-		rc_status
-	;;
-	try-restart|reload)
-		$0 status
-		if test $? = 0; then
-			$0 restart
-		else
-			rc_reset        # Not running is not a failure.
-		fi
-		# Remember status and be quiet
-		rc_status
-	;;
-	status)
-		echo -n "Checking for obsscheduler: "
-                # FIXME: needs proper checking for all invoked schedulers
-		checkproc bs_sched
-		rc_status -v
 	;;
 	*)
-		echo "Usage: $0 {start|stop|status|try-restart|restart|reload}"
+		echo "Usage: $0 {start|stop}"
 		exit 1
 	;;
 esac
-rc_exit

--- a/dist/obsstoragesetup
+++ b/dist/obsstoragesetup
@@ -4,24 +4,7 @@
 # Author: adrian@suse.de
 #
 # /etc/init.d/obsstoragesetup
-#   and its symbolic link
-# /usr/sbin/rcobsstoragesetup
-#
-### BEGIN INIT INFO
-# Provides:          obsstoragesetup
-# X-Start-Before:    mysql sshd obsapisetup
-# Should-Start:      xendomains haveged
-# Should-Stop:       $none
-# Required-Start:    $network
-# Required-Stop:     $null
-# Default-Start:     3 5
-# Default-Stop:      0 1 2 4 6
-# Short-Description  OBS storage setup
-# Description:       Finds the storage device to be used for OBS server and/or worker
-### END INIT INFO
 
-
-. /etc/rc.status
 
 # BOOTSTRAP_TEST_MODE prevents setup-appliance.sh execution
 # this is also sourcing /etc/sysconfig/obs-server
@@ -53,7 +36,6 @@ if [ -z "$OBS_WORKER_DIRECTORY" ]; then
 	OBS_WORKER_DIRECTORY="/var/cache/obs/worker"
 fi
 
-rc_reset
 case "$1" in
 	start)
 
@@ -476,31 +458,13 @@ case "$1" in
 			rm /tmp/obsworkerscript.$$
 		fi
 		[ -d $OBS_WORKER_DIRECTORY/cache ] || mkdir -p $OBS_WORKER_DIRECTORY/cache
-		rc_status -v
 	;;
 	stop)
-                # nothing to do
-		rc_status -v
-	;;
-	restart)
-                # nothing to do
-		rc_status
-	;;
-	try-restart)
-                # nothing to do
-		rc_status
-	;;
-	reload)
-                # nothing to do
-		rc_status
-	;;
-	status)
 		# nothing to do
-		rc_status -v
+		exit 0
 	;;
 	*)
-		echo "Usage: $0 {start|stop|status|try-restart|restart|reload}"
+		echo "Usage: $0 {start|stop}"
 		exit 1
 	;;
 esac
-rc_exit

--- a/dist/obsworker
+++ b/dist/obsworker
@@ -4,22 +4,6 @@
 # Author: adrian@suse.de
 #
 # /etc/init.d/obsworker
-#   and its symbolic link
-# /usr/sbin/rcobsworker
-#
-### BEGIN INIT INFO
-# Provides:          obsworker
-# Required-Start:    $time $network $syslog
-# Required-Stop:     $time $network $syslog
-# Should-Start:      $remote_fs obsstoragesetup obssrcserver obsrepserver xendomains
-# Should-Stop:       $none
-# Default-Start:     3 5
-# Default-Stop:      0 1 2 4 6
-# Short-Description: OBS worker
-# Description:       Open Build Service worker
-### END INIT INFO
-
-. /etc/rc.status
 
 # Is the worker running on Fedora >= 17 ?
 # It lacks the complete path to build other distros then
@@ -333,7 +317,6 @@ EOF
     fi
 }
 
-rc_reset
 case "$1" in
     start)
         # reset screenrc
@@ -352,8 +335,8 @@ case "$1" in
             NUM=`ls -d /sys/devices/system/cpu/cpu[0-9]* | wc -l`
         fi
         if [ "--zvm" == "$vmopt" ]; then
-            check_vmcp || rc_status -v
-            create_initrd $OBS_VM_KERNEL $OBS_VM_INITRD || rc_status -v
+            check_vmcp || exit 1
+            create_initrd $OBS_VM_KERNEL $OBS_VM_INITRD || exit 1
             if [ -n "$OBS_WORKER_INSTANCE_NAMES" ]; then
                 WORKERS=($OBS_WORKER_INSTANCE_NAMES)
                 NUM=${#WORKERS[*]}
@@ -484,7 +467,6 @@ case "$1" in
         popd > /dev/null
     ;;
     stop)
-        echo -n "Shutting down obsworker"
         for I in "$workerdir"/*; do
             test -d "$I" || continue
             test -e "$I/state" || continue
@@ -497,33 +479,9 @@ case "$1" in
         sleep 2
         killall -s 9 bs_worker 2>/dev/null
         screen -S obsworker -X quit
-        rc_status -v
-    ;;
-    restart)
-        ## If first returns OK call the second, if first or
-        ## second command fails, set echo return value.
-        $0 stop
-        $0 start
-        rc_status
-    ;;
-    try-restart|reload)
-        $0 status
-        if test $? = 0; then
-            $0 restart
-        else
-            rc_reset        # Not running is not a failure.
-        fi
-        # Remember status and be quiet
-        rc_status
-    ;;
-    status)
-        echo -n "Checking for obsworker: "
-        checkproc bs_worker
-        rc_status -v
     ;;
     *)
-        echo "Usage: $0 {start|stop|status|try-restart|restart|reload}"
+        echo "Usage: $0 {start|stop}"
         exit 1
     ;;
 esac
-rc_exit

--- a/dist/rc.status
+++ b/dist/rc.status
@@ -1,9 +1,0 @@
-  function rc_status {
-    echo "DEBUG: rc_status $@"
-  }
-  function rc_reset {
-    echo "DEBUG: rc_reset $@"
-  }
-  function rc_exit {
-    echo "DEBUG: rc_exit $@"
-  }


### PR DESCRIPTION
As systemd is being used to manage OBS services, systemV method calls are no longer needed. Removing systemV code and compatibility packages (as insserv-compat) makes it more clear OBS services handling.

Labelling as "DO NOT MERGE" untill the changes in the service scripts are tested. The pull request was created to receive feedback about removing systemV from the OBS codebase.