### PR TITLE
Solve RSpec SourcePackageFinder flickering test

### DIFF
--- a/src/api/spec/models/bs_request_action/differ/source_package_finder_spec.rb
+++ b/src/api/spec/models/bs_request_action/differ/source_package_finder_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe BsRequestAction::Differ::SourcePackageFinder do
       let!(:bs_request_action) { bs_request.bs_request_actions.first }
       let!(:finder) { BsRequestAction::Differ::SourcePackageFinder.new(bs_request_action: bs_request_action) }
       context 'and source access' do
-        it { expect(finder.all).to eq(['another_source_package', 'source_package']) }
+        it { expect(finder.all).to match_array(['another_source_package', 'source_package']) }
       end
 
       context 'and without source access' do


### PR DESCRIPTION
The test was checking the result elements in a specific order. As the result elements are returned unsorted, changing the matcher to the collection membership matcher `match_array` makes the
test not to flick any more.

Fixes #9457.