### PR TITLE
Add autocomplete functionality to Staging::ExcludedRequests controller

### DIFF
--- a/src/api/app/controllers/webui/staging/excluded_requests_controller.rb
+++ b/src/api/app/controllers/webui/staging/excluded_requests_controller.rb
@@ -1,11 +1,11 @@
 module Webui
   module Staging
     class ExcludedRequestsController < WebuiController
-      before_action :require_login, except: [:index]
+      before_action :require_login, except: [:index, :autocomplete]
       before_action :set_workflow_project
       before_action :set_staging_workflow
       before_action :set_request_exclusion, only: [:destroy]
-      after_action :verify_authorized, except: [:index]
+      after_action :verify_authorized, except: [:index, :autocomplete]
 
       def index
         respond_to do |format|
@@ -25,12 +25,12 @@ module Webui
 
         request = @staging_workflow.target_of_bs_requests.find_by(number: staging_request_exclusion[:number])
         unless request
-          redirect_back(fallback_location: root_path, error: "Request #{params[:number]} doesn't exist or it doesn't belong to this project")
+          redirect_back(fallback_location: root_path, error: "Request #{staging_request_exclusion[:number]} doesn't exist or it doesn't belong to this project")
           return
         end
         if request.staging_project
           redirect_back(fallback_location: root_path,
-                        error: "Request #{params[:number]} could not be excluded because is staged in: #{request.staging_project}")
+                        error: "Request #{staging_request_exclusion[:number]} could not be excluded because is staged in: #{request.staging_project}")
           return
         end
 
@@ -53,6 +53,11 @@ module Webui
           flash[:error] = "Request #{@request_exclusion.number} couldn't be unexcluded"
         end
         redirect_to excluded_requests_path(@staging_workflow.project)
+      end
+
+      def autocomplete
+        requests = @staging_workflow.autocomplete(params[:term]).pluck(:number).collect(&:to_s) if params[:term]
+        render json: requests || []
       end
 
       private

--- a/src/api/app/models/staging/workflow.rb
+++ b/src/api/app/models/staging/workflow.rb
@@ -82,6 +82,10 @@ class Staging::Workflow < ApplicationRecord
     users_hash
   end
 
+  def autocomplete(num)
+    unassigned_requests.where('CAST(bs_requests.number AS CHAR) LIKE ?', "%#{num}%")
+  end
+
   private
 
   def create_staging_projects

--- a/src/api/app/views/webui/staging/excluded_requests/_create_dialog.html.haml
+++ b/src/api/app/views/webui/staging/excluded_requests/_create_dialog.html.haml
@@ -5,9 +5,9 @@
         %h5.modal-title#exclude-request-modal-label Exclude Request
       = form_for Staging::RequestExclusion.new, url: excluded_requests_path do |f|
         .modal-body
-          .form-group
-            = f.label :number, 'Request'
-            = f.number_field :number, required: true, class: 'form-control'
+          = render partial: 'webui/shared/autocomplete', locals: { html_id: 'staging_request_exclusion[number]',
+                                                                  label: 'Request', value: f.object.number,
+                                                                  data: { source: autocomplete_excluded_requests_path(staging_workflow_project) } }
           .form-group
             = f.label :description
             = f.text_area :description,

--- a/src/api/app/views/webui/staging/excluded_requests/index.html.haml
+++ b/src/api/app/views/webui/staging/excluded_requests/index.html.haml
@@ -21,7 +21,7 @@
             Exclude request
 
 - if request_exclusion_policy
-  = render partial: 'create_dialog'
+  = render partial: 'create_dialog', locals: { staging_workflow_project: @staging_workflow.project }
   = render partial: 'delete_dialog'
 
 - content_for :ready_function do

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -351,7 +351,11 @@ OBSApi::Application.routes.draw do
         get :preview_copy, on: :member
         post :copy, on: :member
       end
-      resources :excluded_requests, controller: 'webui/staging/excluded_requests'
+      resources :excluded_requests, controller: 'webui/staging/excluded_requests' do
+        collection do
+          get :autocomplete
+        end
+      end
     end
   end
 end

--- a/src/api/spec/models/staging/workflow_spec.rb
+++ b/src/api/spec/models/staging/workflow_spec.rb
@@ -90,4 +90,15 @@ RSpec.describe Staging::Workflow, type: :model do
       it { expect(subject).to contain_exactly(bs_request_2) }
     end
   end
+
+  describe '#autocomplete' do
+    let!(:bs_request_2) do
+      create(:bs_request_with_submit_action,
+             target_package: target_package,
+             source_package: source_package)
+    end
+    it { expect(staging_workflow.autocomplete(bs_request_2.number)).to include(bs_request_2) }
+    it { expect(staging_workflow.autocomplete(bs_request.number)).not_to include(bs_request_2) }
+    it { expect(staging_workflow.autocomplete(-1)).to be_empty }
+  end
 end


### PR DESCRIPTION
Add method autocomplete to model Staging::Workflow

The method look exclusively for unassigned requests (backlog)
and filter by id containing specific digits

To see it working, either you change the value of `minLength` in the `autocomple.js` to 1 or you create more than 10 requests 