### PR TITLE
In-place edition for project basic information

### DIFF
--- a/src/api/app/assets/javascripts/webui/collapsible_text.js
+++ b/src/api/app/assets/javascripts/webui/collapsible_text.js
@@ -1,4 +1,8 @@
 $(document).ready(function() {
+  setCollapsible();
+});
+
+function setCollapsible() {
   $('.obs-collapsible-textbox').on('click', function() {
     var selectedText = document.getSelection().toString();
     if(!selectedText) {
@@ -13,4 +17,4 @@ $(document).ready(function() {
       $(element).after($link);
     }
   });
-});
+}

--- a/src/api/app/assets/javascripts/webui/responsive_ux.js
+++ b/src/api/app/assets/javascripts/webui/responsive_ux.js
@@ -47,3 +47,21 @@ function toggleTabs(tabLinkContainerId) { // jshint ignore:line
     currentTabLink.addClass('active');
   });
 }
+
+function setFormValidation(element, messages) { // jshint ignore:line
+  element.addClass('is-invalid');
+  element.after("<div class='invalid-feedback'>"+ messages + "</div>");
+}
+
+function resetFormValidation() { // jshint ignore:line
+  $('.in-place-editing form .is-invalid').each(function(){
+    $(this).toggleClass('is-invalid');
+    $(this).siblings('.invalid-feedback').remove();
+  });
+}
+
+function scrollToInPlace() { // jshint ignore:line
+  $('html, body').animate({
+    scrollTop: $('.in-place-editing').offset().top - 73 // header height + 16px
+  }, 500);
+}

--- a/src/api/app/assets/javascripts/webui/responsive_ux.js
+++ b/src/api/app/assets/javascripts/webui/responsive_ux.js
@@ -34,6 +34,11 @@ $(function () {
     $('#login').focus();
     $('#username').focus();
   });
