### PR TITLE
Add influx host to influxdb_hosts options section

### DIFF
--- a/src/api/lib/tasks/dev.rake
+++ b/src/api/lib/tasks/dev.rake
@@ -131,6 +131,7 @@ namespace :dev do
 
       copy_example_file('config/options.yml')
       options_yml = YAML.load_file('config/options.yml') || {}
+      options_yml['development']['influxdb_hosts'] = ['influx']
       options_yml['development']['amqp_namespace'] = 'opensuse.obs'
       options_yml['development']['amqp_options'] = { host: 'rabbit', port: '5672', user: 'guest', pass: 'guest', vhost: '/' }
       options_yml['development']['amqp_exchange_name'] = 'pubsub'


### PR DESCRIPTION
In the default configuration, influxdb_hosts is configured to `['localhost']` and it doesn't work following this [HOWTO](https://github.com/openSUSE/open-build-service/wiki/Application-Health-Monitoring)


The other thing that it doesn't work is trying to access the influxdb ´rails` if it doesn't exist. [influxdb-rails](https://github.com/influxdata/influxdb-rails) as far as I can see doesn't do it

We need in the initializers something (assuming all options.yml configuration were already evaluated) like:

```
influxdb = InfluxDB::Client.new host:'influx'
influxdb.create_database('rails')
```

After that you are able to write on `rails.exceptions`, with something like: 

```
pry(main)> InfluxDB::Rails.client.write_point('rails.exceptions', values: { value: 1, error_type: "Source::Errors::NoPermissionForDeleted" })
```