### PR TITLE
Don't send emails to groups without an email

### DIFF
--- a/src/api/app/mailers/event_mailer.rb
+++ b/src/api/app/mailers/event_mailer.rb
@@ -21,6 +21,9 @@ class EventMailer < ActionMailer::Base
     subscribers = subscribers.to_a
     return if subscribers.empty?
 
+    recipients = subscribers.map(&:display_name).reject(&:blank?)
+    return if recipients.empty?
+
     set_headers
     begin
       locals = { event: e.expanded_payload }
@@ -33,7 +36,6 @@ class EventMailer < ActionMailer::Base
 
     template_name = e.template_name
     orig = e.originator
-    tos = subscribers.map(&:display_name)
 
     if orig
       orig = orig.display_name
@@ -41,7 +43,7 @@ class EventMailer < ActionMailer::Base
       orig = mail_sender
     end
 
-    mail(to: tos.sort,
+    mail(to: recipients.sort,
          subject: e.subject,
          from: orig,
          date: e.created_at) do |format|

--- a/src/api/spec/mailers/event_mailer_spec.rb
+++ b/src/api/spec/mailers/event_mailer_spec.rb
@@ -114,5 +114,16 @@ RSpec.describe EventMailer, vcr: true do
         it { expect(mail.html_part.to_s).to include("I =E2=9D=A4=EF=B8=8F <a href=3D'https://build.example.com/users/") }
       end
     end
+
+    context 'when the subscriber has no email' do
+      let(:group) { create(:group, email: nil) }
+      let(:empty_event) { nil }
+      let(:subscribers) { [group] }
+      subject! { EventMailer.event(subscribers, empty_event).deliver_now }
+
+      it 'does not get delivered' do
+        expect(ActionMailer::Base.deliveries).to be_empty
+      end
+    end
   end
 end


### PR DESCRIPTION
The corner case of sending a mail to only a group, that hasn't an email defined, was not taken into account.

This patch makes the code not to send an email in this case.

Fixes #9114.

Co-authored-by: David Kang <dkang@suse.com>