### PR TITLE
Introduce cache versioning

### DIFF
--- a/src/api/app/models/binary_release.rb
+++ b/src/api/app/models/binary_release.rb
@@ -184,7 +184,7 @@ class BinaryRelease < ApplicationRecord
   end
 
   def to_axml(_opts = {})
-    Rails.cache.fetch("xml_binary_release_#{cache_key}") { render_xml }
+    Rails.cache.fetch("xml_binary_release_#{cache_key_with_version}") { render_xml }
   end
 
   def identical_to?(binary_hash)

--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -365,15 +365,15 @@ class BsRequest < ApplicationRecord
 
   def to_axml(opts = {})
     if opts[:withfullhistory]
-      Rails.cache.fetch("xml_bs_request_fullhistory_#{cache_key}") do
+      Rails.cache.fetch("xml_bs_request_fullhistory_#{cache_key_with_version}") do
         render_xml(withfullhistory: 1)
       end
     elsif opts[:withhistory]
-      Rails.cache.fetch("xml_bs_request_history_#{cache_key}") do
+      Rails.cache.fetch("xml_bs_request_history_#{cache_key_with_version}") do
         render_xml(withhistory: 1)
       end
     else
-      Rails.cache.fetch("xml_bs_request_#{cache_key}") do
+      Rails.cache.fetch("xml_bs_request_#{cache_key_with_version}") do
         render_xml
       end
     end

--- a/src/api/app/models/group.rb
+++ b/src/api/app/models/group.rb
@@ -181,7 +181,7 @@ class Group < ApplicationRecord
   end
 
   def tasks
-    Rails.cache.fetch("requests_for_#{cache_key}") do
+    Rails.cache.fetch("requests_for_#{cache_key_with_version}") do
       incoming_requests.count +
         involved_reviews.count
     end

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -125,7 +125,7 @@ class Package < ApplicationRecord
   def self.check_cache(project, package, opts)
     @key = { 'get_by_project_and_name' => 1, :package => package, :opts => opts }
 
-    @key[:user] = User.session.cache_key if User.session
+    @key[:user] = User.session.cache_key_with_version if User.session
 
     # the cache is only valid if the user, prj and pkg didn't change
     if project.is_a?(Project)

--- a/src/api/app/models/project/key_info.rb
+++ b/src/api/app/models/project/key_info.rb
@@ -40,7 +40,7 @@ class Project
     end
 
     def self.key_info_for_project(project)
-      Rails.cache.fetch("key_info_project_#{project.cache_key}", expires_in: CACHE_EXPIRY_TIME) do
+      Rails.cache.fetch("key_info_project_#{project.cache_key_with_version}", expires_in: CACHE_EXPIRY_TIME) do
         Backend::Api::Sources::Project.key_info(project.name)
       end
     end

--- a/src/api/app/models/project_status/calculator.rb
+++ b/src/api/app/models/project_status/calculator.rb
@@ -83,7 +83,7 @@ module ProjectStatus
       proj.repositories_linking_project(@dbproj).each do |r|
         repo = r['name']
         r.elements('arch') do |arch|
-          cachekey = "history2#{proj.cache_key}#{repo}#{arch}"
+          cachekey = "history2#{proj.cache_key_with_version}#{repo}#{arch}"
           jobhistory = Rails.cache.fetch(cachekey, expires_in: 30.minutes) do
             parse_jobhistory(dname, repo, arch)
           end

--- a/src/api/app/models/staging/workflow.rb
+++ b/src/api/app/models/staging/workflow.rb
@@ -63,7 +63,7 @@ class Staging::Workflow < ApplicationRecord
     # Group.where(id: group_ids).each do |group|
     #
     # TODO: Refactor this code using to_h when updating to Ruby 2.6 (performance improvement)
-    Rails.cache.fetch("groups_hash_#{Group.all.cache_key}") do
+    Rails.cache.fetch("groups_hash_#{Group.all.cache_key_with_version}") do
       groups_hash = {}
       Group.find_each do |group|
         groups_hash[group.title] = group

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -821,7 +821,7 @@ class User < ApplicationRecord
 
   # TODO: Remove once responsive_ux is out of beta
   def tasks
-    Rails.cache.fetch("requests_for_#{cache_key}") do
+    Rails.cache.fetch("requests_for_#{cache_key_with_version}") do
       declined_requests.count +
         incoming_requests.count +
         involved_reviews.count

