### PR TITLE
Authorize against the linked project instead of the package's project

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -700,7 +700,14 @@ class Webui::PackageController < Webui::WebuiController
   end
 
   def trigger_rebuild
-    authorize @package, :update?
+    # When we're in a linked project, the package's project points to some other
+    # project, not the one we're triggering the build from.
+    # Here we detect that, and if so, we authorize against the linked project.
+    if @project != @package.project
+      authorize @project, :update?
+    else
+      authorize @package, :update?
+    end
 
     allowed_params = [:project, :package, :repository, :arch]
 


### PR DESCRIPTION
When we're triggering the build from a linked project, the Pundit Policy checker
for the package fetches the package's project, not the one we're rebuilding
from.

This PR detects if we're triggering the build from a linked project and then
passes that project to Pundit to perform the authorization.

Fixes #6289

Co-authored-by: Henne Vogelsang <hvogel@opensuse.org>