### PR TITLE
[backend] create detached gpg signatures of .sha256 files

### DIFF
--- a/ReleaseNotes-2.11
+++ b/ReleaseNotes-2.11
@@ -48,6 +48,11 @@ Bugfixes:
 Intentional changes:
 ====================
 
+Backend:
+ * .sha256 files get gpg signed in detached mode now
+ * Switched from OR to AND when checking CPU flags in _constraints file
+
+Webui:
   Features enabled by default:
     * Image Template
     * Kiwi Image Editor
@@ -60,4 +65,3 @@ Intentional changes:
     - /home/home_project
     - /home/list_my
 
- * Switched from OR to AND when checking CPU flags in _constraints file

--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -1086,10 +1086,10 @@ sub createrepo_staticlinks {
       } elsif (/^(.*)_([^_]*)_([^_]*)-Build[^_]*\.snap$/s) {
         $link = "${1}_${3}.snap";
         $link = "${1}_${3}_$2.snap" if $versioned;
-      } elsif (/^(.*)-Build(?:\d\d\d\d+|\d+\.\d+)(-Media\d?)(\.iso?(\.sha256)?)$/s) {
+      } elsif (/^(.*)-Build(?:\d\d\d\d+|\d+\.\d+)(-Media\d?)(\.iso?(\.sha256(?:\.asc)?)?)$/s) {
         # product builds
         $link = "$1$2$3"; # no support for versioned links
-      } elsif (/^(.*\.(?:$binarchs)?)-([^-]+)?(-.*?)?-([^-]+)(\.(raw\.install\.raw\.xz|raw\.xz|tar\.xz|box|json|install\.iso|tbz|tgz|vmx|vmdk|vmdk\.xz|vhdx|vhdx\.xz|vdi|vdi\.xz|vhdfixed\.xz|iso|phar|qcow2|qcow2\.xz|ova|ova\.xz|cpio\.tar\.bz2)?(?:\.sha256)?)$/s) {
+      } elsif (/^(.*\.(?:$binarchs)?)-([^-]+)?(-.*?)?-([^-]+)(\.(raw\.install\.raw\.xz|raw\.xz|tar\.xz|box|json|install\.iso|tbz|tgz|vmx|vmdk|vmdk\.xz|vhdx|vhdx\.xz|vdi|vdi\.xz|vhdfixed\.xz|iso|phar|qcow2|qcow2\.xz|ova|ova\.xz|cpio\.tar\.bz2)?(?:\.sha256(?:\.asc)?)?)$/s) {
         # kiwi appliance
         my $profile = $3 || "";
         $link = "$1$profile$5";
@@ -1639,6 +1639,7 @@ sub deleterepo {
 sub mapsleimage {
   my ($config, $rdir, $rbin, $p, $media) = @_;
   if ($p =~ /-Build\d+/) {
+    $rbin =~ s/\.asc$//;
     $rbin =~ s/\.sha256$//;
     $rbin =~ s/\.(?:bz2|gz|xz|zst)$//;
     $rbin =~ s/\.(iso|packages|raw|tbz|tgz|tar|qcow2|vhdx|vmdk|vagrant\..*\.box)$//;
@@ -1910,14 +1911,14 @@ sub publish {
 	next unless $q && defined($q->{'arch'});
 	$p = "$q->{'arch'}/$bin";
       } else {
-	if ($bin =~ /\.iso(?:\.sha256)?$/) {
+	if ($bin =~ /\.iso(?:\.sha256(?:\.asc)?)?$/) {
 	  $p = "iso/$bin";
 	  $kiwimedium = "$arch/$1" if $bin =~ /(.+)\.iso$/;
     	  $p = mapsleimage($config, "$reporoot/$prp/$arch/:repo", $rbin, $p, $sleimage) if $sleimage;
 	} elsif ($bin =~ /ONIE\.bin(?:\.sha256)?$/) {
 	  $p = "onie/$bin";
 	  $kiwimedium = "$arch/$1" if $bin =~ /(.+)ONIE\.bin$/;
-	} elsif ($bin =~ /\.raw(?:\.install)?(?:\.(?:gz|bz2|xz))?(?:\.sha256)?$/) {
+	} elsif ($bin =~ /\.raw(?:\.install)?(?:\.(?:gz|bz2|xz))?(?:\.sha256(?:\.asc)?)?$/) {
 	  $p = $bin;
 	  $p = mapsleimage($config, "$reporoot/$prp/$arch/:repo", $rbin, $p, $sleimage) if $sleimage;
 	} elsif ($bin =~ /\.containerinfo$/) {
@@ -1977,19 +1978,19 @@ sub publish {
 	    }
 	  }
 	  next if $bin =~ /-(?:appstream|desktopfiles|polkitactions|mimetypes)\.tar/;
-        } elsif ($bin =~ /\.(?:tgz|zip)?(?:\.sha256)?$/) {
+        } elsif ($bin =~ /\.(?:tgz|zip)?(?:\.sha256(?:\.asc)?)?$/) {
           # esp. for Go builds
           $p = "$bin";
         } elsif ($bin =~ /\.squashfs$/) {
 	  $p = "$bin";	# for simpleimage builds
-	} elsif ($bin =~ /\.diff\.(?:gz)(?:\.sha256)?$/) {
+	} elsif ($bin =~ /\.diff\.(?:gz)(?:\.sha256(?:\.asc)?)?$/) {
 	  $p = "$bin";
-	} elsif ($bin =~ /\.dsc(?:\.sha256)?$/) {
+	} elsif ($bin =~ /\.dsc(?:\.sha256(?:\.asc)?)?$/) {
 	  $p = "$bin";
 	} elsif ($bin =~ /\.orig\.tar\.(gz|xz|bz2)\.asc$/) {
 	  # Debian upstream tarball signature
 	  $p = "$bin";
-        } elsif ($bin =~ /^(.*)\.(?:box|json|ovf|phar|qcow2|vdi|vhdfixed|vmx|vmdk|vhdx)(?:\.xz)?(\.sha256)?$/) {
+        } elsif ($bin =~ /^(.*)\.(?:box|json|ovf|phar|qcow2|vdi|vhdfixed|vmx|vmdk|vhdx)(?:\.xz)?(\.sha256(?:\.asc)?)?$/) {
 	  $p = $bin;
           $kiwimedium = "$arch/$1" if !$2 && -e "$r/$1.packages";
           $p = mapsleimage($config, "$reporoot/$prp/$arch/:repo", $rbin, $p, $sleimage) if $sleimage;

--- a/src/backend/bs_signer
+++ b/src/backend/bs_signer
@@ -549,6 +549,7 @@ sub signjob {
 	@signmode = ('-r', '-T', 'buildtime') if $signfile =~ /\.drpm$/;
 	@signmode = ('-D') if $signfile =~ /\.pkg\.tar\.(?:gz|xz)$/;
 	@signmode = ('-a') if $signfile =~ /\.AppImage$/;
+	@signmode = ('-d') if $signfile =~ /\.sha256$/;
 	if ($signfile =~ /\.key$/s) {
 	  next unless (-s "$jobdir/$signfile") == 8192;
 	  my $signfilec = readstr("$jobdir/$signfile");


### PR DESCRIPTION
incompatible change, but solves the issue with sha256sum -c failures

We try to get rid away without additional configuration option, but it is known that the sha256 files are not identical anymore. We will see if we need to make it optional...

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
