### PR TITLE
Refactor ConsistencyCheckJob job

### DIFF
--- a/src/api/app/jobs/consistency_check_job.rb
+++ b/src/api/app/jobs/consistency_check_job.rb
@@ -1,61 +1,39 @@
 require 'api_error'
-require 'xmlhash'
 
 class ConsistencyCheckJob < ApplicationJob
   queue_as :consistency_check
 
   def perform
-    User.get_default_admin.run_as { _perform(nil) }
+    User.get_default_admin.run_as { _perform(false) }
   end
 
-  def check_one_project(project, fix)
-    unless Project.valid_name?(project.name)
-      @errors << "Invalid project name #{project.name}\n"
-      if fix
-        # just remove it, the backend won't accept it anyway
-        project.commit_opts = { no_backend_write: 1 }
-        project.destroy
-      end
-      return
-    end
-    @errors << package_existence_consistency_check(project, fix)
-    @errors << project_meta_check(project, fix)
+  def check_one_project(project, fix = false)
+    package_existence_consistency_check(project, fix)
+    project_meta_check(project, fix)
+    @errors.flatten.reject(&:empty?).join("\n")
   end
 
-  def _perform(fix)
-    @errors = project_existence_consistency_check(fix)
-    Project.find_each(batch_size: 100) { |project| check_one_project(project, fix) }
-    return if @errors.empty?
-    @errors = "FIXING the following errors:\n" << @errors if fix
-    Rails.logger.error('Detected problems during consistency check')
-    Rails.logger.error(@errors)
-
-    AdminMailer.error(@errors).deliver_now
-    nil
+  # method called by the rake task `fix_project`
+  def fix_project(project)
+    User.get_default_admin.run_as { check_project(project, true) }
   end
 
-  # for manual fixing by admin via rails command
-  def fix_project
-    User.get_default_admin.run_as { check_project(true) }
-  end
-
-  def check_project(fix = nil)
-    if ENV['project'].blank?
-      puts "Please specify the project with 'project=MyProject' on CLI"
-      return
-    end
-    # check api side
+  # method called by the rake task `check_project`
+  def check_project(project_name, fix = false)
+    # check frontend
     begin
-      project = Project.get_by_name(ENV['project'])
+      project = Project.get_by_name(project_name)
       @errors << project_meta_check(project, fix)
     rescue Project::UnknownObjectError
+      #
       # specified but does not exist in api. does it also not exist in backend?
-      answer = import_project_from_backend(ENV['project'])
+      answer = import_project_from_backend(project_name)
       if answer.present?
         @errors << answer
-        return
+        return @errors.flatten.reject(&:empty?).join("\n")
       end
-      project = Project.get_by_name(ENV['project'])
+    ensure
+      project = Project.get_by_name(project_name)
     end
     # check backend side
     begin
@@ -65,202 +43,98 @@ class ConsistencyCheckJob < ApplicationJob
       project.commit_opts = { no_backend_write: 1 }
       project.destroy if fix
     end
-    @errors << package_existence_consistency_check(project, fix)
-    puts @errors if @errors.present?
+    package_existence_consistency_check(project, fix)
+    @errors.flatten.reject(&:empty?).join("\n")
   end
 
   private
 
-  def fix
-    User.get_default_admin.run_as { _perform(true) }
-  end
-
   def initialize
     super
-    @errors = ''
+    @errors = []
   end
 
-  def project_meta_check(project, fix = nil)
-    errors = ''
-    # WARNING: this is using the memcache content. should maybe dropped before
-    api_meta = project.to_axml
-    begin
-      backend_meta = Backend::Api::Sources::Project.meta(project.name)
-    rescue Backend::NotFoundError
-      # project disappeared ... may happen in running system
-      return ''
-    end
-
-    backend_hash = Xmlhash.parse(backend_meta)
-    api_hash = Xmlhash.parse(api_meta)
-    # ignore description and title
-    backend_hash['title'] = api_hash['title'] = nil
-    backend_hash['description'] = api_hash['description'] = nil
-
-    diff = hash_diff(api_hash, backend_hash)
-    unless diff.empty?
-      errors << "Project meta is different in backend for #{project.name}\n#{diff}\n"
-      if fix
-        # Assume that api is right
-        project.store(login: 'Admin', comment: 'out-of-sync fix')
-      end
-    end
-
-    errors
+  def _perform(fix = false)
+    project_existence_consistency_check(fix)
+    Project.find_each(batch_size: 100) { |project| check_one_project(project, fix) }
+    send_error_email unless @errors.empty?
   end
 
