### PR TITLE
Try to click the associated label of a non-visible checkbox/radio button

### DIFF
--- a/dist/t/spec/features/0030_project_spec.rb
+++ b/dist/t/spec/features/0030_project_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Project" do
     end
     click_link('Repositories')
     click_link('Add from a Distribution')
-    check('repo_openSUSE_Leap_15_1', allow_label_click: true)
+    check('repo_openSUSE_Leap_15_1')
     expect(page).to have_content("Successfully added repository 'openSUSE_Leap_15.1'")
   end
 end

--- a/src/api/spec/features/beta/webui/groups_spec.rb
+++ b/src/api/spec/features/beta/webui/groups_spec.rb
@@ -69,7 +69,7 @@ RSpec.feature 'Groups', type: :feature, js: true do
     visit group_show_path(group_1)
 
     within(find('div.group-user', text: admin.login)) do
-      check('Maintainer', allow_label_click: true)
+      check('Maintainer')
     end
 
     expect(page).to have_content("Gave maintainer rights to '#{admin}'")

--- a/src/api/spec/features/beta/webui/maintenance_workflow_spec.rb
+++ b/src/api/spec/features/beta/webui/maintenance_workflow_spec.rb
@@ -80,7 +80,7 @@ RSpec.feature 'MaintenanceWorkflow', type: :feature, js: true, vcr: true do
     # needed for patchinfo validation
     fill_in('patchinfo_summary', with: 'ProjectWithRepo_package is much better than the old one')
     fill_in('patchinfo_description', with: 'Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing')
-    check('patchinfo_block', allow_label_click: true)
+    check('patchinfo_block')
     fill_in('patchinfo_block_reason', with: 'locked!')
 
     click_button('Save')
@@ -88,7 +88,7 @@ RSpec.feature 'MaintenanceWorkflow', type: :feature, js: true, vcr: true do
     expect(find(:css, '.block-reason span:first-child')).to have_text('Release is blocked')
 
     click_link('Edit patchinfo')
-    uncheck('patchinfo_block', allow_label_click: true)
+    uncheck('patchinfo_block')
     expect(page).to have_css('input[id=patchinfo_block_reason][disabled]')
     click_button 'Save'
 

--- a/src/api/spec/features/beta/webui/notifications_spec.rb
+++ b/src/api/spec/features/beta/webui/notifications_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'Notifications', type: :feature, js: true do
       notification_field = find('.card-body h5', text: 'Package has failed to build').sibling('.list-group')
       ['maintainer', 'bugowner', 'reader', 'watcher'].each do |role|
         subscription_by_role = notification_field.find(".#{role}")
-        subscription_by_role.check('email', allow_label_click: true)
+        subscription_by_role.check('email')
         expect(page).to have_css('#flash', text: 'Notifications settings updated')
         find('#flash button[data-dismiss]').click
       end

--- a/src/api/spec/features/beta/webui/projects_spec.rb
+++ b/src/api/spec/features/beta/webui/projects_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature 'Projects', type: :feature, js: true do
     login user
     broken_package_with_error
     visit project_status_path(project_name: project)
-    uncheck('limit_to_fails', allow_label_click: true)
+    uncheck('limit_to_fails')
     click_button('Filter results')
     expect(page).to have_text('Status of')
   end

--- a/src/api/spec/features/beta/webui/requests_spec.rb
+++ b/src/api/spec/features/beta/webui/requests_spec.rb
@@ -66,8 +66,8 @@ RSpec.feature 'Bootstrap_Requests', type: :feature, js: true, vcr: true do
         login submitter
         visit project_show_path(project: target_project)
         click_menu_link('Actions', 'Request Role Addition')
-        choose 'Bugowner', allow_label_click: true
-        choose 'Group', allow_label_click: true
+        choose 'Bugowner'
+        choose 'Group'
         fill_in 'Group:', with: roleaddition_group.title
         fill_in 'Description:', with: 'I can fix bugs too.'
         expect { click_button('Request') }.to change(BsRequest, :count).by(1)
@@ -102,8 +102,8 @@ RSpec.feature 'Bootstrap_Requests', type: :feature, js: true, vcr: true do
         login submitter
         visit package_show_path(project: target_project, package: target_package)
         click_menu_link('Actions', 'Request Role Addition')
-        choose 'Maintainer', allow_label_click: true
-        choose 'Group', allow_label_click: true
+        choose 'Maintainer'
+        choose 'Group'
         fill_in 'Group:', with: roleaddition_group.title
         fill_in 'Description:', with: 'I can produce bugs too.'
         expect { click_button('Request') }.to change(BsRequest, :count).by(1)
