### PR TITLE
Preview on notification

### DIFF
--- a/src/api/app/models/event/request_statechange.rb
+++ b/src/api/app/models/event/request_statechange.rb
@@ -6,7 +6,7 @@ module Event
     receiver_roles :source_maintainer, :target_maintainer, :creator, :reviewer, :source_watcher, :target_watcher
 
     def subject
-      "Request #{payload['number']} changed to #{payload['state']} (#{actions_summary})"
+      "Request #{payload['number']} changed from #{payload['oldstate']} to #{payload['state']} (#{actions_summary})"
     end
 
     def parameters_for_notification

--- a/src/api/app/presenters/notification_presenter.rb
+++ b/src/api/app/presenters/notification_presenter.rb
@@ -31,4 +31,18 @@ class NotificationPresenter < SimpleDelegator
       'Comment'
     end
   end
+
+  def excerpt
+    text =  case @model.notifiable_type
+            when 'Request'
+              @model.notifiable.description
+            when 'Review'
+              @model.notifiable.reason
+            when 'Comment'
+              @model.notifiable.body
+            else
+              ''
+            end
+    text.to_s.truncate(100)
+  end
 end

--- a/src/api/app/views/webui/users/notifications/index.html.haml
+++ b/src/api/app/views/webui/users/notifications/index.html.haml
@@ -47,6 +47,7 @@
                     %span.badge.badge-secondary= notification.notification_badge
                     %small.text-muted= time_ago_in_words(notification.created_at)
                   = link_to(n.title, notification.link_to_notification_target, class: 'text-word-break-all')
+                  %p.text-muted= notification.excerpt
                 - unless params[:type] == 'read'
                   .actions.align-self-end.align-self-sm-start.pl-3.pt-3.pt-sm-0
                     = link_to(my_notification_path(id: notification),

--- a/src/api/spec/db/data/regenerate_notifications_spec.rb
+++ b/src/api/spec/db/data/regenerate_notifications_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe RegenerateNotifications, type: :migration do
         # Checks the Notification's attributes have correct values:
         expect(notification.event_payload['number']).to eq(declined_bs_request.number)
         expect(notification.notifiable).to eq(declined_bs_request)
-        expect(notification.title).to eq("Request #{declined_bs_request.number} changed to declined (submit #{project}/#{package})")
+        expect(notification.title).to eq("Request #{declined_bs_request.number} changed from new to declined (submit #{project}/#{package})")
         expect(notification.created_at.to_s).to eq(declined_bs_request.updated_when.to_s)
         expect(notification.updated_at.to_s).to eq(declined_bs_request.updated_when.to_s)
         expect(notification.bs_request_oldstate).to eq('new')

--- a/src/api/test/fixtures/event_mailer/tom_declined
+++ b/src/api/test/fixtures/event_mailer/tom_declined
@@ -5,7 +5,7 @@ To: Iggy Pop <Iggy@pop.org>
 Message-ID: <notrandom@localhost>
 In-Reply-To: <obs-request-REQUESTID@localhost>
 References: <obs-request-REQUESTID@localhost>
-Subject: Request REQUESTID changed to declined (set_bugowner home:tom)
+Subject: Request REQUESTID changed from new to declined (set_bugowner home:tom)
 Mime-Version: 1.0
 Content-Type: text/plain;
  charset=UTF-8

--- a/src/api/test/functional/request_events_test.rb
+++ b/src/api/test/functional/request_events_test.rb
@@ -99,7 +99,7 @@ class RequestEventsTest < ActionDispatch::IntegrationTest
       email = m if m.to.include?('Iggy@pop.org')
     end
 
-    assert_equal "Request #{myid} changed to declined (set_bugowner home:tom)", email.subject
+    assert_equal "Request #{myid} changed from new to declined (set_bugowner home:tom)", email.subject
     verify_email('tom_declined', myid, email)
   end
 


### PR DESCRIPTION
According to the type, the notifications list will also show an excerpt
of the description (requests), body (comments) or reason (reviews).

![Screenshot_2020-04-21 Open Build Service](https://user-images.githubusercontent.com/2581944/79859630-96d27580-83d1-11ea-8d03-55979edb3b7d.png)


On `RequestStatechange` notifications, both old and new states are included in the title.

![Screenshot from 2020-04-21 13-10-10](https://user-images.githubusercontent.com/2581944/79859643-a0f47400-83d1-11ea-9563-9c92c24ffa9b.png)


<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
