### PR TITLE
[backend] support buildtime services in mergeservice call

### DIFF
--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -394,7 +394,6 @@ sub mergeservicerun {
   die("package has no service\n") unless $servicemark;
   $files = BSSrcServer::Service::handleservice($rev, $files, $servicemark);
   # merge
-  delete $files->{'_service'};
   for (sort keys %$files) {
     next unless /^_service:.*:(.*?)$/s;
     die("cannot create a link from a service") if $1 eq '_link';
@@ -402,6 +401,20 @@ sub mergeservicerun {
     delete $files->{$_};
     BSSrcrep::copyonefile($projid, $packid, $1, $projid, $packid, $_, $files->{$1});
   }
+
+  # filter services, but the "buildtime" ones
+  my $services = BSRevision::revreadxml($rev, '_service', $files->{'_service'}, $BSXML::services, 1) || {};
+  my @btservices = grep {$_->{'mode'} && $_->{'mode'} eq 'buildtime'} @{$services->{'service'} || []};
+  if (@btservices) {
+    # write services using buildtime back
+    $services->{'service'} = \@btservices;
+    mkdir_p($uploaddir);
+    writexml("$uploaddir/$$", undef, $services, $BSXML::services);
+    $files->{'_service'} = BSSrcrep::addfile($projid, $packid, "$uploaddir/$$", '_service');
+  } else {
+    delete $files->{'_service'}
+  }
+
   $rev = addrev_runservice($cgi, $projid, $packid, $files);
   delete $rev->{'project'};
   delete $rev->{'package'};


### PR DESCRIPTION
We must not drop _service file, but write these services back instead.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
