### PR TITLE
Lower z-index of tabs so they don't appear on top of navigation elements

### DIFF
--- a/src/api/app/assets/stylesheets/webui/responsive_ux/_tabs.scss
+++ b/src/api/app/assets/stylesheets/webui/responsive_ux/_tabs.scss
@@ -2,7 +2,7 @@
   overflow: auto;
   white-space: nowrap;
   padding: 0.5rem 1rem 0rem 1rem;
-  z-index: 1035;
+  z-index: 990;
 
   a.scrollable-tab-link {
     display: inline-block;


### PR DESCRIPTION
The `z-index` which was set for tabs in #9218 was higher than the navigation elements and other values set by [Bootstrap](https://getbootstrap.com/docs/4.4/layout/overview/#z-index). 