### PR TITLE
BuildResult Tooltip

### DIFF
--- a/src/api/app/assets/javascripts/webui/buildresult.js
+++ b/src/api/app/assets/javascripts/webui/buildresult.js
@@ -69,3 +69,9 @@ function updateRpmlintDisplay(index) {
     }
   });
 }
+
+function toggleBuildInfo() { // jshint ignore:line
+  $('.toggle-build-info').on('click', function(){
+    $(this).parents('.toggle-build-info-parent').next().toggleClass('collapsed');
+  });
+}

--- a/src/api/app/assets/stylesheets/webui/build-results.scss
+++ b/src/api/app/assets/stylesheets/webui/build-results.scss
@@ -28,7 +28,7 @@
 .build-state {
   @extend .pl-1;
   @extend .pl-sm-2;
-  @extend .text-nowrap;
+  flex-basis: 62%;
 }
 
 .build-results {

--- a/src/api/app/assets/stylesheets/webui/responsive_ux.scss
+++ b/src/api/app/assets/stylesheets/webui/responsive_ux.scss
@@ -3,6 +3,7 @@ body.responsive-ux {
   padding-top: 3.5rem !important;
 
   @import 'responsive_ux/layout';
+  @import 'responsive_ux/build-result';
 
   .build-results .sticky-top { top: 57px; }
 }
@@ -32,5 +33,19 @@ body.responsive-ux {
       .footer-logged { padding-bottom: 0; }
     }
     // END LAYOUT
+
+    .build-info .triangle {
+      &.left { left: .25rem; }
+    }
+  }
+}
+
+@include media-breakpoint-between(sm, md) {
+  body.responsive-ux {
+    .build-info .triangle {
+      &.center { margin-left: calc(38% + .75rem); }
+      &.left { left: .5rem; }
+    }
+
   }
 }

--- a/src/api/app/assets/stylesheets/webui/responsive_ux/_build-result.scss
+++ b/src/api/app/assets/stylesheets/webui/responsive_ux/_build-result.scss
@@ -1,0 +1,43 @@
+.toggle-build-info { cursor: pointer; }
+.toggle-build-info-parent{ z-index: 2; }
+
+.build-info {
+  @extend .d-flex;
+  @extend .flex-column;
+  position: relative;
+  background-color: #eeeeee;
+  max-height: 100vh;
+  width: 100%;
+  font-size: 90%;
+  transition: max-height .3s 0s ease-in-out, margin-bottom .1s .1s linear;
+
+  .triangle{
+    position: absolute;
+    width: 0;
+    height: 0;
+    top: -.5rem;
+    border-left: .5rem solid transparent;
+    border-right: .5rem solid transparent;
+    border-bottom: .5rem solid #eeeeee;
+    transition: top .3s .1s ease-in-out, opacity 0.1s .2s ease-in-out;
+
+    &.center { margin: 0 0 0 calc(38% + .5rem); }
+    &.left { left: .5rem; }
+  }
+
+  .build-info-content {
+    @extend .py-2;
+    @extend .px-3;
+    overflow-y: hidden;
+  }
+
+  &.collapsed {
+    max-height: 0;
+    @extend .mb-0;
+
+    .triangle {
+      top: 0;
+      opacity: 0;
+    }
+  }
+}

--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -735,11 +735,12 @@ class Webui::PackageController < Webui::WebuiController
       show_all = params[:show_all] == 'true'
       @index = params[:index]
       @buildresults = @package.buildresult(@project, show_all)
-      render partial: 'buildstatus', locals: { buildresults: @buildresults,
-                                               index: @index,
-                                               project: @project,
-                                               collapsed_packages: params.fetch(:collapsedPackages, []),
-                                               collapsed_repositories: params.fetch(:collapsedRepositories, {}) }
+      namespace = Flipper.enabled?(:responsive_ux, User.possibly_nobody) ? 'webui/package/responsive_ux/' : ''
+      render partial: "#{namespace}buildstatus", locals: { buildresults: @buildresults,
+                                                           index: @index,
+                                                           project: @project,
+                                                           collapsed_packages: params.fetch(:collapsedPackages, []),
+                                                           collapsed_repositories: params.fetch(:collapsedRepositories, {}) }
     else
       render partial: 'no_repositories', locals: { project: @project }
     end

--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -136,9 +136,10 @@ class Webui::ProjectController < Webui::WebuiController
   end
 
   def buildresult
-    render partial: 'buildstatus', locals: { project: @project,
-                                             buildresults: @project.buildresults,
-                                             collapsed_repositories: params.fetch(:collapsedRepositories, {}) }
+    namespace = Flipper.enabled?(:responsive_ux, User.possibly_nobody) ? 'webui/project/responsive_ux/' : ''
+    render partial: "#{namespace}buildstatus", locals: { project: @project,
+                                                         buildresults: @project.buildresults,
+                                                         collapsed_repositories: params.fetch(:collapsedRepositories, {}) }
   end
 
   def destroy

