### PR TITLE
Fix apidocs rendering

### DIFF
--- a/src/api/app/views/webui/apidocs/index.html.haml
+++ b/src/api/app/views/webui/apidocs/index.html.haml
@@ -1,3 +1,5 @@
 .card
   .card-body
-    = render file: @filename, formats: [:html]
+    -# rubocop:disable Rails/OutputSafety
+    = render(file: @filename).html_safe
+    -# rubocop:enable Rails/OutputSafety


### PR DESCRIPTION
After upgrading to Rails 6, rendering the raw content of a html file needed to use the `raw` method.

Fixes #9382.

Co-authored-by: David Kang <dkang@suse.com>
Co-authored-by: Saray Cabrera Padrón <scabrerapadron@suse.de>