### PR TITLE
[backend] Speedup jobhistory route by 4-6x

### DIFF
--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -3154,24 +3154,30 @@ sub getjobhistory {
   if ($cgi->{'code'} && @{$cgi->{'code'}} == 1 && $cgi->{'code'}->[0] eq 'lastfailures') {
     return getlastfailures($cgi, $projid, $repoid, $arch);
   }
+  my $idx = 0;
+  my %indices = map {$_ => $idx++} @$BSXML::jobhistlay;
+  my $packidx = $indices{'package'};
+  my $codeidx = $indices{'code'};
+  my $endtimeidx = $indices{'endtime'};
   if ($cgi->{'package'} && $cgi->{'code'}) {
-    my %packid = map {$_ => 1} @{$cgi->{'package'}};
+    my %packid = map {BSFileDB::encode_field($_) => 1} @{$cgi->{'package'}};
     my %code = map {$_ => 1} @{$cgi->{'code'}};
-    $filter = sub {$packid{$_[0]->{'package'}} && $code{$_[0]->{'code'}}};
+    $filter = sub {$packid{$_[$packidx]} && $code{$_[$codeidx]}};
   } elsif ($cgi->{'package'}) {
-    my %packid = map {$_ => 1} @{$cgi->{'package'}};
-    $filter = sub {$packid{$_[0]->{'package'}}};
+    my %packid = map {BSFileDB::encode_field($_) => 1} @{$cgi->{'package'}};
+    $filter = sub {$packid{$_[$packidx]}};
   } elsif ($cgi->{'code'}) {
     my %code = map {$_ => 1} @{$cgi->{'code'}};
-    $filter = sub {$code{$_[0]->{'code'}}};
+    $filter = sub {$code{$_[$codeidx]}};
   }
-  if ($cgi->{'endtime_start'} || $cgi->{'endtime_end'} || 1) {
+  if ($cgi->{'endtime_start'} || $cgi->{'endtime_end'}) {
     my $filter2 = $filter;
     my $endtime_start = $cgi->{'endtime_start'} || 0;
     my $endtime_end = $cgi->{'endtime_end'};
-    $filter = sub {$_[0]->{'endtime'} < $endtime_start ? -2 : defined($endtime_end) && $_[0]->{'endtime'} > $endtime_end ? 0 : $filter2 ? $filter2->($_[0]) : 1};
+    $filter = sub { $_[$endtimeidx] < $endtime_start ? -2 : defined($endtime_end) && $_[$endtimeidx] > $endtime_end ? 0 : $filter2 ? $filter2->(@_) : 1 };
   }
-  my @hist = BSFileDB::fdb_getall_reverse("$reporoot/$projid/$repoid/$arch/:jobhistory", $BSXML::jobhistlay, $cgi->{'limit'} || 100, $filter);
+  my @hist = BSFileDB::fdb_getall_reverse("$reporoot/$projid/$repoid/$arch/:jobhistory", undef, $cgi->{'limit'} || 100, $filter);
+  @hist = map {BSFileDB::decode_line($_, $BSXML::jobhistlay)} @hist;
   @hist = reverse @hist;
   my $ret = {jobhist => \@hist};
   return ($ret, $BSXML::jobhistlist);


### PR DESCRIPTION
This patch allows fdb_getall_reverse to return undecoded line to filter.
This raw line can be filtered out earlier without the need of decoding
over the layout.

This is useful for large and long maintained projects. Projects
(Factory, Devel..)  have a long build history, decoding every
line in the jobhistory file only to be filtered out based on filter
conditions (package type, result code, buildtimes) is expensive. This
patch facilitates skipping those costs reach the result faster.

Tested on IBS/SUSE:FACTORY:HEAD/standard/i586/MozillaThunderbird
without patch:
100 results: 6 sec
1000 results: 53 sec

with patch:
100 results: 1 sec
1000 results: 13 sec

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
