### PR TITLE
Remove left-over javascript from old UI

### DIFF
--- a/src/api/app/assets/javascripts/webui/requests_table.js
+++ b/src/api/app/assets/javascripts/webui/requests_table.js
@@ -54,15 +54,3 @@ $(document).on('change', 'select[data-table]', function() {
 
   $(tableSelector).DataTable().ajax.reload();
 });
-
-// The reload button on the user request page
-$(document).on('click', '.result_reload[data-table]', function() {
-  var tableSelector = '#' + $(this).data('table'),
-      loadingSpinner = $(this).children('i');
-
-  loadingSpinner.addClass('fa-spin');
-
-  $(tableSelector).DataTable().ajax.reload(function(){
-    loadingSpinner.removeClass('fa-spin');
-  });
-});


### PR DESCRIPTION
This javascript snippet was used in the old UI. This class `.result_reload` doesn't exist anymore.