### PR TITLE
[api] allow to enforce maintenance request staging

### DIFF
--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -225,7 +225,6 @@ Metrics/CyclomaticComplexity:
     - 'app/models/bs_request/find_for/query.rb'
     - 'app/models/bs_request_action.rb'
     - 'app/models/bs_request_action/differ/query_builder.rb'
-    - 'app/models/bs_request_action_maintenance_incident.rb'
     - 'app/models/bs_request_action_submit.rb'
     - 'app/models/bs_request_permission_check.rb'
     - 'app/models/channel.rb'

--- a/src/api/app/controllers/request_controller.rb
+++ b/src/api/app/controllers/request_controller.rb
@@ -54,6 +54,7 @@ class RequestController < ApplicationController
     @req.set_add_revision       if params[:addrevision].present?
     @req.set_ignore_delegate    if params[:ignore_delegate].present?
     @req.set_ignore_build_state if params[:ignore_build_state].present?
+    @req.enforce_branching      if params[:enforce_branching].present?
 
     authorize @req, :create?
 

--- a/src/api/app/lib/backend/api/sources/package.rb
+++ b/src/api/app/lib/backend/api/sources/package.rb
@@ -141,7 +141,7 @@ module Backend
         # @return [String]
         def self.source_diff(project_name, package_name, options = {})
           accepted = %i[rev orev opackage oproject linkrev olinkrev expand filelimit tarlimit onlyissues withissues view cacheonly nodiff file]
-          diff = http_post(['/source/:project/:package', project_name, package_name], defaults: { cmd: :diff }, params: options, accepted: accepted)
+          diff = http_post(['/source/:project/:package', project_name, package_name], defaults: { cmd: :diff }, params: options.compact, accepted: accepted)
           diff.valid_encoding? ? diff : diff.encode('UTF-8', 'binary', invalid: :replace, undef: :replace)
         end
 

--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -29,6 +29,8 @@ class BsRequest < ApplicationRecord
 
   ACTION_NOTIFY_LIMIT = 50
 
+  attr_internal_accessor :enforce_branching
+
   # Ensure attribute is declared for the enum in a migration-safe way
   # This handles cases where the model is loaded during migrations before the status column exists
   # or when upgrading from older OBS versions
@@ -928,6 +930,8 @@ class BsRequest < ApplicationRecord
     check_bs_request_actions!
     check_uniq_actions!
 
+    bs_request_actions.where(type: 'BsRequestActionMaintenanceIncident').map { |action| action.modify_sources(enforce_branching: enforce_branching) }
+
     # Autoapproval? Is the creator allowed to accept it?
     permission_check_change_state!(newstate: 'accepted') if accept_at
 
@@ -1048,6 +1052,10 @@ class BsRequest < ApplicationRecord
   def canned_responses
     package_ids = bs_request_actions.pluck(:source_package_id, :target_package_id).flatten.uniq
     CannedResponse.where(package_id: package_ids)
+  end
+
+  def enforce_branching
+    @enforce_branching || true
   end
 
   private

--- a/src/api/app/models/bs_request_action_delete.rb
+++ b/src/api/app/models/bs_request_action_delete.rb
@@ -33,38 +33,22 @@ class BsRequestActionDelete < BsRequestAction
   end
 
   def sourcediff(opts = {})
-    raise DiffError, "Project diff isn't implemented yet" unless target_package || target_repository
-    return '' unless target_package
-
-    begin
-      options = { expand: 1, filelimit: 0, rev: 0 }
-      options[:view] = 'xml' if opts[:view] == 'xml' # Request unified diff in full XML view
-      Backend::Api::Sources::Package.source_diff(target_project, target_package, options)
-    rescue Timeout::Error
-      raise DiffError, "Timeout while diffing #{target_project}/#{target_package}"
-    rescue Backend::Error => e
-      raise DiffError, "The diff call for #{target_project}/#{target_package} failed: #{e.summary}"
+    if target_repository
+      repository_remove_diff(view: opts[:view])
+    elsif target_project && target_package
+      get_sourcediff(target_project: target_project, target_package: target_package, view: opts[:view])
+    elsif target_project && !target_package
+      project_remove_diff(view: opts[:view])
     end
   end
 
   def execute_accept(opts)
     if target_repository
