### PR TITLE
Implement project atomic style container signatures

### DIFF
--- a/src/backend/BSConSign.pm
+++ b/src/backend/BSConSign.pm
@@ -1,0 +1,75 @@
+#
+# Copyright (c) 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program (see the file COPYING); if not, write to the
+# Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+#
+################################################################
+#
+# Create an "atomic container signature"
+#
+
+package BSConSign;
+
+use strict;
+
+use BSPGP;
+use JSON::XS ();
+use Digest::MD5 ();
+use MIME::Base64 ();
+use IO::Compress::RawDeflate;
+
+sub createsig {
+  my ($signfunc, $digest, $reference, $creator, $timestamp) = @_;
+  my $critical = {
+    'type' => 'atomic container signature',
+    'image' => { 'docker-manifest-digest' => $digest },
+    'identity' => { 'docker-reference' => $reference },
+  };
+  my $optional = {};
+  $optional->{'creator'} = $creator if $creator;
+  $optional->{'timestamp'} = $timestamp if $timestamp;
+  my $data = { 'critical' => $critical, 'optional' => $optional };
+  my $data_json = JSON::XS->new->utf8->canonical->encode($data);
+  my $sig = $signfunc->($data_json);
+  my $sd = BSPGP::pk2sigdata($sig);
+  die("no issuer\n") unless $sd->{'issuer'};
+  # create onepass_sig packet
+  my $onepass_sig_pkt = pack('CCCCH16C', 3, $sd->{'pgptype'}, $sd->{'pgphash'}, $sd->{'pgpalgo'}, $sd->{'issuer'}, 1);
+  $onepass_sig_pkt = BSPGP::pkencodepacket(4, $onepass_sig_pkt);
+  # create literal data packet
+  my $fn = 'rpmsig-req.bin';
+  my $t = $sd->{'signtime'} || time();
+  my $literal_data_pkt = pack('CCa*N', 0x62, length($fn), $fn, $t).$data_json;
+  $literal_data_pkt = BSPGP::pkencodepacket(11, $literal_data_pkt);
+  # create compressed packet
+  my $packets = "$onepass_sig_pkt$literal_data_pkt$sig";
+  my $compressed_pkt;
+  IO::Compress::RawDeflate::rawdeflate(\$packets, \$compressed_pkt);
+  return pack('CC', 0xa3, 1).$compressed_pkt;
+}
+
+sub sig2openshift {
+  my ($digest, $sig) = @_;
+  my $id = Digest::MD5::md5_hex($sig);
+  my $data = {
+    'version' => 2,
+    'type' => 'atomic',
+    'name' => "$digest\@$id",
+    'content' => MIME::Base64::encode_base64($sig),
+  };
+  return JSON::XS->new->utf8->canonical->encode($data);
+}
+
+1;

--- a/src/backend/BSConSign.pm
+++ b/src/backend/BSConSign.pm
@@ -64,12 +64,12 @@ sub sig2openshift {
   my ($digest, $sig) = @_;
   my $id = Digest::MD5::md5_hex($sig);
   my $data = {
-    'version' => 2,
+    'schemaVersion' => 2,
     'type' => 'atomic',
     'name' => "$digest\@$id",
-    'content' => MIME::Base64::encode_base64($sig),
+    'content' => MIME::Base64::encode_base64($sig, ''),
   };
-  return JSON::XS->new->utf8->canonical->encode($data);
+  return $data;
 }
 
 1;