-  def project_existence_consistency_check(fix = nil)
-    errors = ''
-    # compare projects
-    project_list_api = Project.order(:name).pluck(:name)
-    begin
-      project_list_backend = dir_to_array(Xmlhash.parse(Backend::Api::Sources::Project.list))
-    rescue Backend::NotFoundError
-      # project disappeared ... may happen in running system
-      return ''
-    end
-
-    diff = project_list_api - project_list_backend
-    unless diff.empty?
-      errors << "Additional projects in api:\n #{diff}\n"
-      if fix
-        # just delete ... if it exists in backend it can be undeleted
-        diff.each do |project|
-          project = Project.find_by_name(project)
-          project.destroy if project
-        end
-      end
-    end
-
-    diff = project_list_backend - project_list_api
-    unless diff.empty?
-      errors << "Additional projects in backend:\n #{diff}\n"
-
-      if fix
-        diff.each do |project|
-          errors << import_project_from_backend(project)
-        end
-      end
-    end
-
-    errors
+  def send_error_email
+    AdminMailer.error(@errors.prepend('Fixing the following errors:').join("\n")).deliver_now
   end
 
+  def project_meta_check(project, fix = false)
+    project_meta_checker = ConsistencyCheckJobService::ProjectMetaChecker.new(project)
+    project_meta_checker.call
+
+    unless project_meta_checker.errors.empty?
+      project.store(login: 'Admin', comment: 'out-of-sync fix') if fix
+    end
+
+    project_meta_checker.errors
+  end
+
+  def project_existence_consistency_check(fix = false)
+    project_consistency_checker = ConsistencyCheckJobService::ProjectConsistencyChecker.new.call
+
+    diff = project_consistency_checker.diff_frontend_backend
+
+    #
+    # delete projects which exist in the frontend but not in the backend
+    #
+    unless diff.empty?
+      @errors << "Additional projects in frontend:\n #{diff}"
+      diff.each { |project_name| Project.find_by_name(name: project_name).destroy } if fix
+    end
+
+    diff = project_consistency_checker.diff_backend_frontend
+
+    return if diff.empty?
+
+    @errors << "Additional projects in backend:\n #{diff}"
+    diff.each { |project| import_project_from_backend(project) } if fix
+  end
+
+  # if there is a package in the backend, but not in frontend
+  # we recreate it on frontend using the project meta from backend
   def import_project_from_backend(project)
-    meta = Backend::Api::Sources::Project.meta(project)
-    project = Project.new(name: project)
-    project.commit_opts = { no_backend_write: 1 }
-    project.update_from_xml!(Xmlhash.parse(meta))
-    project.save!
-    return ''
-  rescue APIError => e
-    return "Invalid project meta data hosted in src server for project #{project}: #{e}"
-  rescue ActiveRecord::RecordInvalid
-    Backend::Api::Sources::Project.delete(project)
-    return "DELETED #{project} on backend due to invalid data\n"
-  rescue Backend::NotFoundError
-    return "specified #{project} does not exist on backend\n"
+    backend_project_importer = ConsistencyCheckJobService::BackendProjectImporter.new(project)
+    backend_project_importer.call
+    @errors << backend_project_importer.errors if backend_project_importer.errors.present?
   end
 
-  def package_existence_consistency_check(project, fix = nil)
-    errors = ''
+  def package_existence_consistency_check(project, fix = false)
     begin
       project.reload
     rescue ActiveRecord::RecordNotFound
       # project disappeared ... may happen in running system
-      return ''
+      return []
     end
 
-    # valid package names?
-    package_list_api = project.packages.pluck(:name)
-    package_list_api.each do |name|
-      next if Package.valid_name?(name)
-      errors << "Invalid package name #{name} in project #{project.name}\n"
-      next unless fix
-      # just remove it, the backend won't accept it anyway
-      pkg = project.packages.find_by(name: name)
-      pkg.commit_opts = { no_backend_write: 1 }
-      pkg.destroy
-      next
-    end
+    consistency_checker = ConsistencyCheckJobService::PackageConsistencyChecker.new(project).call
 
-    # compare all packages
-    package_list_api = project.packages.pluck(:name)
-    begin
-      plb = dir_to_array(Xmlhash.parse(Backend::Api::Sources::Project.packages(project.name)))
-    rescue Backend::NotFoundError
-      # project disappeared ... may happen in running system
-      return ''
-    end
-    # filter multibuild source container
-    package_list_backend = plb.map { |e| e.start_with?('_patchinfo:', '_product:') ? e : e.gsub(/:.*$/, '') }
+    diff = consistency_checker.diff_frontend_backend
 
