### PR TITLE
Align navigation items adding always icons and texts for consistency and clarity

### DIFF
--- a/src/api/app/assets/stylesheets/webui/responsive_ux.scss
+++ b/src/api/app/assets/stylesheets/webui/responsive_ux.scss
@@ -1,3 +1,9 @@
+// Variables
+// TODO: move to app/assets/stylesheets/webui/bootstrap_variables/sizes.scss
+$top-bar-height: 57px;
+$bottom-bar-height: 69px;
+$md-top-bar-height: 69px;
+
 body.responsive-ux {
   // open space to not overlap top navigation with content
   padding-top: 3.5rem !important;
@@ -6,16 +12,25 @@ body.responsive-ux {
   @import 'responsive_ux/build-result';
   @import 'responsive_ux/sponsors';
 
-  .build-results .sticky-top { top: 57px; }
+  .build-results .sticky-top { top: $top-bar-height; }
 }
 
 // FIXME: move to somewhere else?
 
 @include media-breakpoint-up(md) {
+
   body.responsive-ux {
     // START LAYOUT
+    .flash-and-announcement.sticky-top { top: $md-top-bar-height + 4px; }
+    #top_0.sticky-top { top: $md-top-bar-height; }
+
+    #navigation {
+      .fixed-top { height: $md-top-bar-height; }
+      .navbar-brand img { height: 42px; }
+    }
+
     .watchlist-collapse, .offcanvas-collapse {
-      top: 57px; /* Height of navbar */
+      top: $md-top-bar-height; /* Height of navbar */
       bottom: 0;
       width: 380px;
 

--- a/src/api/app/assets/stylesheets/webui/responsive_ux/_layout.scss
+++ b/src/api/app/assets/stylesheets/webui/responsive_ux/_layout.scss
@@ -1,17 +1,19 @@
 .border-gray-500 { border-color: $gray-500 !important; }
 .navbar-dark .navbar-toggler { color: $gray-300; }
-.flash-and-announcement.sticky-top { top: 60px; }
-#top_0.sticky-top { top: 57px; }
+.flash-and-announcement.sticky-top { top: $top-bar-height + 16px; }
+#top_0.sticky-top { top: $top-bar-height; }
 
 // NAVIGATION
 
 #navigation {
-  .fixed-top { height: 57px; }
+  .fixed-top { height: $top-bar-height; }
   .toggler {
-    @extend .ml-3;
+    @extend .ml-2;
     @extend .d-none;
     @extend .d-md-block;
     cursor: pointer;
+    &.text-center { min-width: 62px; }
+    &:first-of-type { @extend .ml-3;  }
   }
 
   .navbar-nav .nav-link {
@@ -21,18 +23,26 @@
 
   .menu-right { cursor: pointer; }
   .menu-options { font-size: 1.1rem }
+
+  .navbar-brand img { height: 30px; }
 }
 
-#bottom-navigation { height: 58px; }
+#bottom-navigation { height: $bottom-bar-height; }
 
 #navigation, #bottom-navigation {
   a.nav-link {
+    .small {
+      line-height: 1rem;
+      padding-top: 0.25rem;
+    }
+
     &.active {
       background-color: darken($dark, 10%);
       @extend .rounded;
     }
   }
 }
+
 // BREADCRUMBS
 
 .breadcrumb {
@@ -81,9 +91,9 @@ button.navbar-toggler {
 
 .watchlist-collapse, .offcanvas-collapse {
   position: fixed;
-  top: 57px;
+  top: $top-bar-height;
   left: 100%;
-  bottom: 58px;
+  bottom: $bottom-bar-height;
   width: 100%;
   padding-right: 1rem;
   padding-left: 1rem;
@@ -121,4 +131,4 @@ button.navbar-toggler {
     & a { color: $gray-300; }
   }
 }
-.footer-separator { height: 58px; }
+.footer-separator { height: $bottom-bar-height; }

--- a/src/api/app/helpers/webui/webui_helper.rb
+++ b/src/api/app/helpers/webui/webui_helper.rb
@@ -368,18 +368,38 @@ module Webui::WebuiHelper
 
   def sign_up_link(css_class: nil)
     return unless can_sign_up?
+
     if proxy_mode?
-      link_to('Sign Up', sign_up_params[:url], class: css_class)
+      link_to(sign_up_params[:url], class: css_class) do
+        link_content('Sign Up', css_class, 'fa-user-plus')
+      end
     else
-      link_to('Sign Up', '#', class: css_class, data: { toggle: 'modal', target: '#sign-up-modal' })
+      link_to('#', class: css_class, data: { toggle: 'modal', target: '#sign-up-modal' }) do
+        link_content('Sign Up', css_class, 'fa-user-plus')
+      end
     end
   end
 
   def log_in_link(css_class: nil)
     if kerberos_mode?
-      link_to('Log In', new_session_path, class: css_class)
+      link_to(new_session_path, class: css_class) do
+        link_content('Log In', css_class, 'fa-sign-in-alt')
+      end
     else
-      link_to('Log In', '#', class: css_class, data: { toggle: 'modal', target: '#log-in-modal' })
+      link_to('#', class: css_class, data: { toggle: 'modal', target: '#log-in-modal' }) do
+        link_content('Log In', css_class, 'fa-sign-in-alt')
+      end
+    end
+  end
+
+  def link_content(text, css_class, icon)
+    if css_class && css_class.include?('nav-link')
+      capture do
+        concat(content_tag(:i, '', class: "fas #{icon} fa-lg"))
+        concat(content_tag(:div, text, class: 'small'))
+      end
+    else
+      text
     end
   end
 end

--- a/src/api/app/views/layouts/webui/responsive_ux/_bottom_navigation.html.haml
+++ b/src/api/app/views/layouts/webui/responsive_ux/_bottom_navigation.html.haml
@@ -23,9 +23,9 @@
     - else
       - unless kerberos_mode? || !can_sign_up?
         %li.nav-item.border-right.border-gray-500
-          = sign_up_link(css_class: 'nav-link text-light')
+          = sign_up_link(css_class: 'nav-link text-light p-1')
       %li.nav-item
-        = log_in_link(css_class: 'nav-link text-light')
+        = log_in_link(css_class: 'nav-link text-light p-1')
 
 - if User.session
   = render partial: "layouts/#{responsive_namespace}/watchlist"

--- a/src/api/app/views/layouts/webui/responsive_ux/_bottom_navigation.html.haml
+++ b/src/api/app/views/layouts/webui/responsive_ux/_bottom_navigation.html.haml
@@ -1,19 +1,25 @@
 .footer-separator.d-block.d-md-none
 %nav.navbar.fixed-bottom.navbar-dark.bg-dark.border-top.border-gray-500.d-block.d-md-none#bottom-navigation
-  %ul.nav.justify-content-center.w-100.nav-fill
+  %ul.nav.justify-content-center.w-100.nav-justified
     - if User.session
       %li.nav-item
-        = link_to('javascript:void(0)', class: 'nav-link text-light', alt: 'Watchlist', data: { toggle: 'watchlist' }) do
+        = link_to('javascript:void(0)', class: 'nav-link text-light p-1', alt: 'Watchlist', data: { toggle: 'watchlist' }) do
           %i.fas.fa-bookmark.fa-lg
+          %br
+          .small Watchlist
       %li.nav-item.border-left.border-gray-500
         - tasks = User.session!.tasks
-        = link_to(my_tasks_path, class: 'nav-link text-light', alt: 'Tasks') do
+        = link_to(my_tasks_path, class: 'nav-link text-light p-1', alt: 'Tasks') do
           %i.fas.fa-tasks.fa-lg
           - if tasks.positive?
             .badge.badge-primary.align-text-top= tasks
+          %br
+          .small Tasks
       %li.nav-item.border-left.border-gray-500
-        = link_to('javascript:void(0)', class: 'nav-link text-light', alt: 'Menu', data: { toggle: 'offcanvas' }) do
+        = link_to('javascript:void(0)', class: 'nav-link text-light p-1', alt: 'Menu', data: { toggle: 'offcanvas' }) do
           %i.fas.fa-bars.fa-lg
+          %br
+          .small Menu
     - else
       - unless kerberos_mode? || !can_sign_up?
         %li.nav-item.border-right.border-gray-500

--- a/src/api/app/views/layouts/webui/responsive_ux/_navigation.html.haml
+++ b/src/api/app/views/layouts/webui/responsive_ux/_navigation.html.haml
@@ -1,21 +1,25 @@
 %nav.navbar.navbar-dark.bg-dark.border-bottom.border-gray-500.fixed-top
   .d-flex.flex-nowrap.justify-content-between.w-100
     = link_to(root_path, class: 'navbar-brand', alt: 'Logo') do
-      = image_tag('obs-logo_small.svg', height: '30')
+      = image_tag('obs-logo_small.svg')
     .d-flex
       = render partial: "layouts/#{responsive_namespace}/search"
       - if User.session
-        .toggler
-          = link_to('javascript:void(0)', class: 'nav-link text-light', alt: 'Watchlist', data: { toggle: 'watchlist' }) do
+        .toggler.text-center
+          = link_to('javascript:void(0)', class: 'nav-link text-light p-1', alt: 'Watchlist', data: { toggle: 'watchlist' }) do
             %i.fas.fa-bookmark.fa-lg
-        .toggler
+            %br
+            .small Watchlist
+        .toggler.text-center
           - tasks = User.session!.tasks
-          = link_to(my_tasks_path, class: 'nav-link text-light', alt: 'Tasks') do
+          = link_to(my_tasks_path, class: 'nav-link text-light p-1', alt: 'Tasks') do
             %i.fas.fa-tasks.fa-lg
             - if tasks.positive?
               %span.badge.badge-primary.align-text-top= tasks
+            %br
+            .small Tasks
         .toggler{ data: { toggle: 'offcanvas' } }
-          = image_tag_for(User.session, size: 40, custom_class: 'rounded-circle bg-light')
+          = image_tag_for(User.session, size: 52, custom_class: 'rounded-circle bg-light')
       - else
         = render partial: 'layouts/webui/responsive_ux/nobody_navigation'
 

--- a/src/api/app/views/layouts/webui/responsive_ux/_nobody_navigation.html.haml
+++ b/src/api/app/views/layouts/webui/responsive_ux/_nobody_navigation.html.haml
@@ -1,2 +1,2 @@
-= sign_up_link(css_class: 'nav-link text-light ml-3 toggler')
-= log_in_link(css_class: 'nav-link btn btn-outline-light ml-3 text-nowrap toggler')
+= sign_up_link(css_class: 'nav-link text-light text-center p-1 toggler')
+= log_in_link(css_class: 'nav-link text-light text-center p-1 toggler')


### PR DESCRIPTION
In top and bottom navigation bars, having only icons wasn't clear enough, so we add texts under them.

For consistency, we also add icons to those which didn't have, like _Sign Up_ and _Log In_.

Therefore, the bars height and elements sizes and spacing had to be adapted.

## Compare before and after on small screens:

### No login:

![compare_small_nobody](https://user-images.githubusercontent.com/2581944/76205083-d6664900-61f9-11ea-8f68-b27640563a74.png)

###  Login:

![compare_small_logged](https://user-images.githubusercontent.com/2581944/76020872-869b2f80-5f24-11ea-82bc-2abfa8fd5536.png)

## Compare before and after on larger screens:

### No login:

![compare_large_nobody](https://user-images.githubusercontent.com/2581944/76205112-e1b97480-61f9-11ea-846e-9c0284d7b4fe.png)

### Login:

![compare_large_logged](https://user-images.githubusercontent.com/2581944/76020916-9ca8f000-5f24-11ea-829b-b6d1629e4c79.png)

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
