### PR TITLE
[api] fix change time in reviews (when attriute)

### DIFF
--- a/src/api/app/models/review.rb
+++ b/src/api/app/models/review.rb
@@ -146,7 +146,7 @@ class Review < ApplicationRecord
     r.reviewer = r.creator = hash.delete('who')
     r.reason = hash.delete('comment')
     begin
-      r.created_at = Time.zone.parse(hash.delete('when'))
+      r.updated_at = Time.zone.parse(hash.delete('when'))
     rescue TypeError
       # no valid time -> ignore
     end
@@ -159,7 +159,7 @@ class Review < ApplicationRecord
   def _get_attributes
     attributes = { state: state.to_s }
     # old requests didn't have who and when
-    attributes[:when] = created_at.strftime('%Y-%m-%dT%H:%M:%S')
+    attributes[:when] = updated_at.strftime('%Y-%m-%dT%H:%M:%S')
     attributes[:who] = reviewer if reviewer
     attributes[:by_group] = by_group if by_group
     attributes[:by_user] = by_user if by_user

--- a/src/api/db/data/20200730163910_set_changed_state_at_to_reviews.rb
+++ b/src/api/db/data/20200730163910_set_changed_state_at_to_reviews.rb
@@ -1,0 +1,13 @@
+class SetChangedStateAtToReviews < ActiveRecord::Migration[6.0]
+  def up
+    Review.where(changed_state_at: nil).find_each(batch_size: 5000) do |review|
+      # rubocop:disable Rails/SkipsModelValidations
+      review.update_columns(changed_state_at: review.updated_at)
+      # rubocop:enable Rails/SkipsModelValidations
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/src/api/db/migrate/20200730153057_add_changed_state_at_to_reviews.rb
+++ b/src/api/db/migrate/20200730153057_add_changed_state_at_to_reviews.rb
@@ -1,0 +1,5 @@
+class AddChangedStateAtToReviews < ActiveRecord::Migration[6.0]
+  def change
+    add_column :reviews, :changed_state_at, :datetime
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -873,6 +873,7 @@ ActiveRecord::Schema.define(version: 2022_02_10_154407) do
     t.integer "group_id"
     t.integer "project_id"
     t.integer "package_id"
+    t.datetime "changed_state_at"
     t.index ["bs_request_id"], name: "bs_request_id"
     t.index ["by_group"], name: "index_reviews_on_by_group"
     t.index ["by_package", "by_project"], name: "index_reviews_on_by_package_and_by_project"


### PR DESCRIPTION
It was never updated which made the information in most
cases identical to request creation time always.

The attribute is supposed same as the when attriute
of the request itself, where it is the last time the
request changed.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
