### PR TITLE
User#last_logged_in should fallback to create_at in case it is nil

### DIFF
--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -279,6 +279,11 @@ class User < ApplicationRecord
     raise NotFoundError, "Couldn't find User with login = #{login}"
   end
 
+  # some users have last_logged_in_at empty
+  def last_logged_in_at
+    self[:last_logged_in_at] || created_at
+  end
+
   def away?
     last_logged_in_at < 3.months.ago
   end

--- a/src/api/spec/models/user_spec.rb
+++ b/src/api/spec/models/user_spec.rb
@@ -66,6 +66,30 @@ RSpec.describe User do
     end
   end
 
+  describe '#away?' do
+    subject { user }
+
+    context 'user do not logged in recently' do
+      let(:user) { create(:dead_user, login: 'foo') }
+      it { expect(subject).to be_away }
+    end
+
+    context 'user logged in recently' do
+      let(:user) { create(:confirmed_user, login: 'foo') }
+      it { expect(subject).not_to be_away }
+    end
+
+    context 'user has last_logged_in nil' do
+      let(:user) { create(:confirmed_user, login: 'foo') }
+
+      before do
+        allow(user).to receive(:last_logged_in_at).and_return(user.created_at)
+      end
+
+      it { expect(subject).not_to be_away }
+    end
+  end
+
   describe '#find_by_login!' do
     it 'returns a user if it exists' do
       expect(User.find_by_login!(user.login)).to eq(user)


### PR DESCRIPTION
We have some users which have the field `last_logged_in` `nil` which was leading to break the method `User.away?` 

We fall back the `last_logged_in` to the `created_at` if it's nil