### PR TITLE
Suspend the scheduler if we do binary copies in the background

### DIFF
--- a/src/backend/BSSched/Checker.pm
+++ b/src/backend/BSSched/Checker.pm
@@ -243,9 +243,8 @@ sub setup {
   if ($repo->{'status'} && $repo->{'status'} eq 'disabled') {
     return ('disabled', undef);
   }
-  if ($gctx->{'projsuspended'}->{$projid}) {
-    return ('blocked', $gctx->{'projsuspended'}->{$projid});
-  }
+  my $suspend = $gctx->{'projsuspended'}->{$projid};
+  return ('blocked', "@$suspend") if $suspend;
   $ctx->{'repo'} = $repo;
 
   # set config

--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -2563,7 +2563,13 @@ sub copybuild {
   # for simple files it happened already
   if (%delayed_linking) {
     my $pid = xfork();
-    return $BSStdServer::return_ok if $pid;
+    if ($pid) {
+      # hack: suspend the scheduler until we are done with copying
+      my $ev = {'type' => 'suspendproject', 'project' => $projid, 'job' => "copybuild:$job" };
+      mkdir_p("$eventdir/$arch");
+      writexml("$eventdir/$arch/.suspendproject:$job$$", "$eventdir/$arch/suspendproject:$job", $ev, $BSXML::event);
+      return $BSStdServer::return_ok;
+    }
     for (sort(keys %delayed_linking)) {
       BSUtil::linktree($delayed_linking{$_}, $_);
     }
@@ -2589,6 +2595,11 @@ sub copybuild {
   dirty($projid, $repoid, $arch) if $arch ne 'signer';
   mkdir_p("$eventdir/$arch");
   writexml("$eventdir/$arch/.copybuild:$job$$", "$eventdir/$arch/copybuild:$job", $ev, $BSXML::event);
+  if (%delayed_linking) {
+    # see above
+    $ev = {'type' => 'resumeproject', 'project' => $projid, 'job' => "copybuild:$job" };
+    writexml("$eventdir/$arch/.resumeproject:$job$$", "$eventdir/$arch/resumeproject:$job", $ev, $BSXML::event);
+  }
   BSUtil::ping("$eventdir/$arch/.ping");
   return $BSStdServer::return_ok;
 }

--- a/src/backend/bs_sched
+++ b/src/backend/bs_sched
@@ -629,7 +629,8 @@ if (!$testprojid && -s "$_rundir/bs_sched.$_myarch.state") {
     }
 
     # update projsuspended hash
-    my $oldprojsuspended =  $schedstate->{'projsuspended'} || {};
+    my $oldprojsuspended = $schedstate->{'projsuspended'} || {};
+    $_ = ref($_) ? $_ : [ $_ ] for values %$oldprojsuspended;	# convert to array refs
     %{$gctx->{'projsuspended'}} = %$oldprojsuspended;
 
     # use old start values


### PR DESCRIPTION
This is a bit of a hack. The purpose of this is so that the scheduler does not send a repo finished event if there is still some copying going on in the background.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
