### PR TITLE
Address deprecation warning on render_xml

### DIFF
--- a/src/api/app/mixins/can_render_model.rb
+++ b/src/api/app/mixins/can_render_model.rb
@@ -3,9 +3,7 @@
 # and use my_model to access the model instead of self
 module CanRenderModel
   def render_xml(locals = {})
-    action_view = ActionView::Base.new(Rails.configuration.paths['app/views'].to_ary)
     locals[:my_model] = self
-    action_view.render partial: "models/#{self.class.name.underscore}", formats: [:xml],
-                       locals: locals
+    ApplicationController.render(partial: "models/#{self.class.name.underscore}", locals: locals, formats: [:xml])
   end
 end


### PR DESCRIPTION
Closes #9617 and #9438

Message:

"DEPRECATION WARNING: ActionView::Base instances must implement
compiled_method_container or use the class method
with_empty_template_cache for constructing an ActionView::Base instance
that has an empty cache. (called from render_xml at
/srv/www/obs/api/app/mixins/can_render_model.rb:8)"

Co-authored-by: Victor Pereira <vpereira@suse.com>

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
