### PR TITLE
Remove outdated comment

### DIFF
--- a/src/api/app/models/relationship.rb
+++ b/src/api/app/models/relationship.rb
@@ -125,7 +125,6 @@ class Relationship < ApplicationRecord
     end
 
     def cache_sequence
-      # False positive: https://github.com/rubocop-hq/rubocop/issues/8196
       Rails.cache.fetch(RELATIONSHIP_CACHE_SEQUENCE) { 0 }
     end
 


### PR DESCRIPTION
The update to `rubocop 0.87.1` in #9892 addressed the false positive and the `rubocop:{disable,enable}` comments were removed. This comment also needs to be removed since it's now outdated.