### PR TITLE
Mark notifications read or unread asynchronously

### DIFF
--- a/src/api/app/views/webui/users/notifications/_notifications_filter.html.haml
+++ b/src/api/app/views/webui/users/notifications/_notifications_filter.html.haml
@@ -1,0 +1,12 @@
+.row.list-group-flush
+  = filter_notification_link('Unread', notifications_count['unread'], type: 'unread')
+  = filter_notification_link('Read', nil, type: 'read')
+.row.list-group-flush.mt-5
+  %h5.ml-3 Filter
+  = filter_notification_link('Reviews', notifications_count['Review'], type: 'reviews')
+  = filter_notification_link('Comments', notifications_count['Comment'], type: 'comments')
+  = filter_notification_link('Requests', notifications_count['BsRequest'], type: 'requests')
+.row.list-group-flush.mt-5
+  %h5.ml-3 Projects
+  - projects_for_filter.each_pair do |project_name, amount|
+    = filter_notification_link(project_name, amount, project: project_name)

--- a/src/api/app/views/webui/users/notifications/_notifications_list.html.haml
+++ b/src/api/app/views/webui/users/notifications/_notifications_list.html.haml
@@ -1,0 +1,39 @@
+.card
+  .card-body
+    - if notifications.empty?
+      %p
+        - case params[:type]
+        - when 'reviews', 'comments', 'requests'
+          There are no notifications for this filter
+        - when 'done'
+          Mark notifications as "Done" and they'll appear here
+        - else
+          There are no notifications, but there's a world of opportunities!
+    - else
+      .text-center
+        %span.ml-3= page_entries_info notifications, entry_name: 'notification'
+        = link_to_all unless notifications.total_pages == 1 && params['show_all'].nil?
+
+      .list-group.list-group-flush.mt-3
+        - notifications.each do |n|
+          - notification = NotificationPresenter.new(n)
+          .list-group-item.d-flex.flex-column.flex-sm-row.justify-content-sm-between
+            .content
+              .text-nowrap
+                %span.badge.badge-secondary= notification.notification_badge
+                %small.text-muted= time_ago_in_words(notification.created_at)
+              = link_to(n.title, notification.link_to_notification_target, class: 'text-word-break-all')
+              %p.text-muted= notification.excerpt
+            - unless params[:type] == 'read'
+              .actions.align-self-end.align-self-sm-start.pl-3.pt-3.pt-sm-0
+                = link_to(my_notification_path(id: notification, type: params[:type], project: params[:project]),
+                        method: :put, class: 'btn btn-sm btn-outline-success px-4', title: 'Mark as "Read"', remote: true) do
+                  %i.fas.fa-check
+            - unless notification.unread?
+              .actions.align-self-end.align-self-sm-start.pl-3.pt-3.pt-sm-0
+                = link_to(my_notification_path(id: notification, type: params[:type], project: params[:project]),
+                        method: :put, class: 'btn btn-sm btn-outline-success px-4', title: 'Mark as "Unread"', remote: true) do
+                  %i.fas.fa-undo
+
+      = paginate notifications, views_prefix: 'webui', window: 2
+

--- a/src/api/app/views/webui/users/notifications/_update.js.erb
+++ b/src/api/app/views/webui/users/notifications/_update.js.erb
@@ -1,0 +1,2 @@
+$('#filters').html("<%= j(render partial: 'notifications_filter', locals: { projects_for_filter: projects_for_filter, notifications_count: notifications_count }) %>");
+$('#notifications-list').html("<%= j(render partial: 'notifications_list', locals: { notifications: notifications }) %>");

--- a/src/api/app/views/webui/users/notifications/index.html.haml
+++ b/src/api/app/views/webui/users/notifications/index.html.haml
@@ -7,59 +7,10 @@
   .col-md-4.col-lg-3#notifications-filter-desktop
     .card.mb-3
       %strong.d-block.d-md-none.p-3{ data: { toggle: 'collapse', target: '#filters' },
-                                   aria: { expanded: true, controls: 'filters' } }
+                                  aria: { expanded: true, controls: 'filters' } }
         Filtered by: #{(params[:type] || 'Inbox').humanize}
         %i.float-right.mt-1.fa.fa-chevron-down
-
       .card-body.collapse#filters
