### PR TITLE
[backend] filter out ccache archive while listing package binaries

### DIFF
--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -1010,6 +1010,7 @@ sub getbinarylist {
     @bins = grep {!/^::import::/} @bins if $cgi->{'noimport'};
     @bins = BSRepServer::Containertar::add_containers(@bins) if grep {/\.containerinfo$/} @bins;
     @bins = filtersources(@bins) if $cgi->{'nosource'} || -e "$reporoot/$prp/$arch/$packid/.nosourceaccess";
+    @bins = grep {$_ ne "_ccache.tar.gz"} @bins unless $cgi->{'withccache'};
     for (sort @bins) {
       next if %binaries && !$binaries{$_};
       if (/\.tar$/ && ! -e "$reporoot/$prp/$arch/$packid/$_") {
@@ -1035,6 +1036,7 @@ sub getbinarylist {
     my @bins = grep {/\.rpm$/ && !/^\./} ls("$reporoot/$prp/$arch/$packid");
     @bins = grep {!/^::import::/} @bins if $cgi->{'noimport'};
     @bins = filtersources(@bins) if $cgi->{'nosource'} || -e "$reporoot/$prp/$arch/$packid/.nosourceaccess";
+    @bins = grep {$_ ne "_ccache.tar.gz"} @bins unless $cgi->{'withccache'};
     for my $bin (sort @bins) {
       next if %binaries && !$binaries{$_};
       my ($lead, $sighdr, $hdr, $hdrmd5);
@@ -1066,6 +1068,7 @@ sub getbinarylist {
     my @bins = grep {$_ ne 'logfile' && $_ ne 'status' && $_ ne 'reason' && $_ ne 'history' && !/^\./} ls("$reporoot/$prp/$arch/$packid");
     @bins = grep {!/^::import::/} @bins if $cgi->{'noimport'};
     @bins = filtersources(@bins) if $cgi->{'nosource'} || -e "$reporoot/$prp/$arch/$packid/.nosourceaccess";
+    @bins = grep {$_ ne "_ccache.tar.gz"} @bins unless $cgi->{'withccache'};
     for my $bin (sort @bins) {
       next if %binaries && !$binaries{$bin};
       if ($bin =~ /\.rpm$/) {
@@ -1107,6 +1110,7 @@ sub getbinarylist {
   @bins = grep {!/^::import::/} @bins if $cgi->{'noimport'};
   @bins = BSRepServer::Containertar::add_containers(@bins) if grep {/\.containerinfo$/} @bins;
   @bins = filtersources(@bins) if $cgi->{'nosource'} || -e "$reporoot/$prp/$arch/$packid/.nosourceaccess";
+  @bins = grep {$_ ne "_ccache.tar.gz"} @bins unless $cgi->{'withccache'};
   my %md5sums;
   if ($cgi->{'withmd5'}) {
     if (-s "$reporoot/$prp/$arch/$packid/.checksums") {
@@ -4362,7 +4366,7 @@ my $dispatches = [
   '/build/$project/$repository/$arch/_relsync' => \&getrelsync,
   'POST:/build/$project/$repository/$arch/$package cmd=copy oproject:project? opackage:package? orepository:repository? setupdateinfoid:? resign:bool? setrelease:?' => \&copybuild,
   'POST:/build/$project/$repository/$arch/$package' => \&uploadbuild,
-  '!worker,rw /build/$project/$repository/$arch/$package:package_repository view:? binary:filename* nometa:bool? noajax:bool? nosource:bool? noimport:bool? withmd5:bool? module*' => \&getbinarylist,
+  '!worker,rw /build/$project/$repository/$arch/$package:package_repository view:? binary:filename* nometa:bool? noajax:bool? nosource:bool? noimport:bool? withmd5:bool? module* withccache:bool?' => \&getbinarylist,
   'POST:/build/$project/$repository/$arch/$package_repositorybuild/_buildinfo add:* internal:bool? debug:bool? deps:bool?' => \&getbuildinfo_post,
   '/build/$project/$repository/$arch/$package/_buildinfo add:* internal:bool? debug:bool? deps:bool?' => \&getbuildinfo,
   '/build/$project/$repository/$arch/$package/_reason' => \&getbuildreason,
@@ -4449,7 +4453,7 @@ my $dispatches_ajax = [
   '/' => \&hello,
   '/ajaxstatus' => \&getajaxstatus,
   '/build/$project/$repository/$arch/$package/_log nostream:bool? last:bool? lastsucceeded:bool? start:intnum? end:num? view:?' => \&getlogfile,
-  '/build/$project/$repository/$arch/$package:package_repository view:? binary:filename* nosource:bool? module*' => \&getbinarylist,
+  '/build/$project/$repository/$arch/$package:package_repository view:? binary:filename* nosource:bool? module* withccache:bool?' => \&getbinarylist,
   '/build/$project/$repository/$arch/$package:package_repository/$filename view:? module*' => \&getbinary,
   '/_result $prpa+ oldstate:md5? package* code:* withbinarylist:bool? withstats:bool? summary:bool? withversrel:bool?' => \&getresult,
   '/getbinaries $project $repository $arch binaries: nometa:bool? metaonly:bool? module*' => \&getbinaries,

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -2547,7 +2547,7 @@ sub getbinaries {
 }
 
 sub getoldpackages {
-  my ($buildinfo, $odir) = @_;
+  my ($buildinfo, $odir, $useccache) = @_;
 
   # get old package build for compare and diffing tools
   mkdir_p($odir) || die("mkdir_p $odir: $!\n");
@@ -2558,7 +2558,7 @@ sub getoldpackages {
       'directory' => $odir,
       'timeout' => $gettimeout,
       'receiver' => \&BSHTTP::cpio_receiver,
-    }, undef, 'view=cpio', 'noajax=1', 'noimport=1');
+    }, undef, 'view=cpio', 'noajax=1', 'noimport=1', "withccache=$useccache");
   };
   die("getoldpackages: $@") if $@;
   rmdir($odir);	# if not needed
@@ -3075,7 +3075,24 @@ sub dobuild {
 
   writestr("$buildroot/.build.meta", undef, join("\n", @meta)."\n");
 
-  getoldpackages($buildinfo, $oldpkgdir) if $oldpkgdir && !$kiwimode && $buildinfo->{'file'} ne 'preinstallimage';
+  my @configpath;
+  if ($kiwimode) {
+    @configpath = map {"path=$_->{'project'}/$_->{'repository'}"} @{$buildinfo->{'syspath'} || $buildinfo->{'path'} || []};
+    unshift @configpath, "path=$projid/$repoid" unless @configpath && $configpath[0] eq "path=$projid/$repoid";
+  }
+  my $server = $buildinfo->{'srcserver'} || $srcserver;
+  my $config = BSRPC::rpc("$server/getconfig", undef, "project=$projid", "repository=$repoid", @configpath);
+  writestr("$buildroot/.build.config", undef, $config);
+
+
+  my $bconf = Build::read_config($buildinfo->{'arch'}, "$buildroot/.build.config");
+  my $useccache=0;
+  if (exists $bconf->{'buildflags:useccache'}) {
+      if (grep {$_ eq "useccache:$packid"} @{$bconf->{'buildflags'} || []}) {
+        $useccache = 1;
+    }
+  }
+  getoldpackages($buildinfo, $oldpkgdir, $useccache) if $oldpkgdir && !$kiwimode && $buildinfo->{'file'} ne 'preinstallimage';
 
   $stats->{'times'}->{'download'}->{'time'}->{'unit'} = "s";
   $stats->{'times'}->{'download'}->{'time'}->{'_content'} = (time() - $downloadstarttime);
@@ -3088,16 +3105,6 @@ sub dobuild {
   $stats->{'download'}->{'preinstallimage'} = $preinstallimagedata->{'imagename'} if $preinstallimagedata->{'imagename'};
   ####### end of download phase
 
-  my @configpath;
-  if ($kiwimode) {
-    @configpath = map {"path=$_->{'project'}/$_->{'repository'}"} @{$buildinfo->{'syspath'} || $buildinfo->{'path'} || []};
-    unshift @configpath, "path=$projid/$repoid" unless @configpath && $configpath[0] eq "path=$projid/$repoid";
-  }
-  my $server = $buildinfo->{'srcserver'} || $srcserver;
-  my $config = BSRPC::rpc("$server/getconfig", undef, "project=$projid", "repository=$repoid", @configpath);
-  writestr("$buildroot/.build.config", undef, $config);
-
-  my $bconf;
   if ($deltamode) {
     # replace @mopt@ in specfile
     my $spec = readstr("$srcdir/deltagen.spec");
@@ -3117,15 +3124,6 @@ sub dobuild {
       writestr("$srcdir/deltagen.spec", undef, $spec);
     }
   }
-  $bconf = $bconf || Build::read_config($buildinfo->{'arch'}, "$buildroot/.build.config");
-
-  my $useccache;
-  if (exists $bconf->{'buildflags:useccache'}) {
-      if (grep /^useccache:\Q$packid\E$/, @{$bconf->{'buildflags'} || []}) {
-        $useccache = 1;
-    }
-  }
-
 
   my $release = $buildinfo->{'release'};
   #FIXME2.6: drop the following line


### PR DESCRIPTION
<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
