### PR TITLE
Hide build results for delete requests

### DIFF
--- a/src/api/app/views/webui/shared/_buildresult_box.html.haml
+++ b/src/api/app/views/webui/shared/_buildresult_box.html.haml
@@ -1,51 +1,68 @@
 :ruby
   index ||= ''
+  project ||= nil
+  package ||= nil
+  bs_request ||= nil
+  buildable = package || project
 
-  # For a request staged in a staging project, we display the Build Results / RPM Lint from the staging project instead
-  is_staged_request = defined?(bs_request) && !bs_request.staging_project_id.nil?
-  project = bs_request.staging_project.name if is_staged_request
+- if buildable
+  :ruby
+    # For a request staged in a staging project, we display the Build Results / RPM Lint from the staging project instead
+    is_staged_request = bs_request && !bs_request.staging_project_id.nil?
+    project = bs_request.staging_project.name if is_staged_request
 
-  ajax_data = {}
-  ajax_data['project'] = h(project) if defined?(project)
-  ajax_data['package'] = h(package) if defined?(package)
-  ajax_data['index'] = h(index) if defined?(index)
+    ajax_data = {}
+    ajax_data['project'] = h(project) if project
+    ajax_data['package'] = h(package) if package
+    ajax_data['index'] = h(index) if index
 
-.card
-  .bg-light{ id: "buildresult#{index}-urls", data: { buildresult_url: defined?(package) ? package_buildresult_path : project_buildresult_path } }
-    %ul.nav.nav-tabs.pt-2.px-3.flex-nowrap{ id: "buildresult#{index}-box", role: 'tablist', data: ajax_data }
-      %li.nav-item
-        = link_to("#build#{index}", id: "build#{index}-tab", class: 'nav-link active text-nowrap',
-          data: { toggle: 'tab' }, role: 'tab', aria: { controls: "build#{index}", selected: true }) do
-          Build Results
-      - if defined?(package)
+  .card
+    .bg-light{ id: "buildresult#{index}-urls", data: { buildresult_url: package ? package_buildresult_path : project_buildresult_path } }
+      %ul.nav.nav-tabs.pt-2.px-3.flex-nowrap{ id: "buildresult#{index}-box", role: 'tablist', data: ajax_data }
         %li.nav-item
-          = link_to("#rpm#{index}", id: "rpm#{index}-tab", class: 'nav-link text-nowrap', data: { toggle: 'tab' },
-            role: 'tab', aria: { controls: "rpm#{index}", selected: false }) do
-            RPM Lint
-  .card-body
-    .tab-content
-      .tab-pane.fade.show.active{ id: "build#{index}", role: 'tabpanel', aria: { labelledby: "build#{index}-tab" } }
-        .sticky-top.py-2.bg-white.border-bottom.border-light.clearfix
-          .btn.btn-outline-primary.build-refresh.float-right{ onclick: "updateBuildResult('#{index}')",
-                                                              accesskey: 'r', title: 'Refresh Build Results' }
-            Refresh
-            %i.fas.fa-sync-alt{ id: "build#{index}-reload" }
-        - if is_staged_request
-          %p.font-italic
-            From staging project
-            = link_to(project, project_show_path(project))
-        .result
-      - if defined?(package)
-        .tab-pane.fade{ id: "rpm#{index}", role: 'tabpanel', aria: { labelledby: "rpm#{index}-tab" } }
-          .btn.btn-outline-primary.mb-2{ onclick: "updateRpmlintResult('#{index}')", title: 'Refresh Rpmlint Results' }
-            Refresh
-            %i.fas.fa-sync-alt{ id: "rpm#{index}-reload" }
+          = link_to("#build#{index}", id: "build#{index}-tab", class: 'nav-link active text-nowrap',
+            data: { toggle: 'tab' }, role: 'tab', aria: { controls: "build#{index}", selected: true }) do
+            Build Results
+        - if package
+          %li.nav-item
+            = link_to("#rpm#{index}", id: "rpm#{index}-tab", class: 'nav-link text-nowrap', data: { toggle: 'tab' },
+              role: 'tab', aria: { controls: "rpm#{index}", selected: false }) do
+              RPM Lint
+    .card-body
+      .tab-content
+        .tab-pane.fade.show.active{ id: "build#{index}", role: 'tabpanel', aria: { labelledby: "build#{index}-tab" } }
+          .sticky-top.py-2.bg-white.border-bottom.border-light.clearfix
+            .btn.btn-outline-primary.build-refresh.float-right{ onclick: "updateBuildResult('#{index}')",
+                                                                accesskey: 'r', title: 'Refresh Build Results' }
+              Refresh
+              %i.fas.fa-sync-alt{ id: "build#{index}-reload" }
           - if is_staged_request
             %p.font-italic
               From staging project
               = link_to(project, project_show_path(project))
           .result
+        - if package
+          .tab-pane.fade{ id: "rpm#{index}", role: 'tabpanel', aria: { labelledby: "rpm#{index}-tab" } }
+            .btn.btn-outline-primary.mb-2{ onclick: "updateRpmlintResult('#{index}')", title: 'Refresh Rpmlint Results' }
+              Refresh
+              %i.fas.fa-sync-alt{ id: "rpm#{index}-reload" }
+            - if is_staged_request
+              %p.font-italic
+                From staging project
+                = link_to(project, project_show_path(project))
+            .result
 
-:javascript
-  updateBuildResult('#{index}');
-  if ($('#rpm#{index}').length === 1) updateRpmlintResult('#{index}');
+  :javascript
+    updateBuildResult('#{index}');
+    if ($('#rpm#{index}').length === 1) updateRpmlintResult('#{index}');
+- else
+  .card
+    .bg-light
+      %ul.nav.nav-tabs.pt-2.px-3.flex-nowrap
+        %li.nav-item
+          = link_to('Build Results', "#build#{index}", class: 'nav-link active text-nowrap')
+    .card-body
+      .tab-content
+        .tab-pane.fade.show.active
+          .result
+            %i No build results available


### PR DESCRIPTION
When we are in a request for package deletion, it makes no sense to
build the package which no longer exists.

Using 'defined?' to ckeck if the project or package exist is not a good
idea because it always returns truthy (returns "local-variable") even if they are nil.
Therefore, 'defined?' has been replaced by '||='.

Even if it is not going to display build results, just the text "No build results available" I decided to give it the same aspect: a card with the `Build Results` tab inside.

Fixes #9514 

![Screenshot_2020-05-08 Request 385 (review)(1)](https://user-images.githubusercontent.com/2581944/81395627-458dea00-9124-11ea-8a6b-db1f3bdf019d.png)



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
