### PR TITLE
Adapt Job to handle new notification channels

### DIFF
--- a/src/api/app/controllers/webui/users/notifications_controller.rb
+++ b/src/api/app/controllers/webui/users/notifications_controller.rb
@@ -3,7 +3,7 @@ class Webui::Users::NotificationsController < Webui::WebuiController
   MAX_PER_PAGE = 300
 
   def index
-    notifications_for_subscribed_user = NotificationsFinder.new.for_subscribed_user
+    notifications_for_subscribed_user = User.session.notifications.for_web
     @notifications = NotificationsFinder.new(notifications_for_subscribed_user).for_notifiable_type(params[:type])
     @notifications = params['show_all'] ? show_all : @notifications.page(params[:page])
   end

--- a/src/api/app/jobs/send_event_emails_job.rb
+++ b/src/api/app/jobs/send_event_emails_job.rb
@@ -4,11 +4,7 @@ class SendEventEmailsJob < ApplicationJob
   def perform
     Event::Base.where(mails_sent: false).order(created_at: :asc).limit(1000).each do |event|
       subscribers = event.subscribers
-
-      if subscribers.empty?
-        event.update_attributes(mails_sent: true)
-        next
-      end
+      event.update(mails_sent: true) if subscribers.empty?
 
       NotificationCreator.new(event).call
       send_email(subscribers, event)
@@ -19,6 +15,7 @@ class SendEventEmailsJob < ApplicationJob
   private
 
   def send_email(subscribers, event)
+    return if subscribers.empty?
     EventMailer.event(subscribers, event).deliver_now
   rescue StandardError => e
     Airbrake.notify(e, event_id: event.id)

--- a/src/api/app/models/event/base.rb
+++ b/src/api/app/models/event/base.rb
@@ -189,8 +189,8 @@ module Event
       ret
     end
 
-    def subscriptions
-      EventSubscription::FindForEvent.new(self).subscriptions
+    def subscriptions(channel = :instant_email)
+      EventSubscription::FindForEvent.new(self).subscriptions(channel)
     end
 
     def subscribers
@@ -265,7 +265,6 @@ module Event
         event_payload: payload,
         notifiable_id: payload['id'],
         created_at: payload['when'].to_datetime,
-        updated_at: payload['when'].to_datetime,
         title: subject_to_title }
     end
 

--- a/src/api/app/models/group.rb
+++ b/src/api/app/models/group.rb
@@ -13,6 +13,7 @@ class Group < ApplicationRecord
   has_many :event_subscriptions, dependent: :destroy, inverse_of: :group
   has_many :reviews, dependent: :nullify
 
+  # TODO: Remove with Notification::RssFeedItem
   has_many :rss_feed_items, -> { order(created_at: :desc) }, class_name: 'Notification::RssFeedItem', as: :subscriber, dependent: :destroy
   has_many :notifications, -> { order(created_at: :desc) }, as: :subscriber, dependent: :destroy
 

--- a/src/api/app/models/notification.rb
+++ b/src/api/app/models/notification.rb
@@ -1,4 +1,7 @@
 class Notification < ApplicationRecord
+  MAX_RSS_ITEMS_PER_USER = 10
+  MAX_RSS_ITEMS_PER_GROUP = 10
+
   belongs_to :subscriber, polymorphic: true
   belongs_to :notifiable, polymorphic: true
 
@@ -6,6 +9,9 @@ class Notification < ApplicationRecord
   has_many :projects, through: :notified_projects
 
   serialize :event_payload, JSON
+
+  scope :for_web, -> { where(web: true) }
+  scope :for_rss, -> { where(rss: true) }
 
   def event
     @event ||= event_type.constantize.new(event_payload)

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -61,6 +61,7 @@ class User < ApplicationRecord
   has_one :azure_configuration, class_name: 'Cloud::Azure::Configuration', dependent: :destroy
   has_many :upload_jobs, class_name: 'Cloud::User::UploadJob', dependent: :destroy
 
+  # TODO: Remove with Notification::RssFeedItem
   has_many :rss_feed_items, -> { order(created_at: :desc) }, class_name: 'Notification::RssFeedItem', as: :subscriber, dependent: :destroy
   has_many :notifications, -> { order(created_at: :desc) }, as: :subscriber, dependent: :destroy
 
@@ -812,7 +813,7 @@ class User < ApplicationRecord
   end
 
   def unread_notifications
