### PR TITLE
Enable responsive option and change DOM options for Datatables

### DIFF
--- a/src/api/app/assets/javascripts/webui/datatables.js
+++ b/src/api/app/assets/javascripts/webui/datatables.js
@@ -13,7 +13,8 @@ var DEFAULT_DT_PARAMS = {
     info: "page _PAGE_ of _PAGES_ (_TOTAL_ records)",
     infoFiltered: ""
   },
-
+  responsive: true,
+  dom: 'ftpi',
   pageLength: 25,
   stateSave: true,
   pagingType: 'full',


### PR DESCRIPTION
With this PR I suggest two changes to be done in Datatables to improve the responsive usability.

1-) Enable https://datatables.net/extensions/responsive/
2-) Change the DOM options order and remove the select box for https://datatables.net/reference/option/lengthChange

Before:

![Screenshot_2020-02-24_15-33-30](https://user-images.githubusercontent.com/37418/75161234-c3447b00-571b-11ea-8eb2-7252da86336f.png)

![Screenshot_2020-02-24_15-33-57](https://user-images.githubusercontent.com/37418/75161251-cc354c80-571b-11ea-9a99-f5f34f492731.png)

After:

![Screenshot_2020-02-24_15-32-03](https://user-images.githubusercontent.com/37418/75161277-d48d8780-571b-11ea-99cf-87eda804e2c4.png)

![Screenshot_2020-02-24_15-32-33](https://user-images.githubusercontent.com/37418/75161303-db1bff00-571b-11ea-80c9-8d36688b3191.png)
