### PR TITLE
Migrate AttribNamespacePolicy tests from Minitest to RSpec

### DIFF
--- a/src/api/app/models/attrib_namespace_modifiable_by.rb
+++ b/src/api/app/models/attrib_namespace_modifiable_by.rb
@@ -1,5 +1,5 @@
 class AttribNamespaceModifiableBy < ApplicationRecord
-  belongs_to :attrib_namespaces
+  belongs_to :attrib_namespace
   belongs_to :user
   belongs_to :group
 end

--- a/src/api/spec/factories/attrib_namespace_modifiable_bies.rb
+++ b/src/api/spec/factories/attrib_namespace_modifiable_bies.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :attrib_namespace_modifiable_by do
+    attrib_namespace
+    user
+    group
+  end
+end

--- a/src/api/spec/policies/attrib_namespace_policy_spec.rb
+++ b/src/api/spec/policies/attrib_namespace_policy_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe AttribNamespacePolicy do
+  let(:anonymous_user) { create(:user_nobody) }
+  let(:user_in_a_group) { create(:groups_user, user: create(:confirmed_user)).user }
+  let(:admin_user) { create(:admin_user) }
+  let(:attrib_namespace) { create(:attrib_namespace) }
+
+  subject { AttribNamespacePolicy }
+
+  context :without_explicit_permissions do
+    permissions :create?, :update?, :destroy? do
+      it { is_expected.not_to permit(anonymous_user, attrib_namespace) }
+      it { is_expected.not_to permit(user_in_a_group, attrib_namespace) }
+      it { is_expected.to permit(admin_user, attrib_namespace) }
+    end
+  end
+
+  context :with_explicit_permissions_for_a_group do
+    before do
+      create(:attrib_namespace_modifiable_by, attrib_namespace: attrib_namespace, group: user_in_a_group.groups.first, user: nil)
+    end
+
+    permissions :create?, :update?, :destroy? do
+      it { is_expected.not_to permit(anonymous_user, attrib_namespace) }
+      it { is_expected.to permit(user_in_a_group, attrib_namespace) }
+      it { is_expected.to permit(admin_user, attrib_namespace) }
+    end
+  end
+
+  context :with_explicit_permissions_for_a_user do
+    before do
+      create(:attrib_namespace_modifiable_by, attrib_namespace: attrib_namespace, user: user_in_a_group, group: nil)
+    end
+
+    permissions :create?, :update?, :destroy? do
+      it { is_expected.not_to permit(anonymous_user, attrib_namespace) }
+      it { is_expected.to permit(user_in_a_group, attrib_namespace) }
+      it { is_expected.to permit(admin_user, attrib_namespace) }
+    end
+  end
+end

--- a/src/api/test/policies/attrib_policy_test.rb
+++ b/src/api/test/policies/attrib_policy_test.rb
@@ -38,23 +38,4 @@ class AttribPolicyTest < ActiveSupport::TestCase
     policy = AttribPolicy.new(users(:Iggy), attrib)
     assert_not policy.create?, "#{users(:Iggy)} shouldn't be able to CURD attrib_type"
   end
-
-  # AttribNamespaceModifiableBy
-  test 'group can crud attrib_namespace' do
-    # user6 is in group honks
-    policy = AttribNamespacePolicy.new(users(:user6), attrib_namespaces(:obs))
-    assert policy.create?, "#{users(:user6)} can't CRUD attrib_namespace"
-    # Iggy is not
-    policy = AttribNamespacePolicy.new(users(:Iggy), attrib_namespaces(:obs))
-    assert_not policy.create?, "#{users(:Iggy)} shouldn't be able to CURD attrib_namespace"
-  end
-
-  test 'user can crud attrib_namespace' do
-    # Fred is explicitely set
-    policy = AttribNamespacePolicy.new(users(:fred), attrib_namespaces(:obs))
-    assert policy.create?, "#{users(:fred)} can't CRUD attrib_namespace"
-    # Iggy not
-    policy = AttribNamespacePolicy.new(users(:Iggy), attrib_namespaces(:obs))
-    assert_not policy.create?, "#{users(:Iggy)} shouldn't be able to CURD attrib_namespace"
-  end
 end


### PR DESCRIPTION
We want to move away from Minitest.