### PR TITLE
Use correct form path for request/role_additions#new

### DIFF
--- a/src/api/app/views/webui/requests/role_additions/new.html.haml
+++ b/src/api/app/views/webui/requests/role_additions/new.html.haml
@@ -18,7 +18,7 @@
               = project_or_package_link(project: @project.name, package: @package.try(:name))
               ?
           .col-12.col-md-9.col-lg-6
-            - form_path = @project ? project_role_additions_path(@project) : project_package_role_additions_path(@project, @package)
+            - form_path = @package ? project_package_role_additions_path(@project, @package) : project_role_additions_path(@project)
             = form_for(@bs_request, url: form_path) do |f|
               = f.fields_for(:bs_request_actions) do |bs_request_actions|
                 = bs_request_actions.hidden_field(:target_project)


### PR DESCRIPTION
This should have been in #9579. This was still working since both routes are based on the same controller, only the route parameters vary.

We have feature specs covering this, so there were no regression.