-    diff = package_list_api - package_list_backend
     unless diff.empty?
-      errors << "Additional package in api project #{project.name}:\n #{diff}\n"
-      if fix
-        # delete database object, can be undeleted
-        diff.each do |package|
-          pkg = project.packages.where(name: package).first
-          pkg.destroy if pkg
-        end
-      end
+      @errors << "Additional package in frontend #{project.name}:\n #{diff}"
+      # delete package in frontend, can be undeleted
+      diff.each { |package_name| project.packages.find_by(name: package_name).destroy } if fix
     end
 
-    diff = package_list_backend - package_list_api
-    unless diff.empty?
-      errors << "Additional package in backend project #{project.name}:\n #{diff}\n"
+    diff = consistency_checker.diff_backend_frontend
 
-      if fix
-        # restore from backend
-        diff.each do |package|
-          meta = Backend::Api::Sources::Project.meta(project.name)
-          pkg = project.packages.new(name: package)
-          pkg.commit_opts = { no_backend_write: 1 }
-          pkg.update_from_xml(Xmlhash.parse(meta), true) # ignore locked project
-          pkg.save!
-        rescue ActiveRecord::RecordInvalid,
-               Backend::NotFoundError
-          Backend::Api::Sources::Package.delete(project.name, package)
-          errors << "DELETED in backend due to invalid data #{project.name}/#{package}\n"
-        end
-      end
-    end
-    errors
-  end
+    return if diff.empty?
 
-  def dir_to_array(xmlhash)
-    array = []
-    xmlhash.elements('entry') do |e|
-      array << e['name']
-    end
-    array.sort!
-  end
+    @errors << "Additional package in backend #{project.name}:\n #{diff}"
 
-  def hash_diff(a, b)
-    # ignore the order inside of the hash
-    (a.keys | b.keys).sort!.each_with_object({}) do |diff, k|
-      a_ = a[k]
-      b_ = b[k]
-      # we need to ignore the ordering in some cases
-      # old xml generator wrote them in a different order
-      # but in other cases the order of elements matters
-      if k == 'person' && a_.is_a?(Array)
-        a_ = a_.map { |i| "#{i['userid']}/#{i['role']}" }.sort!
-        b_ = b_.map { |i| "#{i['userid']}/#{i['role']}" }.sort!
-      end
-      if k == 'group' && a_.is_a?(Array)
-        a_ = a_.map { |i| "#{i['groupid']}/#{i['role']}" }.sort!
-        b_ = b_.map { |i| "#{i['groupid']}/#{i['role']}" }.sort!
-      end
-      if a_ != b_
-        if a[k].class == Hash && b[k].class == Hash
-          diff[k] = hash_diff(a[k], b[k])
-        else
-          diff[k] = [a[k], b[k]]
-        end
-      end
-      diff
+    return unless fix
+
+    # restore from backend
+    diff.each do |package_name|
+      backend_package_importer = ConsistencyCheckJobService::BackendPackageImporter.new(project, package_name)
+      backend_package_importer.call
+      @errors << backend_package_importer.errors unless backend_package_importer.errors.empty?
     end
   end
 end

--- a/src/api/app/services/consistency_check_job_service/backend_package_importer.rb
+++ b/src/api/app/services/consistency_check_job_service/backend_package_importer.rb
@@ -1,0 +1,39 @@
+module ConsistencyCheckJobService
+  class BackendPackageImporter
+    attr_reader :errors
+
+    def initialize(project, package_name)
+      @project = project
+      @package = @project.packages.build(name: package_name)
+      @errors = []
+    end
+
+    def call
+      create_package_frontend
+    rescue ActiveRecord::RecordInvalid,
+           Backend::NotFoundError
+      delete_package
+      @errors << delete_error_message
+    end
+
+    private
+
+    def delete_error_message
+      "DELETED in backend due to invalid data #{@project.name}/#{@package.name}"
+    end
+
+    def create_package_frontend
+      @package.commit_opts = { no_backend_write: 1 }
+      @package.update_from_xml!(Xmlhash.parse(meta))
+      @package.save!
+    end
+
+    def meta
+      Backend::Api::Sources::Project.meta(@project)
+    end
+
+    def delete_package
+      Backend::Api::Sources::Package.delete(@project.name, @package.name)
+    end
+  end
+end

