### PR TITLE
[backend] add a project filter to the /source route

### DIFF
--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -1763,7 +1763,16 @@ sub getprojpack {
 
 sub getprojectlist {
   my ($cgi) = @_;
-  my @projects = findprojects($cgi->{'deleted'});
+  my @projects;
+  my %projids = map {$_ => 1} @{$cgi->{'project'} || []};
+  if (%projids && !$cgi->{'deleted'}) {
+    for my $projid (sort keys %projids) {
+      push @projects, $projid if -s "$projectsdir/$projid.xml";
+    }
+  } else {
+    @projects = findprojects($cgi->{'deleted'});
+    @projects = grep {$projids{$_}} @projects if %projids;
+  }
   @projects = map {{'name' => $_}} @projects;
   return ({'entry' => \@projects}, $BSXML::dir);
 }
@@ -6837,7 +6846,7 @@ my $dispatches = [
   'POST:/source cmd: *:*' => \&unknowncmd,
 
   # /source name space: manage project and package data
-  '/source deleted:bool?' => \&getprojectlist,
+  '/source deleted:bool? project*' => \&getprojectlist,
 
   'POST:/source/$project cmd=createkey user:? comment:?' => \&createkey,
   'POST:/source/$project cmd=extendkey user:? comment:?' => \&extendkey,


### PR DESCRIPTION
This can be used for doing fast existance checks.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
