### PR TITLE
[backend] tighten condition for successive_failcount

### DIFF
--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -2156,16 +2156,15 @@ sub notify_jobresult {
   } elsif ($jobstatus->{'result'} eq 'succeeded') {
     BSNotify::notify('BUILD_SUCCESS', \%ninfo);
   } else {
-    my $failcnt = 1;
+    my $failcnt = 0;
     my $filter = sub {
-        if ($_[0]->{'code'} eq 'failed') {
-            $failcnt += 1;
-            return 1;
-        } else {
-            return -1;
-        }
+        return 1 if ($_[0]->{'package'} ne $ninfo{'package'});
+        return -1 if ($_[0]->{'code'} ne 'failed');
+        return -1 if ($failcnt > 100);
+        $failcnt += 1;
+        return 1;
     };
-    BSFileDB::fdb_getall_reverse("$reporoot/$prpa/:jobhistory", $BSXML::jobhistlay, 100, $filter);
+    BSFileDB::fdb_getall_reverse("$reporoot/$prpa/:jobhistory", $BSXML::jobhistlay, undef, $filter);
     $ninfo{'successive_failcount'} = $failcnt;
     BSNotify::notify('BUILD_FAIL', \%ninfo);
   }


### PR DESCRIPTION
<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
