### PR TITLE
Validate notifications at creation time

### DIFF
--- a/src/api/app/models/notification.rb
+++ b/src/api/app/models/notification.rb
@@ -6,11 +6,32 @@ class Notification < ApplicationRecord
 
   scope :stale, -> { where('created_at < ?', 3.months.ago) }
 
+  # apply only to users
+  # by notification creation, check if the user logged in the last 3 months and if not,
+  # don't create it
+
+  # apply only to groups
+  # by notification creation if any user in the group logged in in the last 3 months and if not,
+  # don't create it
+  validate :user_active?, if: -> { subscriber.is_a?(User) }
+  validate :any_user_in_group_active?, if: -> { subscriber.is_a?(Group) }
+
   def event
     @event ||= event_type.constantize.new(event_payload)
   end
 
   def self.cleanup
     Notification.stale.delete_all
+  end
+
+  private
+
+  def user_active?
+    errors.add(:subscriber, 'subscriber not active') if subscriber && subscriber.away?
+  end
+
+  def any_user_in_group_active?
+    return true if subscriber.users.recently_seen.empty?
+    errors.add(:subscriber, 'subscribers aren\'t active')
   end
 end

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -279,6 +279,10 @@ class User < ApplicationRecord
     raise NotFoundError, "Couldn't find User with login = #{login}"
   end
 
+  def away?
+    last_logged_in_at < 3.months.ago
+  end
+
   def authenticate_via_password(password)
     if authenticate(password)
       mark_login!

--- a/src/api/spec/factories/users.rb
+++ b/src/api/spec/factories/users.rb
@@ -56,12 +56,12 @@ FactoryBot.define do
           create(:service_token, user: user)
         end
       end
-    end
-
-    factory :dead_user do
-      after(:create) do |user|
-        user.last_logged_in_at = 4.months.ago
-        user.save!(validate: false)
+      factory :dead_user do
+        after(:create) do |user|
+          user.created_at = 5.months.ago
+          user.last_logged_in_at = 4.months.ago
+          user.save!(validate: false)
+        end
       end
     end
 

--- a/src/api/spec/models/notification_spec.rb
+++ b/src/api/spec/models/notification_spec.rb
@@ -33,4 +33,32 @@ RSpec.describe Notification do
 
     it { expect(test_group.notifications).to include(notification) }
   end
+
+  describe 'validate if user is away or not' do
+    context 'when notification has an away user' do
+      let!(:away_user) { create(:dead_user, login: 'foo') }
+      let(:rss_notification) { build(:rss_notification, subscriber: away_user) }
+
+      it { expect(rss_notification).not_to be_valid }
+
+      context 'error message exist' do
+        before { rss_notification.valid? }
+
+        it { expect(rss_notification.errors[:subscriber]).not_to be_empty }
+      end
+    end
+
+    context 'when notification has an active user' do
+      let!(:confirmed_user) { create(:confirmed_user, login: 'foo') }
+      let(:rss_notification) { build(:rss_notification, subscriber: confirmed_user) }
+
+      it { expect(rss_notification).to be_valid }
+
+      context 'error message is empty' do
+        before { rss_notification.valid? }
+
+        it { expect(rss_notification.errors[:subscriber]).to be_empty }
+      end
+    end
+  end
 end


### PR DESCRIPTION
Notification validatation rules:

apply only to users
  - by notification creation, check if the user logged in the last 3 months and if not,  don't create it

apply only to groups
  - by notification creation if any user in the group logged in in the last 3 months and if not, don't create it