### PR TITLE
Remove Rake::Task monkey patch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ aliases:
 
   - &create_test_db
     name: Create database
-    command: cd src/api; bundle exec rake db:create db:setup RAILS_ENV=test
+    command: cd src/api; bundle exec rake db:create db:structure:load db:seed RAILS_ENV=test
 
   - &bootstrap_old_test_suite
     name: Setup application

--- a/dist/README.UPDATERS
+++ b/dist/README.UPDATERS
@@ -12,7 +12,7 @@ Note: Update from OBS 2.5 should also work, but it is not fully tested.
 
 
   1) The format of the OBS options.yml is now distinguishing between Rails environments.
-     Please run following commands: 
+     Please run following commands:
 
          cd /srv/www/obs/api/
          RAILS_ENV=production bin/rake migrate_options_yml
@@ -416,7 +416,7 @@ For Updaters to OBS 2.1 from OBS 2.0
 
    * populate the database
       # cd /srv/www/obs/webui/
-      # sudo RAILS_ENV="production" rails db:setup
+      # sudo RAILS_ENV="production" rails db:structure:load db:seed
       # sudo chown lighttpd.lighttpd log/*
 
 

--- a/dist/obs-api-testsuite-rspec.spec
+++ b/dist/obs-api-testsuite-rspec.spec
@@ -57,7 +57,7 @@ bundle --local --path %_libdir/obs-api/
 ./script/prepare_spec_tests.sh
 
 export RAILS_ENV=test
-bin/rake db:create db:setup
+bin/rake db:create db:structure:load db:seed
 bin/rails assets:precompile
 
 bin/rspec -f d --exclude-pattern 'spec/db/**/*_spec.rb'

--- a/dist/setup-appliance.sh
+++ b/dist/setup-appliance.sh
@@ -277,7 +277,7 @@ function prepare_database_setup {
   if [ -n "$RUN_INITIAL_SETUP" ]; then
     logline "Initialize OBS api database (first time only)"
     cd $apidir
-    RAKE_COMMANDS="db:create db:setup writeconfiguration"
+    RAKE_COMMANDS="db:create db:structure:load db:seed writeconfiguration"
   else
     logline "Migrate OBS api database"
     cd $apidir

--- a/src/api/lib/tasks/databases.rake
+++ b/src/api/lib/tasks/databases.rake
@@ -1,31 +1,3 @@
-module Rake
-  module TaskManager
-    def redefine_task(task_class, *args, &block)
-      task_name, deps = resolve_args(args)
-      task_name = task_class.scope_name(@scope, task_name)
-      deps = [deps] unless deps.respond_to?(:to_ary)
-      deps = deps.collect(&:to_s)
-      task = @tasks[task_name.to_s] = task_class.new(task_name, self)
-      task.application = self
-      # task.add_comment(@last_comment)
-      @last_comment = nil
-      task.enhance(deps, &block)
-      task
-    end
-  end
-  class Task
-    class << self
-      def redefine_task(args, &block)
-        Rake.application.redefine_task(self, args, &block)
-      end
-    end
-  end
-end
-
-def redefine_task(args, &block)
-  Rake::Task.redefine_task(args, &block)
-end
-
 namespace :db do
   namespace :structure do
     desc 'Dump the database structure to a SQL file'
@@ -113,12 +85,6 @@ namespace :db do
 
       puts 'Ok'
     end
-  end
-
-  desc 'Create the database, load the structure, and initialize with the seed data'
-  redefine_task setup: :environment do
-    Rake::Task['db:structure:load'].invoke
-    Rake::Task['db:seed'].invoke
   end
 
   desc 'Migrate the database (options: VERSION=x, VERBOSE=false, SCOPE=blog)'

--- a/src/api/lib/tasks/dev.rake
+++ b/src/api/lib/tasks/dev.rake
@@ -33,7 +33,8 @@ namespace :dev do
       Rake::Task['db:version'].invoke
     rescue
       Rake::Task['db:create'].invoke
-      Rake::Task['db:setup'].invoke
+      Rake::Task['db:structure:load'].invoke
+      Rake::Task['db:seed'].invoke
       if args.old_test_suite
         puts 'Old test suite. Loading fixtures...'
         Rake::Task['db:fixtures:load'].invoke
@@ -257,7 +258,8 @@ namespace :dev do
       Rails.cache.clear
       Rake::Task['db:drop'].invoke
       Rake::Task['db:create'].invoke
-      Rake::Task['db:setup'].invoke
+      Rake::Task['db:structure:load'].invoke
+      Rake::Task['db:seed'].invoke
 
       # enable responsive_ux as default
       Flipper[:responsive_ux].enable

--- a/src/api/script/api_minitest.sh
+++ b/src/api/script/api_minitest.sh
@@ -14,7 +14,7 @@ bin/rake db:migrate:with_data db:structure:dump db:drop
 
 # entire test suite
 export RAILS_ENV=test
-bin/rake db:create db:setup
+bin/rake db:create db:structure:load db:seed
 
 bin/rails assets:precompile
 


### PR DESCRIPTION
`redefine_task` was used to redefine the `db:setup` task. We prefer to be explicit about having to run `db:structure:load:with_data db:seed` and to avoid monkey patching Rake::Task.

While looking into #9779 and talking with @hennevogel and @saraycp about it, we found this nice :monkey: patch.

Sadly, we cannot use `db:structure:load:with_data`. For some obscure reasons, specs fail due to missing seeds, even if seeds are added after calling `db:structure:load:with_data`. We can still remove the monkey patch.

~~To take data migrations into account when setting up a new database, we need to run `db:structure:load:with_data`, not `db:structure:load`. This will prevent issues like #9779 if somehow data migrations are ran against a new database. It shouldn't happen, but if it does, it's simply going to do nothing since the [data_schema.rb](https://github.com/openSUSE/open-build-service/blob/d42d8310aa25b18637b77831e6816a9f4adf837d/src/api/db/data_schema.rb) is also loaded when creating the database.~~