### PR TITLE
Use long options in rake tasks dev:lint:rubocop:{rails,root}

### DIFF
--- a/src/api/lib/tasks/dev.rake
+++ b/src/api/lib/tasks/dev.rake
@@ -81,13 +81,13 @@ namespace :dev do
 
       desc 'Run the ruby linter in rails'
       task :rails do
-        sh 'rubocop', '-D', '-F', '-S', '--fail-level', 'convention', '--ignore_parent_exclusion'
+        sh 'rubocop', '--fail-fast', '--display-style-guide', '--fail-level', 'convention', '--ignore_parent_exclusion'
       end
 
       desc 'Run the ruby linter in root'
       task :root do
         Dir.chdir('../..') do
-          sh 'rubocop', '-D', '-F', '-S', '--fail-level', 'convention'
+          sh 'rubocop', '--fail-fast', '--display-style-guide', '--fail-level', 'convention'
         end
       end
 


### PR DESCRIPTION
It's easy to understand what options do.

The option `-D` is used to display cop names in offense message, but [this is already the default](https://rubocop.readthedocs.io/en/latest/basic_usage/#command-line-flags). It's redundant, so we removed it.