### PR TITLE
Remove escape_utils gem

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -33,8 +33,6 @@ gem 'cocoon'
 gem 'acts_as_list'
 # to parse a XML string into a ruby hash
 gem 'xmlhash', '>=1.3.6'
-# to escape HTML (FIXME: do we still use this?)
-gem 'escape_utils'
 # as authorization system
 gem 'pundit'
 # for password hashing

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -145,7 +145,6 @@ GEM
     docile (1.3.2)
     erubi (1.9.0)
     erubis (2.7.0)
-    escape_utils (1.2.1)
     execjs (2.7.0)
     factory_bot (6.0.2)
       activesupport (>= 5.0.0)
@@ -470,7 +469,6 @@ DEPENDENCIES
   database_cleaner (>= 1.0.1)
   deep_cloneable (~> 3.0.0)
   delayed_job_active_record (>= 4.0.0)
-  escape_utils
   factory_bot_rails
   faker
   flipper


### PR DESCRIPTION
We don't use this gem anymore. If we did, searching for `EscapeUtils` or `escape_utils` would return at least one result. This is the gem's documented usage: https://github.com/brianmario/escape_utils#usage