--- a/src/api/app/helpers/webui/buildresult_helper.rb
+++ b/src/api/app/helpers/webui/buildresult_helper.rb
@@ -14,6 +14,10 @@ module Webui::BuildresultHelper
       theclass = 'text-warning' if code == 'scheduled' && link_title.present?
     end
 
+    if flipper_responsive?
+      return build_state(code: code, css_class: theclass, package_name: package_name, status_id: status_id, repo: repo, arch: arch)
+    end
+
     capture do
       if enable_help && status['code']
         concat(content_tag(:i, nil, class: ['fa', 'fa-question-circle', 'text-info', 'mr-1'],
@@ -25,6 +29,19 @@ module Webui::BuildresultHelper
         concat(link_to(code.gsub(/\s/, '&nbsp;'),
                        package_live_build_log_path(project: @project.to_s, package: package_name, repository: repo, arch: arch),
                        data: { content: link_title, placement: 'right', toggle: 'popover' }, rel: 'nofollow', class: theclass))
+      end
+    end
+  end
+
+  # NOTE: reponsive_ux
+  def build_state(attr)
+    capture do
+      if attr[:code].in?(['-', 'unresolvable', 'blocked', 'excluded', 'scheduled'])
+        concat(link_to(attr[:code], 'javascript:void(0);', id: attr[:status_id], class: attr[:css_class]))
+      else
+        concat(link_to(attr[:code].gsub(/\s/, '&nbsp;'),
+                       package_live_build_log_path(project: @project.to_s, package: attr[:package_name], repository: attr[:repo], arch: attr[:arch]),
+                       rel: 'nofollow', class: attr[:css_class]))
       end
     end
   end

--- a/src/api/app/helpers/webui/webui_helper.rb
+++ b/src/api/app/helpers/webui/webui_helper.rb
@@ -108,8 +108,16 @@ module Webui::WebuiHelper
 
     repo_state_class = repository_state_class(outdated, status)
 
-    content_tag(:i, '', class: "repository-state-#{repo_state_class} #{html_class} fas fa-#{repo_status_icon(status)}",
-                        data: { content: description, placement: 'top', toggle: 'popover' })
+    data_options = {}
+    data_options.merge!(content: description, placement: 'top', toggle: 'popover') unless flipper_responsive?
+    content_tag(:i, '', class: "repository-state-#{repo_state_class} #{html_class} fas fa-#{repo_status_icon(status)}", data: data_options)
+  end
+
+  # NOTE: reponsive_ux
+  def repository_info(status)
+    outdated = status.sub!(/^outdated_/, '')
+    description = outdated ? 'State needs recalculations, former state was: ' : ''
+    description << repo_status_description(status)
   end
 
   def repository_state_class(outdated, status)

--- a/src/api/app/views/webui/package/responsive_ux/_buildstatus.html.haml
+++ b/src/api/app/views/webui/package/responsive_ux/_buildstatus.html.haml
@@ -1,0 +1,66 @@
+- unless buildresults.excluded_counter.zero? && !buildresults.show_all
+  .mt-3.custom-control-checkbox
+    = check_box_tag("show_all_#{index}", true, buildresults.show_all, class: 'custom-control-input d-none',
+                    onchange: "updateBuildResult('#{index}')")
+    - label_message = buildresults.excluded_counter.zero? ? 'Hide' : "Show #{buildresults.excluded_counter}"
+    = label_tag "show_all_#{index}" do
+      %u.custom-label #{label_message} excluded/disabled results
+
+- buildresults.results.each_pair do |package, results|
+  :ruby
+    package_name = package.tr('.:', '_')
+    expanded = collapsed_packages.exclude?(package_name)
+  %h5.d-flex.flex-row.text-primary.mt-3.mb-3
+    = package
+    - if buildresults.results.count > 1
+      = collapse_link(expanded, package_name)
+  .collapse#package-buildstatus{ class: "collapse-#{package_name}#{expanded ? ' show' : ''}", data: { main: package_name } }
+    - if results.present?
+      - previous_repo = nil
+      - results.each do |result|
+        :ruby
+          repository_name = result.repository.tr('.', '_')
+          expanded = repository_expanded?(collapsed_repositories, repository_name, package_name)
+        - if result.repository != previous_repo
+          .d-flex.flex-row.py-1.bg-light.pl-1.pl-sm-2
+            = link_to(word_break(result.repository, 22),
+              package_binaries_path(project: project, package: package, repository: result.repository),
+              title: "Binaries for #{result.repository}")
+            = collapse_link(expanded, package_name, repository_name)
+
+        .collapse{ class: "collapse-#{package_name}-#{repository_name}#{expanded ? ' show' : ''}",
+                   data: { repository: repository_name, main: package_name } }
+          .d-flex.flex-row.flex-wrap.pt-1
+            .repository-state
+              - if !result.is_repository_in_db
+                %i.fas.fa-clock.text-warning{ title: 'This result is outdated' }
+              - else
+                = repository_status_icon(status: result.state)
+              %span.ml-1
+                = result.architecture
+            .build-state.toggle-build-info-parent
+              %i.fa.fa-question-circle.text-info.px-2.pl-lg-1.toggle-build-info{ title: 'More information' }
+              = arch_repo_table_cell(result.repository, result.architecture, package, 'code' => result.code, 'details' => result.details)
+            .build-info.mt-1.ml-3.mb-3.mr-3.collapsed
+              .triangle.center
+              .build-info-content
+                %p.py-1= Buildresult.status_description(result.code)
+                %div
+                  - if !result.is_repository_in_db
+                    %i.fas.fa-clock.text-warning
+                    This result is outdated
+                  - else
+                    = repository_status_icon(status: result.state)
+                    %span.pl-1= repository_info(result.state)
+                - if result.details
+                  %div
+                    %strong #{result.code}:
+                    %span= result.details
+
+        - previous_repo = result.repository
+    - else
+      All the results have state
+      %strong excluded/disabled
+
+:javascript
+  toggleBuildInfo();

--- a/src/api/app/views/webui/project/responsive_ux/_buildstatus.html.haml
+++ b/src/api/app/views/webui/project/responsive_ux/_buildstatus.html.haml
@@ -1,0 +1,70 @@
+#project-buildstatus
+  - if buildresults.blank?
+    - if project.remoteurl
+      %p
+        %i This project is just used to get referenced for using remote resources.
+    - elsif project.repositories.empty?
+      %p
+        %i
+          This project currently has
+          no #{link_to 'build targets', controller: :repositories, action: :distributions, project: project.name}
+          defined.
+    - else
+      %p
+        %i No build result available
+  - else
+    - buildresults.each do |repository, build_results|
+      - repository_name = repository.tr('.', '_')
+      - expanded = repository_expanded?(collapsed_repositories, repository_name)
+      .d-flex.flex-column
+        .d-flex.flex-row.py-1.bg-light.pl-1.pl-sm-2
+          = link_to(word_break(repository, 12),
+            project_repository_state_path(project: project.name, repository: repository),
+            title: "Repository #{repository}")
+          = collapse_link(expanded, 'project', repository_name)
+
+        .collapse{ class: "collapse-project-#{repository_name}#{expanded ? ' show' : ''}", data: { repository: repository_name } }
+          - build_results.sort_by(&:architecture).each do |build_result|
+            .d-flex.flex-row.flex-nowrap.py-1
+              .repository-state
+                = repository_status_icon(status: build_result.state)
+                %span.ml-1
+                  = link_to(build_result.architecture, { action: :monitor,
+                                                  "#{valid_xml_id('repo_' + repository)}": 1,
+                                                  "arch_#{build_result.architecture}": 1,
+                                                  project: project.name,
+                                                  succeeded: 1,
+                                                  failed: 1,
+                                                  unresolvable: 1,
+                                                  broken: 1,
+                                                  blocked: 1,
+                                                  dispatching: 1,
+                                                  scheduled: 1,
+                                                  building: 1,
+                                                  finished: 1,
+                                                  signing: 1,
+                                                  locked: 1,
+                                                  deleting: 1,
+                                                  defaults: 0 }, rel: 'nofollow', class: 'nowrap')
+
+              .build-state.d-flex.flex-column
+                - build_result.summary.each do |status_count|
+                  .toggle-build-info-parent.text-nowrap
+                    %i.fa.fa-question-circle.text-info.px-2.pl-lg-1.toggle-build-info{ title: 'More information' }
+                    = link_to("#{status_count.code}: #{status_count.count}",
+                      { action: :monitor,
+                        "#{valid_xml_id('repo_' + repository)}": 1,
+                        "arch_#{build_result.architecture}": 1,
+                        project: params[:project],
+                        "#{status_count.code}": 1,
+                        defaults: 0 }, rel: 'nofollow', class: "nowrap build-state-#{status_count.code}")
+                  .build-info.p2.mb-2.mt-1.mr-sm-3.collapsed
+                    .triangle.left
+                    .build-info-content
+                      %p.py-1= Buildresult.status_description(status_count.code)
+                      %div
+                        = repository_status_icon(status: build_result.state)
+                        %span.pl-1= repository_info(build_result.state)
+
+:javascript
+  toggleBuildInfo();


### PR DESCRIPTION
Using tooltips in buildresult are not every usable for small viewports,
even on a big viewport, due to it can contain a considerable amount on
the content.

#### project
![Peek 2020-03-02 13-03](https://user-images.githubusercontent.com/1212806/75674879-533b7500-5c86-11ea-895d-313034947e54.gif)

#### package
![Peek 2020-03-02 13-03-2](https://user-images.githubusercontent.com/1212806/75674912-5e8ea080-5c86-11ea-84a9-9a4f8ed310ab.gif)
