### PR TITLE
Link to Tasks in the Places menu

### DIFF
--- a/src/api/app/views/layouts/webui/responsive_ux/_bottom_navigation.html.haml
+++ b/src/api/app/views/layouts/webui/responsive_ux/_bottom_navigation.html.haml
@@ -7,9 +7,9 @@
           %i.fas.fa-bookmark
           .small Watchlist
       %li.nav-item.border-left.border-gray-500
-        = link_to(user_notifications_path(User.session), class: 'nav-link px-1 py-2 text-light', alt: 'Tasks') do
-          %i.fas.fa-tasks
-          .small Tasks
+        = link_to(user_notifications_path(User.session), class: 'nav-link px-1 py-2 text-light', alt: 'Notifications') do
+          %i.fas.fa-bell
+          .small Notifications
       - if content_for?(:actions)
         %li.nav-item.border-left.border-gray-500
           = link_to('javascript:void(0)', class: 'nav-link px-1 py-2 text-light', alt: 'Actions', data: { toggle: 'actions' }) do

--- a/src/api/app/views/layouts/webui/responsive_ux/_navigation.html.haml
+++ b/src/api/app/views/layouts/webui/responsive_ux/_navigation.html.haml
@@ -10,9 +10,9 @@
             %i.fas.fa-bookmark
             .small Watchlist
         .toggler.text-center.justify-content-center
-          = link_to(user_notifications_path(User.session), class: 'nav-link text-light p-0 w-100', alt: 'Tasks') do
-            %i.fas.fa-tasks
-            .small Tasks
+          = link_to(user_notifications_path(User.session), class: 'nav-link text-light p-0 w-100', alt: 'Notifications') do
+            %i.fas.fa-bell
+            .small Notifications
         - if content_for?(:actions)
           .toggler.text-center.justify-content-center
             = link_to('javascript:void(0)', class: 'nav-link text-light p-0 w-100', alt: 'Actions', data: { toggle: 'actions' }) do

--- a/src/api/app/views/layouts/webui/responsive_ux/_user_navigation.html.haml
+++ b/src/api/app/views/layouts/webui/responsive_ux/_user_navigation.html.haml
@@ -9,6 +9,10 @@
         = image_tag_for(User.session, size: 23, custom_class: 'rounded-circle bg-light mr-2')
         Profile
     %li.nav-item
+      = link_to(my_tasks_path, class: 'nav-link', alt: 'Tasks') do
+        %i.fas.fa-tasks.fa-lg.mr-2
+        Tasks
+    %li.nav-item
       - if User.session!.home_project
         = link_to(project_show_path(User.session!.home_project), class: 'nav-link') do
           %i.fas.fa-cubes.fa-lg.mr-2

--- a/src/api/app/views/webui/users/notifications/index.html.haml
+++ b/src/api/app/views/webui/users/notifications/index.html.haml
@@ -10,7 +10,6 @@
         .row.list-group-flush
           = user_notification_link('Inbox', 'inbox', filter: params[:type])
           = user_notification_link('Done', 'done', filter: params[:type])
-          = user_notification_link('All Requests', 'all-requests', filter: params[:type])
         .row.list-group-flush.mt-5
           %h5.ml-3 Filter
           = user_notification_link('Reviews', 'reviews', filter: params[:type])
@@ -20,21 +19,17 @@
   .col-md-8.col-lg-9#notifications-list
     .card
       .card-body
-        - if params[:type] == 'all-requests'
-          = render(partial: 'webui/shared/requests_table', locals: { id: 'all_requests_table', source_url: user_requests_path(User.session!),
-                    page_length: 10 })
-        - else
-          .list-group.list-group-flush
-            - @notifications.each do |n|
-              - notification = NotificationPresenter.new(n)
-              .list-group-item.d-flex.flex-column.flex-sm-row.justify-content-sm-between
-                .content
-                  .text-nowrap
-                    %span.badge.badge-secondary= notification.notification_badge
-                    %small.text-muted= time_ago_in_words(notification.created_at)
-                  = link_to(n.title, notification.link_to_notification_target, class: 'text-word-break-all')
-                - unless params[:type] == 'done'
-                  .actions.align-self-end.align-self-sm-start.pl-3.pt-3.pt-sm-0
-                    = link_to(user_notification_path(user_login: User.session, id: notification),
-                                      method: :put, class: 'btn btn-sm btn-outline-success px-4', title: 'Done') do
-                      %i.fas.fa-check
+        .list-group.list-group-flush
+          - @notifications.each do |n|
+            - notification = NotificationPresenter.new(n)
+            .list-group-item.d-flex.flex-column.flex-sm-row.justify-content-sm-between
+              .content
+                .text-nowrap
+                  %span.badge.badge-secondary= notification.notification_badge
+                  %small.text-muted= time_ago_in_words(notification.created_at)
+                = link_to(n.title, notification.link_to_notification_target, class: 'text-word-break-all')
+              - unless params[:type] == 'done'
+                .actions.align-self-end.align-self-sm-start.pl-3.pt-3.pt-sm-0
+                  = link_to(user_notification_path(user_login: User.session, id: notification),
+                                    method: :put, class: 'btn btn-sm btn-outline-success px-4', title: 'Done') do
+                    %i.fas.fa-check


### PR DESCRIPTION
This implies removing the `All Requests` workaround we had in the `Notifications` page. The link to the `Notifications` page in the top-level navigation is now correctly named.

The changes on desktop and mobile:
![desktop](https://user-images.githubusercontent.com/1102934/78802563-4402c200-79be-11ea-836f-48d634a78219.png)
![mobile](https://user-images.githubusercontent.com/1102934/78802560-436a2b80-79be-11ea-975a-b805df2c6208.png)