-        .row.list-group-flush
-          = filter_notification_link('Unread', @notifications_count['unread'], type: 'unread')
-          = filter_notification_link('Read', nil, type: 'read')
-        .row.list-group-flush.mt-5
-          %h5.ml-3 Filter
-          = filter_notification_link('Reviews', @notifications_count['Review'], type: 'reviews')
-          = filter_notification_link('Comments', @notifications_count['Comment'], type: 'comments')
-          = filter_notification_link('Requests', @notifications_count['BsRequest'], type: 'requests')
-        .row.list-group-flush.mt-5
-          %h5.ml-3 Projects
-          - @projects_for_filter.each_pair do |project_name, amount|
-            = filter_notification_link(project_name, amount, project: project_name)
+        = render partial: 'notifications_filter', locals: { projects_for_filter: @projects_for_filter, notifications_count: @notifications_count }
   .col-md-8.col-lg-9#notifications-list
-    .card
-      .card-body
-        - if @notifications.empty?
-          %p
-            - case params[:type]
-            - when 'reviews', 'comments', 'requests'
-              There are no notifications for this filter
-            - when 'done'
-              Mark notifications as "Done" and they'll appear here
-            - else
-              There are no notifications, but there's a world of opportunities!
-        - else
-          .text-center
-            %span.ml-3= page_entries_info @notifications, entry_name: 'notification'
-            = link_to_all unless @notifications.total_pages == 1 && params['show_all'].nil?
-
-          .list-group.list-group-flush.mt-3
-            - @notifications.each do |n|
-              - notification = NotificationPresenter.new(n)
-              .list-group-item.d-flex.flex-column.flex-sm-row.justify-content-sm-between
-                .content
-                  .text-nowrap
-                    %span.badge.badge-secondary= notification.notification_badge
-                    %small.text-muted= time_ago_in_words(notification.created_at)
-                  = link_to(n.title, notification.link_to_notification_target, class: 'text-word-break-all')
-                  %p.text-muted= notification.excerpt
-                - unless params[:type] == 'read'
-                  .actions.align-self-end.align-self-sm-start.pl-3.pt-3.pt-sm-0
-                    = link_to(my_notification_path(id: notification),
-                                      method: :put, class: 'btn btn-sm btn-outline-success px-4', title: 'Mark as "Read"') do
-                      %i.fas.fa-check
-                - unless notification.unread?
-                  .actions.align-self-end.align-self-sm-start.pl-3.pt-3.pt-sm-0
-                    = link_to(my_notification_path(id: notification),
-                                      method: :put, class: 'btn btn-sm btn-outline-success px-4', title: 'Mark as "Unread"') do
-                      %i.fas.fa-undo
-
-          = paginate @notifications, views_prefix: 'webui', window: 2
+    = render partial: 'notifications_list', locals: { notifications: @notifications }

--- a/src/api/spec/controllers/webui/users/notifications_controller_spec.rb
+++ b/src/api/spec/controllers/webui/users/notifications_controller_spec.rb
@@ -97,13 +97,13 @@ RSpec.describe Webui::Users::NotificationsController do
   describe 'PUT #update' do
     context 'when a user marks one of his unread notifications as read' do
       subject! do
-        put :update, params: { id: state_change_notification.id, user_login: user_to_log_in.login }
+        put :update, params: { id: state_change_notification.id, user_login: user_to_log_in.login }, xhr: true
       end
 
       let(:user_to_log_in) { user }
 
-      it 'redirects back' do
-        expect(response).to redirect_to(root_path)
+      it 'succeeds' do
+        expect(response).to have_http_status(:ok)
       end
 
       it 'flashes a success message' do
@@ -117,14 +117,14 @@ RSpec.describe Webui::Users::NotificationsController do
 
     context 'when a user marks one of his read notifications as unread' do
       subject! do
-        put :update, params: { id: read_notification.id, user_login: user_to_log_in.login }
+        put :update, params: { id: read_notification.id, user_login: user_to_log_in.login }, xhr: true
       end
 
       let(:read_notification) { create(:web_notification, :request_state_change, subscriber: user, delivered: true) }
       let(:user_to_log_in) { user }
 
-      it 'redirects back' do
-        expect(response).to redirect_to(root_path)
+      it 'succeeds' do
+        expect(response).to have_http_status(:ok)
       end
 
       it 'flashes a success message' do


### PR DESCRIPTION
Mark notifications read or unread asynchronously.

Now, when you are reviewing your notifications and you tick one as read, the whole page reloads and you lose the point in the page you were working on. This change allows you to keep working in place.