### PR TITLE
Fix tabs in users profile view.

### DIFF
--- a/src/api/app/views/webui/user/_involvement.html.haml
+++ b/src/api/app/views/webui/user/_involvement.html.haml
@@ -11,13 +11,13 @@
             Involved Packages
             %span.badge.badge-primary
               = involved_packages.size
-
+        %li.nav-item
           = link_to('#involved-projects', id: 'involved-projects-tab', class: 'nav-link text-nowrap',
                     data: { toggle: 'tab' }, role: 'tab', aria: { controls: 'involved-projects', selected: false }) do
             Involved Projects
             %span.badge.badge-primary
               = involved_projects.size
-
+        %li.nav-item
           = link_to('#owned', id: 'owned-tab', class: 'nav-link text-nowrap',
                     data: { toggle: 'tab' }, role: 'tab', aria: { controls: 'owned', selected: false }) do
             Owned Projects/Packages
@@ -45,7 +45,6 @@
                     = link_to(package_name, package_show_path(package: package_name, project: project_name))
                   %td
                     = link_to(project_name, project_show_path(project: project_name))
-
       .tab-pane.fade#involved-projects{ role: 'tabpanel', aria: { labelledby: 'involved-projects-tab' } }
         - if involved_projects.blank?
           %p.mt-3
@@ -63,7 +62,6 @@
                     = link_to(project_name, project_show_path(project: project_name))
                   %td
                     = project_title
-
       .tab-pane.fade#owned{ role: 'tabpanel', aria: { labelledby: 'owned-tab' } }
         - if owned.blank?
           %p.mt-3


### PR DESCRIPTION
After turning the tabs into horizontally scrollable tabs
for the beta program, there were a few mistakes in the
structure of the haml file and some bootstrap classes got lost.

Fixes #9215

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
