### PR TITLE
[backend] sqlite: rename prp_ext table to repoinfo while we can

### DIFF
--- a/src/backend/BSSched/BuildJob.pm
+++ b/src/backend/BSSched/BuildJob.pm
@@ -374,7 +374,7 @@ sub set_genbuildreqs {
   my $genbuildreqs = $gctx->{'genbuildreqs'}->{$prp};
   if (defined $filecontent) {
     my $md5 = Digest::MD5::md5_hex($filecontent);
-    return if $genbuildreqs && ($genbuildreqs->{$packid} || [''])->[0] eq $md5;
+    return if $genbuildreqs && ($genbuildreqs->{$packid} || [''])->[0] eq $md5 && (($genbuildreqs->{$packid} || [])->[2] || '') eq ($verifymd5 || '');
     $genbuildreqs = $gctx->{'genbuildreqs'}->{$prp} = {} unless $genbuildreqs;
     $genbuildreqs->{$packid} = [ $md5, [ split("\n", $filecontent) ], $verifymd5 ];
   } else {
@@ -1162,7 +1162,6 @@ sub create {
     }
   }
   if (!$ctx->{'isreposerver'}) {
-    my $genbuildreqs = ($ctx->{'genbuildreqs'} || {})->{$packid};
     $binfo->{'logidlelimit'} = $bconf->{'buildflags:logidlelimit'} if $bconf->{'buildflags:logidlelimit'};
     $binfo->{'genbuildreqs'} = $genbuildreqs->[0] if $genbuildreqs;
     if ($bconf->{'buildflags:obsgendiff'} && @{$ctx->{'repo'}->{'releasetarget'} || []}) {

--- a/src/backend/bs_dbtool
+++ b/src/backend/bs_dbtool
@@ -45,7 +45,7 @@ if (defined $user) {
   die "setuid: $!\n" if ($> != $user);
 }
 
-die("usage: bs_dbtool binary|pattern|linkinfo <cmd> [args]\n") unless @ARGV >= 2;
+die("usage: bs_dbtool binary|pattern|repoinfo|linkinfo <cmd> [args]\n") unless @ARGV >= 2;
 
 my $table = shift @ARGV;
 my $cmd = shift @ARGV;
@@ -58,13 +58,14 @@ if ($table eq 'linkinfo') {
     $db = BSDB::opendb($sourcedb, $table);
   }
   $db->{'allkeyspath'} = 'project';
-} elsif ($table eq 'binary' || $table eq 'pattern') {
+} elsif ($table eq 'binary' || $table eq 'pattern' || $table eq 'repoinfo') {
   if ($BSConfig::published_db_sqlite) {
     $db = BSSrcServer::SQLite::opendb($extrepodb, $table);
   } else {
     $db = BSDB::opendb($extrepodb, $table);
   }
   $db->{'allkeyspath'} = 'name';
+  $db->{'allkeyspath'} = 'project' if $table eq 'repoinfo';
 } else {
   die("unknown database table $table\n");
 }
@@ -176,6 +177,8 @@ if ($cmd eq 'convert') {
   } elsif ($table eq 'binary') {
     $ndb = BSSrcServer::SQLite::opendb($extrepodb, $table);
     $db = BSDB::opendb($extrepodb, 'repoinfo');
+  } else {
+    die("unsupported table to convert\n");
   }
 
   my @todo;


### PR DESCRIPTION
This is a better match for the content of the table.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
