### PR TITLE
[backend] support oci content types in bs_regpush -l

### DIFF
--- a/src/backend/bs_regpush
+++ b/src/backend/bs_regpush
@@ -190,7 +190,7 @@ sub manifest_upload {
   return $maniid if manifest_exists($manifest, $tag, $content_type);
   $content_type ||= 'application/vnd.docker.distribution.manifest.v2+json';
   my $fat = '';
-  $fat = 'fat ' if $content_type eq 'application/vnd.docker.distribution.manifest.list.v2+json';
+  $fat = 'fat ' if $content_type eq 'application/vnd.docker.distribution.manifest.list.v2+json' || $content_type eq 'application/vnd.oci.image.index.v1+json';
   if (!$quiet) {
     if (defined($tag)) {
       print "uploading ${fat}manifest $maniid for tag '$tag'... ";
@@ -283,7 +283,7 @@ sub get_manifest_for_tag {
   my $replyheaders;
   my $param = {
     'uri' => "$registryserver/v2/$repository/manifests/$tag",
-    'headers' => [ "Accept: application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json" ],
+    'headers' => [ "Accept: application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.oci.image.index.v1+json" ],
     'authenticator' => $registry_authenticator,
     'replyheaders' => \$replyheaders,
     'timeout' => $registry_timeout,
@@ -340,6 +340,10 @@ sub list_tag {
     printf "%-20s %s %s\n", $tag, $maniid, 'list';
   } elsif ($mani->{'mediaType'} eq 'application/vnd.docker.distribution.manifest.v2+json') {
     printf "%-20s %s %s\n", $tag, $maniid, 'image';
+  } elsif ($mani->{'mediaType'} eq 'application/vnd.oci.image.manifest.v1+json') {
+    printf "%-20s %s %s\n", $tag, $maniid, 'ociimage';
+  } elsif ($mani->{'mediaType'} eq 'application/vnd.oci.image.index.v1+json') {
+    printf "%-20s %s %s\n", $tag, $maniid, 'ocilist';
   } else {
     printf "%-20s %s %s\n", $tag, $maniid, 'unknown';
   }


### PR DESCRIPTION
<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
