### PR TITLE
Disable CircleCI completely on the 2.9 branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,8 @@
+version: 2.0
+
+# Disable CircleCI completely on the 2.9 branch
+jobs:
+  build:
+    branches:
+      ignore:
+        - /.*/


### PR DESCRIPTION
On 2.9, our continuous integration is Travis CI.

While working on #9629, I've noticed that CircleCI is trying to start even though we don't have a config for it in the branch. This is somewhat confusing, so we instead disable CircleCI since we're not using it anyway for any branch targeting `2.9`.