### PR TITLE
Add counter to notification filter links

### DIFF
--- a/src/api/app/controllers/webui/users/notifications_controller.rb
+++ b/src/api/app/controllers/webui/users/notifications_controller.rb
@@ -14,6 +14,7 @@ class Webui::Users::NotificationsController < Webui::WebuiController
                      end
 
     @projects_for_filter = projects_for_filter
+    @notifications_count = notifications_count
 
     @notifications = params['show_all'] ? show_all : @notifications.page(params[:page])
   end
@@ -61,5 +62,10 @@ class Webui::Users::NotificationsController < Webui::WebuiController
            .where(notifications: { subscriber: User.session, delivered: false, web: true })
            .order('name desc').group(:name).count # this query returns a sorted-by-name hash like { "home:b" => 1, "home:a" => 3  }
            .sort_by(&:last).reverse.to_h # this sorts the hash by amount: { "home:a" => 3, "home:b" => 1 }
+  end
+
+  def notifications_count
+    counted_notifications = NotificationsFinder.new(User.session.notifications.for_web).unread.group(:notifiable_type).count
+    counted_notifications.merge!('unread' => User.session.unread_notifications)
   end
 end

--- a/src/api/app/helpers/webui/notification_helper.rb
+++ b/src/api/app/helpers/webui/notification_helper.rb
@@ -9,17 +9,10 @@ module Webui::NotificationHelper
     end
   end
 
-  def filter_by_type_link(link_text, filter_item)
-    link_to(link_text, my_notifications_path(filter_item), class: filter_css(filter_item))
-  end
-
-  def filter_by_project_link(link_text, amount, filter_item)
-    badge_color = notification_filter_active?(filter_item) ? 'badge-light' : 'badge-primary'
+  def filter_notification_link(link_text, amount, filter_item)
     link_to(my_notifications_path(filter_item), class: filter_css(filter_item)) do
-      capture do
-        concat(link_text)
-        concat(tag.span(amount, class: "badge #{badge_color} align-text-top ml-2"))
-      end
+      concat(link_text)
+      concat(tag.span(amount, class: "badge #{badge_color(filter_item)} align-text-top ml-2")) if amount && amount.positive?
     end
   end
 
@@ -39,5 +32,9 @@ module Webui::NotificationHelper
     else
       filter_item[:type] == 'unread'
     end
+  end
+
+  def badge_color(filter_item)
+    notification_filter_active?(filter_item) ? 'badge-light' : 'badge-primary'
   end
 end

--- a/src/api/app/views/webui/users/notifications/index.html.haml
+++ b/src/api/app/views/webui/users/notifications/index.html.haml
@@ -13,17 +13,17 @@
 
       .card-body.collapse#filters
         .row.list-group-flush
-          = filter_by_type_link('Unread', type: 'unread')
-          = filter_by_type_link('Read', type: 'read')
+          = filter_notification_link('Unread', @notifications_count['unread'], type: 'unread')
+          = filter_notification_link('Read', nil, type: 'read')
         .row.list-group-flush.mt-5
           %h5.ml-3 Filter
-          = filter_by_type_link('Reviews', type: 'reviews')
-          = filter_by_type_link('Comments', type: 'comments')
-          = filter_by_type_link('Requests', type: 'requests')
+          = filter_notification_link('Reviews', @notifications_count['Review'], type: 'reviews')
+          = filter_notification_link('Comments', @notifications_count['Comment'], type: 'comments')
+          = filter_notification_link('Requests', @notifications_count['BsRequest'], type: 'requests')
         .row.list-group-flush.mt-5
           %h5.ml-3 Projects
           - @projects_for_filter.each_pair do |project_name, amount|
-            = filter_by_project_link(project_name, amount, project: project_name)
+            = filter_notification_link(project_name, amount, project: project_name)
   .col-md-8.col-lg-9#notifications-list
     .card
       .card-body


### PR DESCRIPTION
Currently we only show the amount of notifications,
for the project filter links.
In order to enable the user to get a quick overview
about the amount of pending notifications,
we now show a badge with the amount also for notifications
related to review, comments, request and overall unread.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
