### PR TITLE
[backend] do not publish .packages files anymore

### DIFF
--- a/ReleaseNotes-2.11
+++ b/ReleaseNotes-2.11
@@ -48,6 +48,7 @@ Intentional changes:
 
 Backend:
  * .sha256 files get gpg signed in detached mode now
+ * .packages files get not anymore published
  * Switched from OR to AND when checking CPU flags in _constraints file
 
 Webui:

--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -1994,9 +1994,6 @@ sub publish {
 	  $p = $bin;
           $kiwimedium = "$arch/$1" if !$2 && -e "$r/$1.packages";
           $p = mapsleimage($config, "$reporoot/$prp/$arch/:repo", $rbin, $p, $sleimage) if $sleimage;
-        } elsif ($bin =~ /\.packages$/) {
-	  $p = $bin;
-	  $p = mapsleimage($config, "$reporoot/$prp/$arch/:repo", $rbin, $p, $sleimage) if $sleimage;
         } elsif ($bin =~ /^(.*)\.report$/) {
 	  # collect reports
 	  $kiwireport{"$arch/$1"} = readxml("$r/$rbin", $BSXML::report, 1) if $do_packtrack;


### PR DESCRIPTION
These files are just intermediate files for the .report files.
The .report files get not published either yet, but we should
not confuse users with internal build artefacts.

Better creating something useful in future if needed.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
