### PR TITLE
Fix missing public key from project directory.

### DIFF
--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -1893,6 +1893,14 @@ sub putproject {
   if ($BSConfig::forceprojectkeys) {
     my ($sk) = getsignkey({}, $projid);
     createkey({ %$cgi, 'comment' => 'autocreate key' }, $projid) if $sk eq '';
+  } elsif ($BSConfig::keyfile) {
+    if (-e $BSConfig::keyfile) {
+       my ($pk) = readstr($BSConfig::keyfile);
+       mkdir_p("$projectsdir/$projid.pkg") || die("creating $projectsdir/$projid.pkg: $!\n");
+       writestr("$projectsdir/$projid.pkg/_pubkey", undef, $pk);
+    } else {
+      print "WARNING: configured default sign key $BSConfig::keyfile does not exist.\n";
+    }
   }
 
   my %except = map {$_ => 1} qw{title description person group url attributes};

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -1893,7 +1893,7 @@ sub putproject {
   if ($BSConfig::forceprojectkeys) {
     my ($sk) = getsignkey({}, $projid);
     createkey({ %$cgi, 'comment' => 'autocreate key' }, $projid) if $sk eq '';
-  } elsif ($BSConfig::keyfile) {
+  } elsif ( ! -e "$projectsdir/$projid.pkg/_pubkey" && $BSConfig::keyfile) {
     if (-e $BSConfig::keyfile) {
        my ($pk) = readstr($BSConfig::keyfile);
        mkdir_p("$projectsdir/$projid.pkg") || die("creating $projectsdir/$projid.pkg: $!\n");


### PR DESCRIPTION
Problem: 
   When a global signing key is defined and BSConfig::forceprojectkeys is 
not set, the default public key defined in BSConfig::keyfile is not placed
in the project/projid.pkg directory.  

This creates a problem for local builds.  Packages are signed using the default
key. When the packages are used during local builds the verification fails because there
isn't a public key to validate the packages from that project.

The default public key is correctly added to the repository during
publishing.

This patch mimics the process the publish routine uses to place the default
pubkey file during project creation.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
