### PR TITLE
Define Review#number temporarily

### DIFF
--- a/src/api/app/models/review.rb
+++ b/src/api/app/models/review.rb
@@ -66,6 +66,8 @@ class Review < ApplicationRecord
   before_validation :set_reviewable_association
   after_commit :update_cache
 
+  delegate :number, to: :bs_request
+
   def review_assignment
     errors.add(:unknown, 'no reviewer defined') unless by_user || by_group || by_project
     errors.add(:base, 'it is not allowed to have more than one reviewer entity: by_user, by_group, by_project') if invalid_reviewers?


### PR DESCRIPTION
Review notifications are going to disappear, meanwhile, we create
Review#number method to take the request number instead.

Fixes error caused by this lines: https://github.com/openSUSE/open-build-service/pull/9873/files#diff-1fc6031128e8767883b805cc36ea1d95R9-R10

Co-authored-by: Victor Pereira <vpereira@suse.com>

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
