### PR TITLE
SubscriptionsController update route

### DIFF
--- a/src/api/app/views/webui/users/subscriptions/index.html.haml
+++ b/src/api/app/views/webui/users/subscriptions/index.html.haml
@@ -18,7 +18,8 @@
     %h4.card-title Events
     %p Choose from which events you want to get an email
     #subscriptions-form
-      = render partial: 'webui/subscriptions/subscriptions_form', locals: { path: my_subscriptions_path, subscriptions_form: @subscriptions_form }
+      = render partial: 'webui/subscriptions/subscriptions_form', locals: { path: update_my_subscriptions_path,
+                                                                            subscriptions_form: @subscriptions_form }
 
 .card.mt-3
   .card-body

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -292,7 +292,7 @@ OBSApi::Application.routes.draw do
 
       resources :subscriptions, only: [:index], controller: 'webui/users/subscriptions', as: :my_subscriptions do
         collection do
-          put 'update'
+          put 'update', as: :update
         end
       end
 

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -293,7 +293,6 @@ OBSApi::Application.routes.draw do
       resources :subscriptions, only: [:index], controller: 'webui/users/subscriptions', as: :my_subscriptions do
         collection do
           put 'update'
-          get 'update'
         end
       end
 


### PR DESCRIPTION
Add a custom name for the update route, to be able to use `/subscriptions/update` without id and keep the `my_subscriptions_path` pointing to the `SubscriptionsController#index`

How to test it:

Visit the Profile -> Change your notifications (update your notifications should work as expected)

Notifications -> Actions -> Manage Subscriptions (should bring you to your subscriptions index, and there you could update your notifications)
