### PR TITLE
Notifications data migration

### DIFF
--- a/src/api/db/data/20200326170855_remove_obsolete_notifications.rb
+++ b/src/api/db/data/20200326170855_remove_obsolete_notifications.rb
@@ -1,0 +1,37 @@
+#  After some changes in Notification's database structure, some data needs to
+#  be updated. But, instead of fixing the existing Notifications, we are going
+#  to delete the affected ones and regenerate them with the correct values.
+#
+#  This data migration only performs the deletion as first step:
+#
+#  - Remove notifications without notifiable element. This includes
+#    CommentForPackage and CommentForProject.
+#  - Remove notifications with event_type values ReviewWanted, RequestCreate,
+#    RequestStatechange or CommentForRequest.
+
+class RemoveObsoleteNotifications < ActiveRecord::Migration[5.2]
+  EVENTS_WITHOUT_NOTIFIABLE_TO_BE_REMOVED = [
+    'Event::CommentForProject',
+    'Event::CommentForPackage'
+  ].freeze
+
+  EVENTS_TO_BE_REMOVED = [
+    'Event::ReviewWanted',
+    'Event::RequestCreate',
+    'Event::RequestStatechange',
+    'Event::CommentForRequest'
+  ].freeze
+
+  def up
+    delete_obsolete_notifications
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  def delete_obsolete_notifications
+    Notification.where(notifiable_type: nil, notifiable_id: nil, event_type: EVENTS_WITHOUT_NOTIFIABLE_TO_BE_REMOVED).delete_all
+    Notification.where(event_type: EVENTS_TO_BE_REMOVED).delete_all
+  end
+end

--- a/src/api/db/data/20200326221616_regenerate_notifications.rb
+++ b/src/api/db/data/20200326221616_regenerate_notifications.rb
@@ -1,0 +1,99 @@
+#  After some changes in Notification's database structure, some data needs to
+#  be updated. But, instead of fixing the existing Notifications, we are going
+#  to delete the affected ones and regenerate them with the correct values.
+#
+#  The deletion is made in a previous data migration. This one re-generates the
+#  notifications.
+#
+#  Steps:
+
+#  - Take all the existing BsRequests in state 'new' and create a RequestCreate
+#    Notification for each of them.
+#  - Take the BsRequests in state 'declined' that where created in the last 100 days and
+#    create a RequesStatechange Notification for each of them.
+#  - Take all the existing BsRequests in state 'review' with reviews in state 'new' and
+#    create a ReviewWanted Notification for each of the reviews.
+#  - Take the BsRequests created in the last 2 weeks and create a CommentForRequest
+#    Notification for each comment on each BsRequest.
+
+class RegenerateNotifications < ActiveRecord::Migration[5.2]
+  def up
+    create_request_create_notifications
+    create_request_statechange_notifications
+    create_review_wanted_notifications
+    create_comment_for_request_notifications
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  # RequestCreated Notifications
+
+  def create_request_create_notifications
+    new_requests = BsRequest.in_states(:new)
+
+    new_requests.each do |request|
+      event = Event::RequestCreate.new(request.event_parameters)
+      NotificationCreator.new(event).call
+    end
+  end
+
+  # RequestStatechange Notifications
+
+  def create_request_statechange_notifications
+    declined_requests = BsRequest.in_states(:declined).where('created_at >= ?', 100.days.ago.midnight)
+
+    declined_requests.each do |request|
+      event = Event::RequestStatechange.new(request.event_parameters)
+      event.payload['oldstate'] = request_old_state(request)
+      NotificationCreator.new(event).call
+    end
+  end
+
+  def request_old_state(request)
+    # Check history elements to guess the previous state
+    # assuming the last one is always HistoryElement::RequestDeclined
+    previous_history_element, last_history_element = request.history_elements.last(2)
+
+    case previous_history_element.try(:type)
+    when nil, 'HistoryElement::RequestAllReviewsApproved'
+      'new'
+    when 'HistoryElement::RequestReviewAdded', 'HistoryElement::ReviewDeclined'
+      'review'
+    when 'HistoryElement::RequestDeclined'
+      'declined'
+    when 'HistoryElement::RequestReopened'
+      return 'review' if request.reviews.find_by(state: :new).present?
+      'new' # when no reviews or all of them were accepted
+    when 'HistoryElement::ReviewAccepted'
+      return 'declined' if last_history_element.description == 'Declined via staging workflow.'
+      'review'
+    else # less accurate result for any other case that was overlooked
+      'review'
+    end
+  end
+
+  # ReviewWanted Notifications
+
+  def create_review_wanted_notifications
+    new_reviews = Review.where(state: 'new').joins(:bs_request).where('bs_requests.state = ?', 'review')
+
+    new_reviews.each do |review|
+      params = review.event_parameters(review.bs_request.event_parameters)
+      event = Event::ReviewWanted.new(params)
+      NotificationCreator.new(event).call
+    end
+  end
+
+  # CommentForRequest Notifications
+
+  def create_comment_for_request_notifications
+    recent_request_comments = Comment.where('commentable_type = ? AND created_at >= ?', 'BsRequest', 2.weeks.ago.midnight)
+
+    recent_request_comments.each do |comment|
+      event = Event::CommentForRequest.new(comment.event_parameters)
+      NotificationCreator.new(event).call
+    end
+  end
+end

