### PR TITLE
Remove column type from notifications table

### DIFF
--- a/src/api/app/models/notification.rb
+++ b/src/api/app/models/notification.rb
@@ -49,7 +49,6 @@ end
 #  subscriber_type            :string(255)      indexed => [subscriber_id]
 #  subscription_receiver_role :string(255)      not null
 #  title                      :string(255)
-#  type                       :string(255)      default(""), not null
 #  web                        :boolean          default(FALSE)
 #  created_at                 :datetime         not null
 #  updated_at                 :datetime         not null

--- a/src/api/db/migrate/20200623084234_remove_type_from_notifications.rb
+++ b/src/api/db/migrate/20200623084234_remove_type_from_notifications.rb
@@ -1,0 +1,5 @@
+class RemoveTypeFromNotifications < ActiveRecord::Migration[6.0]
+  def change
+    safety_assured { remove_column :notifications, :type, :string, null: false, default: '' }
+  end
+end

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -819,7 +819,6 @@ CREATE TABLE `messages` (
 
 CREATE TABLE `notifications` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `type` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `event_type` varchar(255) CHARACTER SET utf8 NOT NULL,
   `event_payload` text COLLATE utf8mb4_unicode_ci NOT NULL,
   `subscription_receiver_role` varchar(255) CHARACTER SET utf8 NOT NULL,
@@ -1508,6 +1507,7 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20200522145733'),
 ('20200522151615'),
 ('20200601083057'),
-('20200618152542');
+('20200618152542'),
+('20200623084234');
 
 

--- a/src/api/spec/factories/notification.rb
+++ b/src/api/spec/factories/notification.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :notification do
-    type { 'Notification' }
     event_type { 'Event::RequestStatechange' }
     event_payload { { fake: 'payload' } }
     subscription_receiver_role { 'owner' }


### PR DESCRIPTION
The column cannot be ignored since it's the reserved `type` column for Single Table Inheritance. See my [comment](https://github.com/openSUSE/open-build-service/pull/9801#issuecomment-647984689) for details.

**DO NOT MERGE**: This forces us to deploy and migrate during on maintenance window this upcoming Thursday.