### PR TITLE
Notifications routes

### DIFF
--- a/src/api/app/controllers/webui/users/notifications_controller.rb
+++ b/src/api/app/controllers/webui/users/notifications_controller.rb
@@ -1,6 +1,5 @@
 class Webui::Users::NotificationsController < Webui::WebuiController
   before_action :require_login
-  before_action :my_page?, except: [:update]
 
   def index
     notification_type = params[:type]
@@ -28,7 +27,7 @@ class Webui::Users::NotificationsController < Webui::WebuiController
   end
 
   def update
-    notification = Notification.find(params[:id])
+    notification = User.session.notifications.find(params[:id])
     authorize notification, policy_class: NotificationPolicy
 
     if notification.update(delivered: true)
@@ -37,13 +36,5 @@ class Webui::Users::NotificationsController < Webui::WebuiController
       flash[:error] = "Couldn't mark the notification as done"
     end
     redirect_back(fallback_location: root_path)
-  end
-
-  private
-
-  def my_page?
-    return true if params[:user_login] == User.session.login
-    flash[:error] = "You are not authorized to access the notifications of #{params[:user_login]}"
-    redirect_to(root_path)
   end
 end

--- a/src/api/app/controllers/webui/users/rss_tokens_controller.rb
+++ b/src/api/app/controllers/webui/users/rss_tokens_controller.rb
@@ -13,7 +13,7 @@ module Webui
           flash[:success] = 'Successfully generated your RSS feed url'
           User.session!.create_rss_token
         end
-        redirect_back(fallback_location: my_notifications_path)
+        redirect_back(fallback_location: my_subscriptions_path)
       end
     end
   end

--- a/src/api/app/helpers/webui/webui_helper.rb
+++ b/src/api/app/helpers/webui/webui_helper.rb
@@ -405,7 +405,7 @@ module Webui::WebuiHelper
   def user_notification_link(link_text, new_filter, filter: 'inbox')
     css_class = 'list-group-item list-group-item-action'
     css_class += ' active' if new_filter == filter || (filter.nil? && new_filter == 'inbox')
-    link_to(link_text, user_notifications_path(type: new_filter), class: css_class)
+    link_to(link_text, my_notifications_path(type: new_filter), class: css_class)
   end
 end
 

--- a/src/api/app/views/layouts/webui/responsive_ux/_bottom_navigation.html.haml
+++ b/src/api/app/views/layouts/webui/responsive_ux/_bottom_navigation.html.haml
@@ -7,7 +7,7 @@
           %i.fas.fa-bookmark
           .small Watchlist
       %li.nav-item.border-left.border-gray-500
-        = link_to(user_notifications_path(User.session), class: 'nav-link px-1 py-2 text-light', alt: 'Notifications') do
+        = link_to(my_notifications_path, class: 'nav-link px-1 py-2 text-light', alt: 'Notifications') do
           %i.fas.fa-bell
           .small Notifications
       - if content_for?(:actions)

--- a/src/api/app/views/layouts/webui/responsive_ux/_navigation.html.haml
+++ b/src/api/app/views/layouts/webui/responsive_ux/_navigation.html.haml
@@ -10,7 +10,7 @@
             %i.fas.fa-bookmark
             .small Watchlist
         .toggler.text-center.justify-content-center
-          = link_to(user_notifications_path(User.session), class: 'nav-link text-light p-0 w-100', alt: 'Notifications') do
+          = link_to(my_notifications_path, class: 'nav-link text-light p-0 w-100', alt: 'Notifications') do
             %i.fas.fa-bell
             .small Notifications
         - if content_for?(:actions)

--- a/src/api/app/views/webui/user/_info.html.haml
+++ b/src/api/app/views/webui/user/_info.html.haml
@@ -50,7 +50,7 @@
           = link_to('#', data: { toggle: 'modal', target: '#password-modal' }, class: 'd-block') do
             %i.fas.fa-key
             Change your password
-        = link_to(my_notifications_path, class: 'd-block') do
+        = link_to(my_subscriptions_path, class: 'd-block') do
           %i.fas.fa-bell
           Change your notifications
         - if user.rss_token

