### PR TITLE
[backend] add option to preload jemalloc for schedulers

### DIFF
--- a/dist/obsscheduler
+++ b/dist/obsscheduler
@@ -52,7 +52,7 @@ case "$1" in
                 # FIXME: not nice, this should receive a proper daemon handling, 
                 #        including real logging, pid file and startproc
 		for i in $OBS_SCHEDULER_ARCHITECTURES; do
-		        ./bs_sched $i >> "$logdir"/scheduler_$i.log 2>&1 &
+		        $OBS_SCHEDULER_WRAPPER ./bs_sched $i >> "$logdir"/scheduler_$i.log 2>&1 &
 		done
 		rc_status -v
 	;;

--- a/dist/sysconfig.obs-server
+++ b/dist/sysconfig.obs-server
@@ -76,6 +76,17 @@ OBS_SRC_SERVER=""
 OBS_REPO_SERVERS=""
 
 ## Path:        Applications/OBS
+## Description: define a malloc wrapper for scheduler
+## Type:        string
+## Default:     ""
+## Config:      OBS
+#
+# Define a wrapper script for preloading libs for scheduler startup
+# "jemalloc.sh" is a possibility here after installing jemalloc package.
+#
+OBS_SCHEDULER_WRAPPER=""
+
+## Path:        Applications/OBS
 ## Description: define number of build instances
 ## Type:        integer
 ## Default:     0


### PR DESCRIPTION
<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
