### PR TITLE
Ensure NOT conditions act as NOR

### DIFF
--- a/src/api/app/queries/notifications_finder.rb
+++ b/src/api/app/queries/notifications_finder.rb
@@ -12,7 +12,7 @@ class NotificationsFinder
   end
 
   def with_notifiable
-    @relation.where.not(notifiable_id: nil, notifiable_type: nil)
+    @relation.where.not(notifiable_id: nil).where.not(notifiable_type: nil)
   end
 
   def without_notifiable

--- a/src/api/db/data/20200421121610_backfill_notified_projects.rb
+++ b/src/api/db/data/20200421121610_backfill_notified_projects.rb
@@ -1,6 +1,6 @@
 class BackfillNotifiedProjects < ActiveRecord::Migration[6.0]
   def up
-    Notification.where.not(notifiable_id: nil, notifiable_type: nil).find_each do |notification|
+    Notification.where.not(notifiable_id: nil).where.not(notifiable_type: nil).find_each do |notification|
       notification.projects << NotifiedProjects.new(notification).call
     rescue ActiveRecord::RecordNotUnique
       # We don't have to do anything...

--- a/src/api/lib/tasks/rollout.rake
+++ b/src/api/lib/tasks/rollout.rake
@@ -38,7 +38,7 @@ namespace :rollout do
   task non_recently_logged_users: :environment do
     User.all_without_nobody
         .not_staff
-        .where.not(in_rollout: true, last_logged_in_at: Time.zone.today.prev_month(3)..Time.zone.today)
+        .where.not(in_rollout: true).where.not(last_logged_in_at: Time.zone.today.prev_month(3)..Time.zone.today)
         .in_batches.update_all(in_rollout: true)
   end
 


### PR DESCRIPTION
NOT conditions will no longer behave as NOR in Rails 6.1.
Instead of using where.not with multiple attributes, they are replaced
by many chained where.not (one per attribute).

Closes #9444.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
