### PR TITLE
Address RuboCop offenses in Haml views

### DIFF
--- a/src/api/.haml-lint.yml
+++ b/src/api/.haml-lint.yml
@@ -34,29 +34,6 @@ linters:
       - Style/IfUnlessModifier
       - Style/Next
       - Style/WhileUntilModifier
-    # FIXME: Address offenses in the following views
-    exclude:
-      - "app/views/webui/monitor/_building.html.haml"
-      - "app/views/webui/monitor/_building_table.html.haml"
-      - "app/views/webui/monitor/_stats.html.haml"
-      - "app/views/webui/package/_commit_item.html.haml"
-      - "app/views/webui/package/_file.html.haml"
-      - "app/views/webui/package/_fileinfo.html.haml"
-      - "app/views/webui/package/_linking_packages.html.haml"
-      - "app/views/webui/package/_side_links.html.haml"
-      - "app/views/webui/package/side_links/_show_developed_packages.html.haml"
-      - "app/views/webui/package/statistics.html.haml"
-      - "app/views/webui/packages/job_history/index.html.haml"
-      - "app/views/webui/project/_side_links.html.haml"
-      - "app/views/webui/project/_tabs.html.haml"
-      - "app/views/webui/project/side_links/_incident_project.html.haml"
-      - "app/views/webui/project/side_links/_requests.html.haml"
-      - "app/views/webui/projects/rebuild_times/show.html.haml"
-      - "app/views/webui/projects/status/show.html.haml"
-      - "app/views/webui/repositories/state.html.haml"
-      - "app/views/webui/request/_issues_table.html.haml"
-      - "app/views/webui/staging/projects/_history_elements.html.haml"
-      - "app/views/webui/staging/workflows/_problems.html.haml"
 
 exclude:
 - 'vendor/bundle/**/*'

--- a/src/api/app/views/webui/monitor/_building.html.haml
+++ b/src/api/app/views/webui/monitor/_building.html.haml
@@ -2,7 +2,7 @@
 - build_count = worker_status.elements('building').length
 #building-all
   %h2 Building
-  - if build_count > 0
+  - if build_count.positive?
     %p.info Hover the job time field to see the start time.
     %p.info
       = configuration_title

--- a/src/api/app/views/webui/monitor/_building_table.html.haml
+++ b/src/api/app/views/webui/monitor/_building_table.html.haml
@@ -33,7 +33,7 @@
                   \-------
                 - else
                   = link_to(repository + ' - ' + architecture, package_live_build_log_path(project, package, repository, architecture))
-              - start_time = Time.at(building['starttime'].to_i)
+              - start_time = Time.zone.at(building['starttime'].to_i)
               - warning_style = nil
               - if start_time < dead_line
                 :ruby

--- a/src/api/app/views/webui/monitor/_stats.html.haml
+++ b/src/api/app/views/webui/monitor/_stats.html.haml
@@ -23,5 +23,5 @@
           %td.avgjobtime
             - worker_status.elements('buildavg') do |build_avg|
               - if build_avg['arch'] == entrywaiting['arch']
-                - outbuildavg = distance_of_time_in_words(Time.at(build_avg['buildavg'].to_i), Time.at(0), include_seconds: true)
+                - outbuildavg = distance_of_time_in_words(Time.zone.at(build_avg['buildavg'].to_i), Time.zone.at(0), include_seconds: true)
             = outbuildavg || ' - '

--- a/src/api/app/views/webui/package/_commit_item.html.haml
+++ b/src/api/app/views/webui/package/_commit_item.html.haml
@@ -15,7 +15,7 @@
   - else
     committed
 
