### PR TITLE
[backend] do not overwrite suspendproject/resumeproject events

### DIFF
--- a/src/backend/BSSched/Checker.pm
+++ b/src/backend/BSSched/Checker.pm
@@ -244,7 +244,7 @@ sub setup {
     return ('disabled', undef);
   }
   my $suspend = $gctx->{'projsuspended'}->{$projid};
-  return ('blocked', "@$suspend") if $suspend;
+  return ('blocked', join(', ', @$suspend)) if $suspend;
   $ctx->{'repo'} = $repo;
 
   # set config

--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -2679,6 +2679,10 @@ sub forwardevent {
   $evname = "${type}:::".Digest::MD5::md5_hex($evname) if length($evname) > 200;
   $arch = 'dispatch' if $type eq 'badhost';
   $arch = 'publish' if $type eq 'publish';
+  if ($type eq 'suspendproject' || $type eq 'resumeproject') {
+    # those events stack - we must not overwrite them. randomize somewhat.
+    $evname = "type:::$$-".Digest::MD5::md5_hex("$$/$evname".time());
+  }
   mkdir_p("$eventdir/$arch") if $arch;
   if ($arch) {
     dirty($projid, $repoid, $arch) unless !defined($repoid) || $arch eq 'dispatch' || $arch eq 'publish';


### PR DESCRIPTION
Now that those events stack they are no longer idempotent. Thus we
need to randomize the event name.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
