### PR TITLE
Add security update note for rails gem in release notes

### DIFF
--- a/ReleaseNotes-2.10.2
+++ b/ReleaseNotes-2.10.2
@@ -21,10 +21,10 @@ Bugfixes
 ========
 
 Frontend:
+ * Security update for gem rails (CVE-2020-5267)
 
 Backend:
 
 Shipment:
 
 Bugfixes:
-


### PR DESCRIPTION
The gem rails was updated in branch 2.10. We should add a note in the release notes for the next 2.10.2 minor release.