### PR TITLE
[api] fix channel indexing for multibuild references

### DIFF
--- a/src/api/app/models/channel.rb
+++ b/src/api/app/models/channel.rb
@@ -26,7 +26,7 @@ class Channel < ApplicationRecord
         if project
           prj = Project.get_by_name(project)
           if b['package']
-            pkg = prj.find_package(b['package'])
+            pkg = prj.find_package(b['package'].gsub(/:.*$/, ''))
             raise UnknownPackage, "Package does not exist #{prj.name}/#{p['package']}" unless pkg
           end
           if b['repository'] && !prj.repositories.find_by_name(b['repository'])
@@ -130,8 +130,8 @@ class Channel < ApplicationRecord
       arch = nil
       arch = Architecture.find_by_name!(b['arch']) if b['arch']
       hash = { name: b['name'], binaryarch: b['binaryarch'], supportstatus: b['supportstatus'],
-               project: nil, architecture: arch,
-               package: b['package'], repository: nil }
+               project: nil, architecture: arch, repository: nil }
+      hash[:package] = b['package'].blank? ? nil : b['package'].gsub(/:.*$/, '')
       if b['project']
         hash[:project] = Project.get_by_name(b['project'])
         hash[:repository] = hash[:project].repositories.find_by_name(b['repository']) if b['repository']


### PR DESCRIPTION
@msmeissn code is deployed and data is re-indexed.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
