### PR TITLE
Fix requests flickering test

### DIFF
--- a/src/api/spec/features/webui/packages_spec.rb
+++ b/src/api/spec/features/webui/packages_spec.rb
@@ -91,7 +91,7 @@ RSpec.feature 'Packages', type: :feature, js: true, vcr: true do
       login user
       visit package_show_path(package: package, project: user.home_project)
       click_link('Requests')
-      expect(page).to have_css('table#all_requests_table tr', count: 1)
+      expect(page).to have_css('table#all_requests_table tbody tr', count: 1)
       find('a', class: 'request_link').click
       expect(page.current_path).to match('/request/show/\\d+')
     end


### PR DESCRIPTION
Before, the test was returning false positives because asking for `tr` elements returned also the `tr` element of the `thead` section of the table. The part `"Created Source Target Requester Type Priority"` was the clue on the error message:

```
expected to find visible css "table#all_requests_table tr" 1 time, found 2 matches: "Created Source Target Requester Type Priority", "now source_project / package_764 home:package_test_user / test_package user_1047 submit moderate"
```

The fix was making the css finder more explicit, searching only for the `tr` elements of the `tbody` part of the table.

Fixes #7533.