### PR TITLE
Add notification factories

### DIFF
--- a/src/api/spec/factories/notification.rb
+++ b/src/api/spec/factories/notification.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :notification do
-    type { 'Notification' }
+    type { 'Notification::RssFeedItem' }
     event_type { 'FakeEventType' }
     event_payload { { fake: 'payload' } }
     subscription_receiver_role { 'owner' }
@@ -13,12 +13,12 @@ FactoryBot.define do
       bs_request_oldstate { :new }
     end
 
-    trait :creation do
+    trait :request_created do
       event_type { 'Event::RequestCreated' }
       association :notifiable, factory: :bs_request_with_submit_action
     end
 
-    trait :review do
+    trait :review_wanted do
       event_type { 'Event::ReviewWanted' }
       association :notifiable, factory: :bs_request_with_submit_action
     end

--- a/src/api/spec/factories/notification.rb
+++ b/src/api/spec/factories/notification.rb
@@ -1,8 +1,42 @@
 FactoryBot.define do
   factory :notification do
+    type { 'Notification' }
     event_type { 'FakeEventType' }
     event_payload { { fake: 'payload' } }
     subscription_receiver_role { 'owner' }
+    title { Faker::Lorem.sentence }
+    delivered { false }
+
+    trait :state_change do
+      event_type { 'Event::StateChange' }
+      association :notifiable, factory: :bs_request_with_submit_action
+      bs_request_oldstate { :new }
+    end
+
+    trait :creation do
+      event_type { 'Event::RequestCreated' }
+      association :notifiable, factory: :bs_request_with_submit_action
+    end
+
+    trait :review do
+      event_type { 'Event::ReviewWanted' }
+      association :notifiable, factory: :bs_request_with_submit_action
+    end
+
+    trait :comment_for_project do
+      event_type { 'Event::CommentForProject' }
+      association :notifiable, factory: :comment_project
+    end
+
+    trait :comment_for_package do
+      event_type { 'Event::CommentForPackage' }
+      association :notifiable, factory: :comment_package
+    end
+
+    trait :comment_for_request do
+      event_type { 'Event::CommentForRequest' }
+      association :notifiable, factory: :comment_request
+    end
   end
 
   factory :rss_notification, parent: :notification, class: 'Notification::RssFeedItem' do

--- a/src/api/spec/factories/notification.rb
+++ b/src/api/spec/factories/notification.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :notification do
     type { 'Notification::RssFeedItem' }
-    event_type { 'FakeEventType' }
+    event_type { 'Event::StateChange' }
     event_payload { { fake: 'payload' } }
     subscription_receiver_role { 'owner' }
     title { Faker::Lorem.sentence }


### PR DESCRIPTION
We need several factories to support the different use cases for the
notifications controller specs

Co-authored-by: Lukas Krause <lkrause@suse.de>