### PR TITLE
Remove :simulate as a value for proxy_auth_mode

### DIFF
--- a/src/api/config/options.yml.example
+++ b/src/api/config/options.yml.example
@@ -37,7 +37,7 @@ default: &default
 
   extended_backend_log: false
 
-  # proxy_auth_mode can be :off, :on or :simulate
+  # proxy_auth_mode can be :off or :on
   proxy_auth_mode: :off
 
   # ATTENTION: If proxy_auth_mode'is :on, the frontend takes the user


### PR DESCRIPTION
`:simulate` option was removed from the codebase years ago. It should have been removed then.