### PR TITLE
Show the flash message after marking a notification as read/unread

### DIFF
--- a/src/api/app/views/webui/users/notifications/_update.js.erb
+++ b/src/api/app/views/webui/users/notifications/_update.js.erb
@@ -1,2 +1,3 @@
 $('#filters').html("<%= j(render partial: 'notifications_filter', locals: { projects_for_filter: projects_for_filter, notifications_count: notifications_count }) %>");
 $('#notifications-list').html("<%= j(render partial: 'notifications_list', locals: { notifications: notifications }) %>");
+$('#flash').html("<%= escape_javascript(render(layout: false, partial: 'layouts/webui/flash', object: flash)) %>");


### PR DESCRIPTION
Without this change, the flash message is only shown after reloading the page.