-      remove_repository(opts)
-      return
-    end
-
-    if target_package
-      package = Package.get_by_project_and_name(target_project, target_package, follow_project_links: false)
-      package.commit_opts = { comment: bs_request.description, request: bs_request }
-      package.destroy
-      Package.source_path(target_project, target_package)
-    else
-      project = Project.get_by_name(target_project)
-      commit_opts_user = bs_request.creator if bs_request.accept_at
-      commit_opts_user = bs_request.approver if bs_request.approver
-      project.commit_opts = { comment: bs_request.description, request: bs_request, login: commit_opts_user }
-      project.destroy
-      "/source/#{target_project}"
+      remove_target_repository(comment: opts[:comment], lowprio: opts[:lowprio])
+    elsif target_project && target_package
+      remove_target_package(comment: opts[:comment])
+    elsif target_project && !target_package
+      remove_target_project(comment: opts[:comment])
     end
   end
 
@@ -84,16 +68,66 @@ class BsRequestActionDelete < BsRequestAction
 
   private
 
-  def remove_repository(opts)
-    prj = Project.get_by_name(target_project)
-    r = prj.repositories.find_by_name(target_repository)
-    raise RepositoryMissing, "The repository #{target_project} / #{target_repository} does not exist" unless r
+  def remove_target_project(comment: nil)
+    # no need to break complex requests if a project has been removed already
+    return "/source/#{target_project}" unless target_project_object
 
-    r.destroy
-    prj.store(lowprio: opts[:lowprio], comment: opts[:comment], request: bs_request)
+    target_project_object.commit_opts = { comment: comment, request: bs_request }.compact
+    target_project_object.commit_user = commit_user if commit_user
+    target_project_object.destroy
+    "/source/#{target_project}"
   end
 
-  #### Alias of methods
+  def remove_target_package(comment: nil)
+    raise Package::UnknownObjectError, "Package not found: #{target_project}/#{target_package}" unless target_package_object
+
+    target_package_object.commit_opts = { comment: comment, request: bs_request }.compact
+    target_package_object.commit_user = commit_user if commit_user
+    target_package_object.destroy
+    Package.source_path(target_project, target_package)
+  end
+
+  def remove_target_repository(comment: nil, lowprio: nil)
+    raise Project::UnknownObjectError, "Project not found: #{target_project}" unless target_project_object
+
+    repository = target_project_object.repositories.find_by(name: target_repository)
+    raise RepositoryMissing, "Repository not found: #{target_project} / #{target_repository}" unless repository
+
+    repository.destroy
+    target_project_object.commit_opts = { comment: comment, request: bs_request, lowprio: lowprio }.compact
+    target_project_object.commit_user = commit_user if commit_user
+    target_project_object.store
+    "/source/#{target_project}"
+  end
+
+  def repository_remove_diff(view:)
+    if view == 'xml'
+      ''
+    else
+      "- Removal of repository '#{target_repository}'"
+    end
+  end
+
+  def project_remove_diff(view:)
+    if view == 'xml'
+      ''
+    else
+      "- Removal of project '#{target_project}'"
+    end
+  end
+
+  def commit_user
+    bs_request.creator if bs_request.accept_at
+    bs_request.approver if bs_request.approver
+  end
+
+  def get_sourcediff(target_project:, target_package:, view: nil)
+    Backend::Api::Sources::Package.source_diff(target_project, target_package, { expand: 1, filelimit: 0, rev: 0, view: view })
+  rescue Timeout::Error
+    raise DiffError, "Timeout while diffing #{target_project}/#{target_package}"
+  rescue Backend::Error => e
+    raise DiffError, "The diff call for #{target_project}/#{target_package} failed: #{e.summary}"
+  end
 end
 
 # == Schema Information

--- a/src/api/app/models/bs_request_action_maintenance_incident.rb
+++ b/src/api/app/models/bs_request_action_maintenance_incident.rb
@@ -62,6 +62,7 @@ class BsRequestActionMaintenanceIncident < BsRequestAction
     # copy all or selected packages and project source files from base project
     # we don't branch from it to keep the link target.
     pkg = _merge_pkg_into_maintenance_incident(incident_project)
+    return unless pkg
 
     incident_project.save!
     incident_project.store(comment: "maintenance_incident request #{bs_request.number}", request: bs_request)
@@ -112,8 +113,69 @@ class BsRequestActionMaintenanceIncident < BsRequestAction
     "Incident #{source_package}"
   end
 
