### PR TITLE
Actions for main#index

### DIFF
--- a/src/api/app/assets/javascripts/webui/responsive_ux.js
+++ b/src/api/app/assets/javascripts/webui/responsive_ux.js
@@ -3,14 +3,27 @@ $(function () {
     $('a[data-toggle="offcanvas"]').toggleClass('active');
     $('.offcanvas-collapse').toggleClass('open');
     $('.watchlist-collapse').removeClass('open');
+    $('.actions-collapse').removeClass('open');
     $('a[data-toggle="watchlist"]').removeClass('active');
+    $('a[data-toggle="actions"]').removeClass('active');
   });
 
   $('[data-toggle="watchlist"]').on('click', function () {
     $('a[data-toggle="watchlist"]').toggleClass('active');
     $('.watchlist-collapse').toggleClass('open');
     $('.offcanvas-collapse').removeClass('open');
+    $('.actions-collapse').removeClass('open');
     $('a[data-toggle="offcanvas"]').removeClass('active');
+    $('a[data-toggle="actions"]').removeClass('active');
+  });
+
+  $('[data-toggle="actions"]').on('click', function () {
+    $('a[data-toggle="actions"]').toggleClass('active');
+    $('.actions-collapse').toggleClass('open');
+    $('.offcanvas-collapse').removeClass('open');
+    $('.watchlist-collapse').removeClass('open');
+    $('a[data-toggle="offcanvas"]').removeClass('active');
+    $('a[data-toggle="watchlist"]').removeClass('active');
   });
 
   $('.access-modal').on('show.bs.modal', function () {

--- a/src/api/app/assets/stylesheets/webui/responsive_ux.scss
+++ b/src/api/app/assets/stylesheets/webui/responsive_ux.scss
@@ -29,7 +29,7 @@ body.responsive-ux {
       .navbar-brand img { height: 42px; }
     }
 
-    .watchlist-collapse, .offcanvas-collapse {
+    .watchlist-collapse, .offcanvas-collapse, .actions-collapse {
       top: $md-top-bar-height; /* Height of navbar */
       bottom: 0;
       width: 380px;

--- a/src/api/app/assets/stylesheets/webui/responsive_ux/_layout.scss
+++ b/src/api/app/assets/stylesheets/webui/responsive_ux/_layout.scss
@@ -10,7 +10,8 @@
   .toggler {
     @extend .ml-2;
     @extend .d-none;
-    @extend .d-md-block;
+    @extend .d-md-flex;
+    @extend .align-items-center;
     cursor: pointer;
     &.text-center { min-width: 62px; }
     &:first-of-type { @extend .ml-3;  }

--- a/src/api/app/assets/stylesheets/webui/responsive_ux/_layout.scss
+++ b/src/api/app/assets/stylesheets/webui/responsive_ux/_layout.scss
@@ -90,7 +90,7 @@ button.navbar-toggler {
   }
 }
 
-.watchlist-collapse, .offcanvas-collapse {
+.watchlist-collapse, .offcanvas-collapse, .actions-collapse {
   position: fixed;
   top: $top-bar-height;
   left: 100%;

--- a/src/api/app/views/layouts/webui/responsive_ux/_actions.html.haml
+++ b/src/api/app/views/layouts/webui/responsive_ux/_actions.html.haml
@@ -1,0 +1,9 @@
+.navbar-collapse.actions-collapse.navbar-dark
+  .navbar-nav
+    .nav.justify-content-end.py-2
+      %button.navbar-toggler{ 'type': 'button', 'data-toggle': 'actions', aria: { expanded: 'false', label: 'Toggle actions' } }
+        %i.fas.fa-times
+  .h5.pt-2
+    Actions on this page
+  %ul.navbar-nav.ml-auto.pt-0.text-nowrap.menu-options
+    = yield :actions

--- a/src/api/app/views/layouts/webui/responsive_ux/_bottom_navigation.html.haml
+++ b/src/api/app/views/layouts/webui/responsive_ux/_bottom_navigation.html.haml
@@ -15,17 +15,17 @@
             .badge.badge-primary.align-text-top= tasks
           %br
           .small Tasks
-      %li.nav-item.border-left.border-gray-500
-        = link_to('javascript:void(0)', class: 'nav-link text-light p-1', alt: 'Menu', data: { toggle: 'offcanvas' }) do
-          %i.fas.fa-bars.fa-lg
-          %br
-          .small Menu
     - else
       - unless kerberos_mode? || !can_sign_up?
         %li.nav-item.border-right.border-gray-500
           = sign_up_link(css_class: 'nav-link text-light p-1')
       %li.nav-item
         = log_in_link(css_class: 'nav-link text-light p-1')
+    %li.nav-item.border-left.border-gray-500
+      = link_to('javascript:void(0)', class: 'nav-link text-light p-1', alt: 'Menu', data: { toggle: 'offcanvas' }) do
+        %i.fas.fa-bars.fa-lg
+        %br
+        .small Menu
 
 - if User.session
   = render partial: "layouts/#{responsive_namespace}/watchlist"

--- a/src/api/app/views/layouts/webui/responsive_ux/_bottom_navigation.html.haml
+++ b/src/api/app/views/layouts/webui/responsive_ux/_bottom_navigation.html.haml
@@ -15,6 +15,12 @@
             .badge.badge-primary.align-text-top= tasks
           %br
           .small Tasks
+      - if content_for?(:actions)
+        %li.nav-item.border-left.border-gray-500
+          = link_to('javascript:void(0)', class: 'nav-link text-light p-1', alt: 'Actions', data: { toggle: 'actions' }) do
+            %i.fas.fa-ellipsis-v.fa-lg
+            %br
+            .small Actions
     - else
       - unless kerberos_mode? || !can_sign_up?
         %li.nav-item.border-right.border-gray-500

--- a/src/api/app/views/layouts/webui/responsive_ux/_navigation.html.haml
+++ b/src/api/app/views/layouts/webui/responsive_ux/_navigation.html.haml
@@ -18,12 +18,19 @@
               %span.badge.badge-primary.align-text-top= tasks
             %br
             .small Tasks
+        - if content_for?(:actions)
+          .toggler
+            = link_to('javascript:void(0)', class: 'nav-link text-light p-1', alt: 'Actions', data: { toggle: 'actions' }) do
+              %i.fas.fa-ellipsis-v.fa-lg
+              %br
+              .small Actions
         .toggler{ data: { toggle: 'offcanvas' } }
           = image_tag_for(User.session, size: 52, custom_class: 'rounded-circle bg-light')
       - else
         = render partial: 'layouts/webui/responsive_ux/nobody_navigation'
 
 - if User.session
+  = render partial: 'layouts/webui/responsive_ux/actions'
   = render partial: 'layouts/webui/responsive_ux/user_navigation'
 - elsif !kerberos_mode?
   - if !proxy_mode? && can_sign_up?

--- a/src/api/app/views/layouts/webui/responsive_ux/_navigation.html.haml
+++ b/src/api/app/views/layouts/webui/responsive_ux/_navigation.html.haml
@@ -19,13 +19,14 @@
             %br
             .small Tasks
         - if content_for?(:actions)
-          .toggler
+          .toggler.text-center
             = link_to('javascript:void(0)', class: 'nav-link text-light p-1', alt: 'Actions', data: { toggle: 'actions' }) do
               %i.fas.fa-ellipsis-v.fa-lg
               %br
               .small Actions
-        .toggler{ data: { toggle: 'offcanvas' } }
-          = image_tag_for(User.session, size: 52, custom_class: 'rounded-circle bg-light')
+        .toggler
+          = link_to('javascript:void(0)', class: 'nav-link text-light', alt: 'Generic Links', data: { toggle: 'offcanvas' }) do
+            = image_tag_for(User.session, size: 32, custom_class: 'rounded-circle bg-light')
       - else
         = render partial: 'layouts/webui/responsive_ux/nobody_navigation'
 

--- a/src/api/app/views/layouts/webui/responsive_ux/_nobody_navigation.html.haml
+++ b/src/api/app/views/layouts/webui/responsive_ux/_nobody_navigation.html.haml
@@ -2,8 +2,9 @@
   = sign_up_link(css_class: 'nav-link text-light text-center p-1')
 .toggler
   = log_in_link(css_class: 'nav-link text-light text-center p-1')
-.toggler{ data: { toggle: 'offcanvas' } }
-  %i.fas.fa-user-circle.fa-2x.text-light
+.toggler
+  = link_to('javascript:void(0)', class: 'nav-link text-light', alt: 'Generic Links', data: { toggle: 'offcanvas' }) do
+    %i.fas.fa-user-circle.fa-2x
 .navbar-collapse.offcanvas-collapse.navbar-dark
   .navbar-nav
     .nav.justify-content-end.py-2

--- a/src/api/app/views/layouts/webui/responsive_ux/_nobody_navigation.html.haml
+++ b/src/api/app/views/layouts/webui/responsive_ux/_nobody_navigation.html.haml
@@ -1,2 +1,21 @@
-= sign_up_link(css_class: 'nav-link text-light text-center p-1 toggler')
-= log_in_link(css_class: 'nav-link text-light text-center p-1 toggler')
+.toggler
+  = sign_up_link(css_class: 'nav-link text-light text-center p-1')
+.toggler
+  = log_in_link(css_class: 'nav-link text-light text-center p-1')
+.toggler{ data: { toggle: 'offcanvas' } }
+  %i.fas.fa-user-circle.fa-2x.text-light
+.navbar-collapse.offcanvas-collapse.navbar-dark
+  .navbar-nav
+    .nav.justify-content-end.py-2
+      %button.navbar-toggler{ 'type': 'button', data: { toggle: 'offcanvas' }, aria: { expanded: 'false', label: 'Toggle navigation' } }
+        %i.fas.fa-times
+  %ul.navbar-nav.ml-auto.pt-0.text-nowrap.menu-options
+    %li.nav-item
+      = link_to(projects_path, class: 'nav-link') do
+        %i.fas.fa-list.fa-lg.mr-2
+        All Projects
+    - unless @spider_bot
+      %li.nav-item
+        = link_to(monitor_path, class: 'nav-link') do
+          %i.fas.fa-heartbeat.fa-lg.mr-2
+          Status Monitor

--- a/src/api/app/views/layouts/webui/responsive_ux/_user_navigation.html.haml
+++ b/src/api/app/views/layouts/webui/responsive_ux/_user_navigation.html.haml
@@ -18,6 +18,19 @@
           %i.fas.fa-cubes.fa-lg.mr-2
           Create Your Home Project
     %li.nav-item
+      = link_to(projects_path, class: 'nav-link') do
+        %i.fas.fa-list.fa-lg.mr-2
+        All Projects
+    %li.nav-item
+      = link_to(monitor_path, class: 'nav-link') do
+        %i.fas.fa-heartbeat.fa-lg.mr-2
+        Status Monitor
+    - if User.admin_session?
+      %li.nav-item
+        = link_to(configuration_path, class: 'nav-link', title: 'Configure this instance') do
+          %i.fas.fa-cogs.mr-2
+          Configuration
+    %li.nav-item
       = link_to(session_path, method: :delete, id: 'logout-link', class: 'nav-link') do
         %i.fas.fa-sign-out-alt.fa-lg.mr-2
         Logout

--- a/src/api/app/views/webui/main/_actions.html.haml
+++ b/src/api/app/views/webui/main/_actions.html.haml
@@ -1,0 +1,14 @@
+- content_for :actions do
+  - if User.admin_session?
+    %li.nav-item
+      = link_to('#', class: 'nav-link', 'data-toggle': 'modal', 'data-target': '#status-message-modal') do
+        %i.fas.fa-plus-square.fa-lg.mr-2
+        Create Status Message
+  %li.nav-item
+    = link_to(new_project_path, class: 'nav-link') do
+      %i.fas.fa-plus-square.fa-lg.mr-2
+      Create Project
+  %li.nav-item
+    = link_to(image_templates_path, class: 'nav-link') do
+      %i.fas.fa-compact-disc.fa-lg.mr-2
+      New Image

--- a/src/api/app/views/webui/main/_actions.html.haml
+++ b/src/api/app/views/webui/main/_actions.html.haml
@@ -8,6 +8,7 @@
     = link_to(new_project_path, class: 'nav-link') do
       %i.fas.fa-plus-square.fa-lg.mr-2
       Create Project
+  -# TODO: Move "New Image" under the project actions once they are available
   %li.nav-item
     = link_to(image_templates_path, class: 'nav-link') do
       %i.fas.fa-compact-disc.fa-lg.mr-2

--- a/src/api/app/views/webui/main/_status_messages.html.haml
+++ b/src/api/app/views/webui/main/_status_messages.html.haml
@@ -9,8 +9,4 @@
     - @status_messages.each do |message|
       = render partial: 'status_message', locals: { message: message }
     - if User.admin_session?
-      .card-footer
-        = link_to('#', 'data-toggle': 'modal', 'data-target': '#status-message-modal') do
-          %i.fas.fa-plus-circle.text-primary
-          Add status message
       = render partial: 'add_status_message_modal'

--- a/src/api/app/views/webui/main/index.html.haml
+++ b/src/api/app/views/webui/main/index.html.haml
@@ -1,4 +1,5 @@
 - @pagetitle = 'Welcome'
+- render partial: 'actions'
 
 .row
   .col-md-8.col-lg-7

--- a/src/api/app/views/webui/main/index.html.haml
+++ b/src/api/app/views/webui/main/index.html.haml
@@ -9,8 +9,9 @@
         -# rubocop:disable Rails/OutputSafety
         = raw @configuration['description']
         -# rubocop:enable Rails/OutputSafety
-        .row.no-gutters.text-center#proceed-list
-          = render partial: 'proceed-list'
+        - unless flipper_responsive?
+          .row.no-gutters.text-center#proceed-list
+            = render partial: 'proceed-list'
     = render(partial: 'system_status', locals: { busy: @busy,
                                                  building_workers: @building_workers,
                                                  overall_workers: @overall_workers,


### PR DESCRIPTION
Before with actions and generic links all over the page.
![before](https://user-images.githubusercontent.com/1102934/76216204-7333e100-6210-11ea-9fec-ef847aab33d3.png)

Now, the actions are in their own menu and generic links in the existing menu where we already have `Profile` and other links. The icons don't have a color anymore as more colors didn't fit well on a dark background. The menu with generic links is also available to anonymous users whenever links make sense for such users (like `All Projects` or `Status Monitor`). The button for the actions menu is hidden whenever it's empty or for anonymous users. Depending on the role of the user, the actions and the generic links will vary to follow the user's permissions.

------
Actions
Large devices:
![actions](https://user-images.githubusercontent.com/1102934/76308165-7d1a1a80-62ca-11ea-8c24-3f3d352c1af6.png)

Small devices:
![actions-small](https://user-images.githubusercontent.com/1102934/76308161-7c818400-62ca-11ea-8ba2-8875b98875fc.png)

-----

Generic menu
Large devices:
![menu](https://user-images.githubusercontent.com/1102934/76308259-ad61b900-62ca-11ea-9ec2-34599d2f918a.png)

Small devices:
![menu-small](https://user-images.githubusercontent.com/1102934/76308257-acc92280-62ca-11ea-8eb6-e23c9d73f815.png)