### PR TITLE
Replace deprecated update_attribute by update 

### DIFF
--- a/src/api/app/controllers/configurations_controller.rb
+++ b/src/api/app/controllers/configurations_controller.rb
@@ -59,7 +59,7 @@ class ConfigurationsController < ApplicationController
       attribs[key] = value
     end
 
-    ret = @configuration.update_attributes(attribs)
+    ret = @configuration.update(attribs)
     if ret
       @configuration.save!
       head :ok

--- a/src/api/app/controllers/issue_trackers_controller.rb
+++ b/src/api/app/controllers/issue_trackers_controller.rb
@@ -66,7 +66,7 @@ class IssueTrackersController < ApplicationController
 
       issue_tracker = IssueTracker.find_by_name(params[:id])
       if issue_tracker
-        issue_tracker.update_attributes(attribs)
+        issue_tracker.update(attribs)
       else
         IssueTracker.create(attribs)
       end

--- a/src/api/app/controllers/webui/download_on_demand_controller.rb
+++ b/src/api/app/controllers/webui/download_on_demand_controller.rb
@@ -32,7 +32,7 @@ class Webui::DownloadOnDemandController < Webui::WebuiController
           repository: @download_on_demand.repository,
           architecture: Architecture.find_by_name(permitted_params[:arch])
         ).first_or_create!
-        @download_on_demand.update_attributes!(permitted_params)
+        @download_on_demand.update!(permitted_params)
         @project.store
       end
     rescue ActiveRecord::RecordInvalid => e

--- a/src/api/app/controllers/webui/kiwi/images_controller.rb
+++ b/src/api/app/controllers/webui/kiwi/images_controller.rb
@@ -69,7 +69,7 @@ module Webui
         ::Kiwi::Image.transaction do
           cleanup_non_project_repositories!
 
-          @image.update_attributes!(image_params) unless params[:kiwi_image].empty?
+          @image.update!(image_params) unless params[:kiwi_image].empty?
           @image.write_to_backend
         end
         redirect_to action: :edit

--- a/src/api/app/controllers/webui/repositories_controller.rb
+++ b/src/api/app/controllers/webui/repositories_controller.rb
@@ -195,7 +195,7 @@ class Webui::RepositoriesController < Webui::WebuiController
       @main_object.flags.of_type(flag_type).where(repo: params[:repository], architecture: architecture).delete_all
     elsif %r{^set-(?<status>disable|enable)$} =~ params[:command]
       flag = @main_object.flags.find_or_create_by(flag: flag_type, repo: params[:repository], architecture: architecture)
-      flag.update_attributes(status: status)
+      flag.update(status: status)
     end
     @main_object.store
   end

--- a/src/api/app/jobs/send_event_emails_job.rb
+++ b/src/api/app/jobs/send_event_emails_job.rb
@@ -20,6 +20,6 @@ class SendEventEmailsJob < ApplicationJob
   rescue StandardError => e
     Airbrake.notify(e, event_id: event.id)
   ensure
-    event.update_attributes(mails_sent: true)
+    event.update(mails_sent: true)
   end
 end

--- a/src/api/app/models/configuration.rb
+++ b/src/api/app/models/configuration.rb
@@ -115,7 +115,7 @@ class Configuration < ApplicationRecord
     unless CONFIG['frontend_host'].blank? || CONFIG['frontend_port'].blank? || CONFIG['frontend_protocol'].blank?
       attribs['api_url'] = "#{CONFIG['frontend_protocol']}://#{CONFIG['frontend_host']}:#{CONFIG['frontend_port']}"
     end
-    update_attributes(attribs)
+    update(attribs)
     save!
   end
 

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -337,7 +337,7 @@ class User < ApplicationRecord
     # the password to a bcrypt one
     if deprecated_password
       if deprecated_password_equals?(unencrypted_password)
-        update_attributes(password: unencrypted_password, deprecated_password: nil, deprecated_password_salt: nil, deprecated_password_hash_type: nil)
+        update(password: unencrypted_password, deprecated_password: nil, deprecated_password_salt: nil, deprecated_password_hash_type: nil)
         return self
       end
 
@@ -867,11 +867,11 @@ class User < ApplicationRecord
   end
 
   def mark_login!
-    update_attributes(last_logged_in_at: Time.zone.today, login_failure_count: 0)
+    update(last_logged_in_at: Time.zone.today, login_failure_count: 0)
   end
 
   def count_login_failure
