### PR TITLE
Bugfix/9149

### DIFF
--- a/src/api/app/helpers/authentication_protocol_helper.rb
+++ b/src/api/app/helpers/authentication_protocol_helper.rb
@@ -47,8 +47,6 @@ module AuthenticationProtocolHelper
   private
 
   def base_url
-    url = "#{request.protocol}#{request.host}"
-    url += ":#{request.port}" if request.port.present?
-    url
+    "#{request.protocol}#{request.host}"
   end
 end

--- a/src/api/app/views/layouts/webui/_login_form.html.haml
+++ b/src/api/app/views/layouts/webui/_login_form.html.haml
@@ -6,4 +6,7 @@
     Log In
   .dropdown-menu.dropdown-menu-right.shadow-lg.bg-dark.top-of-flash{ 'aria-labelledby': 'dropdownMenuButton' }
     .px-4.py-3#login-form
-      = render partial: 'webui/session/form', locals: { label_css: 'text-light', button_css: 'float-right', with_sign_up: false }
+      = render partial: 'webui/session/form', locals: { label_css: 'text-light',
+                                                        button_css: 'float-right',
+                                                        with_sign_up: false,
+                                                        with_redirect: false }

--- a/src/api/app/views/webui/session/_form.html.haml
+++ b/src/api/app/views/webui/session/_form.html.haml
@@ -6,7 +6,8 @@
     = hidden_field_tag(:context, 'default')
     = hidden_field_tag(:proxypath, 'reserve')
     = hidden_field_tag(:message, 'Please log in')
-    = hidden_field_tag(:url, return_to_location)
+    - if with_redirect
+      = hidden_field_tag(:url, return_to_location)
   .form-group
     = label_tag(:username, 'Username', class: "#{label_css}")
     = text_field_tag(:username, nil, placeholder: 'User Name', required: true, id: 'user-login', class: 'form-control')

--- a/src/api/app/views/webui/session/new.html.haml
+++ b/src/api/app/views/webui/session/new.html.haml
@@ -9,4 +9,4 @@
         %p Please ensure you have a valid ticket and try again.
       - else
         %h3= @pagetitle
-        = render partial: 'form', locals: { with_sign_up: true }
+        = render partial: 'form', locals: { with_sign_up: true, with_redirect: true }


### PR DESCRIPTION
Remove port form AuthenticationProtocolHelper.base_url
    
HTTP_REFERER usually does not include the port, so as long as the url
matches, let's redirect there.

and skip redirect in the login modal
    
The modal doesn't need to redirect to the previously visited page as
people never left the page they want to get back to.
    
Fixes #9149
