### PR TITLE
[doc] Add note that filename deletion makes a commit

### DIFF
--- a/docs/api/api/api.txt
+++ b/docs/api/api/api.txt
@@ -816,7 +816,7 @@ XmlResult: status
 
 DELETE /source/<project>/<package>/<filename>
 
-  Delete source file.
+  Delete the specified file and commits the changes.
 
 XmlResult: status
 


### PR DESCRIPTION
The API docs were omitting the detail, that the `DELETE /source/<project>/<package>/<filename>` also makes a commit.