### PR TITLE
Notifications filtered by projects

### DIFF
--- a/src/api/app/controllers/webui/users/notifications_controller.rb
+++ b/src/api/app/controllers/webui/users/notifications_controller.rb
@@ -1,10 +1,20 @@
 class Webui::Users::NotificationsController < Webui::WebuiController
-  before_action :require_login
   MAX_PER_PAGE = 300
+  VALID_NOTIFICATION_TYPES = ['read', 'reviews', 'comments', 'requests', 'unread'].freeze
+
+  before_action :require_login
+  before_action :check_param_type, :check_param_project, only: :index
 
   def index
     notifications_for_subscribed_user = User.session.notifications.for_web
-    @notifications = NotificationsFinder.new(notifications_for_subscribed_user).for_notifiable_type(params[:type])
+    @notifications = if params[:project]
+                       NotificationsFinder.new(notifications_for_subscribed_user).for_project_name(params[:project])
+                     else
+                       NotificationsFinder.new(notifications_for_subscribed_user).for_notifiable_type(params[:type])
+                     end
+
+    @projects_for_filter = projects_for_filter
+
     @notifications = params['show_all'] ? show_all : @notifications.page(params[:page])
   end
 
@@ -22,11 +32,34 @@ class Webui::Users::NotificationsController < Webui::WebuiController
 
   private
 
+  def check_param_type
+    return if params[:type].nil? || VALID_NOTIFICATION_TYPES.include?(params[:type])
+
+    flash[:error] = 'Filter not valid.'
+    redirect_to my_notifications_path
+  end
+
+  def check_param_project
+    return unless params[:project] == ''
+
+    flash[:error] = 'Filter not valid.'
+    redirect_to my_notifications_path
+  end
+
   def show_all
     total = @notifications.size
     if total > MAX_PER_PAGE
       flash.now[:info] = "You have too many notifications. Displaying a maximum of #{MAX_PER_PAGE} notifications per page."
     end
     @notifications = @notifications.page(params[:page]).per([total, MAX_PER_PAGE].min)
+  end
+
+  # Returns a hash where the key is the name of the project and the value is the amount of notifications
+  # associated to that project. The hash is sorted by amount and then name.
+  def projects_for_filter
+    Project.joins(:notifications)
+           .where(notifications: { subscriber: User.session, delivered: false, web: true })
+           .order('name desc').group(:name).count # this query returns a sorted-by-name hash like { "home:b" => 1, "home:a" => 3  }
+           .sort_by(&:last).reverse.to_h # this sorts the hash by amount: { "home:a" => 3, "home:b" => 1 }
   end
 end

--- a/src/api/app/helpers/webui/notification_helper.rb
+++ b/src/api/app/helpers/webui/notification_helper.rb
@@ -8,4 +8,36 @@ module Webui::NotificationHelper
       link_to('Show all', my_notifications_path(parameters), class: 'btn btn-sm btn-secondary ml-2')
     end
   end
+
+  def filter_by_type_link(link_text, filter_item)
+    link_to(link_text, my_notifications_path(filter_item), class: filter_css(filter_item))
+  end
+
+  def filter_by_project_link(link_text, amount, filter_item)
+    badge_color = notification_filter_active?(filter_item) ? 'badge-light' : 'badge-primary'
+    link_to(my_notifications_path(filter_item), class: filter_css(filter_item)) do
+      capture do
+        concat(link_text)
+        concat(content_tag(:span, amount, class: "badge #{badge_color} align-text-top ml-2"))
+      end
+    end
+  end
+
+  private
+
+  def filter_css(filter_item)
+    css_class = 'list-group-item list-group-item-action'
+    css_class += ' active' if notification_filter_active?(filter_item)
+    css_class
+  end
+
+  def notification_filter_active?(filter_item)
+    if params[:project].present?
+      filter_item[:project] == params[:project]
+    elsif params[:type].present?
+      filter_item[:type] == params[:type]
+    else
+      filter_item[:type] == 'unread'
+    end
+  end
 end

