### PR TITLE
Adjust description in notification configuration pages

### DIFF
--- a/src/api/app/views/webui/subscriptions/index.html.haml
+++ b/src/api/app/views/webui/subscriptions/index.html.haml
@@ -7,7 +7,7 @@
     %h3.card-title
       Events
     .card-text#notifications
-      %p Choose default notification settings for events (checked means direct email).
+      %p Configure global default for notification settings and corresponding channels for selected events.
       = render partial: 'subscriptions_form', locals: { path: notifications_path, subscriptions_form: @subscriptions_form }
 
 - content_for :ready_function do

--- a/src/api/app/views/webui/users/subscriptions/index.html.haml
+++ b/src/api/app/views/webui/users/subscriptions/index.html.haml
@@ -16,7 +16,7 @@
             %i.fas.fa-spinner.invisible
   .card-body
     %h4.card-title Events
-    %p Choose from which events you want to get an email
+    %p Choose events you want to get notified about and the corresponding channels.
     #subscriptions-form
       = render partial: 'webui/subscriptions/subscriptions_form', locals: { path: update_my_subscriptions_path,
                                                                             subscriptions_form: @subscriptions_form }

--- a/src/api/spec/features/webui/notifications_spec.rb
+++ b/src/api/spec/features/webui/notifications_spec.rb
@@ -35,7 +35,7 @@ RSpec.feature 'Notifications', type: :feature, js: true do
 
   context 'update as unprivileged user' do
     it_behaves_like 'updatable' do
-      let(:title) { 'Choose from which events you want to get an email' }
+      let(:title) { 'Choose events you want to get notified about and the corresponding channels.' }
       let(:user) { create(:confirmed_user, login: 'eisendieter') }
       let(:path) { my_subscriptions_path }
     end


### PR DESCRIPTION
Since the notification settings can be configured
for different channels now, the description needs to be
adjusted a bit.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
