### PR TITLE
[backend] ccache archive no longer has .gz suffix

### DIFF
--- a/src/backend/BSSched/PublishRepo.pm
+++ b/src/backend/BSSched/PublishRepo.pm
@@ -204,7 +204,7 @@ sub prpfinished {
     next if $all{'.preinstallimage'};
     my $debian = grep {/\.dsc$/} @all;
     my $nosourceaccess = $all{'.nosourceaccess'};
-    @all = grep {$_ ne '_ccache.tar.gz' && $_ ne 'history' && $_ ne 'logfile' && $_ ne 'rpmlint.log' && $_ ne '_statistics' && $_ ne '_buildenv' && $_ ne '_channel' && $_ ne 'meta' && $_ ne 'status' && $_ ne 'reason' && !/^\./} @all;
+    @all = grep {$_ ne '_ccache.tar' && $_ ne 'history' && $_ ne 'logfile' && $_ ne 'rpmlint.log' && $_ ne '_statistics' && $_ ne '_buildenv' && $_ ne '_channel' && $_ ne 'meta' && $_ ne 'status' && $_ ne 'reason' && !/^\./} @all;
     my $taken;
     for my $bin (@all) {
       next if $bin =~ /^::import::/;

--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -1010,7 +1010,7 @@ sub getbinarylist {
     @bins = grep {!/^::import::/} @bins if $cgi->{'noimport'};
     @bins = BSRepServer::Containertar::add_containers(@bins) if grep {/\.containerinfo$/} @bins;
     @bins = filtersources(@bins) if $cgi->{'nosource'} || -e "$reporoot/$prp/$arch/$packid/.nosourceaccess";
-    @bins = grep {$_ ne "_ccache.tar.gz"} @bins unless $cgi->{'withccache'};
+    @bins = grep {$_ ne "_ccache.tar"} @bins unless $cgi->{'withccache'};
     for (sort @bins) {
       next if %binaries && !$binaries{$_};
       if (/\.tar$/ && ! -e "$reporoot/$prp/$arch/$packid/$_") {
@@ -1036,7 +1036,7 @@ sub getbinarylist {
     my @bins = grep {/\.rpm$/ && !/^\./} ls("$reporoot/$prp/$arch/$packid");
     @bins = grep {!/^::import::/} @bins if $cgi->{'noimport'};
     @bins = filtersources(@bins) if $cgi->{'nosource'} || -e "$reporoot/$prp/$arch/$packid/.nosourceaccess";
-    @bins = grep {$_ ne "_ccache.tar.gz"} @bins unless $cgi->{'withccache'};
+    @bins = grep {$_ ne "_ccache.tar"} @bins unless $cgi->{'withccache'};
     for my $bin (sort @bins) {
       next if %binaries && !$binaries{$_};
       my ($lead, $sighdr, $hdr, $hdrmd5);
@@ -1068,7 +1068,7 @@ sub getbinarylist {
     my @bins = grep {$_ ne 'logfile' && $_ ne 'status' && $_ ne 'reason' && $_ ne 'history' && !/^\./} ls("$reporoot/$prp/$arch/$packid");
     @bins = grep {!/^::import::/} @bins if $cgi->{'noimport'};
     @bins = filtersources(@bins) if $cgi->{'nosource'} || -e "$reporoot/$prp/$arch/$packid/.nosourceaccess";
-    @bins = grep {$_ ne "_ccache.tar.gz"} @bins unless $cgi->{'withccache'};
+    @bins = grep {$_ ne "_ccache.tar"} @bins unless $cgi->{'withccache'};
     for my $bin (sort @bins) {
       next if %binaries && !$binaries{$bin};
       if ($bin =~ /\.rpm$/) {
@@ -1110,7 +1110,7 @@ sub getbinarylist {
   @bins = grep {!/^::import::/} @bins if $cgi->{'noimport'};
   @bins = BSRepServer::Containertar::add_containers(@bins) if grep {/\.containerinfo$/} @bins;
   @bins = filtersources(@bins) if $cgi->{'nosource'} || -e "$reporoot/$prp/$arch/$packid/.nosourceaccess";
-  @bins = grep {$_ ne "_ccache.tar.gz"} @bins unless $cgi->{'withccache'};
+  @bins = grep {$_ ne "_ccache.tar"} @bins unless $cgi->{'withccache'};
   my %md5sums;
   if ($cgi->{'withmd5'}) {
     if (-s "$reporoot/$prp/$arch/$packid/.checksums") {

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -3902,8 +3902,8 @@ if ($buildinfo->{'followupfile'}) {
       next unless -s "$buildsrcdir/$f";
       BSUtil::cp("$buildsrcdir/$f", "$buildroot/.build.packages/OTHER/$f");
     }
-    if (-e "$buildsrcdir/_ccache.tar.gz") {
-      link_or_copy("$buildsrcdir/_ccache.tar.gz", "$buildroot/.build.packages/OTHER/_ccache.tar.gz") || die("ccache.tar.gz link_or_copy failed")
+    if (-e "$buildsrcdir/_ccache.tar") {
+      link_or_copy("$buildsrcdir/_ccache.tar", "$buildroot/.build.packages/OTHER/_ccache.tar") || die("_ccache.tar link_or_copy failed")
     }
   }
   # delete follow-up srcrpm


### PR DESCRIPTION
drop the suffix as the archive is no longer compressed but compression
is handled by ccache itself

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
