### PR TITLE
Write data into the new polymorphic fields from the notifications table

### DIFF
--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -176,7 +176,7 @@ Metrics/BlockNesting:
 # Offense count: 84
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 935
+  Max: 936
 
 # Offense count: 219
 Metrics/CyclomaticComplexity:

--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -839,6 +839,7 @@ class BsRequest < ApplicationRecord
   end
 
   def notify_parameters(ret = {})
+    ret[:id] = id
     ret[:number] = number
     ret[:description] = description
     ret[:state] = state

--- a/src/api/app/models/comment.rb
+++ b/src/api/app/models/comment.rb
@@ -39,6 +39,7 @@ class Comment < ApplicationRecord
   private
 
   def create_notification(params = {})
+    params[:id] = id
     params[:commenter] = user.login
     params[:comment_body] = body
     params[:commenters] = involved_users

--- a/src/api/app/models/event/comment_event.rb
+++ b/src/api/app/models/event/comment_event.rb
@@ -2,7 +2,7 @@ module Event
   module CommentEvent
     def self.included(base)
       base.class_eval do
-        payload_keys :commenters, :commenter, :comment_body, :comment_title
+        payload_keys :id, :commenters, :commenter, :comment_body, :comment_title
         receiver_roles :commenter
         shortenable_key :comment_body
       end

--- a/src/api/app/models/event/request.rb
+++ b/src/api/app/models/event/request.rb
@@ -2,7 +2,7 @@ module Event
   class Request < Base
     self.description = 'Request was updated'
     self.abstract_class = true
-    payload_keys :author, :comment, :description, :number, :actions, :state, :when, :who
+    payload_keys :author, :comment, :description, :id, :number, :actions, :state, :when, :who
     shortenable_key :description
 
     DIFF_LIMIT = 120

--- a/src/api/app/models/notification.rb
+++ b/src/api/app/models/notification.rb
@@ -7,23 +7,3 @@ class Notification < ApplicationRecord
     @event ||= event_type.constantize.new(event_payload)
   end
 end
-
-# == Schema Information
-#
-# Table name: notifications
-#
-#  id                         :integer          not null, primary key
-#  type                       :string(255)      not null
-#  event_type                 :string(255)      not null
-#  event_payload              :text(65535)      not null
-#  subscription_receiver_role :string(255)      not null
-#  delivered                  :boolean          default(FALSE)
-#  created_at                 :datetime         not null
-#  updated_at                 :datetime         not null
-#  subscriber_type            :string(255)      indexed => [subscriber_id]
-#  subscriber_id              :integer          indexed => [subscriber_type]
-#
-# Indexes
-#
-#  index_notifications_on_subscriber_type_and_subscriber_id  (subscriber_type,subscriber_id)
-#


### PR DESCRIPTION
We want to store notification data in the newly created polymorphic fields from the notifications table. We don't modify yet the existing way of reading the notifications table.

Co-authored-by: Saray Cabrera Padrón <scabrerapadron@suse.de>