### PR TITLE
Add support to collect exceptions on influxdb

### DIFF
--- a/src/api/config/initializers/influxdb_airbrake.rb
+++ b/src/api/config/initializers/influxdb_airbrake.rb
@@ -1,0 +1,10 @@
+# send exceptions to Influxdb
+
+module Airbrake
+  class << self
+    def notify(exception, params = {}, &block)
+      notice_notifier.notify(exception, params, &block)
+      InfluxDB::Rails.client.write_point('rails.exceptions', values: { value: 1, error_class: exception.class.to_s }) if CONFIG['influxdb_hosts'].present?
+    end
+  end
+end


### PR DESCRIPTION
The influxdb rails gem try to save the whole exception stack when
something happens. The way that we are doing here, we are incremeting
a counter always when Airbrake.notify is called

Kind of related with #9930 

With this change we are able to track number of exceptions on Grafana, under `rails.exceptions`