### PR TITLE
Request delegation

### DIFF
--- a/docs/api/api/api.txt
+++ b/docs/api/api/api.txt
@@ -989,6 +989,8 @@ XmlResult: request
 Parameters:
 
   addrevision: ask the server to add revisions of current sources to the request
+  ignore_delegate: enforce a new package instance in a project which has OBS:DelegateRequestTarget set
+  ignore_build_state: skip the build state check
 
 
 PUT /request/<id>

--- a/src/api/app/controllers/request_controller.rb
+++ b/src/api/app/controllers/request_controller.rb
@@ -146,6 +146,7 @@ class RequestController < ApplicationController
       @req = BsRequest.new_from_xml(request.raw_post.to_s)
       authorize @req, :create?
       @req.set_add_revision       if params[:addrevision].present?
+      @req.set_ignore_delegate    if params[:ignore_delegate].present?
       @req.set_ignore_build_state if params[:ignore_build_state].present?
       @req.save!
       Suse::Validator.validate(:request, @req.render_xml)

--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -293,6 +293,10 @@ class BsRequest < ApplicationRecord
     @ignore_build_state = true
   end
 
+  def set_ignore_delegate
+    @ignore_delegate = true
+  end
+
   def sanitize?
     !@skip_sanitize
   end
@@ -1031,7 +1035,7 @@ class BsRequest < ApplicationRecord
     oldactions = []
 
     bs_request_actions.each do |action|
-      na, ppl = action.expand_targets(!@ignore_build_state.nil?)
+      na, ppl = action.expand_targets(@ignore_build_state.present?, @ignore_delegate.present?)
       @per_package_locking ||= ppl
       next if na.nil?
 

--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -664,30 +664,8 @@ class BsRequestAction < ApplicationRecord
   end
 
   def expand_targets(ignore_build_state, ignore_delegate)
-    # expand target_package
-
-    # target delegation handling
-    if action_type == :submit
-      tprj = Project.get_by_name(target_project) if target_project.present?
-      if tprj.class == Project &&
-         ignore_delegate.blank? &&
-         Attrib.find_by_container_and_fullname(tprj, 'OBS:DelegateRequestTarget')
-
-        # new packages stay in target for now
-        # we may error out in near future to require explicit target via ignore_delegate
-        if Package.exists_by_project_and_name(target_project,
-                                              target_package || source_package,
-                                              { follow_project_links: true,
-                                                follow_multibuild: true,
-                                                check_update_project: true })
-          tpkg = Package.get_by_project_and_name(target_project,
-                                                 target_package || source_package,
-                                                 { follow_project_links: true,
-                                                   follow_multibuild: true,
-                                                   check_update_project: true })
-          self.target_project = tpkg.project.name
-        end
-      end
+    if action_type == :submit && ignore_delegate.blank? && target_project.present?
+      expand_target_project
     end
 
     # empty submission protection
@@ -726,6 +704,24 @@ class BsRequestAction < ApplicationRecord
     end
 
     return
+  end
+
+  # Follow project links for a target project that delegates requests
+  def expand_target_project
+    tprj = Project.get_by_name(target_project)
+    return unless tprj.is_a?(Project) && tprj.delegates_requests?
+
+    return unless Package.exists_by_project_and_name(target_project,
+                                                     target_package || source_package,
+                                                     { follow_project_links: true,
+                                                       follow_multibuild: true,
+                                                       check_update_project: true })
+    tpkg = Package.get_by_project_and_name(target_project,
+                                           target_package || source_package,
+                                           { follow_project_links: true,
+                                             follow_multibuild: true,
+                                             check_update_project: true })
+    self.target_project = tpkg.project.name
   end
 
   def source_access_check!

--- a/src/api/app/models/bs_request_action_maintenance_incident.rb
+++ b/src/api/app/models/bs_request_action_maintenance_incident.rb
@@ -87,7 +87,7 @@ class BsRequestActionMaintenanceIncident < BsRequestAction
     save
   end
 
-  def expand_targets(ignore_build_state)
+  def expand_targets(ignore_build_state, ignore_delegate)
     # find maintenance project
     maintenance_project = nil
     if target_project
@@ -100,7 +100,7 @@ class BsRequestActionMaintenanceIncident < BsRequestAction
       raise NoMaintenanceProject, 'Maintenance incident requests have to go to projects of type maintenance or maintenance_incident'
     end
     raise IllegalRequest, 'Target package must not be specified in maintenance_incident actions' if target_package
