### PR TITLE
Change CircleCI config to use new ci docker containers repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,21 +7,21 @@ images:
       NOKOGIRI_USE_SYSTEM_LIBRARIES: 1
 
   - &mariadb
-    image: registry.opensuse.org/obs/server/unstable/container/sle12/sp4/containers/openbuildservice/mariadb:latest
+    image: registry.opensuse.org/obs/server/unstable/container/ci/containers/openbuildservice/mariadb:latest
     command: |
       /bin/bash -c 'echo -e "[mysqld]\ndatadir = /dev/shm" > /etc/my.cnf.d/obs.cnf && cp -a /var/lib/mysql/* /dev/shm && /usr/lib/mysql/mysql-systemd-helper start'
     name: db
 
-  - &backend registry.opensuse.org/obs/server/unstable/container/sle12/sp4/containers/openbuildservice/backend:latest
+  - &backend registry.opensuse.org/obs/server/unstable/container/ci/containers/openbuildservice/backend:latest
 
   - &frontend_backend
-    image: registry.opensuse.org/obs/server/unstable/container/sle12/sp4/containers/openbuildservice/frontend-backend:latest
+    image: registry.opensuse.org/obs/server/unstable/container/ci/containers/openbuildservice/frontend-backend:latest
     <<: *common_frontend_config
     environment:
       EAGER_LOAD: 1
 
   - &frontend_base
-    image: registry.opensuse.org/obs/server/unstable/container/sle12/sp4/containers/openbuildservice/frontend-base:latest
+    image: registry.opensuse.org/obs/server/unstable/container/ci/containers/openbuildservice/frontend-base:latest
     <<: *common_frontend_config
 
 aliases:


### PR DESCRIPTION
The new ci docker containers project has been created with the idea of creating the containers used in the CI test suite for Unstable. So upgrading the version of the underlying system of the containers doesn't affect the CirleCI configuration any more.

This new ci docker containers repo is now using SLE15 SP1 docker base images, instead of SLE12 SP4.