+
+  $('#navigation .nav-item').on('click', function (){
+    $('.actions-collapse').removeClass('open');
+    $('a[data-toggle="actions"]').removeClass('active');
+  });
 });
 
 /* bootstrap's tabs javascript doesn't remove the active class

--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -10,7 +10,7 @@ class Webui::ProjectController < Webui::WebuiController
                                        :new_release_request, :new_package, :edit_comment]
 
   before_action :set_project, only: [:autocomplete_repositories, :users, :subprojects,
-                                     :new_package,
+                                     :new_package, :edit,
                                      :show, :buildresult,
                                      :destroy, :remove_path_from_target,
                                      :requests, :save, :monitor, :toggle_watch,
@@ -135,6 +135,10 @@ class Webui::ProjectController < Webui::WebuiController
     @has_patchinfo = @project.patchinfos.exists?
     @comments = @project.comments
     @comment = Comment.new
+    respond_to do |format|
+      format.html
+      format.js
+    end
   end
 
   def buildresult
@@ -221,15 +225,29 @@ class Webui::ProjectController < Webui::WebuiController
     end
   end
 
+  def edit
+    authorize @project, :update?
+    respond_to do |format|
+      format.js
+    end
+  end
+
   def update
     authorize @project, :update?
     respond_to do |format|
       if @project.update(project_params)
-        flash[:success] = 'Project was successfully updated.'
+        format.html do
+          flash[:success] = 'Project was successfully updated.'
+          redirect_to project_show_path(@project)
+        end
+        format.js { flash.now[:success] = 'Project was successfully updated.' }
       else
-        flash[:error] = 'Failed to update project'
+        format.html do
+          flash[:error] = 'Failed to update project'
+          redirect_to project_show_path(@project)
+        end
+        format.js
       end
-      format.html { redirect_to project_show_path(@project) }
     end
   end
 

--- a/src/api/app/views/webui/project/_basic_info.html.haml
+++ b/src/api/app/views/webui/project/_basic_info.html.haml
@@ -1,0 +1,13 @@
+.basic-info.mb-3{ class: flipper_responsive? ? 'in-place-editing' : '' }
+  %h3#project-title
+    = project.title.presence || project
+  - if project.categories.any?
+    - project.categories.each do |category|
+      = category_badge(category)
+  - if project.url.present?
+    = link_to(project.url, project.url, class: 'mb-3 d-block')
+  #description-text
+    - if project.description.blank?
+      %i No description set
+    - else
+      = render partial: 'webui/shared/collapsible_text', locals: { text: project.description }

--- a/src/api/app/views/webui/project/_bottom_actions.html.haml
+++ b/src/api/app/views/webui/project/_bottom_actions.html.haml
@@ -11,7 +11,7 @@
                                                                                  has_patchinfo: has_patchinfo,
                                                                                  open_release_requests: open_release_requests,
                                                                                  release_targets: release_targets }
-      = render partial: 'webui/project/bottom_actions/edit_project', locals: { project: project }
+      = render partial: 'webui/project/bottom_actions/edit_project', locals: { project: project } unless flipper_responsive?
       = render partial: 'webui/project/bottom_actions/delete_project', locals: { project: project }
     - elsif !project.is_locked?
       = render partial: 'webui/project/bottom_actions/request_role_addition_and_deletion', locals: { project: project }

--- a/src/api/app/views/webui/project/_edit.html.haml
+++ b/src/api/app/views/webui/project/_edit.html.haml
@@ -1,0 +1,15 @@
+= form_for(project, url: project_update_url, method: :patch, remote: true) do |form|
+  %h5 Edit Project #{project}
+  = hidden_field_tag(:id, project.id)
+  .form-group
+    = form.label(:title, 'Title:')
+    = form.text_field(:title, class: 'form-control', autofocus: true)
+  .form-group
+    = form.label(:url, 'URL:')
+    = form.text_field(:url, class: 'form-control')
+  .form-group
+    = form.label(:description, 'Description:')
+    = form.text_area(:description, rows: 8, class: 'form-control')
+  .form-group.text-right
+    = link_to 'Cancel', project_show_path(project), class: 'cancel btn btn-outline-danger px-4', remote: true
+    = submit_tag('Update', class: 'btn btn-primary px-4')

--- a/src/api/app/views/webui/project/edit.js.erb
+++ b/src/api/app/views/webui/project/edit.js.erb
@@ -1,0 +1,10 @@
+$('#flash').empty();
+$('.in-place-editing').animate({
+  opacity: 0.25
+}, 400, function() {
+  scrollToInPlace();
+  $('.in-place-editing').html("<%= escape_javascript(render(partial: 'webui/project/edit', locals: { project: @project })) %>");
+  $('.in-place-editing').animate({ opacity: 1 }, 400, function() {
+    $("form *[autofocus='autofocus']").focus();
+  });
+});

--- a/src/api/app/views/webui/project/responsive_ux/actions/_edit_project.html.haml
+++ b/src/api/app/views/webui/project/responsive_ux/actions/_edit_project.html.haml
@@ -1,4 +1,4 @@
 %li.nav-item
-  = link_to('#', class: 'nav-link', data: { toggle: 'modal', target: '#edit-project-modal' }) do
+  = link_to(edit_project_path(project), class: 'nav-link', remote: true) do
     %i.fas.fa-edit.fa-lg.mr-1
     Edit Project

--- a/src/api/app/views/webui/project/show.html.haml
+++ b/src/api/app/views/webui/project/show.html.haml
@@ -18,18 +18,7 @@
   .card-body
     .row
       .col-md-8
-        %h3#project-title
-          = @project.title.presence || @project
-        - if @project.categories.any?
-          - @project.categories.each do |category|
-            = category_badge(category)
-        - if @project.url.present?
-          = link_to(@project.url, @project.url, class: 'mb-3 d-block')
-        #description-text
-          - if @project.description.blank?
-            %i No description set
-          - else
-            = render partial: 'webui/shared/collapsible_text', locals: { text: @project.description }
+        = render partial: 'basic_info', locals: { project: @project }
       .col-md-4
         = render partial: 'side_links', locals: { open_maintenance_incidents: @open_maintenance_incidents,
                                                   project: @project,

--- a/src/api/app/views/webui/project/show.js.erb
+++ b/src/api/app/views/webui/project/show.js.erb
@@ -1,0 +1,7 @@
+$('.in-place-editing').animate({
+  opacity: 0.25
+}, 400, function() {
+  scrollToInPlace();
+  $('.in-place-editing').html("<%= escape_javascript(render(partial: 'webui/project/basic_info', locals: { project: @project })) %>");
+  $('.in-place-editing').animate({ opacity: 1 }, 400);
+});

--- a/src/api/app/views/webui/project/show.js.erb
+++ b/src/api/app/views/webui/project/show.js.erb
@@ -3,5 +3,6 @@ $('.in-place-editing').animate({
 }, 400, function() {
   scrollToInPlace();
   $('.in-place-editing').html("<%= escape_javascript(render(partial: 'webui/project/basic_info', locals: { project: @project })) %>");
+  setCollapsible();
   $('.in-place-editing').animate({ opacity: 1 }, 400);
 });

--- a/src/api/app/views/webui/project/update.js.haml
+++ b/src/api/app/views/webui/project/update.js.haml
@@ -1,0 +1,16 @@
+resetFormValidation();
+- if @project.errors.any?
+  - @project.errors.messages.each do |field, messages|
+    element = $("##{@project.class.name.underscore}_#{field}"); // Create strings like "project_title"
+    setFormValidation(element, "#{messages.to_sentence}");
+- else
+  :plain
+    $('.in-place-editing').animate({
+      opacity: 0.25
+    }, 400, function() {
+      scrollToInPlace();
+      $('.in-place-editing').html("#{escape_javascript(render(partial: 'webui/project/basic_info', locals: { project: @project }))}");
+      $('.in-place-editing').animate({ opacity: 1 }, 400, function() {
+        $('#flash').html("#{escape_javascript(render(layout: false, partial: 'layouts/webui/flash', object: flash))}");
+      });
+    });

--- a/src/api/app/views/webui/project/update.js.haml
+++ b/src/api/app/views/webui/project/update.js.haml
@@ -10,6 +10,7 @@ resetFormValidation();
     }, 400, function() {
       scrollToInPlace();
       $('.in-place-editing').html("#{escape_javascript(render(partial: 'webui/project/basic_info', locals: { project: @project }))}");
+      setCollapsible();
       $('.in-place-editing').animate({ opacity: 1 }, 400, function() {
         $('#flash').html("#{escape_javascript(render(layout: false, partial: 'layouts/webui/flash', object: flash))}");
       });

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -188,6 +188,7 @@ OBSApi::Application.routes.draw do
       get 'project/show/:project' => :show, constraints: cons, as: 'project_show'
       get 'project/buildresult' => :buildresult, constraints: cons, as: 'project_buildresult'
       get 'project/new' => :new, as: 'new_project'
+      get 'project/edit/:project' => :edit, constraints: cons, as: 'edit_project'
       post 'project/create' => :create, constraints: cons, as: 'projects_create'
       post 'project/restore' => :restore, constraints: cons, as: 'projects_restore'
       patch 'project/update' => :update, constraints: cons


### PR DESCRIPTION
This is our suggestion:
- in-place edition for the **project**'s basic information
- instead of editing each form element, we propose to edit the whole form (including Title, URL and Description)
- we use Rails UJS
- we add some JavaScript animations for the transitions from content to form and the other way around

It looks like:

![in-place-edition](https://user-images.githubusercontent.com/2581944/76898035-29449e00-6895-11ea-8d12-fc769bcd220b.gif)

Validations are going to be shown in the form as well:

![in-place-edition-validation](https://user-images.githubusercontent.com/2581944/76898119-614be100-6895-11ea-9317-5d53332b0ec8.gif)

Something similar will be done for packages, after we have a quite stable version for projects.

Please take into account that we tried to add little commits to make it easier for you to follow our reasoning. They will be squashed before becoming a real PR.