### PR TITLE
Fix rss notifications creation

### DIFF
--- a/src/api/app/services/notification_service/notifier.rb
+++ b/src/api/app/services/notification_service/notifier.rb
@@ -41,8 +41,7 @@ module NotificationService
     end
 
     def create_notification?(subscriber, channel)
-      return false if subscriber&.away?
-      return false if channel == :rss && !subscriber&.rss_token
+      return false if subscriber.nil? || subscriber.away? || (channel == :rss && !subscriber.try(:rss_token))
       return false unless notifiable_exists?
 
       true


### PR DESCRIPTION
Group model doesn't have `rss_token`, using `try` will return `nil` if the method doesn't exist.

Fix #9900 