### PR TITLE
Fix notifiable id fields in notifications table

### DIFF
--- a/src/api/app/jobs/send_event_emails_job.rb
+++ b/src/api/app/jobs/send_event_emails_job.rb
@@ -40,7 +40,7 @@ class SendEventEmailsJob < ApplicationJob
     if event.eventtype == 'RequestStatechange'
       return {
         notifiable_type: 'BsRequest',
-        notification_id: event.payload['id'],
+        notifiable_id: event.payload['id'],
         bs_request_state: event.payload['state'],
         bs_request_oldstate: event.payload['oldstate']
       }
@@ -49,14 +49,14 @@ class SendEventEmailsJob < ApplicationJob
     if event.eventtype.in?(['ReviewWanted', 'RequestCreate'])
       return {
         notifiable_type: 'BsRequest',
-        notification_id: event.payload['id']
+        notifiable_id: event.payload['id']
       }
     end
 
     if event.eventtype.in?(['CommentForProject', 'CommentForPackage', 'CommentForRequest'])
       return {
         notifiable_type: 'Comment',
-        notification_id: event.payload['id']
+        notifiable_id: event.payload['id']
       }
     end
 


### PR DESCRIPTION
Due to a typo `notification_id` field was introduced when trying to add data to the notifications table. The correct name should have been `notifiable_id`.

Co-authored-by: David Kang <dkang@suse.com>