+  def modify_sources(enforce_branching: true)
+    # is branch enforcement a policy?
+    return unless enforce_branching || Attrib.find_by_container_and_fullname(target_project_object, 'OBS:EnforceIncidentRequestStaging')
+
+    # create package
+    pkg = _merge_pkg_into_maintenance_incident(stage_project_object)
+    return unless pkg
+
+    # adapt request action
+    self.source_project = stage_project_object.name
+    self.source_package = pkg.name
+    self.source_rev = pkg.backend_package.srcmd5 if source_rev.present?
+    # create channels
+    pkg.add_channels(:enable_all)
+    # create patchinfo unless we have one
+    return if PackageKind.exists?(package: stage_project_object.packages, kind: 'patchinfo')
+
+    Patchinfo.new.create_patchinfo_from_request(stage_project_object, bs_request)
+  end
+
   private
 
+  def find_or_create_stage_project
+    return Project.get_by_name(stage_project_name) if Project.exists?(name: stage_project_name)
+
+    create_stage_project
+  end
+  alias stage_project_object find_or_create_stage_project
+
+  def stage_project_name
+    # enforce a request number and use this as branch area
+    bs_request.assign_number
+    "#{maintenance_project.name}:REQUEST:#{bs_request.number}"
+  end
+
+  def create_autocleanup_attribute(project:)
+    at = AttribType.find_by_namespace_and_name!('OBS', 'AutoCleanup')
+    a = Attrib.new(project: project, attrib_type: at)
+    a.values << AttribValue.new(value: (Time.now.to_i + ::Configuration.cleanup_after_days.days), position: 1)
+    a.save
+  end
+
+  def create_stage_project
+    stage_project = Project.create(name: stage_project_name, title: 'Enforce branch project for maintenance incident request')
+    stage_project.flags.create(status: 'disable', flag: 'build')
+    stage_project.flags.create(status: 'disable', flag: 'publish')
+    stage_project.flags.create(status: 'disable', flag: 'access') if source_project_object && source_project_object.disabled_for?('access', nil, nil)
+    # copy maintainer
+    maintainer_role = Role.find_by_title!('maintainer')
+    maintenance_project.relationships.where(role: maintainer_role).find_each do |role|
+      stage_project.relationships.new(role: maintainer_role, user_id: role.user_id, group_id: role.group_id)
+    end
+    stage_project.relationships.new(role: maintainer_role, user_id: User.session!.id)
+    stage_project.store
+    # autocleanup attribute in case request gets not accepted
+    create_autocleanup_attribute(project: stage_project)
+    # remove project on accept in any case
+    bs_request.bs_request_actions << BsRequestActionDelete.new({ target_project: stage_project_name })
+
+    stage_project
+  end
+
+  # rubocop:disable Metrics/CyclomaticComplexity
   def _merge_pkg_into_maintenance_incident(incident_project)
     # recreate package based on link target and throw everything away, except source changes
     # silently as maintenance teams requests ...
@@ -154,7 +216,7 @@ class BsRequestActionMaintenanceIncident < BsRequestAction
                         force: 1,
                         newinstance: 1,
                         comment: 'Initial new branch from specified release project',
-                        project: target_releaseproject, package: package_name }
+                        project: target_releaseproject, package: package_name }.compact
       # accept branching from former update incidents or GM (for kgraft case)
       linkprj = Project.find_by_name(linkinfo['project']) if linkinfo
       if defined?(linkprj) && linkprj && (linkprj.maintenance_incident? || linkprj != linkprj.update_instance_or_self || kinds.include?('channel'))
@@ -178,7 +240,7 @@ class BsRequestActionMaintenanceIncident < BsRequestAction
                         maintenance: 1,
                         force: 1,
                         comment: 'Initial new branch',
-                        project: linked_project, package: linked_package }
+                        project: linked_project, package: linked_package }.compact
       ret = BranchPackage.new(branch_params).branch
       new_pkg = Package.get_by_project_and_name(ret[:data][:target_project], ret[:data][:target_package])
     elsif linkinfo && linkinfo['package'] # a new package for all targets
@@ -195,21 +257,20 @@ class BsRequestActionMaintenanceIncident < BsRequestAction
     end
 
     # backend copy of submitted sources, but keep link
-    cp_params = {
-      requestid: bs_request.number,
-      keeplink: 1,
-      expand: 1,
-      withacceptinfo: 1,
-      comment: "Maintenance incident copy from project #{source_project}"
-    }
+    cp_params = { requestid: bs_request.number,
+                  keeplink: 1,
+                  expand: 1,
+                  comment: "Maintenance incident copy from project #{source_project}" }.compact
+    cp_params[:withacceptinfo] = 1 if cp_params[:requestid]
     cp_params[:orev] = source_rev if source_rev
     response = Backend::Api::Sources::Package.copy(incident_project.name, new_pkg.name, source_project, source_package, User.session&.login, cp_params)
     result = Xmlhash.parse(response)