-    NotificationsFinder.new(notifications).unread.size
+    NotificationsFinder.new(notifications.for_web).unread.size
   end
 
   def watched_project_names
@@ -860,9 +861,9 @@ class User < ApplicationRecord
   end
 
   def combined_rss_feed_items
-    Notification::RssFeedItem.where(subscriber: self).or(
-      Notification::RssFeedItem.where(subscriber: groups)
-    ).order(created_at: :desc, id: :desc).limit(Notification::RssFeedItem::MAX_ITEMS_PER_USER)
+    Notification.for_rss.where(subscriber: self).or(
+      Notification.for_rss.where(subscriber: groups)
+    ).order(created_at: :desc, id: :desc).limit(Notification::MAX_RSS_ITEMS_PER_USER)
   end
 
   def mark_login!

--- a/src/api/app/services/notification_creator.rb
+++ b/src/api/app/services/notification_creator.rb
@@ -28,6 +28,7 @@ class NotificationCreator
   def create_notification_per_subscription(subscription, channel)
     return unless create_notification?(subscription.subscriber, channel)
     params = subscription.parameters_for_notification.merge!(@event.parameters_for_notification)
+    # TODO: Replace by Notification when we remove Notification::RssFeedItem class
     notification = Notification::RssFeedItem.find_or_create_by!(params) # avoid duplication
     notification.update("#{channel}": true)
   end

--- a/src/api/app/services/notification_creator.rb
+++ b/src/api/app/services/notification_creator.rb
@@ -5,6 +5,7 @@ class NotificationCreator
                       'Event::CommentForProject',
                       'Event::CommentForPackage',
                       'Event::CommentForRequest'].freeze
+  CHANNELS = [:web, :rss].freeze
 
   def initialize(event)
     @event = event
@@ -12,16 +13,28 @@ class NotificationCreator
 
   def call
     return unless @event.eventtype.in?(EVENTS_TO_NOTIFY)
-    @event.subscriptions.each { |subscription| create_notification_per_subscription(subscription) }
+
+    CHANNELS.each do |channel|
+      @event.subscriptions(channel).each do |subscription|
+        create_notification_per_subscription(subscription, channel)
+      end
+    end
   rescue StandardError => e
     Airbrake.notify(e, event_id: @event.id)
   end
 
   private
 
-  def create_notification_per_subscription(subscription)
-    return if subscription.subscriber && subscription.subscriber.away?
+  def create_notification_per_subscription(subscription, channel)
+    return unless create_notification?(subscription.subscriber, channel)
     params = subscription.parameters_for_notification.merge!(@event.parameters_for_notification)
-    Notification::RssFeedItem.find_or_create_by!(params) # avoid duplication
+    notification = Notification::RssFeedItem.find_or_create_by!(params) # avoid duplication
+    notification.update("#{channel}": true)
+  end
+
+  def create_notification?(subscriber, channel)
+    return false if subscriber && subscriber.away?
+    return false if channel == :rss && !subscriber.try(:rss_token)
+    true
   end
 end

--- a/src/api/db/data/20200424080753_generate_web_notifications.rb
+++ b/src/api/db/data/20200424080753_generate_web_notifications.rb
@@ -1,0 +1,50 @@
+class GenerateWebNotifications < ActiveRecord::Migration[6.0]
+  def up
+    Notification.update(rss: true, web: true)
+    update_existent_event_subscriptions
+    generate_subscripitions
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  private
+
+  def update_existent_event_subscriptions
+    enabled_subscriptions = EventSubscription.where(channel: :instant_email)
+    enabled_subscriptions.update(enabled: true)
+
+    disabled_subscriptions = EventSubscription.where(channel: :disabled)
+    disabled_subscriptions.update(channel: :instant_email)
+  end
+
+  def generate_subscripitions
+    subscriptions = EventSubscription.where(channel: :instant_email, enabled: true)
+    subscriptions.each do |subscription|
+      create_subscription_for_channel(subscription, :web)
+      create_subscription_for_channel_rss(subscription, subscription.subscriber)
+    end
+  end
+
+  def create_subscription_for_channel(subscription, channel)
+    return if eventtype_disabled_for_web_and_rss?(subscription.eventtype)
+    subscription = EventSubscription.find_or_initialize_by(user_id: subscription.user_id,
+                                                           group_id: subscription.group_id,
+                                                           receiver_role: subscription.receiver_role,
+                                                           eventtype: subscription.eventtype,
+                                                           channel: channel)
+    subscription.enabled = true
+    subscription.save!
+  end
+
+  def create_subscription_for_channel_rss(subscription, subscriber)
+    return if subscriber && !subscriber.try(:rss_token)
+
+    create_subscription_for_channel(subscription, :rss)
+  end
+
+  def eventtype_disabled_for_web_and_rss?(event_type)
+    ['Event::BuildFail', 'Event::ServiceFail'].include?(event_type)
+  end
+end

