### PR TITLE
bs_worker: Allow passing --network to build process

### DIFF
--- a/dist/obsworker
+++ b/dist/obsworker
@@ -120,6 +120,10 @@ if [ -n "$OBS_VM_ENABLE_CONSOLE" ]; then
     OBS_WORKER_OPT="$OBS_WORKER_OPT --vm-enable-console"
 fi
 
+if [ -n "$OBS_WORKER_NETWORK" ]; then
+    OBS_WORKER_OPT="$OBS_WORKER_OPT --network"
+fi
+
 [ -z "$OBS_INSTANCE_MEMORY" ] && OBS_INSTANCE_MEMORY=512
 
 vmopt=

--- a/dist/sysconfig.obs-server
+++ b/dist/sysconfig.obs-server
@@ -148,6 +148,14 @@ OBS_WORKER_JOBS="1"
 OBS_WORKER_TEST_MODE=""
 
 ## Path:        Applications/OBS
+## Description: Allow workers to access the internet
+## Type:        ("yes" | "")
+## Default:     ""
+## Config:      OBS
+#
+OBS_WORKER_NETWORK=""
+
+## Path:        Applications/OBS
 ## Description: define one or more labels for the build host.
 ## Type:        string
 ## Default:     ""

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -103,6 +103,7 @@ my $hardstatus;
 
 my $jobs;
 my $threads;
+my $network;
 my $cachedir;
 my $cachesize;
 my $cleanup_chroot;
@@ -299,6 +300,8 @@ Usage: $0 [OPTION] --root <directory> --statedir <directory>
 
        --tmpfs     : uses tmpfs (memory) for the build root
 
+       --network   : enable network access inside the chroot
+
        --device    : set kvm or xen root device (default is <root>/root file)
 
        --swap      : set kvm or xen swap device (default is <root>/swap file)
@@ -460,6 +463,11 @@ while (@ARGV) {
   if ($ARGV[0] eq '--tmpfs') {
     shift @ARGV;
     $vm_tmpfs_mode = 1;
+    next;
+  }
+  if ($ARGV[0] eq '--network') {
+    shift @ARGV;
+    $network = 1;
     next;
   }
   if ($ARGV[0] eq '--xendevice' || $ARGV[0] eq '--device') {
@@ -3219,6 +3227,7 @@ sub dobuild {
   push @args, '--disturl', $disturl;
   push @args, '--linksources' if $localkiwi;
   push @args, '--signdummy' if ($kiwimode || '') eq 'product' && -e "$statedir/build/signdummy";
+  push @args, '--network' if $network;
   if ($packid =~ /(?<!^_product)(?<!^_patchinfo):./) {
     $packid =~ /^(.*):(.*?)$/;
     push @args, "--obspackage=$1" if $needobspackage;


### PR DESCRIPTION
This will configure bs_worker to allow network access inside the
build.

Please note that this is contingent on openSUSE/obs-build#555.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
