### PR TITLE
Add last_seen_at column to notifications table

### DIFF
--- a/src/api/app/models/notification.rb
+++ b/src/api/app/models/notification.rb
@@ -44,6 +44,7 @@ end
 #  delivered                  :boolean          default(FALSE)
 #  event_payload              :text(65535)      not null
 #  event_type                 :string(255)      not null
+#  last_seen_at               :datetime
 #  notifiable_type            :string(255)      indexed => [notifiable_id]
 #  rss                        :boolean          default(FALSE)
 #  subscriber_type            :string(255)      indexed => [subscriber_id]

--- a/src/api/db/migrate/20200703110429_add_last_seen_at_to_notifications.rb
+++ b/src/api/db/migrate/20200703110429_add_last_seen_at_to_notifications.rb
@@ -1,0 +1,5 @@
+class AddLastSeenAtToNotifications < ActiveRecord::Migration[6.0]
+  def change
+    add_column :notifications, :last_seen_at, :datetime
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_26_095558) do
+ActiveRecord::Schema.define(version: 2020_07_03_110429) do
 
   create_table "architectures", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false, collation: "utf8_general_ci"
@@ -672,6 +672,7 @@ ActiveRecord::Schema.define(version: 2020_06_26_095558) do
     t.string "title", collation: "utf8_unicode_ci"
     t.boolean "rss", default: false
     t.boolean "web", default: false
+    t.datetime "last_seen_at"
     t.index ["notifiable_type", "notifiable_id"], name: "index_notifications_on_notifiable_type_and_notifiable_id"
     t.index ["subscriber_type", "subscriber_id"], name: "index_notifications_on_subscriber_type_and_subscriber_id"
   end


### PR DESCRIPTION
In order to show the avatars of the users involved in the notifiable of the notification since the user last time checked the notification, we need to save the date and time the user lastly did so.

In other words:

One of the improvements in notifications is unifying/merging notifications affecting the same notifiable. Keeping all the information in one single line.

When many users write comments in my project, instead of receiving many notifications, I'll receive only one notification summarizing what's new since last time I checked.

Among others, we need to track who are the new commenters. To do so, we decided to store the date we last checked the notifications `last_seen_at` and then iterate over the list of comments created from that time to the present in order to take the needed information.

Related to https://github.com/openSUSE/open-build-service/pull/9873 & 
https://github.com/openSUSE/open-build-service/pull/9878
<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
