### PR TITLE
Download 1st ccache archive for linked packages in maintenance prjs

### DIFF
--- a/src/backend/BSSched/BuildJob.pm
+++ b/src/backend/BSSched/BuildJob.pm
@@ -1157,6 +1157,9 @@ sub create {
   $binfo->{'constraintsmd5'} = $pdata->{'constraintsmd5'} if $pdata->{'constraintsmd5'};
   $binfo->{'prjconfconstraint'} = $bconf->{'constraint'} if @{$bconf->{'constraint'} || []};
   $binfo->{'nounchanged'} = 1 if $info->{'nounchanged'};
+  if (!$ctx->{'isreposerver'} && ($proj->{'kind'} || '') eq 'maintenance_incident' && $pdata->{'releasename'}) {
+    $binfo->{'releasename'} = $pdata->{'releasename'};
+  }
   if ($pdata->{'revtime'}) {
     $binfo->{'revtime'} = $pdata->{'revtime'};
     # use max of revtime for interproject links

--- a/src/backend/BSXML.pm
+++ b/src/backend/BSXML.pm
@@ -514,6 +514,7 @@ our $buildinfo = [
 	'project',
 	'repository',
 	'package',
+	'releasename',  # internal
 	'srcserver',
 	'reposerver',
 	'downloadurl',

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -2548,6 +2548,49 @@ sub getbinaries {
   return @meta;
 }
 
+sub getlinkedccache {
+  my ($buildinfo, $odir) = @_;
+
+  mkdir_p($odir) || die("mkdir_p $odir: $!\n");
+  for my $other (@{$buildinfo->{'path'}}) {
+    if ($other->{'server'} ne $buildinfo->{'srcserver'}) {
+      my $oprojid = $other->{'project'};
+      my $orepoid = $other->{'repository'};
+      my $opackid = $buildinfo->{'package'};
+
+      next if $oprojid eq $buildinfo->{'project'} && $orepoid eq $buildinfo->{'repository'};
+
+      # do extra work for maintenance incidents
+      if ($buildinfo->{'releasename'}) {
+        $opackid = $buildinfo->{'releasename'};
+        eval {
+          my $link = BSRPC::rpc("$buildinfo->{'srcserver'}/source/$oprojid/$opackid/_link", $BSXML::link);
+          $opackid = $link->{'package'} if $link->{'package'} && !$link->{'project'};
+        };
+        warn($@) if $@ && $@ !~ /^404/;
+      }
+
+      my $res;
+      eval {
+        $res = BSRPC::rpc({
+          'uri' => "$other->{'server'}/build/$oprojid/$orepoid/$buildinfo->{'arch'}/$opackid/_ccache.tar",
+          'filename' => "$odir/_ccache.tar",
+          'timeout' => $gettimeout,
+          'receiver' => \&BSHTTP::file_receiver,
+        }, undef);
+      };
+      if ($@ && $@ !~ /^404/) {
+        warn($@);
+      } else {
+        $binariesdownload += 1;
+        $binariesdownloadsize += int($res->{'size'} / 1024);
+        last;
+      }
+    }
+  }
+  rmdir($odir);	# if not needed
+}
+
 sub getoldpackages {
   my ($buildinfo, $odir, $useccache) = @_;
 
@@ -3094,7 +3137,11 @@ sub dobuild {
         $useccache = 1;
     }
   }
-  getoldpackages($buildinfo, $oldpkgdir, $useccache) if $oldpkgdir && !$kiwimode && $buildinfo->{'file'} ne 'preinstallimage';
+
+  if ($oldpkgdir && !$kiwimode && $buildinfo->{'file'} ne 'preinstallimage') {
+      getoldpackages($buildinfo, $oldpkgdir, $useccache);
+      getlinkedccache($buildinfo, $oldpkgdir) if $useccache && ! -f "$oldpkgdir/_ccache.tar";
+  }
 
   $stats->{'times'}->{'download'}->{'time'}->{'unit'} = "s";
   $stats->{'times'}->{'download'}->{'time'}->{'_content'} = (time() - $downloadstarttime);


### PR DESCRIPTION
Maintenance projects have linked packages. These packages could shared
their ccache archive for initial builds allowing faster rebuilds.

releasename is added as param to job file allowing worker to know that
it should use ccache archive of the (release)named packages part of the
projects mentioned in its own repository paths. Here the first hit
wins.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
