### PR TITLE
[backend] limit reading jobhistory to 1000 entries

### DIFF
--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -2164,7 +2164,10 @@ sub notify_jobresult {
         $failcnt += 1;
         return 1;
     };
-    BSFileDB::fdb_getall_reverse("$reporoot/$prpa/:jobhistory", $BSXML::jobhistlay, undef, $filter);
+    # each line is around <200 chars (biggest can be pacakage name)
+    # 1000 * 200 ~= ~1.6 MB
+    # setting it to 1000 skip over jobhistory of !$package
+    BSFileDB::fdb_getall_reverse("$reporoot/$prpa/:jobhistory", $BSXML::jobhistlay, 1000, $filter);
     $ninfo{'successive_failcount'} = $failcnt;
     BSNotify::notify('BUILD_FAIL', \%ninfo);
   }


### PR DESCRIPTION
jobhistory can be really large (imagine all of project history, since
the beginning of time). If some package rebuild failed and was never
rebuilt(successfully) since ages(searching for that package needs entire
jobhistory(which could be in gbs) to be read) we will have huge memory
consumption.

In otherwords, package build failed now and a prior rebuild was
Gigabytes ago (or not all) then we will have memory issues.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
