### PR TITLE
Add vertical alignment to notification badge

### DIFF
--- a/src/api/app/views/layouts/webui/responsive_ux/_bottom_navigation.html.haml
+++ b/src/api/app/views/layouts/webui/responsive_ux/_bottom_navigation.html.haml
@@ -10,7 +10,7 @@
         = link_to(my_notifications_path, class: 'nav-link px-1 py-2 text-light', alt: 'Notifications') do
           %i.fas.fa-bell
           - unless User.session.unread_notifications.zero?
-            %span.badge.badge-primary= User.session.unread_notifications
+            %span.badge.badge-primary.align-text-top= User.session.unread_notifications
           .small Notifications
       - if content_for?(:actions)
         %li.nav-item.border-left.border-gray-500

--- a/src/api/app/views/layouts/webui/responsive_ux/_navigation.html.haml
+++ b/src/api/app/views/layouts/webui/responsive_ux/_navigation.html.haml
@@ -13,7 +13,7 @@
           = link_to(my_notifications_path, class: 'nav-link text-light p-0 w-100', alt: 'Notifications') do
             %i.fas.fa-bell
             - unless User.session.unread_notifications.zero?
-              %span.badge.badge-primary= User.session.unread_notifications
+              %span.badge.badge-primary.align-text-top= User.session.unread_notifications
             .small Notifications
         - if content_for?(:actions)
           .toggler.text-center.justify-content-center


### PR DESCRIPTION
We added a missing bootstrap class to align the badge with the bell icon.

### Before
![Screenshot_2020-04-13 Open Build Service](https://user-images.githubusercontent.com/1212806/79103636-4160ed80-7d6d-11ea-9888-d61ba9d9bee7.png)


### After
![Screenshot_2020-04-13 Open Build Service(1)](https://user-images.githubusercontent.com/1212806/79103627-3e65fd00-7d6d-11ea-99af-0fba8637ef3e.png)