-    update_attributes(login_failure_count: login_failure_count + 1)
+    update(login_failure_count: login_failure_count + 1)
   end
 
   def proxy_realname(env)

--- a/src/api/db/data/20170831143534_convert_notifications_event_payload_to_json.rb
+++ b/src/api/db/data/20170831143534_convert_notifications_event_payload_to_json.rb
@@ -3,7 +3,7 @@ class ConvertNotificationsEventPayloadToJson < ActiveRecord::Migration[5.1]
     Notification20170831143534.transaction do
       Notification20170831143534.all.find_each do |notification|
         json = yaml_to_json(notification.event_payload)
-        notification.update_attributes!(event_payload: json)
+        notification.update!(event_payload: json)
       end
     end
   end

--- a/src/api/db/data/20180214132015_project_log_entry_user_name.rb
+++ b/src/api/db/data/20180214132015_project_log_entry_user_name.rb
@@ -4,7 +4,7 @@ class ProjectLogEntryUserName < ActiveRecord::Migration[5.1]
       batch.each do |log_entry|
         user = User.find_by(id: log_entry.user_name).try(:login)
         user ||= User::NOBODY_LOGIN
-        log_entry.update_attributes(user_name: user)
+        log_entry.update(user_name: user)
       end
     end
   end
@@ -14,7 +14,7 @@ class ProjectLogEntryUserName < ActiveRecord::Migration[5.1]
       batch.each do |log_entry|
         user = User.find_by(login: log_entry.user_name).try(:id)
         user ||= User.find_nobody!.try(:id)
-        log_entry.update_attributes(user_name: user)
+        log_entry.update(user_name: user)
       end
     end
   end

--- a/src/api/spec/controllers/status/reports_controller_spec.rb
+++ b/src/api/spec/controllers/status/reports_controller_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Status::ReportsController, type: :controller do
       let!(:check) { create(:check, status_report: status_report, name: 'ExampleCI') }
 
       before do
-        repository.update_attributes!(required_checks: ['openQA'])
+        repository.update!(required_checks: ['openQA'])
       end
 
       subject! { get :show, params: { project_name: project.name, repository_name: repository.name, report_uuid: status_report.uuid }, format: :xml }
@@ -50,7 +50,7 @@ RSpec.describe Status::ReportsController, type: :controller do
       let!(:check) { create(:check, status_report: status_report, name: 'ExampleCI') }
 
       before do
-        repository_architecture.update_attributes!(required_checks: ['openQA'])
+        repository_architecture.update!(required_checks: ['openQA'])
       end
 
       subject! do

--- a/src/api/spec/controllers/webui/request_controller_spec.rb
+++ b/src/api/spec/controllers/webui/request_controller_spec.rb
@@ -291,7 +291,7 @@ RSpec.describe Webui::RequestController, vcr: true do
       end
 
       it 'with invalid transition' do
-        request_with_review.update_attributes(state: 'declined')
+        request_with_review.update(state: 'declined')
         post :modify_review, params: { comment: 'yeah',
                                        review_id: request_with_review.reviews.first,
                                        new_state: 'Approve' }

--- a/src/api/spec/controllers/webui/session_controller_spec.rb
+++ b/src/api/spec/controllers/webui/session_controller_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe Webui::SessionController do
       end
 
       it 'updates last_logged_in_at' do
-        user.update_attributes(last_logged_in_at: nil)
+        user.update(last_logged_in_at: nil)
 
         get :new
         expect(user.reload.last_logged_in_at).to eq(Time.zone.today)

--- a/src/api/spec/controllers/webui/webui_controller_spec.rb
+++ b/src/api/spec/controllers/webui/webui_controller_spec.rb
@@ -30,14 +30,14 @@ RSpec.describe Webui::WebuiController do
 
   describe 'GET index as nobody' do
     it 'is allowed when Configuration.anonymous is true' do
-      Configuration.update_attributes(anonymous: true)
+      Configuration.update(anonymous: true)
 
       get :index
       expect(response).to have_http_status(:success)
     end
 
     it 'is not allowed when Configuration.anonymous is false' do
-      Configuration.update_attributes(anonymous: false)
+      Configuration.update(anonymous: false)
 
       get :index
       expect(response).to redirect_to(root_path)
@@ -47,12 +47,12 @@ RSpec.describe Webui::WebuiController do
   describe 'GET index as a user' do
     it 'is always allowed' do
       login(create(:confirmed_user))
