### PR TITLE
Align project and package buildresult

### DIFF
--- a/src/api/app/assets/stylesheets/webui/project-package-show-grid.scss
+++ b/src/api/app/assets/stylesheets/webui/project-package-show-grid.scss
@@ -4,7 +4,6 @@
 
 .build-results {
   grid-area: build-results;
-  .sticky-top { top: 57px; }
 }
 
 .comments {

--- a/src/api/app/assets/stylesheets/webui/responsive_ux.scss
+++ b/src/api/app/assets/stylesheets/webui/responsive_ux.scss
@@ -3,6 +3,8 @@ body.responsive-ux {
   padding-top: 3.5rem !important;
 
   @import 'responsive_ux/layout';
+
+  .build-results .sticky-top { top: 57px; }
 }
 
 // FIXME: move to somewhere else?

--- a/src/api/app/helpers/webui/buildresult_helper.rb
+++ b/src/api/app/helpers/webui/buildresult_helper.rb
@@ -38,7 +38,7 @@ module Webui::BuildresultHelper
     collapse_id = repository_name ? "#{main_name}-#{repository_name}" : main_name
     collapse_text = repository_name ? 'repository' : 'package'
 
-    link_to('#', aria: { controls: "collapse-#{collapse_id}", expanded: expanded }, class: 'px-2 float-right',
+    link_to('#', aria: { controls: "collapse-#{collapse_id}", expanded: expanded }, class: 'px-2 ml-auto',
                  data: { toggle: 'collapse' }, href: ".collapse-#{collapse_id}", role: 'button') do
       capture do
         concat(content_tag(:i, nil, class: ['fas', 'fa-chevron-left', 'expander'], title: "Show build results for this #{collapse_text}"))

--- a/src/api/app/views/webui/package/_buildstatus.html.haml
+++ b/src/api/app/views/webui/package/_buildstatus.html.haml
@@ -10,7 +10,7 @@
   :ruby
     package_name = package.tr('.:', '_')
     expanded = collapsed_packages.exclude?(package_name)
-  %h5.text-primary.mt-3.mb-3
+  %h5.d-flex.flex-row.text-primary.mt-3.mb-3
     = package
     - if buildresults.results.count > 1
       = collapse_link(expanded, package_name)
@@ -22,12 +22,11 @@
           repository_name = result.repository.tr('.', '_')
           expanded = repository_expanded?(collapsed_repositories, repository_name, package_name)
         - if result.repository != previous_repo
-          .row.no-gutters.py-1.bg-light
-            .col.pl-1.pl-sm-2{ title: result.repository.to_s }
-              = link_to(word_break(result.repository, 22),
-                package_binaries_path(project: project, package: package, repository: result.repository),
-                data: { content: "Binaries for #{result.repository}", placement: 'top', toggle: 'popover' })
-              = collapse_link(expanded, package_name, repository_name)
+          .d-flex.flex-row.py-1.bg-light.pl-1.pl-sm-2
+            = link_to(word_break(result.repository, 22),
+              package_binaries_path(project: project, package: package, repository: result.repository),
+              data: { content: "Binaries for #{result.repository}", placement: 'top', toggle: 'popover' })
+            = collapse_link(expanded, package_name, repository_name)
 
         .collapse{ class: "collapse-#{package_name}-#{repository_name}#{expanded ? ' show' : ''}",
                    data: { repository: repository_name, main: package_name } }


### PR DESCRIPTION
Align project and package buildresult:
- Collapse icon placed on the right.
- Fix sticky refresh button when user are not in beta.
- Use flex instead of col and row.

Fix #9157