### PR TITLE
Use automatic_label_click for Capybara inside openQA/minitest suite

### DIFF
--- a/dist/t/spec/support/capybara.rb
+++ b/dist/t/spec/support/capybara.rb
@@ -17,6 +17,8 @@ end
 Capybara.default_driver = :selenium_chrome_headless
 Capybara.javascript_driver = :selenium_chrome_headless
 Capybara.save_path = '/tmp/rspec_screens'
+# Attempt to click the associated label element if a checkbox/radio button are non-visible (This is especially useful for Bootstrap custom controls)
+Capybara.automatic_label_click = true
 
 # Set hostname
 begin

--- a/src/api/test/test_helper.rb
+++ b/src/api/test/test_helper.rb
@@ -42,6 +42,8 @@ require 'mocha/setup'
 
 require 'capybara/rails'
 Capybara.default_max_wait_time = 6
+# Attempt to click the associated label element if a checkbox/radio button are non-visible (This is especially useful for Bootstrap custom controls)
+Capybara.automatic_label_click = true
 
 Capybara.register_driver :rack_test do |app|
   Capybara::RackTest::Driver.new(app, headers: { 'HTTP_ACCEPT' => 'text/html' })


### PR DESCRIPTION
This should have been part of #9600. The minitest suite was already passing, but now it's just like the others.