### PR TITLE
[backend] add support for $BSConfig::certfile to configure a default …

### DIFF
--- a/src/backend/BSConfig.pm.template
+++ b/src/backend/BSConfig.pm.template
@@ -187,9 +187,10 @@ our $relsync_pool = {
 #our $sign = '/usr/bin/sign';
 #Extend sign call with project name as argument "--project $NAME"
 #our $sign_project = 1;
-#Global sign key 
+#Global sign key / cert
 #our $keyfile = '/srv/obs/openSUSE-Build-Service.asc';
 #our $gpg_standard_key = "/etc/obs-default-gpg.asc";
+#our $certfile = '/srv/obs/openSUSE-Build-Service.cert'
 
 # Use a special local arch for product building
 # our $localarch = "x86_64";

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -5500,11 +5500,13 @@ sub getsslcert {
     my $cert = projid2sslcert($skprojid, $sk, $projid, 0, $signtype);
     return ($cert, 'Content-Type: text/plain');
   }
+  my $cert;
   if ($BSConfig::sign_project && $BSConfig::sign) {
-    my $cert = BSSrcServer::Signkey::getdefaultcert($projid, $signtype);
-    return ($cert, 'Content-Type: text/plain') if $cert;
+    $cert = BSSrcServer::Signkey::getdefaultcert($projid, $signtype);
+  } elsif ($BSConfig::certfile) {
+    $cert = readstr($BSConfig::certfile, 1);
   }
-  return ('', 'Content-Type: text/plain');
+  return ($cert || '', 'Content-Type: text/plain');
 }
 
 sub getkeyinfo {
@@ -5527,6 +5529,8 @@ sub getkeyinfo {
     } else {
       $cert = BSSrcServer::Signkey::getdefaultcert($projid, $signtype);
     }
+  } elsif ($cgi->{'withsslcert'} && !$skprojid && $BSConfig::certfile) {
+    $cert = readstr($BSConfig::certfile, 1);
   }
   if (!$pk && $BSConfig::sign_project && $BSConfig::sign) {
     $pk = BSSrcServer::Signkey::getdefaultpubkey($projid);


### PR DESCRIPTION
…cert file

We already have BSConfig::keyfile if forceprojectkeys is false.
We also need a default cert to build things like kernel packages.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
