### PR TITLE
Fix notification creation rake task for development

### DIFF
--- a/src/api/lib/tasks/dev.rake
+++ b/src/api/lib/tasks/dev.rake
@@ -193,7 +193,7 @@ namespace :dev do
       User.session = requestor
 
       # Projects
-      admin_home_project = admin.home_project || create_and_assign_project(admin.home_project, admin)
+      admin_home_project = admin.home_project || create_and_assign_project(admin.home_project_name, admin)
       requestor_project = Project.find_by(name: 'requestor_project') || create_and_assign_project('requestor_project', requestor)
 
       repetitions.times do |repetition|
@@ -416,8 +416,9 @@ def request_for_staging(staging_project, maintainer_project, suffix)
 end
 
 def create_and_assign_project(project_name, user)
-  create(:project, name: project_name)
-  create(:relationship, project: project_name, user: user, role: Role.hashed['maintainer'])
+  create(:project, name: project_name).tap do |project|
+    create(:relationship, project: project, user: user, role: Role.hashed['maintainer'])
+  end
 end
 
 def subscribe_to_all_notifications(user)


### PR DESCRIPTION
- Fixes the following:

* When the admin home project does not exist, calling the
  'create_and_assign_project' with 'admin.home_project' fails
  since it is nil.
* The 'create_and_assign_project' returned the relationship,
  not the project

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
