### PR TITLE
[backend] bs_worker: allow overriding the filesystem type via the bui…

### DIFF
--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -3175,6 +3175,8 @@ sub dobuild {
 
   push @args, "$statedir/build/build";
   if ($vm =~ /(xen|kvm|zvm|emulator|pvm)/) {
+    # allow overriding the filesystem type via the build config
+    my $filesystemtype = $bconf->{'buildflags:vmfstype'} || $vmdisk_filesystem;
     mkdir("$buildroot/.mount") unless -d "$buildroot/.mount";
     push @args, '--root', "$buildroot/.mount";
     push @args, '--vm-type', $vm;
@@ -3191,7 +3193,7 @@ sub dobuild {
     push @args, "--vm-custom-opt=$vm_custom_option" if $vm_custom_option;
     push @args, '--vmdisk-rootsize', $vmdisk_rootsize if $vmdisk_rootsize;
     push @args, '--vmdisk-swapsize', $vmdisk_swapsize if $vmdisk_swapsize;
-    push @args, '--vmdisk-filesystem', $vmdisk_filesystem if $vmdisk_filesystem;
+    push @args, '--vmdisk-filesystem', $filesystemtype if $filesystemtype;
     push @args, "--vmdisk-mount-options=$vmdisk_mount_options" if $vmdisk_mount_options;
     push @args, '--vmdisk-clean'if $vmdisk_clean;
     push @args, '--hugetlbfs', $hugetlbfs if $hugetlbfs;


### PR DESCRIPTION
…ld config

We do this to move the type overriding from the build script to
the worker. The current way of doing it in the build script gives
the user no way to define a filesystem type via the command line.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
