### PR TITLE
[backend] add 'cacheonly' option for diffing sources

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -1035,6 +1035,7 @@ class Webui::PackageController < Webui::WebuiController
 
   def get_diff(project, package, options = {})
     options[:view] = :xml
+    options[:cacheonly] = 1 unless User.session
     options[:withissues] = 1
     begin
       @rdiff = Backend::Api::Sources::Package.source_diff(project, package, options.merge(expand: 1))

--- a/src/api/lib/backend/api/sources/package.rb
+++ b/src/api/lib/backend/api/sources/package.rb
@@ -123,7 +123,7 @@ module Backend
         # @option options [String] :filelimit Sets the maximum lines of the diff which will be returned (0 = all lines)
         # @return [String]
         def self.source_diff(project_name, package_name, options = {})
-          accepted = [:rev, :orev, :opackage, :oproject, :linkrev, :olinkrev, :expand, :filelimit, :tarlimit, :withissues, :view]
+          accepted = [:rev, :orev, :opackage, :oproject, :linkrev, :olinkrev, :expand, :filelimit, :tarlimit, :withissues, :view, :cacheonly]
           diff = http_post(['/source/:project/:package', project_name, package_name], defaults: { cmd: :diff }, params: options, accepted: accepted)
           diff.valid_encoding? ? diff : diff.encode('UTF-8', 'binary', invalid: :replace, undef: :replace)
         end

--- a/src/api/spec/cassettes/Webui_PackageController/GET_rdiff/when_an_empty_revision_is_provided/1_12_2_1.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/GET_rdiff/when_an_empty_revision_is_provided/1_12_2_1.yml
@@ -39,17 +39,17 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:19 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:14 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_file/_meta?user=user_55
+    uri: http://backend:5352/source/home:tom/package_with_file/_meta?user=user_3
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom">
-          <title>Tender Is the Night</title>
-          <description>Iusto autem quos et.</description>
+          <title>Dulce et Decorum Est</title>
+          <description>Enim est rem et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,22 +70,22 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '152'
+      - '149'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom">
-          <title>Tender Is the Night</title>
-          <description>Iusto autem quos et.</description>
+          <title>Dulce et Decorum Est</title>
+          <description>Enim est rem et.</description>
         </package>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:19 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:14 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/package_with_file/_config
     body:
       encoding: UTF-8
-      string: Quia incidunt sed. Voluptas odit non. Ut facilis debitis.
+      string: Id voluptatibus odit. Quia ut enim. Tempore et sunt.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -105,26 +105,26 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '209'
+      - '207'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="79" vrev="79">
-          <srcmd5>55922cb4a92905e14ace49a857024d5d</srcmd5>
+        <revision rev="5" vrev="5">
+          <srcmd5>f4ad85cb4e5121b5221f51771496b3af</srcmd5>
           <version>unknown</version>
-          <time>1569593839</time>
+          <time>1582638374</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:19 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:14 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/package_with_file/somefile.txt
     body:
       encoding: UTF-8
-      string: Sint dolor quo. Ut quia error. Ea eos nulla.
+      string: Natus iste veniam. Perferendis tenetur at. Rerum similique eos.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -144,20 +144,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '209'
+      - '207'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="80" vrev="80">
-          <srcmd5>b160e338d94b2c6bec773deb25b9768e</srcmd5>
+        <revision rev="6" vrev="6">
+          <srcmd5>52ec8ea639d2928c90b2f93c67743a32</srcmd5>
           <version>unknown</version>
-          <time>1569593839</time>
+          <time>1582638374</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:19 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:14 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom/package_with_file
@@ -183,16 +183,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '304'
+      - '302'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_file" rev="80" vrev="80" srcmd5="b160e338d94b2c6bec773deb25b9768e">
-          <entry name="_config" md5="40dd2346b33c9bfb520f62ea822febdc" size="57" mtime="1569593839"/>
-          <entry name="somefile.txt" md5="227e3fea8ccd626ce53b252fe83897e7" size="44" mtime="1569593839"/>
+        <directory name="package_with_file" rev="6" vrev="6" srcmd5="52ec8ea639d2928c90b2f93c67743a32">
+          <entry name="_config" md5="ee263bb99a1cba1d0c772235c5487b53" size="52" mtime="1582638374"/>
+          <entry name="somefile.txt" md5="c83b4e5b329627432235e8cc76e79e5e" size="63" mtime="1582638374"/>
         </directory>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:19 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:14 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom/package_with_file
@@ -218,19 +218,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '304'
+      - '302'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_file" rev="80" vrev="80" srcmd5="b160e338d94b2c6bec773deb25b9768e">
-          <entry name="_config" md5="40dd2346b33c9bfb520f62ea822febdc" size="57" mtime="1569593839"/>
-          <entry name="somefile.txt" md5="227e3fea8ccd626ce53b252fe83897e7" size="44" mtime="1569593839"/>
+        <directory name="package_with_file" rev="6" vrev="6" srcmd5="52ec8ea639d2928c90b2f93c67743a32">
+          <entry name="_config" md5="ee263bb99a1cba1d0c772235c5487b53" size="52" mtime="1582638374"/>
+          <entry name="somefile.txt" md5="c83b4e5b329627432235e8cc76e79e5e" size="63" mtime="1582638374"/>
         </directory>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:19 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:14 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:tom/package_with_file?cmd=diff&expand=1&rev=&view=xml&withissues=1
+    uri: http://backend:5352/source/home:tom/package_with_file?cacheonly=1&cmd=diff&expand=1&rev=&view=xml&withissues=1
     body:
       encoding: UTF-8
       string: ''
@@ -262,11 +262,11 @@ http_interactions:
         <status code="400">
           <summary>revision is empty</summary>
         </status>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:19 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:14 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:tom/package_with_file?cmd=diff&expand=0&rev=&view=xml&withissues=1
+    uri: http://backend:5352/source/home:tom/package_with_file?cacheonly=1&cmd=diff&expand=0&rev=&view=xml&withissues=1
     body:
       encoding: UTF-8
       string: ''
