### PR TITLE
Speedup owner search

### DIFF
--- a/src/api/app/controllers/search_controller.rb
+++ b/src/api/app/controllers/search_controller.rb
@@ -125,6 +125,9 @@ class SearchController < ApplicationController
       owners = OwnerSearch::Assignee.new(params).for(params[:binary])
     elsif (obj = owner_group_or_user)
       owners = OwnerSearch::Owned.new(params).for(obj)
+    elsif params[:project].blank? && params[:package].present?
+      # package container name without specified project
+      owners = OwnerSearch::Assignee.new(params).for_package(params[:package])
     end
     if owners.nil? && (objs = owner_packages_or_projects)
       objs.each do |object|

--- a/src/api/app/models/owner_search/base.rb
+++ b/src/api/app/models/owner_search/base.rb
@@ -31,7 +31,8 @@ module OwnerSearch
       return [Project.get_by_name(params[:project])] if params[:project]
 
       # Find all marked projects
-      projects = Project.joins(:attribs).where(attribs: { attrib_type_id: attribute.id })
+      projects = nil
+      projects = Project.joins(:attribs).where(attribs: { attrib_type_id: attribute.id }) if attribute.present?
       return projects unless projects.empty?
 
       raise AttributeNotSetError, "The attribute #{attribute.fullname} is not set to define default projects."


### PR DESCRIPTION
    [api] speed up maintainer lookup
    
    Using special backend route the owner search is taking 0.15 seconds instead of 8.5 seconds.
    
    We are down from 15 seconds to 2 seconds in total. 1 second of that is python
    startup and SSL handshake.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
