### PR TITLE
Authorize package creation with a Pundit policy

### DIFF
--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -837,7 +837,7 @@ class SourceController < ApplicationController
       raise PackageExists, "the package exists already #{@target_project_name} #{@target_package_name}"
     end
     tprj = Project.get_by_name(@target_project_name)
-    unless tprj.is_a?(Project) && User.session!.can_create_package_in?(tprj)
+    unless tprj.is_a?(Project) && Pundit.policy(User.session!, Package.new(project: tprj)).create?
       raise CmdExecutionNoPermission, "no permission to create package in project #{@target_project_name}"
     end
 
@@ -1103,7 +1103,7 @@ class SourceController < ApplicationController
 
     if Package.exists_by_project_and_name(@target_project_name, @target_package_name, follow_project_links: false)
       verify_can_modify_target_package!
-    elsif !@project.is_a?(Project) || !User.session!.can_create_package_in?(@project)
+    elsif !@project.is_a?(Project) || !Pundit.policy(User.session!, Package.new(project: @project)).create?
       raise CmdExecutionNoPermission, "no permission to create package in project #{@target_project_name}"
     end
   end

--- a/src/api/app/models/bs_request_permission_check.rb
+++ b/src/api/app/models/bs_request_permission_check.rb
@@ -385,10 +385,10 @@ class BsRequestPermissionCheck
         @write_permission_in_this_action = true
       end
     else
-      if @target_project && User.session!.can_create_package_in?(@target_project, true)
+      if @target_project && PackagePolicy.new(User.session!, Package.new(project: @target_project), true).create?
         @write_permission_in_target = true
       end
-      if @target_project && User.session!.can_create_package_in?(@target_project, ignore_lock)
+      if @target_project && PackagePolicy.new(User.session!, Package.new(project: @target_project), ignore_lock).create?
         @write_permission_in_this_action = true
       end
     end

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -448,6 +448,7 @@ class User < ApplicationRecord
     end
   end
 
+  # FIXME: This should be a policy
   def can_modify?(object, ignore_lock = nil)
     case object
     when Project
@@ -461,6 +462,7 @@ class User < ApplicationRecord
     end
   end
 
+  # FIXME: This should be a policy
   # project is instance of Project
   def can_modify_project?(project, ignore_lock = nil)
     unless project.is_a?(Project)
@@ -475,6 +477,7 @@ class User < ApplicationRecord
     can_modify_project_internal(project, ignore_lock)
   end
 
+  # FIXME: This should be a policy
   # package is instance of Package
   def can_modify_package?(package, ignore_lock = nil)
     return false if package.nil? # happens with remote packages easily
@@ -488,23 +491,12 @@ class User < ApplicationRecord
     false
   end
 
+  # FIXME: This should be a policy
   def can_modify_user?(user)
     is_admin? || self == user
   end
 
-  # project is instance of Project
-  def can_create_package_in?(project, ignore_lock = nil)
-    unless project.is_a?(Project)
-      raise ArgumentError, "illegal parameter type to User#can_change?: #{project.class.name}"
-    end
-
-    return false if !ignore_lock && project.is_locked?
-    return true if is_admin?
-    return true if has_global_permission?('create_package')
-    return true if has_local_permission?('create_package', project)
-    false
-  end
-
+  # FIXME: This should be a policy
   # project_name is name of the project
   def can_create_project?(project_name)
     ## special handling for home projects
@@ -518,6 +510,7 @@ class User < ApplicationRecord
     has_local_permission?('create_project', parent_project)
   end
 
+  # FIXME: This should be a policy
   def can_modify_attribute_definition?(object)
     can_create_attribute_definition?(object)
   end
@@ -528,6 +521,7 @@ class User < ApplicationRecord
     true
   end
 
+  # FIXME: This should be a policy
   def can_create_attribute_definition?(object)
     object = object.attrib_namespace if object.is_a?(AttribType)
     unless object.is_a?(AttribNamespace)
@@ -546,6 +540,7 @@ class User < ApplicationRecord
     true
   end
 
+  # FIXME: This should be a policy
   def can_create_attribute_in?(object, atype)
     if !object.is_a?(Project) && !object.is_a?(Package)
       raise ArgumentError, "illegal parameter type to User#can_change?: #{object.class.name}"
