### PR TITLE
Set pulse data for all request types

### DIFF
--- a/src/api/app/controllers/webui/projects/pulse_controller.rb
+++ b/src/api/app/controllers/webui/projects/pulse_controller.rb
@@ -1,6 +1,7 @@
 module Webui
   module Projects
     class PulseController < WebuiController
+      before_action :forbid_bot_access
       before_action :set_project
       before_action :set_range
       before_action :set_pulse
@@ -10,6 +11,10 @@ module Webui
       end
 
       private
+
+      def forbid_bot_access
+        return head :forbidden if request.bot?
+      end
 
       def set_range
         @range = params[:range] == 'month' ? 'month' : 'week'

--- a/src/api/app/controllers/webui/projects/pulse_controller.rb
+++ b/src/api/app/controllers/webui/projects/pulse_controller.rb
@@ -3,7 +3,7 @@ module Webui
     class PulseController < WebuiController
       before_action :set_project
       before_action :set_range
-      before_action :set_pulse, if: -> { request.xhr? }
+      before_action :set_pulse
 
       def show
         @pulse = @project.project_log_entries.page(params[:page])


### PR DESCRIPTION
Now we only set the pulse data for ajax requests.

When bots hit a project's pulse page, the before_action is not called
and then the page breaks.

Fixes #9370
