### PR TITLE
Remove unneeded JS dependencies

### DIFF
--- a/src/api/.jshintrc
+++ b/src/api/.jshintrc
@@ -8,7 +8,6 @@
     "$" :        false,
     "document" : false,
     "editors" :  false, // Set by codemirror
-    "moment" :   false, // Defined by Moment.js
     "Option" :   false, // Constructor for creating an HTMLOptionElement.
     "ui" :       false,
     "window" :   false,

--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -196,8 +196,6 @@ group :assets do
   gem 'sassc-rails'
   # assets for jQuery DataTables
   gem 'jquery-datatables'
-  # assets for jQuery tokeninput
-  gem 'rails_tokeninput', '>= 1.6.1.rc1'
   # to create our sprite images/stylesheets
   gem 'sprite-factory', '>= 1.5.2'
   # to read and write PNG images

--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -210,8 +210,6 @@ group :assets do
   gem 'bootstrap'
   # assets for font-awesome vector icons
   gem 'font-awesome-sass'
-  # assets for formatting dates
-  gem 'momentjs-rails'
   # for catching javascript exceptions
   source 'https://rails-assets.org' do
     gem 'rails-assets-airbrake-js-client'

--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -77,8 +77,6 @@ gem 'addressable'
 gem 'builder'
 # to write the rails metrics directly into InfluxDB.
 gem 'influxdb-rails', '1.0.0'
-# for client side time ago
-gem 'rails-timeago', '~> 2.0'
 # for copying objects with their relations
 gem 'deep_cloneable', '~> 3.0.0'
 # Server-side datatables

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -305,8 +305,6 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
-    rails_tokeninput (1.7.0)
-      railties (>= 3.1.0)
     railties (5.2.4.2)
       actionpack (= 5.2.4.2)
       activesupport (= 5.2.4.2)
@@ -520,7 +518,6 @@ DEPENDENCIES
   rails (~> 5.2)
   rails-assets-airbrake-js-client!
   rails-controller-testing
-  rails_tokeninput (>= 1.6.1.rc1)
   rantly
   rdoc
   redcarpet

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -307,9 +307,6 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
-    rails-timeago (2.18.0)
-      actionpack (>= 3.1)
-      activesupport (>= 3.1)
     rails_tokeninput (1.7.0)
       railties (>= 3.1.0)
     railties (5.2.4.2)
@@ -526,7 +523,6 @@ DEPENDENCIES
   rails (~> 5.2)
   rails-assets-airbrake-js-client!
   rails-controller-testing
-  rails-timeago (~> 2.0)
   rails_tokeninput (>= 1.6.1.rc1)
   rantly
   rdoc

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -241,8 +241,6 @@ GEM
       minitest (>= 5.0)
       ruby-progressbar
     mocha (1.11.2)
-    momentjs-rails (2.20.1)
-      railties (>= 3.1)
     mousetrap-rails (1.4.6)
     mysql2 (0.5.3)
     nio4r (2.5.2)
@@ -508,7 +506,6 @@ DEPENDENCIES
   minitest-fail-fast
   minitest-reporters
   mocha (> 0.13.0)
-  momentjs-rails
   mousetrap-rails
   mysql2
   nokogiri

--- a/src/api/app/assets/javascripts/webui/application.js
+++ b/src/api/app/assets/javascripts/webui/application.js
@@ -50,7 +50,6 @@
 //= require webui/collapsible_text
 //= require webui/patchinfo.js
 //= require webui/image_templates.js
-//= require rails-timeago
 //= require webui/kiwi_editor.js
 //= require webui/monitor.js
 //= require webui/airbrake-js


### PR DESCRIPTION
While working on the [Webpacker card](https://trello.com/c/Gg2gJcwH/1346-try-webpacker-again), I've found out that we have a few JS dependencies which we don't use anymore. Let's remove them.