### PR TITLE
Do not throw an error on missing search defaults

### DIFF
--- a/src/api/app/controllers/webui/search_controller.rb
+++ b/src/api/app/controllers/webui/search_controller.rb
@@ -155,10 +155,6 @@ class Webui::SearchController < Webui::WebuiController
     end
 
     logger.debug "Searching for the string \"#{@search_text}\" in the #{@search_where}'s of #{@search_what}'s"
-    if @search_where.empty? && !@search_attrib_type_id && !@search_issue
-      flash[:error] = "You have to search for #{@search_text} in something. Click the advanced button..."
-      return
-    end
 
     @per_page = 20
     search = FullTextSearch.new(text: @search_text,

--- a/src/api/spec/controllers/webui/search_controller_spec.rb
+++ b/src/api/spec/controllers/webui/search_controller_spec.rb
@@ -88,15 +88,6 @@ RSpec.describe Webui::SearchController, vcr: true do
       end
     end
 
-    context 'with no search scope' do
-      before do
-        get :index, params: { search_text: 'whatever' }
-      end
-
-      it { expect(flash[:error]).to eq('You have to search for whatever in something. Click the advanced button...') }
-      it { expect(response).to have_http_status(:success) }
-    end
-
     context 'with proper parameters but no results' do
       before do
         allow(ThinkingSphinx).to receive(:search).and_return([])

--- a/src/api/spec/features/beta/webui/search_spec.rb
+++ b/src/api/spec/features/beta/webui/search_spec.rb
@@ -133,26 +133,6 @@ RSpec.describe 'Search', type: :feature, js: true do
       expect(page).to have_selector('#search-results', count: 0)
     end
 
-    it 'search in no fields' do
-      apache2
-
-      visit search_path
-      page.evaluate_script('$.fx.off = true;') # Needed to disable javascript animations that can end in not checking the checkboxes properly
-
-      fill_in 'search_input', with: 'awesome'
-      click_button 'Advanced'
-      uncheck 'title'
-      uncheck 'name'
-      uncheck 'description'
-      click_button 'Search'
-
-      within('#flash') do
-        expect(page).to have_text('You have to search for awesome in something. Click the advanced button...')
-      end
-
-      expect(page).to have_selector('#search-results', count: 0)
-    end
-
     it 'search Russian project in UTF-8' do
       russian_project
 

--- a/src/api/spec/features/webui/search_spec.rb
+++ b/src/api/spec/features/webui/search_spec.rb
@@ -133,26 +133,6 @@ RSpec.describe 'Search', type: :feature, js: true do
       expect(page).to have_selector('#search-results', count: 0)
     end
 
-    it 'search in no fields' do
-      apache2
-
-      visit search_path
-      page.evaluate_script('$.fx.off = true;') # Needed to disable javascript animations that can end in not checking the checkboxes properly
-
-      fill_in 'search_input', with: 'awesome'
-      click_button 'Advanced'
-      uncheck 'title'
-      uncheck 'name'
-      uncheck 'description'
-      click_button 'Search'
-
-      within('#flash') do
-        expect(page).to have_text('You have to search for awesome in something. Click the advanced button...')
-      end
-
-      expect(page).to have_selector('#search-results', count: 0)
-    end
-
     it 'search Russian project in UTF-8' do
       russian_project
 


### PR DESCRIPTION
@search_where and @search_what have defaults, no need
to error out

Fixes #9890

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