-  %u= fuzzy_time(Time.at(commit['time'].to_i))
+  %u= fuzzy_time(Time.zone.at(commit['time'].to_i))
 
   (revision #{commit['rev']})
 

--- a/src/api/app/views/webui/package/_file.html.haml
+++ b/src/api/app/views/webui/package/_file.html.haml
@@ -9,7 +9,7 @@
     %span.d-none= file[:size].rjust(10, '0')
     = human_readable_fsize(file[:size])
   %td.text-nowrap{ data: { order: "-#{file[:mtime]}" } }
-    = time_ago_in_words(Time.at(file[:mtime].to_i))
+    = time_ago_in_words(Time.zone.at(file[:mtime].to_i))
   / limit download for anonymous user to avoid getting killed by crawlers
   %td.text-center
     - if !nobody || file[:size].to_i < 4.megabytes

--- a/src/api/app/views/webui/package/_fileinfo.html.haml
+++ b/src/api/app/views/webui/package/_fileinfo.html.haml
@@ -26,7 +26,7 @@
 
   %dt.col-md-2.text-truncate Build Time
   %dd.col-md-10
-    - btime = Time.at(fileinfo.value('mtime').to_i)
+    - btime = Time.zone.at(fileinfo.value('mtime').to_i)
     #{btime} (#{fuzzy_time_string(btime.ctime)})
 
 = render partial: 'deps', locals: { fileinfo: fileinfo,

--- a/src/api/app/views/webui/package/_linking_packages.html.haml
+++ b/src/api/app/views/webui/package/_linking_packages.html.haml
@@ -8,11 +8,11 @@
           - package.linking_packages.each do |linking_package|
             :ruby
               # FIXME: get rid of these helpers
-              if linking_package.name != package.name
-                name = elide_two(linking_package.project.name, linking_package.name, 46).join(' / ')
-              else
-                name = elide(linking_package.project.name, 46)
-              end
+              name = if linking_package.name != package.name
+                       elide_two(linking_package.project.name, linking_package.name, 46).join(' / ')
+                     else
+                       elide(linking_package.project.name, 46)
+                     end
             %li= link_to(name, package_show_path(project: linking_package.project.name, package: linking_package.name))
       .modal-footer
         %a.btn.btn-sm.btn-outline-danger.px-4{ data: { dismiss: 'modal' } }

--- a/src/api/app/views/webui/package/_side_links.html.haml
+++ b/src/api/app/views/webui/package/_side_links.html.haml
@@ -1,5 +1,5 @@
 %ul.list-unstyled
-  - if failures > 0
+  - if failures.positive?
     = render partial: 'webui/package/side_links/show_failures', locals: { failures: failures, package_name: package.name, project: project }
 
   - if devel_package

--- a/src/api/app/views/webui/package/side_links/_show_developed_packages.html.haml
+++ b/src/api/app/views/webui/package/side_links/_show_developed_packages.html.haml
@@ -2,5 +2,5 @@
   %i.fas.fa-info-circle.text-info
   Devel package for
   - developed_packages.each_with_index do |pkg, index|
-    = ',' if index > 0
+    = ',' if index.positive?
     = link_to(elide(pkg.project.name, 40), package_show_path(project: pkg.project.name, package: pkg.name))

--- a/src/api/app/views/webui/package/statistics.html.haml
+++ b/src/api/app/views/webui/package/statistics.html.haml
@@ -24,7 +24,7 @@
                 %strong Sectors read or written:
                 = disk.io_sectors
         - memory = @statistics.memory
-        - if memory && memory.size
+        - if memory&.size
           .col-md-4
             %h3 Memory Statistics
             %p

--- a/src/api/app/views/webui/packages/job_history/index.html.haml
+++ b/src/api/app/views/webui/packages/job_history/index.html.haml
@@ -28,7 +28,7 @@
             %td
               = jobhistory.ready_time
             %td
-              = time_tag(Time.at(jobhistory.ready_time))
+              = time_tag(Time.zone.at(jobhistory.ready_time))
             %td
               - if jobhistory.reason == 'source change'
                 = link_to(jobhistory.reason, package_rdiff_path(project: @project.name,

--- a/src/api/app/views/webui/project/_side_links.html.haml
+++ b/src/api/app/views/webui/project/_side_links.html.haml
@@ -4,7 +4,7 @@
                                                                                 project: project,
                                                                                 maintained_projects: maintained_projects }
   - else
-    - if nr_of_problem_packages && nr_of_problem_packages.positive?
+    - if nr_of_problem_packages&.positive?
       = render partial: 'webui/project/side_links/project_monitor', locals: { project: project,
                                                                               nr_of_problem_packages: nr_of_problem_packages }
 

--- a/src/api/app/views/webui/project/_tabs.html.haml
+++ b/src/api/app/views/webui/project/_tabs.html.haml
@@ -22,7 +22,7 @@
       - active = controller_path.starts_with?('webui/staging')
       - if project.staging_project?
         = tab_link('Staging', staging_workflow_path(project.staging_workflow.project), false, 'scrollable-tab-link')
-      - elsif project.staging && project.staging.persisted?
+      - elsif project.staging&.persisted?
         = tab_link('Staging', staging_workflow_path(project), active, 'scrollable-tab-link')
       - elsif policy(Staging::Workflow.new(project: project)).create?
         = tab_link('Staging', new_staging_workflow_path(project: project), active, 'scrollable-tab-link')
@@ -65,7 +65,7 @@
         - if project.staging_project?
           %li.nav-item
             = tab_link('Staging', staging_workflow_path(project.staging_workflow.project))
-        - elsif project.staging && project.staging.persisted?
+        - elsif project.staging&.persisted?
           -# If Staging::Workflow.new(...) is executed below, project.staging will be a new object.
             It will be persisted if the project is really a staging workflow project.
           %li.nav-item

--- a/src/api/app/views/webui/project/side_links/_incident_project.html.haml
+++ b/src/api/app/views/webui/project/side_links/_incident_project.html.haml
@@ -6,11 +6,11 @@
 - if open_release_requests.present?
   %li
     :ruby
-      if open_release_requests.length == 1
-        path = request_show_path(open_release_requests.first)
-      else
-        path = project_requests_path(project, type: 'maintenance_release')
-      end
+      path = if open_release_requests.length == 1
+               request_show_path(open_release_requests.first)
+             else
+               project_requests_path(project, type: 'maintenance_release')
+             end
     %i.fas.fa-flag.text-success
     = link_to(path) do
       = pluralize(open_release_requests.length, 'release request')

--- a/src/api/app/views/webui/project/side_links/_requests.html.haml
+++ b/src/api/app/views/webui/project/side_links/_requests.html.haml
@@ -1,12 +1,12 @@
 %li
   :ruby
-    if requests.size == 1
-      path = request_show_path(requests.first)
-    elsif package
-      path = package_requests_path(project, package)
-    else
-      path = project_requests_path(project)
-    end
+    path = if requests.size == 1
+             request_show_path(requests.first)
+           elsif package
+             package_requests_path(project, package)
+           else
+             project_requests_path(project)
+           end
   %i.fa.fa-info-circle.text-info
   = link_to(path) do
     = pluralize(requests.size, 'open request')

--- a/src/api/app/views/webui/projects/rebuild_times/show.html.haml
+++ b/src/api/app/views/webui/projects/rebuild_times/show.html.haml
@@ -10,7 +10,7 @@
   .card-body
     %h3
       Rebuildtime:
-      = distance_of_time_in_words(Time.now, Time.now - @rebuildtime)
+      = distance_of_time_in_words(Time.zone.now, Time.zone.now - @rebuildtime)
       (#{format_seconds(@rebuildtime)})
     %p
       %img.rebuildgraph{ alt: 'Rebuild time graph', src: rebuild_time_png_project_rebuild_time_path(project_name: @project, key: @pngkey) }/
@@ -28,7 +28,7 @@
     %h3 Longest Paths
     %table.grid_16.alpha.omega
       %tbody
-        - while p1.size + p2.size + p3.size > 0
+        - while (p1.size + p2.size + p3.size).positive?
           %tr
             %td= rebuild_time_col(p1.shift)
             %td= rebuild_time_col(p2.shift)

--- a/src/api/app/views/webui/projects/status/show.html.haml
+++ b/src/api/app/views/webui/projects/status/show.html.haml
@@ -33,7 +33,7 @@
       .mt-4
         %p
           Displaying #{@packages.size} packages that need handling, including:
-          #{@packages.count { |p| p['firstfail'].to_i > 0 }} not building,
+          #{@packages.count { |p| p['firstfail'].to_i.positive? }} not building,
           #{@packages.count { |p| !p['problems'].empty? }} with a diff in the devel project,
           #{@packages.count { |p| !p['requests_to'].empty? || !p['requests_from'].empty? }} with a pending request.
 

--- a/src/api/app/views/webui/repositories/state.html.haml
+++ b/src/api/app/views/webui/repositories/state.html.haml
@@ -13,7 +13,7 @@
     - @repository.architectures.each do |arch|
       - cycles = @repository.cycles(arch.name)
       - cycles.each_with_index do |cycle, index|
-        - if index == 0
+        - if index.zero?
           %h5
             Cycles for #{arch.name} (##{cycle.length})
         %ul

--- a/src/api/app/views/webui/request/_issues_table.html.haml
+++ b/src/api/app/views/webui/request/_issues_table.html.haml
@@ -12,7 +12,7 @@
             - if issue[:owner]
               = user_with_realname_and_icon issue[:owner], short: true
           %td
-            = issue[:state].capitalize if issue[:state]
+            = issue[:state]&.capitalize
       - else
         %tr.even
           %td{ colspan: '3' }

--- a/src/api/app/views/webui/staging/projects/_history_elements.html.haml
+++ b/src/api/app/views/webui/staging/projects/_history_elements.html.haml
@@ -10,6 +10,6 @@
         by
         %b= element.user_name
       - when 'staging_project_created'
-        %b #{time_ago_in_words(Time.at(element.datetime.to_i))} ago
+        %b #{time_ago_in_words(Time.zone.at(element.datetime.to_i))} ago
         by
         %b= element.user_name

--- a/src/api/app/views/webui/staging/workflows/_problems.html.haml
+++ b/src/api/app/views/webui/staging/workflows/_problems.html.haml
@@ -16,7 +16,7 @@
     - build_problems.each do |name, states|
       = render partial: 'build_problems', locals: { name: name, states: states, staging_project: staging_project }
     - remain_count = remaining_checks.length + remaining_build_problems.length
-    - if remain_count > 0
+    - if remain_count.positive?
       %span.collapse{ 'id': item_project_class }
         - remaining_checks.each do |check|
           = render partial: 'status_problems', locals: { check: check }


### PR DESCRIPTION
Registered offenses were for these:
- Rails/TimeZone
- Style/ConditionalAssignment
- Style/NumericPredicate
- Style/SafeNavigation

This is a follow-up to #9711. The offenses in views which were excluded in the commit `Exclude views with RuboCop offenses` are now addressed.