--- a/src/api/app/helpers/webui/webui_helper.rb
+++ b/src/api/app/helpers/webui/webui_helper.rb
@@ -401,12 +401,6 @@ module Webui::WebuiHelper
       text
     end
   end
-
-  def user_notification_link(link_text, new_filter, filter: 'inbox')
-    css_class = 'list-group-item list-group-item-action'
-    css_class += ' active' if new_filter == filter || (filter.nil? && new_filter == 'inbox')
-    link_to(link_text, my_notifications_path(type: new_filter), class: css_class)
-  end
 end
 
 # rubocop:enable Metrics/ModuleLength

--- a/src/api/app/models/notified_project.rb
+++ b/src/api/app/models/notified_project.rb
@@ -4,4 +4,6 @@ class NotifiedProject < ApplicationRecord
 
   validates :notification, presence: true
   validates :project, presence: true
+
+  validates :notification_id, uniqueness: { scope: :project_id, message: 'These notification and project are already associated' }
 end

--- a/src/api/app/queries/notifications_finder.rb
+++ b/src/api/app/queries/notifications_finder.rb
@@ -24,7 +24,7 @@ class NotificationsFinder
                     user, user.groups.map(&:id))
   end
 
-  def for_notifiable_type(type = '')
+  def for_notifiable_type(type = 'unread')
     notifications = self.class.new(with_notifiable)
 
     case type
@@ -39,6 +39,10 @@ class NotificationsFinder
     else
       notifications.unread
     end
+  end
+
+  def for_project_name(project_name)
+    unread.joins(:projects).where(projects: { name: project_name })
   end
 
   def stale

--- a/src/api/app/services/notification_creator.rb
+++ b/src/api/app/services/notification_creator.rb
@@ -29,9 +29,14 @@ class NotificationCreator
     return unless create_notification?(subscription.subscriber, channel)
     params = subscription.parameters_for_notification.merge!(@event.parameters_for_notification)
     # TODO: Replace by Notification when we remove Notification::RssFeedItem class
-    notification = Notification::RssFeedItem.find_or_create_by!(params) # avoid duplication
+    notification = Notification::RssFeedItem.find_by(params)
+
+    unless notification
+      notification = Notification::RssFeedItem.create(params)
+      notification.projects << NotifiedProjects.new(notification).call
+    end
+
     notification.update("#{channel}": true)
-    notification.projects << NotifiedProjects.new(notification).call
   end
 
   def create_notification?(subscriber, channel)

--- a/src/api/app/views/webui/users/notifications/index.html.haml
+++ b/src/api/app/views/webui/users/notifications/index.html.haml
@@ -13,14 +13,17 @@
 
       .card-body.collapse#filters
         .row.list-group-flush
-          = user_notification_link('Unread', 'unread', filter: params[:type])
-          = user_notification_link('Read', 'read', filter: params[:type])
+          = filter_by_type_link('Unread', type: 'unread')
+          = filter_by_type_link('Read', type: 'read')
         .row.list-group-flush.mt-5
           %h5.ml-3 Filter
-          = user_notification_link('Reviews', 'reviews', filter: params[:type])
-          = user_notification_link('Comments', 'comments', filter: params[:type])
-          = user_notification_link('Requests', 'requests', filter: params[:type])
-
+          = filter_by_type_link('Reviews', type: 'reviews')
+          = filter_by_type_link('Comments', type: 'comments')
+          = filter_by_type_link('Requests', type: 'requests')
+        .row.list-group-flush.mt-5
+          %h5.ml-3 Projects
+          - @projects_for_filter.each_pair do |project_name, amount|
+            = filter_by_project_link(project_name, amount, project: project_name)
   .col-md-8.col-lg-9#notifications-list
     .card
       .card-body


### PR DESCRIPTION
This PR is a follow-up to #9433.

The notifications can be now filtered by the projects associated to them.
To do so, a list of project names and a the number of notifications per project are displayed.

![Screenshot_2020-04-25 Open Build Service](https://user-images.githubusercontent.com/2581944/80262101-b21cd980-868c-11ea-8b82-28065b5e8bcd.png)

Co-authored-by: Eduardo Navarro <enavarro@suse.com>

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
