### PR TITLE
Fix brakeman complain on user model

### DIFF
--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -644,7 +644,7 @@ class User < ApplicationRecord
     save!
 
     # wipe also all home projects
-    Project.where("name LIKE '#{home_project_name}:%'").or(Project.where(name: home_project_name)).each do |project|
+    Project.where('name LIKE ?', "#{home_project_name}:%").or(Project.where(name: home_project_name)).each do |project|
       project.commit_opts = { comment: 'User account got deleted' }
       project.destroy
     end

--- a/src/api/spec/models/user_spec.rb
+++ b/src/api/spec/models/user_spec.rb
@@ -66,6 +66,13 @@ RSpec.describe User do
     end
   end
 
+  describe '#delete!' do
+    subject { user.delete! }
+
+    it { expect { subject }.not_to raise_error }
+    it { expect { subject }.to change(User, :count).by(1) }
+  end
+
   describe '#can_modify_user?' do
     it { expect(admin_user.can_modify_user?(confirmed_user)).to be(true) }
     it { expect(user.can_modify_user?(confirmed_user)).to be(false) }


### PR DESCRIPTION
The construction ` Project.where("name LIKE '#{home_project_name}:%'")` even though safe in the context being used, should be avoided.