@@ -298,6 +298,6 @@ http_interactions:
         <status code="400">
           <summary>revision is empty</summary>
         </status>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:19 GMT
-recorded_with: VCR 5.0.0
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:14 GMT
+recorded_with: VCR 5.1.0

--- a/src/api/spec/cassettes/Webui_PackageController/GET_rdiff/when_an_empty_revision_is_provided/1_12_2_2.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/GET_rdiff/when_an_empty_revision_is_provided/1_12_2_2.yml
@@ -39,17 +39,17 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:19 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:13 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_file/_meta?user=user_56
+    uri: http://backend:5352/source/home:tom/package_with_file/_meta?user=user_2
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom">
-          <title>Arms and the Man</title>
-          <description>Tempore est hic molestiae.</description>
+          <title>The Yellow Meads of Asphodel</title>
+          <description>Repudiandae ea omnis iusto.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,22 +70,22 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '155'
+      - '168'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom">
-          <title>Arms and the Man</title>
-          <description>Tempore est hic molestiae.</description>
+          <title>The Yellow Meads of Asphodel</title>
+          <description>Repudiandae ea omnis iusto.</description>
         </package>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:19 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:13 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/package_with_file/_config
     body:
       encoding: UTF-8
-      string: Perferendis quos quia. Qui odit atque. Ut placeat recusandae.
+      string: Qui et porro. Aut mollitia eos. Assumenda consectetur eum.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -105,27 +105,26 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '209'
+      - '207'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="81" vrev="81">
-          <srcmd5>80487515ae9fd815c92076ff69559ebe</srcmd5>
+        <revision rev="3" vrev="3">
+          <srcmd5>12087ece3fef31d5a1768504d719b61e</srcmd5>
           <version>unknown</version>
-          <time>1569593839</time>
+          <time>1582638373</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:19 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:13 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/package_with_file/somefile.txt
     body:
       encoding: UTF-8
-      string: Reprehenderit quis sit. Necessitatibus omnis molestiae. Voluptatem reprehenderit
-        numquam.
+      string: Hic temporibus ea. Vero architecto dolorum. Vel necessitatibus nulla.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -145,20 +144,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '209'
+      - '207'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="82" vrev="82">
-          <srcmd5>9a0584f82d1abaa4b3ff1c536f5d39ac</srcmd5>
+        <revision rev="4" vrev="4">
+          <srcmd5>ebcd6db7ee71e5d905205206f003b56d</srcmd5>
           <version>unknown</version>
-          <time>1569593839</time>
+          <time>1582638373</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:19 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:14 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom/package_with_file
@@ -184,16 +183,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '304'
+      - '302'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_file" rev="82" vrev="82" srcmd5="9a0584f82d1abaa4b3ff1c536f5d39ac">
-          <entry name="_config" md5="5a3b8b895fab5ee4a70ff1fabcc2fc3a" size="61" mtime="1569593839"/>
-          <entry name="somefile.txt" md5="f1f24dca2e53c5b95cb3688b6ca334ba" size="89" mtime="1569593839"/>
+        <directory name="package_with_file" rev="4" vrev="4" srcmd5="ebcd6db7ee71e5d905205206f003b56d">
+          <entry name="_config" md5="922a255f39d5d39f6b5640f1b91667d9" size="58" mtime="1582638373"/>
+          <entry name="somefile.txt" md5="01c721080edb8e9ba14df88e5c3b9141" size="69" mtime="1582638373"/>
         </directory>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:19 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:14 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom/package_with_file
@@ -219,19 +218,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '304'
+      - '302'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_file" rev="82" vrev="82" srcmd5="9a0584f82d1abaa4b3ff1c536f5d39ac">
-          <entry name="_config" md5="5a3b8b895fab5ee4a70ff1fabcc2fc3a" size="61" mtime="1569593839"/>
-          <entry name="somefile.txt" md5="f1f24dca2e53c5b95cb3688b6ca334ba" size="89" mtime="1569593839"/>
+        <directory name="package_with_file" rev="4" vrev="4" srcmd5="ebcd6db7ee71e5d905205206f003b56d">
+          <entry name="_config" md5="922a255f39d5d39f6b5640f1b91667d9" size="58" mtime="1582638373"/>
+          <entry name="somefile.txt" md5="01c721080edb8e9ba14df88e5c3b9141" size="69" mtime="1582638373"/>
         </directory>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:19 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:14 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:tom/package_with_file?cmd=diff&expand=1&rev=&view=xml&withissues=1
+    uri: http://backend:5352/source/home:tom/package_with_file?cacheonly=1&cmd=diff&expand=1&rev=&view=xml&withissues=1
     body:
       encoding: UTF-8
       string: ''
@@ -263,11 +262,11 @@ http_interactions:
         <status code="400">
           <summary>revision is empty</summary>
         </status>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:19 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:14 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:tom/package_with_file?cmd=diff&expand=0&rev=&view=xml&withissues=1
+    uri: http://backend:5352/source/home:tom/package_with_file?cacheonly=1&cmd=diff&expand=0&rev=&view=xml&withissues=1
     body:
       encoding: UTF-8
       string: ''
@@ -299,6 +298,6 @@ http_interactions:
         <status code="400">
           <summary>revision is empty</summary>
         </status>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:19 GMT
-recorded_with: VCR 5.0.0
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:14 GMT
+recorded_with: VCR 5.1.0

--- a/src/api/spec/cassettes/Webui_PackageController/GET_rdiff/when_no_difference_in_sources_diff_is_empty/1_12_1_1.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/GET_rdiff/when_no_difference_in_sources_diff_is_empty/1_12_1_1.yml
@@ -39,17 +39,17 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:16 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:13 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_file/_meta?user=user_51
+    uri: http://backend:5352/source/home:tom/package_with_file/_meta?user=user_1
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom">
-          <title>To Your Scattered Bodies Go</title>
-          <description>Aut repellat laboriosam omnis.</description>
+          <title>East of Eden</title>
+          <description>Repudiandae illum molestiae nisi.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,22 +70,22 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '170'
+      - '158'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom">
-          <title>To Your Scattered Bodies Go</title>
-          <description>Aut repellat laboriosam omnis.</description>
+          <title>East of Eden</title>
+          <description>Repudiandae illum molestiae nisi.</description>
         </package>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:16 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:13 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/package_with_file/_config
     body:
       encoding: UTF-8
