### PR TITLE
Projects#index improvements 

### DIFF
--- a/src/api/app/assets/javascripts/webui/datatables.js
+++ b/src/api/app/assets/javascripts/webui/datatables.js
@@ -9,6 +9,7 @@ var DEFAULT_DT_PARAMS = {
   language: { search: '', searchPlaceholder: "Search..." },
   pageLength: 25,
   stateSave: true,
+  pagingType: 'full',
   stateDuration: 0 // forever
 };
 

--- a/src/api/app/assets/javascripts/webui/project.js
+++ b/src/api/app/assets/javascripts/webui/project.js
@@ -23,11 +23,11 @@ function initializeProjectDatatable() { // jshint ignore:line
         "data": function (d) {
           d.all = $("#projects-datatable").data("all");
         }
-      },
+      }, "responsive" : true, 
       "columns": [
         { "data": "name" },
         { "data": "title" }
-      ]
+      ], "dom": "ftpi"
     }
   );
   $(".toggle-projects").click(function() { toggleProjectsDatatable(); });

--- a/src/api/app/assets/stylesheets/webui/datatables.scss
+++ b/src/api/app/assets/stylesheets/webui/datatables.scss
@@ -6,12 +6,6 @@ table.table-fixed {
   table-layout: fixed
 }
 
-// TODO: Delete when bug is fixed: https://github.com/mkhairi/jquery-datatables/issues/14
-.obs-dataTable div.dataTables_filter input {
-  width: 100% !important;
-  margin-left: 0 !important;
-}
-
 // TODO: Delete when bug is fixed: https://github.com/mkhairi/jquery-datatables/issues/17
 table.dataTable.table-sm {
   min-width: 100%;

--- a/src/api/app/assets/stylesheets/webui/datatables.scss
+++ b/src/api/app/assets/stylesheets/webui/datatables.scss
@@ -33,3 +33,8 @@ table.dataTable.table-sm {
 .table-hover tbody tr:hover {
   background-color: $gray-300;
 }
+
+#projects-datatable_wrapper .dataTables_paginate {
+  @extend .d-flex;
+  @extend .justify-content-center;
+}


### PR DESCRIPTION
- Change the pagination style (globally) to fit better in smaller resolutions
- Remove the number of elements per page for the `Projects#index`
- Center pagination controls for the `Projects#index`

## Small resolution
![Screenshot_2020-02-18_10-50-41](https://user-images.githubusercontent.com/37418/74726126-38f1a800-523f-11ea-94cf-f60cbc44c870.png)

![Screenshot_2020-02-18_10-50-18](https://user-images.githubusercontent.com/37418/74726138-3f801f80-523f-11ea-9d3a-371175f79b7e.png)


## Normal resolution
![Screenshot_2020-02-18_10-49-28](https://user-images.githubusercontent.com/37418/74726219-60487500-523f-11ea-9696-79290907fa6a.png)


![Screenshot_2020-02-18_10-49-43](https://user-images.githubusercontent.com/37418/74726151-473fc400-523f-11ea-920a-f3bc62cc46d4.png)


## Pagination in other page (Packages#show) for example

![Screenshot_2020-02-18_10-48-53](https://user-images.githubusercontent.com/37418/74726303-83732480-523f-11ea-9d2e-5c4a2e05c665.png)
