### PR TITLE
Remove gem coffee-rails

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -51,8 +51,6 @@ gem 'colorize', require: false
 gem 'activemodel-serializers-xml'
 # Spider Identification
 gem 'voight_kampff'
-# support coffeescript
-gem 'coffee-rails'
 # for issue tracker communication
 gem 'xmlrpc'
 # Multiple feature switch

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -117,13 +117,6 @@ GEM
       simplecov
       url
     coderay (1.1.3)
-    coffee-rails (5.0.0)
-      coffee-script (>= 2.2.0)
-      railties (>= 5.2.0)
-    coffee-script (2.4.1)
-      coffee-script-source
-      execjs
-    coffee-script-source (1.12.2)
     colorize (0.8.1)
     concurrent-ruby (1.1.6)
     coveralls (0.8.23)
@@ -471,7 +464,6 @@ DEPENDENCIES
   cocoon
   codecov
   coderay
-  coffee-rails
   colorize
   coveralls
   daemons


### PR DESCRIPTION
We don't have any CoffeeScript files.

There are some CoffeeScript-related files for CodeMirror, but it's a mode for editing CoffeeScript which is completely unrelated.
