### PR TITLE
[backend] begin adding helmchart support

### DIFF
--- a/src/backend/BSContar.pm
+++ b/src/backend/BSContar.pm
@@ -243,6 +243,8 @@ sub normalize_container {
     'Config' => $newconfig,
     'RepoTags' => $repotags || $manifest->{'RepoTags'},
     'Layers' => \@newlayers,
+    'config' => $manifest->{"config"} || [],
+    'layers' => $manifest->{"layers"} || [],
   };  
   my $newmanifest_ent = create_manifest_entry($newmanifest, $mtime);
 

--- a/src/backend/bs_regpush
+++ b/src/backend/bs_regpush
@@ -567,9 +567,10 @@ for my $tarfile (@tarfiles) {
 
   # process config
   my $config_blobid = BSContar::blobid_entry($config_ent);
+  my $media_type = $manifest->{'config'}->{'MediaType'};
   # create layer data
   my $config_data = { 
-    'mediaType' => 'application/vnd.docker.container.image.v1+json',
+    'mediaType' => $media_type || 'application/vnd.docker.container.image.v1+json',
     'size' => $config_ent->{'size'},
     'digest' => $config_blobid,
   }; 
@@ -599,9 +600,13 @@ for my $tarfile (@tarfiles) {
     my $blobid = BSContar::blobid_entry($layer_ent);
     #print "$layer_file -> $blobid\n";
 
+    my $layer_mediatype = 'application/vnd.docker.image.rootfs.diff.tar.gzip' 
+    if $mediaType eq 'application/vnd.oci.image.manifest.v1+json' {
+      $layer_mediatype = 'application/tar+gzip' 
+    }
     # create layer data
     my $layer_data = {
-      'mediaType' => 'application/vnd.docker.image.rootfs.diff.tar.gzip',
+      'mediaType' => $layer_mediatype,
       'size' => $layer_ent->{'size'},
       'digest' => $blobid,
     };

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -865,6 +865,7 @@ sub findfile {
   return $files{'appimage.yml'} if $files{'appimage.yml'} && $ext eq 'appimage';
   return $files{'Dockerfile'} if $files{'Dockerfile'} && $ext eq 'docker';
   return $files{'fissile.yml'} if $files{'fissile.yml'} && $ext eq 'fissile';
+  return $files{'Helmfile'} if $files{'Helmfile'} && $ext eq 'helm';
 
   if ($ext eq 'arch') {
     return $files{'PKGBUILD'} if $files{'PKGBUILD'};

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -4048,6 +4048,7 @@ if ($ex == 0) {
   @d = ('KIWI') if $buildinfo->{'file'} =~ /\.kiwi$/;
   @d = ('DOCKER') if $buildinfo->{'file'} =~ /Dockerfile$/;
   @d = ('FISSILE') if $buildinfo->{'file'} =~ /fissile\.yml$/;
+  @d = ('HELM') if $buildinfo->{'file'} =~ /Helmfile$/;
   push @d, 'OTHER';
   for my $d ('.', @d) {
     my @files = sort(ls("$buildroot/.build.packages/$d"));


### PR DESCRIPTION
<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