-      string: Sunt doloribus voluptas. Sequi velit voluptas. Possimus dolor facilis.
+      string: Magni dicta est. Iste iusto maxime. Eum quas quo.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -105,26 +105,26 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '209'
+      - '207'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="77" vrev="77">
-          <srcmd5>51c7448f7f2f3d6ce7c38e8b23134a31</srcmd5>
+        <revision rev="1" vrev="1">
+          <srcmd5>608d527ea77a5fe5a5a06669faec6a4f</srcmd5>
           <version>unknown</version>
-          <time>1569593836</time>
+          <time>1582638373</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:16 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:13 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/package_with_file/somefile.txt
     body:
       encoding: UTF-8
-      string: Praesentium a atque. Itaque eos doloribus. Deleniti voluptatem veniam.
+      string: Repellendus vitae libero. Omnis dolorem perferendis. Ut impedit provident.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -144,20 +144,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '209'
+      - '207'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="78" vrev="78">
-          <srcmd5>380674dc41da49b63de53c6c5ee3a152</srcmd5>
+        <revision rev="2" vrev="2">
+          <srcmd5>a4460e6aa8a568f999b41346ab3e28b0</srcmd5>
           <version>unknown</version>
-          <time>1569593836</time>
+          <time>1582638373</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:16 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:13 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom/package_with_file
@@ -183,16 +183,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '304'
+      - '302'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_file" rev="78" vrev="78" srcmd5="380674dc41da49b63de53c6c5ee3a152">
-          <entry name="_config" md5="722f6682081a43551dc6752239afcb63" size="70" mtime="1569593836"/>
-          <entry name="somefile.txt" md5="7ebb2f72aecd81a38bd1449daa42c446" size="70" mtime="1569593836"/>
+        <directory name="package_with_file" rev="2" vrev="2" srcmd5="a4460e6aa8a568f999b41346ab3e28b0">
+          <entry name="_config" md5="fe15eb247757310799a7ece843e951fb" size="49" mtime="1582638373"/>
+          <entry name="somefile.txt" md5="56530076f63e6d1d98de918fe22642d9" size="74" mtime="1582638373"/>
         </directory>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:16 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:13 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom/package_with_file
@@ -218,19 +218,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '304'
+      - '302'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_file" rev="78" vrev="78" srcmd5="380674dc41da49b63de53c6c5ee3a152">
-          <entry name="_config" md5="722f6682081a43551dc6752239afcb63" size="70" mtime="1569593836"/>
-          <entry name="somefile.txt" md5="7ebb2f72aecd81a38bd1449daa42c446" size="70" mtime="1569593836"/>
+        <directory name="package_with_file" rev="2" vrev="2" srcmd5="a4460e6aa8a568f999b41346ab3e28b0">
+          <entry name="_config" md5="fe15eb247757310799a7ece843e951fb" size="49" mtime="1582638373"/>
+          <entry name="somefile.txt" md5="56530076f63e6d1d98de918fe22642d9" size="74" mtime="1582638373"/>
         </directory>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:16 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:13 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:tom/package_with_file?cmd=diff&expand=1&opackage=package_with_file&oproject=home:tom&rev=78&view=xml&withissues=1
+    uri: http://backend:5352/source/home:tom/package_with_file?cacheonly=1&cmd=diff&expand=1&opackage=package_with_file&oproject=home:tom&rev=2&view=xml&withissues=1
     body:
       encoding: UTF-8
       string: ''
@@ -255,15 +255,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '291'
+      - '289'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="ba3accf02f0b9b4098e39834c7645802">
-          <old project="home:tom" package="package_with_file" rev="78" srcmd5="380674dc41da49b63de53c6c5ee3a152"/>
-          <new project="home:tom" package="package_with_file" rev="78" srcmd5="380674dc41da49b63de53c6c5ee3a152"/>
+        <sourcediff key="293b7f4607ebf1310d26607fcb14c31f">
+          <old project="home:tom" package="package_with_file" rev="2" srcmd5="a4460e6aa8a568f999b41346ab3e28b0"/>
+          <new project="home:tom" package="package_with_file" rev="2" srcmd5="a4460e6aa8a568f999b41346ab3e28b0"/>
           <files/>
         </sourcediff>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:16 GMT
-recorded_with: VCR 5.0.0
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:13 GMT
+recorded_with: VCR 5.1.0

--- a/src/api/spec/cassettes/Webui_PackageController/GET_rdiff/with_diff_truncation/full_diff_not_requested/for_ASCII_files/shows_the_truncated_diff.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/GET_rdiff/with_diff_truncation/full_diff_not_requested/for_ASCII_files/shows_the_truncated_diff.yml
@@ -39,17 +39,17 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:18 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:12 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/diff-truncation-test-1/_meta?user=user_53
+    uri: http://backend:5352/source/home:tom/diff-truncation-test-1/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
         <package name="diff-truncation-test-1" project="home:tom">
-          <title>From Here to Eternity</title>
-          <description>Et illo sed est.</description>
+          <title>The Curious Incident of the Dog in the Night-Time</title>
+          <description>Ea blanditiis aperiam sapiente.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,22 +70,22 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '155'
+      - '198'
     body:
       encoding: UTF-8
       string: |
         <package name="diff-truncation-test-1" project="home:tom">
-          <title>From Here to Eternity</title>
-          <description>Et illo sed est.</description>
+          <title>The Curious Incident of the Dog in the Night-Time</title>
+          <description>Ea blanditiis aperiam sapiente.</description>
         </package>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:18 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:12 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/diff-truncation-test-1/_config
     body:
       encoding: UTF-8
-      string: In incidunt quis. Dolores aut omnis. Reprehenderit placeat sunt.
+      string: Assumenda sed nesciunt. Atque quibusdam cumque. Aliquam aut tempore.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -110,15 +110,15 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="7" vrev="7">
-          <srcmd5>267a4532b96f94aeee526ef398ef4a94</srcmd5>
+          <srcmd5>7a2555e26fe90b39bb281e1424c8d1d4</srcmd5>
           <version>unknown</version>
