### PR TITLE
Drop mailcatcher from Procfile

### DIFF
--- a/contrib/Procfile.ha
+++ b/contrib/Procfile.ha
@@ -1,5 +1,4 @@
 web: bundle exec rails server -P tmp/pids/server$NODE_NUMBER.pid
 delayed: bundle exec script/delayed_job.api.rb run
-clock: bundle exec clockworkd --log-dir=log -l -c config/clock.rb run 
+clock: bundle exec clockworkd --log-dir=log -l -c config/clock.rb run
 search: bundle exec rake ts:rebuild NODETACH=true
-mailcatcher: mailcatcher --ip 0.0.0.0 -f --no-quit -v

--- a/src/api/Procfile
+++ b/src/api/Procfile
@@ -2,4 +2,3 @@ web: bundle exec rails server -b 0.0.0.0
 delayed: bundle exec script/delayed_job.api.rb run
 clock: bundle exec clockworkd --log-dir=log -l -c config/clock.rb run
 search: bundle exec rails sphinx:start_for_development
-mailcatcher: mailcatcher --ip 0.0.0.0 -f --no-quit -v


### PR DESCRIPTION
Mailcatcher is not used anymore in the dev environment

Last usage got removed by https://github.com/openSUSE/open-build-service/pull/9807

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
