### PR TITLE
Ignore type column for Notification model

### DIFF
--- a/src/api/app/models/notification.rb
+++ b/src/api/app/models/notification.rb
@@ -13,6 +13,9 @@ class Notification < ApplicationRecord
   scope :for_web, -> { where(web: true) }
   scope :for_rss, -> { where(rss: true) }
 
+  # FIXME: Remove this once the column is removed in the database
+  self.ignored_columns = ['type']
+
   def event
     @event ||= event_type.constantize.new(event_payload)
   end

--- a/src/api/spec/factories/notification.rb
+++ b/src/api/spec/factories/notification.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :notification do
-    type { 'Notification' }
     event_type { 'Event::RequestStatechange' }
     event_payload { { fake: 'payload' } }
     subscription_receiver_role { 'owner' }


### PR DESCRIPTION
We are going to remove this column from the notifications table. This is to avoid a downtime.