### PR TITLE
Adjust z-index of off-canvas menu and scrollable tabs

### DIFF
--- a/src/api/app/assets/stylesheets/webui/responsive_ux/_layout.scss
+++ b/src/api/app/assets/stylesheets/webui/responsive_ux/_layout.scss
@@ -100,7 +100,7 @@ button.navbar-toggler {
   padding-left: 1rem;
   overflow-y: auto;
   visibility: hidden;
-  z-index: 9000;
+  z-index: 1040;
   background-color: #343a40;
   color: $gray-400;
   transition: visibility .3s ease-in-out, -webkit-transform .3s ease-in-out;
@@ -116,7 +116,7 @@ button.navbar-toggler {
     visibility: visible;
     -webkit-transform: translateX(-100%);
     transform: translateX(-100%);
-    z-index: 9000;
+    z-index: 1040;
   }
 }
 

--- a/src/api/app/assets/stylesheets/webui/responsive_ux/_tabs.scss
+++ b/src/api/app/assets/stylesheets/webui/responsive_ux/_tabs.scss
@@ -2,6 +2,7 @@
   overflow: auto;
   white-space: nowrap;
   padding: 0.5rem 1rem 0rem 1rem;
+  z-index: 1035;
 
   a.scrollable-tab-link {
     display: inline-block;


### PR DESCRIPTION
This results in modals appearing on top of the off-canvas menu since they have a `z-index` of 1050.

It prevent the tabs' scrollbar to appear on top of modals with a `z-index` of 1050 and the off-canvas menu with a `z-index` of 1040.

Fixes #9216

Before (modal not visible, it's under the off-canvas menu)
![overlap_canvas_modal](https://user-images.githubusercontent.com/2581944/76520188-bdac9c00-6462-11ea-83cf-3b16a7b953a1.gif)

Before (the tabs' scrollbar is on top of the modal)
![tab-scrollbar](https://user-images.githubusercontent.com/1102934/76532906-914f4a80-6477-11ea-87bd-7e79fba1a5fc.png)

Now (the modal is visible on top of the off-canvas menu and the scrollbar isn't visible anymore on top of the modal) 
![preview_off-canvas_with_modal](https://user-images.githubusercontent.com/1102934/76534559-f015c380-6479-11ea-88f2-2ca832e9176f.png)