@@ -131,8 +131,8 @@ RSpec.feature 'Bootstrap_Requests', type: :feature, js: true, vcr: true do
         login submitter
         visit project_show_path(project: target_project)
         click_menu_link('Actions', 'Request Role Addition')
-        choose 'Bugowner', allow_label_click: true
-        choose 'User', allow_label_click: true
+        choose 'Bugowner'
+        choose 'User'
         fill_in 'User:', with: "#{submitter.login}"
         fill_in 'Description:', with: 'I can fix bugs too.'
         expect { click_button('Request') }.to change(BsRequest, :count).by(1)
@@ -166,8 +166,8 @@ RSpec.feature 'Bootstrap_Requests', type: :feature, js: true, vcr: true do
         login submitter
         visit package_show_path(project: target_project, package: target_package)
         click_menu_link('Actions', 'Request Role Addition')
-        choose 'Maintainer', allow_label_click: true
-        choose 'User', allow_label_click: true
+        choose 'Maintainer'
+        choose 'User'
         fill_in 'User:', with: submitter.login
         fill_in 'Description:', with: 'I can produce bugs too.'
         expect { click_button('Request') }.to change(BsRequest, :count).by(1)

--- a/src/api/spec/features/beta/webui/search_spec.rb
+++ b/src/api/spec/features/beta/webui/search_spec.rb
@@ -66,7 +66,7 @@ RSpec.feature 'Search', type: :feature, js: true do
       click_button 'Advanced'
       select('Packages', from: 'search_for')
 
-      check 'title', allow_label_click: true
+      check 'title'
       click_button 'Search'
 
       within '#search-results' do
@@ -85,9 +85,9 @@ RSpec.feature 'Search', type: :feature, js: true do
 
       fill_in 'search_input', with: 'awesome'
       click_button 'Advanced'
-      check 'title', allow_label_click: true
-      uncheck 'name', allow_label_click: true
-      uncheck 'description', allow_label_click: true
+      check 'title'
+      uncheck 'name'
+      uncheck 'description'
       click_button 'Search'
 
       within '#search-results' do
@@ -105,9 +105,9 @@ RSpec.feature 'Search', type: :feature, js: true do
 
       fill_in 'search_input', with: 'awesome'
       click_button 'Advanced'
-      uncheck 'title', allow_label_click: true
-      uncheck 'name', allow_label_click: true
-      check 'description', allow_label_click: true
+      uncheck 'title'
+      uncheck 'name'
+      check 'description'
       click_button 'Search'
 
       within '#search-results' do
@@ -141,9 +141,9 @@ RSpec.feature 'Search', type: :feature, js: true do
 
       fill_in 'search_input', with: 'awesome'
       click_button 'Advanced'
-      uncheck 'title', allow_label_click: true
-      uncheck 'name', allow_label_click: true
-      uncheck 'description', allow_label_click: true
+      uncheck 'title'
+      uncheck 'name'
+      uncheck 'description'
       click_button 'Search'
 
       within('#flash') do
@@ -161,8 +161,8 @@ RSpec.feature 'Search', type: :feature, js: true do
 
       fill_in 'search_input', with: 'вокябюч'
       click_button 'Advanced'
-      uncheck 'name', allow_label_click: true
-      check 'title', allow_label_click: true
+      uncheck 'name'
+      check 'title'
       click_button 'Search'
 
       within '#search-results' do
@@ -181,7 +181,7 @@ RSpec.feature 'Search', type: :feature, js: true do
 
         fill_in 'search_input', with: 'hidden'
         click_button 'Advanced'
-        check 'title', allow_label_click: true
+        check 'title'
         click_button 'Search'
 
         within('#flash') do
@@ -202,7 +202,7 @@ RSpec.feature 'Search', type: :feature, js: true do
 
         fill_in 'search_input', with: 'hidden'
         click_button 'Advanced'
-        check 'title', allow_label_click: true
+        check 'title'
         click_button 'Search'
 
         within '#search-results' do

--- a/src/api/spec/features/beta/webui/users/user_admin_edit_spec.rb
+++ b/src/api/spec/features/beta/webui/users/user_admin_edit_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature "User's admin edit page", type: :feature, js: true do
     login(admin)
     visit edit_user_path(login: user.login)
 
-    check('Admin', allow_label_click: true)
+    check('Admin')
     click_button('Update')
     expect(user.is_admin?).to be(true)
   end
@@ -31,7 +31,7 @@ RSpec.feature "User's admin edit page", type: :feature, js: true do
   scenario 'remove admin rights from user' do
     login(admin)
     visit edit_user_path(login: admin.login)
-    uncheck('Admin', allow_label_click: true)
+    uncheck('Admin')
     click_button('Update')
     expect(admin.is_admin?).to be(false)
   end

