### PR TITLE
Stop enqueueing CleanupNotifications job

### DIFF
--- a/src/api/config/clock.rb
+++ b/src/api/config/clock.rb
@@ -40,10 +40,6 @@ module Clockwork
     BsRequest.delayed_auto_accept
   end
 
-  every(1.hour, 'cleanup notifications') do
-    CleanupNotifications.perform_later
-  end
-
   every(1.day, 'optimize history', thread: true, at: '05:00') do
     ActiveRecord::Base.connection_pool.with_connection do |sql|
       sql.execute('optimize table status_histories;')


### PR DESCRIPTION
Following the discussion we had in #9774 and offline, we agreed that this job isn't needed since there aren't many notifications.