### PR TITLE
[backend] give api access to .stats file

### DIFF
--- a/src/backend/BSXML.pm
+++ b/src/backend/BSXML.pm
@@ -1874,6 +1874,13 @@ our $buildstatslay = [
 ];
 
 
+our $buildstatslist = [
+    'buildstats' =>
+    [[ 'entry' =>
+         @$buildstatslay
+    ]]
+];
+
 
 our $notifications = [
     'notifications' =>

--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -1161,6 +1161,13 @@ sub getbuildhistory {
   return ({'entry' => \@history}, $BSXML::buildhist);
 }
 
+sub getbuildstats {
+  my ($cgi, $projid, $repoid, $arch, $packid) = @_;
+  my @bstats = BSFileDB::fdb_getall_reverse("$reporoot/$projid/$repoid/$arch/$packid/.stats", $BSXML::buildstatslay, $cgi->{'limit'} || 100);
+  @bstats = reverse @bstats;
+  return ({'entry' => \@bstats}, $BSXML::buildstatslist);
+}
+
 sub getbuildreason {
   my ($cgi, $projid, $repoid, $arch, $packid) = @_;
 
@@ -4306,6 +4313,7 @@ my $dispatches = [
   '/build/$project/$repository/$arch/$package/_status' => \&getbuildstatus,
   '/build/$project/$repository/$arch/$package/_jobstatus' => \&getjobstatus,
   '/build/$project/$repository/$arch/$package/_history limit:num?' => \&getbuildhistory,
+  '/build/$project/$repository/$arch/$package/_buildstats limit:num?' => \&getbuildstats,
   '/build/$project/$repository/$arch/$package/_log nostream:bool? start:intnum? end:num? handoff:bool? last:bool? lastsucceeded:bool? view:?' => \&getlogfile,
   '/build/$project/$repository/$arch/$package:package_repository/$filename view:? module*' => \&getbinary,
   'PUT:/build/$project/$repository/$arch/_repository/$filename ignoreolder:bool? wipe:bool?' => \&putbinary,


### PR DESCRIPTION
this access is very similar to jobhistory route. This patch also add and
extra datastructure to BSXML. This structure acts as dtd for returned
data

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
