### PR TITLE
Remove gem mousetrap-rails

### DIFF
--- a/dist/obs-bundled-gems.spec
+++ b/dist/obs-bundled-gems.spec
@@ -149,8 +149,6 @@ rm -rf %{buildroot}%_libdir/obs-api/ruby/*/gems/diff-lcs-*/bin
 # and often cause errors / warning in rpmlint
 rm -rf %{buildroot}%_libdir/obs-api/ruby/*/gems/*/spec/
 rm -rf %{buildroot}%_libdir/obs-api/ruby/*/gems/*/test/
-# we do not verify signing of the gem
-rm -rf %{buildroot}%_libdir/obs-api/ruby/*/gems/mousetrap-rails-*/gem-public_cert.pem
 
 # remove prebuilt binaries causing broken dependencies
 rm -rf %{buildroot}%_libdir/obs-api/ruby/*/gems/selenium-webdriver-*/lib/selenium/webdriver/firefox/native

--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -53,8 +53,6 @@ gem 'activemodel-serializers-xml'
 gem 'voight_kampff'
 # support coffeescript
 gem 'coffee-rails'
-# bind keyboard shortcuts to actions
-gem 'mousetrap-rails'
 # for issue tracker communication
 gem 'xmlrpc'
 # Multiple feature switch

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -253,7 +253,6 @@ GEM
       minitest (>= 5.0)
       ruby-progressbar
     mocha (1.11.2)
-    mousetrap-rails (1.4.6)
     mysql2 (0.5.3)
     nio4r (2.5.2)
     nokogiri (1.10.9)
@@ -506,7 +505,6 @@ DEPENDENCIES
   minitest-fail-fast
   minitest-reporters
   mocha (> 0.13.0)
-  mousetrap-rails
   mysql2
   nokogiri
   pry (>= 0.9.12)


### PR DESCRIPTION
We don't use it.

Going through its documentation makes it pretty clear that we use none of its features: https://kugaevsky.github.io/mousetrap-rails/