### PR TITLE
Allow authenticated users to see latest_updates card on the main page.

### DIFF
--- a/src/api/app/views/webui/main/index.html.haml
+++ b/src/api/app/views/webui/main/index.html.haml
@@ -26,4 +26,5 @@
     = render partial: 'sponsors'
     - if @status_messages.present? || User.admin_session?
       = render partial: 'status_messages'
-    = render(partial: 'latest_updates') if @latest_updates && ::Configuration.anonymous
+    - if @latest_updates && (::Configuration.anonymous || User.session)
+      = render(partial: 'latest_updates')


### PR DESCRIPTION
The "latest_updates" card is only displayed if allow_anonymous configuration
option is allowed.  This patch allows authenticated users to get the
"latest_updates" card even if allow_anonymous is not allowed.