### PR TITLE
[backend] trim list of blocking packages to at most 10 entries

### DIFF
--- a/src/backend/BSSched/BuildJob/Aggregate.pm
+++ b/src/backend/BSSched/BuildJob/Aggregate.pm
@@ -202,12 +202,9 @@ sub check {
     return ('broken', $error);
   }
   if (@blocked) {
+    splice(@blocked, 10, scalar(@blocked), '...') if @blocked > 10;
     print "      - $packid (aggregate)\n";
-    if (@blocked < 11) {
-      print "        blocked (@blocked)\n";
-    } else {
-      print "        blocked (@blocked[0..9] ...)\n";
-    }
+    print "        blocked (@blocked)\n";
     return ('blocked', join(', ', @blocked));
   }
   my @new_meta;

--- a/src/backend/BSSched/BuildJob/Channel.pm
+++ b/src/backend/BSSched/BuildJob/Channel.pm
@@ -260,12 +260,9 @@ sub check {
     return ('broken', 'missing: '.join(', ', @broken));
   }
   if (@blocked) {
+    splice(@blocked, 10, scalar(@blocked), '...') if @blocked > 10;
     print "      - $packid (channel)\n";
-    if (@blocked < 11) {
-      print "        blocked (@blocked)\n";
-    } else {
-      print "        blocked (@blocked[0..9] ...)\n";
-    }
+    print "        blocked (@blocked)\n";
     return ('blocked', join(', ', @blocked));
   }
   my @meta;

--- a/src/backend/BSSched/BuildJob/Docker.pm
+++ b/src/backend/BSSched/BuildJob/Docker.pm
@@ -296,13 +296,10 @@ sub check {
     push @new_meta, $pool->pkg2pkgid($p)."  $aprp/$n" unless @blocked;
   }
   if (@blocked) {
+    splice(@blocked, 10, scalar(@blocked), '...') if @blocked > 10;
     if ($ctx->{'verbose'}) {
       print "      - $packid ($buildtype)\n";
-      if (@blocked < 11) {
-	print "        blocked (@blocked)\n";
-      } else {
-	print "        blocked (@blocked[0..9] ...)\n";
-      }
+      print "        blocked (@blocked)\n";
     }
     return ('blocked', join(', ', @blocked));
   }

--- a/src/backend/BSSched/BuildJob/KiwiImage.pm
+++ b/src/backend/BSSched/BuildJob/KiwiImage.pm
@@ -257,13 +257,10 @@ sub check {
     push @new_meta, $pool->pkg2pkgid($p)."  $aprp/$n" unless @blocked;
   }
   if (@blocked) {
+    splice(@blocked, 10, scalar(@blocked), '...') if @blocked > 10;
     if ($ctx->{'verbose'}) {
       print "      - $packid (kiwi-image)\n";
-      if (@blocked < 11) {
-	print "        blocked (@blocked)\n";
-      } else {
-	print "        blocked (@blocked[0..9] ...)\n";
-      }
+      print "        blocked (@blocked)\n";
     }
     return ('blocked', join(', ', @blocked));
   }

--- a/src/backend/BSSched/BuildJob/KiwiProduct.pm
+++ b/src/backend/BSSched/BuildJob/KiwiProduct.pm
@@ -254,13 +254,10 @@ sub check {
     }
     @blocked = () if $neverblock;
     if (@blocked) {
+      splice(@blocked, 10, scalar(@blocked), '...') if @blocked > 10;
       if ($ctx->{'verbose'}) {
         print "      - $packid (kiwi-product)\n";
-        if (@blocked < 10) {
-          print "        blocked for sysbuild (@blocked)\n";
-        } else {
-          print "        blocked for sysbuild (@blocked[0..9] ...)\n";
-        }
+        print "        blocked for sysbuild (@blocked)\n";
       }
       return ('blocked', join(', ', @blocked));
     }

--- a/src/backend/BSSched/BuildJob/Package.pm
+++ b/src/backend/BSSched/BuildJob/Package.pm
@@ -108,6 +108,7 @@ sub check {
       print "      - $packid ($buildtype)\n";
       print "        blocked by cycle builds ($blocked[0]...)\n";
     }
+    splice(@blocked, 10, scalar(@blocked), '...') if @blocked > 10;
     return ('blocked', join(', ', @blocked));
   }
   # prune cycle packages from blocked
@@ -119,6 +120,7 @@ sub check {
   if (@blocked) {
     # print "      - $packid ($buildtype)\n";
     # print "        blocked\n";
+    splice(@blocked, 10, scalar(@blocked), '...') if @blocked > 10;
     return ('blocked', join(', ', @blocked));
   }
   my $reason;

--- a/src/backend/BSSched/BuildJob/Patchinfo.pm
+++ b/src/backend/BSSched/BuildJob/Patchinfo.pm
@@ -310,12 +310,9 @@ sub check {
   }
 
   if (@blocked) {
+    splice(@blocked, 10, scalar(@blocked), '...') if @blocked > 10;
     print "      - $packid (patchinfo)\n";
-    if (@blocked < 11) {
-      print "        blocked (@blocked)\n";
-    } else {
-      print "        blocked (@blocked[0..9] ...)\n";
-    }
+    print "        blocked (@blocked)\n";
     return ('blocked', join(', ', @blocked));
   }
 

--- a/src/backend/BSSched/BuildJob/PreInstallImage.pm
+++ b/src/backend/BSSched/BuildJob/PreInstallImage.pm
@@ -81,7 +81,10 @@ sub check {
   my $dep2src = $ctx->{'dep2src'};
   my $dep2pkg = $ctx->{'dep2pkg'};
   my @blocked = grep {$notready->{$dep2src->{$_}}} @$edeps;
-  return ('blocked', join(', ', @blocked)) if @blocked;
+  if (@blocked) {
+    splice(@blocked, 10, scalar(@blocked), '...') if @blocked > 10;
+    return ('blocked', join(', ', @blocked));
+  }
 
   # expand like in BSSched::BuildJob::create, so that we have all used packages
   # in the meta file

--- a/src/backend/bs_notifyforward
+++ b/src/backend/bs_notifyforward
@@ -180,7 +180,10 @@ sub forwarddata {
     my $len = length($_);
     die("bad line\n") unless chop($_) eq "\n";
     my @line = split('\|', $_);
-    next unless @line && $line[0];
+    if (!@line || !$line[0]) {
+	$markoff += $len;	# empty or marked as done
+	next;
+    }
     s/%([a-fA-F0-9]{2})/chr(hex($1))/ge for @line;
     my $type = shift @line;
 

--- a/src/backend/bs_redis
+++ b/src/backend/bs_redis
@@ -159,7 +159,6 @@ sub forwarddata {
       $markoff += $len;		# empty or marked as done
       next;
     }
-    next unless @line && $line[0];
     s/%([a-fA-F0-9]{2})/chr(hex($1))/ge for @line;
     my $cmd = shift @line;
     my $prpa = shift @line;


### PR DESCRIPTION
It does not make sense to show hundreds of packages to the user.
This just leads to the packstatus and the redis updates being way
too big.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