--- a/src/api/app/views/webui/users/subscriptions/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui/users/subscriptions/_breadcrumb_items.html.haml
@@ -1,4 +1,4 @@
 = render partial: 'webui/main/breadcrumb_items'
-- if current_page?(my_notifications_path)
+- if current_page?(my_subscriptions_path)
   %li.breadcrumb-item.active{ 'aria-current' => 'page' }
     Notifications

--- a/src/api/app/views/webui/users/subscriptions/index.html.haml
+++ b/src/api/app/views/webui/users/subscriptions/index.html.haml
@@ -11,14 +11,14 @@
         - @groups_users.each do |group_user|
           .custom-control.custom-checkbox.custom-control-inline
             = check_box_tag group_user.group, '1', group_user.email, class: 'custom-control-input', id: "checkbox-#{group_user.group}",
-              data: { url: my_notifications_path, method: :put, remote: true }
+              data: { url: my_subscriptions_path, method: :put, remote: true }
             = label_tag group_user.group.title, nil, class: 'custom-control-label', for: "checkbox-#{group_user.group}"
             %i.fas.fa-spinner.invisible
   .card-body
     %h4.card-title Events
     %p Choose from which events you want to get an email
     #subscriptions-form
-      = render partial: 'webui/subscriptions/subscriptions_form', locals: { path: my_notifications_path, subscriptions_form: @subscriptions_form }
+      = render partial: 'webui/subscriptions/subscriptions_form', locals: { path: my_subscriptions_path, subscriptions_form: @subscriptions_form }
 
 .card.mt-3
   .card-body

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -276,7 +276,6 @@ OBSApi::Application.routes.draw do
 
     resources :users, controller: 'webui/users', param: :login, constraints: cons do
       resources :requests, only: [:index], controller: 'webui/users/bs_requests'
-      resources :notifications, only: [:index, :update], controller: 'webui/users/notifications'
       collection do
         get 'autocomplete'
         get 'tokens'
@@ -288,6 +287,8 @@ OBSApi::Application.routes.draw do
 
     scope :my do
       resources :tasks, only: [:index], controller: 'webui/users/tasks', as: :my_tasks
+
+      resources :notifications, only: [:index, :update], controller: 'webui/users/notifications', as: :my_notifications
 
       resources :subscriptions, only: [:index], controller: 'webui/users/subscriptions', as: :my_subscriptions do
         collection do

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -288,8 +288,14 @@ OBSApi::Application.routes.draw do
 
     scope :my do
       resources :tasks, only: [:index], controller: 'webui/users/tasks', as: :my_tasks
-      get 'notifications' => :index,  controller: 'webui/users/subscriptions', as: :my_notifications
-      put 'notifications' => :update, controller: 'webui/users/subscriptions'
+
+      resources :subscriptions, only: [:index], controller: 'webui/users/subscriptions', as: :my_subscriptions do
+        collection do
+          put 'update'
+          get 'update'
+        end
+      end
+
       post 'rss_tokens' => :create, controller: 'webui/users/rss_tokens', as: :my_rss_token
       # To accept announcements as user
       post 'announcements/:id' => :create, controller: 'webui/users/announcements', as: :my_announcements

--- a/src/api/spec/controllers/webui/users/notifications_controller_spec.rb
+++ b/src/api/spec/controllers/webui/users/notifications_controller_spec.rb
@@ -91,15 +91,6 @@ RSpec.describe Webui::Users::NotificationsController do
         expect(assigns[:notifications]).to include(state_change_notification.reload)
       end
     end
-
-    context 'when user uses user_login param of different user in the path' do
-      let(:params) { default_params.merge(user_login: other_user.login) }
-
-      it 'flashes error and redirects to root_path' do
-        expect(flash[:error]).to eq("You are not authorized to access the notifications of #{other_user.login}")
-        expect(response).to redirect_to(root_path)
-      end
-    end
   end
 
   describe 'PUT #update' do
