### PR TITLE
Modify data migration for announcements

### DIFF
--- a/src/api/db/data/20200528135241_dump_announcements_into_status_messages.rb
+++ b/src/api/db/data/20200528135241_dump_announcements_into_status_messages.rb
@@ -1,8 +1,18 @@
 class DumpAnnouncementsIntoStatusMessages < ActiveRecord::Migration[6.0]
+  class DummyAnnouncement < ApplicationRecord
+    self.table_name = 'announcements'
+    has_and_belongs_to_many :users, class_name: 'DummyUser', foreign_key: 'announcement_id', association_foreign_key: 'user_id'
+  end
+
+  class DummyUser < ApplicationRecord
+    self.table_name = 'users'
+    has_and_belongs_to_many :announcements, class_name: 'DummyAnnouncement', foreign_key: 'user_id', association_foreign_key: 'announcement_id'
+  end
+
   def up
-    Announcement.all.each do |announcement|
-      sm = StatusMessage.create(message: announcement.content, severity: 'announcement', communication_scope: 'all_users', user: User.admins.first)
-      sm.users << announcement.users
+    DummyAnnouncement.all.each do |dummy_announcement|
+      sm = StatusMessage.create(message: dummy_announcement.content, severity: 'announcement', communication_scope: 'all_users', user: User.admins.first)
+      sm.users << User.where(id: dummy_announcement.users.pluck(:id))
     end
   end
 


### PR DESCRIPTION
The data migration to dump announcements into status messages has been
modified to make it work even after the Announcement model is removed
(something that is planned for the near future).

Inside the data migration file, we define "fake" models to use the
tables involved. The tables will be removed, but this data migrations is
going to be executed first.

Co-authored-by: David Kang <dkang@suse.com>

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
