### PR TITLE
Add a session identifier to influxdb

### DIFF
--- a/src/api/app/controllers/application_controller.rb
+++ b/src/api/app/controllers/application_controller.rb
@@ -455,6 +455,7 @@ class ApplicationController < ActionController::Base
   def set_influxdb_data
     InfluxDB::Rails.current.tags = {
       beta: User.possibly_nobody.in_beta?,
+      session_id: Digest::SHA1.hexdigest(OBSApi::Application.config.secret_key_base[0..8] + User.possibly_nobody.login + request.port.to_s),
       anonymous: !User.session,
       interface: :api
     }

--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -323,7 +323,8 @@ class Webui::WebuiController < ActionController::Base
   def set_influxdb_additional_tags
     tags = {
       beta: User.possibly_nobody.in_beta?,
-      anonymous: !User.session
+      anonymous: !User.session,
+      session_id: Digest::SHA1.hexdigest(OBSApi::Application.config.secret_key_base[0..8] + User.possibly_nobody.login + request.port.to_s)
     }
 
     InfluxDB::Rails.current.tags = InfluxDB::Rails.current.tags.merge(tags)


### PR DESCRIPTION
Having a session concept in the influxdb allows us to monitor
how many simultaneous users are accessing the
frontend

Example of panel in Grafana:

![Screenshot_2020-07-28_12-15-36](https://user-images.githubusercontent.com/37418/88654230-5881dc00-d0cd-11ea-8055-1663247c8467.png)

