### PR TITLE
Replace sanitize with rails-html-sanitizer

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -35,8 +35,6 @@ gem 'acts_as_list'
 gem 'xmlhash', '>=1.3.6'
 # to escape HTML (FIXME: do we still use this?)
 gem 'escape_utils'
-# to sanitize HTML/CSS
-gem 'sanitize'
 # as authorization system
 gem 'pundit'
 # for password hashing

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -256,8 +256,6 @@ GEM
     nio4r (2.5.2)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
-    nokogumbo (2.0.2)
-      nokogiri (~> 1.8, >= 1.8.4)
     parallel (1.19.1)
     parser (2.7.1.3)
       ast (~> 2.4.0)
@@ -367,10 +365,6 @@ GEM
       sexp_processor (~> 4.9)
     rubyzip (2.3.0)
     safe_yaml (1.0.5)
-    sanitize (5.2.0)
-      crass (~> 1.0.2)
-      nokogiri (>= 1.8.0)
-      nokogumbo (~> 2.0)
     sassc (2.4.0)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
@@ -522,7 +516,6 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rspec
   ruby-ldap
-  sanitize
   sassc-rails
   selenium-webdriver
   shoulda-matchers (~> 4.0)

--- a/src/api/lib/obsapi/markdown_renderer.rb
+++ b/src/api/lib/obsapi/markdown_renderer.rb
@@ -24,9 +24,8 @@ module OBSApi
 
     def block_html(raw_html)
       # sanitize the HTML we get
-      Sanitize.fragment(raw_html, Sanitize::Config.merge(Sanitize::Config::RESTRICTED,
-                                                         elements: Sanitize::Config::RESTRICTED[:elements] + ['pre'],
-                                                         remove_contents: true))
+      scrubber = Rails::Html::PermitScrubber.new.tap { |a| a.tags = ['b', 'em', 'i', 'strong', 'u', 'pre'] }
+      Rails::Html::SafeListSanitizer.new.sanitize(raw_html, scrubber: scrubber)
     end
 
     # unfortunately we can't call super (into C) - see vmg/redcarpet#51


### PR DESCRIPTION
This allows us to remove the gem "sanitize" since it's now unused.

We don't remove anymore the content of tags which are removed, so the inner text stays. It could be done, but it would involve using `Loofah` which is what `rails-html-sanitizer` builds upon. I prefer to keep it simple and keeping the inner text is fine.

I've used the same tags as `Sanitize::Config::RESTRICTED[:elements] + ['pre']`.