### PR TITLE
Make refresh button sticky on top of build results

### DIFF
--- a/src/api/app/assets/stylesheets/webui/project-package-show-grid.scss
+++ b/src/api/app/assets/stylesheets/webui/project-package-show-grid.scss
@@ -4,6 +4,7 @@
 
 .build-results {
   grid-area: build-results;
+  .sticky-top { top: 57px; }
 }
 
 .comments {

--- a/src/api/app/views/webui/shared/_buildresult_box.html.haml
+++ b/src/api/app/views/webui/shared/_buildresult_box.html.haml
@@ -20,9 +20,11 @@
   .card-body
     .tab-content
       .tab-pane.fade.show.active{ id: "build#{index}", role: 'tabpanel', aria: { labelledby: "build#{index}-tab" } }
-        .btn.btn-outline-primary.mb-2.build-refresh{ onclick: "updateBuildResult('#{index}')", accesskey: 'r', title: 'Refresh Build Results' }
-          Refresh
-          %i.fas.fa-sync-alt{ id: "build#{index}-reload" }
+        .sticky-top.py-2.bg-white.border-bottom.border-light.clearfix
+          .btn.btn-outline-primary.build-refresh.float-right{ onclick: "updateBuildResult('#{index}')",
+                                                              accesskey: 'r', title: 'Refresh Build Results' }
+            Refresh
+            %i.fas.fa-sync-alt{ id: "build#{index}-reload" }
         .result
       - if defined?(package)
         .tab-pane.fade{ id: "rpm#{index}", role: 'tabpanel', aria: { labelledby: "rpm#{index}-tab" } }


### PR DESCRIPTION
Make it easier to trigger a refresh of the build results, without the need of scrolling up and down on pages with lots of build results elements.

Co-authored-by: David Kang <dkang@suse.com>

![Peek 2020-02-21 13-15_build_results_refresh_sticky_top_right](https://user-images.githubusercontent.com/24919/75034008-845cbe00-54ac-11ea-9ae2-a2010723f476.gif)
