### PR TITLE
Ignore type column for Notification model

### DIFF
--- a/src/api/app/models/notification.rb
+++ b/src/api/app/models/notification.rb
@@ -15,6 +15,8 @@ class Notification < ApplicationRecord
 
   # FIXME: This is to avoid creating a migration for a column which we are going to drop anyway
   attribute :type, default: ''
+  # FIXME: Remove this once the column is removed in the database
+  self.ignored_columns = ['type']
 
   def event
     @event ||= event_type.constantize.new(event_payload)


### PR DESCRIPTION
We are going to remove this column from the notifications table. This is to avoid a downtime.