### PR TITLE
Disable notifications for group

### DIFF
--- a/src/api/app/views/webui/users/subscriptions/index.html.haml
+++ b/src/api/app/views/webui/users/subscriptions/index.html.haml
@@ -11,7 +11,7 @@
         - @groups_users.each do |group_user|
           .custom-control.custom-checkbox.custom-control-inline
             = check_box_tag group_user.group, '1', group_user.email, class: 'custom-control-input', id: "checkbox-#{group_user.group}",
-              data: { url: my_subscriptions_path, method: :put, remote: true }
+              data: { url: update_my_subscriptions_path, method: :put, remote: true }
             = label_tag group_user.group.title, nil, class: 'custom-control-label', for: "checkbox-#{group_user.group}"
             %i.fas.fa-spinner.invisible
   .card-body

--- a/src/api/spec/features/beta/webui/notifications_spec.rb
+++ b/src/api/spec/features/beta/webui/notifications_spec.rb
@@ -40,4 +40,20 @@ RSpec.feature 'Notifications', type: :feature, js: true do
       let(:path) { my_subscriptions_path }
     end
   end
+
+  context 'update group notification' do
+    let(:user) { create(:confirmed_user, login: 'Tom') }
+    let!(:group) { create(:group_with_user, title: 'test', user: user) }
+
+    scenario 'disable group notification' do
+      login user
+      visit my_subscriptions_path
+
+      find("label[for='checkbox-#{group}']").click
+
+      visit my_subscriptions_path
+
+      expect(find_field(group.title, visible: false)).not_to be_checked
+    end
+  end
 end

--- a/src/api/spec/features/webui/notifications_spec.rb
+++ b/src/api/spec/features/webui/notifications_spec.rb
@@ -40,4 +40,20 @@ RSpec.feature 'Notifications', type: :feature, js: true do
       let(:path) { my_subscriptions_path }
     end
   end
+
+  context 'update group notification' do
+    let(:user) { create(:confirmed_user, login: 'Tom') }
+    let!(:group) { create(:group_with_user, title: 'test', user: user) }
+
+    scenario 'disable group notification' do
+      login user
+      visit my_subscriptions_path
+
+      find("label[for='checkbox-#{group}']").click
+
+      visit my_subscriptions_path
+
+      expect(find_field(group.title, visible: false)).not_to be_checked
+    end
+  end
 end


### PR DESCRIPTION
Updating subscription group wasn't working because we were pointing
to index instead of update.

Fix #9556 