### PR TITLE
Introduce beta feature tests for mobile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,6 +116,15 @@ jobs:
             fi
 
             bundle exec rspec --format progress --format RspecJunitFormatter -o /home/frontend/rspec/rspec.xml $(cat $pickfile)
+            if test "$CIRCLE_NODE_INDEX" = $((CIRCLE_NODE_TOTAL-1)); then
+              echo "Running feature tests for mobile"
+              # simulating parallel tests - otherwise one rspec call overwrites the previous
+              export TEST_ENV_NUMBER=2
+              export PARALLEL_TEST_GROUPS="RSpec"
+              export CAPYBARA_DRIVER="mobile"
+              bundle exec rspec --format progress --format RspecJunitFormatter \
+                -o /home/frontend/rspec/rspec.mobile.xml $(circleci tests glob 'spec/features/beta/**/*_spec.rb')
+            fi
 
             # run DB tests at the end of node 0
             # see https://github.com/openSUSE/open-build-service/issues/4959

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
             - .
 
   rspec:
-    parallelism: 5
+    parallelism: 3
     docker:
       - <<: *frontend_base
       - <<: *mariadb
@@ -105,26 +105,11 @@ jobs:
             cd src/api
             pickfile=log/pick.$CIRCLE_NODE_INDEX.list
 
-            # reserve the latest node for beta
-            if test "$CIRCLE_NODE_INDEX" = $((CIRCLE_NODE_TOTAL-1)); then
-              echo "Testing beta"
-              circleci tests glob 'spec/features/beta/**/*_spec.rb' > $pickfile
-            else
-              # single out beta and db specs
-              circleci tests glob 'spec/**/*_spec.rb' | grep -v 'spec/\(features/beta\|db\)' > spec.list
-              circleci tests split --total $((CIRCLE_NODE_TOTAL-1)) --split-by=timings < spec.list > $pickfile
-            fi
+            # single out beta and db specs
+            circleci tests glob 'spec/**/*_spec.rb' | grep -v 'spec/\(features\|db\)' > spec.list
+            circleci tests split --total $CIRCLE_NODE_TOTAL --split-by=timings < spec.list > $pickfile
 
             bundle exec rspec --format progress --format RspecJunitFormatter -o /home/frontend/rspec/rspec.xml $(cat $pickfile)
-            if test "$CIRCLE_NODE_INDEX" = $((CIRCLE_NODE_TOTAL-1)); then
-              echo "Running feature tests for mobile"
-              # simulating parallel tests - otherwise one rspec call overwrites the previous
-              export TEST_ENV_NUMBER=2
-              export PARALLEL_TEST_GROUPS="RSpec"
-              export CAPYBARA_DRIVER="mobile"
-              bundle exec rspec --format progress --format RspecJunitFormatter \
-                -o /home/frontend/rspec/rspec.mobile.xml $(circleci tests glob 'spec/features/beta/**/*_spec.rb')
-            fi
 
             # run DB tests at the end of node 0
             # see https://github.com/openSUSE/open-build-service/issues/4959
@@ -145,9 +130,6 @@ jobs:
       - store_artifacts:
           path: ./src/api/log
           destination: rspec
-      - store_artifacts:
-          path: ./src/api/tmp/capybara
-          destination: capybara
       - store_test_results:
           path: /home/frontend/rspec
 
@@ -259,6 +241,55 @@ jobs:
             cd src/api
             brakeman .
 
+  feature:
+    parallelism: 3
+    docker:
+      - <<: *frontend_base
+      - <<: *mariadb
+    steps:
+      - attach_workspace:
+         at: .
+      - run: *install_dependencies
+      - run: *wait_for_database
+      - run: *create_test_db
+      - run: mkdir /home/frontend/feature
+      - run:
+          name: Run rspec feature tests
+          command: |
+            cd src/api
+            pickfile=log/pick.$CIRCLE_NODE_INDEX.list
+
+            if test "$CIRCLE_NODE_INDEX" = 0; then
+              message="Running feature tests"
+              circleci tests glob 'spec/features/**/*_spec.rb' | grep -v 'spec/features/beta/' > $pickfile
+            else
+              message="Running beta feature tests"
+              circleci tests glob 'spec/features/beta/**/*_spec.rb' > $pickfile
+            fi
+
+            if test "$CIRCLE_NODE_INDEX" = $((CIRCLE_NODE_TOTAL-1)); then
+              message="Running beta feature tests for mobile"
+              export CAPYBARA_DRIVER='mobile'
+            fi
+
+            echo $message
+            bundle exec rspec --format progress --format RspecJunitFormatter -o /home/frontend/feature/feature.xml $(cat $pickfile)
+
+            mkdir coverage_results
+            cp -R coverage/.resultset.json coverage_results/resultset-feature-${CIRCLE_NODE_INDEX}.json
+
+      - persist_to_workspace:
+          root: .
+          paths:
+            - src/api/coverage_results
+      - store_artifacts:
+          path: ./src/api/log
+          destination: feature
+      - store_artifacts:
+          path: ./src/api/tmp/capybara
+          destination: capybara
+      - store_test_results:
+          path: /home/frontend/feature
 
 workflows:
   version: 2
