### PR TITLE
[backend] maintain the history of the last failed jobs

### DIFF
--- a/src/backend/BSSched/BuildJob.pm
+++ b/src/backend/BSSched/BuildJob.pm
@@ -802,6 +802,13 @@ sub addjobhist {
   my $gdst = "$gctx->{'reporoot'}/$prp/$myarch";
   mkdir_p($gdst);
   BSFileDB::fdb_add("$gdst/:jobhistory", $BSXML::jobhistlay, $jobhist);
+  my $dst = "$gdst/$jobhist->{'package'}";
+  if ($jobhist->{'code'} eq 'failed') {
+    mkdir_p($dst);
+    BSFileDB::fdb_add_i("$dst/.failhistory", [ 'failcount', @$BSXML::jobhistlay ] , { %$jobhist });
+  } else {
+    unlink("$dst/.failhistory");
+  }
 }
 
 

--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -2156,16 +2156,8 @@ sub notify_jobresult {
   } elsif ($jobstatus->{'result'} eq 'succeeded') {
     BSNotify::notify('BUILD_SUCCESS', \%ninfo);
   } else {
-    my $failcnt = 0;
-    my $filter = sub {
-        return 1 if ($_[0]->{'package'} ne $ninfo{'package'});
-        return -1 if ($_[0]->{'code'} ne 'failed');
-        return -1 if ($failcnt > 100);
-        $failcnt += 1;
-        return 1;
-    };
-    BSFileDB::fdb_getall_reverse("$reporoot/$prpa/:jobhistory", $BSXML::jobhistlay, undef, $filter);
-    $ninfo{'successive_failcount'} = $failcnt;
+    my $lastfail = BSFileDB::fdb_getlast("$reporoot/$prpa/$info->{'package'}/.failhistory", [ 'failcount', @$BSXML::jobhistlay ]) || {};
+    $ninfo{'successive_failcount'} = ($lastfail->{'failcount'} || 0);
     BSNotify::notify('BUILD_FAIL', \%ninfo);
   }
 }


### PR DESCRIPTION
This is a much saner approach than calling Build::readdeps and fixing up
the dependencies of the packages.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
