### PR TITLE
Fix error at notifications index with show_all

### DIFF
--- a/src/api/app/controllers/webui/users/notifications_controller.rb
+++ b/src/api/app/controllers/webui/users/notifications_controller.rb
@@ -49,12 +49,12 @@ class Webui::Users::NotificationsController < Webui::WebuiController
     redirect_to my_notifications_path
   end
 
-  def show_all
-    total = @notifications.size
+  def show_all(notifications)
+    total = notifications.size
     if total > MAX_PER_PAGE
       flash.now[:info] = "You have too many notifications. Displaying a maximum of #{MAX_PER_PAGE} notifications per page."
     end
-    @notifications = @notifications.page(params[:page]).per([total, MAX_PER_PAGE].min)
+    notifications.page(params[:page]).per([total, MAX_PER_PAGE].min)
   end
 
   # Returns a hash where the key is the name of the project and the value is the amount of notifications
@@ -78,6 +78,6 @@ class Webui::Users::NotificationsController < Webui::WebuiController
                     else
                       NotificationsFinder.new(notifications_for_subscribed_user).for_notifiable_type(params[:type])
                     end
-    params['show_all'] ? show_all : notifications.page(params[:page])
+    params['show_all'] ? show_all(notifications) : notifications.page(params[:page])
   end
 end


### PR DESCRIPTION
<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->

Hello all! 
This PR fixes an error at the notifications controller.
The error is that the reference to `@notifications` at the notifications controller is being called before any value is assign to it.

This PR proposes to pass the `notifications` as parameter to the private method `show_all` instead of referencing them as `@notifications` from the `show_all`.

To verify this fix

- Using the master branch, navigate to http://localhost:3000/my/notifications?show_all=1
- Verify that you saw the error 

- Using this branch, navigate to http://localhost:3000/my/notifications?show_all=1
- Verify that you see the notifications page

Fix #9909 

Error:
![Screenshot from 2020-07-14 06-45-30](https://user-images.githubusercontent.com/17273872/87381594-b8d92f80-c59d-11ea-9152-73c5f3782957.png)

After the fix:
![Screenshot from 2020-07-14 06-45-14](https://user-images.githubusercontent.com/17273872/87381598-ba0a5c80-c59d-11ea-9cb7-74a76201bb81.png)

