### PR TITLE
Move attribute actions to Actions menu

### DIFF
--- a/src/api/app/views/webui/attribute/index.html.haml
+++ b/src/api/app/views/webui/attribute/index.html.haml
@@ -1,6 +1,7 @@
 - @pagetitle = "Attributes of #{@package ? "#{@package} (Project #{@project})" : "Project #{@project}"}"
 - can_update_container = policy(@container).update?
-
+- if can_update_container && flipper_responsive?
+  = render partial: 'webui/attribute/responsive_ux/index_actions', locals: { project: @project, package: @package }
 .card
   = render(partial: "webui/#{@container.model_name.singular}/tabs", locals: { project: @project, package: @package })
 
@@ -38,7 +39,7 @@
       %p
         %em No attributes set
 
-    - if can_update_container
+    - if can_update_container && !flipper_responsive?
       %p
         = link_to(new_attribs_path(project: @project.name, package: @package), title: 'Add a new attribute') do
           %i.fas.fa-plus-circle.text-primary

--- a/src/api/app/views/webui/attribute/index.html.haml
+++ b/src/api/app/views/webui/attribute/index.html.haml
@@ -41,7 +41,7 @@
 
     - if can_update_container && !flipper_responsive?
       %p
-        = link_to(new_attribs_path(project: @project.name, package: @package), title: 'Add a new attribute') do
+        = link_to(new_attribs_path(project: @project.name, package: @package), title: 'Add Attribute') do
           %i.fas.fa-plus-circle.text-primary
-          Add a new attribute
+          Add Attribute
       = render(partial: 'delete_dialog')

--- a/src/api/app/views/webui/attribute/responsive_ux/_index_actions.html.haml
+++ b/src/api/app/views/webui/attribute/responsive_ux/_index_actions.html.haml
@@ -1,5 +1,5 @@
 - content_for :actions do
   %li.nav-item
-  = link_to(new_attribs_path(project: project.name, package: package), title: 'Add a new attribute') do
+  = link_to(new_attribs_path(project: project.name, package: package), title: 'Add Attribute') do
     %i.fas.fa-plus-circle.fa-lg.mr-2
-    Add a new attribute
+    Add Attribute

--- a/src/api/app/views/webui/attribute/responsive_ux/_index_actions.html.haml
+++ b/src/api/app/views/webui/attribute/responsive_ux/_index_actions.html.haml
@@ -1,0 +1,5 @@
+- content_for :actions do
+  %li.nav-item
+  = link_to(new_attribs_path(project: project.name, package: package), title: 'Add a new attribute') do
+    %i.fas.fa-plus-circle.fa-lg.mr-2
+    Add a new attribute

--- a/src/api/spec/features/webui/attributes_spec.rb
+++ b/src/api/spec/features/webui/attributes_spec.rb
@@ -40,7 +40,7 @@ RSpec.feature 'Attributes', type: :feature, js: true do
         login user
 
         visit index_attribs_path(project: user.home_project_name)
-        click_link('Add a new attribute')
+        click_link('Add Attribute')
         find('select#attrib_attrib_type_id').select('OBS:VeryImportantProject')
         click_button('Add')
         expect(page).to have_content('Sorry, you are not authorized to create this Attrib.')
@@ -64,7 +64,7 @@ RSpec.feature 'Attributes', type: :feature, js: true do
           login other_user
 
           visit index_attribs_path(project: user.home_project_name)
-          expect(page).not_to have_content('Add a new attribute')
+          expect(page).not_to have_content('Add Attribute')
         end
       end
 

--- a/src/api/spec/features/webui/projects_spec.rb
+++ b/src/api/spec/features/webui/projects_spec.rb
@@ -219,7 +219,7 @@ RSpec.feature 'Projects', type: :feature, js: true do
       visit project_show_path(project)
 
       click_link('Attributes')
-      click_link('Add a new attribute')
+      click_link('Add Attribute')
       select('OBS:MaintenanceProject')
       click_button('Add')
 

--- a/src/api/spec/support/features/features_attribute.rb
+++ b/src/api/spec/support/features/features_attribute.rb
@@ -1,7 +1,7 @@
 module FeaturesAttribute
   def add_attribute_with_values(package = nil)
     visit index_attribs_path(project: user.home_project_name, package: package.try(:name))
-    click_link('Add a new attribute')
+    click_link('Add Attribute')
     expect(page).to have_text('Add Attribute')
     find('select#attrib_attrib_type_id').select("#{attribute_type.attrib_namespace}:#{attribute_type.name}", match: :first)
     click_button('Add')


### PR DESCRIPTION
Under beta program, the general actions related to attribute are
moved to the Actions menu.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
