### PR TITLE
Fix notification list with large project names

### DIFF
--- a/src/api/app/views/webui/users/notifications/index.html.haml
+++ b/src/api/app/views/webui/users/notifications/index.html.haml
@@ -32,7 +32,7 @@
                   .text-nowrap
                     %span.badge.badge-secondary= notification.notification_badge
                     %small.text-muted= time_ago_in_words(notification.created_at)
-                  = link_to(n.title, notification.link_to_notification_target)
+                  = link_to(n.title, notification.link_to_notification_target, class: 'text-word-break-all')
                 - unless params[:type] == 'done'
                   .actions.align-self-end.align-self-sm-start.pl-3.pt-3.pt-sm-0
                     = link_to(user_notification_path(user_login: User.session, id: notification),


### PR DESCRIPTION
The names was not break words like 'home:bar:foo:..'
breaking the responsiveness of the page

Fix #9276

### Before
![Screenshot_2020-04-01 Open Build Service](https://user-images.githubusercontent.com/1212806/78123173-117d2600-740e-11ea-9659-29b7292dd173.png)


### After
![Screenshot_2020-04-01 Open Build Service(1)](https://user-images.githubusercontent.com/1212806/78123186-1641da00-740e-11ea-9314-63ea327efb0c.png)
