### PR TITLE
WIP: Filter notifications by project

### DIFF
--- a/src/api/app/helpers/webui/notification_helper.rb
+++ b/src/api/app/helpers/webui/notification_helper.rb
@@ -8,4 +8,11 @@ module Webui::NotificationHelper
       link_to('Show all', my_notifications_path(parameters), class: 'btn btn-sm btn-secondary ml-2')
     end
   end
+
+  def project_list(projects)
+    hash_projects = Hash.new(0)
+    projects.each { |project| hash_projects[project] += 1 }
+
+    hash_projects.sort_by(&:last).reverse
+  end
 end

--- a/src/api/app/helpers/webui/webui_helper.rb
+++ b/src/api/app/helpers/webui/webui_helper.rb
@@ -402,10 +402,22 @@ module Webui::WebuiHelper
     end
   end
 
-  def user_notification_link(link_text, new_filter, filter: 'inbox')
+  def user_notification_link(link_text, filter_item)
     css_class = 'list-group-item list-group-item-action'
-    css_class += ' active' if new_filter == filter || (filter.nil? && new_filter == 'inbox')
-    link_to(link_text, my_notifications_path(type: new_filter), class: css_class)
+    css_class += ' active' if notification_filter_active?(filter_item)
+    link_to(link_text, my_notifications_path(type: filter_item[:type], project: filter_item[:project]), class: css_class)
+  end
+
+  private
+
+  def notification_filter_active?(filter_item)
+    if params[:project].present?
+      filter_item[:project].try(:name) == params[:project]
+    elsif params[:type].present?
+      filter_item[:type] == params[:type]
+    else
+      filter_item[:type] == 'unread'
+    end
   end
 end
 

--- a/src/api/app/queries/notifications_finder.rb
+++ b/src/api/app/queries/notifications_finder.rb
@@ -24,7 +24,7 @@ class NotificationsFinder
                     user, user.groups.map(&:id))
   end
 
-  def for_notifiable_type(type = '')
+  def for_notifiable_type(type = 'unread')
     notifications = self.class.new(with_notifiable)
 
     case type
@@ -39,6 +39,15 @@ class NotificationsFinder
     else
       notifications.unread
     end
+  end
+
+  def for_project_name(project_name)
+    notification_ids = unread.includes(:notifiable).select do |notification|
+      projects = NotificationProjects.new([notification]).call
+
+      projects.pluck(:name).include?(project_name)
+    end.map(&:id)
+    @relation.where(id: notification_ids)
   end
 
   def stale

--- a/src/api/app/services/notification_projects.rb
+++ b/src/api/app/services/notification_projects.rb
@@ -1,0 +1,29 @@
+class NotificationProjects
+  attr_reader :notifications
+
+  def initialize(notifications)
+    @notifications = notifications
+  end
+
+  def call
+    notifications.map do |notification|
+      notifiable = notification.notifiable
+
+      case notification.notifiable_type
+      when 'BsRequest'
+        notifiable.target_project_objects.uniq
+      when 'Comment'
+        case notifiable.commentable_type
+        when 'Project'
+          [notifiable.commentable]
+        when 'Package'
+          [notifiable.commentable.project]
+        when 'BsRequest'
+          notifiable.commentable.target_project_objects.uniq
+        end
+      when 'Review'
+        notifiable.bs_request.target_project_objects.uniq
+      end
+    end.flatten!
+  end
+end

--- a/src/api/app/views/webui/users/notifications/index.html.haml
+++ b/src/api/app/views/webui/users/notifications/index.html.haml
@@ -13,13 +13,17 @@
 
       .card-body.collapse#filters
         .row.list-group-flush
-          = user_notification_link('Unread', 'unread', filter: params[:type])
-          = user_notification_link('Read', 'read', filter: params[:type])
+          = user_notification_link('Unread', type: 'unread')
+          = user_notification_link('Read', type: 'read')
         .row.list-group-flush.mt-5
           %h5.ml-3 Filter
-          = user_notification_link('Reviews', 'reviews', filter: params[:type])
-          = user_notification_link('Comments', 'comments', filter: params[:type])
-          = user_notification_link('Requests', 'requests', filter: params[:type])
+          = user_notification_link('Reviews', type: 'reviews')
+          = user_notification_link('Comments', type: 'comments')
+          = user_notification_link('Requests', type: 'requests')
+        .row.list-group-flush.mt-5
+          %h5.ml-3 Projects
+          - project_list(@projects).each do |project_name, notification_number|
+            = user_notification_link("#{project_name} (#{notification_number})", project: project_name)
 
   .col-md-8.col-lg-9#notifications-list
     .card


### PR DESCRIPTION
Show a clickable list of projects to filter notifications by project.
Adapt models used by notifications to be able to filter by project.

Co-authored-by: David Kang <dkang@suse.com>
Co-authored-by: Saray Cabrera Padrón <scabrerapadron@suse.de>
