### PR TITLE
 Fix checking for diffs between structure.sql files 

### DIFF
--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -518,7 +518,7 @@ CREATE TABLE `event_subscriptions` (
   `updated_at` datetime(6) DEFAULT NULL,
   `group_id` int(11) DEFAULT NULL,
   `channel` int(11) NOT NULL DEFAULT '0',
-  `enabled` tinyint(1) DEFAULT 0,
+  `enabled` tinyint(1) DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `index_event_subscriptions_on_user_id` (`user_id`) USING BTREE,
   KEY `index_event_subscriptions_on_group_id` (`group_id`)

--- a/src/api/lib/tasks/databases.rake
+++ b/src/api/lib/tasks/databases.rake
@@ -89,7 +89,7 @@ namespace :db do
       Rake::Task['db:migrate:with_data'].invoke
       normalize_structure
       puts 'Diffing the db/structure.sql'
-      sh %(git diff db/structure.sql) do |ok, _|
+      sh %(git diff --exit-code db/structure.sql) do |ok, _|
         unless ok
           abort 'Generated structure.sql differs from structure.sql stored in git. ' \
                 'Please run rake db:migrate and check the differences.'


### PR DESCRIPTION
In our CI test suite we have a check for diffs in the `structure.sql` file.

## What we had before

The `git diff` check was not working properly. There were three cases:
1. When there were no differences: it worked properly.
2. When the diff output was too small: it gave a false positive.
3. When the diff output was big enough: it gave a false negative. It errored because of a timeout, and not because of an exit code of `git diff`.

## How we fixed it

The fix in this pull request makes the `git diff` command return the proper exit code:
- `1` when there are diffs.
- `0` when there are no diffs

### Before, when the diff output was too small

![Screenshot from 2020-04-27 12-49-56](https://user-images.githubusercontent.com/24919/80364283-eefff080-8885-11ea-8d5a-8779d48deae0.png)

### Before, when the diff output was big enough

![Screenshot from 2020-04-27 12-04-16](https://user-images.githubusercontent.com/24919/80360330-7433d700-887f-11ea-8d78-f69cb5c00ca4.png)

### After, when there are diffs

![Screenshot from 2020-04-27 12-05-21](https://user-images.githubusercontent.com/24919/80360696-01772b80-8880-11ea-87bc-a06921449c05.png)
