### PR TITLE
Remove soft deletion of StatusMessage

### DIFF
--- a/src/api/app/controllers/status_messages_controller.rb
+++ b/src/api/app/controllers/status_messages_controller.rb
@@ -3,7 +3,7 @@ class StatusMessagesController < ApplicationController
   before_action :set_status_message, except: [:index, :create]
 
   def index
-    @status_messages = StatusMessage.alive.limit(params[:limit]).order('created_at DESC').includes(:user)
+    @status_messages = StatusMessage.limit(params[:limit]).order('created_at DESC').includes(:user)
     @count = @status_messages.size
   end
 
@@ -28,7 +28,7 @@ class StatusMessagesController < ApplicationController
 
   def destroy
     authorize @status_message
-    @status_message.delete
+    @status_message.destroy
     render_ok
   end
 

--- a/src/api/app/controllers/webui/feeds_controller.rb
+++ b/src/api/app/controllers/webui/feeds_controller.rb
@@ -5,7 +5,7 @@ class Webui::FeedsController < Webui::WebuiController
   before_action :set_project, only: [:commits]
 
   def news
-    @news = StatusMessage.alive.includes(:user).limit(5)
+    @news = StatusMessage.order('created_at DESC').includes(:user).limit(5)
   end
 
   def latest_updates

--- a/src/api/app/controllers/webui/main_controller.rb
+++ b/src/api/app/controllers/webui/main_controller.rb
@@ -4,7 +4,7 @@ class Webui::MainController < Webui::WebuiController
   skip_before_action :check_anonymous, only: [:index]
 
   def index
-    @status_messages = StatusMessage.alive.where(communication_scope: StatusMessage.communication_scopes_for_current_user).includes(:user).limit(4)
+    @status_messages = StatusMessage.order('created_at DESC').where(communication_scope: StatusMessage.communication_scopes_for_current_user).includes(:user).limit(4)
     @workerstatus = Rails.cache.fetch('workerstatus_hash', expires_in: 10.minutes) do
       Xmlhash.parse(WorkerStatus.hidden.to_xml)
     end

--- a/src/api/app/controllers/webui/status_messages_controller.rb
+++ b/src/api/app/controllers/webui/status_messages_controller.rb
@@ -22,7 +22,7 @@ class Webui::StatusMessagesController < Webui::WebuiController
   def destroy
     status_message = StatusMessage.find(params[:id])
 
-    if status_message.delete
+    if status_message.destroy
       flash[:success] = 'Status message was successfully deleted.'
     else
       flash[:error] = "Could not delete status message: #{status_message.errors.full_messages.to_sentence}"

--- a/src/api/app/models/status_message.rb
+++ b/src/api/app/models/status_message.rb
@@ -5,8 +5,7 @@ class StatusMessage < ApplicationRecord
 
   validates :user, :severity, :message, presence: true
 
-  scope :alive, -> { where(deleted_at: nil).order('created_at DESC') }
-  scope :announcements, -> { alive.where(severity: 'announcement') }
+  scope :announcements, -> { order('created_at DESC').where(severity: 'announcement') }
 
   enum severity: { information: 0, green: 1, yellow: 2, red: 3, announcement: 4 }
   enum communication_scope: { all_users: 0, logged_in_users: 1, admin_users: 2, in_beta_users: 3, in_rollout_users: 4 }
@@ -20,11 +19,6 @@ class StatusMessage < ApplicationRecord
     scope = doc.css('scope').text
     scope = 'all_users' if scope.blank?
     StatusMessage.new(message: message, severity: severity, communication_scope: scope, user: User.session!)
-  end
-
-  def delete
-    self.deleted_at = Time.now
-    save
   end
 
   def acknowledge!

--- a/src/api/app/models/status_message.rb
+++ b/src/api/app/models/status_message.rb
@@ -10,6 +10,9 @@ class StatusMessage < ApplicationRecord
   enum severity: { information: 0, green: 1, yellow: 2, red: 3, announcement: 4 }
   enum communication_scope: { all_users: 0, logged_in_users: 1, admin_users: 2, in_beta_users: 3, in_rollout_users: 4 }
 
+  # FIXME: Remove this once the `deleted_at` column is removed
+  self.ignored_columns = ['deleted_at']
+
   # xml: A Nokogiri object
   def self.from_xml(xml)
     StatusMessage.create! if xml.blank?

--- a/src/api/spec/controllers/webui/status_messages_controller_spec.rb
+++ b/src/api/spec/controllers/webui/status_messages_controller_spec.rb
@@ -74,26 +74,28 @@ RSpec.describe Webui::StatusMessagesController do
   end
 
   describe 'DELETE destroy' do
-    let(:message) { create(:status_message, user: admin_user) }
+    let!(:message) { create(:status_message, user: admin_user) }
 
-    it 'marks a message as deleted' do
-      login(admin_user)
+    context 'as an admin' do
+      before do
+        login(admin_user)
+      end
 
-      delete :destroy, params: { id: message.id }
-      expect(response).to redirect_to(root_path)
-      expect(message.reload.deleted_at).to be_a_kind_of(ActiveSupport::TimeWithZone)
+      subject { delete :destroy, params: { id: message.id } }
+
+      it { is_expected.to redirect_to(root_path) }
+      it { expect { subject }.to change(StatusMessage, :count).by(-1) }
     end
 
     context 'non-admin users' do
       before do
         login(user)
-        delete :destroy, params: { id: message.id }
       end
 
-      it "can't delete messages" do
-        expect(response).to redirect_to(root_path)
-        expect(message.reload.deleted_at).to be(nil)
-      end
+      subject { delete :destroy, params: { id: message.id } }
+
+      it { is_expected.to redirect_to(root_path) }
+      it { expect { subject }.not_to(change(StatusMessage, :count)) }
     end
   end
 


### PR DESCRIPTION
We don't need this feature. We are going to remove the `deleted_at` column in an upcoming PR.