### PR TITLE
Make notifications filter sticky on mobile

### DIFF
--- a/src/api/app/assets/stylesheets/webui/responsive_ux.scss
+++ b/src/api/app/assets/stylesheets/webui/responsive_ux.scss
@@ -65,6 +65,15 @@ body.responsive-ux {
       &.center { margin-left: calc(38% + .75rem); }
       &.left { left: .5rem; }
     }
+  }
+}
 
+@include media-breakpoint-between(xs, sm) {
+  body.responsive-ux {
+    #notifications-filter-desktop {
+      &.show { border-top: 1px solid $gray-300; }
+      &.sticky-top { top: $top-bar-height; }
+      #filters { height: 200px; overflow: auto; }
+    }
   }
 }

--- a/src/api/app/views/webui/users/notifications/index.html.haml
+++ b/src/api/app/views/webui/users/notifications/index.html.haml
@@ -4,7 +4,7 @@
   end
 
 .row
-  .col-md-4.col-lg-3#notifications-filter-desktop
+  .col-md-4.col-lg-3.sticky-top#notifications-filter-desktop
     .card.mb-3
       %strong.d-block.d-md-none.p-3{ data: { toggle: 'collapse', target: '#filters' },
                                   aria: { expanded: true, controls: 'filters' } }


### PR DESCRIPTION
The PR is work in progress because the colors of the filter box need to be adjusted.
<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
