### PR TITLE
[backend] do not reconstruct containers in the root filesystem

### DIFF
--- a/src/backend/BSRepServer/Containertar.pm
+++ b/src/backend/BSRepServer/Containertar.pm
@@ -19,6 +19,7 @@ package BSRepServer::Containertar;
 
 use JSON::XS ();
 
+use BSConfiguration;
 use BSTar;
 use BSContar;
 use BSHTTP;
@@ -26,6 +27,8 @@ use BSServer;
 use BSUtil;
 
 use strict;
+
+my $uploaddir = "$BSConfig::bsdir/upload";
 
 sub normalize_container {
   my ($dir, $container, $writeblobs, $deletetar, $arch) = @_;
@@ -154,8 +157,11 @@ sub open_container {
   my $dir = $container;
   $dir =~ s/[^\/]*$/./;
   my ($tar) = construct_container_tar($dir, $containerinfo, 1);
+  my $tmpfilename = "$uploaddir/open_container.$$";
+  unlink($tmpfilename);
   my $fd;
-  open($fd, '+>', undef) || die("tmpfile open: $!\n");
+  open($fd, '+>', $tmpfilename) || die("tmpfile open: $!\n");
+  unlink($tmpfilename);
   BSTar::writetar($fd, $tar);
   seek($fd, 0, 0);
   return $fd;


### PR DESCRIPTION
Instead, use the uploaddir in our partition.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
