### PR TITLE
Add configuration file for codebeat

### DIFF
--- a/.codebeatsettings
+++ b/.codebeatsettings
@@ -1,0 +1,12 @@
+{
+  "RUBY": {
+    "LOC_COMMENT": "Increase the values for LOC/method",
+    "LOC": [30, 45, 70, 100],
+    "TOTAL_LOC_COMMENT": "Increase the namespace value, making it 10x the LOC",
+    "TOTAL_LOC": [300, 450, 700, 1000],
+    "ABC_COMMENT": "Increase in 20% from the defaults",
+    "ABC": [15, 30, 60, 90],
+    "TOO_MANY_FUNCTIONS_COMMENT": "Increase num of allowed methods/classes",
+    "TOO_MANY_FUNCTIONS": [200, 250, 320, 450] 
+  }
+}


### PR DESCRIPTION
We are experimenting with [codebeat](https://codebeat.co/projects/github-com-opensuse-open-build-service-master/)

and this PR adds a configuration file for it with some basic
configuration, for ruby.

Based on the documentation we increased:

- LOC: explained here https://hub.codebeat.co/docs/software-quality-metrics#lines-of-code
- TOTAL_LOC: explained here https://hub.codebeat.co/docs/namespace-level-metrics#lines-of-code
- ABC: explained here https://hub.codebeat.co/docs/software-quality-metrics#assignment-branch-condition
- TOO_MANY_FUNCTIONS: explained here https://hub.codebeat.co/docs/namespace-level-metrics#number-of-functions
