### PR TITLE
Add descendent order in notification

### DIFF
--- a/src/api/app/models/notification.rb
+++ b/src/api/app/models/notification.rb
@@ -10,6 +10,7 @@ class Notification < ApplicationRecord
           user, user.groups.map(&:id))
   }
   scope :not_marked_as_done, -> { where(delivered: false) }
+  default_scope -> { order(created_at: :desc) }
 
   serialize :event_payload, JSON
 


### PR DESCRIPTION
We always want to see the most recent notifications.