### PR TITLE
Specify case_sensitive on uniqueness validations

### DIFF
--- a/src/api/app/models/architecture.rb
+++ b/src/api/app/models/architecture.rb
@@ -19,7 +19,7 @@ class Architecture < ApplicationRecord
   scope :unavailable, -> { where(available: 0) }
 
   #### Validations macros
-  validates :name, uniqueness: true
+  validates :name, uniqueness: { case_sensitive: false }
   validates :name, presence: true
 
   #### Class methods using self. (public and then private)

--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -32,6 +32,7 @@ class BsRequestAction < ApplicationRecord
   validates :type, presence: true
   validates :type, uniqueness: {
     scope: [:target_project, :target_package, :bs_request_id],
+    case_sensitive: false,
     conditions: -> { where.not(type: ['add_role', 'maintenance_incident']) }
   }
 

--- a/src/api/app/models/cloud/ec2/configuration.rb
+++ b/src/api/app/models/cloud/ec2/configuration.rb
@@ -23,7 +23,7 @@ module Cloud
       belongs_to :user
 
       validates :external_id, uniqueness: true
-      validates :arn, uniqueness: true, allow_nil: true
+      validates :arn, uniqueness: { case_sensitive: true }, allow_nil: true
       # http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
       validates :arn, format: { with: /\Aarn:([\w\/:* +=,.@\-_])+\z/, message: 'not a valid format', allow_blank: true }
 

--- a/src/api/app/models/download_repository.rb
+++ b/src/api/app/models/download_repository.rb
@@ -4,7 +4,7 @@ class DownloadRepository < ApplicationRecord
   belongs_to :repository
 
   validates :repository, presence: true
-  validates :arch, uniqueness: { scope: :repository_id }, presence: true
+  validates :arch, uniqueness: { scope: :repository_id, case_sensitive: false }, presence: true
   validate :architecture_inclusion
   validates :url, presence: true, format: { with: /\A[a-zA-Z]+:.*\Z/ } # from backend/BSVerify.pm
   validates :repotype, presence: true

--- a/src/api/app/models/flag.rb
+++ b/src/api/app/models/flag.rb
@@ -19,7 +19,7 @@ class Flag < ApplicationRecord
 
   validate :validate_custom_save
 
-  validates :flag, uniqueness: { scope: [:project_id, :package_id, :architecture_id, :repo] }
+  validates :flag, uniqueness: { scope: [:project_id, :package_id, :architecture_id, :repo], case_sensitive: false }
 
   def to_xml(builder)
     raise "FlagError: No flag-status set. \n #{inspect}" if status.nil?

--- a/src/api/app/models/group.rb
+++ b/src/api/app/models/group.rb
@@ -27,7 +27,7 @@ class Group < ApplicationRecord
                       allow_nil: false }
   # We want to validate a group's title pretty thoroughly.
   validates :title,
-            uniqueness: { message: 'is the name of an already existing group' }
+            uniqueness: { case_sensitive: true, message: 'is the name of an already existing group' }
 
   # groups have a n:m relation to groups
   has_and_belongs_to_many :roles, -> { distinct }

--- a/src/api/app/models/issue_tracker.rb
+++ b/src/api/app/models/issue_tracker.rb
@@ -8,7 +8,7 @@ class IssueTracker < ApplicationRecord
   end
 
   validates :name, :regex, :url, :kind, presence: true
-  validates :name, :regex, uniqueness: true
+  validates :name, :regex, uniqueness: { case_sensitive: true }
   validates :kind, inclusion: { in: ['other', 'bugzilla', 'cve', 'fate', 'trac', 'launchpad', 'sourceforge', 'github', 'jira'] }
   validates :description, presence: true
   validates :show_url, presence: true

