### PR TITLE
Add request state field to notifications table

### DIFF
--- a/src/api/app/jobs/send_event_emails_job.rb
+++ b/src/api/app/jobs/send_event_emails_job.rb
@@ -37,20 +37,29 @@ class SendEventEmailsJob < ApplicationJob
   end
 
   def notification_dynamic_params(event)
-    case event.eventtype
-    when 'ReviewWanted', 'RequestCreate', 'RequestStatechange'
-      {
+    if event.eventtype == 'RequestStatechange'
+      return {
         notifiable_type: 'BsRequest',
         notification_id: event.payload['id'],
-        bs_request_oldstate: (event.payload['oldstate'] if event.eventtype == 'RequestStatechange')
-      }.compact
-    when 'CommentForProject', 'CommentForPackage', 'CommentForRequest'
-      {
+        bs_request_state: event.payload['state'],
+        bs_request_oldstate: event.payload['oldstate']
+      }
+    end
+
+    if event.eventtype.in?(['ReviewWanted', 'RequestCreate'])
+      return {
+        notifiable_type: 'BsRequest',
+        notification_id: event.payload['id']
+      }
+    end
+
+    if event.eventtype.in?(['CommentForProject', 'CommentForPackage', 'CommentForRequest'])
+      return {
         notifiable_type: 'Comment',
         notification_id: event.payload['id']
       }
-    else
-      {}
     end
+
+    {}
   end
 end

--- a/src/api/db/migrate/20200313143312_add_bs_request_status_to_notification.rb
+++ b/src/api/db/migrate/20200313143312_add_bs_request_status_to_notification.rb
@@ -1,0 +1,5 @@
+class AddBsRequestStatusToNotification < ActiveRecord::Migration[5.2]
+  def change
+    add_column :notifications, :bs_request_status, :string, collation: 'utf8_unicode_ci'
+  end
+end

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -848,6 +848,7 @@ CREATE TABLE `notifications` (
   `notifiable_type` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `notifiable_id` int(11) DEFAULT NULL,
   `bs_request_oldstate` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
+  `bs_request_status` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `index_notifications_on_subscriber_type_and_subscriber_id` (`subscriber_type`,`subscriber_id`),
   KEY `index_notifications_on_notifiable_type_and_notifiable_id` (`notifiable_type`,`notifiable_id`)
@@ -1487,6 +1488,7 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20190710094253'),
 ('20190712084813'),
 ('20200107105426'),
-('20200311132129');
+('20200311132129'),
+('20200313143312');
 
 


### PR DESCRIPTION
At the time we access the state, it could already have been changed. We need to store this field when the notification is created.

We store the "state" only when it is needed, for notifications coming from events with type "RequestStatechange". The other request and comment notifications don't make use of this "state" field.

Related to #9206 and #9220.