--- a/src/api/app/services/consistency_check_job_service/backend_project_importer.rb
+++ b/src/api/app/services/consistency_check_job_service/backend_project_importer.rb
@@ -1,0 +1,37 @@
+module ConsistencyCheckJobService
+  class BackendProjectImporter
+    attr_reader :errors
+
+    def initialize(project_name)
+      @project = Project.new(name: project_name)
+      @errors = []
+    end
+
+    def call
+      create_project_frontend
+    rescue APIError => e
+      @errors << "Invalid project meta data hosted in src server for project #{@project}: #{e}"
+    rescue ActiveRecord::RecordInvalid
+      delete_source
+      @errors << "DELETED #{@project} on backend due to invalid data"
+    rescue Backend::NotFoundError
+      @errors << "specified #{@project} does not exist on backend"
+    end
+
+    private
+
+    def create_project_frontend
+      @project.commit_opts = { no_backend_write: 1 }
+      @project.update_from_xml!(Xmlhash.parse(meta))
+      @project.save!
+    end
+
+    def meta
+      Backend::Api::Sources::Project.meta(@project)
+    end
+
+    def delete_source
+      Backend::Api::Sources::Project.delete(@project)
+    end
+  end
+end

--- a/src/api/app/services/consistency_check_job_service/base_consistency_checker.rb
+++ b/src/api/app/services/consistency_check_job_service/base_consistency_checker.rb
@@ -1,0 +1,27 @@
+module ConsistencyCheckJobService
+  class BaseConsistencyChecker
+    def initialize(_project = nil)
+      @diff_backend_frontend = []
+      @diff_frontend_backend = []
+    end
+
+    def call
+      # generate diffs
+      diff_frontend_backend
+      diff_backend_frontend
+      self
+    end
+
+    def diff_frontend_backend
+      @diff_frontend_backend ||= (list_frontend - list_backend)
+    end
+
+    def diff_backend_frontend
+      @diff_backend_frontend ||= (list_backend - list_frontend)
+    end
+
+    def dir_to_array(xmlhash)
+      xmlhash.elements('entry').collect { |e| e['name'] }.sort
+    end
+  end
+end

--- a/src/api/app/services/consistency_check_job_service/package_consistency_checker.rb
+++ b/src/api/app/services/consistency_check_job_service/package_consistency_checker.rb
@@ -1,0 +1,26 @@
+module ConsistencyCheckJobService
+  class PackageConsistencyChecker < BaseConsistencyChecker
+    def initialize(project)
+      @project = project
+      super
+    end
+
+    def list_frontend
+      @project.packages.pluck(:name)
+    end
+
+    # filter multibuild source container
+    def list_backend
+      list_backend_packages.map { |e| e.start_with?('_patchinfo:', '_product:') ? e : e.gsub(/:.*$/, '') }
+    end
+
+    private
+
+    def list_backend_packages
+      dir_to_array(Xmlhash.parse(Backend::Api::Sources::Project.packages(@project.name)))
+    # project disappeared ... may happen in running system
+    rescue Backend::NotFoundError
+      return []
+    end
+  end
+end

--- a/src/api/app/services/consistency_check_job_service/project_consistency_checker.rb
+++ b/src/api/app/services/consistency_check_job_service/project_consistency_checker.rb
@@ -1,0 +1,18 @@
+module ConsistencyCheckJobService
+  class ProjectConsistencyChecker < BaseConsistencyChecker
+    def initialize
+      super
+    end
+
+    def list_frontend
+      Project.order(:name).pluck(:name)
+    end
+
+    def list_backend
+      dir_to_array(Xmlhash.parse(Backend::Api::Sources::Project.list))
+    rescue Backend::NotFoundError
+      # project disappeared ... may happen in running system
+      return []
+    end
+  end
+end

--- a/src/api/app/services/consistency_check_job_service/project_meta_checker.rb
+++ b/src/api/app/services/consistency_check_job_service/project_meta_checker.rb
@@ -1,0 +1,55 @@
+module ConsistencyCheckJobService
+  class ProjectMetaChecker
+    attr_reader :errors
+
+    def initialize(project)
+      @project = project
+      @errors = []
+    end
+
+    def call
+      @errors << "Project meta is different in backend for #{@project.name}\n#{diff}" if diff.present?
+    end
+
+    private
+
+    def diff
+      hash_diff(frontend_meta, backend_meta)
+    end
+
+    def frontend_meta
+      Xmlhash.parse(@project.to_axml)
+    end
+
+    def backend_meta
+      Xmlhash.parse(Backend::Api::Sources::Project.meta(@project))
+    end
+
+    def hash_diff(a, b)
+      # ignore the order inside of the hash
+      (a.keys | b.keys).sort!.each_with_object({}) do |diff, k|
+        a_ = a[k]
+        b_ = b[k]
+        # we need to ignore the ordering in some cases
+        # old xml generator wrote them in a different order
+        # but in other cases the order of elements matters
+        if k == 'person' && a_.is_a?(Array)
+          a_ = a_.map { |i| "#{i['userid']}/#{i['role']}" }.sort!
+          b_ = b_.map { |i| "#{i['userid']}/#{i['role']}" }.sort!
+        end
+        if k == 'group' && a_.is_a?(Array)
+          a_ = a_.map { |i| "#{i['groupid']}/#{i['role']}" }.sort!
+          b_ = b_.map { |i| "#{i['groupid']}/#{i['role']}" }.sort!
+        end
+        if a_ != b_
+          if a[k].class == Hash && b[k].class == Hash
+            diff[k] = hash_diff(a[k], b[k])
+          else
+            diff[k] = [a[k], b[k]]
+          end
+        end
+        diff
+      end
+    end
+  end
+end

