### PR TITLE
Move action links to Actions menu for package#show

### DIFF
--- a/src/api/app/views/webui/package/responsive_ux/_show_actions.html.haml
+++ b/src/api/app/views/webui/package/responsive_ux/_show_actions.html.haml
@@ -1,0 +1,28 @@
+- content_for :actions do
+  - if bugowners_mail.present? && configuration['bugzilla_url']
+    = render partial: 'webui/package/responsive_ux/show_actions/bugzilla_owner', locals: { bugowners_mail: bugowners_mail,
+                                                                                            package_name: package.name, project_name: project.name }
+  - if User.session
+    - if current_rev && is_working
+      = render partial: 'webui/package/responsive_ux/show_actions/branch_package'
+      = render partial: 'webui/package/responsive_ux/show_actions/submit_package', locals: { package: package, project: project,
+                                                                                             revision: revision }
+    - if User.possibly_nobody.can_modify?(package)
+      = render partial: 'webui/package/responsive_ux/show_actions/edit_description'
+      = render partial: 'webui/package/responsive_ux/show_actions/delete_package'
+
+      - if package.kiwi_image? && policy(package).update?
+        = render partial: 'webui/package/responsive_ux/show_actions/view_kiwi', locals: { package_id: package.id }
+
+      - if package.kiwi_image?
+        = render partial: 'webui/package/responsive_ux/show_actions/cloud_upload', locals: { cloud_upload_index_path: cloud_upload_index_path }
+
+      - if services.present?
+        = render partial: 'webui/package/responsive_ux/show_actions/trigger_services', locals: { package: package, project: project }
+    - else
+      = render partial: 'webui/package/responsive_ux/show_actions/request_role_addition'
+      = render partial: 'webui/package/responsive_ux/show_actions/request_deletion'
+
+      //TODO: only users w/o rights should see this, maintainers should get a different dialog:
+    - if package.develpackage
+      = render partial: 'webui/package/responsive_ux/show_actions/request_devel_project_change', locals: { package: package, project: project }

--- a/src/api/app/views/webui/package/responsive_ux/show_actions/_branch_package.html.haml
+++ b/src/api/app/views/webui/package/responsive_ux/show_actions/_branch_package.html.haml
@@ -1,0 +1,4 @@
+%li.nav-item
+  = link_to('#', class: 'nav-link', data: { toggle: 'modal', target: '#branch-modal' }) do
+    %i.fas.fa-code-branch.fa-lg.mr-2
+    Branch package

--- a/src/api/app/views/webui/package/responsive_ux/show_actions/_bugzilla_owner.html.haml
+++ b/src/api/app/views/webui/package/responsive_ux/show_actions/_bugzilla_owner.html.haml
@@ -1,0 +1,4 @@
+%li.nav-item
+  = link_to(bugzilla_url(bugowners_mail, "#{project_name}/#{package_name}: Bug"), class: 'nav-link') do
+    %i.fas.fa-bug.fa-lg.mr-1
+    Report Bug

--- a/src/api/app/views/webui/package/responsive_ux/show_actions/_cloud_upload.html.haml
+++ b/src/api/app/views/webui/package/responsive_ux/show_actions/_cloud_upload.html.haml
@@ -1,0 +1,4 @@
+%li.nav-item
+  = link_to(cloud_upload_index_path, id: 'cloud-upload', class: 'nav-link') do
+    %i.fas.fa-cloud-upload-alt.fa-lg.mr-2
+    Cloud Upload

--- a/src/api/app/views/webui/package/responsive_ux/show_actions/_delete_package.html.haml
+++ b/src/api/app/views/webui/package/responsive_ux/show_actions/_delete_package.html.haml
@@ -1,0 +1,4 @@
+%li.nav-item
+  = link_to('#', class: 'nav-link', data: { toggle: 'modal', target: '#delete-modal' }) do
+    %i.fas.fa-times-circle.fa-lg.mr-2
+    Delete package

--- a/src/api/app/views/webui/package/responsive_ux/show_actions/_edit_description.html.haml
+++ b/src/api/app/views/webui/package/responsive_ux/show_actions/_edit_description.html.haml
@@ -1,0 +1,4 @@
+%li.nav-item
+  = link_to('#', class: 'nav-link', data: { toggle: 'modal', target: '#edit-modal' }) do
+    %i.fas.fa-edit.fa-lg.mr-2
+    Edit description

--- a/src/api/app/views/webui/package/responsive_ux/show_actions/_request_deletion.html.haml
+++ b/src/api/app/views/webui/package/responsive_ux/show_actions/_request_deletion.html.haml
@@ -1,0 +1,4 @@
+%li.nav-item
+  = link_to('#', class: 'nav-link', data: { toggle: 'modal', target: '#delete-request-modal' }) do
+    %i.fas.fa-list-alt.fa-lg.mr-2
+    Request deletion

--- a/src/api/app/views/webui/package/responsive_ux/show_actions/_request_devel_project_change.html.haml
+++ b/src/api/app/views/webui/package/responsive_ux/show_actions/_request_devel_project_change.html.haml
@@ -1,0 +1,4 @@
+%li.nav-item
+  = link_to('#', class: 'nav-link', data: { toggle: 'modal', target: '#change-devel-request-modal' }) do
+    %i.fas.fa-exchange-alt.fa-lg.mr-2
+    Request devel project change

