### PR TITLE
Update script/compare_structure_sql.sh

### DIFF
--- a/src/api/script/compare_structure_sql.sh
+++ b/src/api/script/compare_structure_sql.sh
@@ -15,6 +15,18 @@ for file in "$git_file" "$migrate_file"; do
   sed -i -e '/^(.21.),$/,/^(.9.);/d' "${file}.normalized" || exit 1
   # we have a different last migration, therefore ; => ,
   sed -i -e 's/\(^(.20.............)\);$/\1,/' "${file}.normalized" || exit 1
+  # From MariaDB 10.2.2, numbers are no longer quoted in the DEFAULT clause in SHOW CREATE statement.
+  # https://mariadb.com/kb/en/library/show-create-table/
+  # TODO: drop this line when we drop support for Mariadb < 10.2.2 (SLE12 & Leap 42.3)
+  sed -i -r "s/DEFAULT '([[:digit:]]+)'/DEFAULT \1/g" "${file}.normalized" || exit 1
+  # MariaDB 10.2.1 permits TEXT and BLOB data types to be assigned a DEFAULT value.
+  # As a result, from MariaDB 10.2.1, SHOW CREATE TABLE will append a DEFAULT NULL
+  # to nullable TEXT or BLOB fields if no specific default is provided.
+  # https://mariadb.com/kb/en/library/show-create-table/
+  # TODO: drop this line when we drop support for Mariadb < 10.2.2 (SLE12 & Leap 42.3)
+  sed -r -i "s/(\`[a-zA-Z0-9_]*\` (medium)*text\s*[a-zA-Z0-9_ ]*) DEFAULT NULL,/\1,/g" "${file}.normalized" || exit 1
+  # The default charset is different depending on the Mariadb version
+  sed -i -e 's/\(CHARSET=utf8\).*;$/\1;/g' "${file}.normalized" || exit 1
 done
 
 if ! diff "${git_file}.normalized" "${migrate_file}.normalized"; then


### PR DESCRIPTION
This solves comparison issues due to various MariaDB versions changing defaults. Since we're building the applications for SLE12-SP4 and openSUSE Leap 42.3, this is needed.

The first 2 `sed` commands are from `master`.