### PR TITLE
[backend]pass --ccache param if usecache:packid is present as buildflag

### DIFF
--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -3097,6 +3097,7 @@ sub dobuild {
   my $config = BSRPC::rpc("$server/getconfig", undef, "project=$projid", "repository=$repoid", @configpath);
   writestr("$buildroot/.build.config", undef, $config);
 
+  my $bconf;
   if ($deltamode) {
     # replace @mopt@ in specfile
     my $spec = readstr("$srcdir/deltagen.spec");
@@ -3105,7 +3106,7 @@ sub dobuild {
       $mopt = $BSConfig::deltagen_mopt if defined $BSConfig::deltagen_mopt;
       importbuild() unless defined &Build::queryhdrmd5;
       eval {
-	my $bconf = Build::read_config($buildinfo->{'arch'}, [ split("\n", $config) ]);
+	$bconf = Build::read_config($buildinfo->{'arch'}, [ split("\n", $config) ]);
 	for (@{$bconf->{'repotype'}}) {
 	  $mopt = $1 eq '' ? undef : $1 if /^deltagen-mopt:(\d*)/;
 	}
@@ -3116,6 +3117,15 @@ sub dobuild {
       writestr("$srcdir/deltagen.spec", undef, $spec);
     }
   }
+  $bconf = $bconf || Build::read_config($buildinfo->{'arch'}, "$buildroot/.build.config");
+
+  my $useccache;
+  if (exists $bconf->{'buildflags:useccache'}) {
+      if (grep /^useccache:\Q$packid\E$/, @{$bconf->{'buildflags'} || []}) {
+        $useccache = 1;
+    }
+  }
+
 
   my $release = $buildinfo->{'release'};
   #FIXME2.6: drop the following line
@@ -3219,6 +3229,7 @@ sub dobuild {
   push @args, '--debug' if $buildinfo->{'debuginfo'};
   push @args, '--arch', $arch;
   push @args, '--jobs', $jobs if $jobs;
+  push @args, '--ccache' if $useccache && $oldpkgdir;
   push @args, '--threads', $threads if $threads;
   push @args, '--reason', "Building $packid for project '$projid' repository '$repoid' arch '$arch' srcmd5 '$buildinfo->{'srcmd5'}'";
   push @args, '--disturl', $disturl;


### PR DESCRIPTION
this buildflag is to be manually added in project config as

BuildFlags: useccache:package-name

along with this ccache has be included as BuildRequires in the spec file
for ccache to be installable.

If buildflag is added but ccache is not present it will result in error

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