--- a/src/api/db/data_schema.rb
+++ b/src/api/db/data_schema.rb
@@ -1,2 +1,2 @@
 # encoding: UTF-8
-DataMigrate::Data.define(version: 20190902110039)
+DataMigrate::Data.define(version: 20200424080753)

--- a/src/api/db/migrate/20200422134122_add_rss_and_web_to_notification.rb
+++ b/src/api/db/migrate/20200422134122_add_rss_and_web_to_notification.rb
@@ -1,0 +1,15 @@
+class AddRssAndWebToNotification < ActiveRecord::Migration[6.0]
+  def up
+    safety_assured do
+      add_column :notifications, :rss, :boolean, default: false
+      add_column :notifications, :web, :boolean, default: false
+    end
+  end
+
+  def down
+    safety_assured do
+      remove_column :notifications, :rss
+      remove_column :notifications, :web
+    end
+  end
+end

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -851,6 +851,8 @@ CREATE TABLE `notifications` (
   `bs_request_oldstate` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
   `bs_request_state` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `title` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
+  `rss` tinyint(1) DEFAULT '0',
+  `web` tinyint(1) DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `index_notifications_on_subscriber_type_and_subscriber_id` (`subscriber_type`,`subscriber_id`),
   KEY `index_notifications_on_notifiable_type_and_notifiable_id` (`notifiable_type`,`notifiable_id`)
@@ -1506,6 +1508,7 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20200318123203'),
 ('20200402141344'),
 ('20200421115317'),
+('20200422134122'),
 ('20200423160517');
 
 

--- a/src/api/spec/controllers/webui/users/notifications_controller_spec.rb
+++ b/src/api/spec/controllers/webui/users/notifications_controller_spec.rb
@@ -4,14 +4,14 @@ RSpec.describe Webui::Users::NotificationsController do
   let(:username) { 'reynoldsm' }
   let!(:user) { create(:confirmed_user, login: username) }
   let!(:other_user) { create(:confirmed_user) }
-  let(:state_change_notification) { create(:notification, :request_state_change, subscriber: user) }
-  let(:creation_notification) { create(:notification, :request_created, subscriber: user) }
-  let(:review_notification) { create(:notification, :review_wanted, subscriber: user) }
-  let(:comment_for_project_notification) { create(:notification, :comment_for_project, subscriber: user) }
-  let(:comment_for_package_notification) { create(:notification, :comment_for_package, subscriber: user) }
-  let(:comment_for_request_notification) { create(:notification, :comment_for_request, subscriber: user) }
-  let(:read_notification) { create(:notification, :request_state_change, subscriber: user, delivered: true) }
-  let(:notifications_for_other_users) { create(:notification, :request_state_change, subscriber: other_user) }
+  let(:state_change_notification) { create(:web_notification, :request_state_change, subscriber: user) }
+  let(:creation_notification) { create(:web_notification, :request_created, subscriber: user) }
+  let(:review_notification) { create(:web_notification, :review_wanted, subscriber: user) }
+  let(:comment_for_project_notification) { create(:web_notification, :comment_for_project, subscriber: user) }
+  let(:comment_for_package_notification) { create(:web_notification, :comment_for_package, subscriber: user) }
+  let(:comment_for_request_notification) { create(:web_notification, :comment_for_request, subscriber: user) }
+  let(:read_notification) { create(:web_notification, :request_state_change, subscriber: user, delivered: true) }
+  let(:notifications_for_other_users) { create(:web_notification, :request_state_change, subscriber: other_user) }
 
   shared_examples 'returning success' do
     it 'returns ok status' do
@@ -120,7 +120,7 @@ RSpec.describe Webui::Users::NotificationsController do
         put :update, params: { id: read_notification.id, user_login: user_to_log_in.login }
       end
 
-      let(:read_notification) { create(:notification, :request_state_change, subscriber: user, delivered: true) }
+      let(:read_notification) { create(:web_notification, :request_state_change, subscriber: user, delivered: true) }
       let(:user_to_log_in) { user }
 
       it 'redirects back' do

--- a/src/api/spec/db/data/generate_web_notifications_spec.rb
+++ b/src/api/spec/db/data/generate_web_notifications_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+require Rails.root.join('db/data/20200424080753_generate_web_notifications.rb')
+
+RSpec.describe GenerateWebNotifications, type: :migration do
+  describe 'up' do
+    let(:owner) { create(:confirmed_user, login: 'bob') }
+    let(:requester) { create(:confirmed_user, login: 'ann') }
+    let!(:rss_notifications) { create_list(:rss_notification, 5, subscriber: owner) }
+    let!(:event_subscription_1) { create(:event_subscription_comment_for_project, user: owner) }
+    let!(:event_subscription_2) { create(:event_subscription_comment_for_project, user: owner, receiver_role: 'maintainer') }
+    let!(:event_subscription_3) { create(:event_subscription_comment_for_project, user: owner, receiver_role: 'bugowner') }
+    let!(:disabled_event_for_web_and_rss) { create(:event_subscription, eventtype: 'Event::BuildFail', user: owner, receiver_role: 'maintainer') }
+    let!(:default_subscription) { create(:event_subscription_comment_for_project_without_subscriber, receiver_role: 'bugowner') }
+    let!(:default_subscription_1) { create(:event_subscription_comment_for_project_without_subscriber, receiver_role: 'watcher') }
+    let!(:default_subscription_2) do
+      create(:event_subscription_comment_for_project_without_subscriber,
+             receiver_role: 'maintainer',
+             channel: :disabled,
+             enabled: false)
+    end
+
+    subject { GenerateWebNotifications.new.up }
+
+    it { expect { subject }.to change(EventSubscription, :count).from(7).to(14) }
+
+    context 'check notification data' do
+      before do
+        subject
+      end
+
+      it { expect(Notification.pluck(:web)).to be_none(false) }
+      it { expect(Notification.pluck(:rss)).to be_none(false) }
+    end
+
+    context 'check user subscriptions' do
+      before do
+        subject
+      end
+
+      it { expect(owner.event_subscriptions.where(channel: :rss)).to be_empty }
+      it { expect(owner.event_subscriptions.where(channel: :web)).not_to be_empty }
+      it { expect(owner.event_subscriptions.where(channel: :web).count).to eq(3) }
+      it { expect(owner.event_subscriptions.where(eventtype: 'Event::BuildFail').count).to eq(1) }
+    end
+
+    context 'check default subscriptions' do
+      before do
+        subject
+      end
+
+      it { expect(EventSubscription.defaults.where(channel: :rss)).not_to be_empty }
+      it { expect(EventSubscription.defaults.where(channel: :rss).count).to be(2) }
+      it { expect(EventSubscription.defaults.where(channel: :web)).not_to be_empty }
+      it { expect(EventSubscription.defaults.where(channel: :web).count).to be(2) }
+      it { expect(EventSubscription.defaults.find_by(receiver_role: 'maintainer')).to be_instant_email }
+      it { expect(EventSubscription.defaults.find_by(receiver_role: 'maintainer')).not_to be_enabled }
+    end
+  end
+end

--- a/src/api/spec/factories/notification.rb
+++ b/src/api/spec/factories/notification.rb
@@ -40,6 +40,22 @@ FactoryBot.define do
   end
 
   factory :rss_notification, parent: :notification, class: 'Notification::RssFeedItem' do
+    rss { true }
+
+    transient do
+      stale { false }
+    end
+    after(:create) do |notification, evaluator|
+      if evaluator.stale
+        notification.created_at = 6.months.ago
+        notification.save
+      end
+    end
+  end
+
+  factory :web_notification, parent: :notification, class: 'Notification::RssFeedItem' do
+    web { true }
+
     transient do
       stale { false }
     end

--- a/src/api/spec/models/user_spec.rb
+++ b/src/api/spec/models/user_spec.rb
@@ -362,8 +362,8 @@ RSpec.describe User do
   end
 
   describe '#combined_rss_feed_items' do
-    let(:max_items_per_user) { Notification::RssFeedItem::MAX_ITEMS_PER_USER }
-    let(:max_items_per_group) { Notification::RssFeedItem::MAX_ITEMS_PER_GROUP }
+    let(:max_items_per_user) { Notification::MAX_RSS_ITEMS_PER_USER }
+    let(:max_items_per_group) { Notification::MAX_RSS_ITEMS_PER_GROUP }
     let(:group) { create(:group) }
     let!(:groups_user) { create(:groups_user, user: confirmed_user, group: group) }
 

--- a/src/api/spec/services/notification_creator_spec.rb
+++ b/src/api/spec/services/notification_creator_spec.rb
@@ -5,8 +5,9 @@ RSpec.describe NotificationCreator do
   let(:user_kim) { create(:confirmed_user, login: 'kim') }
   let(:commenter) { create(:confirmed_user, login: 'ann') }
 
-  let!(:bob_subscription) { create(:event_subscription_comment_for_project, receiver_role: 'maintainer', user: user_bob) }
-  let!(:kim_subscription) { create(:event_subscription_comment_for_project, receiver_role: 'maintainer', user: user_kim) }
+  let!(:bob_subscription) { create(:event_subscription_comment_for_project, receiver_role: 'maintainer', user: user_bob, channel: :rss) }
+  let!(:bob_web_subscription) { create(:event_subscription_comment_for_project, receiver_role: 'maintainer', user: user_bob, channel: :web) }
+  let!(:kim_subscription) { create(:event_subscription_comment_for_project, receiver_role: 'maintainer', user: user_kim, channel: :rss) }
 
   let(:project) { create(:project, name: 'bobkim_project') }
   let!(:relationship_bob) { create(:relationship_project_user, user: user_bob, project: project) }
@@ -17,19 +18,48 @@ RSpec.describe NotificationCreator do
   let(:comment_notifications) { Notification.where(notifiable_type: 'Comment') }
 
   describe '#call' do
-    subject! { NotificationCreator.new(event).call }
+    subject { NotificationCreator.new(event).call }
 
-    it 'creates only one CommentForProject notifications for subscriber' do
-      expect(Notification::RssFeedItem.count).to eq(2)
-      expect(Notification::RssFeedItem.where(event_type: 'Event::CommentForProject').pluck(:subscriber_id)).to match_array([user_bob.id, user_kim.id])
+    context 'when users has rss token' do
+      before do
+        user_bob.create_rss_token
+        user_kim.create_rss_token
+
+        subject
+      end
+
+      it 'creates only one CommentForProject notifications for subscriber' do
+        expect(Notification.count).to eq(2)
+        expect(Notification.where(event_type: 'Event::CommentForProject').pluck(:subscriber_id)).to match_array([user_bob.id, user_kim.id])
+      end
+
+      it 'creates one notification with rss and web checked' do
+        expect(Notification.find_by(subscriber: user_bob)).to be_web
+        expect(Notification.find_by(subscriber: user_bob)).to be_rss
+      end
+
+      it 'creates one notification with rss checked' do
+        expect(Notification.find_by(subscriber: user_kim)).not_to be_web
+        expect(Notification.find_by(subscriber: user_kim)).to be_rss
+      end
+
+      context 'when tries to create notifications twice' do
+        it 'creates only one CommentForProject notifications for subscriber and do not duplicate them' do
+          expect(Notification.count).to eq(2)
+          # Tries to create the same notifications twice:
+          expect { NotificationCreator.new(event).call }.not_to change(Notification, :count)
+        end
+      end
     end
 
-    context 'when tries to create notifications twice' do
-      it 'creates only one CommentForProject notifications for subscriber and do not duplicate them' do
-        expect(Notification::RssFeedItem.count).to eq(2)
-        # Tries to create the same notifications twice:
-        expect { NotificationCreator.new(event).call }.not_to change(Notification::RssFeedItem, :count)
+    context "when users don't have rss token" do
+      before do
+        subject
       end
+
+      it { expect(Notification.count).to eq(1) }
+      it { expect(Notification.first).to be_web }
+      it { expect(Notification.first).not_to be_rss }
     end
   end
 end


### PR DESCRIPTION
Following with the PR #9405. This PR affects `send_event_emails_job` job (a job for creating the notifications and send email) and user notifications view.

We also added a data migration to duplicate the existent notifications to create Notification::WebItem records and also create subscriptions for `rss` and `web`.