@@ -120,22 +111,6 @@ RSpec.describe Webui::Users::NotificationsController do
 
       it 'sets the notification as delivered' do
         expect(state_change_notification.reload.delivered).to be true
-      end
-    end
-
-    context "when the user upddates other user's notifications" do
-      let(:user_to_log_in) { other_user }
-
-      it 'redirects to the root path' do
-        expect(response).to redirect_to(root_path)
-      end
-
-      it 'flashes an error message' do
-        expect(flash[:error]).to eql('Sorry, you are not authorized to update this Notification::RssFeedItem.')
-      end
-
-      it 'does not set the notification as delivered' do
-        expect(state_change_notification.reload.delivered).to be false
       end
     end
   end

--- a/src/api/spec/controllers/webui/users/rss_tokens_controller_spec.rb
+++ b/src/api/spec/controllers/webui/users/rss_tokens_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Webui::Users::RssTokensController do
       end
 
       it { expect(flash[:success]).to eq('Successfully generated your RSS feed url') }
-      it { is_expected.to redirect_to(my_notifications_path) }
+      it { is_expected.to redirect_to(my_subscriptions_path) }
       it { expect(user.reload.rss_token.string).not_to eq(last_token) }
     end
 
@@ -28,7 +28,7 @@ RSpec.describe Webui::Users::RssTokensController do
       end
 
       it { expect(flash[:success]).to eq('Successfully generated your RSS feed url') }
-      it { is_expected.to redirect_to(my_notifications_path) }
+      it { is_expected.to redirect_to(my_subscriptions_path) }
       it { expect(user.reload.rss_token).not_to be_nil }
       it { expect(last_token).to be_nil }
     end

--- a/src/api/spec/features/webui/notifications_spec.rb
+++ b/src/api/spec/features/webui/notifications_spec.rb
@@ -35,7 +35,7 @@ RSpec.feature 'Notifications', type: :feature, js: true do
     it_behaves_like 'updatable' do
       let(:title) { 'Choose from which events you want to get an email' }
       let(:user) { create(:confirmed_user, login: 'eisendieter') }
-      let(:path) { my_notifications_path }
+      let(:path) { my_subscriptions_path }
     end
   end
 end

--- a/src/api/test/fixtures/event_mailer/another_comment_event
+++ b/src/api/test/fixtures/event_mailer/another_comment_event
@@ -35,7 +35,7 @@ Thor wrote in request 4:
 Another Body
 
 -- 
