### PR TITLE
Do not fail when acknowledging twice

### DIFF
--- a/src/api/app/controllers/webui/status_messages_controller.rb
+++ b/src/api/app/controllers/webui/status_messages_controller.rb
@@ -33,13 +33,16 @@ class Webui::StatusMessagesController < Webui::WebuiController
 
   def acknowledge
     status_message = StatusMessage.find(params[:id])
-    if status_message.acknowledge!
-      RabbitmqBus.send_to_bus('metrics', "user.acknowledged_status_message status_message_id=#{status_message.id}")
-    else
-      flash.now[:error] = "Could not accept status message: #{status_message.errors.full_messages.to_sentence}"
-    end
+    collect_metrics(status_message) if status_message.acknowledge!
+
     respond_to do |format|
       format.js { render controller: 'status_message', action: 'acknowledge' }
     end
+  end
+
+  private
+
+  def collect_metrics(status_message)
+    RabbitmqBus.send_to_bus('metrics', "user.acknowledged_status_message status_message_id=#{status_message.id}")
   end
 end

--- a/src/api/app/models/status_message.rb
+++ b/src/api/app/models/status_message.rb
@@ -28,7 +28,14 @@ class StatusMessage < ApplicationRecord
   end
 
   def acknowledge!
+    return false if acknowledged?
+
     users << User.session!
+    true
+  end
+
+  def acknowledged?
+    users.include?(User.session!)
   end
 
   def self.latest_for_current_user

--- a/src/api/spec/models/status_message_spec.rb
+++ b/src/api/spec/models/status_message_spec.rb
@@ -126,4 +126,43 @@ RSpec.describe StatusMessage do
       end
     end
   end
+
+  describe '#acknowledge!' do
+    context 'when there is a previous acknowledgement' do
+      let(:user) { create(:confirmed_user, in_beta: true, in_rollout: false) }
+      let!(:status_message) { create(:status_message, severity: 'announcement', communication_scope: :all_users) }
+
+      before do
+        login(user)
+        status_message.acknowledge!
+      end
+
+      subject(:acknowledge) { status_message.acknowledge! }
+
+      it 'does not raise an exception while acknowledging the status message twice' do
+        expect { acknowledge }.not_to raise_error
+      end
+
+      it 'returns false' do
+        expect(acknowledge).to be false
+      end
+    end
+  end
+
+  describe 'acknowledged?' do
+    let(:user) { create(:confirmed_user, in_beta: true, in_rollout: false) }
+    let!(:status_message) { create(:status_message, severity: 'announcement', communication_scope: :all_users) }
+
+    before { login(user) }
+
+    context 'when the status message is not acknowledged yet' do
+      it { expect(status_message.acknowledged?).to be false }
+    end
+
+    context 'when the status message is already acknowledged' do
+      before { status_message.acknowledge! }
+
+      it { expect(status_message.acknowledged?).to be true }
+    end
+  end
 end


### PR DESCRIPTION
Now an exception is raised when acknowledging an already acknowledged status message.

This PR makes OBS ignore a re-acknowledging. OBS will show an error to the user only when the failure is something else.

Fixes #9714 