### PR TITLE
Force association chain reload

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -797,10 +797,13 @@ class Webui::PackageController < Webui::WebuiController
   def set_linkinfo
     return unless @package.is_link?
 
-    linked_package = @package.backend_package.links_to
+    # https://github.com/rails/rails/issues/38709
+    linked_package = @package.backend_package.links_to&.reload
     return set_remote_linkinfo unless linked_package
 
     @linkinfo = { package: linked_package, error: @package.backend_package.error }
+    # when linked_package reloads then the md5 differs and the if kicks in
+    # with the foreign_key: :package_id
     @linkinfo[:diff] = true if linked_package.backend_package.verifymd5 != @package.backend_package.verifymd5
   end
 

--- a/src/api/spec/features/webui/packages_spec.rb
+++ b/src/api/spec/features/webui/packages_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe 'Packages', type: :feature, js: true, vcr: true do
       click_link('home:package_test_user...ome:package_test_user')
       # Wait for the new page being loaded (aka. the ajax request to finish)
       expect(page).to have_text("Links to #{user.home_project} / #{package}")
+      expect(page).to have_text('Has a link diff')
       expect(page).to have_current_path(package_show_path(project: branched_project, package: branched_project.packages.first), ignore_query: true)
     end
   end


### PR DESCRIPTION
Looks like when we
removed the `foreign_key: :package_id` from the
`has_one :backend_package`
here (https://github.com/openSUSE/open-build-service/pull/9701), we hit an Rails/ActiveRecord
bug (https://github.com/rails/rails/issues/38709).

This PR is a workaround.

Until we find another workaround or the issue gets fixed we are gonna
hit a bit of a penalty due to the association reload.

As an alternative we can revert https://github.com/openSUSE/open-build-service/pull/9701.

Fixes #9763

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
