### PR TITLE
Show Project monitor's repository dropdown's topmost options

### DIFF
--- a/src/api/app/assets/stylesheets/webui/application.scss
+++ b/src/api/app/assets/stylesheets/webui/application.scss
@@ -59,6 +59,7 @@
 @import 'image_templates';
 @import 'search';
 @import 'monitor';
+@import 'project-monitor';
 @import 'cloud_upload';
 
 @import 'responsive_ux';

--- a/src/api/app/assets/stylesheets/webui/project-monitor.scss
+++ b/src/api/app/assets/stylesheets/webui/project-monitor.scss
@@ -1,4 +1,4 @@
-#project-monitor-repositories-dropdown {
+#project-monitor-repositories-dropdown, #project-monitor-architectures-dropdown, #project-monitor-status-dropdown {
     .dropdown-menu {
         z-index: 1031;
     }

--- a/src/api/app/assets/stylesheets/webui/project-monitor.scss
+++ b/src/api/app/assets/stylesheets/webui/project-monitor.scss
@@ -1,0 +1,5 @@
+#project-monitor-repositories-dropdown {
+    .dropdown-menu {
+        z-index: 1031;
+    }
+}


### PR DESCRIPTION
When there are many repositories to render in the Repositories dropdown the
topmost options were being rendered behind the top navbar.

Raising the z-index of the dropdown's content, we make them visible again.

Fixes #9350

Co-authored-by: David Kang <dkang@suse.com>

Here is a screenshot of how it looks:

**Before**
![image](https://user-images.githubusercontent.com/2650/79449554-b63d5d00-7fe3-11ea-8271-8e55d22b4374.png)

**After**
![image](https://user-images.githubusercontent.com/2650/79449590-cce3b400-7fe3-11ea-8749-8b7620ec93bb.png)
