### PR TITLE
Rename bs_request_status column to bs_request_state in notifications table

### DIFF
--- a/src/api/db/migrate/20200318123203_rename_status_to_state_in_notifications.rb
+++ b/src/api/db/migrate/20200318123203_rename_status_to_state_in_notifications.rb
@@ -1,0 +1,5 @@
+class RenameStatusToStateInNotifications < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :notifications, :bs_request_status, :bs_request_state
+  end
+end

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -848,7 +848,7 @@ CREATE TABLE `notifications` (
   `notifiable_type` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `notifiable_id` int(11) DEFAULT NULL,
   `bs_request_oldstate` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
-  `bs_request_status` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
+  `bs_request_state` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `title` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `index_notifications_on_subscriber_type_and_subscriber_id` (`subscriber_type`,`subscriber_id`),
@@ -1491,6 +1491,7 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20200107105426'),
 ('20200311132129'),
 ('20200313143312'),
-('20200317120346');
+('20200317120346'),
+('20200318123203');
 
 


### PR DESCRIPTION
The original name of the field in the `bs_requests` table ~was~ is `state`, not `status`.

Co-authored-by: David Kang <dkang@suse.com>