### PR TITLE
Dump announcement into status message

### DIFF
--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -79,6 +79,7 @@ class User < ApplicationRecord
   scope :active, -> { confirmed.or(User.where(state: :subaccount, owner: User.confirmed)) }
   scope :staff, -> { joins(:roles).where('roles.title = ?', 'Staff') }
   scope :not_staff, -> { where.not(id: User.staff.pluck(:id)) }
+  scope :admins, -> { joins(:roles).where('roles.title = ?', 'Admin') }
 
   scope :in_beta, -> { where(in_beta: true) }
   scope :in_rollout, -> { where(in_rollout: true) }

--- a/src/api/db/data/20200528135241_dump_announcements_into_status_messages.rb
+++ b/src/api/db/data/20200528135241_dump_announcements_into_status_messages.rb
@@ -1,0 +1,12 @@
+class DumpAnnouncementsIntoStatusMessages < ActiveRecord::Migration[6.0]
+  def up
+    Announcement.all.each do |announcement|
+      sm = StatusMessage.create(message: announcement.content, severity: 'announcement', communication_scope: 'all_users', user: User.admins.first)
+      sm.users << announcement.users
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/src/api/db/data_schema.rb
+++ b/src/api/db/data_schema.rb
@@ -1,2 +1,2 @@
 # encoding: UTF-8
-DataMigrate::Data.define(version: 20200430112548)
+DataMigrate::Data.define(version: 20200528135241)

--- a/src/api/spec/db/data/dump_announcements_into_status_messages_spec.rb
+++ b/src/api/spec/db/data/dump_announcements_into_status_messages_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+require Rails.root.join('db/data/20200528135241_dump_announcements_into_status_messages.rb')
+
+RSpec.describe DumpAnnouncementsIntoStatusMessages, type: :migration do
+  describe 'up' do
+    let!(:announcement_1) { create(:announcement, created_at: 2.days.ago) }
+    let!(:announcement_2) { create(:announcement, created_at: 1.day.ago) }
+    let!(:announcement_3) { create(:announcement) }
+    let!(:status_message) { create(:status_message) }
+    let(:user_a) { create(:confirmed_user) }
+    let(:user_b) { create(:confirmed_user) }
+    let(:user_c) { create(:confirmed_user) }
+    let!(:admin) { create(:admin_user) }
+
+    before do
+      announcement_1.users << [user_a, user_b, user_c]
+      announcement_2.users << user_b
+      DumpAnnouncementsIntoStatusMessages.new.up
+    end
+
+    it 'creates 3 status messages with "announcement" severity' do
+      expect(StatusMessage.count).to eq(4)
+      expect(StatusMessage.announcements.count).to eq(3)
+    end
+
+    it 'creates 4 relationships between status messages and users' do
+      expect(user_a.acknowledged_status_messages.count).to eq(1)
+      expect(user_b.acknowledged_status_messages.count).to eq(2)
+      expect(user_c.acknowledged_status_messages.count).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
As announcement functionality has been merged to status message, we also dump the existing data from the old to the new table.

This PR is part of a series, the previous ones were: #9590 and #9613

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
