### PR TITLE
Remove gem cssmin

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -188,8 +188,6 @@ end
 
 # Gems used only for assets and not required in production environments by default.
 group :assets do
-  # for minifying CSS
-  gem 'cssmin', '>= 1.0.2'
   # for minifying JavaScript
   gem 'uglifier', '>= 1.2.2'
   # to use sass in the asset pipeline

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -135,7 +135,6 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.6)
-    cssmin (1.0.3)
     daemons (1.3.1)
     dalli (2.7.10)
     data_migrate (6.3.0)
@@ -476,7 +475,6 @@ DEPENDENCIES
   coffee-rails
   colorize
   coveralls
-  cssmin (>= 1.0.2)
   daemons
   dalli
   data_migrate


### PR DESCRIPTION
We don't use it.

This is how it's used and we don't do that:
https://github.com/rgrove/cssmin/blob/60e7050744a0fc18ecd79ad49c64f250ad28e0a7/lib/cssmin.rb#L43-L46