-    super(ignore_build_state)
+    super(ignore_build_state, ignore_delegate)
   end
 
   private

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -111,6 +111,10 @@ class Project < ApplicationRecord
   scope :local_image_templates, lambda {
     ProjectsWithImageTemplatesFinder.new.call
   }
+  # will return all projects with attribute 'OBS:DelegateRequestTarget'
+  scope :delegates_requests, lambda {
+    ProjectsWithDelegateRequestTargetFinder.new.call
+  }
 
   scope :for_user, ->(user_id) { joins(:relationships).where(relationships: { user_id: user_id, role_id: Role.hashed['maintainer'] }) }
   scope :for_group, ->(group_id) { joins(:relationships).where(relationships: { group_id: group_id, role_id: Role.hashed['maintainer'] }) }
@@ -687,6 +691,10 @@ class Project < ApplicationRecord
 
   def defines_remote_instance?
     remoteurl.present?
+  end
+
+  def delegates_requests?
+    find_attribute('OBS', 'DelegateRequestTarget').present?
   end
 
   def can_free_repositories?

--- a/src/api/app/queries/projects_with_delegate_request_target_finder.rb
+++ b/src/api/app/queries/projects_with_delegate_request_target_finder.rb
@@ -1,0 +1,5 @@
+class ProjectsWithDelegateRequestTargetFinder < AttribFinder
+  def initialize(relation = Project.all, namespace = 'OBS', name = 'DelegateRequestTarget')
+    super(relation, namespace, name)
+  end
+end

--- a/src/api/db/attribute_descriptions.rb
+++ b/src/api/db/attribute_descriptions.rb
@@ -26,7 +26,8 @@ def update_all_attrib_type_descriptions
     'IncidentPriority' => 'A numeric value which defines the importance of this incident project.',
     'EmbargoDate' => 'A timestamp until outgoing requests can not get accepted.',
     'PlannedReleaseDate' => 'A timestamp for the planned release date of an incident.',
-    'MakeOriginOlder' => 'Initialize packages by making the build results newer then updated ones'
+    'MakeOriginOlder' => 'Initialize packages by making the build results newer then updated ones',
+    'DelegateRequestTarget' => 'Delegate the target project of requests even when target_project is specified'
   }
   # rubocop:enable Layout/LineLength
 

--- a/src/api/db/data/20200627135426_request_delegate_attribute.rb
+++ b/src/api/db/data/20200627135426_request_delegate_attribute.rb
@@ -1,0 +1,20 @@
+require_relative '../attribute_descriptions'
+
+class RequestDelegateAttribute < ActiveRecord::Migration[6.0]
+  def self.up
+    ans = AttribNamespace.find_by_name('OBS')
+
+    AttribTypeModifiableBy.reset_column_information
+
+    at = AttribType.create(attrib_namespace: ans, name: 'DelegateRequestTarget')
+
+    role = Role.find_by_title('maintainer')
+    AttribTypeModifiableBy.create(role_id: role.id, attrib_type_id: at.id)
+
+    update_all_attrib_type_descriptions
+  end
+
+  def self.down
+    AttribType.find_by_namespace_and_name('OBS', 'DelegateRequestTarget').delete
+  end
+end

