### PR TITLE
Read RSS feeds also from new polymorphic notification columns

### DIFF
--- a/src/api/app/models/comment.rb
+++ b/src/api/app/models/comment.rb
@@ -57,6 +57,8 @@ class Comment < ApplicationRecord
       Event::CommentForProject.create(params)
     when 'BsRequest'
       params = commentable.notify_parameters(params)
+      # params[:id] got overwritten with notify_parameters. We need to assign it again
+      params[:id] = id
       # call the action
       Event::CommentForRequest.create(params)
     end

--- a/src/api/app/models/notification.rb
+++ b/src/api/app/models/notification.rb
@@ -21,4 +21,8 @@ class Notification < ApplicationRecord
   def any_user_in_group_active?
     !subscriber.users.recently_seen.empty?
   end
+
+  def template_name
+    event_type.gsub('Event::', '').underscore
+  end
 end

--- a/src/api/app/models/review.rb
+++ b/src/api/app/models/review.rb
@@ -12,6 +12,8 @@ class Review < ApplicationRecord
   belongs_to :bs_request, touch: true
   has_many :history_elements, -> { order(:created_at) }, class_name: 'HistoryElement::Review', foreign_key: :op_object_id
   has_many :history_elements_assigned, class_name: 'HistoryElement::ReviewAssigned', foreign_key: :op_object_id
+  has_many :notifications, as: :notifiable, dependent: :delete_all
+
   validates :state, inclusion: { in: VALID_REVIEW_STATES }
 
   validates :by_user, length: { maximum: 250 }
@@ -203,6 +205,7 @@ class Review < ApplicationRecord
 
   def create_notification(params = {})
     params = params.merge(_get_attributes)
+    params[:id] = id
     params[:comment] = reason
     params[:reviewers] = map_objects_to_ids(users_and_groups_for_review)
 

--- a/src/api/app/views/notifications/_actions.text.erb
+++ b/src/api/app/views/notifications/_actions.text.erb
@@ -1,0 +1,8 @@
+Actions:
+<% actions.each do |action| -%>
+<% if %w(submit maintenance_incident maintenance_release).include? action.type -%>
+<%= render partial: 'notifications/submit_action', locals: { action: action } -%>
+<% else -%>
+<%= render partial: "notifications/#{action.type}_action", locals: { action: action } -%>
+<% end -%>
+<% end -%>

--- a/src/api/app/views/notifications/_add_role_action.text.erb
+++ b/src/api/app/views/notifications/_add_role_action.text.erb
@@ -1,0 +1,5 @@
+<% if action.group_name.blank? -%>
+- <%= action.person_name %> wants to be <%= action.role %> in <%= project_or_package_text(action.target_project, action.target_package) -%>
+<% else -%>
+- Group <%= action.group_name %> wants to be <%= action.role %> in <%= project_or_package_text(action.target_project, action.target_package) -%>
+<% end -%>

--- a/src/api/app/views/notifications/_change_devel_action.text.erb
+++ b/src/api/app/views/notifications/_change_devel_action.text.erb
@@ -1,0 +1,1 @@
+- change devel package of <%= action.target_project %>/<%= action.target_package %> to <%= action.source_project %>/<%= action.source_package %>

--- a/src/api/app/views/notifications/_delete_action.text.erb
+++ b/src/api/app/views/notifications/_delete_action.text.erb
@@ -1,0 +1,5 @@
+<% if action.target_repository -%>
+- delete repository <%= action.target_repository %> in <%= action.target_project -%>
+<% else -%>
+- delete <%= project_or_package_text(action.target_project, action.target_package) -%>
+<% end %>

--- a/src/api/app/views/notifications/_group_action.text.erb
+++ b/src/api/app/views/notifications/_group_action.text.erb
@@ -1,0 +1,1 @@
+- <%= action.inspect %>

--- a/src/api/app/views/notifications/_set_bugowner_action.text.erb
+++ b/src/api/app/views/notifications/_set_bugowner_action.text.erb
@@ -1,0 +1,5 @@
+<% if action.group_name.blank? -%>
+- set the bugowner of <%= project_or_package_text(action.target_project, action.target_package) %> to <%= action.person_name -%>
+<% else -%>
+- set the bugowner of <%= project_or_package_text(action.target_project, action.target_package) %> to group <%= action.group_name -%>
+<% end -%>

