### PR TITLE
Skip flickering test on mobile

### DIFF
--- a/src/api/spec/features/beta/webui/image_templates_spec.rb
+++ b/src/api/spec/features/beta/webui/image_templates_spec.rb
@@ -47,6 +47,9 @@ RSpec.feature 'ImageTemplatesBeta', type: :feature, js: true do
     end
 
     scenario 'branch Kiwi image template' do
+      # FIXME: This scenario is flickering on mobile
+      skip('This scenario fails most of the time') if mobile?
+
       visit image_templates_path
       expect(page).to have_css('input[type=submit][disabled]')
 


### PR DESCRIPTION
We skip a `scenario` that is flickering only on mobile.