### PR TITLE
[api] support plain release request

### DIFF
--- a/docs/api/api/request.rng
+++ b/docs/api/api/request.rng
@@ -64,7 +64,8 @@
           <value>set_bugowner</value>
           <value>maintenance_incident</value>
           <value>maintenance_release</value>
-          <value>group</value>
+          <value>release</value>
+          <value>group</value> <!-- should not be used anymore -->
         </choice>
       </attribute>
       <interleave>

--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -96,7 +96,7 @@ Lint/UriEscapeUnescape:
 # Offense count: 807
 # Configuration parameters: IgnoredMethods.
 Metrics/AbcSize:
-  Max: 208
+  Max: 235
 
 # Offense count: 19
 # Configuration parameters: CountBlocks, Max.

--- a/src/api/app/helpers/webui/request_helper.rb
+++ b/src/api/app/helpers/webui/request_helper.rb
@@ -19,7 +19,7 @@ module Webui::RequestHelper
     'superseded' => 'fa-plus'
   }.freeze
 
-  AVAILABLE_TYPES = ['all', 'submit', 'delete', 'add_role', 'change_devel', 'maintenance_incident', 'maintenance_release'].freeze
+  AVAILABLE_TYPES = ['all', 'submit', 'delete', 'add_role', 'change_devel', 'maintenance_incident', 'maintenance_release', 'release'].freeze
   AVAILABLE_STATES = ['new or review', 'new', 'review', 'accepted', 'declined', 'revoked', 'superseded'].freeze
 
   def request_state_color(state)
@@ -79,6 +79,8 @@ module Webui::RequestHelper
       'incident'
     when :maintenance_release
       'release'
+    when :release
+      'release' # same as maintenance_release but the difference should matter in simplified view
     else
       type.to_s
     end
@@ -149,6 +151,11 @@ module Webui::RequestHelper
         target_container: project_or_package_link(project: action[:tprj], package: action[:tpkg])
       }
     when :maintenance_release
+      'Maintenance release %{source_container} to %{target_container}' % {
+        source_container: project_or_package_link(source_project_hash),
+        target_container: project_or_package_link(project: action[:tprj], package: action[:tpkg])
+      }
+    when :release
       'Release %{source_container} to %{target_container}' % {
         source_container: project_or_package_link(source_project_hash),
         target_container: project_or_package_link(project: action[:tprj], package: action[:tpkg])

--- a/src/api/spec/helpers/webui/request_helper_spec.rb
+++ b/src/api/spec/helpers/webui/request_helper_spec.rb
@@ -179,7 +179,7 @@ RSpec.describe Webui::RequestHelper do
 
     context 'when action is :maintenance_release' do
       let(:expected_regex) do
-        Regexp.new("Release package .*#{source_package.project}.* / .*#{source_package}.* to package " \
+        Regexp.new("Maintenance release package .*#{source_package.project}.* / .*#{source_package}.* to package " \
                    ".*#{target_package.project}.* / .*#{target_package}.* ")
       end
 


### PR DESCRIPTION
This is basically the same functionality as release command for
packages, but it allows to involve review workflows.

A very much stripped down version of maintenance_release action,
not relying on incident setups.

OBS-51

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
