### PR TITLE
Keep the redundant `foreign_key` option in the association

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -797,6 +797,10 @@ class Webui::PackageController < Webui::WebuiController
   def set_linkinfo
     return unless @package.is_link?
 
+    # FIXME: We have a rails bug here.
+    # the `.backend_package.links_to` is an association chain.
+    # Due to this bug https://github.com/rails/rails/issues/38709 `linked_package` will not get the refreshed
+    # contents and then the md5 at the bottom of this method are the same, thus no rendering the linkinfo
     linked_package = @package.backend_package.links_to
     return set_remote_linkinfo unless linked_package
 

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -110,7 +110,7 @@ class Package < ApplicationRecord
   }
   validate :valid_name
 
-  has_one :backend_package, dependent: :destroy, inverse_of: :package
+  has_one :backend_package, foreign_key: :package_id, dependent: :destroy, inverse_of: :package # rubocop:disable Rails/RedundantForeignKey
   has_one :token, class_name: 'Token::Service', dependent: :destroy
 
   has_many :tokens, class_name: 'Token::Service', dependent: :destroy, inverse_of: :package


### PR DESCRIPTION
Looks like when we removed the `foreign_key: :package_id` from the `has_one :backend_package`
here (https://github.com/openSUSE/open-build-service/pull/9701), we hit an Rails/ActiveRecord bug (https://github.com/rails/rails/issues/38709).

This PR is a workaround.

As an alternative we can revert https://github.com/openSUSE/open-build-service/pull/9701, or reload the `linked_package`

Fixes #9763