@@ -281,6 +312,10 @@ workflows:
           requires:
             - rspec
             - minitest
+            - feature
       - brakeman:
+          requires:
+            - checkout_code
+      - feature:
           requires:
             - checkout_code

--- a/src/api/spec/features/beta/webui/attributes_spec.rb
+++ b/src/api/spec/features/beta/webui/attributes_spec.rb
@@ -73,6 +73,7 @@ RSpec.feature 'Attributes', type: :feature, js: true do
           login user
 
           visit index_attribs_path(project: user.home_project_name)
+          first('table tbody tr td').click if mobile?
           click_link 'Delete attribute'
           expect(find('#delete-attribute-modal')).to have_text('Delete attribute?')
           within('#delete-attribute-modal .modal-footer') do

--- a/src/api/spec/features/beta/webui/groups_spec.rb
+++ b/src/api/spec/features/beta/webui/groups_spec.rb
@@ -28,6 +28,8 @@ RSpec.feature 'Groups', type: :feature, js: true do
   scenario 'visit group show page' do
     visit group_show_path(group_1)
 
+    # TODO: Remove this line if the dropdown is changed to a scrollable tab, and responsive_ux is out of beta.
+    find('.nav-link.dropdown-toggle').click if mobile?
     expect(page).to have_content('Incoming Reviews')
     expect(page).to have_content('Incoming Requests')
     expect(page).to have_content('All Requests')

--- a/src/api/spec/features/beta/webui/login_spec.rb
+++ b/src/api/spec/features/beta/webui/login_spec.rb
@@ -31,14 +31,14 @@ RSpec.feature 'Login', type: :feature, js: true do
 
   scenario 'login via widget' do
     visit root_path
-    within('#navigation') do
+    within(desktop? ? '#navigation' : '#bottom-navigation') do
       click_link('Log In')
+    end
 
-      within('#log-in-modal') do
-        fill_in 'username', with: user.login
-        fill_in 'password', with: 'buildservice'
-        click_button('Log In')
-      end
+    within('#log-in-modal') do
+      fill_in 'username', with: user.login
+      fill_in 'password', with: 'buildservice'
+      click_button('Log In')
     end
 
     expect(page).to have_link('Your Home Project', visible: false)
@@ -46,14 +46,14 @@ RSpec.feature 'Login', type: :feature, js: true do
 
   scenario 'login with wrong data' do
     visit root_path
-    within('#navigation') do
+    within(desktop? ? '#navigation' : '#bottom-navigation') do
       click_link('Log In')
+    end
 
-      within('#log-in-modal') do
-        fill_in 'username', with: user.login
-        fill_in 'password', with: 'foo'
-        click_button('Log In')
-      end
+    within('#log-in-modal') do
+      fill_in 'username', with: user.login
+      fill_in 'password', with: 'foo'
+      click_button('Log In')
     end
 
     expect(page).to have_content('Authentication failed')

--- a/src/api/spec/features/beta/webui/packages_spec.rb
+++ b/src/api/spec/features/beta/webui/packages_spec.rb
@@ -92,6 +92,7 @@ RSpec.feature 'Packages', type: :feature, js: true, vcr: true do
       visit package_show_path(package: package, project: user.home_project)
       click_link('Requests')
       expect(page).to have_css('table#all_requests_table tbody tr', count: 1)
+      first('table#all_requests_table tbody tr td').click if mobile?
       find('a', class: 'request_link').click
       expect(page.current_path).to match('/request/show/\\d+')
     end

--- a/src/api/spec/features/beta/webui/users/admin_configuration_spec.rb
+++ b/src/api/spec/features/beta/webui/users/admin_configuration_spec.rb
@@ -12,6 +12,8 @@ RSpec.feature 'Admin user configuration page', type: :feature, js: true do
   end
 
   scenario 'view users' do
+    skip_on_mobile
+
     expect(find_all('tbody tr').count).to eq(5)
     expect(find_all('td', text: 'confirmed').count).to eq(5)
     # The actions column
@@ -23,6 +25,8 @@ RSpec.feature 'Admin user configuration page', type: :feature, js: true do
   end
 
   scenario 'delete user' do
