### PR TITLE
[dist] fix test case 0110-check_signd.ta for obs < 2.11

### DIFF
--- a/dist/t/0110-check_signd.ta
+++ b/dist/t/0110-check_signd.ta
@@ -1,20 +1,21 @@
-#!/bin/bash
+#!/usr/bin/perl
 
-export BASH_TAP_ROOT=$(dirname $0)
+use strict;
+use warnings;
+use Test::More;
 
-. $(dirname $0)/bash-tap-bootstrap
+plan tests => 3;
 
-plan tests 3
+`grep -q "function create_sign_cert" /usr/lib/obs/server/setup-appliance.sh`;
 
-for file in \
-  obs-default-gpg.asc\
-  obs-default-gpg.cert
-do
-  [ -e /srv/obs/$file ]
-  is "$?" 0 "Checking file $file"
-done
+SKIP: {
+  skip "obs version less then 2.11", 3 if $?;
+  for my $file (qw{obs-default-gpg.asc obs-default-gpg.cert}) {
+    ok(-f "/srv/obs/$file", "Checking file $file");
+  }
 
-openssl x509 -text -noout < /srv/obs/obs-default-gpg.cert |grep -q "private OBS"
-is "$?" 0 "X509 Certificate for package signing"
+  `openssl x509 -text -noout < /srv/obs/obs-default-gpg.cert |grep -q "private OBS"`;
+  ok($? == 0, "X509 Certificate for package signing");
+}
 
-exit 0
+exit 0;


### PR DESCRIPTION
Re-written 0110-check_signd.ta in perl.

This patch checks if the function "create_sign_cert" exists in
/usr/lib/obs/server/setup-appliance.sh which was introduced in 2.11.
We do not compare version of obs-server package to be more flexible
if this feature gets backported.

Without this patch our test cases for 2.10 are failing.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