--- a/src/api/lib/tasks/delayed_job.rake
+++ b/src/api/lib/tasks/delayed_job.rake
@@ -29,11 +29,23 @@ task(importrequests: :environment) do
   end
 end
 
-desc('Check project for consitency now, specify project with: project=MyProject')
-task(check_project: :environment) { ConsistencyCheckJob.new.check_project }
+# basic argument check for check_project and fix_project tasks
+task(project_environment: :environment) do
+  unless ENV['project']
+    puts "Please specify the project with 'project=MyProject' on CLI"
+    exit 1
+  end
+end
+
+desc('Check project for consistency now, specify project with: project=MyProject')
+task(check_project: [:environment, :project_environment]) do
+  puts ConsistencyCheckJob.new.check_project(ENV['project'])
+end
 
 desc('Fix inconsitent projects now, specify project with: project=MyProject')
-task(fix_project: :environment) { ConsistencyCheckJob.new.fix_project }
+task(fix_project: [:environment, :project_environment]) do
+  ConsistencyCheckJob.new.fix_project(ENV['project'])
+end
 
 namespace :jobs do
   desc 'Inject a job to write issue tracker information to backend'

--- a/src/api/spec/cassettes/ConsistencyCheckJob/_check_one_project/1_2_1.yml
+++ b/src/api/spec/cassettes/ConsistencyCheckJob/_check_one_project/1_2_1.yml
@@ -1,0 +1,77 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/super_project/_meta?user=user_1
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="super_project">
+          <title>Behold the Man</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '104'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="super_project">
+          <title>Behold the Man</title>
+          <description></description>
+        </project>
+    http_version: null
+  recorded_at: Wed, 22 Apr 2020 15:51:36 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/super_project/_project/_meta
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '104'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="super_project">
+          <title>Behold the Man</title>
+          <description></description>
+        </project>
+    http_version: null
+  recorded_at: Wed, 22 Apr 2020 15:51:36 GMT
+recorded_with: VCR 5.1.0

--- a/src/api/spec/cassettes/ConsistencyCheckJob/_check_project/fix_false/1_3_1_1.yml
+++ b/src/api/spec/cassettes/ConsistencyCheckJob/_check_project/fix_false/1_3_1_1.yml
@@ -1,0 +1,75 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/super_project/_meta?user=user_2
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="super_project">
+          <title>Eyeless in Gaza</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '105'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="super_project">
+          <title>Eyeless in Gaza</title>
+          <description></description>
+        </project>
+    http_version: null
+  recorded_at: Wed, 22 Apr 2020 15:51:36 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/super_project
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '25'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory>
+        </directory>
+    http_version: null
+  recorded_at: Wed, 22 Apr 2020 15:51:36 GMT
+recorded_with: VCR 5.1.0

--- a/src/api/spec/cassettes/ConsistencyCheckJob/_check_project/fix_true/project_should_call_store.yml
+++ b/src/api/spec/cassettes/ConsistencyCheckJob/_check_project/fix_true/project_should_call_store.yml
@@ -1,0 +1,75 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/super_project/_meta?user=user_3
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="super_project">
+          <title>Nectar in a Sieve</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '107'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="super_project">
+          <title>Nectar in a Sieve</title>
+          <description></description>
+        </project>
+    http_version: null
+  recorded_at: Wed, 22 Apr 2020 15:51:37 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/super_project
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '25'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory>
+        </directory>
+    http_version: null
+  recorded_at: Wed, 22 Apr 2020 15:51:37 GMT
+recorded_with: VCR 5.1.0

