### PR TITLE
Set column default to an empty string for notifications.type

### DIFF
--- a/src/api/app/models/notification.rb
+++ b/src/api/app/models/notification.rb
@@ -13,9 +13,6 @@ class Notification < ApplicationRecord
   scope :for_web, -> { where(web: true) }
   scope :for_rss, -> { where(rss: true) }
 
-  # FIXME: This is to avoid creating a migration for a column which we are going to drop anyway
-  attribute :type, default: ''
-
   def event
     @event ||= event_type.constantize.new(event_payload)
   end
@@ -52,7 +49,7 @@ end
 #  subscriber_type            :string(255)      indexed => [subscriber_id]
 #  subscription_receiver_role :string(255)      not null
 #  title                      :string(255)
-#  type                       :string(255)      not null
+#  type                       :string(255)      default(""), not null
 #  web                        :boolean          default(FALSE)
 #  created_at                 :datetime         not null
 #  updated_at                 :datetime         not null

--- a/src/api/db/migrate/20200618152542_set_default_value_for_type_in_notifications.rb
+++ b/src/api/db/migrate/20200618152542_set_default_value_for_type_in_notifications.rb
@@ -1,0 +1,5 @@
+class SetDefaultValueForTypeInNotifications < ActiveRecord::Migration[6.0]
+  def change
+    change_column_default :notifications, :type, from: nil, to: ''
+  end
+end

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -819,7 +819,7 @@ CREATE TABLE `messages` (
 
 CREATE TABLE `notifications` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `type` varchar(255) CHARACTER SET utf8 NOT NULL,
+  `type` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `event_type` varchar(255) CHARACTER SET utf8 NOT NULL,
   `event_payload` text COLLATE utf8mb4_unicode_ci NOT NULL,
   `subscription_receiver_role` varchar(255) CHARACTER SET utf8 NOT NULL,
@@ -1507,6 +1507,7 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20200522092917'),
 ('20200522145733'),
 ('20200522151615'),
-('20200601083057');
+('20200601083057'),
+('20200618152542');
 
 


### PR DESCRIPTION
`attribute :type, default: ''` won't make it when we need to ignore the column before removing it. The column would then be empty and the database doesn't accept this.