### PR TITLE
Ccache relasename and first archive

### DIFF
--- a/src/backend/BSSched/BuildJob.pm
+++ b/src/backend/BSSched/BuildJob.pm
@@ -1046,7 +1046,9 @@ sub create {
   unshift @bdeps, @{$info->{'dep'} || []}, @btdeps, @{$ctx->{'extradeps'} || []};
   push @bdeps, '--ignoreignore--' if @sysdeps || $buildtype eq 'simpleimage';
   if ($packid && exists($bconf->{'buildflags:useccache'}) && ($buildtype eq 'arch' || $buildtype eq 'spec' || $buildtype eq 'dsc')) {
-    if (grep {$_ eq "useccache:$packid"} @{$bconf->{'buildflags'} || []}) {
+    my $opackid = $packid;
+    $opackid = $pdata->{'releasename'} if $pdata->{'releasename'};
+    if (grep {$_ eq "useccache:$opackid" || $_ eq "useccache:$packid"} @{$bconf->{'buildflags'} || []}) {
       push @bdeps, @{$bconf->{'substitute'}->{'build-packages:ccache'} || [ 'ccache' ] };
     }
   }

--- a/src/backend/BSSched/BuildJob.pm
+++ b/src/backend/BSSched/BuildJob.pm
@@ -546,6 +546,11 @@ sub jobfinished {
     BSUtil::appendstr("$dst/logfile", "\nRetried build at ".localtime(time())." returned same result, skipped\n");
     my $jobhist = makejobhist($info, $status, $js, 'unchanged');
     addbuildstats($jobdatadir, $dst, $jobhist) if $all{'_statistics'};
+
+    my $ccachetar = "$jobdatadir/_ccache.tar";
+    my $occachetar = "$dst/_ccache.tar";
+    rename($ccachetar, $occachetar) if $all{'_ccache.tar'} && !-e $occachetar;
+
     unlink("$gdst/:logfiles.fail/$packid");
     rename($meta, "$gdst/:meta/$packid") if $meta;
     unlink($_) for @all;

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -4102,6 +4102,12 @@ if (!$ex) {
   $code = 'unchanged';
   my $statsfile = "$buildroot/.build.packages/OTHER/_statistics";
   push @send, {name => '_statistics', filename => $statsfile} if -e $statsfile;
+
+  # ccache is enabled and there is no tar from previous builds,
+  # this is a good ccache archive and should be used for subsequent builds.
+  my $ccachetar = "$buildroot/.build.packages/OTHER/_ccache.tar";
+  my $occachetar = "$buildroot/.build.oldpackages/_ccache.tar";
+  push @send, {name => '_ccache.tar', filename => $ccachetar} if -e $ccachetar && !-e $occachetar;
 } elsif ($ex == 3 && $buildinfo->{'nobadhost'}) {
   print "build failed (ignored bad build host flag)...\n";
   BSUtil::appendstr("$buildroot/.build.log", "\n$buildinfo->{'nobadhost'}\n");


### PR DESCRIPTION
Commit 1:
use releasename too to decide ccache as buildrequirement
this is in continuation to d5352ff

Commit 2:
store the first _ccache.tar for unchanged results
it is better to store ccache archive even in case of unchanged builds if
it is the first archive created.
this is a corner case - ccache is enabled, but the built result is same as
last successful result when ccache was not enabled.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
