### PR TITLE
Display selected project name for mobile

### DIFF
--- a/src/api/app/controllers/webui/users/notifications_controller.rb
+++ b/src/api/app/controllers/webui/users/notifications_controller.rb
@@ -9,6 +9,7 @@ class Webui::Users::NotificationsController < Webui::WebuiController
     @notifications = fetch_notifications
     @projects_for_filter = projects_for_filter
     @notifications_count = notifications_count
+    @filtered_project = Project.find_by(name: params[:project])
   end
 
   def update

--- a/src/api/app/controllers/webui/users/notifications_controller.rb
+++ b/src/api/app/controllers/webui/users/notifications_controller.rb
@@ -3,11 +3,10 @@ class Webui::Users::NotificationsController < Webui::WebuiController
   VALID_NOTIFICATION_TYPES = ['read', 'reviews', 'comments', 'requests', 'unread'].freeze
 
   before_action :require_login
-  before_action :check_param_type, :check_param_project, only: :index
+  before_action :check_param_type, :projects_for_filter, :check_param_project, only: :index
 
   def index
     @notifications = fetch_notifications
-    @projects_for_filter = projects_for_filter
     @notifications_count = notifications_count
   end
 
@@ -42,9 +41,9 @@ class Webui::Users::NotificationsController < Webui::WebuiController
   end
 
   def check_param_project
-    return unless params[:project] == ''
+    return if params[:project].nil? || @projects_for_filter.keys.include?(params[:project])
 
-    flash[:error] = 'Filter not valid.'
+    flash[:error] = 'Project filter not valid.'
     redirect_to my_notifications_path
   end
 
@@ -59,10 +58,10 @@ class Webui::Users::NotificationsController < Webui::WebuiController
   # Returns a hash where the key is the name of the project and the value is the amount of notifications
   # associated to that project. The hash is sorted by amount and then name.
   def projects_for_filter
-    Project.joins(:notifications)
-           .where(notifications: { subscriber: User.session, delivered: false, web: true })
-           .order('name desc').group(:name).count # this query returns a sorted-by-name hash like { "home:b" => 1, "home:a" => 3  }
-           .sort_by(&:last).reverse.to_h # this sorts the hash by amount: { "home:a" => 3, "home:b" => 1 }
+    @projects_for_filter = Project.joins(:notifications)
+                                  .where(notifications: { subscriber: User.session, delivered: false, web: true })
+                                  .order('name desc').group(:name).count # this returns a sorted-by-name hash: { "home:b" => 1, "home:a" => 3  }
+                                  .sort_by(&:last).reverse.to_h # this sorts the hash by amount: { "home:a" => 3, "home:b" => 1 }
   end
 
   def notifications_count

--- a/src/api/app/views/webui/users/notifications/index.html.haml
+++ b/src/api/app/views/webui/users/notifications/index.html.haml
@@ -8,7 +8,7 @@
     .card.mb-3
       %strong.d-block.d-md-none.p-3{ data: { toggle: 'collapse', target: '#filters' },
                                   aria: { expanded: true, controls: 'filters' } }
-        Filtered by: #{(params[:type] || 'Inbox').humanize}
+        Filtered by: #{(params[:type] || params[:project] || 'Inbox').humanize}
         %i.float-right.mt-1.fa.fa-chevron-down
       .card-body.collapse#filters
         = render partial: 'notifications_filter', locals: { projects_for_filter: @projects_for_filter, notifications_count: @notifications_count }

--- a/src/api/app/views/webui/users/notifications/index.html.haml
+++ b/src/api/app/views/webui/users/notifications/index.html.haml
@@ -8,7 +8,7 @@
     .card.mb-3
       %strong.d-block.d-md-none.p-3{ data: { toggle: 'collapse', target: '#filters' },
                                   aria: { expanded: true, controls: 'filters' } }
-        Filtered by: #{(params[:type] || params[:project] || 'Inbox').humanize}
+        Filtered by: #{params[:type]&.humanize || params[:project] || 'Unread'}
         %i.float-right.mt-1.fa.fa-chevron-down
       .card-body.collapse#filters
         = render partial: 'notifications_filter', locals: { projects_for_filter: @projects_for_filter, notifications_count: @notifications_count }

--- a/src/api/app/views/webui/users/notifications/index.html.haml
+++ b/src/api/app/views/webui/users/notifications/index.html.haml
@@ -8,7 +8,7 @@
     .card.mb-3
       %strong.d-block.d-md-none.p-3{ data: { toggle: 'collapse', target: '#filters' },
                                   aria: { expanded: true, controls: 'filters' } }
-        Filtered by: #{params[:type]&.humanize || params[:project] || 'Unread'}
+        Filtered by: #{params[:type]&.humanize || @filtered_project || 'Unread'}
         %i.float-right.mt-1.fa.fa-chevron-down
       .card-body.collapse#filters
         = render partial: 'notifications_filter', locals: { projects_for_filter: @projects_for_filter, notifications_count: @notifications_count }


### PR DESCRIPTION
For small devices the notification filter box now displays the project
name instead of 'Inbox'.

Fixes #9882  

**Before**
![issue_9982_before](https://user-images.githubusercontent.com/54893750/86771502-9fdaf680-c052-11ea-9303-7daf290fec49.gif)

**After**
![issue_9982_after](https://user-images.githubusercontent.com/54893750/86771512-a4071400-c052-11ea-9b56-45531ba5f231.gif)

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
