### PR TITLE
[api] fix build for mariadb-10.4

### DIFF
--- a/src/api/script/api_minitest.sh
+++ b/src/api/script/api_minitest.sh
@@ -8,7 +8,7 @@ source ./mysql_environment
 export RAILS_ENV=development
 bin/rake db:create || exit 1
 mv db/structure.sql db/structure.sql.git
-xzcat test/dump_2.5.sql.xz | mysql  -u root --socket=$MYSQL_SOCKET
+xzcat test/dump_2.5.sql.xz | mysql  -u $MYSQLD_USER --socket=$MYSQL_SOCKET
 bin/rake db:migrate:with_data db:structure:dump db:drop
 ./script/compare_structure_sql.sh db/structure.sql.git db/structure.sql
 
@@ -22,7 +22,7 @@ rm -f log/test.log
 bin/rake test:api test:spider
 
 #cleanup
-/usr/bin/mysqladmin -u root --socket=$MYSQL_SOCKET shutdown || true
+/usr/bin/mysqladmin -u $MYSQLD_USER --socket=$MYSQL_SOCKET shutdown || true
 rm -rf $MYSQL_DATADIR $MYSQL_SOCKET_DIR
 
 exit 0

--- a/src/api/script/prepare_spec_tests.sh
+++ b/src/api/script/prepare_spec_tests.sh
@@ -5,6 +5,7 @@ BASE_DIR=$PWD
 TEMP_DIR=$BASE_DIR/tmp
 MYSQL_BASEDIR=$TEMP_DIR/mysql/
 MYSQL_DATADIR=$MYSQL_BASEDIR/data
+MYSQL_EXTRA_CONF=$TEMP_DIR/my.cnf.add
 MYSQL_SOCKET_DIR=`mktemp -d`
 MYSQL_SOCKET=$MYSQL_SOCKET_DIR/mysql.socket
 
@@ -25,16 +26,19 @@ if [ -z "$MYSQL_SERVER" ]; then
   exit 1
 fi
 
+cat << EOF > $MYSQL_EXTRA_CONF
+[mysqld]
+plugin-load-add = auth_socket.so
+EOF
 
 ### do testing now
 
 rm -rf $MYSQL_DATADIR $MYSQL_SOCKET
 mkdir -p $MYSQL_BASEDIR
 chown -R $MYSQLD_USER $MYSQL_BASEDIR
-mysql_install_db --user=$MYSQLD_USER --datadir=$MYSQL_DATADIR
-$MYSQL_SERVER --user=$MYSQLD_USER --datadir=$MYSQL_DATADIR --skip-networking --socket=$MYSQL_SOCKET --pid-file=$TEMP_DIR/mysqld.pid &
+mysql_install_db --user=$MYSQLD_USER --datadir=$MYSQL_DATADIR --auth-root-authentication-method=socket --auth-root-socket-user=$MYSQLD_USER --defaults-extra-file=$MYSQL_EXTRA_CONF
+$MYSQL_SERVER --defaults-extra-file=$MYSQL_EXTRA_CONF --user=$MYSQLD_USER --datadir=$MYSQL_DATADIR --skip-networking --socket=$MYSQL_SOCKET --pid-file=$TEMP_DIR/mysqld.pid &
 sleep 2
-
 ##################### api
 
 # setup files
@@ -46,14 +50,14 @@ development:
   adapter:  mysql2
   host:     localhost
   database: api_25
-  username: root
+  username: $MYSQLD_USER
   encoding: utf8mb4
   socket:   $MYSQL_SOCKET
 test:
   adapter:  mysql2
   host:     localhost
   database: api_test
-  username: root
+  username: $MYSQLD_USER
   encoding: utf8mb4
   socket:   $MYSQL_SOCKET
   # disable timeout, required on SLES 11 SP3 at least
@@ -64,4 +68,5 @@ EOF
 echo "MYSQL_BASEDIR=$MYSQL_BASEDIR" > mysql_environment
 echo "MYSQL_SOCKET_DIR=$MYSQL_SOCKET_DIR" >> mysql_environment
 echo "MYSQL_SOCKET=$MYSQL_SOCKET" >> mysql_environment
+echo "MYSQLD_USER=$MYSQLD_USER" >> mysql_environment
 


### PR DESCRIPTION
build using the current user and try not to break older mariadb
revisions in the process where socket auth was not loaded by default.
