### PR TITLE
Do not run data migrations in db:verify

### DIFF
--- a/src/api/db/migrate/001_initial_database.rb
+++ b/src/api/db/migrate/001_initial_database.rb
@@ -269,6 +269,8 @@ class InitialDatabase < ActiveRecord::Migration[4.2]
       t.string   'admin_email',                                     default: 'unconfigured@openbuildservice.org'
     end
 
+    create_table :data_migrations, primary_key: 'version', id: :string
+
     create_table 'db_project_types', force: :cascade, options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin' do |t|
       t.string 'name', null: false, collation: 'utf8_general_ci'
     end

--- a/src/api/lib/tasks/databases.rake
+++ b/src/api/lib/tasks/databases.rake
@@ -85,8 +85,8 @@ namespace :db do
       puts 'Dropping database...'
       Rake::Task['db:drop'].invoke
       Rake::Task['db:create'].invoke
-      puts 'Running rails db:migrate:with_data'
-      Rake::Task['db:migrate:with_data'].invoke
+      puts 'Running rails db:migrate'
+      Rake::Task['db:migrate'].invoke
       normalize_structure
       puts 'Diffing the db/structure.sql'
       sh %(git diff --exit-code db/structure.sql) do |ok, _|


### PR DESCRIPTION
Data migrations have nothing to do with `db/structure.sql`

This avoids issues like in #9801 right now.