-      Configuration.update_attributes(anonymous: true)
+      Configuration.update(anonymous: true)
 
       get :index
       expect(response).to have_http_status(:success)
 
-      Configuration.update_attributes(anonymous: false)
+      Configuration.update(anonymous: false)
 
       get :index
       expect(response).to have_http_status(:success)

--- a/src/api/spec/db/data/regenerate_notifications_spec.rb
+++ b/src/api/spec/db/data/regenerate_notifications_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe RegenerateNotifications, type: :migration do
                source_package: another_package,
                created_at: 3.days.ago,
                updated_at: 2.days.ago)
-      bs_request_to_decline.update_attributes(state: 'declined')
+      bs_request_to_decline.update(state: 'declined')
       bs_request_to_decline
     end
     let!(:old_declined_bs_request) do
@@ -39,7 +39,7 @@ RSpec.describe RegenerateNotifications, type: :migration do
                target_package: package,
                source_package: another_package,
                created_at: 101.days.ago)
-      bs_request_to_decline.update_attributes(state: 'declined')
+      bs_request_to_decline.update(state: 'declined')
       bs_request_to_decline
     end
     let!(:revoked_bs_request) { create(:bs_request, type: 'maintenance_release', state: :revoked) } # This shouldn't regenerate notification

--- a/src/api/spec/decorators/staging/project_decorator_spec.rb
+++ b/src/api/spec/decorators/staging/project_decorator_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Staging::ProjectDecorator do
 
   context 'when the project has a title' do
     before do
-      staging_project.update_attributes(title: 'A')
+      staging_project.update(title: 'A')
     end
 
     it 'returns the title' do

--- a/src/api/spec/factories/bs_requests.rb
+++ b/src/api/spec/factories/bs_requests.rb
@@ -117,7 +117,7 @@ FactoryBot.define do
       state = evaluator.state
       state ||= :review if evaluator.reviews.present?
       if state
-        request.update_attributes(state: state)
+        request.update(state: state)
         request.reload
       end
     end

--- a/src/api/spec/features/webui/requests_spec.rb
+++ b/src/api/spec/features/webui/requests_spec.rb
@@ -313,11 +313,11 @@ RSpec.feature 'Bootstrap_Requests', type: :feature, js: true, vcr: true do
 
   describe 'shows the correct auto accepted message' do
     before do
-      bs_request.update_attributes(accept_at: Time.now)
+      bs_request.update(accept_at: Time.now)
     end
 
     scenario 'when request is in a final state' do
-      bs_request.update_attributes(state: :accepted)
+      bs_request.update(state: :accepted)
       visit request_show_path(bs_request)
       expect(page).to have_text("Auto-accept was set to #{I18n.localize bs_request.accept_at, format: :only_date}.")
     end
@@ -328,7 +328,7 @@ RSpec.feature 'Bootstrap_Requests', type: :feature, js: true, vcr: true do
     end
 
     scenario 'when request auto_accept is in the future and not in a final state' do
-      bs_request.update_attributes(accept_at: Time.now + 1.day)
+      bs_request.update(accept_at: Time.now + 1.day)
       visit request_show_path(bs_request)
       expect(page).
         to have_text("This request will be automatically accepted in #{ApplicationController.helpers.time_ago_in_words(bs_request.accept_at)}.")

--- a/src/api/spec/jobs/bs_request_action_webui_infos_job_spec.rb
+++ b/src/api/spec/jobs/bs_request_action_webui_infos_job_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe BsRequestActionWebuiInfosJob, type: :job, vcr: true do
 
       let(:path) { "#{CONFIG['source_url']}/source/#{another_source_project}/#{another_source_package}?#{params.to_param}" }
       before do
-        request.update_attributes(superseded_by: superseding_request.number, state: :superseded)
+        request.update(superseded_by: superseding_request.number, state: :superseded)
       end
 
       subject! { BsRequestActionWebuiInfosJob.new.perform(superseding_request_action) }

--- a/src/api/spec/lib/statistics_calculations_spec.rb
+++ b/src/api/spec/lib/statistics_calculations_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe StatisticsCalculations do
 
       before do
         # We need to be able to identify the project
-        package_3.project.update_attributes!(name: 'my_project')
+        package_3.project.update!(name: 'my_project')
       end
 
       it { expect(subject.length).to eq(2) }

