### PR TITLE
[backend] fix container variant handling

### DIFF
--- a/src/backend/BSPublisher/Registry.pm
+++ b/src/backend/BSPublisher/Registry.pm
@@ -488,8 +488,9 @@ sub push_containers {
       die("layer number mismatch\n") if @layers != @{$config_layers || []};
 
       # see if a already have this arch/os combination
+      my $variant = $config->{'variant'} || $containerinfo->{'govariant'};
       my $platformstr = "architecture:$config->{'architecture'} os:$config->{'os'}";
-      $platformstr .= "variant: $config->{'variant'}" if $config->{'variant'};
+      $platformstr .= " variant:$variant" if $variant;
       if ($multiplatforms{$platformstr}) {
 	print "ignoring $containerinfo->{'file'}, already have $platformstr\n";
 	close $tarfd if $tarfd;
@@ -546,7 +547,7 @@ sub push_containers {
 	'digest' => $mani_id,
 	'platform' => {'architecture' => $config->{'architecture'}, 'os' => $config->{'os'}},
       };
-      $multimani->{'platform'}->{'variant'} = $config->{'variant'} if $config->{'variant'};
+      $multimani->{'platform'}->{'variant'} = $variant if $variant;
       push @multimanifests, $multimani;
 
       my $imginfo = {
@@ -555,7 +556,7 @@ sub push_containers {
         'goos' => $config->{'os'},
 	'distmanifest' => $mani_id,
       };
-      $imginfo->{'govariant'} = $containerinfo->{'govariant'} if $containerinfo->{'govariant'};
+      $imginfo->{'govariant'} = $variant if $variant;
       $imginfo->{'package'} = $containerinfo->{'_origin'} if $containerinfo->{'_origin'};
       $imginfo->{'disturl'} = $containerinfo->{'disturl'} if $containerinfo->{'disturl'};
       $imginfo->{'buildtime'} = $containerinfo->{'buildtime'} if $containerinfo->{'buildtime'};

--- a/src/backend/bs_regpush
+++ b/src/backend/bs_regpush
@@ -361,11 +361,9 @@ sub tags_from_digestfile {
 }
 
 sub construct_container_tar {
-  my ($containerinfofile) = @_; 
+  my ($containerinfo) = @_; 
 
   die("Must specify a blobdir for containerinfos\n") unless $blobdir;
-  my $containerinfo_json = readstr($containerinfofile);
-  my $containerinfo = JSON::XS::decode_json($containerinfo_json);
   my $manifest = $containerinfo->{'tar_manifest'};
   my $mtime = $containerinfo->{'tar_mtime'};
   my $blobids = $containerinfo->{'tar_blobids'};
@@ -383,15 +381,18 @@ sub construct_container_tar {
 sub open_tarfile {
   my ($tarfile) = @_;
 
-  my ($tar, $tarfd);
+  my ($tar, $tarfd, $variant);
   if ($tarfile =~ /\.containerinfo$/) {
-    $tar = construct_container_tar($tarfile);
+    my $containerinfo_json = readstr($tarfile);
+    my $containerinfo = JSON::XS::decode_json($containerinfo_json);
+    $variant = $containerinfo->{'govariant'};
+    $tar = construct_container_tar($containerinfo);
   } else {
     open($tarfd, '<', $tarfile) || die("$tarfile: $!\n");
     $tar = BSTar::list($tarfd);
     $_->{'file'} = $tarfd for @$tar;
   }
-  return ($tar, $tarfd);
+  return ($tar, $tarfd, $variant);
 }
 
 sub die_with_usage {
@@ -530,7 +531,7 @@ if ($use_image_tags && @tarfiles > 1) {
 my @multimanifests;
 my %multiplatforms;
 for my $tarfile (@tarfiles) {
-  my ($tar, $tarfd) = open_tarfile($tarfile);
+  my ($tar, $tarfd, $variant) = open_tarfile($tarfile);
   my %tar = map {$_->{'name'} => $_} @$tar;
 
   my ($manifest_ent, $manifest) = BSContar::get_manifest(\%tar);
@@ -550,10 +551,11 @@ for my $tarfile (@tarfiles) {
   my $config_layers = $config->{'rootfs'}->{'diff_ids'};
   die("layer number mismatch\n") if @layers != @{$config_layers || []};
 
+  $variant = $config->{'variant'} if $config->{'variant'};
   if ($multiarch) {
     # see if a already have this arch/os combination
     my $platformstr = "architecture:$config->{'architecture'} os:$config->{'os'}";
-    $platformstr .= " variant:$config->{'variant'}" if $config->{'variant'};
+    $platformstr .= " variant:$variant" if $variant;
     if ($multiplatforms{$platformstr}) {
       print "ignoring $tarfile, already have $platformstr\n";
       close $tarfd if $tarfd;
@@ -627,7 +629,7 @@ for my $tarfile (@tarfiles) {
       'digest' => 'sha256:'.Digest::SHA::sha256_hex($mani_json),
       'platform' => {'architecture' => $config->{'architecture'}, 'os' => $config->{'os'}},
     };
-    $multimani->{'platform'}->{'variant'} = $config->{'variant'} if $config->{'variant'};
+    $multimani->{'platform'}->{'variant'} = $variant if $variant;
     push @multimanifests, $multimani;
   } else {
     manifest_upload_tags($mani_json, \@tags);


### PR DESCRIPTION
The variant is not in the image config, but only in the containerinfo
data.


<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
