### PR TITLE
Fix inserting comments and requests, and fill title in notifications

### DIFF
--- a/src/api/app/jobs/send_event_emails_job.rb
+++ b/src/api/app/jobs/send_event_emails_job.rb
@@ -43,6 +43,7 @@ class SendEventEmailsJob < ApplicationJob
       return {
         notifiable_type: 'BsRequest',
         notifiable_id: event.payload['id'],
+        title: event.subject,
         bs_request_state: event.payload['state'],
         bs_request_oldstate: event.payload['oldstate']
       }
@@ -51,14 +52,16 @@ class SendEventEmailsJob < ApplicationJob
     if event.eventtype.in?(['ReviewWanted', 'RequestCreate'])
       return {
         notifiable_type: 'BsRequest',
-        notifiable_id: event.payload['id']
+        notifiable_id: event.payload['id'],
+        title: event.subject
       }
     end
 
     if event.eventtype.in?(['CommentForProject', 'CommentForPackage', 'CommentForRequest'])
       return {
         notifiable_type: 'Comment',
-        notifiable_id: event.payload['id']
+        notifiable_id: event.payload['id'],
+        title: event.subject
       }
     end
 

--- a/src/api/app/jobs/send_event_emails_job.rb
+++ b/src/api/app/jobs/send_event_emails_job.rb
@@ -1,6 +1,13 @@
 class SendEventEmailsJob < ApplicationJob
   queue_as :mailers
 
+  EVENTS_TO_NOTIFY = ['Event::RequestStatechange',
+                      'Event::RequestCreate',
+                      'Event::ReviewWanted',
+                      'Event::CommentForProject',
+                      'Event::CommentForPackage',
+                      'Event::CommentForRequest'].freeze
+
   def perform
     Event::Base.where(mails_sent: false).order(created_at: :asc).limit(1000).each do |event|
       subscribers = event.subscribers
@@ -39,32 +46,23 @@ class SendEventEmailsJob < ApplicationJob
   end
 
   def notification_dynamic_params(event)
-    if event.eventtype == 'RequestStatechange'
-      return {
-        notifiable_type: 'BsRequest',
-        notifiable_id: event.payload['id'],
-        title: event.subject,
-        bs_request_state: event.payload['state'],
-        bs_request_oldstate: event.payload['oldstate']
-      }
+    return {} unless event.eventtype.in?(EVENTS_TO_NOTIFY)
+
+    dynamic_params = { notifiable_id: event.payload['id'], notifiable_type: 'BsRequest', title: notification_title(event.subject) }
+
+    if event.eventtype == 'Event::RequestStatechange'
+      return dynamic_params.merge!({ bs_request_state: event.payload['state'], bs_request_oldstate: event.payload['oldstate'] })
     end
 
-    if event.eventtype.in?(['ReviewWanted', 'RequestCreate'])
-      return {
-        notifiable_type: 'BsRequest',
-        notifiable_id: event.payload['id'],
-        title: event.subject
-      }
-    end
+    return dynamic_params if event.eventtype == 'Event::RequestCreate'
+    return dynamic_params.merge!({ notifiable_type: 'Review' }) if event.eventtype == 'Event::ReviewWanted'
 
-    if event.eventtype.in?(['CommentForProject', 'CommentForPackage', 'CommentForRequest'])
-      return {
-        notifiable_type: 'Comment',
-        notifiable_id: event.payload['id'],
-        title: event.subject
-      }
-    end
+    dynamic_params.merge!({ notifiable_type: 'Comment' })
+  end
 
-    {}
+  def notification_title(subject)
+    return subject if subject.size <= 255
+
+    subject.slice(0, 252).concat('...')
   end
 end


### PR DESCRIPTION
 Fix storing `comments` and `bs_requests` in notifications. The complete name of the class, starting with `Event::`, was needed.

The `title` field of notifications is filled with the result of calling the `subject` method of the event.

Co-authored-by: David Kang <dkang@suse.com>