### PR TITLE
Fix typos in ruby variables in Makefile

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -12,7 +12,7 @@ APACHE_CONFDIR_VHOST=$(APACHE_CONFDIR)/vhosts.d
 APACHE_VHOST_CONF=obs-apache24.conf
 APACHE_LOGDIR=/var/log/apache2
 
-OBS_RUBY_BIN=/usr/bin/ruby.ruby25
-OBS_BUNDLE_BIN=/usr/bin/bundle.ruby25
-OBS_RAKE_BIN=/usr/bin/rake.ruby25
+OBS_RUBY_BIN=/usr/bin/ruby.ruby2.5
+OBS_BUNDLE_BIN=/usr/bin/bundle.ruby2.5
+OBS_RAKE_BIN=/usr/bin/rake.ruby2.5
 OBS_RUBY_VERSION=2.5.0


### PR DESCRIPTION
The correct ruby version should be 2.5 instead of 25.

This issue was found trying to generate the apidocs in the development environment.

Co-authored-by: David Kang <dkang@suse.com>
Co-authored-by: Saray Cabrera Padrón <scabrerapadron@suse.de>