--- a/src/api/app/services/monitor_controller_service/status_history_fetcher.rb
+++ b/src/api/app/services/monitor_controller_service/status_history_fetcher.rb
@@ -6,7 +6,7 @@ module MonitorControllerService
     end
 
     def call
-      Rails.cache.fetch(cache_key, expires_in: (@range.to_i * 3600) / 150, shared: true) do
+      Rails.cache.fetch(custom_cache_key, expires_in: (@range.to_i * 3600) / 150, shared: true) do
         status_history
       end
     end
@@ -21,7 +21,7 @@ module MonitorControllerService
       24 * 365
     end
 
-    def cache_key
+    def custom_cache_key
       "#{@key}-#{@range}"
     end
 

--- a/src/api/app/views/webui/users/tasks/index.html.haml
+++ b/src/api/app/views/webui/users/tasks/index.html.haml
@@ -4,7 +4,7 @@
   .bg-light
     %ul.nav.nav-tabs.pt-2.px-3.flex-nowrap.collapsible{ 'role': 'tablist' }
       %li.nav-item
-        - cache "#{User.session!.cache_key}-reviews-in" do
+        - cache "#{User.session!.cache_key_with_version}-reviews-in" do
           %a.nav-link.text-nowrap.active{ href: '#reviews-in', title: "Requests that #{User.session!} has to review" }
             Incoming Reviews
             %span.badge.badge-primary
@@ -19,7 +19,7 @@
   .bg-light
     %ul.nav.nav-tabs.pt-2.px-3.flex-nowrap.collapsible{ 'role': 'tablist' }
       %li.nav-item
-        - cache "#{User.session!.cache_key}-requests-in" do
+        - cache "#{User.session!.cache_key_with_version}-requests-in" do
           %a.nav-link.text-nowrap.active#requests-in-tab{ href: '#requests-in', title: "Requests that #{User.session!} has to merge",
             'data-toggle': 'tab', 'aria-controls': 'requests-in-tab', 'aria-selected': 'true', role: 'tab' }
             Incoming Requests

--- a/src/api/config/application.rb
+++ b/src/api/config/application.rb
@@ -85,8 +85,7 @@ module OBSApi
 
     config.action_controller.perform_caching = true
 
-    # Don't use cache versioning for now
-    config.active_record.cache_versioning = false
+    config.active_record.cache_versioning = true
     config.active_record.collection_cache_versioning = false
 
     config.action_controller.action_on_unpermitted_parameters = :raise

--- a/src/api/spec/models/bs_request_spec.rb
+++ b/src/api/spec/models/bs_request_spec.rb
@@ -298,13 +298,13 @@ RSpec.describe BsRequest, vcr: true do
     RSpec.shared_examples "the subject's cache is reset when it's request changes" do
       before do
         Timecop.travel(1.minute)
-        @cache_key = user.cache_key
+        @cache_key = user.cache_key_with_version
         request.state = :review
         request.save
         user.reload
       end
 
-      it { expect(user.cache_key).not_to eq(@cache_key) }
+      it { expect(user.cache_key_with_version).not_to eq(@cache_key) }
     end
 
     context 'creator of bs_request' do

--- a/src/api/spec/models/review_spec.rb
+++ b/src/api/spec/models/review_spec.rb
@@ -345,13 +345,13 @@ RSpec.describe Review do
     RSpec.shared_examples "the subject's cache is reset when it's review changes" do
       before do
         Timecop.travel(1.minute)
-        @cache_key = subject.cache_key
+        @cache_key = subject.cache_key_with_version
         review.state = :accepted
         review.save
         subject.reload
       end
 
-      it { expect(subject.cache_key).not_to eq(@cache_key) }
+      it { expect(subject.cache_key_with_version).not_to eq(@cache_key) }
     end
 
     context 'by_user' do


### PR DESCRIPTION
Before cache versioning, `cache_key` contained the key and the version.

Introducing cache versioning makes `cache_key` to contain only the key. In order to have the same content as before, we have to use `cache_key_with_version`.

This is a follow up of #9392.

Have a look at this [blog entry](https://blog.bigbinary.com/2019/08/06/rails-adds-support-for-recyclable-cache-keys.html) as reference.