### PR TITLE
Remove unneeded enabling of RuboCop pending cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,15 +31,6 @@ Layout/DotPosition:
 Layout/EndAlignment:
   EnforcedStyleAlignWith: variable
 
-#################### Lint ###########################
-
-# New cops added between major versions need to be enabled manually.
-# https://docs.rubocop.org/en/stable/versioning/#pending-cops
-Lint/RaiseException:
-  Enabled: true
-Lint/StructNewOverride:
-  Enabled: true
-
 #################### Style ###########################
 
 Style/Alias:

--- a/src/api/.rubocop.yml
+++ b/src/api/.rubocop.yml
@@ -17,15 +17,6 @@ AllCops:
     - 'files/*'
     - 'db/data_schema.rb'
 
-#################### Lint ###########################
-
-# New cops added between major versions need to be enabled manually.
-# https://docs.rubocop.org/en/stable/versioning/#pending-cops
-Lint/RaiseException:
-  Enabled: true
-Lint/StructNewOverride:
-  Enabled: true
-
 #################### Style ###########################
 
 # We need to allow some variables related to rabbiMQ.


### PR DESCRIPTION
Since we enable pending cops by default (commit 1484283), this isn't needed anymore.