### PR TITLE
Adapt ConsistencyCheckJob to use its own mailer

### DIFF
--- a/src/api/app/mailers/admin_mailer.rb
+++ b/src/api/app/mailers/admin_mailer.rb
@@ -35,14 +35,16 @@ class AdminMailer < ActionMailer::Base
     # issues to the admins in webui and they can work on them
     # the problems should get updated or removed when we detect changes.
 
-    # find all admins. No opt-out atm
-    r = Role.find_by_title('Admin')
-    admins = RolesUser.where(role: r).map { |ru| ru.user.email }
-
     mail(to: admins,
          subject: "OBS Administrator #{level}",
          from: ::Configuration.admin_email,
          date: Time.now,
          body: message)
+  end
+
+  def admins
+    # find all admins. No opt-out atm
+    r = Role.find_by_title('Admin')
+    RolesUser.where(role: r).map { |ru| ru.user.email }
   end
 end

--- a/src/api/app/mailers/consistency_mailer.rb
+++ b/src/api/app/mailers/consistency_mailer.rb
@@ -1,0 +1,12 @@
+class ConsistencyMailer < AdminMailer
+  def errors(errors)
+    set_headers
+    return unless @host
+
+    @errors = errors
+    mail(to: admins,
+         subject: 'OBS Administrator errors',
+         from: ::Configuration.admin_email,
+         date: Time.now.utc)
+  end
+end

--- a/src/api/app/views/consistency_mailer/errors.text.erb
+++ b/src/api/app/views/consistency_mailer/errors.text.erb
@@ -1,0 +1,5 @@
+Inconsistencies found:
+
+<%@errors.each do |error| %>
+  <%= error %>
+<% end %>

--- a/src/api/config/environments/development.rb
+++ b/src/api/config/environments/development.rb
@@ -12,9 +12,7 @@ OBSApi::Application.configure do
   config.eager_load = false
 
   # see http://guides.rubyonrails.org/action_mailer_basics.html#example-action-mailer-configuration
-  config.action_mailer.delivery_method = :smtp
-  # we deliver to mailcatcher https://github.com/sj26/mailcatcher
-  config.action_mailer.smtp_settings = { address: '127.0.0.1', port: '1025' }
+  config.action_mailer.delivery_method = :test
   config.action_mailer.raise_delivery_errors = true
 
   # Show full error reports and disable caching


### PR DESCRIPTION
In this PR we did three things:

- Instead of using `mailercatcher` use the `:test` mailer delivery method in development
- Create a custom Mailer and use ERB template to generate the mail message
- Adapt `ConsistencyCheckJob` to use the new mailer