### PR TITLE
Fixed logout redirection when anonymous access is not allowed.

### DIFF
--- a/src/api/app/controllers/webui/session_controller.rb
+++ b/src/api/app/controllers/webui/session_controller.rb
@@ -52,8 +52,10 @@ class Webui::SessionController < Webui::WebuiController
   def redirect_on_logout
     if CONFIG['proxy_auth_mode'] == :on
       redirect_to CONFIG['proxy_auth_logout_page']
-    else
+    elsif ::Configuration.anonymous
       redirect_back(fallback_location: root_path)
+    else
+      redirect_to root_path
     end
   end
 


### PR DESCRIPTION
If anonymous access is not allowed and a user logs out the
user is redirected back to the referring page prior to logout.  This
redirection produces a error since anything other than the root path
is now unavailable to the user.

This patch will redirect the use to the root path on logout if anonymous
access is not allowed.

