### PR TITLE
Adjust smoketests to the latest webui changes

### DIFF
--- a/dist/t/spec/features/0040_package_spec.rb
+++ b/dist/t/spec/features/0040_package_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe "Package" do
       click_link('Home Project')
     end
     click_link('Create Package')
-    fill_in 'name', with: 'hello_world'
-    fill_in 'title', with: 'hello_world'
-    fill_in 'description', with: 'hello_world'
+    fill_in 'package_name', with: 'hello_world'
+    fill_in 'package_title', with: 'hello_world'
+    fill_in 'package_description', with: 'hello_world'
     click_button('Create')
     expect(page).to have_content("Package 'hello_world' was created successfully")
   end
@@ -37,12 +37,9 @@ RSpec.describe "Package" do
       click_link('Home Project')
     end
     click_link('Branch Existing Package')
-    page.evaluate_script('$.fx.off = true;') # Needed to disable javascript animations to avoid race conditions
-    within('#new-package-branch-modal') do
-      fill_in 'linked_project', with: 'openSUSE.org:openSUSE:Tools'
-      fill_in 'linked_package', with: 'build'
-      click_button('Accept')
-    end
+    fill_in 'linked_project', with: 'openSUSE.org:openSUSE:Tools'
+    fill_in 'linked_package', with: 'build'
+    click_button('Accept')
     expect(page).to have_content('build.spec')
   end
 


### PR DESCRIPTION
The smoketests were failing in openQA due to changes
in our webui.

Co-authored-by: Eduardo Navarro <enavarro@suse.com>

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
