### PR TITLE
Extract method Package.verify_file! to a set of Services

### DIFF
--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -361,7 +361,7 @@ class SourceController < ApplicationController
       @pack.save
     end
 
-    Package.verify_file!(@pack, params[:filename], request.raw_post.to_s)
+    Package.verify_file!(@pack, params[:filename], request.raw_post)
 
     @path += build_query_from_hash(params, [:user, :comment, :rev, :linkrev, :keeplink, :meta])
     pass_to_backend(@path)

--- a/src/api/app/services/package_service/file_verifier.rb
+++ b/src/api/app/services/package_service/file_verifier.rb
@@ -1,0 +1,49 @@
+module PackageService
+  class FileVerifier
+    attr_accessor :package, :file_name, :content
+
+    def initialize(package:, file_name:, content:)
+      @package = package
+      @content = content_readable(content)
+      @file_name = file_name
+    end
+
+    def call
+      # Prohibit dotfiles (files with leading .) and files with a / character in the name
+      raise Package::IllegalFileName, "'#{@file_name}' is not a valid filename" if file_name_invalid?
+
+      PackageService::SchemaVerifier.new(content: @content, package: @package, file_name: @file_name).call
+      PackageService::LinkVerifier.new(content: @content, package: @package).call if link? && @content.present?
+      # special checks in their models
+      Service.verify_xml!(@content) if service?
+      Channel.verify_xml!(@content) if channel?
+      Patchinfo.new.verify_data(@package.project, @content) if patchinfo?
+    end
+
+    private
+
+    def content_readable(content)
+      content.is_a?(ActionDispatch::Http::UploadedFile) ? File.open(content.path).read : content
+    end
+
+    def file_name_invalid?
+      @file_name.blank? || @file_name !~ /^[^\.\/][^\/]+$/
+    end
+
+    def service?
+      @file_name == '_service'
+    end
+
+    def channel?
+      @file_name == '_channel'
+    end
+
+    def patchinfo?
+      @file_name == '_patchinfo'
+    end
+
+    def link?
+      @file_name == '_link'
+    end
+  end
+end

--- a/src/api/app/services/package_service/link_verifier.rb
+++ b/src/api/app/services/package_service/link_verifier.rb
@@ -1,0 +1,41 @@
+module PackageService
+  class LinkVerifier
+    def initialize(package:, content:)
+      @package = package
+      @content = Xmlhash.parse(content)
+    end
+
+    def call
+      if @content['missingok']
+        check_project_and_package!
+      else
+        # permission check
+        Package.get_by_project_and_name(target_project_name, target_package_name)
+      end
+    end
+
+    private
+
+    def target_package_name
+      @content.value('package') || @package.name
+    end
+
+    def target_project_name
+      @content.value('project') || @package.project.name
+    end
+
+    def check_project_and_package!
+      Project.get_by_name(target_project_name) # permission check
+      raise NotMissingError, missingok_error_message if package_exist?
+    end
+
+    def package_exist?
+      Package.exists_by_project_and_name(target_project_name, target_package_name,
+                                         follow_project_links: true, allow_remote_packages: true)
+    end
+
+    def missingok_error_message
+      "Link contains a missingok statement but link target (#{target_project_name}/#{target_package_name}) exists."
+    end
+  end
+end

--- a/src/api/app/services/package_service/schema_verifier.rb
+++ b/src/api/app/services/package_service/schema_verifier.rb
@@ -3,7 +3,7 @@ require_dependency 'opensuse/validator'
 module PackageService
   class SchemaVerifier
     SCHEMAS = ['aggregate', 'constraints', 'link',
-               'service', 'patchinfo', 'channel', 'multibuild'].freeze
+               'service', 'patchinfo', 'channel', 'multibuild', 'pattern'].freeze
 
     def initialize(content:, package:, file_name:)
       @content = content
@@ -12,16 +12,16 @@ module PackageService
     end
 
     def call
-      return unless  allowed_schema? || pattern?
+      return unless allowed_schema?
       # if it doesn't validate, exception will be raised
       SCHEMAS.each { |schema| validate_schema!(schema) if schema?(schema) }
-      validate_schema!('pattern') if pattern?
     end
 
     private
 
     def allowed_schema?
-      SCHEMAS.include?(@file_name[1..-1])
+      schema = pattern? ? @package.try(:name) : @file_name
+      SCHEMAS.include?(schema[1..-1])
     end
 
     def pattern?
@@ -33,7 +33,7 @@ module PackageService
     end
 
     def schema?(schema)
-      @file_name == "_#{schema}"
+      pattern? ? @package.try(:name) == "_#{schema}" : @file_name == "_#{schema}"
     end
   end
 end

--- a/src/api/app/services/package_service/schema_verifier.rb
+++ b/src/api/app/services/package_service/schema_verifier.rb
@@ -1,0 +1,39 @@
+require_dependency 'opensuse/validator'
+
+module PackageService
+  class SchemaVerifier
+    SCHEMAS = ['aggregate', 'constraints', 'link',
+               'service', 'patchinfo', 'channel', 'multibuild'].freeze
+
+    def initialize(content:, package:, file_name:)
+      @content = content
+      @package = package
+      @file_name = file_name
+    end
+
+    def call
+      return unless  allowed_schema? || pattern?
+      # if it doesn't validate, exception will be raised
+      SCHEMAS.each { |schema| validate_schema!(schema) if schema?(schema) }
+      validate_schema!('pattern') if pattern?
+    end
+
+    private
+
+    def allowed_schema?
+      SCHEMAS.include?(@file_name[1..-1])
+    end
+
+    def pattern?
+      @package.try(:name) == '_pattern'
+    end
+
+    def validate_schema!(schema)
+      Suse::Validator.validate(schema, @content)
+    end
+
+    def schema?(schema)
+      @file_name == "_#{schema}"
+    end
+  end
+end