--- a/src/api/spec/cassettes/ConsistencyCheckJobService_BackendPackageImporter/_call/it_raises_ActiveRecord_RecordInvalid/1_1_1_1.yml
+++ b/src/api/spec/cassettes/ConsistencyCheckJobService_BackendPackageImporter/_call/it_raises_ActiveRecord_RecordInvalid/1_1_1_1.yml
@@ -1,0 +1,153 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/super_project/_meta?user=user_1
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="super_project">
+          <title>Ah, Wilderness!</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '105'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="super_project">
+          <title>Ah, Wilderness!</title>
+          <description></description>
+        </project>
+    http_version: null
+  recorded_at: Mon, 27 Apr 2020 10:12:16 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/super_project/foo/_meta?user=user_2
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="foo" project="super_project">
+          <title>A Time of Gifts</title>
+          <description>Quidem dolorum ut veniam.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '144'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="foo" project="super_project">
+          <title>A Time of Gifts</title>
+          <description>Quidem dolorum ut veniam.</description>
+        </package>
+    http_version: null
+  recorded_at: Mon, 27 Apr 2020 10:12:16 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/super_project/foo/_meta?user=user_2
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="foo" project="super_project">
+          <title>A Time of Gifts</title>
+          <description>Quidem dolorum ut veniam.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '144'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="foo" project="super_project">
+          <title>A Time of Gifts</title>
+          <description>Quidem dolorum ut veniam.</description>
+        </package>
+    http_version: null
+  recorded_at: Mon, 27 Apr 2020 10:12:16 GMT
+- request:
+    method: delete
+    uri: http://backend:5352/source/super_project/foo
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: null
+  recorded_at: Mon, 27 Apr 2020 10:12:16 GMT
+recorded_with: VCR 5.1.0

--- a/src/api/spec/cassettes/ConsistencyCheckJobService_BackendPackageImporter/_call/it_raises_Backend_NotFoundError/1_1_2_1.yml
+++ b/src/api/spec/cassettes/ConsistencyCheckJobService_BackendPackageImporter/_call/it_raises_Backend_NotFoundError/1_1_2_1.yml
@@ -1,0 +1,153 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/super_project/_meta?user=user_3
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="super_project">
+          <title>Tender Is the Night</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '109'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="super_project">
+          <title>Tender Is the Night</title>
+          <description></description>
+        </project>
+    http_version: null
+  recorded_at: Mon, 27 Apr 2020 10:12:16 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/super_project/foo/_meta?user=user_4
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="foo" project="super_project">
+          <title>The Wind's Twelve Quarters</title>
+          <description>Et inventore quidem quia.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '155'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="foo" project="super_project">
+          <title>The Wind's Twelve Quarters</title>
+          <description>Et inventore quidem quia.</description>
+        </package>
+    http_version: null
+  recorded_at: Mon, 27 Apr 2020 10:12:16 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/super_project/foo/_meta?user=user_4
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="foo" project="super_project">
+          <title>The Wind's Twelve Quarters</title>
+          <description>Et inventore quidem quia.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '155'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="foo" project="super_project">
+          <title>The Wind's Twelve Quarters</title>
+          <description>Et inventore quidem quia.</description>
+        </package>
+    http_version: null
+  recorded_at: Mon, 27 Apr 2020 10:12:16 GMT
+- request:
+    method: delete
+    uri: http://backend:5352/source/super_project/foo
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: null
+  recorded_at: Mon, 27 Apr 2020 10:12:16 GMT
+recorded_with: VCR 5.1.0

--- a/src/api/spec/cassettes/ConsistencyCheckJobService_BackendProjectImporter/_call/it_raises_APIError/1_1_1_1.yml
+++ b/src/api/spec/cassettes/ConsistencyCheckJobService_BackendProjectImporter/_call/it_raises_APIError/1_1_1_1.yml
@@ -1,0 +1,42 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/super_project/_meta?user=user_3
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="super_project">
+          <title>Consider Phlebas</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '106'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="super_project">
+          <title>Consider Phlebas</title>
+          <description></description>
+        </project>
+    http_version: null
+  recorded_at: Tue, 21 Apr 2020 13:15:26 GMT
+recorded_with: VCR 5.1.0

--- a/src/api/spec/cassettes/ConsistencyCheckJobService_BackendProjectImporter/_call/it_raises_ActiveRecord_RecordInvalid/1_1_2_1.yml
+++ b/src/api/spec/cassettes/ConsistencyCheckJobService_BackendProjectImporter/_call/it_raises_ActiveRecord_RecordInvalid/1_1_2_1.yml
@@ -1,0 +1,73 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/super_project/_meta?user=user_2
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="super_project">
+          <title>Blue Remembered Earth</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '111'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="super_project">
+          <title>Blue Remembered Earth</title>
+          <description></description>
+        </project>
+    http_version: null
+  recorded_at: Tue, 21 Apr 2020 13:15:26 GMT
+- request:
+    method: delete
+    uri: http://backend:5352/source/super_project
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: null
+  recorded_at: Tue, 21 Apr 2020 13:15:26 GMT
+recorded_with: VCR 5.1.0

