### PR TITLE
Disable cache versioning

### DIFF
--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -804,7 +804,7 @@ class User < ApplicationRecord
 
   # TODO: Remove once responsive_ux is out of beta
   def tasks
-    Rails.cache.fetch("requests_for_#{cache_key}", version: cache_version) do
+    Rails.cache.fetch("requests_for_#{cache_key}") do
       declined_requests.count +
         incoming_requests.count +
         involved_reviews.count

--- a/src/api/app/views/webui/users/tasks/index.html.haml
+++ b/src/api/app/views/webui/users/tasks/index.html.haml
@@ -4,7 +4,7 @@
   .bg-light
     %ul.nav.nav-tabs.pt-2.px-3.flex-nowrap.collapsible{ 'role': 'tablist' }
       %li.nav-item
-        - cache("#{User.session!.cache_key}-reviews-in", version: User.session!.cache_version) do
+        - cache "#{User.session!.cache_key}-reviews-in" do
           %a.nav-link.text-nowrap.active{ href: '#reviews-in', title: "Requests that #{User.session!} has to review" }
             Incoming Reviews
             %span.badge.badge-primary
@@ -19,7 +19,7 @@
   .bg-light
     %ul.nav.nav-tabs.pt-2.px-3.flex-nowrap.collapsible{ 'role': 'tablist' }
       %li.nav-item
-        - cache("#{User.session!.cache_key}-requests-in", version: User.session!.cache_version) do
+        - cache "#{User.session!.cache_key}-requests-in" do
           %a.nav-link.text-nowrap.active#requests-in-tab{ href: '#requests-in', title: "Requests that #{User.session!} has to merge",
             'data-toggle': 'tab', 'aria-controls': 'requests-in-tab', 'aria-selected': 'true', role: 'tab' }
             Incoming Requests

--- a/src/api/config/application.rb
+++ b/src/api/config/application.rb
@@ -87,6 +87,10 @@ module OBSApi
 
     config.action_controller.perform_caching = true
 
+    # Don't use cache versioning for now
+    config.active_record.cache_versioning = false
+    config.active_record.collection_cache_versioning = false
+
     config.action_controller.action_on_unpermitted_parameters = :raise
 
     config.action_dispatch.rescue_responses['Backend::Error'] = 500

--- a/src/api/spec/models/bs_request_spec.rb
+++ b/src/api/spec/models/bs_request_spec.rb
@@ -300,13 +300,13 @@ RSpec.describe BsRequest, vcr: true do
     RSpec.shared_examples "the subject's cache is reset when it's request changes" do
       before do
         Timecop.travel(1.minute)
-        @cache_version = user.cache_version
+        @cache_key = user.cache_key
         request.state = :review
         request.save
         user.reload
       end
 
-      it { expect(user.cache_version).not_to eq(@cache_version) }
+      it { expect(user.cache_key).not_to eq(@cache_key) }
     end
 
     context 'creator of bs_request' do

--- a/src/api/spec/models/review_spec.rb
+++ b/src/api/spec/models/review_spec.rb
@@ -345,13 +345,13 @@ RSpec.describe Review do
     RSpec.shared_examples "the subject's cache is reset when it's review changes" do
       before do
         Timecop.travel(1.minute)
-        @cache_version = subject.cache_version
+        @cache_key = subject.cache_key
         review.state = :accepted
         review.save
         subject.reload
       end
 
-      it { expect(subject.cache_version).not_to eq(@cache_version) }
+      it { expect(subject.cache_key).not_to eq(@cache_key) }
     end
 
     context 'by_user' do


### PR DESCRIPTION
Since we lately experienced some issues related to the newly
introduced cache versioning, we should disable it for now and
first adjust/check our codebase accordingly.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
