### PR TITLE
Add perltidy linter and configuration

### DIFF
--- a/.circleci/conditional_config.yml
+++ b/.circleci/conditional_config.yml
@@ -25,6 +25,10 @@ parameters:
     type: boolean
     default: false
 
+  run-perl-linter:
+    type: boolean
+    default: false
+
 images:
   - &common_frontend_config
     user: frontend
@@ -145,6 +149,7 @@ jobs:
       - run: echo "run-migrations-tests is << pipeline.parameters.run-migrations-tests >>"
       - run: echo "run-dist-linter is << pipeline.parameters.run-dist-linter >>"
       - run: echo "run-haml-linter is << pipeline.parameters.run-haml-linter >>"
+      - run: echo "run-perl-linter is << pipeline.parameters.run-perl-linter >>"
 
   linters:
     docker:
@@ -182,6 +187,13 @@ jobs:
                 command: |
                   cd src/api
                   bundle exec rake dev:lint:haml
+      - when:
+          condition: << pipeline.parameters.run-perl-linter >>
+          steps:
+            - run:
+                name: Run perl linters
+                command: |
+                  make -C dist test_linters
       - when:
           condition: << pipeline.parameters.run-apidocs-linter >>
           steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,8 @@ workflows:
           name: Define dynamic CI pipeline
           mapping: |
             dist/.* run-dist-linter true
+            dist/t/.* run-perl-linter true
+            src/backend/.* run-perl-linter true
             src/backend/.* run-backend-tests true
             src/api/app/(views|components)/.* run-haml-linter true
             src/api/db/.* run-migrations-tests true

--- a/dist/.perltidyrc
+++ b/dist/.perltidyrc
@@ -1,0 +1,9 @@
+-l=120   # 120 characters per line
+-fbl     # don't change blank lines
+-nsfs    # no spaces before semicolons
+-baao    # space after operators
+-bbao    # space before operators
+-pt=2    # no spaces around ()
+-bt=2    # no spaces around []
+-sbt=2   # no spaces around {}
+-sct     # stack closing tokens )}

--- a/dist/Makefile
+++ b/dist/Makefile
@@ -86,6 +86,9 @@ test_appliance:
 scripts_linters:
 	./run_shellcheck.sh
 
+test_linters:
+	prove -v t/linters/*.t
+
 .PHONY: test_unit test_system
 
 include ../Makefile.targets

--- a/dist/t/lib/OBS/Test/Utils.pm
+++ b/dist/t/lib/OBS/Test/Utils.pm
@@ -3,14 +3,14 @@ use strict;
 use warnings;
 
 sub get_package_version {
-  my ($pkg, $num) = @_;
-  my @pkg_ver = `rpm -q --qf '%{version}' $pkg`;
-  my $raw_ver = $pkg_ver[0];
-  chomp $raw_ver;
-  $raw_ver =~ s/^([\d\.]*).*/$1/;
-  my @ver_raw = split(/\./, $raw_ver);
-  my @ver = splice(@ver_raw, 0, $num);
-  return join('.',@ver);
+    my ($pkg, $num) = @_;
+    my @pkg_ver = `rpm -q --qf '%{version}' $pkg`;
+    my $raw_ver = $pkg_ver[0];
+    chomp $raw_ver;
+    $raw_ver =~ s/^([\d\.]*).*/$1/;
+    my @ver_raw = split(/\./, $raw_ver);
+    my @ver     = splice(@ver_raw, 0, $num);
+    return join('.', @ver);
 }
 
 1;

--- a/dist/t/linters/0010-perltidy.t
+++ b/dist/t/linters/0010-perltidy.t
@@ -1,0 +1,15 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Test::PerlTidy qw( run_tests );
+
+run_tests(
+    exclude => [
+        '../dist/t/0010-obs-bootstrap-api.t', '../dist/t/0030-installed-files.t',
+        '../dist/t/lib/OBS/Test/Utils.pm',    '../src/api/vendor/',
+        '../src/backend/'
+    ],
+    path => '..'
+);

--- a/dist/t/linters/0010-perltidy.t
+++ b/dist/t/linters/0010-perltidy.t
@@ -8,8 +8,7 @@ use Test::PerlTidy qw( run_tests );
 run_tests(
     exclude => [
         '../dist/t/0010-obs-bootstrap-api.t', '../dist/t/0030-installed-files.t',
-        '../dist/t/lib/OBS/Test/Utils.pm',    '../src/api/vendor/',
-        '../src/backend/'
+        '../src/api/vendor/',                 '../src/backend/'
     ],
     path => '..'
 );


### PR DESCRIPTION
We want to benefit from having a linter that checks our perl files.

Initially it is only run on only one file. The second commit of this pull request is an example of fixing the offenses of the linter for only one more perl file.