### PR TITLE
[backend] avoid debug lines in call service wrapper

### DIFF
--- a/src/backend/call-service-in-docker.sh
+++ b/src/backend/call-service-in-docker.sh
@@ -126,7 +126,7 @@ echo -n "${INNERSCRIPT}.command"                                                
 # dirname /srv/obs/service/11875/out/
 printlog "Creating INNERSCRIPT.command '$MOUNTDIR/${INNERSCRIPT}.command'"
 echo "#!/bin/bash"               			>  "$MOUNTDIR/${INNERSCRIPT}.command"
-echo "set -x" 						>> "$MOUNTDIR/${INNERSCRIPT}.command"
+#echo "set -x" 						>> "$MOUNTDIR/${INNERSCRIPT}.command"
 echo "echo Running ${COMMAND[@]} --outdir $INNEROUTDIR" >> "$MOUNTDIR/${INNERSCRIPT}.command"
 
 DOCKER_OPTS_NET="--net=bridge"
@@ -164,7 +164,6 @@ if [[ $DEBUG_DOCKER ]];then
 	INNERSCRIPT=/bin/bash
 fi
 
-find $MOUNTDIR
 # run jailed process
 DOCKER_RUN_CMD="docker run -u 2:2 $DOCKER_OPTS_NET $LINK --rm --name $CONTAINER_ID $DOCKER_CUSTOM_OPT $DOCKER_VOLUMES $DEBUG_OPTIONS $DOCKER_IMAGE $INNERSCRIPT"
 printlog "DOCKER_RUN_CMD: '$DOCKER_RUN_CMD'"


### PR DESCRIPTION
listing all files with local temporary filenames is confusing.
Also the shell wrapper debug should not be needed, we should
give proper messages in the tooling instead

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
