### PR TITLE
Align `Add file` link text and adapt tests

### DIFF
--- a/dist/t/spec/features/0040_package_spec.rb
+++ b/dist/t/spec/features/0040_package_spec.rb
@@ -26,9 +26,9 @@ RSpec.describe "Package" do
       click_link('Home Project')
     end
     click_link('hello_world')
-    click_link('Add file')
+    click_link('Add File')
     attach_file("file", File.expand_path('../fixtures/hello_world.spec', __dir__), make_visible: true)
-    click_button('Add file')
+    click_button('Add File')
     expect(page).to have_content("The file 'hello_world.spec' has been successfully saved.")
   end
 

--- a/src/api/app/views/webui/package/_files_view.html.haml
+++ b/src/api/app/views/webui/package/_files_view.html.haml
@@ -20,7 +20,7 @@
     .pt-4
       = link_to(new_project_package_files_path(project, package)) do
         %i.fas.fa-plus-circle.text-primary
-        Add file
+        Add File
     = render(partial: 'delete_file_dialog', locals: { project: project, package: package })
 - unless files.blank? || spider_bot
   - if revision.present?

--- a/src/api/spec/features/beta/webui/packages_spec.rb
+++ b/src/api/spec/features/beta/webui/packages_spec.rb
@@ -186,7 +186,7 @@ RSpec.describe 'Packages', type: :feature, js: true, vcr: true do
     login user
 
     visit package_show_path(project: user.home_project, package: package)
-    click_link('Add file')
+    click_link('Add File')
 
     fill_in 'Filename', with: 'new_file'
     click_button('Add File')
@@ -199,7 +199,7 @@ RSpec.describe 'Packages', type: :feature, js: true, vcr: true do
     login user
 
     visit package_show_path(project: user.home_project, package: package)
-    click_link('Add file')
+    click_link('Add File')
 
     fill_in 'Filename', with: 'inv/alid'
     click_button('Add File')

--- a/src/api/spec/features/webui/packages_spec.rb
+++ b/src/api/spec/features/webui/packages_spec.rb
@@ -185,7 +185,7 @@ RSpec.describe 'Packages', type: :feature, js: true, vcr: true do
     login user
 
     visit package_show_path(project: user.home_project, package: package)
-    click_link('Add file')
+    click_link('Add File')
 
     fill_in 'Filename', with: 'new_file'
     click_button('Add File')
@@ -198,7 +198,7 @@ RSpec.describe 'Packages', type: :feature, js: true, vcr: true do
     login user
 
     visit package_show_path(project: user.home_project, package: package)
-    click_link('Add file')
+    click_link('Add File')
 
     fill_in 'Filename', with: 'inv/alid'
     click_button('Add File')


### PR DESCRIPTION
For consistency we renamed `Add file` to `Add File`.
We also adapted the features tests and openQA tests.

### Before
![Screenshot_2020-06-11 multifile(1)](https://user-images.githubusercontent.com/1212806/84374139-dd786b00-abdd-11ea-81c8-620cd3d2cd3a.png)


### After
![Screenshot_2020-06-11 multifile](https://user-images.githubusercontent.com/1212806/84374153-e23d1f00-abdd-11ea-9a9d-e1f925d25ccf.png)
