### PR TITLE
Fix beta breadcrumb

### DIFF
--- a/src/api/app/assets/stylesheets/webui/responsive_ux/_layout.scss
+++ b/src/api/app/assets/stylesheets/webui/responsive_ux/_layout.scss
@@ -45,7 +45,10 @@
 .breadcrumb {
   padding-bottom: 0;
   @extend .mt-2;
-  .breadcrumb-item { line-height: 1.5rem; }
+  .breadcrumb-item {
+    display: block;
+    line-height: 1.5rem;
+  }
   .breadcrumb-item::after {
     display: inline-block;
     padding: 0 0.5rem 0 0.25rem;


### PR DESCRIPTION
After introducing Bootstrap 4.5.0, the breadcrumb icons weren't aligned
anymore.


### Before
![Screenshot_2020-05-20 testing](https://user-images.githubusercontent.com/1212806/82436037-77447080-9a95-11ea-95c5-b022e0be3456.png)


### After
![Screenshot_2020-05-20 testing(1)](https://user-images.githubusercontent.com/1212806/82436045-7c092480-9a95-11ea-92e7-deab398a6e3e.png)