-          <time>1569593838</time>
+          <time>1582638372</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:18 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:12 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/diff-truncation-test-1/somefile.txt
@@ -11149,15 +11149,15 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="8" vrev="8">
-          <srcmd5>267a4532b96f94aeee526ef398ef4a94</srcmd5>
+          <srcmd5>7a2555e26fe90b39bb281e1424c8d1d4</srcmd5>
           <version>unknown</version>
-          <time>1569593838</time>
+          <time>1582638372</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:18 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:12 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom/diff-truncation-test-1
@@ -11187,12 +11187,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="diff-truncation-test-1" rev="8" vrev="8" srcmd5="267a4532b96f94aeee526ef398ef4a94">
-          <entry name="_config" md5="b3404c0684001bc3a9c00cdddd8c03b1" size="64" mtime="1569593838"/>
-          <entry name="somefile.txt" md5="3ba28480d8b6af8ddebf044417388dde" size="22000" mtime="1569593836"/>
+        <directory name="diff-truncation-test-1" rev="8" vrev="8" srcmd5="7a2555e26fe90b39bb281e1424c8d1d4">
+          <entry name="_config" md5="22e0973acf852d1b6fc38a8b46a51cae" size="68" mtime="1582638372"/>
+          <entry name="somefile.txt" md5="3ba28480d8b6af8ddebf044417388dde" size="22000" mtime="1582638371"/>
         </directory>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:18 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:12 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom/diff-truncation-test-1
@@ -11222,12 +11222,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="diff-truncation-test-1" rev="8" vrev="8" srcmd5="267a4532b96f94aeee526ef398ef4a94">
-          <entry name="_config" md5="b3404c0684001bc3a9c00cdddd8c03b1" size="64" mtime="1569593838"/>
-          <entry name="somefile.txt" md5="3ba28480d8b6af8ddebf044417388dde" size="22000" mtime="1569593836"/>
+        <directory name="diff-truncation-test-1" rev="8" vrev="8" srcmd5="7a2555e26fe90b39bb281e1424c8d1d4">
+          <entry name="_config" md5="22e0973acf852d1b6fc38a8b46a51cae" size="68" mtime="1582638372"/>
+          <entry name="somefile.txt" md5="3ba28480d8b6af8ddebf044417388dde" size="22000" mtime="1582638371"/>
         </directory>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:18 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:12 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom/diff-truncation-test-1?cmd=diff&expand=1&rev=2&view=xml&withissues=1
@@ -11259,9 +11259,9 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="facad58e887cbea9e144b5a3e36cd8a6">
-          <old project="home:tom" package="diff-truncation-test-1" rev="1" srcmd5="02fd3f2edebc5db1a9e110759c405f23"/>
-          <new project="home:tom" package="diff-truncation-test-1" rev="2" srcmd5="87c8721caaefa96959cba4d0906f9cc4"/>
+        <sourcediff key="6258bd6e3e8ad5d3278bb3e5aa78d16d">
+          <old project="home:tom" package="diff-truncation-test-1" rev="1" srcmd5="f06f3df8d97589cc0f3bc7fb93057982"/>
+          <new project="home:tom" package="diff-truncation-test-1" rev="2" srcmd5="0fc8721833ff9f28fa9ea0cd7ef8ac23"/>
           <files>
             <file state="added">
               <new name="somefile.txt" md5="3ba28480d8b6af8ddebf044417388dde" size="22000"/>
@@ -11471,6 +11471,6 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:18 GMT
-recorded_with: VCR 5.0.0
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:12 GMT
+recorded_with: VCR 5.1.0

--- a/src/api/spec/cassettes/Webui_PackageController/GET_rdiff/with_diff_truncation/full_diff_not_requested/for_archives/shows_the_truncated_diff.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/GET_rdiff/with_diff_truncation/full_diff_not_requested/for_archives/shows_the_truncated_diff.yml
@@ -39,17 +39,17 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:18 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:13 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/diff-truncation-test-2/_meta?user=user_54
+    uri: http://backend:5352/source/home:tom/diff-truncation-test-2/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
         <package name="diff-truncation-test-2" project="home:tom">
-          <title>The Torment of Others</title>
-          <description>Laborum animi eveniet ipsum.</description>
+          <title>In Death Ground</title>
+          <description>Ex adipisci sint unde.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,16 +70,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '155'
     body:
       encoding: UTF-8
       string: |
         <package name="diff-truncation-test-2" project="home:tom">
-          <title>The Torment of Others</title>
-          <description>Laborum animi eveniet ipsum.</description>
+          <title>In Death Ground</title>
+          <description>Ex adipisci sint unde.</description>
         </package>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:18 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:13 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/diff-truncation-test-2/bigfile_archive.tar.gz
@@ -115,13 +115,13 @@ http_interactions:
         <revision rev="3" vrev="3">
           <srcmd5>a9789ffd295bf47f77113616443547ac</srcmd5>
           <version>unknown</version>
-          <time>1569593838</time>
+          <time>1582638373</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:18 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:13 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/diff-truncation-test-2/bigfile_archive.tar.gz
@@ -157,13 +157,13 @@ http_interactions:
         <revision rev="4" vrev="4">
           <srcmd5>f83eab96d07ccb93931e4136c117e1df</srcmd5>
           <version>unknown</version>
-          <time>1569593838</time>
+          <time>1582638373</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:18 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:13 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom/diff-truncation-test-2
@@ -194,10 +194,10 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="diff-truncation-test-2" rev="4" vrev="4" srcmd5="f83eab96d07ccb93931e4136c117e1df">
-          <entry name="bigfile_archive.tar.gz" md5="e4f963909dcadcfb2cb888d0ce167570" size="10240" mtime="1569593837"/>
+          <entry name="bigfile_archive.tar.gz" md5="e4f963909dcadcfb2cb888d0ce167570" size="10240" mtime="1582638371"/>
         </directory>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:19 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:13 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom/diff-truncation-test-2
