### PR TITLE
Fix notification link for Notification

### DIFF
--- a/src/api/app/presenters/notification_presenter.rb
+++ b/src/api/app/presenters/notification_presenter.rb
@@ -9,9 +9,9 @@ class NotificationPresenter < SimpleDelegator
     when 'Event::RequestStatechange', 'Event::RequestCreate'
       Rails.application.routes.url_helpers.request_show_path(@model.notifiable.number)
     when 'Event::ReviewWanted'
-      Rails.application.routes.url_helpers.request_show_path(@model.notifiable.bs_request.number)
+      Rails.application.routes.url_helpers.request_show_path(@model.event_payload['number'])
     when 'Event::CommentForRequest'
-      Rails.application.routes.url_helpers.request_show_path(@model.notifiable.commentable.number)
+      Rails.application.routes.url_helpers.request_show_path(@model.event_payload['number'])
     when 'Event::CommentForProject'
       Rails.application.routes.url_helpers.project_show_path(@model.notifiable.commentable)
     when 'Event::CommentForPackage'


### PR DESCRIPTION
The notifications for ReviewWanted and CommentForRequest
are taking the wrong object.