### PR TITLE
findpackages: move multibuild processing after project link processing

### DIFF
--- a/src/backend/BSSrcServer/Multibuild.pm
+++ b/src/backend/BSSrcServer/Multibuild.pm
@@ -188,8 +188,9 @@ sub addmultibuildpackages {
     my @mbp = map {"$packid:$_"} @{$mb->{'flavor'} || $mb->{'package'} || []};
     push @packages, @mbp;
     if ($origins) {
+      my $origin = defined($origins->{$packid}) ? $origins->{$packid} : $projid;
       for (@mbp) {
-	$origins->{$_} = $projid unless defined $origins->{$_};
+	$origins->{$_} = $origin unless defined $origins->{$_};
       }
     }
   }

--- a/src/backend/BSSrcServer/Projlink.pm
+++ b/src/backend/BSSrcServer/Projlink.pm
@@ -136,6 +136,8 @@ sub findpackages_projlink {
       unshift @todo, map {$_->{'project'}} @$llink if $llink;
     }
     @lpackids = grep {$_ ne '_product' && !/^_product:/} @lpackids if $packids{'_product'};
+    # strip out multibuild packages
+    @lpackids = grep {!/(?<!^_product)(?<!^_patchinfo):./} @lpackids;
     $packids{$_} = 1 for @lpackids;
     if ($origins && $lorigins) {
       for (@lpackids) {

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -771,13 +771,15 @@ sub findpackages {
       $origins->{$_} = $projid unless defined $origins->{$_};
     }
   }
-  @packids = BSSrcServer::Multibuild::addmultibuildpackages($projid, $origins, @packids) unless $deleted;
 
   # handle project links (but not if deleted)
   if ($proj && $proj->{'link'} && !$noexpand && !$deleted) {
     push @packids, BSSrcServer::Projlink::findpackages_projlink($projid, $proj, $nonfatal, $origins);
     @packids = sort(BSUtil::unify(@packids));
   }
+
+  # add multibuild packages
+  @packids = BSSrcServer::Multibuild::addmultibuildpackages($projid, $origins, @packids) unless $deleted;
 
   return @packids;
 }


### PR DESCRIPTION
<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
