### PR TITLE
Remove sprited_text helper method

### DIFF
--- a/src/api/app/helpers/webui/webui_helper.rb
+++ b/src/api/app/helpers/webui/webui_helper.rb
@@ -193,10 +193,6 @@ module Webui::WebuiHelper
     image_tag('s.gif', opts)
   end
 
-  def sprited_text(icon, text)
-    sprite_tag(icon, title: text) + ' ' + text
-  end
-
   def next_codemirror_uid
     return @codemirror_editor_setup = 0 unless @codemirror_editor_setup
     @codemirror_editor_setup += 1

--- a/src/api/spec/helpers/webui/webui_helper_spec.rb
+++ b/src/api/spec/helpers/webui/webui_helper_spec.rb
@@ -105,15 +105,6 @@ RSpec.describe Webui::WebuiHelper do
     end
   end
 
-  describe '#sprited_text' do
-    it 'returns a img element with a matching icon class and title attribute and text' do
-      expect(sprited_text('brick_edit', 'Edit description')).to eq('<img title="Edit description" ' \
-                       'class="icons-brick_edit" alt="Edit description" src="/images/s.gif" /> Edit description')
-      expect(sprited_text('user_add', 'Request role addition')).to eq('<img title="Request role addition" ' \
-                       'class="icons-user_add" alt="Request role addition" src="/images/s.gif" /> Request role addition')
-    end
-  end
-
   describe '#next_codemirror_uid' do
     before do
       @codemirror_editor_setup = 0


### PR DESCRIPTION
This is a remnant of the Bento UI.

I found this while transferring the `Request Role Addition` modal to its own page.