### PR TITLE
Create data migration to adapt review and duplicated notifications 

### DIFF
--- a/src/api/db/data/20200702145811_adapt_review_and_duplicated_notifications.rb
+++ b/src/api/db/data/20200702145811_adapt_review_and_duplicated_notifications.rb
@@ -1,0 +1,59 @@
+class AdaptReviewAndDuplicatedNotifications < ActiveRecord::Migration[6.0]
+  def up
+    transform_review_notifications
+    remove_outdated_notifications
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  private
+
+  # associate the review notifications to the corresponding bs_request, since
+  # they won't be treated separately anymore
+  def transform_review_notifications
+    Notification.where("notifiable_type = 'Review'").find_each do |notification|
+      notification.update(notifiable_id: notification.notifiable.bs_request.id, notifiable_type: 'BsRequest')
+    end
+  end
+
+  # only keep the latest comment and request notifications related to the same notifiable and subscriber
+  def remove_outdated_notifications
+    Notification.find_each do |notification|
+      next if delete_notification_without_notifiable(notification)
+
+      notifications = outdated_notifications(notification)
+
+      notifications.destroy_all
+    end
+  end
+
+  def outdated_notifications(notification)
+    return fetch_comment_notifications(notification) if notification.notifiable_type == 'Comment'
+
+    fetch_bsrequest_notifications(notification)
+  end
+
+  def fetch_comment_notifications(notification)
+    notifiable = notification.notifiable
+    Notification.for_web.where(notifiable_type: 'Comment', subscriber_id: notification.subscriber_id)
+                .joins('JOIN comments ON notifications.notifiable_id = comments.id')
+                .where(comments: { commentable_type: notifiable.commentable_type,
+                                   commentable_id: notifiable.commentable_id }).order(id: :desc).offset(1)
+  end
+
+  def fetch_bsrequest_notifications(notification)
+    Notification.for_web.where(notifiable_id: notification.notifiable_id,
+                               notifiable_type: notification.notifiable_type,
+                               subscriber_id: notification.subscriber_id).order(id: :desc).offset(1)
+  end
+
+  # make sure the notifiable exist, otherwise delete the notification since it refers to nothing
+  def delete_notification_without_notifiable(notification)
+    return false if notification.notifiable
+
+    notification.destroy
+    true
+  end
+end

--- a/src/api/spec/db/data/adapt_review_and_duplicated_notifications_spec.rb
+++ b/src/api/spec/db/data/adapt_review_and_duplicated_notifications_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+require Rails.root.join('db/data/20200702145811_adapt_review_and_duplicated_notifications.rb')
+
+RSpec.describe AdaptReviewAndDuplicatedNotifications, type: :migration do
+  describe 'up' do
+    subject { AdaptReviewAndDuplicatedNotifications.new.up }
+
+    let(:subscriber) { create(:confirmed_user) }
+    let(:bs_request_with_submit_action) { create(:bs_request_with_submit_action, state: :review) }
+    let(:subscriber_review) do
+      create(:user_review, by_user: subscriber, user_id: subscriber.id,
+                           bs_request: bs_request_with_submit_action)
+    end
+
+    context 'review notifiable' do
+      before do
+        create(:notification, :review_wanted, notifiable: subscriber_review, subscriber: subscriber)
+        subject
+      end
+
+      it 'associates review notifications to the corresponding bs_request' do
+        expect(Notification.find_by(subscriber: subscriber).notifiable).to eq(bs_request_with_submit_action)
+      end
+
+      it 'removes all review notifications' do
+        expect(Notification.where(notifiable_type: 'Review')).not_to exist
+      end
+    end
+
+    context 'comment and bs_request notifiable' do
+      let(:comment_request) { create(:comment_request, commentable: bs_request_with_submit_action) }
+      let(:comment_request02) { create(:comment_request, commentable: bs_request_with_submit_action) }
+
+      let(:first_request_notification) do
+        create(:notification, :request_state_change, notifiable: bs_request_with_submit_action,
+                                                     subscriber: subscriber, web: true)
+      end
+      let(:second_request_notification) do
+        create(:notification, :request_state_change, notifiable: bs_request_with_submit_action,
+                                                     subscriber: subscriber, web: true)
+      end
+      let(:first_comment_notification) do
+        create(:notification, :comment_for_request, notifiable: comment_request,
+                                                    subscriber: subscriber, web: true)
+      end
+      let(:second_comment_notification) do
+        create(:notification, :comment_for_request, notifiable: comment_request02,
+                                                    subscriber: subscriber, web: true)
+      end
+
+      before do
+        first_request_notification
+        second_request_notification
+        first_comment_notification
+        second_comment_notification
+        subject
+      end
+
+      it 'keeps the latest request notifications for the subscriber' do
+        expect(Notification.find_by(notifiable: bs_request_with_submit_action, subscriber: subscriber)).to eq(second_request_notification)
+      end
+
+      it 'removes duplicated request notifications for the subscriber' do
+        expect(Notification.where(notifiable: bs_request_with_submit_action, subscriber: subscriber).count).to eq(1)
+      end
+
+      it 'keeps the latest comment notifications for the subscriber' do
+        expect(Notification.find_by(notifiable_type: 'Comment', subscriber: subscriber)).to eq(second_comment_notification)
+      end
+
+      it 'removes duplicated comment notifications for the subscriber' do
+        expect(Notification.where(notifiable_type: 'Comment', subscriber: subscriber).count).to eq(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Instead of having dedicated notification for `Event::ReviewWanted`,
we will from now on unify this with the request notifications.
The association to the review will be dropped. Therefore we
need to associate the review notifications to the corresponding
request through a data migration.
Also, we are going to show only the latest state of a request
or comment through the notifications. The data migration
needs to remove duplicated/outdated notifications that already
exist.

DO NOT MERGE: The data migration will cause a downtime, we need to wait for the maintenance window. This should
be merged close to it.