### PR TITLE
Implement in-place editing in project overview page

### DIFF
--- a/src/api/app/assets/javascripts/webui/application.js
+++ b/src/api/app/assets/javascripts/webui/application.js
@@ -55,3 +55,5 @@
 //= require webui/monitor.js
 //= require webui/airbrake-js
 //= require webui/responsive_ux
+//= require webui/in_place_editing.js
+

--- a/src/api/app/assets/javascripts/webui/collapsible_text.js
+++ b/src/api/app/assets/javascripts/webui/collapsible_text.js
@@ -1,4 +1,4 @@
-$(document).ready(function() {
+var activateCollapsibleText = function() {
   $('.obs-collapsible-textbox').on('click', function() {
     var selectedText = document.getSelection().toString();
     if(!selectedText) {
@@ -13,4 +13,4 @@ $(document).ready(function() {
       $(element).after($link);
     }
   });
-});
+}

--- a/src/api/app/assets/javascripts/webui/in_place_editing.js
+++ b/src/api/app/assets/javascripts/webui/in_place_editing.js
@@ -1,0 +1,32 @@
+var activate_in_place_editing = function() {
+    var $edit_button = $('#in-place-editing-edit-button');
+    var $cancel_button = $('#in-place-editing-cancel-button');
+    var $editing_form_wrapper = $('.in-place-editing-form-wrapper');
+    var $editing_content_wrapper = $('.in-place-editing-content');
+    var $editing_form = $('#in-place-editing-form');
+    $edit_button.on('click', function(event) {
+        // Show the editing form and the cancel button
+        $editing_form_wrapper.removeClass('d-none');
+        $cancel_button.removeClass('d-none');
+        // Hide the "read only" content and the edit button
+        $editing_content_wrapper.addClass('d-none');
+        $edit_button.addClass('d-none');
+    });
+    $editing_form.on('ajax:success', function(event, data, status, xhr) {
+        // Hide the editing form and the cancel button
+        $editing_form_wrapper.addClass('d-none');
+        $cancel_button.addClass('d-none');
+        // Update and show the read only content with the updated content
+        // from the controller and show the edit button back
+        $editing_content_wrapper.html(xhr.responseText).removeClass('d-none');
+        $edit_button.removeClass('d-none');
+    });
+    $cancel_button.on('click', function(event) {
+        // Hide the editing form and the cancel button
+        $editing_form_wrapper.addClass('d-none');
+        $cancel_button.addClass('d-none');
+        // Show the read only content and the edit button back
+        $editing_content_wrapper.removeClass('d-none');
+        $edit_button.removeClass('d-none');
+    });
+};

--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -10,7 +10,7 @@ class Webui::ProjectController < Webui::WebuiController
                                        :new_release_request, :new_package, :edit_comment]
 
   before_action :set_project, only: [:autocomplete_repositories, :users, :subprojects,
-                                     :new_package, :edit,
+                                     :new_package,
                                      :show, :buildresult,
                                      :destroy, :remove_path_from_target,
                                      :requests, :save, :monitor, :toggle_watch,
@@ -218,13 +218,6 @@ class Webui::ProjectController < Webui::WebuiController
     else
       flash[:error] = 'Project was never deleted.'
       redirect_back(fallback_location: root_path)
-    end
-  end
-
-  def edit
-    authorize @project, :update?
-    respond_to do |format|
-      format.js
     end
   end
 

--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -10,7 +10,7 @@ class Webui::ProjectController < Webui::WebuiController
                                        :new_release_request, :new_package, :edit_comment]
 
   before_action :set_project, only: [:autocomplete_repositories, :users, :subprojects,
-                                     :new_package,
+                                     :new_package, :edit,
                                      :show, :buildresult,
                                      :destroy, :remove_path_from_target,
                                      :requests, :save, :monitor, :toggle_watch,
@@ -221,6 +221,13 @@ class Webui::ProjectController < Webui::WebuiController
     end
   end
 
+  def edit
+    authorize @project, :update?
+    respond_to do |format|
+      format.js
+    end
+  end
+
   def update
     authorize @project, :update?
     respond_to do |format|
@@ -230,6 +237,7 @@ class Webui::ProjectController < Webui::WebuiController
         flash[:error] = 'Failed to update project'
       end
       format.html { redirect_to project_show_path(@project) }
+      format.js
     end
   end
 

--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -233,11 +233,21 @@ class Webui::ProjectController < Webui::WebuiController
     respond_to do |format|
       if @project.update(project_params)
         flash[:success] = 'Project was successfully updated.'
+        format.html do
+          if request.xhr?
+            render partial: 'basic_info', locals: { project: @project }, layout: false, status: :ok
+          else
+            redirect_to project_show_path(@project)
+          end
+        end
       else
         flash[:error] = 'Failed to update project'
+        format.html do
+          if request.xhr?
+            render partial: 'edit', locals: { project: @project }, layout: false, status: :ok
+          end
+        end
       end
-      format.html { redirect_to project_show_path(@project) }
-      format.js
     end
   end
 

--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -224,18 +224,16 @@ class Webui::ProjectController < Webui::WebuiController
   def update
     authorize @project, :update?
     respond_to do |format|
-      if @project.update(project_params)
-        flash[:success] = 'Project was successfully updated.'
-        format.html do
+      format.html do
+        if @project.update(project_params)
+          flash[:success] = 'Project was successfully updated.'
           if request.xhr?
             render partial: 'basic_info', locals: { project: @project }, layout: false, status: :ok
           else
             redirect_to project_show_path(@project)
           end
-        end
-      else
-        flash[:error] = 'Failed to update project'
-        format.html do
+        else
+          flash[:error] = 'Failed to update project'
           if request.xhr?
             render partial: 'edit', locals: { project: @project }, layout: false, status: :ok
           end

--- a/src/api/app/helpers/validation_helper.rb
+++ b/src/api/app/helpers/validation_helper.rb
@@ -63,4 +63,12 @@ module ValidationHelper
     # FIXME: actually a per user checking would be more accurate here
     raise Project::UnknownObjectError, project.to_s if FlagHelper.xml_disabled_for?(Xmlhash.parse(meta), 'access')
   end
+
+  def show_error_messages(object, field_name)
+    if object.errors[field_name].any?
+      content_tag(:div, class: 'alert alert-dismissible alert-error') do
+        object.errors[:url].join.capitalize
+      end
+    end
+  end
 end

--- a/src/api/app/helpers/webui/in_place_editing_helper.rb
+++ b/src/api/app/helpers/webui/in_place_editing_helper.rb
@@ -1,0 +1,33 @@
+module Webui::InPlaceEditingHelper
+  def render_controls
+    content_tag(:div, class: 'basic-info mb-3 d-flex justify-content-end', id: 'project-in-place-editing') do
+      concat(link_to('Edit', '#', id: 'in-place-editing-edit-button', class: 'btn btn-primary btn-sm'))
+      concat(link_to('Cancel', '#', id: 'in-place-editing-cancel-button', class: 'btn btn-outline-danger btn-sm d-none'))
+    end
+  end
+
+  def render_editing_form(object)
+    object_type = object.class.to_s.underscore.to_sym
+    content_tag(:div, class: 'in-place-editing-form-wrapper d-none') do
+      form_for(object,
+               url: url_for(controller: object_type, action: 'update'),
+               method: :patch, remote: true, html: { id: 'in-place-editing-form' }) do |form|
+        content_tag(:h5, 'Edit Project')
+        render(partial: 'edit', locals: { form: form, project: object })
+      end
+    end
+  end
+
+  def render_read_only_content(object)
+    content_tag(:div, class: 'in-place-editing-content') do
+      concat(render(partial: 'basic_info', locals: { project: object }))
+    end
+  end
+
+  def in_place_editing(object)
+    concat(render_controls)
+    concat(render_editing_form(object))
+    concat(render_read_only_content(object))
+    content_for(:ready_function, 'activate_in_place_editing();')
+  end
+end

--- a/src/api/app/views/webui/project/_basic_info.html.haml
+++ b/src/api/app/views/webui/project/_basic_info.html.haml
@@ -1,0 +1,29 @@
+- if flipper_responsive?
+  .basic-info.mb-3{ class: 'in-place-edition' }
+    = link_to 'Edit', edit_project_path(@project), remote: true
+    %h3#project-title
+      = @project.title.presence || @project
+    - if @project.categories.any?
+      - @project.categories.each do |category|
+        = category_badge(category)
+    - if @project.url.present?
+      = link_to(@project.url, @project.url, class: 'mb-3 d-block')
+    #description-text
+      - if @project.description.blank?
+        %i No description set
+      - else
+        = render partial: 'webui/shared/collapsible_text', locals: { text: @project.description }
+- else
+  .basic-info.mb-3
+    %h3#project-title
+      = @project.title.presence || @project
+    - if @project.categories.any?
+      - @project.categories.each do |category|
+        = category_badge(category)
+    - if @project.url.present?
+      = link_to(@project.url, @project.url, class: 'mb-3 d-block')
+    #description-text
+      - if @project.description.blank?
+        %i No description set
+      - else
+        = render partial: 'webui/shared/collapsible_text', locals: { text: @project.description }

--- a/src/api/app/views/webui/project/_basic_info.html.haml
+++ b/src/api/app/views/webui/project/_basic_info.html.haml
@@ -1,29 +1,12 @@
-- if flipper_responsive?
-  .basic-info.mb-3{ class: 'in-place-edition' }
-    = link_to 'Edit', edit_project_path(@project), remote: true
-    %h3#project-title
-      = @project.title.presence || @project
-    - if @project.categories.any?
-      - @project.categories.each do |category|
-        = category_badge(category)
-    - if @project.url.present?
-      = link_to(@project.url, @project.url, class: 'mb-3 d-block')
-    #description-text
-      - if @project.description.blank?
-        %i No description set
-      - else
-        = render partial: 'webui/shared/collapsible_text', locals: { text: @project.description }
-- else
-  .basic-info.mb-3
-    %h3#project-title
-      = @project.title.presence || @project
-    - if @project.categories.any?
-      - @project.categories.each do |category|
-        = category_badge(category)
-    - if @project.url.present?
-      = link_to(@project.url, @project.url, class: 'mb-3 d-block')
-    #description-text
-      - if @project.description.blank?
-        %i No description set
-      - else
-        = render partial: 'webui/shared/collapsible_text', locals: { text: @project.description }
+%h3#project-title
+  = @project.title.presence || @project
+- if @project.categories.any?
+  - @project.categories.each do |category|
+    = category_badge(category)
+- if @project.url.present?
+  = link_to(@project.url, @project.url, class: 'mb-3 d-block')
+#description-text
+  - if @project.description.blank?
+    %i No description set
+  - else
+    = render partial: 'webui/shared/collapsible_text', locals: { text: @project.description }

--- a/src/api/app/views/webui/project/_bottom_actions.html.haml
+++ b/src/api/app/views/webui/project/_bottom_actions.html.haml
@@ -11,7 +11,7 @@
                                                                                  has_patchinfo: has_patchinfo,
                                                                                  open_release_requests: open_release_requests,
                                                                                  release_targets: release_targets }
-      = render partial: 'webui/project/bottom_actions/edit_project', locals: { project: project }
+      = render partial: 'webui/project/bottom_actions/edit_project', locals: { project: project } unless flipper_responsive?
       = render partial: 'webui/project/bottom_actions/delete_project', locals: { project: project }
     - elsif !project.is_locked?
       = render partial: 'webui/project/bottom_actions/request_role_addition_and_deletion', locals: { project: project }

--- a/src/api/app/views/webui/project/_edit.html.haml
+++ b/src/api/app/views/webui/project/_edit.html.haml
@@ -1,0 +1,15 @@
+= form_for(project, url: project_update_url, method: :patch, remote: true) do |form|
+  %h5 Edit Project #{project}
+  = hidden_field_tag(:id, project.id)
+  .form-group
+    = form.label(:title, 'Title:')
+    = form.text_field(:title, class: 'form-control')
+  .form-group
+    = form.label(:url, 'URL:')
+    = form.text_field(:url, class: 'form-control')
+  .form-group
+    = form.label(:description, 'Description:')
+    = form.text_area(:description, rows: 8, class: 'form-control')
+  %a.cancel.btn.btn-outline-danger.px-4
+    Cancel
+  = submit_tag('Update', class: 'btn btn-primary px-4')

--- a/src/api/app/views/webui/project/_edit.html.haml
+++ b/src/api/app/views/webui/project/_edit.html.haml
@@ -1,15 +1,23 @@
-= form_for(project, url: project_update_url, method: :patch, remote: true) do |form|
+= form_for(project, url: project_update_url, method: :patch, remote: true, html: { id: 'in_place_editing_for_project', class: 'd-none' }) do |form|
   %h5 Edit Project #{project}
   = hidden_field_tag(:id, project.id)
   .form-group
     = form.label(:title, 'Title:')
     = form.text_field(:title, class: 'form-control')
+    = show_error_messages(project, :title)
   .form-group
     = form.label(:url, 'URL:')
     = form.text_field(:url, class: 'form-control')
+    = show_error_messages(project, :url)
   .form-group
     = form.label(:description, 'Description:')
     = form.text_area(:description, rows: 8, class: 'form-control')
-  %a.cancel.btn.btn-outline-danger.px-4
+    = show_error_messages(project, :description)
+  %a.cancel.btn.btn-outline-danger.px-4.in-place-editing-cancel
     Cancel
   = submit_tag('Update', class: 'btn btn-primary px-4')
+
+:javascript
+  $('#in_place_editing_for_project').on("ajax:success", function(event, data, status, xhr) {
+    $('#project-in-place-editing').html(xhr.responseText);
+  });

--- a/src/api/app/views/webui/project/_edit.html.haml
+++ b/src/api/app/views/webui/project/_edit.html.haml
@@ -1,23 +1,15 @@
-= form_for(project, url: project_update_url, method: :patch, remote: true, html: { id: 'in_place_editing_for_project', class: 'd-none' }) do |form|
-  %h5 Edit Project #{project}
-  = hidden_field_tag(:id, project.id)
-  .form-group
-    = form.label(:title, 'Title:')
-    = form.text_field(:title, class: 'form-control')
-    = show_error_messages(project, :title)
-  .form-group
-    = form.label(:url, 'URL:')
-    = form.text_field(:url, class: 'form-control')
-    = show_error_messages(project, :url)
-  .form-group
-    = form.label(:description, 'Description:')
-    = form.text_area(:description, rows: 8, class: 'form-control')
-    = show_error_messages(project, :description)
-  %a.cancel.btn.btn-outline-danger.px-4.in-place-editing-cancel
-    Cancel
-  = submit_tag('Update', class: 'btn btn-primary px-4')
+= hidden_field_tag(:id, project.id)
+.form-group
+  = form.label(:title, 'Title:')
+  = form.text_field(:title, class: 'form-control')
+  = show_error_messages(project, :title)
+.form-group
+  = form.label(:url, 'URL:')
+  = form.text_field(:url, class: 'form-control')
+  = show_error_messages(project, :url)
+.form-group
+  = form.label(:description, 'Description:')
+  = form.text_area(:description, rows: 8, class: 'form-control')
+  = show_error_messages(project, :description)
+= submit_tag('Update', class: 'btn btn-primary px-4')
 
-:javascript
-  $('#in_place_editing_for_project').on("ajax:success", function(event, data, status, xhr) {
-    $('#project-in-place-editing').html(xhr.responseText);
-  });

--- a/src/api/app/views/webui/project/edit.js.haml
+++ b/src/api/app/views/webui/project/edit.js.haml
@@ -1,0 +1,2 @@
+$('#flash').html("#{escape_javascript(render(layout: false, partial: 'layouts/webui/flash', object: flash))}");
+$('.in-place-edition').html("#{escape_javascript(render(partial: 'webui/project/edit', locals: { project: @project }))}");

--- a/src/api/app/views/webui/project/edit.js.haml
+++ b/src/api/app/views/webui/project/edit.js.haml
@@ -1,2 +1,2 @@
 $('#flash').html("#{escape_javascript(render(layout: false, partial: 'layouts/webui/flash', object: flash))}");
-$('.in-place-edition').html("#{escape_javascript(render(partial: 'webui/project/edit', locals: { project: @project }))}");
+$('#project-in-place-editing').html("#{escape_javascript(render(partial: 'webui/project/edit', locals: { project: @project }))}");

--- a/src/api/app/views/webui/project/show.html.haml
+++ b/src/api/app/views/webui/project/show.html.haml
@@ -18,18 +18,8 @@
   .card-body
     .row
       .col-md-8
-        %h3#project-title
-          = @project.title.presence || @project
-        - if @project.categories.any?
-          - @project.categories.each do |category|
-            = category_badge(category)
-        - if @project.url.present?
-          = link_to(@project.url, @project.url, class: 'mb-3 d-block')
-        #description-text
-          - if @project.description.blank?
-            %i No description set
-          - else
-            = render partial: 'webui/shared/collapsible_text', locals: { text: @project.description }
+        = render partial: 'basic_info', locals: { project: @project }
+
       .col-md-4
         = render partial: 'side_links', locals: { open_maintenance_incidents: @open_maintenance_incidents,
                                                   project: @project,

--- a/src/api/app/views/webui/project/show.html.haml
+++ b/src/api/app/views/webui/project/show.html.haml
@@ -18,7 +18,50 @@
   .card-body
     .row
       .col-md-8
-        = render partial: 'basic_info', locals: { project: @project }
+        - if flipper_responsive?
+          - project = @project
+          .basic-info.mb-3{ id: 'project-in-place-editing', class: 'd-flex justify-content-end' }
+            = link_to 'Edit', '#', id: 'in-place-editing-edit-button', class: 'btn btn-primary btn-sm'
+            = link_to 'Cancel', '#', id: 'in-place-editing-cancel-button', class: 'btn btn-outline-danger btn-sm d-none'
+          .in-place-editing-form-wrapper.d-none
+            = form_for(project, url: project_update_url, method: :patch, remote: true, html: { id: 'in-place-editing-form' }) do |form|
+              %h5 Edit Project
+              = render partial: 'edit', locals: { form: form, project: @project }
+          .in-place-editing-content
+            = render partial: 'basic_info', locals: { project: @project }
+          :javascript
+            var $edit_button = $('#in-place-editing-edit-button');
+            var $cancel_button = $('#in-place-editing-cancel-button');
+            var $editing_form_wrapper = $('.in-place-editing-form-wrapper');
+            var $editing_content_wrapper = $('.in-place-editing-content');
+            var $editing_form = $('#in-place-editing-form');
+            $edit_button.on('click', function(event) {
+              // Show the editing form and the cancel button
+              $editing_form_wrapper.removeClass('d-none');
+              $cancel_button.removeClass('d-none');
+              // Hide the "read only" content and the edit button
+              $editing_content_wrapper.addClass('d-none');
+              $edit_button.addClass('d-none');
+            });
+            $editing_form.on('ajax:success', function(event, data, status, xhr) {
+              // Hide the editing form and the cancel button
+              $editing_form_wrapper.addClass('d-none');
+              $cancel_button.addClass('d-none');
+              // Update and show the read only content with the updated content
+              // from the controller and show the edit button back
+              $editing_content_wrapper.html(xhr.responseText).removeClass('d-none');
+              $edit_button.removeClass('d-none');
+            });
+            $cancel_button.on('click', function(event) {
+              // Hide the editing form and the cancel button
+              $editing_form_wrapper.addClass('d-none');
+              $cancel_button.addClass('d-none');
+              // Show the read only content and the edit button back
+              $editing_content_wrapper.removeClass('d-none');
+              $edit_button.removeClass('d-none');
+            });
+        - else
+          = render partial: 'basic_info', locals: { proejct: @project }
 
       .col-md-4
         = render partial: 'side_links', locals: { open_maintenance_incidents: @open_maintenance_incidents,

--- a/src/api/app/views/webui/project/show.html.haml
+++ b/src/api/app/views/webui/project/show.html.haml
@@ -20,46 +20,7 @@
       .col-md-8
         - if flipper_responsive?
           - project = @project
-          .basic-info.mb-3{ id: 'project-in-place-editing', class: 'd-flex justify-content-end' }
-            = link_to 'Edit', '#', id: 'in-place-editing-edit-button', class: 'btn btn-primary btn-sm'
-            = link_to 'Cancel', '#', id: 'in-place-editing-cancel-button', class: 'btn btn-outline-danger btn-sm d-none'
-          .in-place-editing-form-wrapper.d-none
-            = form_for(project, url: project_update_url, method: :patch, remote: true, html: { id: 'in-place-editing-form' }) do |form|
-              %h5 Edit Project
-              = render partial: 'edit', locals: { form: form, project: @project }
-          .in-place-editing-content
-            = render partial: 'basic_info', locals: { project: @project }
-          :javascript
-            var $edit_button = $('#in-place-editing-edit-button');
-            var $cancel_button = $('#in-place-editing-cancel-button');
-            var $editing_form_wrapper = $('.in-place-editing-form-wrapper');
-            var $editing_content_wrapper = $('.in-place-editing-content');
-            var $editing_form = $('#in-place-editing-form');
-            $edit_button.on('click', function(event) {
-              // Show the editing form and the cancel button
-              $editing_form_wrapper.removeClass('d-none');
-              $cancel_button.removeClass('d-none');
-              // Hide the "read only" content and the edit button
-              $editing_content_wrapper.addClass('d-none');
-              $edit_button.addClass('d-none');
-            });
-            $editing_form.on('ajax:success', function(event, data, status, xhr) {
-              // Hide the editing form and the cancel button
-              $editing_form_wrapper.addClass('d-none');
-              $cancel_button.addClass('d-none');
-              // Update and show the read only content with the updated content
-              // from the controller and show the edit button back
-              $editing_content_wrapper.html(xhr.responseText).removeClass('d-none');
-              $edit_button.removeClass('d-none');
-            });
-            $cancel_button.on('click', function(event) {
-              // Hide the editing form and the cancel button
-              $editing_form_wrapper.addClass('d-none');
-              $cancel_button.addClass('d-none');
-              // Show the read only content and the edit button back
-              $editing_content_wrapper.removeClass('d-none');
-              $edit_button.removeClass('d-none');
-            });
+          = in_place_editing(@project)
         - else
           = render partial: 'basic_info', locals: { proejct: @project }
 

--- a/src/api/app/views/webui/project/update.js.haml
+++ b/src/api/app/views/webui/project/update.js.haml
@@ -1,0 +1,2 @@
+$('#flash').html("#{escape_javascript(render(layout: false, partial: 'layouts/webui/flash', object: flash))}");
+$('.in-place-edition').html("#{escape_javascript(render(partial: 'webui/project/basic_info', locals: { project: @project }))}");

--- a/src/api/app/views/webui/shared/_collapsible_text.html.haml
+++ b/src/api/app/views/webui/shared/_collapsible_text.html.haml
@@ -3,3 +3,6 @@
   .obs-collapsible-textbox
     .obs-collapsible-text
       = simple_format(text)
+
+:javascript
+  activateCollapsibleText();

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -188,6 +188,7 @@ OBSApi::Application.routes.draw do
       get 'project/show/:project' => :show, constraints: cons, as: 'project_show'
       get 'project/buildresult' => :buildresult, constraints: cons, as: 'project_buildresult'
       get 'project/new' => :new, as: 'new_project'
+      get 'project/edit/:project' => :edit, constraints: cons, as: 'edit_project'
       post 'project/create' => :create, constraints: cons, as: 'projects_create'
       post 'project/restore' => :restore, constraints: cons, as: 'projects_restore'
       patch 'project/update' => :update, constraints: cons


### PR DESCRIPTION
Use in-place editing for the project's

- Title
- Url
- Description

We've been using modals to edit the project's title, url and description. We
think we have better tools for that. In-place editing is one of the ways to do
it.

With this PR we introduce a new way of updating some of the project's
information from the projects overview page.

**NOTE**: Still missing/not working:

- [x] Cancel button
- [x] Make it work with model validations
- [x] Refresh only the affected area instead of the whole screen
- [ ] Visual feedback when switching from editing to read only

Here is a screenshot of how it looks:

**Before**
![Screenshot of the project monitor](https://example.com/screenshot1.png)

**After**
![Screenshot of the project monitor](https://example.com/screenshot2.png)

Co-authored-by: Saray Cabrera Padrón scabrerapadron@suse.de