### PR TITLE
Remove duplicated unread_date method

### DIFF
--- a/src/api/app/models/notification.rb
+++ b/src/api/app/models/notification.rb
@@ -40,10 +40,6 @@ class Notification < ApplicationRecord
   def unread_date
     last_seen_at || created_at
   end
-
-  def unread_date
-    last_seen_at || created_at
-  end
 end
 
 # == Schema Information


### PR DESCRIPTION
`unread_date` was defined twice.