### PR TITLE
[backend] report source publisher in server status

### DIFF
--- a/src/backend/BSConfiguration.pm
+++ b/src/backend/BSConfiguration.pm
@@ -94,5 +94,6 @@ $BSConfig::cloudupload_pubkey       = $BSConfig::cloudupload_pubkey       || '/e
 
 $BSConfig::redisserver = undef unless $BSConfig::redisserver;
 $BSConfig::local_registry_signatures_extension = undef unless $BSConfig::local_registry_signatures_extension;
+$BSConfig::sourcepublish_sync = undef unless $BSConfig::sourcepublish_sync;
 
 1;

--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -1813,7 +1813,7 @@ sub publish {
 
   # do we need to do source publishing?
   my $do_sourcepublish;
-  if ($BSConfig::sourcepublish_sync || $BSConfig::sourcepublish_sync) {
+  if ($BSConfig::sourcepublish_sync) {
     if ($BSConfig::sourcepublish_filter) {
       $do_sourcepublish = 1 if grep {$prp =~ /^$_/} @$BSConfig::sourcepublish_filter;
     } else {

--- a/src/backend/bs_sourcepublish
+++ b/src/backend/bs_sourcepublish
@@ -42,7 +42,7 @@ my $eventdir = "$BSConfig::bsdir/events";
 my $srcrep = "$BSConfig::bsdir/sources";
 my $uploaddir = "$srcrep/:upload";
 
-my $rsyncserver = $BSConfig::sourcepublish_sync || $BSConfig::sourcepublish_sync;
+my $rsyncserver = $BSConfig::sourcepublish_sync;
 
 my $maxchild = 1;
 $maxchild = $BSConfig::sourcepublish_maxchild if defined $BSConfig::sourcepublish_maxchild;

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -4501,6 +4501,7 @@ sub add_localworkerstatus {
   return $ws if $cgi->{'arch'} && !grep {$_ eq $type} @{$cgi->{'arch'}};
   return $ws if $type eq 'servicedispatch' && !$BSConfig::servicedispatch;
   return $ws if $type eq 'redis' && !$BSConfig::redisserver;
+  return $ws if $type eq 'sourcepublish' && !$BSConfig::sourcepublish_sync;
   return $ws if $type ne 'srcserver' && ! -e $lock;
   my $daemondata = {'state' => 'dead', 'type' => $type};
   if ($type eq 'srcserver') {
@@ -4589,6 +4590,7 @@ sub getworkerstatus {
     add_localworkerstatus($cgi, $ws, 'deltastore', "$rundir/bs_deltastore.lock");
     add_localworkerstatus($cgi, $ws, 'servicedispatch', "$rundir/bs_servicedispatch.lock");
     add_localworkerstatus($cgi, $ws, 'redis', "$rundir/bs_redis.lock");
+    add_localworkerstatus($cgi, $ws, 'sourcepublish', "$rundir/bs_sourcepublish.lock");
     add_localworkerstatus($cgi, $ws, 'srcserver');
     return ($ws, $BSXML::workerstatus);
   }
@@ -4675,6 +4677,7 @@ sub getworkerstatus {
   add_localworkerstatus($cgi, $cws, 'deltastore', "$rundir/bs_deltastore.lock");
   add_localworkerstatus($cgi, $cws, 'servicedispatch', "$rundir/bs_servicedispatch.lock");
   add_localworkerstatus($cgi, $cws, 'redis', "$rundir/bs_redis.lock");
+  add_localworkerstatus($cgi, $cws, 'sourcepublish', "$rundir/bs_sourcepublish.lock");
   add_localworkerstatus($cgi, $cws, 'srcserver');
   return ($cws, $BSXML::workerstatus);
 }


### PR DESCRIPTION
<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
