### PR TITLE
Remove colorize gem

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -43,8 +43,6 @@ gem 'bcrypt'
 gem 'acts_as_tree'
 # js plotting (OBS monitor)
 gem 'flot-rails'
-# colorize for scripts
-gem 'colorize', require: false
 # XML Serialization got moved here
 gem 'activemodel-serializers-xml'
 # Spider Identification

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -118,7 +118,6 @@ GEM
       simplecov
       url
     coderay (1.1.3)
-    colorize (0.8.1)
     concurrent-ruby (1.1.6)
     coveralls (0.8.23)
       json (>= 1.8, < 3)
@@ -462,7 +461,6 @@ DEPENDENCIES
   cocoon
   codecov
   coderay
-  colorize
   coveralls
   daemons
   dalli


### PR DESCRIPTION
Following the merge of #9816, this gem isn't in use anymore.