### PR TITLE
[backend] fake container variant by looking at the scheduler arch

### DIFF
--- a/src/backend/BSRepServer/Containertar.pm
+++ b/src/backend/BSRepServer/Containertar.pm
@@ -28,7 +28,7 @@ use BSUtil;
 use strict;
 
 sub normalize_container {
-  my ($dir, $container, $writeblobs, $deletetar) = @_;
+  my ($dir, $container, $writeblobs, $deletetar, $arch) = @_;
 
   # sanity check
   die("must not delete container if blobs are not stored\n") if $deletetar && !$writeblobs;
@@ -67,6 +67,11 @@ sub normalize_container {
   $containerinfo->{'imageid'} =~ s/^sha256://;
   $containerinfo->{'goarch'} = $config->{'architecture'};
   $containerinfo->{'goos'} = $config->{'os'};
+  if (!$config->{'variant'} && $arch) {
+    # fake variant by looking at the scheduler architecture
+    $config->{'variant'} = "v$1" if $config->{'architecture'} eq 'arm' && $arch =~ /^armv(\d+)/;
+    $config->{'variant'} = "v8" if $config->{'architecture'} eq 'arm64';
+  }
   $containerinfo->{'govariant'} = $config->{'variant'} if $config->{'variant'};
   BSRepServer::Containerinfo::writecontainerinfo("$dir/.$containerinfo_file", "$dir/$containerinfo_file", $containerinfo);
 

--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -2276,7 +2276,7 @@ sub putjob {
       # check that the containerinfo is well formed
       BSRepServer::Containerinfo::readcontainerinfo($tmpdir, $containerinfofile);
       # now do the rewrite
-      BSRepServer::Containertar::normalize_container($tmpdir, $container, 1, 1);
+      BSRepServer::Containertar::normalize_container($tmpdir, $container, 1, 1, $arch);
     };
     warn($@) if $@;
   }


### PR DESCRIPTION
We need a variant for the publishing of arm container. Unfortunately
no container build tool writes the variant in the container config,
so we're using the scheduler architecture as a hint.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
