### PR TITLE
[backend] Add a config option to enable the X-Registry-Supports-Signa…

### DIFF
--- a/dist/obs-apache24.conf
+++ b/dist/obs-apache24.conf
@@ -113,4 +113,8 @@ LimitRequestFieldsize 20000
 
         ProxyPass /v2 http://localhost:5352/registry
         ProxyPassReverse /v2 http://localhost:5352/registry
+        ProxyPass /sigstore http://localhost:5352/sigstore
+        ProxyPassReverse /sigstore http://localhost:5352/sigstore
+        ProxyPass /extensions/v2 http://localhost:5352/registry
+        ProxyPassReverse /extensions/v2 http://localhost:5352/registry
 </VirtualHost>

--- a/src/backend/BSConfig.pm.template
+++ b/src/backend/BSConfig.pm.template
@@ -284,6 +284,10 @@ our $publish_containers = [
    '.*'             => ['local'],
 ];
 
+# enable this to announce the X-Registry-Supports-Signatures extension
+# (this needs a proxy entry for /extensions/v2 in the web server config)
+our $local_registry_signatures_extension = 1;
+
 
 # special options to use for starting containers in run-service-containerized
 # our $docker_custom_opt = [];

--- a/src/backend/BSConfiguration.pm
+++ b/src/backend/BSConfiguration.pm
@@ -93,5 +93,6 @@ $BSConfig::service_timeout          = $BSConfig::service_timeout          || 360
 $BSConfig::cloudupload_pubkey       = $BSConfig::cloudupload_pubkey       || '/etc/obs/cloudupload/_pubkey';
 
 $BSConfig::redisserver = undef unless $BSConfig::redisserver;
+$BSConfig::local_registry_signatures_extension = undef unless $BSConfig::local_registry_signatures_extension;
 
 1;

--- a/src/backend/BSSrcServer/Registry.pm
+++ b/src/backend/BSSrcServer/Registry.pm
@@ -61,6 +61,14 @@ sub catalog {
   return sort keys %$registries;
 }
 
+sub rootinfo {
+  my $registries = BSUtil::retrieve("$registrydir/:repos", 1) || {};
+  my $info = {
+    'owners' => $registries,
+  };
+  return $info;
+}
+
 sub regrepo2reposerver {
   my ($repo) = @_;
   my $registries = BSUtil::retrieve("$registrydir/:repos", 1) || {};

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -6743,6 +6743,13 @@ sub registry_catalog {
   return undef;
 }
 
+sub registry_rootinfo {
+  my ($cgi) = @_;
+  my $rootinfo = BSSrcServer::Registry::rootinfo();
+  BSRegistryServer::reply($rootinfo);
+  return undef;
+}
+
 sub registry_version {
   my ($cgi) = @_;
   my @hdrs;
@@ -6970,6 +6977,7 @@ my $dispatches = [
   'GET|HEAD:/registry/$...:regrepo/tags/list' => \&registry_forward,
   'GET|HEAD:/registry/$...:regrepo/info.json' => \&registry_forward,
   'GET|HEAD:/registry/_catalog' => \&registry_catalog,
+  'GET|HEAD:/registry/info.json' => \&registry_rootinfo,
   'GET|HEAD:/registry' => \&registry_version,
   'GET|HEAD:/sigstore/$...:regrepo/$sig:' => \&sigstore_forward,
 

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -6745,7 +6745,9 @@ sub registry_catalog {
 
 sub registry_version {
   my ($cgi) = @_;
-  BSRegistryServer::reply({}, 'X-Registry-Supports-Signatures: 1');
+  my @hdrs;
+  push @hdrs, 'X-Registry-Supports-Signatures: 1' if $BSConfig::local_registry_signatures_extension;
+  BSRegistryServer::reply({}, @hdrs);
   return undef;
 }
 


### PR DESCRIPTION
…tures extension

The extension needs an update to the registry's apache config, so
always enabling it is dangerous.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