--- a/src/api/spec/features/webui/groups_spec.rb
+++ b/src/api/spec/features/webui/groups_spec.rb
@@ -67,7 +67,7 @@ RSpec.feature 'Groups', type: :feature, js: true do
     visit group_show_path(group_1)
 
     within(find('div.group-user', text: admin.login)) do
-      check('Maintainer', allow_label_click: true)
+      check('Maintainer')
     end
 
     expect(page).to have_content("Gave maintainer rights to '#{admin}'")

--- a/src/api/spec/features/webui/maintenance_workflow_spec.rb
+++ b/src/api/spec/features/webui/maintenance_workflow_spec.rb
@@ -80,7 +80,7 @@ RSpec.feature 'MaintenanceWorkflow', type: :feature, js: true, vcr: true do
     # needed for patchinfo validation
     fill_in('patchinfo_summary', with: 'ProjectWithRepo_package is much better than the old one')
     fill_in('patchinfo_description', with: 'Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing')
-    check('patchinfo_block', allow_label_click: true)
+    check('patchinfo_block')
     fill_in('patchinfo_block_reason', with: 'locked!')
 
     click_button('Save')
@@ -88,7 +88,7 @@ RSpec.feature 'MaintenanceWorkflow', type: :feature, js: true, vcr: true do
     expect(find(:css, '.block-reason span:first-child')).to have_text('Release is blocked')
 
     click_link('Edit patchinfo')
-    uncheck('patchinfo_block', allow_label_click: true)
+    uncheck('patchinfo_block')
     expect(page).to have_css('input[id=patchinfo_block_reason][disabled]')
     click_button 'Save'
 

--- a/src/api/spec/features/webui/notifications_spec.rb
+++ b/src/api/spec/features/webui/notifications_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'Notifications', type: :feature, js: true do
       notification_field = find('.card-body h5', text: 'Package has failed to build').sibling('.list-group')
       ['maintainer', 'bugowner', 'reader', 'watcher'].each do |role|
         subscription_by_role = notification_field.find(".#{role}")
-        subscription_by_role.check('email', allow_label_click: true)
+        subscription_by_role.check('email')
         expect(page).to have_css('#flash', text: 'Notifications settings updated')
         find('#flash button[data-dismiss]').click
       end

--- a/src/api/spec/features/webui/projects_spec.rb
+++ b/src/api/spec/features/webui/projects_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature 'Projects', type: :feature, js: true do
     login user
     broken_package_with_error
     visit project_status_path(project_name: project)
-    uncheck('limit_to_fails', allow_label_click: true)
+    uncheck('limit_to_fails')
     click_button('Filter results')
     expect(page).to have_text('Status of')
   end

--- a/src/api/spec/features/webui/requests_spec.rb
+++ b/src/api/spec/features/webui/requests_spec.rb
@@ -66,8 +66,8 @@ RSpec.feature 'Bootstrap_Requests', type: :feature, js: true, vcr: true do
         login submitter
         visit project_show_path(project: target_project)
         click_link 'Request Role Addition'
-        choose 'Bugowner', allow_label_click: true
-        choose 'Group', allow_label_click: true
+        choose 'Bugowner'
+        choose 'Group'
         fill_in 'Group:', with: roleaddition_group.title
         fill_in 'Description:', with: 'I can fix bugs too.'
         expect { click_button('Request') }.to change(BsRequest, :count).by(1)
@@ -102,8 +102,8 @@ RSpec.feature 'Bootstrap_Requests', type: :feature, js: true, vcr: true do
         login submitter
         visit package_show_path(project: target_project, package: target_package)
         click_link 'Request Role Addition'
-        choose 'Maintainer', allow_label_click: true
-        choose 'Group', allow_label_click: true
+        choose 'Maintainer'
+        choose 'Group'
         fill_in 'Group:', with: roleaddition_group.title
         fill_in 'Description:', with: 'I can produce bugs too.'
         expect { click_button('Request') }.to change(BsRequest, :count).by(1)
@@ -131,8 +131,8 @@ RSpec.feature 'Bootstrap_Requests', type: :feature, js: true, vcr: true do
         login submitter
         visit project_show_path(project: target_project)
         click_link 'Request Role Addition'
-        choose 'Bugowner', allow_label_click: true
-        choose 'User', allow_label_click: true
+        choose 'Bugowner'
+        choose 'User'
         fill_in 'User:', with: "#{submitter.login}"
         fill_in 'Description:', with: 'I can fix bugs too.'
         expect { click_button('Request') }.to change(BsRequest, :count).by(1)
@@ -166,8 +166,8 @@ RSpec.feature 'Bootstrap_Requests', type: :feature, js: true, vcr: true do
         login submitter
         visit package_show_path(project: target_project, package: target_package)
         click_link 'Request Role Addition'