--- a/src/api/app/views/notifications/_submit_action.text.erb
+++ b/src/api/app/views/notifications/_submit_action.text.erb
@@ -1,0 +1,1 @@
+- <%= action.type %> <%= action.source_project %>/<%= action.source_package %> => <%= action.target_project %>/<%= action.target_package %>

--- a/src/api/app/views/notifications/comment_for_package.text.erb
+++ b/src/api/app/views/notifications/comment_for_package.text.erb
@@ -1,0 +1,6 @@
+<%- comment = notification.notifiable %>
+Visit <%= url_for(project: comment.commentable.project, package: comment.commentable, controller: 'webui/package', action: :show, only_path: false, host: @host) %>
+
+<%= comment.user.realname %> wrote in package <%= comment.commentable.project %>/<%= comment.commentable %>:
+
+<%= comment.body %>

--- a/src/api/app/views/notifications/comment_for_project.text.erb
+++ b/src/api/app/views/notifications/comment_for_project.text.erb
@@ -1,0 +1,6 @@
+<%- comment = notification.notifiable %>
+Visit <%= url_for(project: comment.commentable, controller: 'webui/project', action: :show, only_path: false, host: @host) %>
+
+<%= comment.user.realname %> wrote in project <%= comment.commentable %>:
+
+<%= comment.body %>

--- a/src/api/app/views/notifications/comment_for_request.text.erb
+++ b/src/api/app/views/notifications/comment_for_request.text.erb
@@ -1,0 +1,6 @@
+<%- comment = notification.notifiable %>
+Visit <%= url_for(controller: 'webui/request', action: :show, number: comment.commentable.number, host: @host, only_path: false) %>
+
+<%= comment.user.realname %> wrote in request <%= comment.commentable.number %>:
+
+<%= comment.body %>

--- a/src/api/app/views/notifications/request_create.text.erb
+++ b/src/api/app/views/notifications/request_create.text.erb
@@ -1,0 +1,21 @@
+<%- bs_request = notification.notifiable %>
+Visit <%= url_for(controller: 'webui/request', action: :show, number: bs_request.number, host: @host, only_path: false) %>
+
+<% if bs_request.description -%>
+Description:
+<%= bs_request.description %>
+
+<%-end-%>
+<%= render partial: 'notifications/actions', locals: { actions: bs_request.bs_request_actions } %>
+
+To REVIEW against the previous version:
+   osc request show --diff <%= bs_request.number %>
+
+To ACCEPT the request:
+   osc request accept <%= bs_request.number %> --message="reviewed ok."
+
+To DECLINE the request:
+   osc request decline <%= bs_request.number %> --message="declined for reason xyz (see ... for background / policy / ...)."
+
+To REVOKE the request:
+   osc request revoke <%= bs_request.number %> --message="retracted because ..., sorry / thx / see better version ..."

--- a/src/api/app/views/notifications/request_statechange.text.erb
+++ b/src/api/app/views/notifications/request_statechange.text.erb
@@ -1,0 +1,13 @@
+<%- bs_request = notification.notifiable %>
+Visit <%= url_for(controller: 'webui/request', action: :show, number: bs_request.number, host: @host, only_path: false) %>
+
+State of request <%= bs_request.number %> was changed by <%= bs_request.commenter %>:
+
+  <%= notification.bs_request_oldstate %> -> <%= notification.bs_request_state %>
+
+<% if bs_request.comment.present? -%>
+Comment:
+  <%= bs_request.comment %>
+
+<% end -%>
+<%= render partial: 'notifications/actions', locals: { actions: bs_request.bs_request_actions } %>

