### PR TITLE
Fix typo on expect to have content

### DIFF
--- a/dist/t/spec/features/0040_package_spec.rb
+++ b/dist/t/spec/features/0040_package_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Package" do
     click_link('Add file')
     attach_file("file", File.expand_path('../fixtures/hello_world.spec', __dir__), make_visible: true)
     click_button('Save')
-    expect(page).to have_content("The file 'hello_word.spec' has been successfully saved.")
+    expect(page).to have_content("The file 'hello_world.spec' has been successfully saved.")
   end
 
   it "should be able to branch" do


### PR DESCRIPTION
Fix openQA failure because of a typo :roll_eyes: 