### PR TITLE
Add ShellCheck scripts linter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,9 @@ jobs:
       - <<: *frontend_base
     steps:
       - checkout
+      - run:
+          name: Run scripts linters
+          command: make -C dist scripts_linters
       - run: *install_dependencies
       - run: *install_circle_cli
       - restore_cache:
@@ -71,7 +74,7 @@ jobs:
           name: Install jshint
           command: sudo npm install -g jshint
       - run:
-          name: Run linters
+          name: Run src/api linters
           command: cd src/api; bundle exec rake dev:lint RAILS_ENV=test
       - save_cache:
           key: v4-lint-{{ epoch }}

--- a/dist/Makefile
+++ b/dist/Makefile
@@ -82,6 +82,9 @@ test_system:
 test_appliance:
 	prove -v t/*.ta
 
+scripts_linters:
+	./run_shellcheck.sh
+
 .PHONY: test_unit test_system
 
 include ../Makefile.targets

--- a/dist/run_shellcheck.sh
+++ b/dist/run_shellcheck.sh
@@ -11,6 +11,7 @@ DIRECTORIES=$(printf "../%s " "${DIRECTORIES_ARRAY[@]}")
 # shellcheck disable=SC2086
 find $DIRECTORIES \
   -name run_shellcheck.sh \
+    -o -name 0000-check_users_and_group.ts \
   -type f -exec sh -c "head -n 1 {} | grep -Eq '^#!(.*/|.*env +)(sh|bash)'" \; -print |
   while IFS="" read -r file
   do

--- a/dist/run_shellcheck.sh
+++ b/dist/run_shellcheck.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Script that retrieves the files to be checked with shellcheck,
+# and that runs shellcheck on them.
+
+#DIRECTORIES_ARRAY=( contrib dist src/api/script src/api/test src/backend )
+DIRECTORIES_ARRAY=( dist )
+
+DIRECTORIES=$(printf "../%s " "${DIRECTORIES_ARRAY[@]}")
+
+# shellcheck disable=SC2086
+find $DIRECTORIES \
+  -name run_shellcheck.sh \
+  -type f -exec sh -c "head -n 1 {} | grep -Eq '^#!(.*/|.*env +)(sh|bash)'" \; -print |
+  while IFS="" read -r file
+  do
+    shellcheck "$file"
+  done

--- a/dist/t/0000-check_users_and_group.ts
+++ b/dist/t/0000-check_users_and_group.ts
@@ -1,20 +1,20 @@
 #!/bin/bash
 
-export BASH_TAP_ROOT=$(dirname $0)
+BASH_TAP_ROOT=$(dirname "$0")
 
 
-. $(dirname $0)/bash-tap-bootstrap
+# shellcheck disable=SC1090
+. "$BASH_TAP_ROOT"/bash-tap-bootstrap
 
 
 plan tests 3
 
 
-for group in obsrun;do
-  result_group=$(getent group $group | cut -f1 -d:)
-  is "$result_group" "$group" "Checking group $group"
-done
+group='obsrun'
+result_group=$(getent group $group | cut -f1 -d:)
+is "$result_group" "$group" "Checking group $group"
 
-for user in obsrun obsservicerun;do
+for user in obsrun obsservicerun; do
   result_user=$(getent passwd $user | cut -f1 -d:)
   is "$result_user" "$user" "Checking user $user"
 done


### PR DESCRIPTION
We want to benefit from having a linter that checks our script files (bash or sh).

Initially it is only run on only one file. The second commit of this pull request is an example of including a file into the list of files to be checked by the linter.