@@ -560,14 +555,17 @@ class User < ApplicationRecord
     abies.any? { |rule| attribute_modification_rule_matches?(rule, object) }
   end
 
+  # FIXME: This should be a policy
   def can_download_binaries?(package)
     can?(:download_binaries, package)
   end
 
+  # FIXME: This should be a policy
   def can_source_access?(package)
     can?(:source_access, package)
   end
 
+  # FIXME: This should be a policy
   def can?(key, package)
     is_admin? ||
       has_global_permission?(key.to_s) ||
@@ -933,6 +931,7 @@ class User < ApplicationRecord
     errors.add(:password, 'can\'t be blank')
   end
 
+  # FIXME: This should be a policy
   def can_modify_project_internal(project, ignore_lock)
     # The ordering is important because of the lock status check
     return false if !ignore_lock && project.is_locked?

--- a/src/api/app/policies/package_policy.rb
+++ b/src/api/app/policies/package_policy.rb
@@ -1,4 +1,18 @@
 class PackagePolicy < ApplicationPolicy
+  # FIXME: Using more than 2 arguments is considered a code smell.
+  def initialize(user, record, ignore_lock = false)
+    super(user, record)
+    @ignore_lock = ignore_lock
+  end
+
+  def create?
+    return false if !@ignore_lock && record.project.is_locked?
+    return true if user.is_admin? ||
+                   user.has_global_permission?('create_package') ||
+                   user.has_local_permission?('create_package', record.project)
+    false
+  end
+
   def branch?
     # same as Package.check_source_access!
     if source_access? || project_source_access?

--- a/src/api/app/policies/project_policy.rb
+++ b/src/api/app/policies/project_policy.rb
@@ -59,11 +59,7 @@ class ProjectPolicy < ApplicationPolicy
     record.is_a?(Project)
   end
 
-  def can_create_package_in?
-    user.can_create_package_in?(record)
-  end
-
   def local_project_and_allowed_to_create_package_in?
-    local? && can_create_package_in?
+    local? && Pundit.policy(user, Package.new(project: record)).create?
   end
 end

--- a/src/api/spec/controllers/webui/package_controller_spec.rb
+++ b/src/api/spec/controllers/webui/package_controller_spec.rb
@@ -1378,13 +1378,12 @@ RSpec.describe Webui::PackageController, vcr: true do
 
     context 'Package#save failed' do
       before do
-        allow_any_instance_of(Package).to receive(:save).and_return(false)
         login(my_user)
-        post :create, params: post_params
+        post :create, params: post_params.merge(package: { name: package_name, title: 'a' * 251 })
       end
 
       it { expect(response).to redirect_to(project_show_path(source_project)) }
-      it { expect(flash[:error]).to eq("Failed to create package '#{package_name}'") }
+      it { expect(flash[:error]).to eq('Failed to create package: Title is too long (maximum is 250 characters)') }
     end
 
     context 'package creation' do
@@ -1427,8 +1426,8 @@ RSpec.describe Webui::PackageController, vcr: true do
         let(:package_name) { 'foo' }
         let(:my_user) { create(:confirmed_user, login: 'another_user') }
 
-        it { expect(response).to redirect_to(new_package_path(source_project)) }
-        it { expect(flash[:error]).to eq("You can't create packages in #{source_project.name}") }
+        it { expect(response).to redirect_to(root_path) }
+        it { expect(flash[:error]).to eq('Sorry, you are not authorized to create this Package.') }
       end
     end
   end

--- a/src/api/spec/features/webui/packages_spec.rb
+++ b/src/api/spec/features/webui/packages_spec.rb
@@ -397,7 +397,7 @@ RSpec.feature 'Packages', type: :feature, js: true, vcr: true do
         # Use direct path instead
         visit "/package/new/#{global_project}"
 
-        expect(page).to have_text('Sorry, you are not authorized to update this Project')
+        expect(page).to have_text('Sorry, you are not authorized to create this Package')
         expect(page.current_path).to eq(root_path)
       end
 


### PR DESCRIPTION
Refactoring `can_create_package_in?` out of existence.

Following up on #9551.