-Configure notifications at http://localhost/my/notifications
+Configure notifications at http://localhost/my/subscriptions
 Open Build Service (http://localhost/)
 
 Content-Type: text/html;
@@ -50,6 +50,6 @@ Content-Transfer-Encoding: 7bit
 </div>
 <br/>
 -- <br/>
-Configure notifications at <a href="http://localhost/my/notifications">http://localhost/my/notifications</a><br/>
+Configure notifications at <a href="http://localhost/my/subscriptions">http://localhost/my/subscriptions</a><br/>
 Open Build Service (<a href="http://localhost/">http://localhost/</a>)<br/>
 

--- a/src/api/test/fixtures/event_mailer/comment_event
+++ b/src/api/test/fixtures/event_mailer/comment_event
@@ -37,7 +37,7 @@ Thor wrote in request 4:
 Comment Body
 
 -- 
-Configure notifications at http://localhost/my/notifications
+Configure notifications at http://localhost/my/subscriptions
 Open Build Service (http://localhost/)
 
 Content-Type: text/html;
@@ -52,6 +52,6 @@ Content-Transfer-Encoding: 7bit
 </div>
 <br/>
 -- <br/>
-Configure notifications at <a href="http://localhost/my/notifications">http://localhost/my/notifications</a><br/>
+Configure notifications at <a href="http://localhost/my/subscriptions">http://localhost/my/subscriptions</a><br/>
 Open Build Service (<a href="http://localhost/">http://localhost/</a>)<br/>
 

--- a/src/api/test/fixtures/event_mailer/commit_event
+++ b/src/api/test/fixtures/event_mailer/commit_event
@@ -18,5 +18,5 @@ Check out the package for editing:
    osc checkout BaseDistro pack1
 
 -- 
-Configure notifications at http://localhost/my/notifications
+Configure notifications at http://localhost/my/subscriptions
 Open Build Service (http://localhost/)

--- a/src/api/test/fixtures/event_mailer/project_comment
+++ b/src/api/test/fixtures/event_mailer/project_comment
@@ -28,7 +28,7 @@ Thor wrote in project home:Iggy:
 Comment Body
 
 -- 
-Configure notifications at http://localhost/my/notifications
+Configure notifications at http://localhost/my/subscriptions
 Open Build Service (http://localhost/)
 
 Content-Type: text/html;
@@ -48,7 +48,7 @@ wrote in project home:Iggy:
 <br>
 --
 <br>
-Configure notifications at <a href="http://localhost/my/notifications">http://localhost/my/notifications</a>
+Configure notifications at <a href="http://localhost/my/subscriptions">http://localhost/my/subscriptions</a>
 <br>
 Open Build Service
 (<a href="http://localhost/">http://localhost/</a>)

--- a/src/api/test/fixtures/event_mailer/repo_delete_request
+++ b/src/api/test/fixtures/event_mailer/repo_delete_request
@@ -37,5 +37,5 @@ To REVOKE the request:
    osc request revoke REQUESTID --message="retracted because ..., sorry / thx / see better version ..."
 
 -- 
-Configure notifications at http://localhost/my/notifications
+Configure notifications at http://localhost/my/subscriptions
 Open Build Service (http://localhost/)

--- a/src/api/test/fixtures/event_mailer/request_event
+++ b/src/api/test/fixtures/event_mailer/request_event
@@ -37,5 +37,5 @@ To REVOKE the request:
    osc request revoke REQUESTID --message="retracted because ..., sorry / thx / see better version ..."
 
 -- 
-Configure notifications at http://localhost/my/notifications
+Configure notifications at http://localhost/my/subscriptions
 Open Build Service (http://localhost/)

--- a/src/api/test/fixtures/event_mailer/review_wanted
+++ b/src/api/test/fixtures/event_mailer/review_wanted
@@ -51,5 +51,5 @@ other changes:
 
 
 -- 
-Configure notifications at http://localhost/my/notifications
+Configure notifications at http://localhost/my/subscriptions
 Open Build Service (http://localhost/)

--- a/src/api/test/fixtures/event_mailer/set_bugowner_event
+++ b/src/api/test/fixtures/event_mailer/set_bugowner_event
@@ -37,5 +37,5 @@ To REVOKE the request:
    osc request revoke REQUESTID --message="retracted because ..., sorry / thx / see better version ..."
 
 -- 
-Configure notifications at http://localhost/my/notifications
+Configure notifications at http://localhost/my/subscriptions
 Open Build Service (http://localhost/)

--- a/src/api/test/fixtures/event_mailer/tom_declined
+++ b/src/api/test/fixtures/event_mailer/tom_declined
@@ -31,5 +31,5 @@ Actions:
 - set the bugowner of project home:tom to Iggy
 
 -- 
-Configure notifications at http://localhost/my/notifications
+Configure notifications at http://localhost/my/subscriptions
 Open Build Service (http://localhost/)

--- a/src/api/test/fixtures/event_mailer/tom_gets_mail_too
+++ b/src/api/test/fixtures/event_mailer/tom_gets_mail_too
@@ -39,5 +39,5 @@ To REVOKE the request:
    osc request revoke REQUESTID --message="retracted because ..., sorry / thx / see better version ..."
 
 -- 
-Configure notifications at http://localhost/my/notifications
+Configure notifications at http://localhost/my/subscriptions
 Open Build Service (http://localhost/)


### PR DESCRIPTION
Today we have the `SubscriptionsController` pointing to the `/my/notifications` routes and the `/users/:username/notifications` pointing to the `Users::NotificationsController` which should point to `/my/notifications` 

after this PR we are going to have the following routes:

`/my/notifications` and `/my/submissions`. One pointing to the users notifications and the other to manage the notification submissions.  