### PR TITLE
[webui] Show full humanized time

### DIFF
--- a/src/api/app/helpers/webui/package_helper.rb
+++ b/src/api/app/helpers/webui/package_helper.rb
@@ -63,9 +63,9 @@ module Webui::PackageHelper
   end
 
   def humanize_time(seconds)
-    [[60, :s], [60, :m], [24, :h]].map do |count, name|
+    [[60, :s], [60, :m], [24, :h], [0, :d]].map do |count, name|
       if seconds > 0
-        seconds, n = seconds.divmod(count)
+        seconds, n = seconds.divmod(count > 0 ? count : seconds + 1)
         "#{n.to_i}#{name}"
       end
     end.compact.reverse.join(' ')

--- a/src/api/spec/helpers/webui/package_helper_spec.rb
+++ b/src/api/spec/helpers/webui/package_helper_spec.rb
@@ -91,6 +91,10 @@ RSpec.describe Webui::PackageHelper, type: :helper do
     it 'returns hours, minutes and seconds' do
       expect(humanize_time(3688)).to eq('1h 1m 28s')
     end
+
+    it 'returns days, hours, minutes and seconds' do
+      expect(humanize_time(53 * 4283)).to eq('2d 15h 3m 19s')
+    end
   end
 
   describe '#file_url' do


### PR DESCRIPTION
Fixes #8878

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