@@ -228,10 +228,10 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="diff-truncation-test-2" rev="4" vrev="4" srcmd5="f83eab96d07ccb93931e4136c117e1df">
-          <entry name="bigfile_archive.tar.gz" md5="e4f963909dcadcfb2cb888d0ce167570" size="10240" mtime="1569593837"/>
+          <entry name="bigfile_archive.tar.gz" md5="e4f963909dcadcfb2cb888d0ce167570" size="10240" mtime="1582638371"/>
         </directory>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:19 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:13 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom/diff-truncation-test-2?cmd=diff&expand=1&rev=4&view=xml&withissues=1
@@ -289,6 +289,6 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:19 GMT
-recorded_with: VCR 5.0.0
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:13 GMT
+recorded_with: VCR 5.1.0

--- a/src/api/spec/cassettes/Webui_PackageController/GET_rdiff/with_diff_truncation/full_diff_not_requested/shows_a_hint.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/GET_rdiff/with_diff_truncation/full_diff_not_requested/shows_a_hint.yml
@@ -39,17 +39,17 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:18 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:12 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/diff-truncation-test-1/_meta?user=user_52
+    uri: http://backend:5352/source/home:tom/diff-truncation-test-1/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
         <package name="diff-truncation-test-1" project="home:tom">
-          <title>Terrible Swift Sword</title>
-          <description>Repellendus et et accusamus.</description>
+          <title>I Know Why the Caged Bird Sings</title>
+          <description>Consequuntur ut unde quae.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,22 +70,22 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '166'
+      - '175'
     body:
       encoding: UTF-8
       string: |
         <package name="diff-truncation-test-1" project="home:tom">
-          <title>Terrible Swift Sword</title>
-          <description>Repellendus et et accusamus.</description>
+          <title>I Know Why the Caged Bird Sings</title>
+          <description>Consequuntur ut unde quae.</description>
         </package>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:18 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:12 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/diff-truncation-test-1/_config
     body:
       encoding: UTF-8
-      string: Qui labore totam. Qui nam facilis. Veniam molestiae sit.
+      string: Qui omnis exercitationem. Recusandae neque dolorem. In aut excepturi.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -110,15 +110,15 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="5" vrev="5">
-          <srcmd5>72db53964ce34ea96a626bbae47d0685</srcmd5>
+          <srcmd5>64519a8e954f3a6b867d5928f6bc9b66</srcmd5>
           <version>unknown</version>
-          <time>1569593838</time>
+          <time>1582638372</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:18 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:12 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/diff-truncation-test-1/somefile.txt
@@ -11149,15 +11149,15 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="6" vrev="6">
-          <srcmd5>72db53964ce34ea96a626bbae47d0685</srcmd5>
+          <srcmd5>64519a8e954f3a6b867d5928f6bc9b66</srcmd5>
           <version>unknown</version>
-          <time>1569593838</time>
+          <time>1582638372</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:18 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:12 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom/diff-truncation-test-1
@@ -11187,12 +11187,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="diff-truncation-test-1" rev="6" vrev="6" srcmd5="72db53964ce34ea96a626bbae47d0685">
-          <entry name="_config" md5="6aea552592dd61d8e3b72e638b06a50a" size="56" mtime="1569593838"/>
-          <entry name="somefile.txt" md5="3ba28480d8b6af8ddebf044417388dde" size="22000" mtime="1569593836"/>
+        <directory name="diff-truncation-test-1" rev="6" vrev="6" srcmd5="64519a8e954f3a6b867d5928f6bc9b66">
+          <entry name="_config" md5="93f1961a63e744c19b05350bda188a20" size="69" mtime="1582638372"/>
+          <entry name="somefile.txt" md5="3ba28480d8b6af8ddebf044417388dde" size="22000" mtime="1582638371"/>
         </directory>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:18 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:12 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom/diff-truncation-test-1
@@ -11222,12 +11222,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="diff-truncation-test-1" rev="6" vrev="6" srcmd5="72db53964ce34ea96a626bbae47d0685">
-          <entry name="_config" md5="6aea552592dd61d8e3b72e638b06a50a" size="56" mtime="1569593838"/>
-          <entry name="somefile.txt" md5="3ba28480d8b6af8ddebf044417388dde" size="22000" mtime="1569593836"/>
+        <directory name="diff-truncation-test-1" rev="6" vrev="6" srcmd5="64519a8e954f3a6b867d5928f6bc9b66">
+          <entry name="_config" md5="93f1961a63e744c19b05350bda188a20" size="69" mtime="1582638372"/>
+          <entry name="somefile.txt" md5="3ba28480d8b6af8ddebf044417388dde" size="22000" mtime="1582638371"/>
         </directory>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:18 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:12 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom/diff-truncation-test-1?cmd=diff&expand=1&rev=2&view=xml&withissues=1
@@ -11259,9 +11259,9 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="facad58e887cbea9e144b5a3e36cd8a6">
-          <old project="home:tom" package="diff-truncation-test-1" rev="1" srcmd5="02fd3f2edebc5db1a9e110759c405f23"/>
-          <new project="home:tom" package="diff-truncation-test-1" rev="2" srcmd5="87c8721caaefa96959cba4d0906f9cc4"/>
+        <sourcediff key="6258bd6e3e8ad5d3278bb3e5aa78d16d">
+          <old project="home:tom" package="diff-truncation-test-1" rev="1" srcmd5="f06f3df8d97589cc0f3bc7fb93057982"/>
+          <new project="home:tom" package="diff-truncation-test-1" rev="2" srcmd5="0fc8721833ff9f28fa9ea0cd7ef8ac23"/>
           <files>
             <file state="added">
               <new name="somefile.txt" md5="3ba28480d8b6af8ddebf044417388dde" size="22000"/>
@@ -11471,6 +11471,6 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:18 GMT
-recorded_with: VCR 5.0.0
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:12 GMT
+recorded_with: VCR 5.1.0

