### PR TITLE
Always verify an uploaded file in case of a _pattern package

### DIFF
--- a/src/api/test/functional/source_controller_test.rb
+++ b/src/api/test/functional/source_controller_test.rb
@@ -2188,6 +2188,10 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_match(/_pattern/, @response.body)
 
+    # verify a pattern file (_pattern package exists)
+    put '/source/home:coolo:test/_pattern/mypattern', params: 'broken'
+    assert_response 400
+
     # delete failure
     prepare_request_with_user('adrian_nobody', 'buildservice')
     delete '/source/home:coolo:test/_pattern/mypattern'


### PR DESCRIPTION
This is just the rework of #9554

As of now, if a file is PUTed to a _pattern package, the file is
only verified if the _pattern package was non-existent. Instead, the
the file should be always verified (regardless whether the _pattern
package was created or already existed).
Since @pack is not set in check_permissions_for_file in case of a
_pattern package (which is perfectly fine), it is set up in
update_file (the code also takes a potential race into account).
Hence, @pack is always defined when it is passed to
Package.verify_file!.
The new behavior is documented in a testcase.

Co-authored-by: Marcus Hüwe <suse-tux@gmx.de>
