### PR TITLE
Add subproject creation link to actions menu

### DIFF
--- a/src/api/app/views/webui/project/responsive_ux/_subprojects_actions.html.haml
+++ b/src/api/app/views/webui/project/responsive_ux/_subprojects_actions.html.haml
@@ -1,0 +1,5 @@
+- content_for :actions do
+  - if User.possibly_nobody.can_modify?(project)
+    = link_to(new_project_path(namespace: project), class: 'nav-link') do
+      %i.fas.fa-plus-circle.fa-lg.mr-2
+      Create Subproject

--- a/src/api/app/views/webui/project/subprojects.html.haml
+++ b/src/api/app/views/webui/project/subprojects.html.haml
@@ -1,5 +1,8 @@
 :ruby
   @pagetitle = "Subprojects of #{@project}"
+  if flipper_responsive?
+    render partial: 'webui/project/responsive_ux/subprojects_actions', locals: { project: @project }
+  end
 
 .card.mb-3
   = render partial: 'tabs', locals: { project: @project }
@@ -15,7 +18,7 @@
         - else
           %p
             %i This project has no subprojects
-        - if User.possibly_nobody.can_modify?(@project)
+        - if User.possibly_nobody.can_modify?(@project) && !flipper_responsive?
           = link_to(new_project_path(namespace: @project), class: 'nav-link') do
             %i.fas.fa-plus-circle.text-primary
             Create Subproject


### PR DESCRIPTION
The subproject creation link should be part of the actions
menu, which contains actions related to the current view.
For now, only shown in the beta program.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
