### PR TITLE
Add title field to notifications table

### DIFF
--- a/src/api/db/migrate/20200317120346_add_title_to_notification.rb
+++ b/src/api/db/migrate/20200317120346_add_title_to_notification.rb
@@ -1,0 +1,5 @@
+class AddTitleToNotification < ActiveRecord::Migration[5.2]
+  def change
+    add_column :notifications, :title, :string, collation: 'utf8_unicode_ci'
+  end
+end

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -849,6 +849,7 @@ CREATE TABLE `notifications` (
   `notifiable_id` int(11) DEFAULT NULL,
   `bs_request_oldstate` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
   `bs_request_status` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
+  `title` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `index_notifications_on_subscriber_type_and_subscriber_id` (`subscriber_type`,`subscriber_id`),
   KEY `index_notifications_on_notifiable_type_and_notifiable_id` (`notifiable_type`,`notifiable_id`)
@@ -1489,6 +1490,7 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20190712084813'),
 ('20200107105426'),
 ('20200311132129'),
-('20200313143312');
+('20200313143312'),
+('20200317120346');
 
 


### PR DESCRIPTION
We want to store the subject of an event in the notifications table when a notification is inserted in the table, so we add this new `title` field.

Co-authored-by: David Kang <dkang@suse.com>