--- a/src/api/spec/cassettes/ConsistencyCheckJobService_BackendProjectImporter/_call/it_raises_Backend_NotFoundError/1_1_3_1.yml
+++ b/src/api/spec/cassettes/ConsistencyCheckJobService_BackendProjectImporter/_call/it_raises_Backend_NotFoundError/1_1_3_1.yml
@@ -1,0 +1,42 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/super_project/_meta?user=user_1
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="super_project">
+          <title>The Way Through the Woods</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '115'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="super_project">
+          <title>The Way Through the Woods</title>
+          <description></description>
+        </project>
+    http_version: null
+  recorded_at: Tue, 21 Apr 2020 13:15:26 GMT
+recorded_with: VCR 5.1.0

--- a/src/api/spec/cassettes/ConsistencyCheckJobService_ProjectMetaChecker/_call/everything_goes_well/1_1_1_1.yml
+++ b/src/api/spec/cassettes/ConsistencyCheckJobService_ProjectMetaChecker/_call/everything_goes_well/1_1_1_1.yml
@@ -1,0 +1,38 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/source/super_bacana/_project/_meta
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '113'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="super_bacana">
+          <title>Tirra Lirra by the River</title>
+          <description></description>
+        </project>
+    http_version: null
+  recorded_at: Tue, 21 Apr 2020 15:12:48 GMT
+recorded_with: VCR 5.1.0

--- a/src/api/spec/jobs/consistency_check_job_spec.rb
+++ b/src/api/spec/jobs/consistency_check_job_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe ConsistencyCheckJob, type: :job, vcr: true do
+  include ActiveJob::TestHelper
+
+  describe '#perform' do
+    let!(:admin_user) { create(:admin_user, login: 'Admin') }
+
+    it { expect { ConsistencyCheckJob.new.perform }.not_to raise_error }
+  end
+
+  describe '#check_one_project' do
+    let!(:project) { create(:project, name: 'super_project') }
+    let(:consistency_checkjob) { described_class.new }
+    it { expect(consistency_checkjob.check_one_project(project, false)).to be_empty }
+  end
+
+  describe '#check_project' do
+    let!(:project) { create(:project, name: 'super_project') }
+    let(:consistency_checkjob) { described_class.new }
+    let(:error_message) { "Project meta is different in backend for super_project\n{:foo=>\"bar\"}" }
+
+    before do
+      allow_any_instance_of(ConsistencyCheckJobService::ProjectMetaChecker).to receive(:diff).and_return({ foo: 'bar' })
+    end
+
+    context 'fix = false' do
+      it { expect(consistency_checkjob.check_project(project.name, false)).to include(error_message) }
+    end
+
+    context 'fix = true' do
+      before do
+        allow(Project).to receive(:get_by_name).with(project.name).and_return(project)
+      end
+
+      it 'project should call store' do
+        # rubocop:disable RSpec/MessageSpies
+        expect(project).to receive(:store).with(hash_including(login: 'Admin'))
+        # rubocop:enable RSpec/MessageSpies
+        consistency_checkjob.check_project(project.name, true)
+      end
+    end
+  end
+end

--- a/src/api/spec/services/consistency_check_job_service/backend_package_importer_spec.rb
+++ b/src/api/spec/services/consistency_check_job_service/backend_package_importer_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe ::ConsistencyCheckJobService::BackendPackageImporter, vcr: true do
+  let(:project) { create(:project_with_package, name: 'super_project', package_name: 'foo') }
+  let(:error_message) { "DELETED in backend due to invalid data #{project.name}/foo" }
+  let(:backend_package_importer) { described_class.new(project, 'foo') }
+
+  describe '#call' do
+    subject { backend_package_importer.call }
+
+    before do
+      allow(backend_package_importer).to receive(:create_package_frontend).and_raise(custom_exception)
+      subject
+    end
+
+    context 'it raises ActiveRecord::RecordInvalid' do
+      let(:custom_exception) { ActiveRecord::RecordInvalid }
+      it { expect(backend_package_importer.errors).to include(error_message) }
+    end
+
+    context 'it raises Backend::NotFoundError' do
+      let(:custom_exception) { Backend::NotFoundError }
+      it { expect(backend_package_importer.errors).to include(error_message) }
+    end
+  end
+end