-    fill_acceptinfo(result['acceptinfo'])
+    fill_acceptinfo(result['acceptinfo']) if bs_request.number && new_pkg.project.maintenance_incident?
 
     new_pkg.sources_changed
     new_pkg
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   #### Alias of methods
 end

--- a/src/api/app/models/bs_request_permission_check.rb
+++ b/src/api/app/models/bs_request_permission_check.rb
@@ -45,6 +45,9 @@ class BsRequestPermissionCheck
     req.bs_request_actions.each do |action|
       set_permissions_for_action(action)
 
+      # all others are no-op
+      next unless action.maintenance_incident?
+
       raise TargetNotMaintenance, 'The target project is already an incident, changing is not possible via set_incident' if @target_project.maintenance_incident?
       raise TargetNotMaintenance, "The target project is not of type maintenance but #{@target_project.kind}" unless @target_project.kind == 'maintenance'
 

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -1028,7 +1028,7 @@ class Project < ApplicationRecord
 
     return unless disable_publish_for_branches
 
-    flags.create(status: 'disable', flag: 'publish') unless flags.find_by_flag_and_status('publish', 'disable')
+    flags.find_or_create_by(status: 'disable', flag: 'publish')
   end
 
   def open_requests_with_project_as_source_or_target

--- a/src/api/db/attribute_descriptions.rb
+++ b/src/api/db/attribute_descriptions.rb
@@ -27,6 +27,7 @@ def update_all_attrib_type_descriptions
     'EmbargoDate' => 'A timestamp until outgoing requests can not get accepted.',
     'PlannedReleaseDate' => 'A timestamp for the planned release date of an incident.',
     'MakeOriginOlder' => 'Initialize packages by making the build results newer then updated ones',
+    'EnforceIncidentRequestStaging' => 'Will create new projects to submit maintenance incidents requests',
     'DelegateRequestTarget' => 'Delegate the target project of requests even when target_project is specified',
     'AllowSubmitToMaintenanceRelease' => 'Allow submit requests to maintenance release projects',
     'EnforceRevisionsInRequests' => 'Enforce revisions in request actions',

--- a/src/api/db/data/20260821163526_add_enforce_incident_request_staging_attribute.rb
+++ b/src/api/db/data/20260821163526_add_enforce_incident_request_staging_attribute.rb
@@ -1,0 +1,20 @@
+require_relative '../attribute_descriptions'
+
+class AddEnforceIncidentRequestStagingAttribute < ActiveRecord::Migration[6.0]
+  def self.up
+    ans = AttribNamespace.find_by_name('OBS')
+
+    AttribTypeModifiableBy.reset_column_information
+
+    at = AttribType.find_or_create_by!(attrib_namespace: ans, name: 'EnforceIncidentRequestStaging')
+
+    role = Role.find_by_title!('maintainer')
+    AttribTypeModifiableBy.find_or_create_by!(role_id: role.id, attrib_type_id: at.id)
+
+    update_all_attrib_type_descriptions
+  end
+
+  def self.down
+    AttribType.find_by_namespace_and_name('OBS', 'EnforceIncidentRequestStaging').delete
+  end
+end

--- a/src/api/db/data_schema.rb
+++ b/src/api/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 2026_07_28_131917)
+DataMigrate::Data.define(version: 2026_08_21_163526)

