### PR TITLE
Fix smoke tests switching to apparition capybara driver

### DIFF
--- a/dist/t/Gemfile
+++ b/dist/t/Gemfile
@@ -4,4 +4,4 @@ gem 'capybara'
 gem 'rspec-core'
 gem 'rspec-expectations'
 # as driver for capybara
-gem 'selenium-webdriver'
+gem 'apparition'

--- a/dist/t/Gemfile.lock
+++ b/dist/t/Gemfile.lock
@@ -1,50 +1,49 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.5.0)
-      public_suffix (~> 2.0, >= 2.0.2)
-    capybara (2.13.0)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    apparition (0.6.0)
+      capybara (~> 3.13, < 4)
+      websocket-driver (>= 0.6.5)
+    capybara (3.33.0)
       addressable
-      mime-types (>= 1.16)
-      nokogiri (>= 1.3.3)
-      rack (>= 1.0.0)
-      rack-test (>= 0.5.4)
-      xpath (~> 2.0)
-    childprocess (0.9.0)
-      ffi (~> 1.0, >= 1.0.11)
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (~> 1.5)
+      xpath (~> 3.2)
     diff-lcs (1.3)
-    ffi (1.9.25)
-    mime-types (3.1)
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2016.0521)
-    mini_portile2 (2.1.0)
-    nokogiri (1.7.1)
-      mini_portile2 (~> 2.1.0)
-    public_suffix (2.0.5)
-    rack (2.0.1)
-    rack-test (0.6.3)
-      rack (>= 1.0)
+    mini_mime (1.0.2)
+    mini_portile2 (2.4.0)
+    nokogiri (1.10.9)
+      mini_portile2 (~> 2.4.0)
+    public_suffix (4.0.5)
+    rack (2.2.3)
+    rack-test (1.1.0)
+      rack (>= 1.0, < 3)
+    regexp_parser (1.7.1)
     rspec-core (3.5.4)
       rspec-support (~> 3.5.0)
     rspec-expectations (3.5.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    rubyzip (1.2.1)
-    selenium-webdriver (3.14.0)
-      childprocess (~> 0.5)
-      rubyzip (~> 1.2)
-    xpath (2.0.0)
-      nokogiri (~> 1.3)
+    websocket-driver (0.7.2)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  apparition
   capybara
   rspec-core
   rspec-expectations
-  selenium-webdriver
 
 BUNDLED WITH
-   1.13.7
+   1.17.1

--- a/dist/t/spec/features/0040_package_spec.rb
+++ b/dist/t/spec/features/0040_package_spec.rb
@@ -55,7 +55,9 @@ RSpec.describe "Package" do
     within("div#personal-navigation") do
       click_link('Home Project')
     end
-    click_link('build')
+    within("table#packages-table") do
+      click_link('build')
+    end
     click_link('Delete package')
     expect(page).to have_content('Do you really want to delete this package?')
     click_button('Delete')

--- a/dist/t/spec/spec_helper.rb
+++ b/dist/t/spec/spec_helper.rb
@@ -32,7 +32,7 @@ def take_screenshot(example)
   line_number = example.metadata[:line_number]
   screenshot_name = "screenshot-#{filename}-#{line_number}.png"
   screenshot_path = File.join(SCREENSHOT_DIR, screenshot_name)
-  page.save_screenshot(screenshot_path)
+  page.save_screenshot(screenshot_path, full: true)
 end
 
 def login

--- a/dist/t/spec/support/capybara.rb
+++ b/dist/t/spec/support/capybara.rb
@@ -1,17 +1,18 @@
 require 'capybara'
+require 'capybara/apparition'
 require 'capybara/dsl'
-require 'selenium-webdriver'
 require 'socket'
 
-Selenium::WebDriver::Chrome.driver_path = '/usr/lib64/chromium/chromedriver'
-
 Capybara.register_driver :selenium_chrome_headless do |app|
-  browser_options = ::Selenium::WebDriver::Chrome::Options.new
-  browser_options.args << '--headless'
-  browser_options.args << '--no-sandbox'
-  browser_options.args << '--allow-insecure-localhost'
-  browser_options.add_option('w3c', false)
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
+  options = {
+    window_size:         [1280, 1024],
+    js_errors:           false,
+    headless:            true,
+    ignore_https_errors: true,
+    w3c:                 false,
+    browser_options:     { 'disable-gpu': true, 'no-sandbox': true }
+  }
+  Capybara::Apparition::Driver.new(app, options)
 end
 
 Capybara.default_driver = :selenium_chrome_headless


### PR DESCRIPTION
Smoke tests where fixed for Unstable in #9809. This does the same for branch 2.10.

The capybara gem had to be updated to support apparition.