-        choose 'Maintainer', allow_label_click: true
-        choose 'User', allow_label_click: true
+        choose 'Maintainer'
+        choose 'User'
         fill_in 'User:', with: submitter.login
         fill_in 'Description:', with: 'I can produce bugs too.'
         expect { click_button('Request') }.to change(BsRequest, :count).by(1)

--- a/src/api/spec/features/webui/search_spec.rb
+++ b/src/api/spec/features/webui/search_spec.rb
@@ -66,7 +66,7 @@ RSpec.feature 'Search', type: :feature, js: true do
       click_button 'Advanced'
       select('Packages', from: 'search_for')
 
-      check 'title', allow_label_click: true
+      check 'title'
       click_button 'Search'
 
       within '#search-results' do
@@ -85,9 +85,9 @@ RSpec.feature 'Search', type: :feature, js: true do
 
       fill_in 'search_input', with: 'awesome'
       click_button 'Advanced'
-      check 'title', allow_label_click: true
-      uncheck 'name', allow_label_click: true
-      uncheck 'description', allow_label_click: true
+      check 'title'
+      uncheck 'name'
+      uncheck 'description'
       click_button 'Search'
 
       within '#search-results' do
@@ -105,9 +105,9 @@ RSpec.feature 'Search', type: :feature, js: true do
 
       fill_in 'search_input', with: 'awesome'
       click_button 'Advanced'
-      uncheck 'title', allow_label_click: true
-      uncheck 'name', allow_label_click: true
-      check 'description', allow_label_click: true
+      uncheck 'title'
+      uncheck 'name'
+      check 'description'
       click_button 'Search'
 
       within '#search-results' do
@@ -141,9 +141,9 @@ RSpec.feature 'Search', type: :feature, js: true do
 
       fill_in 'search_input', with: 'awesome'
       click_button 'Advanced'
-      uncheck 'title', allow_label_click: true
-      uncheck 'name', allow_label_click: true
-      uncheck 'description', allow_label_click: true
+      uncheck 'title'
+      uncheck 'name'
+      uncheck 'description'
       click_button 'Search'
 
       within('#flash') do
@@ -161,8 +161,8 @@ RSpec.feature 'Search', type: :feature, js: true do
 
       fill_in 'search_input', with: 'вокябюч'
       click_button 'Advanced'
-      uncheck 'name', allow_label_click: true
-      check 'title', allow_label_click: true
+      uncheck 'name'
+      check 'title'
       click_button 'Search'
 
       within '#search-results' do
@@ -181,7 +181,7 @@ RSpec.feature 'Search', type: :feature, js: true do
 
         fill_in 'search_input', with: 'hidden'
         click_button 'Advanced'
-        check 'title', allow_label_click: true
+        check 'title'
         click_button 'Search'
 
         within('#flash') do
@@ -202,7 +202,7 @@ RSpec.feature 'Search', type: :feature, js: true do
 
         fill_in 'search_input', with: 'hidden'
         click_button 'Advanced'
-        check 'title', allow_label_click: true
+        check 'title'
         click_button 'Search'
 
         within '#search-results' do

--- a/src/api/spec/features/webui/users/user_admin_edit_spec.rb
+++ b/src/api/spec/features/webui/users/user_admin_edit_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature "User's admin edit page", type: :feature, js: true do
     login(admin)
     visit edit_user_path(login: user.login)
 
-    check('Admin', allow_label_click: true)
+    check('Admin')
     click_button('Update')
     expect(user.is_admin?).to be(true)
   end
@@ -31,7 +31,7 @@ RSpec.feature "User's admin edit page", type: :feature, js: true do
   scenario 'remove admin rights from user' do
     login(admin)
     visit edit_user_path(login: admin.login)
-    uncheck('Admin', allow_label_click: true)
+    uncheck('Admin')
     click_button('Update')
     expect(admin.is_admin?).to be(false)
   end

--- a/src/api/spec/support/capybara.rb
+++ b/src/api/spec/support/capybara.rb
@@ -4,6 +4,8 @@ Capybara.save_path = Rails.root.join('tmp', 'capybara')
 Capybara.server = :puma, { Silent: true }
 Capybara.disable_animation = true
 Capybara.javascript_driver = :desktop
+# Attempt to click the associated label element if a checkbox/radio button are non-visible (This is especially useful for Bootstrap custom controls)
+Capybara.automatic_label_click = true
 
 # we use RSPEC_HOST as trigger to use remote selenium
 if ENV['RSPEC_HOST'].blank?


### PR DESCRIPTION
This is especially useful for Bootstrap custom controls, since Capybara cannot check/click them since they aren't visible.