--- a/src/api/db/seeds.rb
+++ b/src/api/db/seeds.rb
@@ -154,6 +154,8 @@ at = ans.attrib_types.where(name: 'IncidentPriority').first_or_create(value_coun
 at.attrib_type_modifiable_bies.where(user_id: admin.id).first_or_create
 at = ans.attrib_types.where(name: 'EmbargoDate').first_or_create(value_count: 1)
 at.attrib_type_modifiable_bies.where(role_id: maintainer_role.id).first_or_create
+at = ans.attrib_types.where(name: 'EnforceIncidentRequestStaging').first_or_create(value_count: 0)
+at.attrib_type_modifiable_bies.where(role_id: maintainer_role.id).first_or_create
 at = ans.attrib_types.where(name: 'DelegateRequestTarget').first_or_create
 at.attrib_type_modifiable_bies.where(role_id: maintainer_role.id).first_or_create
 at = ans.attrib_types.where(name: 'AllowSubmitToMaintenanceRelease').first_or_create

--- a/src/api/test/fixtures/attrib_types.yml
+++ b/src/api/test/fixtures/attrib_types.yml
@@ -152,5 +152,12 @@ OBS_RejectBranch:
 OBS_LimitReleaseSourceProject:
   id: 86
   name: LimitReleaseSourceProject
+  value_count: 0
+  attrib_namespace_id: 9
+  issue_list: 0
+OBS_EnforceIncidentRequestStaging:
+  id: 87
+  name: EnforceIncidentRequestStaging
+  value_count: 0
   attrib_namespace_id: 9
   issue_list: 0

--- a/src/api/test/functional/maintenance_test.rb
+++ b/src/api/test/functional/maintenance_test.rb
@@ -352,6 +352,68 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  def test_maintenance_request_enforce_branching
+    login_king
+    # special kdelibs
+    put '/source/BaseDistro2.0:LinkedUpdateProject/kdelibs/_meta', params: "<package name='kdelibs'><title/><description/></package>"
+    assert_response :success
+    put '/source/BaseDistro2.0:LinkedUpdateProject/kdelibs/empty', params: 'NOOP'
+    assert_response :success
+
+    login_tom
+    # create maintenance request for one package from a unrelated project
+    post '/request?cmd=create&addrevision=1&enforce_branching=1', params: '<request>
+                                   <action type="maintenance_incident">
+                                     <source project="kde4" package="kdelibs" />
+                                     <target project="My:Maintenance" releaseproject="BaseDistro2.0:LinkedUpdateProject" />
+                                   </action>
+                                   <description>To fix my bug</description>
+                                   <state name="new" />
+                                 </request>'
+    assert_response :success
+    node = Xmlhash.parse(@response.body)
+    assert node['id']
+    reqid = node['id']
+    branch_project = "My:Maintenance:REQUEST:#{reqid}"
+    assert_xml_tag(tag: 'target', attributes: { project: 'My:Maintenance', releaseproject: 'BaseDistro2.0:LinkedUpdateProject' })
+    assert_xml_tag(tag: 'source', attributes: { project: branch_project, package: 'kdelibs.BaseDistro2.0_LinkedUpdateProject' })
+    assert_no_xml_tag(tag: 'acceptinfo')
+    assert_xml_tag(parent: { tag: 'action', attributes: { type: 'delete' } },
+                   tag: 'target', attributes: { project: "My:Maintenance:REQUEST:#{reqid}" })
+
+    # validate that request is diffable (not broken)
+    post "/request/#{reqid}?cmd=diff&view=xml"
+    assert_response :success
+    # the diffed packages
+    assert_xml_tag(tag: 'old', attributes: { project: 'BaseDistro2.0:LinkedUpdateProject', package: 'kdelibs' })
+    assert_xml_tag(tag: 'new', attributes: { project: branch_project, package: 'kdelibs.BaseDistro2.0_LinkedUpdateProject' })
+
+    get "/source/#{branch_project}/_meta"
+    assert_response :success
+    assert_xml_tag(tag: 'disable', parent: { tag: 'build' })
+    assert_xml_tag(tag: 'disable', parent: { tag: 'publish' })
+
+    get "/source/#{branch_project}/patchinfo/_meta"
+    assert_response :success
+    assert_xml_tag(tag: 'enable', parent: { tag: 'build' })
+    assert_xml_tag(tag: 'enable', parent: { tag: 'publish' })
+
+    get "/source/#{branch_project}/kdelibs.BaseDistro2.0_LinkedUpdateProject/_meta"
+    assert_response :success
+    assert_xml_tag(tag: 'enable', parent: { tag: 'build' }, attributes: { repository: 'BaseDistro2.0_LinkedUpdateProject' })
+
+    get "/source/#{branch_project}"
+    assert_response :success
+    assert_xml_tag(tag: 'directory', attributes: { count: '2' })
+    get "/source/#{branch_project}/kdelibs.BaseDistro2.0_LinkedUpdateProject/_link"
+    assert_response :success
+    assert_xml_tag(tag: 'link', attributes: { project: 'BaseDistro2.0:LinkedUpdateProject', package: 'kdelibs' })
+
+    # cleanup
+    delete "/source/#{branch_project}"
+    assert_response :success
+  end
+
   def test_OBS_BranchTarget
     login_king
     put '/source/ServicePack/_meta', params: "<project name='ServicePack'><title/><description/><link project='kde4'/></project>"


### PR DESCRIPTION
To create or to enforce staged maintenace submissions as part of
maintenance_incident request actions.

This can be used either on demand when creating the request by
user or can be enforced in the maintenance project by creating
OBS:EnforceIncidentRequestStaging attribute

Still waiting from feedback from maintenance team. So not merging before I hear from their experience, but to ensure that we do not forget about it.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
