### PR TITLE
Create notifications_projects join table

### DIFF
--- a/src/api/db/migrate/20200421115317_create_join_table_notifications_projects.rb
+++ b/src/api/db/migrate/20200421115317_create_join_table_notifications_projects.rb
@@ -1,0 +1,8 @@
+class CreateJoinTableNotificationsProjects < ActiveRecord::Migration[6.0]
+  def change
+    create_join_table :notifications, :projects, column_options: { type: :integer, null: false } do |t|
+      t.index :notification_id
+      t.index [:notification_id, :project_id], unique: true
+    end
+  end
+end

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -855,6 +855,13 @@ CREATE TABLE `notifications` (
   KEY `index_notifications_on_notifiable_type_and_notifiable_id` (`notifiable_type`,`notifiable_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
+CREATE TABLE `notifications_projects` (
+  `notification_id` int(11) NOT NULL,
+  `project_id` int(11) NOT NULL,
+  UNIQUE KEY `index_notifications_projects_on_notification_id_and_project_id` (`notification_id`,`project_id`),
+  KEY `index_notifications_projects_on_notification_id` (`notification_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
 CREATE TABLE `package_issues` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `package_id` int(11) NOT NULL,
@@ -1493,6 +1500,7 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20200313143312'),
 ('20200317120346'),
 ('20200318123203'),
-('20200402141344');
+('20200402141344'),
+('20200421115317');
 
 


### PR DESCRIPTION
Retrieving the projects of a notification, requires querying for comments, requests and reviews. We want to avoid n+1 queries instead of going through the polymorphic associations notifiable and notifiable.commentable for comments.

Co-authored-by: David Kang <dkang@suse.com>
