### PR TITLE
Use flex in build results elements

### DIFF
--- a/src/api/app/assets/stylesheets/webui/build-results.scss
+++ b/src/api/app/assets/stylesheets/webui/build-results.scss
@@ -18,6 +18,19 @@
   }
 }
 
+.repository-state {
+  @extend .pl-1;
+  @extend .pl-sm-3;
+  @extend .text-nowrap;
+  flex-basis: 38%;
+}
+
+.build-state {
+  @extend .pl-1;
+  @extend .pl-sm-2;
+  @extend .text-nowrap;
+}
+
 .build-state-succeeded {
   color: $green;
 }

--- a/src/api/app/views/webui/package/_buildstatus.html.haml
+++ b/src/api/app/views/webui/package/_buildstatus.html.haml
@@ -29,15 +29,15 @@
 
         .collapse{ class: "collapse-#{package_name}-#{repository_name}#{expanded ? ' show' : ''}",
                    data: { repository: repository_name, main: package_name } }
-          .row.no-gutters.py-1
-            .col-6.col-sm-5.col-xl-4.pl-1.pl-sm-3.text-nowrap
+          .d-flex.flex-row.flex-wrap.py-1
+            .repository-state
               - if !result.is_repository_in_db
                 %i.fas.fa-clock.text-warning{ title: 'This result is outdated' }
               - else
                 = repository_status_icon(status: result.state, details: result.details)
               %span.ml-1
                 = result.architecture
-            .col.pl-1.pl-sm-2.text-nowrap
+            .build-state
               = arch_repo_table_cell(result.repository, result.architecture, package, 'code' => result.code, 'details' => result.details)
         - previous_repo = result.repository
     - else

--- a/src/api/app/views/webui/project/_buildstatus.html.haml
+++ b/src/api/app/views/webui/project/_buildstatus.html.haml
@@ -17,7 +17,7 @@
       - repository_name = repository.tr('.', '_')
       - expanded = repository_expanded?(collapsed_repositories, repository_name)
       .d-flex.flex-column
-        .d-flex.flex-row.py-1.bg-light.pl-3
+        .d-flex.flex-row.py-1.bg-light.pl-1.pl-sm-2
           = link_to(word_break(repository, 12),
             project_repository_state_path(project: project.name, repository: repository),
             title: "Repository #{repository}")
@@ -28,8 +28,8 @@
 
         .collapse{ class: "collapse-project-#{repository_name}#{expanded ? ' show' : ''}", data: { repository: repository_name } }
           - build_results.sort_by(&:architecture).each do |build_result|
-            .row.py-1
-              .col-4.col-sm-3.offset-1.offset-sm-2.text-nowrap{ title: "#{repository} summary" }
+            .d-flex.flex-row.flex-wrap.py-1
+              .repository-state{ title: "#{repository} summary" }
                 = repository_status_icon(status: build_result.state, details: build_result.details)
                 %span.ml-1
                   = link_to(build_result.architecture, { action: :monitor,
@@ -50,17 +50,15 @@
                                                   deleting: 1,
                                                   defaults: 0 }, rel: 'nofollow', class: 'nowrap')
 
-              .col.text-nowrap
-                .d-flex.flex-column
-                  - build_result.summary.each do |status_count|
-                    %div
-                      %i.fa.fa-question-circle.text-info{ data: { content: Buildresult.status_description(status_count.code),
-                        placement: 'top', toggle: 'popover' } }
-                      = link_to("#{status_count.code}: #{status_count.count}",
-                        { action: :monitor,
-                          "#{valid_xml_id('repo_' + repository)}": 1,
-                          "arch_#{build_result.architecture}": 1,
-                          project: params[:project],
-                          "#{status_count.code}": 1,
-                          defaults: 0 }, rel: 'nofollow', class: "nowrap build-state-#{status_count.code}")
-
+              .build-state.d-flex.flex-column
+                - build_result.summary.each do |status_count|
+                  %div
+                    %i.fa.fa-question-circle.text-info{ data: { content: Buildresult.status_description(status_count.code),
+                      placement: 'top', toggle: 'popover' } }
+                    = link_to("#{status_count.code}: #{status_count.count}",
+                      { action: :monitor,
+                        "#{valid_xml_id('repo_' + repository)}": 1,
+                        "arch_#{build_result.architecture}": 1,
+                        project: params[:project],
+                        "#{status_count.code}": 1,
+                        defaults: 0 }, rel: 'nofollow', class: "nowrap build-state-#{status_count.code}")


### PR DESCRIPTION
This way we prevent the elements to wrap when there is still enough space, or to overlap. This change is applied both to the build results of a project and a package.

**Before:**
![Screenshot from 2020-02-21 14-02-27_build_results_project_before](https://user-images.githubusercontent.com/24919/75036989-6b0b4000-54b3-11ea-80c3-fdd3c1bb16f3.png)

**After:**
![Screenshot from 2020-02-21 14-02-51_build_results_project_after](https://user-images.githubusercontent.com/24919/75036996-7199b780-54b3-11ea-843c-2c1a10255c86.png)

Co-authored-by: David Kang <dkang@suse.com>