### PR TITLE
allow more chars for github tracker identifier

### DIFF
--- a/src/api/db/data/20190130115727_add_github_issue_tracker.rb
+++ b/src/api/db/data/20190130115727_add_github_issue_tracker.rb
@@ -2,7 +2,7 @@ class AddGithubIssueTracker < ActiveRecord::Migration[5.1]
   def up
     IssueTracker.where(name: 'gh').first_or_create(description: 'Generic github tracker',
                                                    kind: 'github',
-                                                   regex: '(?:gh|github)#(\w+\/\w+#\d+)',
+                                                   regex: '(?:gh|github)#([\w-]+\/[\w-]+#\d+)',
                                                    url: 'https://www.github.com',
                                                    label: 'gh#@@@', show_url: 'https://github.com/@@@')
   end

--- a/src/api/db/data/20210730130616_change_issuetracker_github_regex.rb
+++ b/src/api/db/data/20210730130616_change_issuetracker_github_regex.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# rubocop:disable Rails/SkipsModelValidations
+# We don't want the IssueTracker callbacks to run...
+class ChangeIssuetrackerGithubRegex < ActiveRecord::Migration[6.1]
+  def up
+    IssueTracker.where(name: 'gh').update_all(regex: '(?:gh|github)#([\w-]+\/[\w-]+#\d+)')
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end
+# rubocop:enable Rails/SkipsModelValidations

--- a/src/api/db/data_schema.rb
+++ b/src/api/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20210726221203)
+DataMigrate::Data.define(version: 20210730130616)

--- a/src/api/db/seeds.rb
+++ b/src/api/db/seeds.rb
@@ -327,6 +327,6 @@ IssueTracker.where(name: 'lf').first_or_create(description: 'Linux Foundation Bu
                                                label: 'lf#@@@', show_url: 'https://developerbugs.linuxfoundation.org/show_bug.cgi?id=@@@')
 IssueTracker.where(name: 'gh').first_or_create(description: 'Generic Github Tracker',
                                                kind: 'github',
-                                               regex: '(?:gh|github)#(\w+\/\w+#\d+)',
+                                               regex: '(?:gh|github)#([\w-]+\/[\w-]+#\d+)',
                                                url: 'https://www.github.com',
                                                label: 'gh#@@@', show_url: 'https://github.com/@@@')


### PR DESCRIPTION
rename migration to re-apply. fixed missing entry in structure.sql

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