--- a/src/api/spec/cassettes/Webui_PackageController/GET_rdiff/with_diff_truncation/full_diff_requested/does_not_show_a_hint.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/GET_rdiff/with_diff_truncation/full_diff_requested/does_not_show_a_hint.yml
@@ -39,8 +39,8 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:16 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:11 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/diff-truncation-test-1/_meta?user=tom
@@ -48,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="diff-truncation-test-1" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Laudantium vero explicabo minima.</description>
+          <title>This Lime Tree Bower</title>
+          <description>Aut dolor dolore qui.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,22 +70,22 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '169'
+      - '159'
     body:
       encoding: UTF-8
       string: |
         <package name="diff-truncation-test-1" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Laudantium vero explicabo minima.</description>
+          <title>This Lime Tree Bower</title>
+          <description>Aut dolor dolore qui.</description>
         </package>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:16 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:11 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/diff-truncation-test-1/_config
     body:
       encoding: UTF-8
-      string: Qui eum provident. Dolor consequatur nostrum. Quia sunt voluptas.
+      string: Inventore ipsum minima. Explicabo eum eos. Fuga ipsa voluptatem.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -110,15 +110,15 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="1" vrev="1">
-          <srcmd5>02fd3f2edebc5db1a9e110759c405f23</srcmd5>
+          <srcmd5>f06f3df8d97589cc0f3bc7fb93057982</srcmd5>
           <version>unknown</version>
-          <time>1569593836</time>
+          <time>1582638371</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:16 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:11 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/diff-truncation-test-1/somefile.txt
@@ -11149,15 +11149,15 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="2" vrev="2">
-          <srcmd5>87c8721caaefa96959cba4d0906f9cc4</srcmd5>
+          <srcmd5>0fc8721833ff9f28fa9ea0cd7ef8ac23</srcmd5>
           <version>unknown</version>
-          <time>1569593836</time>
+          <time>1582638371</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:17 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:11 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom/diff-truncation-test-1
@@ -11187,12 +11187,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="diff-truncation-test-1" rev="2" vrev="2" srcmd5="87c8721caaefa96959cba4d0906f9cc4">
-          <entry name="_config" md5="b207c1287ba73b69bb57c9e07065d035" size="65" mtime="1569593836"/>
-          <entry name="somefile.txt" md5="3ba28480d8b6af8ddebf044417388dde" size="22000" mtime="1569593836"/>
+        <directory name="diff-truncation-test-1" rev="2" vrev="2" srcmd5="0fc8721833ff9f28fa9ea0cd7ef8ac23">
+          <entry name="_config" md5="ace34c724bb8e8766064ba4be18d72dc" size="64" mtime="1582638371"/>
+          <entry name="somefile.txt" md5="3ba28480d8b6af8ddebf044417388dde" size="22000" mtime="1582638371"/>
         </directory>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:17 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:11 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom/diff-truncation-test-1
@@ -11222,12 +11222,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="diff-truncation-test-1" rev="2" vrev="2" srcmd5="87c8721caaefa96959cba4d0906f9cc4">
-          <entry name="_config" md5="b207c1287ba73b69bb57c9e07065d035" size="65" mtime="1569593836"/>
-          <entry name="somefile.txt" md5="3ba28480d8b6af8ddebf044417388dde" size="22000" mtime="1569593836"/>
+        <directory name="diff-truncation-test-1" rev="2" vrev="2" srcmd5="0fc8721833ff9f28fa9ea0cd7ef8ac23">
+          <entry name="_config" md5="ace34c724bb8e8766064ba4be18d72dc" size="64" mtime="1582638371"/>
+          <entry name="somefile.txt" md5="3ba28480d8b6af8ddebf044417388dde" size="22000" mtime="1582638371"/>
         </directory>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:17 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:11 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom/diff-truncation-test-1?cmd=diff&expand=1&filelimit=0&rev=2&tarlimit=0&view=xml&withissues=1
@@ -11259,9 +11259,9 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="fed077595ad4db44fb13145b25725341">
-          <old project="home:tom" package="diff-truncation-test-1" rev="1" srcmd5="02fd3f2edebc5db1a9e110759c405f23"/>
-          <new project="home:tom" package="diff-truncation-test-1" rev="2" srcmd5="87c8721caaefa96959cba4d0906f9cc4"/>
+        <sourcediff key="6fc4169df2b41980e57d1ae40cf36409">
+          <old project="home:tom" package="diff-truncation-test-1" rev="1" srcmd5="f06f3df8d97589cc0f3bc7fb93057982"/>
+          <new project="home:tom" package="diff-truncation-test-1" rev="2" srcmd5="0fc8721833ff9f28fa9ea0cd7ef8ac23"/>
           <files>
             <file state="added">
               <new name="somefile.txt" md5="3ba28480d8b6af8ddebf044417388dde" size="22000"/>
@@ -22272,6 +22272,6 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:17 GMT
-recorded_with: VCR 5.0.0
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:11 GMT
+recorded_with: VCR 5.1.0

--- a/src/api/spec/cassettes/Webui_PackageController/GET_rdiff/with_diff_truncation/full_diff_requested/for_ASCII_files/shows_the_complete_diff.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/GET_rdiff/with_diff_truncation/full_diff_requested/for_ASCII_files/shows_the_complete_diff.yml
@@ -39,8 +39,8 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:17 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:11 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/diff-truncation-test-1/_meta?user=tom
@@ -48,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="diff-truncation-test-1" project="home:tom">
-          <title>In a Dry Season</title>
-          <description>Est quod nesciunt veniam.</description>
+          <title>For Whom the Bell Tolls</title>
+          <description>Iure tenetur est voluptatem.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,22 +70,22 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '158'
+      - '169'
     body:
       encoding: UTF-8
       string: |
         <package name="diff-truncation-test-1" project="home:tom">
-          <title>In a Dry Season</title>
-          <description>Est quod nesciunt veniam.</description>
+          <title>For Whom the Bell Tolls</title>
+          <description>Iure tenetur est voluptatem.</description>
         </package>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:17 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:11 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/diff-truncation-test-1/_config
     body:
       encoding: UTF-8
