### PR TITLE
Remove notifications without notifiable

### DIFF
--- a/src/api/db/data/20200430112548_remove_notifications_without_notifiable.rb
+++ b/src/api/db/data/20200430112548_remove_notifications_without_notifiable.rb
@@ -1,0 +1,9 @@
+class RemoveNotificationsWithoutNotifiable < ActiveRecord::Migration[6.0]
+  def up
+    Notification.where(notifiable_type: nil, notifiable_id: nil).destroy_all
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/src/api/db/data_schema.rb
+++ b/src/api/db/data_schema.rb
@@ -1,2 +1,2 @@
 # encoding: UTF-8
-DataMigrate::Data.define(version: 20200424080753)
+DataMigrate::Data.define(version: 20200430112548)


### PR DESCRIPTION
Previously, we excluded the events `Event::BuildFail` and
`Event::ServiceFail` for creating rss and web notifications.
We also regenerated the notifications for the users except for
those with event_type `Event::BuildFail` and `Event::ServiceFail`.

This commit, will remove the notifications without notfiable, fixing
at the same time the inconsistency in the DB and also the notifications
web counter.

Fix #9443 