--- a/src/api/app/views/notifications/review_wanted.text.erb
+++ b/src/api/app/views/notifications/review_wanted.text.erb
@@ -1,0 +1,24 @@
+<%- review = notification.notifiable %>
+<%- bs_request = review.bs_request %>
+<% bystring = ''
+   if review.by_user
+     bystring = "by user #{review.by_user}"
+   elsif review.by_group
+     bystring = "by group #{review.by_group}"
+   elsif review.by_package
+     bystring = "by package maintainers of #{review.by_project}/#{review.by_package}"
+   else
+     bystring = "by project maintainers of #{review.by_project}"
+   end -%>
+Request <%= bs_request.number %> (by <%= bs_request.creator %>) requires a review <%= bystring %>
+  Visit <%= url_for(controller: 'webui/request', action: :show, number: bs_request.number, host: @host, only_path: false) %>
+
+<% if bs_request.comment -%>
+Review reason set by <%= review.reviewer || bs_request.commenter %>:
+<%= bs_request.comment %>
+
+<% end -%>
+Request description:
+<%= bs_request.description %>
+
+<%= render partial: 'notifications/actions', locals: { actions: bs_request.bs_request_actions } -%>

--- a/src/api/app/views/webui/feeds/notifications.rss.builder
+++ b/src/api/app/views/webui/feeds/notifications.rss.builder
@@ -9,14 +9,24 @@ xml.rss version: '2.0' do
 
     @notifications.each do |notification|
       xml.item do
-        xml.title notification.event.subject
-        # We render the event_mailer view to 'description'
-        xml.description render(
-          template: "event_mailer/#{notification.event.template_name}",
-          layout: false,
-          formats: :text,
-          locals: { event: notification.event.expanded_payload }
-        )
+        if notification.notifiable
+          xml.title notification.title
+          xml.description render(
+            template: "notifications/#{notification.template_name}",
+            layout: false,
+            formats: :text,
+            locals: { notification: notification }
+          )
+        else
+          # TODO: responsive_ux: This 'else' clause will be removed after all records from notifications are migrated
+          xml.title notification.event.subject
+          xml.description render(
+            template: "event_mailer/#{notification.event.template_name}",
+            layout: false,
+            formats: :text,
+            locals: { event: notification.event.expanded_payload }
+          )
+        end
         xml.category "#{notification.event_type}/#{notification.subscription_receiver_role}"
         xml.pubDate notification.created_at
         xml.author @configuration['title']

--- a/src/api/spec/controllers/webui/feeds_controller_spec.rb
+++ b/src/api/spec/controllers/webui/feeds_controller_spec.rb
@@ -65,14 +65,11 @@ RSpec.describe Webui::FeedsController do
 
   describe 'GET #notifications' do
     let(:user) { create(:confirmed_user) }
-    let(:payload) do
-      { author: 'heino', description: 'I want this role', number: 1899,
-        actions: [{ action_id: 2004, type: 'add_role', person: 'heino', role: 'maintainer', targetproject: user.home_project.to_param }],
-        state: 'new',
-        when: '2017-06-27T10:34:30',
-        who: 'heino' }
+    let(:bs_request) do
+      create(:add_maintainer_request, bs_request_actions: [create(:bs_request_action_add_maintainer_role,
+                                                                  person_name: user.login, target_project: project)])
     end
-    let!(:rss_notification) { create(:rss_notification, event_payload: payload, subscriber: user, event_type: 'Event::RequestCreate') }
+    let!(:rss_notification) { create(:rss_notification, subscriber: user, event_type: 'Event::RequestCreate', notifiable: bs_request) }
 
     context 'with a working token' do
       render_views
@@ -89,7 +86,7 @@ RSpec.describe Webui::FeedsController do
       it { expect(assigns(:notifications)).to eq(user.combined_rss_feed_items) }
       it { expect(response).to have_http_status(:success) }
       it { is_expected.to render_template('webui/feeds/notifications') }
-      it { expect(response.body).to match(/heino wants to be maintainer in project/) }
+      it { expect(response.body).to match(/#{user.login} wants to be maintainer in project #{project}/) }
     end
 
     context 'with an invalid token' do


### PR DESCRIPTION
As part of our proccess of migrating notifications to new polymorphic columns with zero downtime, here we read RSS feeds also from the new polymorphic columns.

Co-authored-by: David Kang <dkang@suse.com>
Co-authored-by: Saray Cabrera Padrón <scabrerapadron@suse.de>