-      string: At nulla incidunt. Quo non totam. Laudantium consequatur quaerat.
+      string: Alias impedit at. Porro libero aut. Sit tenetur dignissimos.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -110,15 +110,15 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="3" vrev="3">
-          <srcmd5>eb50ffe8b13aebe6229f3033d4669651</srcmd5>
+          <srcmd5>7cd0ca5f7c2328bd84914eeb37da0298</srcmd5>
           <version>unknown</version>
-          <time>1569593837</time>
+          <time>1582638371</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:17 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:12 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/diff-truncation-test-1/somefile.txt
@@ -11149,15 +11149,15 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="4" vrev="4">
-          <srcmd5>eb50ffe8b13aebe6229f3033d4669651</srcmd5>
+          <srcmd5>7cd0ca5f7c2328bd84914eeb37da0298</srcmd5>
           <version>unknown</version>
-          <time>1569593837</time>
+          <time>1582638372</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:17 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:12 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom/diff-truncation-test-1
@@ -11187,12 +11187,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="diff-truncation-test-1" rev="4" vrev="4" srcmd5="eb50ffe8b13aebe6229f3033d4669651">
-          <entry name="_config" md5="f233b2f35fdb75395b05114d56f9e895" size="65" mtime="1569593837"/>
-          <entry name="somefile.txt" md5="3ba28480d8b6af8ddebf044417388dde" size="22000" mtime="1569593836"/>
+        <directory name="diff-truncation-test-1" rev="4" vrev="4" srcmd5="7cd0ca5f7c2328bd84914eeb37da0298">
+          <entry name="_config" md5="94af07eaee6eda1f7ff1e01153fccf77" size="60" mtime="1582638371"/>
+          <entry name="somefile.txt" md5="3ba28480d8b6af8ddebf044417388dde" size="22000" mtime="1582638371"/>
         </directory>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:17 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:12 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom/diff-truncation-test-1
@@ -11222,12 +11222,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="diff-truncation-test-1" rev="4" vrev="4" srcmd5="eb50ffe8b13aebe6229f3033d4669651">
-          <entry name="_config" md5="f233b2f35fdb75395b05114d56f9e895" size="65" mtime="1569593837"/>
-          <entry name="somefile.txt" md5="3ba28480d8b6af8ddebf044417388dde" size="22000" mtime="1569593836"/>
+        <directory name="diff-truncation-test-1" rev="4" vrev="4" srcmd5="7cd0ca5f7c2328bd84914eeb37da0298">
+          <entry name="_config" md5="94af07eaee6eda1f7ff1e01153fccf77" size="60" mtime="1582638371"/>
+          <entry name="somefile.txt" md5="3ba28480d8b6af8ddebf044417388dde" size="22000" mtime="1582638371"/>
         </directory>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:17 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:12 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom/diff-truncation-test-1?cmd=diff&expand=1&filelimit=0&rev=2&tarlimit=0&view=xml&withissues=1
@@ -11259,9 +11259,9 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="fed077595ad4db44fb13145b25725341">
-          <old project="home:tom" package="diff-truncation-test-1" rev="1" srcmd5="02fd3f2edebc5db1a9e110759c405f23"/>
-          <new project="home:tom" package="diff-truncation-test-1" rev="2" srcmd5="87c8721caaefa96959cba4d0906f9cc4"/>
+        <sourcediff key="6fc4169df2b41980e57d1ae40cf36409">
+          <old project="home:tom" package="diff-truncation-test-1" rev="1" srcmd5="f06f3df8d97589cc0f3bc7fb93057982"/>
+          <new project="home:tom" package="diff-truncation-test-1" rev="2" srcmd5="0fc8721833ff9f28fa9ea0cd7ef8ac23"/>
           <files>
             <file state="added">
               <new name="somefile.txt" md5="3ba28480d8b6af8ddebf044417388dde" size="22000"/>
@@ -22272,6 +22272,6 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:17 GMT
-recorded_with: VCR 5.0.0
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:12 GMT
+recorded_with: VCR 5.1.0

--- a/src/api/spec/cassettes/Webui_PackageController/GET_rdiff/with_diff_truncation/full_diff_requested/for_archives/shows_the_complete_diff.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/GET_rdiff/with_diff_truncation/full_diff_requested/for_archives/shows_the_complete_diff.yml
@@ -39,8 +39,8 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:17 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:11 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/diff-truncation-test-2/_meta?user=tom
@@ -48,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="diff-truncation-test-2" project="home:tom">
-          <title>Behold the Man</title>
-          <description>Rerum ut eligendi repellendus.</description>
+          <title>Clouds of Witness</title>
+          <description>Non laborum praesentium animi.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,16 +70,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '162'
+      - '165'
     body:
       encoding: UTF-8
       string: |
         <package name="diff-truncation-test-2" project="home:tom">
-          <title>Behold the Man</title>
-          <description>Rerum ut eligendi repellendus.</description>
+          <title>Clouds of Witness</title>
+          <description>Non laborum praesentium animi.</description>
         </package>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:17 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:11 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/diff-truncation-test-2/bigfile_archive.tar.gz
@@ -115,13 +115,13 @@ http_interactions:
         <revision rev="1" vrev="1">
           <srcmd5>a9789ffd295bf47f77113616443547ac</srcmd5>
           <version>unknown</version>
-          <time>1569593837</time>
+          <time>1582638371</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:17 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:11 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/diff-truncation-test-2/bigfile_archive.tar.gz
@@ -157,13 +157,13 @@ http_interactions:
         <revision rev="2" vrev="2">
           <srcmd5>f83eab96d07ccb93931e4136c117e1df</srcmd5>
           <version>unknown</version>
-          <time>1569593837</time>
+          <time>1582638371</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:17 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:11 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom/diff-truncation-test-2
@@ -194,10 +194,10 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="diff-truncation-test-2" rev="2" vrev="2" srcmd5="f83eab96d07ccb93931e4136c117e1df">
-          <entry name="bigfile_archive.tar.gz" md5="e4f963909dcadcfb2cb888d0ce167570" size="10240" mtime="1569593837"/>
+          <entry name="bigfile_archive.tar.gz" md5="e4f963909dcadcfb2cb888d0ce167570" size="10240" mtime="1582638371"/>
         </directory>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:17 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:11 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom/diff-truncation-test-2
