### PR TITLE
[backend] user/pass for obs services called in docker

### DIFF
--- a/src/backend/BSConfig.pm.template
+++ b/src/backend/BSConfig.pm.template
@@ -308,4 +308,10 @@ our $local_registry_signatures_extension = 1;
 # public cloud uploader configuration
 # our $cloudupload_pubkey = "/etc/obs/cloudupload/_pubkey"; # default setting
 
+# user/password to be used by services which needs to authenticate at
+# OBS (e.g. kiwi_import)
+
+# our $obs_service_user = "";
+# our $obs_service_pass = "";
+
 1;

--- a/src/backend/call-service-in-docker.sh
+++ b/src/backend/call-service-in-docker.sh
@@ -21,6 +21,8 @@ DOCKER_IMAGE=`obs_admin --query-config docker_image`
 DOCKER_CUSTOM_OPT=`obs_admin --query-config docker_custom_opt`
 SERVICES_DIR=`obs_admin --query-config servicetempdir`
 OBS_SERVICE_BUNDLE_GEMS_MIRROR_URL=`obs_admin --query-config gems_mirror`
+OBS_SERVICE_USER=`obs_admin --query-config obs_service_user`
+OBS_SERVICE_PASS=`obs_admin --query-config obs_service_pass`
 SCM_COMMAND=0
 WITH_NET=0
 COMMAND="$1"
@@ -119,6 +121,8 @@ echo "#!/bin/bash"                                                              
 echo "export OBS_SERVICE_APIURL=\"$OBS_SERVICE_APIURL\""                                   >> "$MOUNTDIR/$INNERSCRIPT"
 echo "export OBS_SERVICE_BUNDLE_GEMS_MIRROR_URL=\"$OBS_SERVICE_BUNDLE_GEMS_MIRROR_URL\""   >> "$MOUNTDIR/$INNERSCRIPT"
 echo "export OBS_SERVICE_DAEMON=\"$OBS_SERVICE_DAEMON\""                                   >> "$MOUNTDIR/$INNERSCRIPT"
+echo "export OBS_SERVICE_USER=\"$OBS_SERVICE_USER\""                                       >> "$MOUNTDIR/$INNERSCRIPT"
+echo "export OBS_SERVICE_PASS=\"$OBS_SERVICE_PASS\""                                       >> "$MOUNTDIR/$INNERSCRIPT"
 echo "cd $INNERSRCDIR"                                                                     >> "$MOUNTDIR/$INNERSCRIPT"
 echo -n "${INNERSCRIPT}.command"                                                           >> "$MOUNTDIR/$INNERSCRIPT"
 


### PR DESCRIPTION
This patch adds the possibilty to specify a user/password combination
in BSConfig.pm and export to ENV in the container to use for basic auth
at the API server (specified in api_url).
This is required e.g. for kiwi_import.

Without this patch the service fails with '401 - Unauthorized' when using
e.g. 'https://build.opensuse.org' as api url.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
