### PR TITLE
Add pagination to notifications

### DIFF
--- a/src/api/app/controllers/webui/users/notifications_controller.rb
+++ b/src/api/app/controllers/webui/users/notifications_controller.rb
@@ -1,10 +1,11 @@
 class Webui::Users::NotificationsController < Webui::WebuiController
   before_action :require_login
+  MAX_PER_PAGE = 300
 
   def index
     notifications_for_subscribed_user = NotificationsFinder.new.for_subscribed_user
     @notifications = NotificationsFinder.new(notifications_for_subscribed_user).for_notifiable_type(params[:type])
-    @notifications = @notifications.page(params[:page])
+    @notifications = params['show_all'] ? show_all : @notifications.page(params[:page])
   end
 
   def update
@@ -17,5 +18,15 @@ class Webui::Users::NotificationsController < Webui::WebuiController
       flash[:error] = "Couldn't mark the notification as #{notification.unread? ? 'read' : 'unread'}"
     end
     redirect_back(fallback_location: root_path)
+  end
+
+  private
+
+  def show_all
+    total = @notifications.size
+    if total > MAX_PER_PAGE
+      flash.now[:info] = "You have too many notifications. Displaying a maximum of #{MAX_PER_PAGE} notifications per page."
+    end
+    @notifications = @notifications.page(params[:page]).per([total, MAX_PER_PAGE].min)
   end
 end

--- a/src/api/app/controllers/webui/users/notifications_controller.rb
+++ b/src/api/app/controllers/webui/users/notifications_controller.rb
@@ -3,8 +3,8 @@ class Webui::Users::NotificationsController < Webui::WebuiController
 
   def index
     notifications_for_subscribed_user = NotificationsFinder.new.for_subscribed_user
-
     @notifications = NotificationsFinder.new(notifications_for_subscribed_user).for_notifiable_type(params[:type])
+    @notifications = @notifications.page(params[:page])
   end
 
   def update

--- a/src/api/app/helpers/webui/notification_helper.rb
+++ b/src/api/app/helpers/webui/notification_helper.rb
@@ -1,0 +1,11 @@
+module Webui::NotificationHelper
+  def link_to_all
+    parameters = params[:type] ? { type: params[:type] } : {}
+    if params['show_all'] # already showing all
+      link_to('Show less', my_notifications_path(parameters), class: 'btn btn-sm btn-secondary ml-2')
+    else
+      parameters.merge!({ show_all: 1 })
+      link_to('Show all', my_notifications_path(parameters), class: 'btn btn-sm btn-secondary ml-2')
+    end
+  end
+end

--- a/src/api/app/views/webui/kaminari/_paginator.html.haml
+++ b/src/api/app/views/webui/kaminari/_paginator.html.haml
@@ -1,5 +1,5 @@
 = paginator.render do
-  %nav
+  %nav.mt-3
     %ul.pagination.justify-content-center
       = first_page_tag unless current_page.first?
       = prev_page_tag unless current_page.first?

--- a/src/api/app/views/webui/users/notifications/index.html.haml
+++ b/src/api/app/views/webui/users/notifications/index.html.haml
@@ -36,6 +36,7 @@
         - else
           .text-center
             %span.ml-3= page_entries_info @notifications, entry_name: 'notification'
+            = link_to_all unless @notifications.total_pages == 1 && params['show_all'].nil?
 
           .list-group.list-group-flush.mt-3
             - @notifications.each do |n|

--- a/src/api/app/views/webui/users/notifications/index.html.haml
+++ b/src/api/app/views/webui/users/notifications/index.html.haml
@@ -34,7 +34,10 @@
             - else
               There are no notifications, but there's a world of opportunities!
         - else
-          .list-group.list-group-flush
+          .text-center
+            %span.ml-3= page_entries_info @notifications, entry_name: 'notification'
+
+          .list-group.list-group-flush.mt-3
             - @notifications.each do |n|
               - notification = NotificationPresenter.new(n)
               .list-group-item.d-flex.flex-column.flex-sm-row.justify-content-sm-between
@@ -53,3 +56,5 @@
                     = link_to(my_notification_path(id: notification),
                                       method: :put, class: 'btn btn-sm btn-outline-success px-4', title: 'Mark as "Unread"') do
                       %i.fas.fa-undo
+
+          = paginate @notifications, views_prefix: 'webui', window: 2

--- a/src/api/config/locales/kaminari.en.yml
+++ b/src/api/config/locales/kaminari.en.yml
@@ -7,3 +7,12 @@ en:
       previous: "Previous"
       next: "Next"
       truncate: "..."
+  helpers:
+    page_entries_info:
+      one_page:
+        display_entries:
+          zero: "No %{entry_name} found."
+          one: "Displaying <b>1</b> %{entry_name}."
+          other: "Displaying <b>all %{count}</b> %{entry_name}."
+      more_pages:
+        display_entries: "Displaying %{entry_name} <b>%{first}&nbsp;-&nbsp;%{last}</b> of <b>%{total}</b>."


### PR DESCRIPTION
Notifications are now paginated.

A `Show all` link is provided to display the notifications all at once. But there is a limit set by `MAX_PER_PAGE`. In case of exceeding this limit, a flash message will be shown and the results will be paginated with `MAX_PER_PAGE` notifications per page.

![show_all_notifications](https://user-images.githubusercontent.com/2581944/79360182-d61d4400-7f43-11ea-9b01-9c2e68fb3058.gif)


<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
