### PR TITLE
Distinguish between subscriptions and notifications

### DIFF
--- a/src/api/app/controllers/webui/subscriptions_controller.rb
+++ b/src/api/app/controllers/webui/subscriptions_controller.rb
@@ -7,9 +7,9 @@ class Webui::SubscriptionsController < Webui::WebuiController
 
   def update
     subscriptions_form.update!(params[:subscriptions])
-    flash[:success] = 'Notifications settings updated'
+    flash[:success] = 'Subscriptions settings updated'
   rescue ActiveRecord::RecordInvalid
-    flash[:error] = 'Notifications settings could not be updated due to an error'
+    flash[:error] = 'Subscriptions settings could not be updated due to an error'
   ensure
     respond_to do |format|
       format.html { redirect_to action: :index }

--- a/src/api/app/controllers/webui/users/rss_tokens_controller.rb
+++ b/src/api/app/controllers/webui/users/rss_tokens_controller.rb
@@ -13,7 +13,7 @@ module Webui
           flash[:success] = 'Successfully generated your RSS feed url'
           User.session!.create_rss_token
         end
-        redirect_back(fallback_location: my_notifications_path)
+        redirect_back(fallback_location: my_subscriptions_path)
       end
     end
   end

--- a/src/api/app/controllers/webui/users/subscriptions_controller.rb
+++ b/src/api/app/controllers/webui/users/subscriptions_controller.rb
@@ -20,9 +20,9 @@ class Webui::Users::SubscriptionsController < Webui::WebuiController
     end
 
     subscriptions_form.update!(params[:subscriptions]) if params[:subscriptions]
-    flash[:success] = 'Notifications settings updated'
+    flash[:success] = 'Subscriptions settings updated'
   rescue ActiveRecord::RecordInvalid
-    flash[:error] = 'Notifications settings could not be updated due to an error'
+    flash[:error] = 'Subscriptions settings could not be updated due to an error'
   ensure
     respond_to do |format|
       format.html { redirect_to action: :index }

--- a/src/api/app/views/webui/configuration/_tabs.html.haml
+++ b/src/api/app/views/webui/configuration/_tabs.html.haml
@@ -4,7 +4,7 @@
     = tab_link('Architectures', architectures_path, false, 'scrollable-tab-link')
     = tab_link('Manage Users', users_path, false, 'scrollable-tab-link')
     = tab_link('Manage Groups', groups_path, false, 'scrollable-tab-link')
-    = tab_link('Notifications', notifications_path, false, 'scrollable-tab-link')
+    = tab_link('Subscriptions', subscriptions_path, false, 'scrollable-tab-link')
     = tab_link('Interconnect', new_interconnect_path, false, 'scrollable-tab-link')
 - else
   .bg-light
@@ -18,7 +18,7 @@
       %li.nav-item
         = tab_link('Manage Groups', groups_path)
       %li.nav-item
-        = tab_link('Notifications', notifications_path)
+        = tab_link('Subscriptions', subscriptions_path)
       %li.nav-item
         = tab_link('Interconnect', new_interconnect_path)
       %li.nav-item.dropdown

--- a/src/api/app/views/webui/subscriptions/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui/subscriptions/_breadcrumb_items.html.haml
@@ -1,3 +1,3 @@
 = render partial: 'webui/configuration/breadcrumb_items'
 %li.breadcrumb-item.active{ 'aria-current' => 'page' }
-  Notifications
+  Subscriptions

--- a/src/api/app/views/webui/subscriptions/index.html.haml
+++ b/src/api/app/views/webui/subscriptions/index.html.haml
@@ -1,17 +1,17 @@
 :ruby
-  @pagetitle = 'Notifications'
+  @pagetitle = 'Subscriptions'
 
 .card.mb-3
   = render partial: 'webui/configuration/tabs'
   .card-body
     %h3.card-title
       Events
-    .card-text#notifications
-      %p Choose default notification settings for events (checked means direct email).
-      = render partial: 'subscriptions_form', locals: { path: notifications_path, subscriptions_form: @subscriptions_form }
+    .card-text#subscriptions
+      %p Choose default subscription settings for events (checked means direct email).
+      = render partial: 'subscriptions_form', locals: { path: subscriptions_path, subscriptions_form: @subscriptions_form }
 
 - content_for :ready_function do
   :plain