@@ -228,10 +228,10 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="diff-truncation-test-2" rev="2" vrev="2" srcmd5="f83eab96d07ccb93931e4136c117e1df">
-          <entry name="bigfile_archive.tar.gz" md5="e4f963909dcadcfb2cb888d0ce167570" size="10240" mtime="1569593837"/>
+          <entry name="bigfile_archive.tar.gz" md5="e4f963909dcadcfb2cb888d0ce167570" size="10240" mtime="1582638371"/>
         </directory>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:17 GMT
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:11 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom/diff-truncation-test-2?cmd=diff&expand=1&filelimit=0&rev=2&tarlimit=0&view=xml&withissues=1
@@ -289,6 +289,6 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-    http_version: 
-  recorded_at: Fri, 27 Sep 2019 14:17:17 GMT
-recorded_with: VCR 5.0.0
+    http_version: null
+  recorded_at: Tue, 25 Feb 2020 13:46:11 GMT
+recorded_with: VCR 5.1.0

--- a/src/api/spec/controllers/webui/package_controller_spec.rb
+++ b/src/api/spec/controllers/webui/package_controller_spec.rb
@@ -920,12 +920,14 @@ RSpec.describe Webui::PackageController, vcr: true do
 
       context 'full diff not requested' do
         it 'shows a hint' do
+          login user
           get :rdiff, params: { project: source_project, package: package_ascii_file, rev: 2 }
           expect(assigns(:not_full_diff)).to be_truthy
         end
 
         context 'for ASCII files' do
           before do
+            login user
             get :rdiff, params: { project: source_project, package: package_ascii_file, rev: 2 }
           end
 
@@ -937,6 +939,7 @@ RSpec.describe Webui::PackageController, vcr: true do
 
         context 'for archives' do
           before do
+            login user
             get :rdiff, params: { project: source_project, package: package_binary_file }
           end
 

--- a/src/api/test/functional/webui/spider_test.rb
+++ b/src/api/test/functional/webui/spider_test.rb
@@ -7,7 +7,7 @@ class Webui::SpiderTest < Webui::IntegrationTest
   def ignore_link?(link)
     return true if link =~ %r{/mini-profiler-resources}
     # that link is just a top ref
-    return true if link.end_with?('/package/rdiff')
+    return true if link =~ %r{/package/rdiff}
     # admin can see even the hidden
     return true if link.end_with?('/package/show/HiddenRemoteInstance')
     return true if link =~ %r{/package/show/SourceprotectedProject}

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -2927,6 +2927,7 @@ sub sourcediff {
       BSServer::reply_file(\*F, $view eq 'xml' ? 'Content-Type: text/xml' : 'Content-Type: text/plain');
       return undef;
     }
+    die("412 diff not yet in cache\n") if $cgi->{'cacheonly'};
     mkdir_p("$diffcache/".substr($cacheid, 0, 2));
     if (!BSUtil::lockcheck('>>', "$cn.run")) {
       my @args;
@@ -6623,9 +6624,9 @@ my $dispatches = [
   '/source/$project/_history rev? meta:bool? deleted:bool? limit:num?' => \&getpackagehistory,
   '/source/$project/_keyinfo withsslcert:bool? autoextend:bool? donotcreatecert:bool? signtype:?' => \&getkeyinfo,
 
-  'POST:/source/$project/$package cmd=diff rev? orev:rev? oproject:project? opackage:package? expand:bool? linkrev? olinkrev:? unified:bool? missingok:bool? meta:bool? file:filename* filelimit:num? tarlimit:num? view:? withissues:bool? onlyissues:bool? nocache:bool? nodiff:bool?' => \&sourcediff,
-  'POST:/source/$project/$package cmd=linkdiff rev? linkrev? unified:bool? file:filename* filelimit:num? tarlimit:num? view:? withissues:bool? onlyissues:bool?' => \&linkdiff,
-  'POST:/source/$project/$package cmd=servicediff rev? unified:bool? file:filename* filelimit:num? tarlimit:num? view:? withissues:bool? onlyissues:bool?' => \&servicediff,
+  'POST:/source/$project/$package cmd=diff rev? orev:rev? oproject:project? opackage:package? expand:bool? linkrev? olinkrev:? unified:bool? missingok:bool? meta:bool? file:filename* filelimit:num? tarlimit:num? view:? withissues:bool? onlyissues:bool? nocache:bool? cacheonly:bool? nodiff:bool?' => \&sourcediff,
+  'POST:/source/$project/$package cmd=linkdiff rev? linkrev? unified:bool? file:filename* filelimit:num? tarlimit:num? view:? withissues:bool? onlyissues:bool? nocache:bool? cacheonly:bool? nodiff:bool?' => \&linkdiff,
+  'POST:/source/$project/$package cmd=servicediff rev? unified:bool? file:filename* filelimit:num? tarlimit:num? view:? withissues:bool? onlyissues:bool? nocache:bool? cacheonly:bool? nodiff:bool?' => \&servicediff,
   'POST:/source/$project/$package cmd=commit rev? user:? comment:? keeplink:bool? repairlink:bool? linkrev? setrev:bool? requestid:num? noservice:bool?' => \&sourcecommit,
   'POST:/source/$project/$package cmd=commitfilelist rev? user:? comment:? keeplink:bool? repairlink:bool? linkrev? setrev:bool? requestid:num? time:num? version:? vrev:? noservice:bool? servicemark:? withvalidate:?' => \&sourcecommitfilelist,
   'POST:/source/$project/$package cmd=copy rev? user:? comment:? orev:rev? oproject:project? opackage:package? expand:bool? keeplink:bool? repairlink:bool? linkrev? setrev:linkrev? olinkrev:linkrev? requestid:num? dontupdatesource:bool? noservice:bool? withvrev:bool? withacceptinfo:bool? makeoriginolder:bool? freezelink:bool? vrevbump:num? instantiate:bool?' => \&sourcecopy,


### PR DESCRIPTION
We'll use this in the API to defer source diffing to a delay job,
so that the WebUI does not clog up all source server slots.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