--- a/src/api/app/views/webui/package/responsive_ux/show_actions/_request_role_addition.html.haml
+++ b/src/api/app/views/webui/package/responsive_ux/show_actions/_request_role_addition.html.haml
@@ -1,0 +1,4 @@
+%li.nav-item
+  = link_to('#', class: 'nav-link', data: { toggle: 'modal', target: '#add-role-modal' }) do
+    %i.fas.fa-plus-circle.fa-lg.mr-2
+    Request Role Addition

--- a/src/api/app/views/webui/package/responsive_ux/show_actions/_submit_package.html.haml
+++ b/src/api/app/views/webui/package/responsive_ux/show_actions/_submit_package.html.haml
@@ -1,0 +1,8 @@
+%li.nav-item
+  = link_to('#',
+      class: 'nav-link',
+      data: { toggle: 'modal',
+              target: '#submit-request-modal',
+              url: package_branch_diff_info_path(@project.name, @package.name) }) do
+    %i.fas.fa-share-square.fa-lg.mr-2
+    Submit package

--- a/src/api/app/views/webui/package/responsive_ux/show_actions/_trigger_services.html.haml
+++ b/src/api/app/views/webui/package/responsive_ux/show_actions/_trigger_services.html.haml
@@ -1,0 +1,4 @@
+%li.nav-item
+  = link_to(package_trigger_services_path(package: package, project: project), method: :post, class: 'nav-link') do
+    %i.fas.fa-project-diagram.fa-lg.mr-2
+    Trigger services

--- a/src/api/app/views/webui/package/responsive_ux/show_actions/_view_kiwi.html.haml
+++ b/src/api/app/views/webui/package/responsive_ux/show_actions/_view_kiwi.html.haml
@@ -1,0 +1,4 @@
+%li.nav-item
+  = link_to(import_kiwi_image_path(package_id), id: 'edit-kiwi', class: 'nav-link') do
+    %i.fas.fa-compact-disc.fa-lg.mr-2
+    View Image

--- a/src/api/app/views/webui/package/show.html.haml
+++ b/src/api/app/views/webui/package/show.html.haml
@@ -1,10 +1,22 @@
+-# haml-lint:disable ViewLength
 :ruby
   @pagetitle = "Show #{@project} / #{truncate(@package.name, length: 50)}"
   devel_package = @package.develpackage
 
   content_for(:meta_title, @package.title.presence || @package.name)
   content_for(:meta_description, @package.description)
-
+  if flipper_responsive?
+    render partial: 'webui/package/responsive_ux/show_actions', locals: { bugowners_mail: @bugowners_mail,
+                                                    configuration: @configuration,
+                                                    revision: @revision,
+                                                    current_rev: @current_rev,
+                                                    spec_count: @spec_count,
+                                                    cleanup_source: @cleanup_source,
+                                                    services: @services,
+                                                    project: @project,
+                                                    package: @package,
+                                                    is_working: @forced_unexpand.blank? }
+  end
 .card.mb-3
   = render partial: 'tabs', locals: { project: @project, package: @package }
   .card-body
@@ -26,16 +38,17 @@
                                                   revision: @revision,
                                                   project: @project,
                                                   package: @package }
-      = render partial: 'bottom_actions', locals: { bugowners_mail: @bugowners_mail,
-                                                    configuration: @configuration,
-                                                    revision: @revision,
-                                                    current_rev: @current_rev,
-                                                    spec_count: @spec_count,
-                                                    cleanup_source: @cleanup_source,
-                                                    services: @services,
-                                                    project: @project,
-                                                    package: @package,
-                                                    is_working: @forced_unexpand.blank? }
+        - unless flipper_responsive?
+          = render partial: 'bottom_actions', locals: { bugowners_mail: @bugowners_mail,
+                                                      configuration: @configuration,
+                                                      revision: @revision,
+                                                      current_rev: @current_rev,
+                                                      spec_count: @spec_count,
+                                                      cleanup_source: @cleanup_source,
+                                                      services: @services,
+                                                      project: @project,
+                                                      package: @package,
+                                                      is_working: @forced_unexpand.blank? }
 .overview
   .build-results
     = render partial: 'webui/shared/buildresult_box', locals: { project: @project.name, package: @package.name }
@@ -80,7 +93,6 @@
       .card-body#comments
         = render partial: 'webui/comment/show', locals: { commentable: @package,
           comment_counter_id: "#comment-counter-package-#{@package.id}" }
-
 - if User.session
   - if @current_rev
     = render partial: 'branch_dialog', locals: { project: @project, package: @package, revision: @revision }
@@ -93,3 +105,4 @@
     = render partial: 'webui/request/delete_request_dialog', locals: { project: @project, package: @package }
   - if @package.develpackage
     = render partial: 'webui/request/change_devel_request_dialog', locals: { project: @project, package: @package }
+-# haml-lint:enable ViewLength


### PR DESCRIPTION
The bottom actions of the page package#show are moved to the responsive Actions menu.
Only available in the beta program.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
