### PR TITLE
Rename notify_parameters to event_parameters

### DIFF
--- a/src/api/app/controllers/request_controller.rb
+++ b/src/api/app/controllers/request_controller.rb
@@ -113,7 +113,7 @@ class RequestController < ApplicationController
 
     BsRequest.transaction do
       oldrequest = BsRequest.find_by_number!(params[:id])
-      notify = oldrequest.notify_parameters
+      notify = oldrequest.event_parameters
       oldrequest.destroy
 
       req = BsRequest.new_from_xml(body)
@@ -131,7 +131,7 @@ class RequestController < ApplicationController
   # DELETE /request/:id
   def destroy
     request = BsRequest.find_by_number!(params[:id])
-    notify = request.notify_parameters
+    notify = request.event_parameters
     request.destroy # throws us out of here if failing
     notify[:who] = User.session!.login
     Event::RequestDelete.create(notify)

--- a/src/api/app/jobs/project_create_auto_cleanup_requests.rb
+++ b/src/api/app/jobs/project_create_auto_cleanup_requests.rb
@@ -58,6 +58,6 @@ Such requests get not created for projects with open requests or if you remove t
                                        <accept_at>' + @cleanup_time.to_s + '</accept_at>
                                      </request>')
     req.save!
-    Event::RequestCreate.create(req.notify_parameters)
+    Event::RequestCreate.create(req.event_parameters)
   end
 end

--- a/src/api/app/models/event/comment_for_request.rb
+++ b/src/api/app/models/event/comment_for_request.rb
@@ -8,7 +8,7 @@ module Event
 
     def subject
       req = BsRequest.find_by_number(payload['number'])
-      req_payload = req.notify_parameters
+      req_payload = req.event_parameters
       "Request #{payload['number']} commented by #{payload['commenter']} (#{BsRequest.actions_summary(req_payload)})"
     end
 

--- a/src/api/app/models/review.rb
+++ b/src/api/app/models/review.rb
@@ -221,7 +221,7 @@ class Review < ApplicationRecord
     self.state = new_state
     self.reviewer = User.session!.login
     save!
-    Event::ReviewChanged.create(bs_request.notify_parameters)
+    Event::ReviewChanged.create(bs_request.event_parameters)
 
     arguments = { review: self, comment: comment, user: User.session! }
     if new_state == :accepted


### PR DESCRIPTION
The BsRequest method is renamed for consistency with the rest of the
equivalent methods added to models related to notifications.

This is a follow-up to the refactoring PR #9307 (starting from [this line](https://github.com/openSUSE/open-build-service/pull/9307/files#diff-d476b59ba5326de67e0c155e8e226d6fR1070)).

Co-authored-by: David Kang <dkang@suse.com>

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