--- a/src/api/spec/models/download_repository_spec.rb
+++ b/src/api/spec/models/download_repository_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe DownloadRepository do
       subject(:download_repository) { create(:download_repository) }
 
       it {
-        expect { download_repository.update_attributes!(arch: 's390x') }.to raise_error(
+        expect { download_repository.update!(arch: 's390x') }.to raise_error(
           ActiveRecord::RecordInvalid, 'Validation failed: Architecture has to be available via repository association'
         )
       }

--- a/src/api/spec/models/owner_search_spec.rb
+++ b/src/api/spec/models/owner_search_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe OwnerSearch do
       # the User.owner is only interesting for locked accounts
       it 'does not respect User.owner' do
         create(:relationship_package_user, package: package, user: user, role: Role.find_by_title('bugowner'))
-        user.update_attributes(owner: develuser)
+        user.update(owner: develuser)
 
         subject = OwnerSearch::Container.new(devel: false, filter: 'bugowner').for(package).first
         expect(subject.users['bugowner']).to eq([user])
@@ -39,7 +39,7 @@ RSpec.describe OwnerSearch do
 
       it 'respects User.state' do
         create(:relationship_package_user, package: package, user: user, role: Role.find_by_title('bugowner'))
-        user.update_attributes(state: :locked)
+        user.update(state: :locked)
 
         subject = OwnerSearch::Container.new(devel: false, filter: 'bugowner').for(package)
         expect(subject).to eq([])
@@ -68,7 +68,7 @@ RSpec.describe OwnerSearch do
 
       it 'respects User.state' do
         create(:relationship_package_user, package: package, user: user, role: Role.find_by_title('bugowner'))
-        user.update_attributes(state: :locked)
+        user.update(state: :locked)
 
         subject = OwnerSearch::Missing.new(devel: false, filter: 'bugowner').find.first
         expect(subject.rootproject).to eq('home:Iggy')
@@ -79,12 +79,12 @@ RSpec.describe OwnerSearch do
 
       it 'respects User.owner' do
         create(:relationship_package_user, package: package, user: user, role: Role.find_by_title('bugowner'))
-        user.update_attributes(owner: develuser)
+        user.update(owner: develuser)
 
         subject = OwnerSearch::Missing.new(devel: false, filter: 'bugowner').find
         expect(subject).to eq([])
 
-        develuser.update_attributes(state: :locked)
+        develuser.update(state: :locked)
 
         subject = OwnerSearch::Missing.new(devel: false, filter: 'bugowner').find.first
         expect(subject.rootproject).to eq('home:Iggy')
@@ -95,7 +95,7 @@ RSpec.describe OwnerSearch do
 
     context 'in maintenance projects' do
       let(:project) { Project.find_by(name: 'home:Iggy') }
-      let!(:project_kind) { project.update_attributes(kind: 'maintenance_release') }
+      let!(:project_kind) { project.update(kind: 'maintenance_release') }
       let(:other_user) { create(:confirmed_user, login: 'hans') }
 
       # A package with bugowner develuser
@@ -106,7 +106,7 @@ RSpec.describe OwnerSearch do
       # A local link to package.42 with bugowner other_user
       let(:package) { create(:package, name: 'package', project: project) }
       # FIXME: package link should be a transitive argument to the package factory
-      let!(:package_link) { package.build_backend_package.update_attributes(links_to_id: package_42) }
+      let!(:package_link) { package.build_backend_package.update(links_to_id: package_42) }
       let!(:other_bugowner) { create(:relationship_package_user_as_bugowner, user: other_user, package: package) }
 
       # A patchinfo with bugowner maintenance_user
@@ -130,7 +130,7 @@ RSpec.describe OwnerSearch do
       context 'with owned user' do
         let(:owning) { create(:confirmed_user) }
         before do
-          other_user.update_attributes(owner: owning, state: :subaccount)
+          other_user.update(owner: owning, state: :subaccount)
         end
 
         it 'still returns the owned user as bugowner' do

--- a/src/api/spec/models/user_spec.rb
+++ b/src/api/spec/models/user_spec.rb
@@ -467,7 +467,7 @@ RSpec.describe User do
 
   describe '.mark_login!' do
     before do
-      user.update_attributes!(login_failure_count: 7, last_logged_in_at: Time.zone.yesterday)
+      user.update!(login_failure_count: 7, last_logged_in_at: Time.zone.yesterday)
       user.mark_login!
     end
 


### PR DESCRIPTION
Method update_attributes is deprecated and will be removed from Rails 6.1.

Closes #9441

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
