### PR TITLE
[backend] clean up publisher side of source publishing feature

### DIFF
--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -1625,7 +1625,11 @@ sub deleterepo {
   # also delete the split debug repo
   deleterepo($projid, $repoid, $repoinfo->{'splitdebug'}) if $repoinfo->{'splitdebug'} && !$dbgsplit;
 
-  if (!$dbgsplit && $BSConfig::packtrack && (($repoinfo->{'projectkind'} || '') eq 'maintenance_release' || grep {$prp =~ /^$_/} @$BSConfig::packtrack)) {
+  my $do_packtrack;
+  if ($BSConfig::packtrack && (($repoinfo->{'projectkind'} || '') eq 'maintenance_release' || grep {$prp =~ /^$_/} @$BSConfig::packtrack)) {
+    $do_packtrack = 1;
+  }
+  if (!$dbgsplit && $do_packtrack) {
     my $packtrack = {};
     print "    sending binary release tracking notification\n";
     BSNotify::notify('PACKTRACK', { project => $projid , 'repo' => $repoid }, Storable::nfreeze([ map { $packtrack->{$_} } sort keys %$packtrack ]));
@@ -1656,7 +1660,7 @@ sub mapsleimage {
 }
 
 sub publish {
-  my ($projid, $repoid, $dbgsplit, $dbgpacktrack) = @_;
+  my ($projid, $repoid, $dbgsplit, $dbgpacktrack, $dbgsources) = @_;
   my $prp = "$projid/$repoid";
   BSUtil::printlog("publishing $prp");
   my $starttime = time();
@@ -1718,7 +1722,7 @@ sub publish {
 
   # do we need to do source publishing?
   my $do_sourcepublish;
-  if ($BSConfig::sourcepublish_sync) {
+  if ($BSConfig::sourcepublish_sync || $BSConfig::sourcepublish_sync) {
     if ($BSConfig::sourcepublish_filter) {
       $do_sourcepublish = 1 if grep {$prp =~ /^$_/} @$BSConfig::sourcepublish_filter;
     } else {
@@ -2423,10 +2427,10 @@ sub publish {
   my $sources;
   if ($do_packtrack || $do_sourcepublish) {
     $packtrack = $dbgpacktrack || {};
+    $sources = $dbgsources || {};
     my %cache = @{$packtrackcache || []};
     for my $bin (sort keys %{ { %bins, %containers } }) {
       my $reportfile;
-      my $sourceid;
       if ($bin =~ /\.(?:$binsufsre)$/) {
 	my $res;
 	my @s = stat("$extrep/$bin");
@@ -2451,30 +2455,22 @@ sub publish {
 	    $res->{'cpeid'} = BSHTTP::urldecode($cpeid);
 	  }
 	}
-
-        if ($do_sourcepublish && $res->{disturl} =~ /^obs:\/\/[^\/]*\/([^\/]*)\/[^\/]*\/([^-]*)-(.*)/) {
-          $sourceid = "$1/$3/$2";
-        }
-
-        # packtrack specific code
-        if ($do_packtrack) {
-	  my $pt = { 'project' => $projid, 'repository' => $repoid };
-	  $pt->{'arch'} = $1 if $bins{$bin} =~ /^\Q$reporoot\E\/\Q$prp\E\/([^\/]+)\//;
-	  $pt->{'package'} = $binaryorigins->{$bin} if $binaryorigins->{$bin};
-	  for (qw{name epoch version release disturl buildtime}) {
-	    $pt->{$_} = $res->{$_} if defined $res->{$_};
-	  }
-	  $pt->{'binaryarch'} = $res->{'arch'} if defined $res->{'arch'};
-	  $pt->{'binaryid'} = $res->{'hdrmd5'} if defined $res->{'hdrmd5'};
-	  $pt->{'id'} = "$bin/$s[9]/$s[7]/$s[1]";
-	  $pt->{'cpeid'} = $res->{'cpeid'} if $res->{'cpeid'};
-	  $packtrack->{$bin} = $pt;
-	  if ($pt->{'arch'}) {
-	    $reportfile = $bin;
-	    $reportfile =~ s/.*\///;    # basename
-	    $reportfile = "$pt->{'arch'}/$reportfile";
-	  }
-        }
+	my $pt = { 'project' => $projid, 'repository' => $repoid };
+	$pt->{'arch'} = $1 if $bins{$bin} =~ /^\Q$reporoot\E\/\Q$prp\E\/([^\/]+)\//;
+	$pt->{'package'} = $binaryorigins->{$bin} if $binaryorigins->{$bin};
+	for (qw{name epoch version release disturl buildtime}) {
+	  $pt->{$_} = $res->{$_} if defined $res->{$_};
+	}
+	$pt->{'binaryarch'} = $res->{'arch'} if defined $res->{'arch'};
+	$pt->{'binaryid'} = $res->{'hdrmd5'} if defined $res->{'hdrmd5'};
+	$pt->{'id'} = "$bin/$s[9]/$s[7]/$s[1]";
+	$pt->{'cpeid'} = $res->{'cpeid'} if $res->{'cpeid'};
+	$packtrack->{$bin} = $pt;
+	if ($pt->{'arch'}) {
+	  $reportfile = $bin;
+	  $reportfile =~ s/.*\///;    # basename
+	  $reportfile = "$pt->{'arch'}/$reportfile";
+	}
       }
 
       # track containers
@@ -2494,11 +2490,7 @@ sub publish {
 	}
         $pt->{'binaryid'} = $containerinfo->{'imageid'} if $containerinfo->{'imageid'};
 	$pt->{'ismedium'} = $medium;
-	$packtrack->{$bin} = $pt if $do_packtrack;
-
-        if ($do_sourcepublish && $pt->{disturl} =~ /^obs:\/\/[^\/]*\/([^\/]*)\/[^\/]*\/([^-]*)-(.*)/) {
-          $sourceid = "$1/$3/$2";
-        }
+	$packtrack->{$bin} = $pt;
       }
 
       # track images and kiwi products
@@ -2506,30 +2498,30 @@ sub publish {
 	my $medium = $bin;
 	$medium =~ s/.*\///;	# basename
 	my $report = $kiwireport{$kiwimedium{$bin}};
-
-        if ($do_sourcepublish && $report->{'disturl'} =~ /^obs:\/\/[^\/]*\/([^\/]*)\/[^\/]*\/([^-]*)-(.*)/) {
-          $sourceid = "$1/$3/$2";
-        }
-
-        if ($do_packtrack) {
-	  my $pt = { 'project' => $projid, 'repository' => $repoid };
-	  $pt->{'arch'} = (split('/', $kiwimedium{$bin}, 2))[0];
-	  $pt->{'package'} = $binaryorigins->{$bin} if $binaryorigins->{$bin};
-	  $pt->{'name'} = $medium;	# hmm...
-	  $pt->{'version'} = defined($report->{'version'}) ? $report->{'version'} : '0';
-	  $pt->{'release'} = defined($report->{'release'}) ? $report->{'release'} : '0';
-	  $pt->{'binaryarch'} = $report->{'binaryarch'} || $pt->{'arch'} || 'noarch';
-	  $pt->{'buildtime'} = $report->{'buildtime'} if $report->{'buildtime'};
-	  $pt->{'cpeid'} = BSHTTP::urldecode($report->{'cpeid'}) if $report->{'cpeid'};
-	  # need a way to get disturl, buildtime and binaryid...
-	  $pt->{'disturl'} = $report->{'disturl'} if $report->{'disturl'};
-	  $pt->{'ismedium'} = $medium;
-	  $packtrack->{$bin} = $pt;
-        }
+	my $pt = { 'project' => $projid, 'repository' => $repoid };
+	$pt->{'arch'} = (split('/', $kiwimedium{$bin}, 2))[0];
+	$pt->{'package'} = $binaryorigins->{$bin} if $binaryorigins->{$bin};
+	$pt->{'name'} = $medium;	# hmm...
+	$pt->{'version'} = defined($report->{'version'}) ? $report->{'version'} : '0';
+	$pt->{'release'} = defined($report->{'release'}) ? $report->{'release'} : '0';
+	$pt->{'binaryarch'} = $report->{'binaryarch'} || $pt->{'arch'} || 'noarch';
+	$pt->{'buildtime'} = $report->{'buildtime'} if $report->{'buildtime'};
+	$pt->{'cpeid'} = BSHTTP::urldecode($report->{'cpeid'}) if $report->{'cpeid'};
+	# need a way to get disturl, buildtime and binaryid...
+	$pt->{'disturl'} = $report->{'disturl'} if $report->{'disturl'};
+	$pt->{'ismedium'} = $medium;
+	$packtrack->{$bin} = $pt;
       }
 
-      # adds a published source entry
-      $sources->{$sourceid} = [] if $sourceid;
+      # add a published source entry
+      my $sourceid;
+      if ($do_sourcepublish) {
+        my $pt = $packtrack->{$bin};
+        if ($pt->{'disturl'} && $pt->{'disturl'} =~ /^obs:\/\/[^\/]*\/([^\/]*)\/[^\/]*\/([^-]*)-(.*)$/) {
+	  $sourceid = "$1/$3/$2";
+	  $sources->{$sourceid} = [];
+        }
+      }
 
       # check if there is a report associated with this binary
       # this adds the content to the referenced binary
@@ -2546,11 +2538,10 @@ sub publish {
 	  $pt->{'medium'} = $medium;
 	  my $fn = '';
 	  $fn .= "/".(defined($pt->{$_}) ? $pt->{$_} : '') for qw{binaryarch name epoch version release};
-	  $packtrack->{"$medium$fn"} = $pt if $do_packtrack;
-
-          if ($sourceid && $pt->{disturl} =~ /^obs:\/\/[^\/]*\/([^\/]*)\/[^\/]*\/([^-]*)-(.*)/) {
-            push @{$sources->{$sourceid}}, "$1/$3/$2";
-          }
+	  $packtrack->{"$medium$fn"} = $pt;
+	  if ($sourceid && $pt->{'disturl'} && $pt->{disturl} =~ /^obs:\/\/[^\/]*\/([^\/]*)\/[^\/]*\/([^-]*)-(.*)$/) {
+	    push @{$sources->{$sourceid}}, "$1/$3/$2";
+	  }
 	}
       }
     }
@@ -2856,7 +2847,7 @@ publishprog_done:
   }
 
   # recurse for dbgsplit
-  publish($projid, $repoid, $repoinfo->{'splitdebug'}, $packtrack) if $repoinfo->{'splitdebug'} && !$dbgsplit;
+  publish($projid, $repoid, $repoinfo->{'splitdebug'}, $packtrack, $sources) if $repoinfo->{'splitdebug'} && !$dbgsplit;
 
   if ($packtrack && !$dbgsplit) {
     # update the packtrack cache (and remove the 'id' entry)
@@ -2873,12 +2864,15 @@ publishprog_done:
       @newcache = ();	# free mem
       undef $repoinfo;	# free mem
     }
+  }
+
+  if ($do_packtrack && $packtrack && !$dbgsplit) {
     # send notification
     print "    sending binary release tracking notification\n";
     BSNotify::notify('PACKTRACK', { project => $projid , 'repo' => $repoid }, Storable::nfreeze([ map { $packtrack->{$_} } sort keys %$packtrack ]));
   }
 
-  if ($sources && !$dbgsplit) {
+  if ($do_sourcepublish && $sources && %$sources && !$dbgsplit) {
     print "    sending source publish notification\n";
     BSNotify::notify('sourcepublish', { project => $projid , 'repo' => $repoid }, BSUtil::tostorable($sources));
   }


### PR DESCRIPTION
- fix handling of debug repositories
- use packtrack cache to speed up generation of the source data

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