--- a/src/backend/BSPublisher/Registry.pm
+++ b/src/backend/BSPublisher/Registry.pm
@@ -391,10 +391,10 @@ sub update_sigs {
 
   my $gpgpubkey = BSPGP::unarmor($pubkey);
   my $pubkey_fp = BSPGP::pk2fingerprint($gpgpubkey);
-  if (($oldsigs->{'pubkey'} || '') ne $pubkey_fp) {
-    $oldsigs = {};	# fingerprint does not match, do not use old signatures
+  if (($oldsigs->{'pubkey'} || '') ne $pubkey_fp || ($oldsigs->{'gun'} || '') ne $gun || ($oldsigs->{'creator'} || '') ne ($creator || '')) {
+    $oldsigs = {};	# fingerprint/gun/creator mismatch, do not use old signatures
   }
-  my $sigs = { 'pubkey' => $pubkey_fp, 'digests' => {} };
+  my $sigs = { 'pubkey' => $pubkey_fp, 'gun' => $gun, 'creator' => $creator, 'digests' => {} };
   for my $digest (sort keys %$imagedigests) {
     my %old = map { $_->[0] => $_->[1] } @{($oldsigs->{'digests'} || {})->{$digest} || []};
     my @d;

--- a/src/backend/BSPublisher/Registry.pm
+++ b/src/backend/BSPublisher/Registry.pm
@@ -32,6 +32,7 @@ use BSPublisher::Blobstore;
 use BSContar;
 use BSRPC;
 use BSTUF;
+use BSConSign;
 
 my $registrydir = "$BSConfig::bsdir/registry";
 my $uploaddir = "$BSConfig::bsdir/upload";
@@ -374,6 +375,51 @@ sub update_tuf {
   close($fd) if $fd;
 }
 
+sub update_sigs {
+  my ($prp, $repo, $gun, $imagedigests, $pubkey, $signargs) = @_;
+
+  my $creator = 'OBS';
+  my ($projid, $repoid) = split('/', $prp, 2);
+  my @signcmd;
+  push @signcmd, $BSConfig::sign;
+  push @signcmd, '--project', $projid if $BSConfig::sign_project;
+  push @signcmd, @{$signargs || []};
+  my $signfunc =  sub { BSUtil::xsystem($_[0], @signcmd, '-D', '-h', 'sha256') };
+  my $repodir = "$registrydir/$repo";
+  my $oldsigs = BSUtil::retrieve("$repodir/:sigs", 1) || {};
+  return if !%$oldsigs && !%$imagedigests;
+
+  my $gpgpubkey = BSPGP::unarmor($pubkey);
+  my $pubkey_fp = BSPGP::pk2fingerprint($gpgpubkey);
+  if (($oldsigs->{'pubkey'} || '') ne $pubkey_fp) {
+    $oldsigs = {};	# fingerprint does not match, do not use old signatures
+  }
+  my $sigs = { 'pubkey' => $pubkey_fp, 'digests' => {} };
+  for my $digest (sort keys %$imagedigests) {
+    my %old = map { $_->[0] => $_->[1] } @{($oldsigs->{'digests'} || {})->{$digest} || []};
+    my @d;
+    for my $tag (sort keys %{$imagedigests->{$digest}}) {
+      if ($old{$tag}) {
+        push @d, [ $tag, $old{$tag} ];
+	next;
+      }
+      print "creating atomic signature for $gun:$tag $digest\n";
+      my $sig = BSConSign::createsig($signfunc, $digest, "$gun:$tag", $creator);
+      push @d, [ $tag, $sig ];
+    }
+    $sigs->{'digests'}->{$digest} = \@d;
+  }
+  if (BSUtil::identical($oldsigs, $sigs)) {
+    print "local signatures: no change.\n";
+    return;
+  }
+  if (%{$sigs->{'digests'}}) {
+    BSUtil::store("$repodir/.sigs.$$", "$repodir/:sigs", $sigs);
+  } else {
+    unlink("$repodir/:sigs");
+  }
+}
+
 sub push_containers {
   my ($prp, $repo, $gun, $multiarch, $tags, $pubkey, $signargs) = @_;
 
@@ -393,6 +439,7 @@ sub push_containers {
   my %knownblobs;
   my %knownmanifests;
   my %knowntags;
+  my %knownimagedigests;
 
   my %info;
 
@@ -418,6 +465,7 @@ sub push_containers {
 	$multiplatforms{$platformstr} = 1;
         push @multimanifests, $multimani;
         push @imginfos, $imginfo;
+        $knownimagedigests{$imginfo->{'distmanifest'}}->{$tag} = 1;
 	next;
       }
 
@@ -523,6 +571,7 @@ sub push_containers {
 	};
       }
       push @imginfos, $imginfo;
+      $knownimagedigests{$imginfo->{'distmanifest'}}->{$tag} = 1;
       # cache result
       $done{$containerinfo} = [ $multimani, $platformstr, $imginfo ];
     }
@@ -578,6 +627,7 @@ sub push_containers {
     unlink("$repodir/:info");
     unlink("$repodir/:tuf.old");
     unlink("$repodir/:tuf");
+    unlink("$repodir/:sigs");
     disownrepo($prp, $repo);
     return $containerdigests;
   }
@@ -599,6 +649,13 @@ sub push_containers {
   } elsif (-e "$repodir/:tuf") {
     unlink("$repodir/:tuf.old");
     unlink("$repodir/:tuf");
+  }
+
+  # write signatures file
+  if ($gun) {
+    update_sigs($prp, $repo, $gun, \%knownimagedigests, $pubkey, $signargs);
+  } elsif (-e "$repodir/:sigs") {
+    unlink("$repodir/:sigs");
   }
 
   # and we're done, return digests

--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -68,6 +68,7 @@ use BSNotify;
 use BSUrlmapper;
 use BSRegistryServer;
 use BSRedisnotify;
+use BSConSign;
 
 use BSSolv;
 
@@ -4215,17 +4216,27 @@ sub registry_blob {
 sub registry_sigstore {
   my ($cgi, $regrepo, $sig) = @_;
   my $digest;
-  ($sig, $digest) = split('@', $sig, 2);
-  die("404 NAME_UNKNOWN\n") unless $sig =~ s/^signature-(\d+)$/$1/s;
-  $digest =~ s/=/:/;
+  if ($sig =~ /\@/) {
+    ($sig, $digest) = split('@', $sig, 2);
+    die("404 NAME_UNKNOWN\n") unless $sig =~ s/^signature-(\d+)$/$1/s;
+    $digest =~ s/=/:/;
+  } else {
+    $digest = $sig;
+    $sig = undef;
+  }
   die("400 DIGEST_INVALID\n") unless $digest =~ /^sha256:[0-9a-f]{64}$/s;
   my $repodir = "$registrydir/$regrepo";
   die("404 NAME_UNKNOWN\n") unless -f "$repodir/:info";
   my $sigs = BSUtil::retrieve("$repodir/:sigs", 1) || {};
   my $d = ($sigs->{'digests'} || {})->{$digest};
-  die("404 NAME_UNKNOWN\n") unless $d;
-  die("404 NAME_UNKNOWN\n") unless $sig >= 1 && @$d >= $sig;
-  BSServer::reply($d->[$sig - 1]->[1], 'Content-Type: application/octet-stream');
+  if (defined($sig)) {
+    die("404 NAME_UNKNOWN\n") unless $d;
+    die("404 NAME_UNKNOWN\n") unless $sig >= 1 && @$d >= $sig;
+    BSServer::reply($d->[$sig - 1]->[1], 'Content-Type: application/octet-stream');
+  } else {
+    my @sigs = map { BSConSign::sig2openshift($digest, $_->[1]) } @{$d || []};
+    BSRegistryServer::reply({ 'signatures' => \@sigs });
+  }
   return undef;
 }
 

--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -4212,6 +4212,23 @@ sub registry_blob {
   return undef;
 }
 
+sub registry_sigstore {
+  my ($cgi, $regrepo, $sig) = @_;
+  my $digest;
+  ($sig, $digest) = split('@', $sig, 2);
+  die("404 NAME_UNKNOWN\n") unless $sig =~ s/^signature-(\d+)$/$1/s;
+  $digest =~ s/=/:/;
+  die("400 DIGEST_INVALID\n") unless $digest =~ /^sha256:[0-9a-f]{64}$/s;
+  my $repodir = "$registrydir/$regrepo";
+  die("404 NAME_UNKNOWN\n") unless -f "$repodir/:info";
+  my $sigs = BSUtil::retrieve("$repodir/:sigs", 1) || {};
+  my $d = ($sigs->{'digests'} || {})->{$digest};
+  die("404 NAME_UNKNOWN\n") unless $d;
+  die("404 NAME_UNKNOWN\n") unless $sig >= 1 && @$d >= $sig;
+  BSServer::reply($d->[$sig - 1]->[1], 'Content-Type: application/octet-stream');
+  return undef;
+}
+
 sub registry_taglist {
   my ($cgi, $regrepo) = @_;
   my $repodir = "$registrydir/$regrepo";
@@ -4388,6 +4405,7 @@ my $dispatches = [
   'GET|HEAD:/registry/$gunprefix:/$...:regrepo/_trust/tuf/$filename' => \&registry_tuf,
   'GET|HEAD:/registry/$...:regrepo/manifests/$manifest:' => \&registry_manifest,
   'GET|HEAD:/registry/$...:regrepo/blobs/$blob:' => \&registry_blob,
+  'GET|HEAD:/registry/$...:regrepo/signatures/$sig:' => \&registry_sigstore,
   'GET|HEAD:/registry/$...:regrepo/tags/list' => \&registry_taglist,
   'GET|HEAD:/registry/$...:regrepo/info.json' => \&registry_info,
   'GET|HEAD:/registry/_catalog' => \&registry_catalog,

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -6743,7 +6743,7 @@ sub registry_catalog {
 
 sub registry_version {
   my ($cgi) = @_;
-  BSRegistryServer::reply({});
+  BSRegistryServer::reply({}, 'X-Registry-Supports-Signatures: 1');
   return undef;
 }
 
@@ -6962,6 +6962,7 @@ my $dispatches = [
   'GET|HEAD:/registry/$gunprefix:/$...:regrepo/_trust/tuf/$filename' => \&notary_forward,
   'GET|HEAD:/registry/$...:regrepo/manifests/$manifest:' => \&registry_forward,
   'GET|HEAD:/registry/$...:regrepo/blobs/$blob:' => \&registry_forward,
+  'GET|HEAD:/registry/$...:regrepo/signatures/$sig:' => \&registry_forward,
   'GET|HEAD:/registry/$...:regrepo/tags/list' => \&registry_forward,
   'GET|HEAD:/registry/$...:regrepo/info.json' => \&registry_forward,
   'GET|HEAD:/registry/_catalog' => \&registry_catalog,

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -6753,6 +6753,15 @@ sub notary_forward {
   return undef;
 }
 
+sub sigstore_forward {
+  my ($cgi, $regrepo, $sig) = @_;
+  my $req = $BSServer::request;
+  die("404 not found\n") unless $req->{'path'} =~ s/\@([^\@\/]+)\/([^\@\/]+)$/\/signatures\/$2\@$1/;
+  die("404 not found\n") unless $regrepo =~ s/\@[^\@\/]+$//;
+  registry_forward($cgi, $regrepo);
+  return undef;
+}
+
 ####################################################################
 
 sub run {
@@ -6957,6 +6966,7 @@ my $dispatches = [
   'GET|HEAD:/registry/$...:regrepo/info.json' => \&registry_forward,
   'GET|HEAD:/registry/_catalog' => \&registry_catalog,
   'GET|HEAD:/registry' => \&registry_version,
+  'GET|HEAD:/sigstore/$...:regrepo/$sig:' => \&sigstore_forward,
 
   '/ajaxstatus' => \&getajaxstatus,
   '/serverstatus' => \&BSStdServer::serverstatus,


### PR DESCRIPTION
<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