--- a/src/api/db/seeds.rb
+++ b/src/api/db/seeds.rb
@@ -150,6 +150,8 @@ at = ans.attrib_types.where(name: 'IncidentPriority').first_or_create(value_coun
 at.attrib_type_modifiable_bies.where(user_id: admin.id).first_or_create
 at = ans.attrib_types.where(name: 'EmbargoDate').first_or_create(value_count: 1)
 at.attrib_type_modifiable_bies.where(role_id: maintainer_role.id).first_or_create
+at = ans.attrib_types.where(name: 'DelegateRequestTarget').first_or_create
+at.attrib_type_modifiable_bies.where(user_id: maintainer_role.id).first_or_create
 
 at = ans.attrib_types.where(name: 'OwnerRootProject').first_or_create
 at.attrib_type_modifiable_bies.where(user_id: admin.id).first_or_create

--- a/src/api/spec/factories/attribs.rb
+++ b/src/api/spec/factories/attribs.rb
@@ -30,6 +30,10 @@ FactoryBot.define do
       attrib_type { AttribType.find_by_namespace_and_name!('OBS', 'ImageTemplates') }
     end
 
+    factory :delegate_requests_attrib do
+      attrib_type { AttribType.find_by_namespace_and_name!('OBS', 'DelegateRequestTarget') }
+    end
+
     factory :approved_request_source_attrib do
       attrib_type { AttribType.find_by_namespace_and_name!('OBS', 'ApprovedRequestSource') }
     end

--- a/src/api/spec/queries/projects_with_delegate_request_target_finder_spec.rb
+++ b/src/api/spec/queries/projects_with_delegate_request_target_finder_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe ProjectsWithDelegateRequestTargetFinder do
+  let(:project) { create(:project, name: 'project_that_delegates') }
+  let!(:delegate_attrib) { create(:delegate_requests_attrib, project: project) }
+
+  describe '.call' do
+    subject { ProjectsWithDelegateRequestTargetFinder.new.call }
+
+    it { expect(subject).not_to be_empty }
+    it { expect(subject).to include(project) }
+  end
+end

--- a/src/api/spec/support/database_cleaner.rb
+++ b/src/api/spec/support/database_cleaner.rb
@@ -37,6 +37,7 @@ RSpec.configure do |config|
     create(:obs_attrib_type, name: 'ProjectStatusPackageFailComment')
     create(:obs_attrib_type, name: 'UpdateProject')
     create(:obs_attrib_type, name: 'VeryImportantProject')
+    create(:obs_attrib_type, name: 'DelegateRequestTarget')
     Configuration.update(allow_user_to_create_home_project: false)
   end
 

--- a/src/api/test/fixtures/attrib_types.yml
+++ b/src/api/test/fixtures/attrib_types.yml
@@ -125,3 +125,9 @@ OBS_MakeOriginOlder:
   value_count: 0
   attrib_namespace_id: 9
   issue_list: 0
+OBS_DelegateRequestTarget:
+  id: 82
+  name: DelegateRequestTarget
+  value_count: 0
+  attrib_namespace_id: 9
+  issue_list: 0

--- a/src/api/test/fixtures/linked_projects.yml
+++ b/src/api/test/fixtures/linked_projects.yml
@@ -23,3 +23,9 @@ linked_db_projects_44:
   linked_remote_project_name: nil
   project: BaseDistro_Update
   linked_db_project: BaseDistro
+linked_db_projects_46:
+  id: 46
+  position: 1
+  linked_remote_project_name: nil
+  project: BaseDistro_SP1
+  linked_db_project: BaseDistro

--- a/src/api/test/fixtures/projects.yml
+++ b/src/api/test/fixtures/projects.yml
@@ -20,6 +20,14 @@ BaseDistro:
   updated_at: 2005-01-01 01:00:01.000000000 Z
   kind: standard
   delta: 1
+BaseDistro_SP1:
+  name: BaseDistro:SP1
+  title: This is a service pack for base distro
+  description: This could be SUSE:SLE-15-SP2:GA project for example
+  created_at: 2020-01-01 01:00:01.000000000 Z
+  updated_at: 2020-01-01 01:00:01.000000000 Z
+  kind: standard
+  delta: 1
 BaseDistro2.0:
   name: BaseDistro2.0
   title: This is another base distro

--- a/src/api/test/functional/attributes_test.rb
+++ b/src/api/test/functional/attributes_test.rb
@@ -32,7 +32,7 @@ class AttributeControllerTest < ActionDispatch::IntegrationTest
 
     get '/attribute/OBS'
     assert_response :success
-    count = 21
+    count = 22
     assert_xml_tag tag: 'directory', attributes: { count: count }
     assert_xml_tag children: { count: count }
     assert_xml_tag child: { tag: 'entry', attributes: { name: 'Maintained' } }
@@ -276,7 +276,7 @@ ription</description>
 
     get '/attribute/OBS'
     assert_response :success
-    count = 21
+    count = 22
     assert_xml_tag tag: 'directory', attributes: { count: count }
     assert_xml_tag children: { count: count }
     assert_xml_tag child: { tag: 'entry', attributes: { name: 'Maintained' } }


### PR DESCRIPTION
    [api] support request delegation to package origin project.
    
    Adds an option to let the server delegate the request for
    a target project to the project where the packages is actual
    living.
    
    This works when source has no package link, eg from submitting
    from a base distro project to another one.
    
    This is needed for Jump submissions in first place (jsc#OBS-59)