--- a/src/api/spec/services/consistency_check_job_service/backend_project_importer_spec.rb
+++ b/src/api/spec/services/consistency_check_job_service/backend_project_importer_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe ::ConsistencyCheckJobService::BackendProjectImporter, vcr: true do
+  let(:project) { create(:project, name: 'super_project') }
+  let(:backend_project_importer) { described_class.new(project.name) }
+
+  describe '#call' do
+    subject { backend_project_importer.call }
+
+    before do
+      allow(backend_project_importer).to receive(:create_project_frontend).and_raise(custom_exception)
+      subject
+    end
+
+    context 'it raises APIError' do
+      let(:custom_exception) { APIError }
+      let(:error_message) { "Invalid project meta data hosted in src server for project #{project}: APIError" }
+      it { expect(backend_project_importer.errors).to include(error_message) }
+    end
+
+    context 'it raises ActiveRecord::RecordInvalid' do
+      let(:custom_exception) { ActiveRecord::RecordInvalid }
+      let(:error_message) { "DELETED #{project} on backend due to invalid data" }
+      it { expect(backend_project_importer.errors).to include(error_message) }
+    end
+
+    context 'it raises Backend::NotFoundError' do
+      let(:custom_exception) { Backend::NotFoundError }
+      let(:error_message) { "specified #{project} does not exist on backend" }
+      it { expect(backend_project_importer.errors).to include(error_message) }
+    end
+  end
+end

--- a/src/api/spec/services/consistency_check_job_service/base_consistency_checker_spec.rb
+++ b/src/api/spec/services/consistency_check_job_service/base_consistency_checker_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe ::ConsistencyCheckJobService::BaseConsistencyChecker, vcr: false do
+  let(:base_consistency_checker) { described_class.new }
+  describe '#dir_to_array' do
+    let(:xml_hash) do
+      Xmlhash::XMLHash.new({ 'entry' => [{ 'name' => 'home:Admin' }, { 'name' => 'super_bacana' }, { 'name' => 'super_project' }] })
+    end
+    it { expect(base_consistency_checker.dir_to_array(xml_hash)).to be_an(Array) }
+    it { expect(base_consistency_checker.dir_to_array(xml_hash)).to eq(['home:Admin', 'super_bacana', 'super_project']) }
+  end
+end

--- a/src/api/spec/services/consistency_check_job_service/package_consistency_checker_spec.rb
+++ b/src/api/spec/services/consistency_check_job_service/package_consistency_checker_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe ::ConsistencyCheckJobService::PackageConsistencyChecker, vcr: true do
+  let(:project) { create(:project, name: 'super_bacana') }
+  let(:package_consistency_checker) { described_class.new(project) }
+  describe '#call' do
+    context 'everything goes well' do
+      it { expect { package_consistency_checker.call }.not_to raise_error }
+    end
+  end
+end

--- a/src/api/spec/services/consistency_check_job_service/project_consistency_checker_spec.rb
+++ b/src/api/spec/services/consistency_check_job_service/project_consistency_checker_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe ::ConsistencyCheckJobService::ProjectConsistencyChecker, vcr: true do
+  let(:project) { create(:project, name: 'super_bacana') }
+  let(:project_consistency_checker) { described_class.new }
+  describe '#call' do
+    context 'everything goes well' do
+      it { expect { project_consistency_checker.call }.not_to raise_error }
+    end
+  end
+end

--- a/src/api/spec/services/consistency_check_job_service/project_meta_checker_spec.rb
+++ b/src/api/spec/services/consistency_check_job_service/project_meta_checker_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe ::ConsistencyCheckJobService::ProjectMetaChecker, vcr: true do
+  let(:project) { create(:project, name: 'super_bacana') }
+  let(:project_meta_checker) { described_class.new(project) }
+  describe '#call' do
+    context 'everything goes well' do
+      it { expect { project_meta_checker.call }.not_to raise_error }
+    end
+  end
+end


### PR DESCRIPTION
This PR looks big, but actually it's not.

It's basic a refactoring of two rake tasks from [delayed_job.rake](https://github.com/openSUSE/open-build-service/blob/master/src/api/lib/tasks/delayed_job.rake#L33), `check_project` and `fix_project`

The changes are:

- Removed two checks: if there are packages and projects with invalid names. We have name validation for both, on frontend and backend. 
- Added spec for the the `ConsistencyCheckJob` class itself
- Extracted auxiliary code to services 
- Added spec to the services
- Changed the `ConsistencyCheckJob` class without change it's API
- Improved documentation

