### PR TITLE
Take file name into account for file partial caching

### DIFF
--- a/src/api/app/views/webui/package/_files_view.html.haml
+++ b/src/api/app/views/webui/package/_files_view.html.haml
@@ -13,7 +13,7 @@
         - file_locals = { package: package, project: project, expand: expand, is_current_rev: is_current_rev,
         can_modify: user_can_modify_package, nobody: !User.session }
         = render partial: 'file', collection: files,
-        cached: proc { |file| [file[:mtime], file[:md5], file_locals, User.possibly_nobody.in_beta].hash }, locals: file_locals
+        cached: proc { |file| [file[:name], file[:mtime], file[:md5], file_locals, User.possibly_nobody.in_beta].hash }, locals: file_locals
   - else
     %i This package has no files yet
   - if user_can_modify_package

--- a/src/api/app/views/webui/package/_files_view.html.haml
+++ b/src/api/app/views/webui/package/_files_view.html.haml
@@ -13,7 +13,7 @@
         - file_locals = { package: package, project: project, expand: expand, is_current_rev: is_current_rev,
         can_modify: user_can_modify_package, nobody: !User.session }
         = render partial: 'file', collection: files,
-        cached: proc { |file| [file[:name], file[:mtime], file[:md5], file_locals, User.possibly_nobody.in_beta].hash }, locals: file_locals
+        cached: proc { |file| [file[:name], file[:mtime], file[:md5], file_locals].hash }, locals: file_locals
   - else
     %i This package has no files yet
   - if user_can_modify_package


### PR DESCRIPTION
In certain cases, the md5 and mtime value of a file is the same
for multiple files. Only the file name differs in those cases.
This needs to be considered, in order to have uniq data in the
cache.

In the past this lead to not show certain files in the
webui due to this rails/rails#35145
Since this got fixed, it now does the opposite (showing duplicated entries),
which is more obvious.

Since osc shows the correct files, and missing files are less
obvious than duplicates, this probably took a while to be reported
as an issue.

Fixes #9352

Co-authored-by: David Kang <dkang@suse.com>
Co-authored-by: Eduardo Navarro <enavarro@suse.com>

**Example data:**

```
{:name=>"cross-i386-gcc7.changes", :size=>"21895", :mtime=>"1586940815", :md5=>"8cb7fb57285bc929b7bc0ffa5edc6b29", :viewable=>true, :editable=>true, :srcmd5=>"dcd3ebb0cdc6f697682ddfc123352b87"},
 {:name=>"cross-m68k-gcc7.changes", :size=>"21895", :mtime=>"1586940815", :md5=>"8cb7fb57285bc929b7bc0ffa5edc6b29", :viewable=>true, :editable=>true, :srcmd5=>"dcd3ebb0cdc6f697682ddfc123352b87"},
 {:name=>"cross-mips-gcc7.changes", :size=>"21895", :mtime=>"1586940815", :md5=>"8cb7fb57285bc929b7bc0ffa5edc6b29", :viewable=>true, :editable=>true, :srcmd5=>"dcd3ebb0cdc6f697682ddfc123352b87"},
```
