### PR TITLE
Show the correct number of unread notifications

### DIFF
--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -813,7 +813,7 @@ class User < ApplicationRecord
   end
 
   def unread_notifications
-    NotificationsFinder.new(notifications.for_web).unread.size
+    NotificationsFinder.new(notifications.for_web).unread_with_notifiable.size
   end
 
   def watched_project_names

--- a/src/api/app/queries/notifications_finder.rb
+++ b/src/api/app/queries/notifications_finder.rb
@@ -11,6 +11,10 @@ class NotificationsFinder
     @relation.where(delivered: false)
   end
 
+  def unread_with_notifiable
+    self.class.new(unread).with_notifiable
+  end
+
   def with_notifiable
     @relation.where.not(notifiable_id: nil, notifiable_type: nil)
   end


### PR DESCRIPTION
Before we were counting all unread notifications. Now we only count those that have a notifiable.

Fixes #9443.

Co-authored-by: David Kang <dkang@suse.com>
Co-authored-by: Saray Cabrera Padrón <scabrerapadron@suse.de>