### PR TITLE
Don't mark the Staging tab as active for a staging project

### DIFF
--- a/src/api/app/views/webui/project/_tabs.html.haml
+++ b/src/api/app/views/webui/project/_tabs.html.haml
@@ -21,7 +21,7 @@
       = tab_link('Pulse', project_pulse_path(project), false, 'scrollable-tab-link')
       - active = controller_path.starts_with?('webui/staging')
       - if project.staging_project?
-        = tab_link('Staging', staging_workflow_path(project.staging_workflow.project), active, 'scrollable-tab-link')
+        = tab_link('Staging', staging_workflow_path(project.staging_workflow.project), false, 'scrollable-tab-link')
       - elsif project.staging && project.staging.persisted?
         = tab_link('Staging', staging_workflow_path(project), active, 'scrollable-tab-link')
       - elsif policy(Staging::Workflow.new(project: project)).create?
@@ -64,7 +64,7 @@
         - active = controller_path.starts_with?('webui/staging')
         - if project.staging_project?
           %li.nav-item
-            = tab_link('Staging', staging_workflow_path(project.staging_workflow.project), active)
+            = tab_link('Staging', staging_workflow_path(project.staging_workflow.project))
         - elsif project.staging && project.staging.persisted?
           -# If Staging::Workflow.new(...) is executed below, project.staging will be a new object.
             It will be persisted if the project is really a staging workflow project.


### PR DESCRIPTION
This applies to the beta UI (under `responsive_ux`) and the default UI.

Preview:
![preview](https://user-images.githubusercontent.com/1102934/80596057-0f66b100-8a26-11ea-86c2-0e3d1ff7037c.png)