-    $('#notifications').on('ajax:before ajax:complete', '.custom-control-input', function() {
+    $('#subscriptions').on('ajax:before ajax:complete', '.custom-control-input', function() {
       $(this).siblings('i.fa-spinner').toggleClass('fa-spin invisible');
     });

--- a/src/api/app/views/webui/user/_info.html.haml
+++ b/src/api/app/views/webui/user/_info.html.haml
@@ -50,9 +50,9 @@
           = link_to('#', data: { toggle: 'modal', target: '#password-modal' }, class: 'd-block') do
             %i.fas.fa-key
             Change your password
-        = link_to(my_notifications_path, class: 'd-block') do
+        = link_to(my_subscriptions_path, class: 'd-block') do
           %i.fas.fa-bell
-          Change your notifications
+          Change your subscriptions
         - if user.rss_token
           = link_to(user_rss_notifications_path(token: user.rss_token.string, format: 'rss'),
                                                 title: 'RSS Feed for Notifications', class: 'd-block') do

--- a/src/api/app/views/webui/users/subscriptions/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui/users/subscriptions/_breadcrumb_items.html.haml
@@ -1,4 +1,4 @@
 = render partial: 'webui/main/breadcrumb_items'
-- if current_page?(my_notifications_path)
+- if current_page?(my_subscriptions_path)
   %li.breadcrumb-item.active{ 'aria-current' => 'page' }
-    Notifications
+    Subscriptions

--- a/src/api/app/views/webui/users/subscriptions/index.html.haml
+++ b/src/api/app/views/webui/users/subscriptions/index.html.haml
@@ -1,24 +1,24 @@
-- @pagetitle = 'Notifications'
+- @pagetitle = 'Subscriptions'
 
 .card
   .card-header.d-flex.justify-content-between
-    %h5 Notifications
+    %h5 Subscriptions
   - unless @groups_users.empty?
     .card-body
       %h4.card-title Groups
-      .card-text#notifications-groups
+      .card-text#subscriptions-groups
         %p You will receive emails from the checked groups
         - @groups_users.each do |group_user|
           .custom-control.custom-checkbox.custom-control-inline
             = check_box_tag group_user.group, '1', group_user.email, class: 'custom-control-input', id: "checkbox-#{group_user.group}",
-              data: { url: my_notifications_path, method: :put, remote: true }
+              data: { url: my_subscriptions_path, method: :put, remote: true }
             = label_tag group_user.group.title, nil, class: 'custom-control-label', for: "checkbox-#{group_user.group}"
             %i.fas.fa-spinner.invisible
   .card-body
     %h4.card-title Events
     %p Choose from which events you want to get an email
     #subscriptions-form
-      = render partial: 'webui/subscriptions/subscriptions_form', locals: { path: my_notifications_path, subscriptions_form: @subscriptions_form }
+      = render partial: 'webui/subscriptions/subscriptions_form', locals: { path: my_subscriptions_path, subscriptions_form: @subscriptions_form }
 
 .card.mt-3
   .card-body
@@ -30,12 +30,12 @@
         = link_to(user_rss_notifications_url(token: @user.rss_token.string, format: 'rss'),
         user_rss_notifications_url(token: @user.rss_token.string, format: 'rss'), target: '_blank', rel: 'noopener')
       - else
-        No feed url exists for your notifications.
+        No feed url exists for your subscription.
       .card-body
         = submit_tag "#{@user.rss_token ? 'Regenerate Url' : 'Generate Url'}", class: 'btn btn-primary'
 
 - content_for :ready_function do
   :plain
-    $('#notifications-groups, #subscriptions-form').on('ajax:before ajax:complete', '.custom-control-input', function() {
+    $('#subscriptions-groups, #subscriptions-form').on('ajax:before ajax:complete', '.custom-control-input', function() {
       $(this).siblings('i.fa-spinner').toggleClass('fa-spin invisible');
     });

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -32,8 +32,8 @@ OBSApi::Application.routes.draw do
     resources :interconnects, only: [:new, :create], controller: 'webui/interconnects'
 
     controller 'webui/subscriptions' do
-      get 'notifications' => :index
-      put 'notifications' => :update
+      get 'subscriptions' => :index
+      put 'subscriptions' => :update
     end
 
     controller 'webui/architectures' do

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -286,8 +286,8 @@ OBSApi::Application.routes.draw do
 
     scope :my do
       resources :tasks, only: [:index], controller: 'webui/users/tasks', as: :my_tasks
-      get 'notifications' => :index,  controller: 'webui/users/subscriptions', as: :my_notifications
-      put 'notifications' => :update, controller: 'webui/users/subscriptions'
+      get 'subscriptions' => :index,  controller: 'webui/users/subscriptions', as: :my_subscriptions
+      put 'subscriptions' => :update, controller: 'webui/users/subscriptions'
       post 'rss_tokens' => :create, controller: 'webui/users/rss_tokens', as: :my_rss_token
       # To accept announcements as user
       post 'announcements/:id' => :create, controller: 'webui/users/announcements', as: :my_announcements

--- a/src/api/spec/controllers/webui/users/rss_tokens_controller_spec.rb
+++ b/src/api/spec/controllers/webui/users/rss_tokens_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Webui::Users::RssTokensController do
       end
 
       it { expect(flash[:success]).to eq('Successfully generated your RSS feed url') }
-      it { is_expected.to redirect_to(my_notifications_path) }
+      it { is_expected.to redirect_to(my_subscriptions_path) }
       it { expect(user.reload.rss_token.string).not_to eq(last_token) }
     end
 
@@ -28,7 +28,7 @@ RSpec.describe Webui::Users::RssTokensController do
       end
 
       it { expect(flash[:success]).to eq('Successfully generated your RSS feed url') }
-      it { is_expected.to redirect_to(my_notifications_path) }
+      it { is_expected.to redirect_to(my_subscriptions_path) }
       it { expect(user.reload.rss_token).not_to be_nil }
       it { expect(last_token).to be_nil }
     end

--- a/src/api/spec/features/webui/notifications_spec.rb
+++ b/src/api/spec/features/webui/notifications_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature 'Notifications', type: :feature, js: true do
     it_behaves_like 'updatable' do
       let(:title) { 'Notifications' }
       let(:user) { create(:admin_user, login: 'king') }
-      let(:path) { notifications_path }
+      let(:path) { subscriptions_path }
     end
   end
 
@@ -35,7 +35,7 @@ RSpec.feature 'Notifications', type: :feature, js: true do
     it_behaves_like 'updatable' do
       let(:title) { 'Choose from which events you want to get an email' }
       let(:user) { create(:confirmed_user, login: 'eisendieter') }
-      let(:path) { my_notifications_path }
+      let(:path) { my_subscriptions_path }
     end
   end
 end


### PR DESCRIPTION
Since the users tasks are moved to a more notification's
like workflow, we should distinguish between notifications
and the subscriptions to certain events which might end up
as notifications.
<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
