### PR TITLE
Clean up notifications with Notification.cleanup

### DIFF
--- a/src/api/app/jobs/cleanup_notifications.rb
+++ b/src/api/app/jobs/cleanup_notifications.rb
@@ -1,5 +1,5 @@
 class CleanupNotifications < ApplicationJob
   def perform
-    Notification::RssFeedItem.cleanup
+    Notification.cleanup
   end
 end


### PR DESCRIPTION
Instead of keeping at most 10 notifications for groups and active users, we keep notifications if they were created up to 3 months ago.

There are no specs for this job, but it's one line and that one line is covered in the specs for the Notification model.