### PR TITLE
Chunk binaryversion requests when querying a remote server

### DIFF
--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -4098,6 +4098,14 @@ sub getpackagelist_build {
       if (!$BSStdServer::isajax) {
 	BSHandoff::handoff("/build/$projid/$repoid/$arch", undef, @args);
       }
+      if (@{$cgi->{'package'} || []} && ($view eq 'binaryversions' || $view eq 'binaryversionscode')) {
+	my $pbvl = BSSrcServer::Remote::getpackagebinaryversionlist($proj, $projid, $repoid, $arch, $cgi->{'package'}, $view);
+	return ($pbvl, $BSXML::packagebinaryversionlist);
+      }
+      if (@{$cgi->{'package'} || []} && $view eq 'binarychecksums') {
+	my $pbc = BSSrcServer::Remote::getpackagebinaryversionlist($proj, $projid, $repoid, $arch, $cgi->{'package'}, $view);
+	return ($pbc, $BSXML::packagebinarychecksums);
+      }
       $param->{'uri'} = "$proj->{'remoteurl'}/build/$proj->{'remoteproject'}/$repoid/$arch";
       $param->{'proxy'} = $proxy;
     }

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -2802,6 +2802,22 @@ sub getsourcediffcache {
   die("cache entry '$cacheid' does not exist\n");
 }
 
+sub cleandiffcache {
+  my ($cacheid, $thr) = @_;
+  my $now = time();
+  my $slot = substr($cacheid, 0, 2);
+  my $dir = "$diffcache/$slot";
+  my $cnt = 0;
+  for my $e (sort(ls($dir))) {
+     next unless $e =~ /^[0-9a-f]{32}$/;
+     my @s = stat("$dir/$e");
+     next if $s[9] > $now - $thr;
+     unlink("$dir/$e");
+     $cnt++;
+  }
+  print "cleandiffcache: removed $cnt entries in slot $slot\n";
+}
+
 sub sourcediff {
   my ($cgi, $projid, $packid) = @_;
 
@@ -3009,7 +3025,11 @@ sub sourcediff {
     unlink("$cn.run");
     close LF;
   }
-  return ($d, $view eq 'xml' ? 'Content-Type: text/xml' : 'Content-Type: text/plain');
+  BSServer::reply($d, $view eq 'xml' ? 'Content-Type: text/xml' : 'Content-Type: text/plain');
+  undef $d;
+  BSServer::done(1);
+  cleandiffcache($cacheid, 86400 * 100) if $cn && substr($cacheid, -2, 2) eq '00';
+  return undef;
 }
 
 sub linkdiff {


### PR DESCRIPTION
<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
