### PR TITLE
Address deprecation warning regarding scoping

### DIFF
--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -75,7 +75,7 @@ class User < ApplicationRecord
   scope :not_deleted, -> { where.not(state: 'deleted') }
   scope :not_locked, -> { where.not(state: 'locked') }
   scope :with_login_prefix, ->(prefix) { where('login LIKE ?', "#{prefix}%") }
-  scope :active, -> { confirmed.or(User.where(state: :subaccount, owner: User.confirmed)) }
+  scope :active, -> { confirmed.or(User.unscoped.where(state: :subaccount, owner: User.unscoped.confirmed)) }
   scope :staff, -> { joins(:roles).where('roles.title = ?', 'Staff') }
   scope :not_staff, -> { where.not(id: User.staff.pluck(:id)) }
   scope :admins, -> { joins(:roles).where('roles.title = ?', 'Admin') }

--- a/src/api/app/queries/projects_with_image_templates_finder.rb
+++ b/src/api/app/queries/projects_with_image_templates_finder.rb
@@ -1,5 +1,5 @@
 class ProjectsWithImageTemplatesFinder < AttribFinder
-  def initialize(relation = Project.all, namespace = 'OBS', name = 'ImageTemplates')
+  def initialize(relation = Project.default_scoped, namespace = 'OBS', name = 'ImageTemplates')
     super(relation, namespace, name)
   end
 end


### PR DESCRIPTION
Having the following warning:

"[...] Class level methods will no longer inherit scoping
from `<scope name>` in Rails 6.1.
To continue using the scoped relation, pass it into the block directly.
To instead access the full set of models, as Rails 6.1 will, use
`<model>.unscoped`, or `<model>.default_scoped` if a model has default scopes.
[...]"

It is addressed by adding .unscoped or .default_scoped when needed.

Closes #9442

This PR addresses two of the three deprecation warnings included in the issue. As soon as this gets approved, I can apply the same fix to other similar existing scopes.
 
<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
