### PR TITLE
Don't query for the rss feed for a non logged user

### DIFF
--- a/src/api/app/views/layouts/webui/webui.html.haml
+++ b/src/api/app/views/layouts/webui/webui.html.haml
@@ -35,7 +35,7 @@
 
     = auto_discovery_link_tag(:rss, news_feed_path(format: 'rss'), title: 'News')
     = csrf_meta_tag
-    - if User.possibly_nobody.rss_token
+    - if User.session.try(:rss_token)
       = auto_discovery_link_tag(:rss, user_rss_notifications_url(token: User.session!.rss_token.string, format: :rss), title: 'Notifications')
     = auto_discovery_link_tag(:rss, latest_updates_feed_path(format: 'rss'), title: 'Latest updates')
   %body.d-flex.flex-column{ class: "#{'responsive-ux' if flipper_responsive?}" }


### PR DESCRIPTION
There is no need to retrieve the RSS token for a non logged user. It isn't defined. This prevents querying the database on each page request for an anonymous user.

This was found in the logs of the development environment:

```
Token::Rss Load (1.0ms)  SELECT `tokens`.* FROM `tokens` WHERE `tokens`.`type` = 'Token::Rss' AND `tokens`.`user_id` = 1 LIMIT 1
```

Co-authored-by: David Kang <dkang@suse.com>
