### PR TITLE
[backend] urlmapper: match both http and https when mapping urls

### DIFF
--- a/src/backend/BSUrlmapper.pm
+++ b/src/backend/BSUrlmapper.pm
@@ -33,18 +33,23 @@ sub urlmapper {
   my ($url, $cache) = @_;
   $url =~ s/\/+$//;
   return undef if $url eq '';
+  $url =~ s/^https:/http:/;
   $cache ||= $urlmapcache;
   if (!exists $cache->{''}) {
     $cache->{''} = undef;
     for my $prp (sort keys %{$BSConfig::prp_ext_map || {}}) {
       my $u = $BSConfig::prp_ext_map->{$prp};
       $u =~ s/\/+$//;
+      $u =~ s/^https:/http:/;
       $cache->{$u} = $prp;
     }
   }
   my $prp = $cache->{$url};
   return $prp if $prp;
-  if ($BSConfig::repodownload && $url =~ /^\Q$BSConfig::repodownload\E\/(.+\/.+)/) {
+  my $repodownload = $BSConfig::repodownload;
+  return undef unless $repodownload;
+  $repodownload =~ s/^https:/http:/;
+  if ($url =~ /^\Q$repodownload\E\/(.+\/.+)/) {
     my $path = $1;
     $path =~ s/%([a-fA-F0-9]{2})/chr(hex($1))/ge;
     my @p = split('/', $path); 


### PR DESCRIPTION
Fixes issue #5130

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
