### PR TITLE
Disable responsiveness on project#monitor datatable

### DIFF
--- a/src/api/app/assets/javascripts/webui/project_monitor.js
+++ b/src/api/app/assets/javascripts/webui/project_monitor.js
@@ -41,6 +41,7 @@ function initializeMonitorDataTable() {
   var projectName = data.project;
 
   initializeDataTable('#project-monitor-table', { // jshint ignore:line
+    responsive: false,
     scrollX: true,
     fixedColumns: true,
     pageLength: 50,


### PR DESCRIPTION
Following #9136, datatables are all responsive by default and this causes
issues for datatables with many columns like project#monitor, which is often
huge. Eventually, pages with such datatables will have to be redesigned. For
now, disabling the responsiveness will do.

Fixes #9145