+    skip_on_mobile
+
     within(find('td', text: /#{user.realname}/).ancestor('tr')) do
       expect(page).to have_css('td', text: 'confirmed')
       page.find('a[data-method=delete]').click

--- a/src/api/spec/features/beta/webui/users/user_home_page_spec.rb
+++ b/src/api/spec/features/beta/webui/users/user_home_page_spec.rb
@@ -48,6 +48,8 @@ RSpec.feature "User's home project creation", type: :feature, js: true do
       visit my_tasks_path
 
       expect(page).to have_link('Incoming Requests')
+      # TODO: Remove this line if the dropdown is changed to a scrollable tab, and responsive_ux is out of beta.
+      find('.nav-link.dropdown-toggle').click if mobile?
       expect(page).to have_link('Outgoing Requests')
       expect(page).to have_link('Declined Requests')
       expect(page).to have_link('All Requests')

--- a/src/api/spec/spec_helper.rb
+++ b/src/api/spec/spec_helper.rb
@@ -59,10 +59,14 @@ RSpec.configure do |config|
   # the seed, which is printed after each run.
   config.order = :random
 
-  # Tag all groups and examples in the spec/features directory with
-  # :vcr => :true
+  # Tag all groups and examples in the spec/features directory with :vcr => :true
+  #
+  # CAPYBARA_DRIVER => choose one of existing drivers: ['desktop', 'mobile']
+  # If you want to run the feature tests for mobile, you need to specify the driver
+  # environment variable. By default it is :desktop.
   config.define_derived_metadata(file_path: %r{/spec/features/}) do |metadata|
     metadata[:vcr] = true
+    metadata[:driver] = ENV.fetch('CAPYBARA_DRIVER', 'desktop').to_sym
   end
 
   # Tag all groups and examples in the spec/features directory with

--- a/src/api/spec/support/features/features_beta.rb
+++ b/src/api/spec/support/features/features_beta.rb
@@ -5,6 +5,18 @@ module FeaturesBeta
       click_link(action_name)
     end
   end
+
+  def skip_on_mobile
+    skip('Run this test only for desktop') if Capybara.current_driver == :mobile
+  end
+
+  def desktop?
+    Capybara.current_driver == :desktop
+  end
+
+  def mobile?
+    Capybara.current_driver == :mobile
+  end
 end
 
 RSpec.configure do |c|

--- a/src/api/spec/support/shared_examples/features/beta/user_tab.rb
+++ b/src/api/spec/support/shared_examples/features/beta/user_tab.rb
@@ -110,6 +110,8 @@ RSpec.shared_examples 'user tab' do
     end
 
     scenario 'Add role to user' do
+      skip_on_mobile
+
       toggle_checkbox('user_reviewer_user_tab_user')
 
       visit project_path # project_users_path
@@ -118,6 +120,8 @@ RSpec.shared_examples 'user tab' do
     end
 
     scenario 'Remove role from user' do
+      skip_on_mobile
+
       toggle_checkbox('user_bugowner_user_tab_user')
 
       visit project_path
@@ -201,6 +205,8 @@ RSpec.shared_examples 'user tab' do
     end
 
     scenario 'Add role to group' do
+      skip_on_mobile
+
       toggle_checkbox('group_reviewer_existing_group')
 
       visit project_path
@@ -209,6 +215,8 @@ RSpec.shared_examples 'user tab' do
     end
 
     scenario 'Remove role from group' do
+      skip_on_mobile
+
       toggle_checkbox('group_bugowner_existing_group')
 
       visit project_path

--- a/src/api/spec/support/shared_examples/features/beta/user_tab.rb
+++ b/src/api/spec/support/shared_examples/features/beta/user_tab.rb
@@ -42,6 +42,8 @@ RSpec.shared_examples 'user tab' do
     end
 
     scenario 'Viewing user roles' do
+      skip_on_mobile
+
       expect(page).to have_text('User Roles')
       expect(find_field('user_maintainer_user_tab_user', visible: false)).to be_checked
       expect(find_field('user_bugowner_user_tab_user', visible: false)).to be_checked
@@ -97,6 +99,8 @@ RSpec.shared_examples 'user tab' do
     end
 
     scenario 'Remove user from package / project' do
+      skip_on_mobile
+
       find('td', text: "#{reader.realname} (reader_user)").ancestor('tr').find('.remove-user').click
       sleep 1 # FIXME: Needed to avoid a flickering test because the animation of the modal is sometimes faster than capybara
       click_button('Delete')
@@ -141,6 +145,8 @@ RSpec.shared_examples 'user tab' do
     end
 
     scenario 'Viewing group roles' do
+      skip_on_mobile
+
       expect(page).to have_text('Group Roles')
       expect(find_field('group_maintainer_existing_group', visible: false)).to be_checked
       expect(find_field('group_bugowner_existing_group', visible: false)).to be_checked


### PR DESCRIPTION
We register a new driver called `:mobile`, where we emulate a mobile viewport. We also renamed the default driver to `:desktop`.

To run the tests for mobile, set the environment variable. For example:

```
CAPYBARA_DRIVER=mobile rspec spec/features/beta/webui/example_spec.rb
```

Without specifying the environment variable, tests should run within the desktop driver, as always.

In CircleCI we run the feature beta tests for desktop and mobile in the last container for the `rspec` CircleCI job.