### PR TITLE
Display the number of unread notifications in the top-level navigation

### DIFF
--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -1171,6 +1171,7 @@ class BsRequest < ApplicationRecord
     review_comment
   end
 
+  # TODO: Remove once responsive_ux is out of beta
   def update_cache
     target_package_ids = bs_request_actions.with_target_package.pluck(:target_package_id)
     target_project_ids = bs_request_actions.with_target_project.pluck(:target_project_id)

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -802,12 +802,17 @@ class User < ApplicationRecord
     to_s
   end
 
+  # TODO: Remove once responsive_ux is out of beta
   def tasks
     Rails.cache.fetch("requests_for_#{cache_key}") do
       declined_requests.count +
         incoming_requests.count +
         involved_reviews.count
     end
+  end
+
+  def unread_notifications
+    notifications.not_marked_as_done.size
   end
 
   def watched_project_names

--- a/src/api/app/views/layouts/webui/responsive_ux/_bottom_navigation.html.haml
+++ b/src/api/app/views/layouts/webui/responsive_ux/_bottom_navigation.html.haml
@@ -9,6 +9,8 @@
       %li.nav-item.border-left.border-gray-500
         = link_to(user_notifications_path(User.session), class: 'nav-link px-1 py-2 text-light', alt: 'Notifications') do
           %i.fas.fa-bell
+          - unless User.session.unread_notifications.zero?
+            %span.badge.badge-primary= User.session.unread_notifications
           .small Notifications
       - if content_for?(:actions)
         %li.nav-item.border-left.border-gray-500

--- a/src/api/app/views/layouts/webui/responsive_ux/_navigation.html.haml
+++ b/src/api/app/views/layouts/webui/responsive_ux/_navigation.html.haml
@@ -12,6 +12,8 @@
         .toggler.text-center.justify-content-center
           = link_to(user_notifications_path(User.session), class: 'nav-link text-light p-0 w-100', alt: 'Notifications') do
             %i.fas.fa-bell
+            - unless User.session.unread_notifications.zero?
+              %span.badge.badge-primary= User.session.unread_notifications
             .small Notifications
         - if content_for?(:actions)
           .toggler.text-center.justify-content-center


### PR DESCRIPTION
We don't rely on a cache for this since it's only a simple count.

Preview on desktop and mobile:
![desktop](https://user-images.githubusercontent.com/1102934/78897413-6ce48f00-7a72-11ea-8d66-d5e57cb3fad0.png)
![mobile](https://user-images.githubusercontent.com/1102934/78897416-6d7d2580-7a72-11ea-972b-73a44585e8d8.png)

In case you wonder, this would fit 999 999 notifications before it breaks. It's even more on desktop, so we should be alright!
![mobile-edge-case](https://user-images.githubusercontent.com/1102934/78897418-6e15bc00-7a72-11ea-8962-782c54151538.png)