--- a/src/api/app/models/kiwi/profile.rb
+++ b/src/api/app/models/kiwi/profile.rb
@@ -23,6 +23,7 @@ module Kiwi
     validates :selected, inclusion: { in: [true, false] }
     validates :name, uniqueness: {
       scope: :image,
+      case_sensitive: false,
       message: lambda do |object, data|
         "#{data[:value]} has already been taken for the Image ##{object.image_id}"
       end

--- a/src/api/app/models/kiwi/repository.rb
+++ b/src/api/app/models/kiwi/repository.rb
@@ -19,7 +19,7 @@ module Kiwi
     #### Scopes (first the default_scope macro if is used)
 
     #### Validations macros
-    validates :alias, :source_path, uniqueness: { scope: :image, message: "'%{value}' has already been taken" }, allow_blank: true
+    validates :alias, :source_path, uniqueness: { scope: :image, case_sensitive: true, message: "'%{value}' has already been taken" }, allow_blank: true
     validates :source_path, presence: { message: 'can\'t be nil' }
     validate :source_path_format
     validates :priority, numericality: { only_integer: true, allow_nil: true, greater_than_or_equal_to: 0,

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -121,7 +121,7 @@ class Project < ApplicationRecord
     ProjectsWithVeryImportantAttributeFinder.new.call
   }
 
-  validates :name, presence: true, length: { maximum: 200 }, uniqueness: true
+  validates :name, presence: true, length: { maximum: 200 }, uniqueness: { case_sensitive: true }
   validates :title, length: { maximum: 250 }
   validate :valid_name
 

--- a/src/api/app/models/repository.rb
+++ b/src/api/app/models/repository.rb
@@ -30,6 +30,7 @@ class Repository < ApplicationRecord
   # Note that remote repositories have to be unique among their remote project (remote_project_name)
   # and the associated db_project.
   validates :name, uniqueness: { scope: [:db_project_id, :remote_project_name],
+                                 case_sensitive: true,
                                  message: '%{value} is already used by a repository of this project' }
 
   validates :project, presence: true

--- a/src/api/app/models/static_permission.rb
+++ b/src/api/app/models/static_permission.rb
@@ -10,7 +10,7 @@ class StaticPermission < ApplicationRecord
 
   # We want to validate a static permission's title pretty thoroughly.
   validates :title,
-            uniqueness: { message: 'is the name of an already existing static permission' }
+            uniqueness: { case_sensitive: false, message: 'is the name of an already existing static permission' }
   validates :title, presence: { message: 'must be given.' }
 
   validates :title, format: { with: %r{\A[\w\-]*\z},

--- a/src/api/app/models/status/check.rb
+++ b/src/api/app/models/status/check.rb
@@ -16,7 +16,7 @@ class Status::Check < ApplicationRecord
     message: "State '%{value}' is not a valid. Valid states are: #{VALID_STATES.join(', ')}"
   }
 
-  validates :name, uniqueness: { scope: :status_report }
+  validates :name, uniqueness: { scope: :status_report, case_sensitive: true }
 
   #### Associations macros (Belongs to, Has one, Has many)
   belongs_to :status_report, class_name: 'Status::Report', foreign_key: 'status_reports_id'

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -92,7 +92,7 @@ class User < ApplicationRecord
   validates :login, :state, presence: { message: 'must be given' }
 
   validates :login,
-            uniqueness: { message: 'is the name of an already existing user' }
+            uniqueness: { case_sensitive: true, message: 'is the name of an already existing user' }
 
   validates :login,
             format: { with: %r{\A[\w $\^\-.#*+&'"]*\z},

--- a/src/api/spec/models/architecture_spec.rb
+++ b/src/api/spec/models/architecture_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Architecture do
   it { is_expected.to validate_presence_of(:name) }
-  it { is_expected.to validate_uniqueness_of(:name) }
+  it { is_expected.to validate_uniqueness_of(:name).case_insensitive }
 
   describe '#worker' do
     let(:i586) { Architecture.find_by(name: 'i586') }

--- a/src/api/spec/models/download_repository_spec.rb
+++ b/src/api/spec/models/download_repository_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe DownloadRepository do
     it { is_expected.to validate_presence_of(:arch) }
     it { is_expected.to validate_presence_of(:repotype) }
     it { is_expected.to validate_presence_of(:repository) }
-    it { is_expected.to validate_uniqueness_of(:arch).scoped_to(:repository_id) }
+    it { is_expected.to validate_uniqueness_of(:arch).scoped_to(:repository_id).case_insensitive }
 
     it do
       expect(subject).to validate_inclusion_of(:repotype).in_array(['rpmmd', 'susetags', 'deb', 'arch', 'mdk'])


### PR DESCRIPTION
Uniqueness validation has been `case_sensitive: true` by default. From Rails 6.1 on, the default will be false so we have to specify the opposite to avoid deprecation warnings and malfunction in the future.

The concept can be a bit confusing, but `case_sensitive: true` means: the validation is going to check if an object with the same value and the **same capitalization** already exists.

Example:
If we have this validation in the Project's model
```validates :name, uniqueness: { case_sensitive: true }```
This means a project with "lorem" name and another project with "LOREM" name can be both created. Because the validation is taking capitalization into account.


Some has been considered case insensitive for the following reasons.
- it makes sense according to the values and usage,
- they contain fixed values added by developers and not users,
- they create indexes in database that crash with equal values using
different capitalization.

Closes #9439

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
