### PR TITLE
Sort staging requests by state and name

### DIFF
--- a/src/api/app/models/concerns/staging_project.rb
+++ b/src/api/app/models/concerns/staging_project.rb
@@ -63,7 +63,7 @@ module StagingProject
         missing_reviews: missing_reviews_for_classified_requests(request, request.not_accepted_reviews)
       }
     end
-    requests.sort_by { |request| request[:package] }
+    requests.sort_by { |request| request_weight(request) }
   end
 
   def untracked_requests
@@ -252,6 +252,17 @@ module StagingProject
       # No need to duplicate reviews
       break extracted
     end
+  end
+
+  def request_weight(request)
+    weight = if request[:state].in?(BsRequest::OBSOLETE_STATES) # obsolete
+               '0'
+             elsif request[:missing_reviews].present? # in review
+               '1'
+             else
+               '2' # ready
+             end
+    [weight, request[:package]]
   end
 end
 # rubocop:enable Metrics/ModuleLength


### PR DESCRIPTION
The list of requests in a staging project was sorted by name.

![Screenshot_2020-04-29 Open Build Service(2)](https://user-images.githubusercontent.com/2581944/80691371-7771d180-8ad0-11ea-8b14-595e20740124.png)

Now it is sorted by state and then by name. This way, the requests that require more attention will be on the top of the list.

![Screenshot_2020-04-29 Open Build Service(1)](https://user-images.githubusercontent.com/2581944/80691392-7d67b280-8ad0-11ea-8c6a-f3944175e1b3.png)


<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
