### PR TITLE
Align structure of the generic menu for all devices and users

### DIFF
--- a/src/api/app/views/layouts/webui/responsive_ux/_bottom_navigation.html.haml
+++ b/src/api/app/views/layouts/webui/responsive_ux/_bottom_navigation.html.haml
@@ -28,10 +28,10 @@
       %li.nav-item
         = log_in_link(css_class: 'nav-link text-light p-1')
     %li.nav-item.border-left.border-gray-500
-      = link_to('javascript:void(0)', class: 'nav-link text-light p-1', alt: 'Menu', data: { toggle: 'offcanvas' }) do
+      = link_to('javascript:void(0)', class: 'nav-link text-light p-1', alt: 'Places', data: { toggle: 'offcanvas' }) do
         %i.fas.fa-bars.fa-lg
         %br
-        .small Menu
+        .small Places
 
 - if User.session
   = render partial: "layouts/#{responsive_namespace}/watchlist"

--- a/src/api/app/views/layouts/webui/responsive_ux/_navigation.html.haml
+++ b/src/api/app/views/layouts/webui/responsive_ux/_navigation.html.haml
@@ -24,9 +24,11 @@
               %i.fas.fa-ellipsis-v.fa-lg
               %br
               .small Actions
-        .toggler
-          = link_to('javascript:void(0)', class: 'nav-link text-light', alt: 'Generic Links', data: { toggle: 'offcanvas' }) do
-            = image_tag_for(User.session, size: 32, custom_class: 'rounded-circle bg-light')
+        .toggler.text-center
+          = link_to('javascript:void(0)', class: 'nav-link text-light p-1', alt: 'Places', data: { toggle: 'offcanvas' }) do
+            %i.fas.fa-bars.fa-lg
+            %br
+            .small Places
       - else
         = render partial: 'layouts/webui/responsive_ux/nobody_navigation'
 

--- a/src/api/app/views/layouts/webui/responsive_ux/_nobody_navigation.html.haml
+++ b/src/api/app/views/layouts/webui/responsive_ux/_nobody_navigation.html.haml
@@ -1,10 +1,12 @@
-.toggler
-  = sign_up_link(css_class: 'nav-link text-light text-center p-1')
-.toggler
-  = log_in_link(css_class: 'nav-link text-light text-center p-1')
-.toggler
-  = link_to('javascript:void(0)', class: 'nav-link text-light', alt: 'Generic Links', data: { toggle: 'offcanvas' }) do
-    %i.fas.fa-user-circle.fa-2x
+.toggler.text-center
+  = sign_up_link(css_class: 'nav-link text-light p-1')
+.toggler.text-center
+  = log_in_link(css_class: 'nav-link text-light p-1')
+.toggler.text-center
+  = link_to('javascript:void(0)', class: 'nav-link text-light p-1', alt: 'Places', data: { toggle: 'offcanvas' }) do
+    %i.fas.fa-bars.fa-lg
+    %br
+    .small Places
 .navbar-collapse.offcanvas-collapse.navbar-dark
   .navbar-nav
     .nav.justify-content-end.py-2


### PR DESCRIPTION
Following up on #9188, we now have the same icon for the generic menu. Other
changes were done to have a consistent look.

The changes are for large devices only. Small devices didn't need them since it's already done.

Menu as an anonymous user
Before:
![menu-before](https://user-images.githubusercontent.com/1102934/76314461-236c1d00-62d7-11ea-876a-189db2e3189a.png)
Now:
![menu-anonymous](https://user-images.githubusercontent.com/1102934/76314125-8610e900-62d6-11ea-9135-ca90a2d61ce5.png)

Menu as an authenticated user
Before:
![menu-before-authenticated](https://user-images.githubusercontent.com/1102934/76314550-50b8cb00-62d7-11ea-93ce-7ef380f9a0e3.png)
Now:
![menu](https://user-images.githubusercontent.com/1102934/76314129-87421600-62d6-11ea-8d34-0f7be8dde3ad.png)