### PR TITLE
[dist] enable xforward in setup-appliance.sh

### DIFF
--- a/dist/setup-appliance.sh
+++ b/dist/setup-appliance.sh
@@ -510,7 +510,7 @@ function prepare_apache2 {
   fi
 
   if [ "$CONFIGURE_APACHE" == 1 ];then
-    MODULES="passenger rewrite proxy proxy_http headers socache_shmcb"
+    MODULES="passenger rewrite proxy proxy_http headers socache_shmcb xforward"
 
     for mod in $MODULES;do
       a2enmod -q $mod || a2enmod $mod


### PR DESCRIPTION
Without this patch starting apache in a setup with setup-appliance.sh runs into the following error:

```
Feb 27 08:09:55 wizard-install start_apache2[5138]: AH00526: Syntax error on line 86 of /etc/apache2/vhosts.d/obs.conf:
Feb 27 08:09:55 wizard-install start_apache2[5138]: Invalid command 'XForward', perhaps misspelled or defined by a module not included in the server configuration
```
