### PR TITLE
Enable datatable responsive plugin as default

### DIFF
--- a/src/api/app/assets/javascripts/webui/datatables.js
+++ b/src/api/app/assets/javascripts/webui/datatables.js
@@ -13,7 +13,7 @@ var DEFAULT_DT_PARAMS = {
     info: "page _PAGE_ of _PAGES_ (_TOTAL_ records)",
     infoFiltered: ""
   },
-
+  responsive: true,
   pageLength: 25,
   stateSave: true,
   pagingType: 'full',


### PR DESCRIPTION
Enable the responsive extension to be able to control datatables in different query medias https://datatables.net/extensions/responsive/