--- a/src/api/spec/db/data/regenerate_notifications_spec.rb
+++ b/src/api/spec/db/data/regenerate_notifications_spec.rb
@@ -1,0 +1,195 @@
+require 'rails_helper'
+require Rails.root.join('db/data/20200326221616_regenerate_notifications.rb')
+
+RSpec.describe RegenerateNotifications, type: :migration do
+  describe 'up' do
+    let(:owner) { create(:confirmed_user, login: 'bob') }
+    let(:requester) { create(:confirmed_user, login: 'ann') }
+    let(:project) { create(:project, name: 'bob_project', maintainer: [owner]) }
+    let(:package) { create(:package, name: 'bob_package', project: project) }
+    let(:another_package) { create(:package) }
+
+    let!(:new_bs_request) do
+      create(:bs_request_with_submit_action,
+             state: :new,
+             creator: requester,
+             target_project: project,
+             target_package: package,
+             source_package: another_package)
+    end
+    let!(:declined_bs_request) do
+      bs_request_to_decline =
+        create(:bs_request_with_submit_action,
+               state: :new,
+               creator: requester,
+               target_project: project,
+               target_package: package,
+               source_package: another_package,
+               created_at: 3.days.ago,
+               updated_at: 2.days.ago)
+      bs_request_to_decline.update_attributes(state: 'declined')
+      bs_request_to_decline
+    end
+    let!(:old_declined_bs_request) do
+      bs_request_to_decline =
+        create(:bs_request_with_submit_action,
+               state: :new,
+               creator: requester,
+               target_project: project,
+               target_package: package,
+               source_package: another_package,
+               created_at: 101.days.ago)
+      bs_request_to_decline.update_attributes(state: 'declined')
+      bs_request_to_decline
+    end
+    let!(:revoked_bs_request) { create(:bs_request, type: 'maintenance_release', state: :revoked) } # This shouldn't regenerate notification
+
+    subject { RegenerateNotifications.new.up }
+
+    context 'for RequestCreate Notifications' do
+      let!(:subscription) { create(:event_subscription_request_created, receiver_role: 'target_maintainer', user: owner) }
+
+      before do
+        subject
+      end
+
+      it 'creates a RequestCreate Notification' do
+        expect(Notification.where(event_type: 'Event::RequestCreate').count).to eq(1)
+        notification = Notification.find_by(event_type: 'Event::RequestCreate')
+
+        # Checks the Notification's attributes have correct values:
+        expect(notification.event_payload['number']).to eq(new_bs_request.number)
+        expect(notification.notifiable).to eq(new_bs_request)
+        # Timestamps compared with .to_s because they have different precision and the values differ slightly.
+        expect(notification.created_at.to_s).to eq(new_bs_request.updated_when.to_s)
+        expect(notification.updated_at.to_s).to eq(new_bs_request.updated_when.to_s)
+        expect(notification.title).to eq("Request #{new_bs_request.number} created by #{requester} (submit #{project}/#{package})")
+      end
+    end
+
+    context 'for RequesStatechange Notifications' do
+      let!(:subscription) { create(:event_subscription_request_statechange, receiver_role: 'target_maintainer', user: owner) }
+
+      before do
+        subject
+      end
+
+      it 'creates a RequestStatechange Notification' do
+        expect(Notification.where(event_type: 'Event::RequestStatechange').count).to eq(1)
+        notification = Notification.find_by(event_type: 'Event::RequestStatechange')
+
+        # Checks the Notification's attributes have correct values:
+        expect(notification.event_payload['number']).to eq(declined_bs_request.number)
+        expect(notification.notifiable).to eq(declined_bs_request)
+        expect(notification.title).to eq("Request #{declined_bs_request.number} changed to declined (submit #{project}/#{package})")
+        expect(notification.created_at.to_s).to eq(declined_bs_request.updated_when.to_s)
+        expect(notification.updated_at.to_s).to eq(declined_bs_request.updated_when.to_s)
+        expect(notification.bs_request_oldstate).to eq('new')
+      end
+    end
+
+    context 'for ReviewWanted Notifications' do
+      let!(:review_request) do # The type, submit, shouldn't matter
+        create(:bs_request_with_submit_action,
+               state: :review,
+               creator: requester,
+               target_project: project,
+               target_package: package,
+               source_package: another_package,
+               updated_at: 15.days.ago)
+      end
+      let!(:accepted_review) { create(:review, bs_request: review_request, by_user: owner, state: :accepted) }
+
+      context 'with review by user' do
+        let!(:subscription) { create(:event_subscription_review_wanted, receiver_role: 'reviewer', user: owner) }
+        let!(:review) { create(:review, bs_request: review_request, by_user: owner, state: :new, updated_at: 10.days.ago) }
+
+        before do
+          subject
+        end
+
+        it 'creates a ReviewWanted Notification' do
+          expect(Notification.where(event_type: 'Event::ReviewWanted').count).to eq(1)
+          notification = Notification.find_by(event_type: 'Event::ReviewWanted')
+
+          # Checks the Notification's attributes have correct values:
+          expect(notification.event_payload['number']).to eq(review_request.number)
+          expect(notification.notifiable).to eq(review)
+          expect(notification.created_at.to_s).to eq(review.updated_at.to_s)
+          expect(notification.updated_at.to_s).to eq(review.updated_at.to_s)
+          expect(notification.title).to eq("Request #{review_request.number} requires review (submit #{project}/#{package})")
+        end
+      end
+
+      context 'with review by project and by package' do
+        let(:reviewer_1) { create(:confirmed_user, login: 'reviewer_1') }
+        let(:package_2) { create(:package, name: 'package_2') }
+        let!(:relationship) { create(:relationship_package_user, user: reviewer_1, package: package_2) }
+        let!(:subscription) { create(:event_subscription_review_wanted, receiver_role: 'reviewer', user: reviewer_1) }
+        let!(:review_by_package) { create(:review, bs_request: review_request, by_project: package_2.project, by_package: package_2, state: :new) }
+
+        before do
+          subject
+        end
+
+        it 'creates a ReviewWanted Notification' do
+          expect(Notification.where(event_type: 'Event::ReviewWanted').count).to eq(1)
+          notification = Notification.find_by(event_type: 'Event::ReviewWanted')
+
+          # Checks the Notification's attributes have correct values:
+          expect(notification.event_payload['number']).to eq(review_request.number)
+          expect(notification.notifiable).to eq(review_by_package)
+          expect(notification.title).to eq("Request #{review_request.number} requires review (submit #{project}/#{package})")
+        end
+      end
+    end
+
+    context 'for CommentForRequest Notifications' do
+      let!(:subscription) { create(:event_subscription_comment_for_request, receiver_role: 'target_maintainer', user: owner) }
+      let!(:old_comment_for_request) { create(:comment_request, commentable: new_bs_request, user: requester, created_at: 4.weeks.ago) }
+      let!(:comment_for_request) { create(:comment_request, commentable: new_bs_request, user: requester, updated_at: 1.week.ago) }
+      let!(:comment_for_project) { create(:comment_project, commentable: project, user: requester) } # Shouldn't regenerate notification
+      let!(:comment_for_package) { create(:comment_package, commentable: package, user: requester) } # Shouldn't regenerate notification
+
+      before do
+        subject
+      end
+
+      it 'creates a CommentForRequest Notification' do
+        expect(Notification.where(notifiable_type: 'Comment').count).to eq(1)
+        notification = Notification.find_by(notifiable_type: 'Comment')
+
+        # Checks the Notification's attributes have correct values:
+        expect(notification.event_type).to eq('Event::CommentForRequest')
+        expect(notification.event_payload['number']).to eq(new_bs_request.number)
+        expect(notification.notifiable).to eq(comment_for_request)
+        expect(notification.created_at.to_s).to eq(comment_for_request.updated_at.to_s)
+        expect(notification.updated_at.to_s).to eq(comment_for_request.updated_at.to_s)
+        expect(notification.title).to eq("Request #{new_bs_request.number} commented by #{requester} (submit #{project}/#{package})")
+      end
+    end
+
+    context 'when running the job after running the data migration' do
+      let!(:subscription) { create(:event_subscription_comment_for_request, receiver_role: 'target_maintainer', user: owner) }
+      let!(:comment_for_request) { create(:comment_request, commentable: new_bs_request, user: requester, body: 'bla') }
+      let(:events) { Event::Base.where(eventtype: 'Event::CommentForRequest') }
+      let(:comment_notifications) { Notification.where(notifiable_type: 'Comment') }
+
+      before do
+        subject
+      end
+
+      it 'creates only one CommentForRequest Notification' do
+        expect(comment_notifications.count).to eq(1)
+        expect(events.count).to eq(1)
+        expect(events.last.mails_sent).to be_falsey
+
+        # we run this to ensure the job doesn't duplicate notifications
+        SendEventEmailsJob.new.perform
+        expect(events.last.mails_sent).to be_truthy
+        expect(comment_notifications.count).to eq(1)
+        expect(events.last.payload['id']).to eq(comment_notifications.last.notifiable_id)
+      end
+    end
+  end
+end

