### PR TITLE
Prevent deprecation warnings on scopes

### DIFF
--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -107,9 +107,10 @@ class Project < ApplicationRecord
   scope :remote, -> { where('NOT ISNULL(projects.remoteurl)') }
   scope :local, -> { where.not('NOT ISNULL(projects.remoteurl)') }
 
-  scope :autocomplete, ->(search) { AutocompleteProjectsFinder.new(Project.all, search).call }
+  scope :autocomplete, ->(search) { AutocompleteProjectsFinder.new(Project.default_scoped, search).call }
 
   # will return all projects with attribute 'OBS:ImageTemplates'
+  # FIXME: still generates deprecation warning
   scope :local_image_templates, lambda {
     ProjectsWithImageTemplatesFinder.new.call
   }

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -77,7 +77,7 @@ class User < ApplicationRecord
   scope :with_login_prefix, ->(prefix) { where('login LIKE ?', "#{prefix}%") }
   scope :active, -> { confirmed.or(User.unscoped.where(state: :subaccount, owner: User.unscoped.confirmed)) }
   scope :staff, -> { joins(:roles).where('roles.title = ?', 'Staff') }
-  scope :not_staff, -> { where.not(id: User.staff.pluck(:id)) }
+  scope :not_staff, -> { where.not(id: User.unscoped.staff.pluck(:id)) }
   scope :admins, -> { joins(:roles).where('roles.title = ?', 'Admin') }
 
   scope :in_beta, -> { where(in_beta: true) }

--- a/src/api/app/queries/projects_with_delegate_request_target_finder.rb
+++ b/src/api/app/queries/projects_with_delegate_request_target_finder.rb
@@ -1,5 +1,5 @@
 class ProjectsWithDelegateRequestTargetFinder < AttribFinder
-  def initialize(relation = Project.all, namespace = 'OBS', name = 'DelegateRequestTarget')
+  def initialize(relation = Project.default_scoped, namespace = 'OBS', name = 'DelegateRequestTarget')
     super(relation, namespace, name)
   end
 end

--- a/src/api/app/queries/projects_with_very_important_attribute_finder.rb
+++ b/src/api/app/queries/projects_with_very_important_attribute_finder.rb
@@ -1,5 +1,5 @@
 class ProjectsWithVeryImportantAttributeFinder < AttribFinder
-  def initialize(relation = Project.all, namespace = 'OBS', name = 'VeryImportantProject')
+  def initialize(relation = Project.default_scoped, namespace = 'OBS', name = 'VeryImportantProject')
     super(relation, namespace, name)
   end
 end


### PR DESCRIPTION
Other scope definitions are affected by the deprecation warnings related to scoping.

Message:

```
DEPRECATION WARNING: Class level methods will no longer inherit scoping from 
`for_project` in Rails 6.1. To continue using the scoped relation, 
pass it into the block directly. 
To instead access the full set of models, as Rails 6.1 will, use `BsRequest.unscoped`, 
or `BsRequest.default_scoped` if a model has default scopes. 
(called from initialize at /srv/www/obs/api/app/models/bs_request/find_for/base.rb:4)
```
Follow-up of #9742

Co-authored-by:  Quang Tran <quang.tran@suse.com>

PS: this skips BsRequest and Package scopes, there is an specific issue for them: #9748


<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