--- a/src/api/spec/services/package_service/file_verifier_spec.rb
+++ b/src/api/spec/services/package_service/file_verifier_spec.rb
@@ -1,0 +1,95 @@
+require 'rails_helper'
+
+RSpec.describe ::PackageService::FileVerifier do
+  let(:file_verifier) { described_class.new(package: package, file_name: file_name, content: content) }
+  let!(:project) { create(:project_with_package, name: 'openSUSE:Maintenance', package_name: 'chromium') }
+
+  let(:temp_file) do
+    Tempfile.new.tap do |f|
+      f << 'Hello World'
+      f.close
+    end
+  end
+
+  after { temp_file.unlink }
+
+  describe '.new' do
+    let(:package) { project.packages.first }
+    let(:file_name) { 'foo.txt' }
+    let(:content) { ActionDispatch::Http::UploadedFile.new(filename: file_name, type: 'text/plain', tempfile: temp_file) }
+
+    context 'content upload file' do
+      it { expect { file_verifier }.not_to raise_error }
+    end
+
+    context 'content is xml' do
+      let(:content) { '<xml></xml>' }
+      it { expect { file_verifier }.not_to raise_error }
+    end
+  end
+
+  describe '.call' do
+    let(:package) { project.packages.first }
+    context 'invalid constraints' do
+      let(:file_name) { '_constraints' }
+      let(:content) { 'illegal' }
+      subject { file_verifier.call }
+
+      it { expect { subject }.to raise_error(Suse::ValidationError) }
+    end
+
+    context 'invalid service file' do
+      let(:file_name) { '_service' }
+      let(:content) { 'illegal' }
+      subject { file_verifier.call }
+
+      it { expect { subject }.to raise_error(Suse::ValidationError) }
+    end
+
+    context 'valid uploaded file' do
+      let(:file_name) { 'foo.txt' }
+      let(:content) { ActionDispatch::Http::UploadedFile.new(filename: file_name, type: 'text/plain', tempfile: temp_file) }
+      subject { file_verifier.call }
+
+      it { expect { subject }.not_to raise_error }
+    end
+
+    context 'valid uploaded file has the right content' do
+      let(:file_name) { 'foo.txt' }
+      let(:content) { ActionDispatch::Http::UploadedFile.new(filename: file_name, type: 'text/plain', tempfile: temp_file) }
+
+      before { file_verifier.call }
+
+      it { expect(file_verifier.content).to eq('Hello World') }
+    end
+
+    context 'valid service file' do
+      let(:file_name) { '_service' }
+      let(:content) do
+        <<-XML
+        <services> 
+        <service name="download_files" mode="disabled" />
+        </services>
+        XML
+      end
+      subject { file_verifier.call }
+
+      it { expect { subject }.not_to raise_error }
+    end
+
+    context 'valid service file has the right content' do
+      let(:file_name) { '_service' }
+      let(:content) do
+        <<-XML
+          <services> 
+          <service name="download_files" mode="disabled" />
+          </services>
+        XML
+      end
+
+      before { file_verifier.call }
+
+      it { expect(file_verifier.content).to eq(content) }
+    end
+  end
+end

--- a/src/api/spec/services/package_service/schema_verifier_spec.rb
+++ b/src/api/spec/services/package_service/schema_verifier_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe ::PackageService::SchemaVerifier do
+  let!(:package) { create(:package, name: 'chromium') }
+  let(:schema_verifier) { described_class.new(file_name: file_name, package: package, content: content) }
+
+  describe '.call' do
+    subject { schema_verifier.call }
+
+    context 'no error' do
+      let(:file_name) { 'foo' }
+      let(:content) { 'bar' }
+      it { expect { subject }.not_to raise_error }
+    end
+
+    context 'right pattern' do
+      let!(:package) { create(:package, name: '_pattern') }
+      let(:file_name) { 'OBS-Server' }
+      let(:content) do
+        <<-XML_DATA
+            <pattern xmlns="http://novell.com/package/metadata/suse/pattern"
+                     xmlns:rpm="http://linux.duke.edu/metadata/rpm">
+                <name>OBS_Server</name>
+                <summary lang="en">Open Build Service Server</summary>
+                <description lang="en">The Open Build Service is an enviroment to allow
+                    automated package building. The official server from the openSUSE project
+                    is reachable at http://build.opensuse.org .
+                </description>
+                <uservisible/>
+                <category lang="en">System</category>
+                <rpm:requires>
+                    <rpm:entry name="obs-server"/>
+                </rpm:requires>
+            </pattern>
+        XML_DATA
+      end
+      it { expect { subject }.not_to raise_error }
+    end
+
+    context 'wrong pattern' do
+      let!(:package) { create(:package, name: '_pattern') }
+      let(:file_name) { 'OBS-Server' }
+      let(:content) { 'foo' }
+      it { expect { subject }.to raise_error(Suse::ValidationError) }
+    end
+  end
+end


### PR DESCRIPTION
We split this method in a set of services:

  - FileVerifier
  - LinkVerifier
  - SchemaVerifier

Beside it there were some optimizations proposed by @marcus-h in the method `Package.verify_file` which was implemented too.

How to test it manually:

visit the review app and upload a file via browser

or via cli:

```osc copypac openSUSE:Factory hello -t dosc home:Admin```

and

```osc -A dosc api -X PUT -d "<pattern xmlns="http://novell.com/package/metadata/suse/pattern"><name>OBS</name></pattern>" /source/home:Admin/_pattern/obs-test```

where `dosc` is equal the review app address 