### PR TITLE
Do not assert_match for specific error messages

### DIFF
--- a/src/api/test/unit/validator_test.rb
+++ b/src/api/test/unit/validator_test.rb
@@ -4,70 +4,59 @@ require 'opensuse/validator'
 
 class ValidatorTest < ActiveSupport::TestCase
   def test_validator
-    exception = assert_raise ArgumentError do
+    assert_raise ArgumentError do
       Suse::Validator.validate 'notthere'
     end
-    assert_match('wrong number of arguments (given 1, expected 2)', exception.message)
 
-    exception = assert_raise RuntimeError do
+    assert_raise RuntimeError do
       # passing garbage
       Suse::Validator.validate [], ''
     end
-    assert_match(/illegal option/, exception.message)
 
-    exception = assert_raise ArgumentError do
+    assert_raise ArgumentError do
       # no action, no schema
       Suse::Validator.validate controller: :project
     end
-    assert_match('wrong number of arguments (given 1, expected 2)', exception.message)
 
     request = ActionController::TestRequest.create({})
-    exception = assert_raise Suse::ValidationError do
+    assert_raise Suse::ValidationError do
       Suse::Validator.validate 'link', request.raw_post.to_s
     end
-    assert_match(/Document is empty/, exception.message)
 
     request.env['RAW_POST_DATA'] = '<link test="invalid"/>'
-    exception = assert_raise Suse::ValidationError do
+    assert_raise Suse::ValidationError do
       Suse::Validator.validate 'link', request.raw_post.to_s
     end
-    assert_match(/Invalid attribute test for element link/, exception.message)
 
     request.env['RAW_POST_DATA'] = '<link test"invalid"/>'
-    exception = assert_raise Suse::ValidationError do
+    assert_raise Suse::ValidationError do
       Suse::Validator.validate 'link', request.raw_post.to_s
     end
-    assert_match(/Extra content at the end of the document/, exception.message)
 
     request.env['RAW_POST_DATA'] = '<link test="invalid">'
-    exception = assert_raise Suse::ValidationError do
+    assert_raise Suse::ValidationError do
       Suse::Validator.validate 'link', request.raw_post.to_s
     end
-    assert_match(/EndTag: '<\/' not found/, exception.message)
 
     request.env['RAW_POST_DATA'] = '<link test="invalid"></ink>'
-    exception = assert_raise Suse::ValidationError do
+    assert_raise Suse::ValidationError do
       Suse::Validator.validate 'link', request.raw_post.to_s
     end
-    assert_match(/Opening and ending tag mismatch/, exception.message)
 
     request.env['RAW_POST_DATA'] = '<link test="invalid" fun="foo"/>'
-    exception = assert_raise Suse::ValidationError do
+    assert_raise Suse::ValidationError do
       Suse::Validator.validate 'link', request.raw_post.to_s
     end
-    assert_match(/Invalid attribute test for element link/, exception.message)
 
     request.env['RAW_POST_DATA'] = '<link test="invalid">foo</link>'
-    exception = assert_raise Suse::ValidationError do
+    assert_raise Suse::ValidationError do
       Suse::Validator.validate 'link', request.raw_post.to_s
     end
-    assert_match(/Did not expect text in element link content/, exception.message)
 
     request.env['RAW_POST_DATA'] = '<link test="invalid"><foo/></link>'
-    exception = assert_raise Suse::ValidationError do
+    assert_raise Suse::ValidationError do
       Suse::Validator.validate 'link', request.raw_post.to_s
     end
-    assert_match(/Did not expect element foo there/, exception.message)
 
     # projects can be anything
     request.env['RAW_POST_DATA'] = '<link project="invalid"/>'


### PR DESCRIPTION
This is causing inconsistencies in tests between the continuous integration and the appliance. The culprit is the test which was changed in the commit 28fb40fce6. The error message is not important. The error is still raised with a slightly different message and this is perfectly fine.