### PR TITLE
Change the datatables information text

### DIFF
--- a/src/api/app/assets/javascripts/webui/datatables.js
+++ b/src/api/app/assets/javascripts/webui/datatables.js
@@ -6,7 +6,14 @@
 //= require datatables/extensions/FixedColumns/dataTables.fixedColumns
 
 var DEFAULT_DT_PARAMS = {
-  language: { search: '', searchPlaceholder: "Search..." },
+  language: { 
+    search: '', searchPlaceholder: "Search...",
+    zeroRecords: "Nothing found",
+    infoEmpty: "No records available",
+    info: "page _PAGE_ of _PAGES_ (_TOTAL_ records)",
+    infoFiltered: ""
+  },
+
   pageLength: 25,
   stateSave: true,
   pagingType: 'full',

--- a/src/api/spec/features/webui/groups_spec.rb
+++ b/src/api/spec/features/webui/groups_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature 'Groups', type: :feature, js: true do
       group_in_datatable(page, group)
     end
 
-    expect(page).to have_content('Showing 1 to 2 of 2 entries')
+    expect(page).to have_content('1 of 1 (2 records)')
   end
 
   scenario 'visit group show page' do

--- a/src/api/spec/features/webui/users/admin_configuration_spec.rb
+++ b/src/api/spec/features/webui/users/admin_configuration_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature 'Admin user configuration page', type: :feature, js: true do
   end
 
   scenario 'create user' do
-    expect(page).to have_text('5 entries')
+    expect(page).to have_text('5 records')
     click_link('Create User')
 
     fill_in 'Username:', with: 'tux'


### PR DESCRIPTION
Reducing redundant text from Datatables information as described: https://datatables.net/reference/option/language 

### before:

![Screenshot_2020-02-19_16-55-36](https://user-images.githubusercontent.com/37418/74849721-5acf5580-5339-11ea-8252-34131a3f28cc.png)

### after:

![Screenshot_2020-02-19_16-54-32](https://user-images.githubusercontent.com/37418/74849757-63c02700-5339-11ea-8a0f-aced1b8ec630.png)


### before:

![Screenshot_2020-02-19_16-56-06](https://user-images.githubusercontent.com/37418/74849788-6c186200-5339-11ea-832b-a552c7394c07.png)

### after:

#### without filtering:
![Screenshot_2020-02-19_17-03-42](https://user-images.githubusercontent.com/37418/74850206-fa8ce380-5339-11ea-849e-a7724ceb8017.png)


#### with filtering:

![Screenshot_2020-02-19_17-03-25](https://user-images.githubusercontent.com/37418/74850130-e21cc900-5339-11ea-9acb-afdbe2bdf344.png)

