### PR TITLE
[api] introduce "manual" service mode

### DIFF
--- a/docs/api/api/obs.rng
+++ b/docs/api/api/obs.rng
@@ -86,12 +86,13 @@
 
   <define ns="" name="service-modes">
     <choice>
-                                   <!-- DEFAULT: the attribute is not used, service running on server and locally on build time -->
+                                   <!-- DEFAULT: the attribute is not used, service running on server and locally before starting a build -->
       <value>trylocal</value>      <!-- try on local clients and merge result, but run also on server side -->
-      <value>localonly</value>     <!-- never run on server side, but on the clients (not enforced) -->
+      <value>localonly</value>     <!-- never run on server side, but on the clients before commit or build -->
       <value>serveronly</value>    <!-- run on server side, but not on the clients by default -->
-      <value>buildtime</value>     <!-- run during build time, pulls in services as build dependencies -->
-      <value>disabled</value>      <!-- never run, except user explicit starts it locally -->
+      <value>buildtime</value>     <!-- run during build time inside build env, pulls in services as build dependencies -->
+      <value>manual</value>        <!-- never run, except user explicit starts it locally -->
+      <value>disabled</value>      <!-- never run, except user explicit starts it locally (old termonology) -->
     </choice>
   </define>
 

--- a/src/backend/bs_service
+++ b/src/backend/bs_service
@@ -159,7 +159,7 @@ sub run_source_update {
     for my $service (@{$serviceinfo->{'service'}}) {
       my $name = $service->{'name'};
       BSVerify::verify_filename($name);
-      if (defined($service->{'mode'}) && ($service->{'mode'} eq 'localonly' || $service->{'mode'} eq 'disabled' || $service->{'mode'} eq 'buildtime')) {
+      if (defined($service->{'mode'}) && ($service->{'mode'} eq 'localonly' || $service->{'mode'} eq 'disabled' || $service->{'mode'} eq 'manual' || $service->{'mode'} eq 'buildtime')) {
         print "Skip $name\n";
         next;
       }


### PR DESCRIPTION
It is just an alias for "disabled" on the server side, but osc may
make a difference here in future.

It is the better name for the todays usage of "disabled", while
"disabled" may mean in future really the original documented purpose
of keeping it disabled, just for reference.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
