### PR TITLE
Go to the "Incoming Reviews" of a group when clicking on "Backlog" link

### DIFF
--- a/src/api/app/views/webui/staging/workflows/_infos.html.haml
+++ b/src/api/app/views/webui/staging/workflows/_infos.html.haml
@@ -10,7 +10,7 @@
       %dt Empty projects:
       %dd= render 'empty_projects_list', projects: empty_projects, staging_workflow: staging_workflow
 
-      %dt= link_to('Backlog:', group_show_path(staging_workflow.managers_group))
+      %dt= link_to('Backlog:', group_show_path(staging_workflow.managers_group, anchor: 'reviews-in'))
       %dd= render 'requests_list', requests: unassigned_requests, more_requests: more_unassigned_requests
 
       %dt= link_to('Ready:', project_requests_path(staging_workflow.project, state: :new))


### PR DESCRIPTION
This isn't fixing #8745, it's only a slight improvement.