--- a/src/api/spec/db/data/remove_obsolete_notifications_spec.rb
+++ b/src/api/spec/db/data/remove_obsolete_notifications_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+require Rails.root.join('db/data/20200326170855_remove_obsolete_notifications.rb')
+
+RSpec.describe RemoveObsoleteNotifications, type: :migration do
+  describe 'up' do
+    # 'Event::RequestCreate'
+    let!(:request_create_with_notifiable) { create(:notification, :request_created) }
+    let!(:request_create_without_notifiable) { create(:notification, :request_created, notifiable: nil) }
+    # 'Event::RequestStatechange'
+    let!(:request_state_change_with_notifiable) { create(:notification, :request_state_change) }
+    let!(:request_state_change_without_notifiable) { create(:notification, :request_state_change, notifiable: nil) }
+    # 'Event::ReviewWanted'
+    let!(:review_wanted_with_notifiable) { create(:notification, :review_wanted) }
+    let!(:review_wanted_without_notifiable) { create(:notification, :review_wanted, notifiable: nil) }
+    # 'Event::CommentForRequest'
+    let!(:comment_for_request_with_notifiable) { create(:notification, :comment_for_request) }
+    let!(:comment_for_request_without_notifiable) { create(:notification, :comment_for_request, notifiable: nil) }
+    # 'Event::CommentForProject'
+    let!(:comment_for_project_with_notifiable) { create(:notification, :comment_for_project) }
+    let!(:comment_for_project_without_notifiable) { create(:notification, :comment_for_project, notifiable: nil) }
+    # 'Event::CommentForPackage'
+    let!(:comment_for_package_with_notifiable) { create(:notification, :comment_for_package) }
+    let!(:comment_for_package_without_notifiable) { create(:notification, :comment_for_package, notifiable: nil) }
+
+    before do
+      RemoveObsoleteNotifications.new.up
+    end
+
+    it 'deletes all the notifications without notifiable' do
+      expect(Notification.without_notifiable.count).to be_zero
+    end
+
+    it 'deletes all the notifications except CommentForProject and CommentForPackage' do
+      expect(Notification.all.count).to eq(2)
+      expect(Notification.all.pluck(:event_type)).to contain_exactly('Event::CommentForProject', 'Event::CommentForPackage')
+    end
+  end
+end

