### PR TITLE
[backend] fix oracle to match multiple cpu flags

### DIFF
--- a/ReleaseNotes-2.11
+++ b/ReleaseNotes-2.11
@@ -59,3 +59,5 @@ Intentional changes:
     - /home/my_work
     - /home/home_project
     - /home/list_my
+
+ * Switched from OR to AND when checking CPU flags in _constraints file

--- a/src/backend/BSDispatcher/Constraints.pm
+++ b/src/backend/BSDispatcher/Constraints.pm
@@ -115,7 +115,7 @@ sub oracle {
     if ($constraints->{'hardware'}->{'cpu'}) {
       return 0 unless $worker->{'hardware'}->{'cpu'};
       my %workerflags = map {$_ => 1} @{$worker->{'hardware'}->{'cpu'}->{'flag'} || []};
-      return 0 unless grep {$workerflags{$_}} @{$constraints->{'hardware'}->{'cpu'}->{'flag'} || []};
+      return 0 if grep {!$workerflags{$_}} @{$constraints->{'hardware'}->{'cpu'}->{'flag'} || []};
     }
   }
   return 1;


### PR DESCRIPTION
Instead of accepting only one match of cpu flags while
constraints validation all flags must be present in the
worker