### PR TITLE
Add method .projects for Backend::Api::Search

### DIFF
--- a/src/api/app/lib/backend/api/search.rb
+++ b/src/api/app/lib/backend/api/search.rb
@@ -36,6 +36,11 @@ module Backend
       def self.packages_for_project(project_name)
         http_get('/search/package', params: { match: "@project='#{project_name}'" })
       end
+
+      def self.projects(projects)
+        xpath = projects.collect { |project| "@name='#{project}'" }.join(' or ')
+        http_get('/search/project', params: { match: xpath }) if xpath.present?
+      end
     end
   end
 end

--- a/src/api/spec/cassettes/Backend_Api_Search/_projects/with_projects/1_1_1_1.yml
+++ b/src/api/spec/cassettes/Backend_Api_Search/_projects/with_projects/1_1_1_1.yml
@@ -1,0 +1,119 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/foo_0/_meta?user=user_1
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="foo_0">
+          <title>The Painted Veil</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '98'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="foo_0">
+          <title>The Painted Veil</title>
+          <description></description>
+        </project>
+  recorded_at: Thu, 18 Jun 2020 09:53:57 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/foo_1/_meta?user=user_2
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="foo_1">
+          <title>Butter In a Lordly Dish</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '105'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="foo_1">
+          <title>Butter In a Lordly Dish</title>
+          <description></description>
+        </project>
+  recorded_at: Thu, 18 Jun 2020 09:53:57 GMT
+- request:
+    method: get
+    uri: http://backend:5352/search/project?match=@name='foo_0'%20or%20@name='foo_1'
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '246'
+    body:
+      encoding: UTF-8
+      string: |
+        <collection>
+          <project name="foo_0">
+            <title>The Painted Veil</title>
+            <description></description>
+          </project>
+          <project name="foo_1">
+            <title>Butter In a Lordly Dish</title>
+            <description></description>
+          </project>
+        </collection>
+  recorded_at: Thu, 18 Jun 2020 09:53:57 GMT
+recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Backend_Api_Search/_projects/with_unexistent_projects/1_1_3_1.yml
+++ b/src/api/spec/cassettes/Backend_Api_Search/_projects/with_unexistent_projects/1_1_3_1.yml
@@ -1,0 +1,35 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/search/project?match=@name='xaa'%20or%20@name='xee'
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '27'
+    body:
+      encoding: UTF-8
+      string: |
+        <collection>
+        </collection>
+  recorded_at: Thu, 18 Jun 2020 09:53:57 GMT
+recorded_with: VCR 6.0.0

--- a/src/api/spec/lib/backend/api/search_spec.rb
+++ b/src/api/spec/lib/backend/api/search_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe Backend::Api::Search, vcr: true do
+  describe '.projects' do
+    context 'with projects' do
+      let(:project_names) { create_list(:project, 2) { |prj, i| prj.name = "foo_#{i}" }.map(&:name) }
+
+      subject { Backend::Api::Search.projects(project_names) }
+
+      it { expect(Nokogiri::XML(subject).xpath('//collection//project').count).to eq(2) }
+    end
+
+    context 'no projects' do
+      subject { Backend::Api::Search.projects([]) }
+
+      it { expect(Nokogiri::XML(subject).xpath('//collection//project').count).to eq(0) }
+    end
+
+    context 'with unexistent projects' do
+      subject { Backend::Api::Search.projects(['xaa', 'xee']) }
+
+      it { expect(Nokogiri::XML(subject).xpath('//collection//project').count).to eq(0) }
+    end
+  end
+end


### PR DESCRIPTION
We need a better way to search for a set of projects on backend. Therefore the `Backend::Api::Search` now supports it. passing an array of names to the method `.projects` it will create a xpath and search for it on backend. 

