### PR TITLE
Improve responsive UX of the notifiations page

### DIFF
--- a/src/api/app/assets/stylesheets/webui/responsive_ux.scss
+++ b/src/api/app/assets/stylesheets/webui/responsive_ux.scss
@@ -73,7 +73,19 @@ body.responsive-ux {
     #notifications-filter-desktop {
       &.show { border-top: 1px solid $gray-300; }
       &.sticky-top { top: $top-bar-height; }
-      #filters { height: 200px; overflow: auto; }
+      #filters {
+        max-height: 100vw; overflow: auto;
+        -webkit-box-shadow: 2px 3px 5px rgba(0,0,0,.2);
+        -moz-box-shadow: 2px 3px 5px rgba(0,0,0,.2);
+        box-shadow: 2px 3px 5px rgba(0,0,0,.2);
+      }
+    }
+  }
+  @media (orientation: landscape){
+    body.responsive-ux {
+      #notifications-filter-desktop{
+        #filters{ max-height: 20vw; }
+      }
     }
   }
 }


### PR DESCRIPTION
* Add shadow to the filter button to differntiate it better from the
notifications list below.

* Change the fixed height of the shown filter to a screen size
dependable height.

* Resize height in landscape mode.

Co-authored-by: David Kang <dkang@suse.com>

**Screenshots**
Before and after screenshots of portrait mode
![before small screen portrait](https://user-images.githubusercontent.com/54893750/86014302-700f6b80-ba20-11ea-8d72-413333d1fe8a.png)

![after small screen portrait](https://user-images.githubusercontent.com/54893750/86014360-861d2c00-ba20-11ea-85d9-17aeeef542d3.png)

Before and after screenshots of landscape mode
![before small screen landscape](https://user-images.githubusercontent.com/54893750/86014385-8caba380-ba20-11ea-9cf6-d3709ba4dd37.png)

![after small screen landscape](https://user-images.githubusercontent.com/54893750/86014378-8ae1e000-ba20-11ea-8749-8b35ac3e048e.png)


<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
