### PR TITLE
Fix table width when tab is switched in small screens

### DIFF
--- a/src/api/app/assets/javascripts/webui/requests_table.js
+++ b/src/api/app/assets/javascripts/webui/requests_table.js
@@ -1,4 +1,9 @@
 $(document).ready(function() {
+  $('#requests').find('a[data-toggle="tab"]').on('shown.bs.tab', function(){
+    $($.fn.dataTable.tables(true)).DataTable()
+       .columns.adjust();
+  });
+
   $('.requests-datatable').each(function(){
     // 1. Create DataTable
     var dataTableId = $(this).attr('id');


### PR DESCRIPTION
Both tables have the same column widths defined with column.width option.
However table in “Tab 2” has column widths different from the table in “Tab 1”.

After click we have to adjust the columns

Before:

![Screenshot_2020-02-28_13-03-54](https://user-images.githubusercontent.com/37418/75547286-d496cb80-5a2a-11ea-9012-900ed58c0ea0.png)

After:

![Screenshot_2020-02-28_13-05-41](https://user-images.githubusercontent.com/37418/75547399-1293ef80-5a2b-11ea-845f-adabae74681c.png)
