### PR TITLE
Adjust pagination in some pages

### DIFF
--- a/src/api/app/views/webui/kaminari/_paginator.html.haml
+++ b/src/api/app/views/webui/kaminari/_paginator.html.haml
@@ -1,5 +1,5 @@
 = paginator.render do
-  %nav
+  %nav.mt-3
     %ul.pagination.justify-content-center
       = first_page_tag unless current_page.first?
       = prev_page_tag unless current_page.first?

--- a/src/api/app/views/webui/package/revisions.html.haml
+++ b/src/api/app/views/webui/package/revisions.html.haml
@@ -17,8 +17,11 @@
             - else
               %i Revision #{revision} not found
       - unless params['show_all']
-        = paginate @revisions
-        = link_to('Show all', action: 'revisions', project: @project, package: @package, show_all: 1)
+        = paginate @revisions, views_prefix: 'webui'
+        - unless @revisions.total_pages == 1
+          .text-center= link_to('Show all',
+                                package_view_revisions_path(project: @project, package: @package, show_all: 1),
+                                class: 'btn btn-sm btn-secondary')
     - else
       %p
         %i No commits exists yet.

--- a/src/api/app/views/webui/search/_results.html.haml
+++ b/src/api/app/views/webui/search/_results.html.haml
@@ -23,4 +23,4 @@
           - desc.split(/\n/).each do |line|
             = highlight(line, search_text, highlighter: '<b>\1</b>')
   - if per_page
-    = paginate results
+    = paginate results, views_prefix: 'webui'

--- a/src/api/app/views/webui/search/_results_issue.html.haml
+++ b/src/api/app/views/webui/search/_results_issue.html.haml
@@ -21,4 +21,4 @@
         - else
           = truncate(result.description, length: 80)
   - if per_page
-    = paginate results
+    = paginate results, views_prefix: 'webui'


### PR DESCRIPTION
Some pages use [kaminari](https://github.com/amatsuda/kaminari) for pagination. However, they weren't taking the right generated views for them.

We have to specify that the views are inside `webui` with `views_prefix: 'webui'`. Otherwise, kaminari would try to find them in  `app/views/kaminari` instead of `app/views/webui/kaminari`.

**Before:**

![Screenshot_2020-04-15 Open Build Service(2)](https://user-images.githubusercontent.com/2581944/79384368-07f3d200-7f67-11ea-8b8a-c51cd7b17ecb.png)

**After:**

![Screenshot_2020-04-15 Open Build Service(3)](https://user-images.githubusercontent.com/2581944/79384375-0cb88600-7f67-11ea-9274-41a110a3d0d9.png)

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
