### PR TITLE
Render collection of status_messages instead of render with loop

### DIFF
--- a/src/api/app/views/webui/main/_status_message.html.haml
+++ b/src/api/app/views/webui/main/_status_message.html.haml
@@ -1,15 +1,15 @@
 .list-group-item.list-group-item-integrated.border-left-0.border-right-0
   .row
     .col-1
-      %i.fa.fa-lg{ icon_for_status(message) }
+      %i.fa.fa-lg{ icon_for_status(status_message) }
     .col
-      = user_with_realname_and_icon(message.user, short: true)
+      = user_with_realname_and_icon(status_message.user, short: true)
       wrote
       %u
-        #{time_ago_in_words(message.created_at)} ago
+        #{time_ago_in_words(status_message.created_at)} ago
       - if User.admin_session?
         .float-right
-          = link_to(status_message_path(message), method: :delete, title: 'Remove status message') do
+          = link_to(status_message_path(status_message), method: :delete, title: 'Remove status message') do
             %i.fas.fa-times-circle.text-danger
       .mt-2.mb-0
-        = render_as_markdown(message.message)
+        = render_as_markdown(status_message.message)

--- a/src/api/app/views/webui/main/_status_messages.html.haml
+++ b/src/api/app/views/webui/main/_status_messages.html.haml
@@ -6,8 +6,7 @@
       = link_to(news_feed_path(format: 'rss'), title: 'RSS Feed') do
         %i.fa.fa-rss
   .list-group
-    - @status_messages.each do |message|
-      = render partial: 'status_message', locals: { message: message }
+    = render partial: 'status_message', collection: status_messages
     - if User.admin_session?
       - unless flipper_responsive?
         .card-footer

--- a/src/api/app/views/webui/main/index.html.haml
+++ b/src/api/app/views/webui/main/index.html.haml
@@ -31,5 +31,5 @@
         .card-body
           = render partial: 'webui/shared/sign_up', locals: { submit_btn_text: 'Sign Up' }
     - if @status_messages.present? || User.admin_session?
-      = render partial: 'status_messages'
+      = render partial: 'status_messages', locals: { status_messages: @status_messages }
     = render(partial: 'latest_updates') if @latest_updates && (::Configuration.anonymous || User.session)


### PR DESCRIPTION
It's normally a bad idea to loop through objects and call inside the loop the render. The Rails way to do it is to pass the collection to the `render` method.