--- a/src/api/spec/factories/event_subscriptions.rb
+++ b/src/api/spec/factories/event_subscriptions.rb
@@ -13,9 +13,37 @@ FactoryBot.define do
       channel { :instant_email }
     end
 
+    factory :event_subscription_comment_for_package do
+      eventtype { 'Event::CommentForPackage' }
+      receiver_role { 'commenter' }
+      channel { :instant_email }
+      user
+    end
+
+    factory :event_subscription_comment_for_request do
+      eventtype { 'Event::CommentForRequest' }
+      receiver_role { 'commenter' }
+      channel { :instant_email }
+      user
+    end
+
     factory :event_subscription_request_created do
       eventtype { 'Event::RequestCreate' }
       receiver_role { 'target_maintainer' }
+      channel { :instant_email }
+      user
+    end
+
+    factory :event_subscription_request_statechange do
+      eventtype { 'Event::RequestStatechange' }
+      receiver_role { 'target_maintainer' }
+      channel { :instant_email }
+      user
+    end
+
+    factory :event_subscription_review_wanted do
+      eventtype { 'Event::ReviewWanted' }
+      receiver_role { 'reviewer' }
       channel { :instant_email }
       user
     end


### PR DESCRIPTION
After some refactoring made on the Notifications code and database structure, some data had inconsistent values.

Therefore, we have added data migrations to remove the affected notifications and re-generate them based on the objects existing in the database. For example, if we find in the database a request with state new, we are adding a notification to announce its creation even if it was created some weeks ago.

The data migrations affects notifications related to: RequestCreate, ReviewStatechange, ReviewWanted and CommentForProject.

The migration for removal and re-generation are in different files and has independent tests. It's been made like this to simplify understanding and testing.

This is a follow-on #9307. Which includes some refactoring needed to be able to create notifications from the data migration file.

Co-authored-by: Eduardo Navarro <enavarro@suse.com>
Co-authored-by: David Kang <dkang@suse.com>
