### PR TITLE
Add /package/dependency route to robots.txt

### DIFF
--- a/src/api/public/robots.txt
+++ b/src/api/public/robots.txt
@@ -4,6 +4,7 @@ Disallow: /package/live_build_log
 Disallow: /ICSLogin
 Disallow: /project/monitor
 Disallow: /project/buildresult
+Disallow: /package/dependency
 Disallow: /package/reload_buildstatus
 Disallow: /project/buildstatus
 Disallow: /project/status


### PR DESCRIPTION
The route `/package/dependency` is too expensive to be hit by crawlers. 

Closes #9872