### PR TITLE
Remove word-break break-all from flash messages and announcement

### DIFF
--- a/src/api/app/views/layouts/webui/webui.html.haml
+++ b/src/api/app/views/layouts/webui/webui.html.haml
@@ -51,7 +51,7 @@
           .col-auto.ml-auto#personal-navigation
             = render partial: 'layouts/webui/personal_navigation'
 
-    .container-xxl.sticky-top.flash-and-announcement.text-word-break-all
+    .container-xxl.sticky-top.flash-and-announcement.text-break
       = render partial: 'layouts/webui/status_message_announcement', locals: { current_announcement: @current_announcement }
       #flash= render partial: 'layouts/webui/flash', object: flash
     .modal.fade#modal{ tabindex: '-1', role: 'dialog', aria: { labelledby: 'modalLabel', hidden: true } }


### PR DESCRIPTION
The break-all style just breaks the lines between letters. This
makes the annoucements unpleasent to read.
Leaving the default and breaking the lines between the words
is the better option.

**Before**
![Screenshot_2020-06-05 openSUSE Build Service](https://user-images.githubusercontent.com/22001671/83888122-b509f000-a749-11ea-8b51-00e8319a99f9.png)

**After**
![Screenshot_2020-06-05 Open Build Service](https://user-images.githubusercontent.com/22001671/83888150-bdfac180-a749-11ea-8b1f-d923b2b44ba5.png)


<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
