### PR TITLE
Use user-defined network in call-services-in-docker.sh for service which need local proxies

### DIFF
--- a/dist/setup_source_service_docker.sh
+++ b/dist/setup_source_service_docker.sh
@@ -15,6 +15,18 @@ if [ $UID != 0 ];then
   exit 1
 fi
 
+MTU=1500
+
+while [ -n "$1" ];do
+  case $1 in 
+    --mtu)
+      shift
+      MTU=$1
+      shift
+    ;;
+  esac
+done
+
 if [ "$SUSE" == "opensuse" ]; then
   SUSE=openSUSE
   downloadserver="http://download.opensuse.org"
@@ -74,7 +86,8 @@ cat <<EOF > /etc/docker/daemon.json
     "dm.thinp_autoextend_threshold=80",
     "dm.thinp_autoextend_percent=20",
     "dm.directlvm_device_force=false"
-   ]
+   ],
+   "mtu": $MTU
 }
 EOF
 }

--- a/src/backend/BSConfig.pm.template
+++ b/src/backend/BSConfig.pm.template
@@ -314,4 +314,7 @@ our $local_registry_signatures_extension = 1;
 # our $obs_service_user = "";
 # our $obs_service_pass = "";
 
+# network name required for services using a local proxy/cache like gemianbox
+# our $obs_service_network = "obs_services";
+
 1;


### PR DESCRIPTION
Some of our services like bundle_gems use a local proxy/cache like geminabox.
So far we used the "--link" option to make the geminabox container accessible
by name for the service container.
    
Using "--link" on a bridge is deprecated and only worked so far because we
patched the docker package on the service server.
    
* The first patch makes the network name configurable so we can use user-defined networks in the future.
* The second patch makes it possible to set a custom MTU size for docker which is required in our test setup
