### PR TITLE
Add polymorphic association between BsRequest, Comment and Notification Model

### DIFF
--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -80,10 +80,10 @@ class BsRequest < ApplicationRecord
   has_many :review_history_elements, through: :reviews, source: :history_elements
   has_many :status_reports, as: :checkable, class_name: 'Status::Report', dependent: :destroy
   has_many :target_project_objects, through: :bs_request_actions
-
   belongs_to :staging_project, class_name: 'Project', foreign_key: 'staging_project_id'
   has_one :request_exclusion, class_name: 'Staging::RequestExclusion', foreign_key: 'bs_request_id', dependent: :destroy
   has_many :not_accepted_reviews, -> { where.not(state: :accepted) }, class_name: 'Review'
+  has_many :notifications, as: :notifiable, dependent: :delete_all
 
   validates :state, inclusion: { in: VALID_REQUEST_STATES }
   validates :creator, presence: true

--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -2,6 +2,7 @@ require 'xmlhash'
 
 include MaintenanceHelper
 
+# rubocop:disable Metrics/ClassLength
 class BsRequest < ApplicationRecord
   include BsRequest::Errors
   SEARCHABLE_FIELDS = [
@@ -1189,6 +1190,8 @@ class BsRequest < ApplicationRecord
     # rubocop:enable Rails/SkipsModelValidations
   end
 end
+
+# rubocop: enable Metrics/ClassLength
 
 # == Schema Information
 #

--- a/src/api/app/models/comment.rb
+++ b/src/api/app/models/comment.rb
@@ -16,6 +16,7 @@ class Comment < ApplicationRecord
   after_destroy :delete_parent_if_unused
 
   has_many :children, dependent: :destroy, class_name: 'Comment', foreign_key: 'parent_id'
+  has_many :notifications, as: :notifiable, dependent: :delete_all
 
   extend ActsAsTree::TreeWalker
   acts_as_tree order: 'created_at'

--- a/src/api/app/models/notification.rb
+++ b/src/api/app/models/notification.rb
@@ -1,5 +1,6 @@
 class Notification < ApplicationRecord
   belongs_to :subscriber, polymorphic: true
+  belongs_to :notifiable, polymorphic: true
 
   serialize :event_payload, JSON
 


### PR DESCRIPTION
In order to query the comments and request related to a
notification, the polymorphic association needs to be
indicated in the models.

Related to #9206 and #9220.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
