### PR TITLE
Run brakeman in checkout_code CI step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,9 @@ jobs:
             - src/api/tmp/rubocop_cache_rails_dir
       - run: rm -rf src/api/tmp/rubocop*
       - run:
+          name: Run brakeman
+          command: sudo gem install --no-format-executable brakeman; brakeman --rails6 -p src/api
+      - run:
           name: Setup application
           command: cd src/api; bundle exec rake dev:prepare assets:precompile RAILS_ENV=test FORCE_EXAMPLE_FILES=1
       - persist_to_workspace:
@@ -226,24 +229,6 @@ jobs:
           path: src/api/coverage_results
           destination: raw_coverage
 
-  brakeman:
-    docker:
-      - <<: *frontend_base
-
-    steps:
-      - attach_workspace:
-         at: .
-      - run:
-          name: Patch brakeman in
-          command: |
-            sed -i -e 's,# BRAKEMAN,gem "brakeman",' src/api/Gemfile
-      - run: *install_dependencies
-      - run:
-          name: Run brakeman
-          command: |
-            cd src/api
-            brakeman .
-
   feature:
     parallelism: 3
     docker:
@@ -316,9 +301,6 @@ workflows:
             - rspec
             - minitest
             - feature
-      - brakeman:
-          requires:
-            - checkout_code
       - feature:
           requires:
             - checkout_code

--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -174,8 +174,6 @@ group :development, :test do
   gem 'puma'
   # to drive headless chrome
   gem 'selenium-webdriver'
-  # scan for security vulnerability (circleci only, do not touch)
-  # BRAKEMAN
 end
 
 group :development do


### PR DESCRIPTION
brakeman is a linter, we should run it where we run all the other linters too.
Firing up a container is too expensive just for this.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
