### PR TITLE
Allow authenticated users to see latest_updates card on the main page.

### DIFF
--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -251,7 +251,7 @@ GEM
     mousetrap-rails (1.4.6)
     mysql2 (0.5.2)
     nio4r (2.5.2)
-    nokogiri (1.10.5)
+    nokogiri (1.10.8)
       mini_portile2 (~> 2.4.0)
     nokogumbo (2.0.1)
       nokogiri (~> 1.8, >= 1.8.4)

--- a/src/api/app/views/webui2/webui/main/index.html.haml
+++ b/src/api/app/views/webui2/webui/main/index.html.haml
@@ -26,4 +26,5 @@
     = render partial: 'sponsors'
     - if @status_messages.present? || User.admin_session?
       = render partial: 'status_messages'
-    = render(partial: 'latest_updates') if @latest_updates && ::Configuration.anonymous
+    - if @latest_updates && (::Configuration.anonymous || User.session)
+      = render(partial: 'latest_updates')


### PR DESCRIPTION
The "latest_updates" card is only displayed if allow_anonymous configuration
option is allowed.  This patch allows authenticated users to get the
"latest_updates" card even if allow_anonymous is not allowed.
