### PR TITLE
Always show the message while branching failed

### DIFF
--- a/src/api/app/controllers/webui/packages/branches_controller.rb
+++ b/src/api/app/controllers/webui/packages/branches_controller.rb
@@ -83,16 +83,10 @@ module Webui
       rescue BranchPackage::DoubleBranchPackageError => e
         flash[:notice] = 'You have already branched this package'
         redirect_to(package_show_path(project: e.project, package: e.package))
-      rescue Package::UnknownObjectError, Project::UnknownObjectError
-        flash[:error] = 'Failed to branch: Package does not exist.'
-        redirect_back(fallback_location: root_path)
-      rescue ArgumentError => e
-        flash[:error] = "Failed to branch: #{e.message}"
-        redirect_back(fallback_location: root_path)
       rescue CreateProjectNoPermission
         flash[:error] = 'Sorry, you are not authorized to create this Project.'
         redirect_back(fallback_location: root_path)
-      rescue APIError, ActiveRecord::RecordInvalid => e
+      rescue ArgumentError, Package::UnknownObjectError, Project::UnknownObjectError, APIError, ActiveRecord::RecordInvalid => e
         flash[:error] = "Failed to branch: #{e.message}"
         redirect_back(fallback_location: root_path)
       end

--- a/src/api/spec/cassettes/Webui_Packages_BranchesController/POST_create/shows_an_error_if_current_revision_parameter_is_provided_but_there_wasn_t_any_revision_before.yml
+++ b/src/api/spec/cassettes/Webui_Packages_BranchesController/POST_create/shows_an_error_if_current_revision_parameter_is_provided_but_there_wasn_t_any_revision_before.yml
@@ -39,8 +39,7 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:48 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:43 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/my_package/_meta?user=tom
@@ -48,8 +47,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="my_package" project="home:tom">
-          <title>Mr Standfast</title>
-          <description>Neque odio ratione eum.</description>
+          <title>The Sun Also Rises</title>
+          <description>Voluptatem alias aut non.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,16 +69,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '141'
+      - '149'
     body:
       encoding: UTF-8
       string: |
         <package name="my_package" project="home:tom">
-          <title>Mr Standfast</title>
-          <description>Neque odio ratione eum.</description>
+          <title>The Sun Also Rises</title>
+          <description>Voluptatem alias aut non.</description>
         </package>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:48 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:43 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom/my_package?expand=1&rev=2
@@ -113,6 +111,5 @@ http_interactions:
           <summary>no such revision</summary>
           <details>404 no such revision</details>
         </status>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:48 GMT
-recorded_with: VCR 5.1.0
+  recorded_at: Fri, 31 Jul 2020 14:58:43 GMT
+recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Webui_Packages_BranchesController/POST_create/shows_an_error_if_source_package_does_not_exist.yml
+++ b/src/api/spec/cassettes/Webui_Packages_BranchesController/POST_create/shows_an_error_if_source_package_does_not_exist.yml
@@ -39,6 +39,5 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:47 GMT
-recorded_with: VCR 5.1.0
+  recorded_at: Fri, 31 Jul 2020 14:58:44 GMT
+recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Webui_Packages_BranchesController/POST_create/shows_an_error_if_source_package_parameter_not_provided.yml
+++ b/src/api/spec/cassettes/Webui_Packages_BranchesController/POST_create/shows_an_error_if_source_package_parameter_not_provided.yml
@@ -39,6 +39,5 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:49 GMT
-recorded_with: VCR 5.1.0
+  recorded_at: Fri, 31 Jul 2020 14:58:44 GMT
+recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Webui_Packages_BranchesController/POST_create/shows_an_error_if_source_project_does_not_exist.yml
+++ b/src/api/spec/cassettes/Webui_Packages_BranchesController/POST_create/shows_an_error_if_source_project_does_not_exist.yml
@@ -39,8 +39,7 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:49 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:44 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/my_package/_meta?user=tom
@@ -48,8 +47,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="my_package" project="home:tom">
-          <title>Edna O'Brien</title>
-          <description>Deserunt autem quaerat ut.</description>
+          <title>Frequent Hearses</title>
+          <description>Officiis cum veniam tempore.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,14 +69,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '144'
+      - '150'
     body:
       encoding: UTF-8
       string: |
         <package name="my_package" project="home:tom">
-          <title>Edna O'Brien</title>
-          <description>Deserunt autem quaerat ut.</description>
+          <title>Frequent Hearses</title>
+          <description>Officiis cum veniam tempore.</description>
         </package>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:49 GMT
-recorded_with: VCR 5.1.0
+  recorded_at: Fri, 31 Jul 2020 14:58:44 GMT
+recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Webui_Packages_BranchesController/POST_create/shows_an_error_if_source_project_parameter_not_provided.yml
+++ b/src/api/spec/cassettes/Webui_Packages_BranchesController/POST_create/shows_an_error_if_source_project_parameter_not_provided.yml
@@ -39,8 +39,7 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:48 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:44 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/my_package/_meta?user=tom
@@ -48,8 +47,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="my_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Non eaque sed atque.</description>
+          <title>The Widening Gyre</title>
+          <description>Et sunt sit fugiat.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,14 +69,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '144'
+      - '142'
     body:
       encoding: UTF-8
       string: |
         <package name="my_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Non eaque sed atque.</description>
+          <title>The Widening Gyre</title>
+          <description>Et sunt sit fugiat.</description>
         </package>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:48 GMT
-recorded_with: VCR 5.1.0
+  recorded_at: Fri, 31 Jul 2020 14:58:44 GMT
+recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Webui_Packages_BranchesController/POST_create/shows_an_error_if_the_target_package_exists_already.yml
+++ b/src/api/spec/cassettes/Webui_Packages_BranchesController/POST_create/shows_an_error_if_the_target_package_exists_already.yml
@@ -1,0 +1,231 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '128'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer"/>
+        </project>
+  recorded_at: Fri, 31 Jul 2020 14:58:43 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/my_package/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="my_package" project="home:tom">
+          <title>Rosemary Sutcliff</title>
+          <description>Incidunt quae minus ut.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '146'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="my_package" project="home:tom">
+          <title>Rosemary Sutcliff</title>
+          <description>Incidunt quae minus ut.</description>
+        </package>
+  recorded_at: Fri, 31 Jul 2020 14:58:43 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/existing_project/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="existing_project">
+          <title>Edna O'Brien</title>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '148'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="existing_project">
+          <title>Edna O'Brien</title>
+          <description></description>
+          <person userid="tom" role="maintainer"/>
+        </project>
+  recorded_at: Fri, 31 Jul 2020 14:58:43 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/existing_project/existing_package/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="existing_package" project="existing_project">
+          <title>Fear and Trembling</title>
+          <description>Vel et velit aut.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '155'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="existing_package" project="existing_project">
+          <title>Fear and Trembling</title>
+          <description>Vel et velit aut.</description>
+        </package>
+  recorded_at: Fri, 31 Jul 2020 14:58:43 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/existing_project/existing_package/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="existing_package" project="existing_project">
+          <title>Fear and Trembling</title>
+          <description>Vel et velit aut.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '155'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="existing_package" project="existing_project">
+          <title>Fear and Trembling</title>
+          <description>Vel et velit aut.</description>
+        </package>
+  recorded_at: Fri, 31 Jul 2020 14:58:43 GMT
+- request:
+    method: post
+    uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22my_package%22%20and%20linkinfo/@project=%22home:tom%22%20and%20@project=%22home:tom%22)
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '27'
+    body:
+      encoding: UTF-8
+      string: |
+        <collection>
+        </collection>
+  recorded_at: Fri, 31 Jul 2020 14:58:43 GMT
+recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Webui_Packages_BranchesController/POST_create/shows_an_error_if_user_has_no_permissions_for_source_project.yml
+++ b/src/api/spec/cassettes/Webui_Packages_BranchesController/POST_create/shows_an_error_if_user_has_no_permissions_for_source_project.yml
@@ -39,8 +39,7 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:48 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:44 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/my_package/_meta?user=tom
@@ -48,8 +47,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="my_package" project="home:tom">
-          <title>A Time to Kill</title>
-          <description>Et molestiae omnis dolore.</description>
+          <title>Quo Vadis</title>
+          <description>Et fuga ut et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,16 +69,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '146'
+      - '129'
     body:
       encoding: UTF-8
       string: |
         <package name="my_package" project="home:tom">
-          <title>A Time to Kill</title>
-          <description>Et molestiae omnis dolore.</description>
+          <title>Quo Vadis</title>
+          <description>Et fuga ut et.</description>
         </package>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:48 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:44 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22my_package%22%20and%20linkinfo/@project=%22home:tom%22%20and%20@project=%22home:tom%22)
@@ -113,6 +111,5 @@ http_interactions:
       string: |
         <collection>
         </collection>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:48 GMT
-recorded_with: VCR 5.1.0
+  recorded_at: Fri, 31 Jul 2020 14:58:44 GMT
+recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Webui_Packages_BranchesController/POST_create/with_currrent_revision_parameter/1_1_10_1.yml
+++ b/src/api/spec/cassettes/Webui_Packages_BranchesController/POST_create/with_currrent_revision_parameter/1_1_10_1.yml
@@ -39,8 +39,7 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:50 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/package_with_revisions/_meta?user=tom
@@ -48,8 +47,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_revisions" project="home:tom">
-          <title>Down to a Sunless Sea</title>
-          <description>Sunt tempora voluptas minus.</description>
+          <title>An Evil Cradling</title>
+          <description>Voluptatem sint debitis provident.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,16 +69,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '168'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_revisions" project="home:tom">
-          <title>Down to a Sunless Sea</title>
-          <description>Sunt tempora voluptas minus.</description>
+          <title>An Evil Cradling</title>
+          <description>Voluptatem sint debitis provident.</description>
         </package>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:50 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/package_with_revisions/somefile.txt
@@ -105,20 +103,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="5" vrev="5">
+        <revision rev="13" vrev="13">
           <srcmd5>cabf9a1f9a0b7c19d4f7ff46166f4ee0</srcmd5>
           <version>unknown</version>
-          <time>1589466830</time>
+          <time>1596207526</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:50 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/package_with_revisions/somefile.txt
@@ -144,20 +141,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="6" vrev="6">
+        <revision rev="14" vrev="14">
           <srcmd5>efbe5f0a5dd48df5129b4319df43aa45</srcmd5>
           <version>unknown</version>
-          <time>1589466830</time>
+          <time>1596207526</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:50 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/package_with_revisions/somefile.txt
@@ -183,20 +179,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="7" vrev="7">
+        <revision rev="15" vrev="15">
           <srcmd5>6ba292a7c75f8b46e4d39ac7cb20ebcd</srcmd5>
           <version>unknown</version>
-          <time>1589466830</time>
+          <time>1596207526</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:50 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/package_with_revisions/somefile.txt
@@ -222,20 +217,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="8" vrev="8">
+        <revision rev="16" vrev="16">
           <srcmd5>60d83e04e1adc0a7e399a5b10312faf1</srcmd5>
           <version>unknown</version>
-          <time>1589466830</time>
+          <time>1596207526</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:50 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:46 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom/package_with_revisions?rev=2
@@ -266,10 +260,9 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="package_with_revisions" rev="2" vrev="2" srcmd5="efbe5f0a5dd48df5129b4319df43aa45">
-          <entry name="somefile.txt" md5="c4ca4238a0b923820dcc509a6f75849b" size="1" mtime="1589466829"/>
+          <entry name="somefile.txt" md5="c4ca4238a0b923820dcc509a6f75849b" size="1" mtime="1596207469"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:50 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:46 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22package_with_revisions%22%20and%20linkinfo/@project=%22home:tom%22%20and%20@project=%22home:tom%22)
@@ -303,8 +296,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:50 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:home:tom/_meta?user=tom
@@ -344,8 +336,7 @@ http_interactions:
           <description>This project was created for package package_with_revisions via attribute OBS:Maintained</description>
           <person userid="tom" role="maintainer"/>
         </project>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:51 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:home:tom/package_with_revisions/_meta?user=tom
@@ -353,8 +344,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_revisions" project="home:tom:branches:home:tom">
-          <title>Down to a Sunless Sea</title>
-          <description>Sunt tempora voluptas minus.</description>
+          <title>An Evil Cradling</title>
+          <description>Voluptatem sint debitis provident.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -375,16 +366,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '185'
+      - '186'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_revisions" project="home:tom:branches:home:tom">
-          <title>Down to a Sunless Sea</title>
-          <description>Sunt tempora voluptas minus.</description>
+          <title>An Evil Cradling</title>
+          <description>Voluptatem sint debitis provident.</description>
         </package>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:51 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:46 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:home:tom/package_with_revisions?cmd=branch&noservice=1&opackage=package_with_revisions&oproject=home:tom&orev=efbe5f0a5dd48df5129b4319df43aa45&user=tom
@@ -416,16 +406,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2" vrev="2">
+        <revision rev="4" vrev="4">
           <srcmd5>b40e9cce84f2c67bd45ff4667726a62f</srcmd5>
           <version>unknown</version>
-          <time>1589466831</time>
+          <time>1596207526</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:51 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:home:tom/package_with_revisions/_meta?user=tom
@@ -433,8 +422,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_revisions" project="home:tom:branches:home:tom">
-          <title>Down to a Sunless Sea</title>
-          <description>Sunt tempora voluptas minus.</description>
+          <title>An Evil Cradling</title>
+          <description>Voluptatem sint debitis provident.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -455,16 +444,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '185'
+      - '186'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_revisions" project="home:tom:branches:home:tom">
-          <title>Down to a Sunless Sea</title>
-          <description>Sunt tempora voluptas minus.</description>
+          <title>An Evil Cradling</title>
+          <description>Voluptatem sint debitis provident.</description>
         </package>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:51 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:46 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:home:tom/package_with_revisions
@@ -494,13 +482,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_revisions" rev="2" vrev="2" srcmd5="b40e9cce84f2c67bd45ff4667726a62f">
+        <directory name="package_with_revisions" rev="4" vrev="4" srcmd5="b40e9cce84f2c67bd45ff4667726a62f">
           <linkinfo project="home:tom" package="package_with_revisions" rev="efbe5f0a5dd48df5129b4319df43aa45" srcmd5="efbe5f0a5dd48df5129b4319df43aa45" baserev="efbe5f0a5dd48df5129b4319df43aa45" xsrcmd5="d83b1df8a7dcda9ddd21113b898a835f" lsrcmd5="b40e9cce84f2c67bd45ff4667726a62f"/>
-          <entry name="_link" md5="7190e2d17317df95c397ad7f48dac06a" size="155" mtime="1589466830"/>
-          <entry name="somefile.txt" md5="c4ca4238a0b923820dcc509a6f75849b" size="1" mtime="1589466829"/>
+          <entry name="_link" md5="7190e2d17317df95c397ad7f48dac06a" size="155" mtime="1596207469"/>
+          <entry name="somefile.txt" md5="c4ca4238a0b923820dcc509a6f75849b" size="1" mtime="1596207469"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:51 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:46 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:home:tom/package_with_revisions?view=info
@@ -530,12 +517,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="package_with_revisions" rev="2" vrev="2" srcmd5="d83b1df8a7dcda9ddd21113b898a835f" lsrcmd5="b40e9cce84f2c67bd45ff4667726a62f" verifymd5="efbe5f0a5dd48df5129b4319df43aa45">
+        <sourceinfo package="package_with_revisions" rev="4" vrev="4" srcmd5="d83b1df8a7dcda9ddd21113b898a835f" lsrcmd5="b40e9cce84f2c67bd45ff4667726a62f" verifymd5="efbe5f0a5dd48df5129b4319df43aa45">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="home:tom" package="package_with_revisions"/>
         </sourceinfo>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:51 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:46 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:home:tom/package_with_revisions
@@ -565,13 +551,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_revisions" rev="2" vrev="2" srcmd5="b40e9cce84f2c67bd45ff4667726a62f">
+        <directory name="package_with_revisions" rev="4" vrev="4" srcmd5="b40e9cce84f2c67bd45ff4667726a62f">
           <linkinfo project="home:tom" package="package_with_revisions" rev="efbe5f0a5dd48df5129b4319df43aa45" srcmd5="efbe5f0a5dd48df5129b4319df43aa45" baserev="efbe5f0a5dd48df5129b4319df43aa45" xsrcmd5="d83b1df8a7dcda9ddd21113b898a835f" lsrcmd5="b40e9cce84f2c67bd45ff4667726a62f"/>
-          <entry name="_link" md5="7190e2d17317df95c397ad7f48dac06a" size="155" mtime="1589466830"/>
-          <entry name="somefile.txt" md5="c4ca4238a0b923820dcc509a6f75849b" size="1" mtime="1589466829"/>
+          <entry name="_link" md5="7190e2d17317df95c397ad7f48dac06a" size="155" mtime="1596207469"/>
+          <entry name="somefile.txt" md5="c4ca4238a0b923820dcc509a6f75849b" size="1" mtime="1596207469"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:51 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:46 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:home:tom/package_with_revisions?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -603,15 +588,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="cf62f23409d806138f8999fd5540ea22">
+        <sourcediff key="254c366be7e3c6e8fdcdd9189e4acf5b">
           <old project="home:tom:branches:home:tom" package="package_with_revisions" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:tom:branches:home:tom" package="package_with_revisions" rev="2" srcmd5="b40e9cce84f2c67bd45ff4667726a62f"/>
+          <new project="home:tom:branches:home:tom" package="package_with_revisions" rev="4" srcmd5="b40e9cce84f2c67bd45ff4667726a62f"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:51 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:46 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:home:tom/package_with_revisions?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -648,8 +632,7 @@ http_interactions:
           <new project="home:tom:branches:home:tom" package="package_with_revisions" rev="d83b1df8a7dcda9ddd21113b898a835f" srcmd5="d83b1df8a7dcda9ddd21113b898a835f"/>
           <files/>
         </sourcediff>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:51 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:home:tom/_meta?user=tom
@@ -695,6 +678,5 @@ http_interactions:
             <disable/>
           </publish>
         </project>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:51 GMT
-recorded_with: VCR 5.1.0
+  recorded_at: Fri, 31 Jul 2020 14:58:46 GMT
+recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Webui_Packages_BranchesController/POST_create/with_currrent_revision_parameter/1_1_10_3.yml
+++ b/src/api/spec/cassettes/Webui_Packages_BranchesController/POST_create/with_currrent_revision_parameter/1_1_10_3.yml
@@ -39,8 +39,7 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:49 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:45 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/package_with_revisions/_meta?user=tom
@@ -48,8 +47,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_revisions" project="home:tom">
-          <title>Dulce et Decorum Est</title>
-          <description>Quia ipsa aut vel.</description>
+          <title>Consider Phlebas</title>
+          <description>Eligendi et quidem sed.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,16 +69,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '156'
+      - '157'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_revisions" project="home:tom">
-          <title>Dulce et Decorum Est</title>
-          <description>Quia ipsa aut vel.</description>
+          <title>Consider Phlebas</title>
+          <description>Eligendi et quidem sed.</description>
         </package>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:49 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:45 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/package_with_revisions/somefile.txt
@@ -109,16 +107,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1" vrev="1">
+        <revision rev="9" vrev="9">
           <srcmd5>cabf9a1f9a0b7c19d4f7ff46166f4ee0</srcmd5>
           <version>unknown</version>
-          <time>1589466829</time>
+          <time>1596207525</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:49 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:45 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/package_with_revisions/somefile.txt
@@ -144,20 +141,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2" vrev="2">
+        <revision rev="10" vrev="10">
           <srcmd5>efbe5f0a5dd48df5129b4319df43aa45</srcmd5>
           <version>unknown</version>
-          <time>1589466829</time>
+          <time>1596207525</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:49 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:45 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/package_with_revisions/somefile.txt
@@ -183,20 +179,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="3" vrev="3">
+        <revision rev="11" vrev="11">
           <srcmd5>6ba292a7c75f8b46e4d39ac7cb20ebcd</srcmd5>
           <version>unknown</version>
-          <time>1589466829</time>
+          <time>1596207525</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:49 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:45 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/package_with_revisions/somefile.txt
@@ -222,20 +217,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="4" vrev="4">
+        <revision rev="12" vrev="12">
           <srcmd5>60d83e04e1adc0a7e399a5b10312faf1</srcmd5>
           <version>unknown</version>
-          <time>1589466829</time>
+          <time>1596207525</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:49 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:45 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom/package_with_revisions?rev=2
@@ -266,10 +260,9 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="package_with_revisions" rev="2" vrev="2" srcmd5="efbe5f0a5dd48df5129b4319df43aa45">
-          <entry name="somefile.txt" md5="c4ca4238a0b923820dcc509a6f75849b" size="1" mtime="1589466829"/>
+          <entry name="somefile.txt" md5="c4ca4238a0b923820dcc509a6f75849b" size="1" mtime="1596207469"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:49 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:45 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22package_with_revisions%22%20and%20linkinfo/@project=%22home:tom%22%20and%20@project=%22home:tom%22)
@@ -303,8 +296,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:49 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:45 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:home:tom/_meta?user=tom
@@ -344,8 +336,7 @@ http_interactions:
           <description>This project was created for package package_with_revisions via attribute OBS:Maintained</description>
           <person userid="tom" role="maintainer"/>
         </project>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:49 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:45 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:home:tom/package_with_revisions/_meta?user=tom
@@ -353,8 +344,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_revisions" project="home:tom:branches:home:tom">
-          <title>Dulce et Decorum Est</title>
-          <description>Quia ipsa aut vel.</description>
+          <title>Consider Phlebas</title>
+          <description>Eligendi et quidem sed.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -375,16 +366,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '174'
+      - '175'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_revisions" project="home:tom:branches:home:tom">
-          <title>Dulce et Decorum Est</title>
-          <description>Quia ipsa aut vel.</description>
+          <title>Consider Phlebas</title>
+          <description>Eligendi et quidem sed.</description>
         </package>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:50 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:45 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:home:tom/package_with_revisions?cmd=branch&noservice=1&opackage=package_with_revisions&oproject=home:tom&orev=efbe5f0a5dd48df5129b4319df43aa45&user=tom
@@ -416,16 +406,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1" vrev="1">
+        <revision rev="3" vrev="3">
           <srcmd5>b40e9cce84f2c67bd45ff4667726a62f</srcmd5>
           <version>unknown</version>
-          <time>1589466830</time>
+          <time>1596207525</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:50 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:45 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:home:tom/package_with_revisions/_meta?user=tom
@@ -433,8 +422,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_revisions" project="home:tom:branches:home:tom">
-          <title>Dulce et Decorum Est</title>
-          <description>Quia ipsa aut vel.</description>
+          <title>Consider Phlebas</title>
+          <description>Eligendi et quidem sed.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -455,16 +444,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '174'
+      - '175'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_revisions" project="home:tom:branches:home:tom">
-          <title>Dulce et Decorum Est</title>
-          <description>Quia ipsa aut vel.</description>
+          <title>Consider Phlebas</title>
+          <description>Eligendi et quidem sed.</description>
         </package>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:50 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:45 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:home:tom/package_with_revisions
@@ -494,13 +482,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_revisions" rev="1" vrev="1" srcmd5="b40e9cce84f2c67bd45ff4667726a62f">
+        <directory name="package_with_revisions" rev="3" vrev="3" srcmd5="b40e9cce84f2c67bd45ff4667726a62f">
           <linkinfo project="home:tom" package="package_with_revisions" rev="efbe5f0a5dd48df5129b4319df43aa45" srcmd5="efbe5f0a5dd48df5129b4319df43aa45" baserev="efbe5f0a5dd48df5129b4319df43aa45" xsrcmd5="d83b1df8a7dcda9ddd21113b898a835f" lsrcmd5="b40e9cce84f2c67bd45ff4667726a62f"/>
-          <entry name="_link" md5="7190e2d17317df95c397ad7f48dac06a" size="155" mtime="1589466830"/>
-          <entry name="somefile.txt" md5="c4ca4238a0b923820dcc509a6f75849b" size="1" mtime="1589466829"/>
+          <entry name="_link" md5="7190e2d17317df95c397ad7f48dac06a" size="155" mtime="1596207469"/>
+          <entry name="somefile.txt" md5="c4ca4238a0b923820dcc509a6f75849b" size="1" mtime="1596207469"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:50 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:45 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:home:tom/package_with_revisions?view=info
@@ -530,12 +517,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="package_with_revisions" rev="1" vrev="1" srcmd5="d83b1df8a7dcda9ddd21113b898a835f" lsrcmd5="b40e9cce84f2c67bd45ff4667726a62f" verifymd5="efbe5f0a5dd48df5129b4319df43aa45">
+        <sourceinfo package="package_with_revisions" rev="3" vrev="3" srcmd5="d83b1df8a7dcda9ddd21113b898a835f" lsrcmd5="b40e9cce84f2c67bd45ff4667726a62f" verifymd5="efbe5f0a5dd48df5129b4319df43aa45">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="home:tom" package="package_with_revisions"/>
         </sourceinfo>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:50 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:45 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:home:tom/package_with_revisions
@@ -565,13 +551,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_revisions" rev="1" vrev="1" srcmd5="b40e9cce84f2c67bd45ff4667726a62f">
+        <directory name="package_with_revisions" rev="3" vrev="3" srcmd5="b40e9cce84f2c67bd45ff4667726a62f">
           <linkinfo project="home:tom" package="package_with_revisions" rev="efbe5f0a5dd48df5129b4319df43aa45" srcmd5="efbe5f0a5dd48df5129b4319df43aa45" baserev="efbe5f0a5dd48df5129b4319df43aa45" xsrcmd5="d83b1df8a7dcda9ddd21113b898a835f" lsrcmd5="b40e9cce84f2c67bd45ff4667726a62f"/>
-          <entry name="_link" md5="7190e2d17317df95c397ad7f48dac06a" size="155" mtime="1589466830"/>
-          <entry name="somefile.txt" md5="c4ca4238a0b923820dcc509a6f75849b" size="1" mtime="1589466829"/>
+          <entry name="_link" md5="7190e2d17317df95c397ad7f48dac06a" size="155" mtime="1596207469"/>
+          <entry name="somefile.txt" md5="c4ca4238a0b923820dcc509a6f75849b" size="1" mtime="1596207469"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:50 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:45 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:home:tom/package_with_revisions?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -603,15 +588,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="256df5a3770dac88b6a1b6b681bf577f">
+        <sourcediff key="0f96636475e0e88d4db5f175db6b1b53">
           <old project="home:tom:branches:home:tom" package="package_with_revisions" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:tom:branches:home:tom" package="package_with_revisions" rev="1" srcmd5="b40e9cce84f2c67bd45ff4667726a62f"/>
+          <new project="home:tom:branches:home:tom" package="package_with_revisions" rev="3" srcmd5="b40e9cce84f2c67bd45ff4667726a62f"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:50 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:45 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:home:tom/package_with_revisions?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -648,8 +632,7 @@ http_interactions:
           <new project="home:tom:branches:home:tom" package="package_with_revisions" rev="d83b1df8a7dcda9ddd21113b898a835f" srcmd5="d83b1df8a7dcda9ddd21113b898a835f"/>
           <files/>
         </sourcediff>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:50 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:45 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:home:tom/_meta?user=tom
@@ -695,8 +678,7 @@ http_interactions:
             <disable/>
           </publish>
         </project>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:50 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:45 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:home:tom/package_with_revisions
@@ -726,11 +708,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_revisions" rev="1" vrev="1" srcmd5="b40e9cce84f2c67bd45ff4667726a62f">
+        <directory name="package_with_revisions" rev="3" vrev="3" srcmd5="b40e9cce84f2c67bd45ff4667726a62f">
           <linkinfo project="home:tom" package="package_with_revisions" rev="efbe5f0a5dd48df5129b4319df43aa45" srcmd5="efbe5f0a5dd48df5129b4319df43aa45" baserev="efbe5f0a5dd48df5129b4319df43aa45" xsrcmd5="d83b1df8a7dcda9ddd21113b898a835f" lsrcmd5="b40e9cce84f2c67bd45ff4667726a62f"/>
-          <entry name="_link" md5="7190e2d17317df95c397ad7f48dac06a" size="155" mtime="1589466830"/>
-          <entry name="somefile.txt" md5="c4ca4238a0b923820dcc509a6f75849b" size="1" mtime="1589466829"/>
+          <entry name="_link" md5="7190e2d17317df95c397ad7f48dac06a" size="155" mtime="1596207469"/>
+          <entry name="somefile.txt" md5="c4ca4238a0b923820dcc509a6f75849b" size="1" mtime="1596207469"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:50 GMT
-recorded_with: VCR 5.1.0
+  recorded_at: Fri, 31 Jul 2020 14:58:46 GMT
+recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Webui_Packages_BranchesController/POST_create/with_currrent_revision_parameter/redirects_to_the_branched_package.yml
+++ b/src/api/spec/cassettes/Webui_Packages_BranchesController/POST_create/with_currrent_revision_parameter/redirects_to_the_branched_package.yml
@@ -39,8 +39,7 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:51 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/package_with_revisions/_meta?user=tom
@@ -48,8 +47,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_revisions" project="home:tom">
-          <title>O Pioneers!</title>
-          <description>Dolorem nesciunt quibusdam fugiat.</description>
+          <title>Cover Her Face</title>
+          <description>Quis error sunt eius.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,16 +69,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '163'
+      - '153'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_revisions" project="home:tom">
-          <title>O Pioneers!</title>
-          <description>Dolorem nesciunt quibusdam fugiat.</description>
+          <title>Cover Her Face</title>
+          <description>Quis error sunt eius.</description>
         </package>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:51 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/package_with_revisions/somefile.txt
@@ -105,20 +103,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="9" vrev="9">
+        <revision rev="17" vrev="17">
           <srcmd5>cabf9a1f9a0b7c19d4f7ff46166f4ee0</srcmd5>
           <version>unknown</version>
-          <time>1589466831</time>
+          <time>1596207526</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:51 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/package_with_revisions/somefile.txt
@@ -148,16 +145,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="10" vrev="10">
+        <revision rev="18" vrev="18">
           <srcmd5>efbe5f0a5dd48df5129b4319df43aa45</srcmd5>
           <version>unknown</version>
-          <time>1589466831</time>
+          <time>1596207526</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:51 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/package_with_revisions/somefile.txt
@@ -187,16 +183,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="11" vrev="11">
+        <revision rev="19" vrev="19">
           <srcmd5>6ba292a7c75f8b46e4d39ac7cb20ebcd</srcmd5>
           <version>unknown</version>
-          <time>1589466831</time>
+          <time>1596207526</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:51 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/package_with_revisions/somefile.txt
@@ -226,16 +221,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="12" vrev="12">
+        <revision rev="20" vrev="20">
           <srcmd5>60d83e04e1adc0a7e399a5b10312faf1</srcmd5>
           <version>unknown</version>
-          <time>1589466831</time>
+          <time>1596207526</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:51 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:46 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom/package_with_revisions?rev=2
@@ -266,10 +260,9 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="package_with_revisions" rev="2" vrev="2" srcmd5="efbe5f0a5dd48df5129b4319df43aa45">
-          <entry name="somefile.txt" md5="c4ca4238a0b923820dcc509a6f75849b" size="1" mtime="1589466829"/>
+          <entry name="somefile.txt" md5="c4ca4238a0b923820dcc509a6f75849b" size="1" mtime="1596207469"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:51 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:46 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22package_with_revisions%22%20and%20linkinfo/@project=%22home:tom%22%20and%20@project=%22home:tom%22)
@@ -303,8 +296,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:51 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:home:tom/_meta?user=tom
@@ -344,8 +336,7 @@ http_interactions:
           <description>This project was created for package package_with_revisions via attribute OBS:Maintained</description>
           <person userid="tom" role="maintainer"/>
         </project>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:51 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:home:tom/package_with_revisions/_meta?user=tom
@@ -353,8 +344,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_revisions" project="home:tom:branches:home:tom">
-          <title>O Pioneers!</title>
-          <description>Dolorem nesciunt quibusdam fugiat.</description>
+          <title>Cover Her Face</title>
+          <description>Quis error sunt eius.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -375,16 +366,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '181'
+      - '171'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_revisions" project="home:tom:branches:home:tom">
-          <title>O Pioneers!</title>
-          <description>Dolorem nesciunt quibusdam fugiat.</description>
+          <title>Cover Her Face</title>
+          <description>Quis error sunt eius.</description>
         </package>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:51 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:46 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:home:tom/package_with_revisions?cmd=branch&noservice=1&opackage=package_with_revisions&oproject=home:tom&orev=efbe5f0a5dd48df5129b4319df43aa45&user=tom
@@ -416,16 +406,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="3" vrev="3">
+        <revision rev="5" vrev="5">
           <srcmd5>b40e9cce84f2c67bd45ff4667726a62f</srcmd5>
           <version>unknown</version>
-          <time>1589466831</time>
+          <time>1596207526</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:52 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:home:tom/package_with_revisions/_meta?user=tom
@@ -433,8 +422,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_revisions" project="home:tom:branches:home:tom">
-          <title>O Pioneers!</title>
-          <description>Dolorem nesciunt quibusdam fugiat.</description>
+          <title>Cover Her Face</title>
+          <description>Quis error sunt eius.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -455,16 +444,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '181'
+      - '171'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_revisions" project="home:tom:branches:home:tom">
-          <title>O Pioneers!</title>
-          <description>Dolorem nesciunt quibusdam fugiat.</description>
+          <title>Cover Her Face</title>
+          <description>Quis error sunt eius.</description>
         </package>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:52 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:47 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:home:tom/package_with_revisions
@@ -494,13 +482,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_revisions" rev="3" vrev="3" srcmd5="b40e9cce84f2c67bd45ff4667726a62f">
+        <directory name="package_with_revisions" rev="5" vrev="5" srcmd5="b40e9cce84f2c67bd45ff4667726a62f">
           <linkinfo project="home:tom" package="package_with_revisions" rev="efbe5f0a5dd48df5129b4319df43aa45" srcmd5="efbe5f0a5dd48df5129b4319df43aa45" baserev="efbe5f0a5dd48df5129b4319df43aa45" xsrcmd5="d83b1df8a7dcda9ddd21113b898a835f" lsrcmd5="b40e9cce84f2c67bd45ff4667726a62f"/>
-          <entry name="_link" md5="7190e2d17317df95c397ad7f48dac06a" size="155" mtime="1589466830"/>
-          <entry name="somefile.txt" md5="c4ca4238a0b923820dcc509a6f75849b" size="1" mtime="1589466829"/>
+          <entry name="_link" md5="7190e2d17317df95c397ad7f48dac06a" size="155" mtime="1596207469"/>
+          <entry name="somefile.txt" md5="c4ca4238a0b923820dcc509a6f75849b" size="1" mtime="1596207469"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:52 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:47 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:home:tom/package_with_revisions?view=info
@@ -530,12 +517,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="package_with_revisions" rev="3" vrev="3" srcmd5="d83b1df8a7dcda9ddd21113b898a835f" lsrcmd5="b40e9cce84f2c67bd45ff4667726a62f" verifymd5="efbe5f0a5dd48df5129b4319df43aa45">
+        <sourceinfo package="package_with_revisions" rev="5" vrev="5" srcmd5="d83b1df8a7dcda9ddd21113b898a835f" lsrcmd5="b40e9cce84f2c67bd45ff4667726a62f" verifymd5="efbe5f0a5dd48df5129b4319df43aa45">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="home:tom" package="package_with_revisions"/>
         </sourceinfo>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:52 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:47 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:home:tom/package_with_revisions
@@ -565,13 +551,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_revisions" rev="3" vrev="3" srcmd5="b40e9cce84f2c67bd45ff4667726a62f">
+        <directory name="package_with_revisions" rev="5" vrev="5" srcmd5="b40e9cce84f2c67bd45ff4667726a62f">
           <linkinfo project="home:tom" package="package_with_revisions" rev="efbe5f0a5dd48df5129b4319df43aa45" srcmd5="efbe5f0a5dd48df5129b4319df43aa45" baserev="efbe5f0a5dd48df5129b4319df43aa45" xsrcmd5="d83b1df8a7dcda9ddd21113b898a835f" lsrcmd5="b40e9cce84f2c67bd45ff4667726a62f"/>
-          <entry name="_link" md5="7190e2d17317df95c397ad7f48dac06a" size="155" mtime="1589466830"/>
-          <entry name="somefile.txt" md5="c4ca4238a0b923820dcc509a6f75849b" size="1" mtime="1589466829"/>
+          <entry name="_link" md5="7190e2d17317df95c397ad7f48dac06a" size="155" mtime="1596207469"/>
+          <entry name="somefile.txt" md5="c4ca4238a0b923820dcc509a6f75849b" size="1" mtime="1596207469"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:52 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:47 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:home:tom/package_with_revisions?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -603,15 +588,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="0f96636475e0e88d4db5f175db6b1b53">
+        <sourcediff key="bf716a49bc8504ccc72819e335737f91">
           <old project="home:tom:branches:home:tom" package="package_with_revisions" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:tom:branches:home:tom" package="package_with_revisions" rev="3" srcmd5="b40e9cce84f2c67bd45ff4667726a62f"/>
+          <new project="home:tom:branches:home:tom" package="package_with_revisions" rev="5" srcmd5="b40e9cce84f2c67bd45ff4667726a62f"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:52 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:47 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:home:tom/package_with_revisions?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -648,8 +632,7 @@ http_interactions:
           <new project="home:tom:branches:home:tom" package="package_with_revisions" rev="d83b1df8a7dcda9ddd21113b898a835f" srcmd5="d83b1df8a7dcda9ddd21113b898a835f"/>
           <files/>
         </sourcediff>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:52 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:home:tom/_meta?user=tom
@@ -695,6 +678,5 @@ http_interactions:
             <disable/>
           </publish>
         </project>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:52 GMT
-recorded_with: VCR 5.1.0
+  recorded_at: Fri, 31 Jul 2020 14:58:47 GMT
+recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Webui_Packages_BranchesController/POST_create/with_default_parameters/1_1_8_1.yml
+++ b/src/api/spec/cassettes/Webui_Packages_BranchesController/POST_create/with_default_parameters/1_1_8_1.yml
@@ -39,7 +39,7 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Fri, 31 Jul 2020 14:58:44 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/my_package/_meta?user=tom
@@ -47,8 +47,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="my_package" project="home:tom">
-          <title>Unweaving the Rainbow</title>
-          <description>Assumenda rerum tenetur dignissimos.</description>
+          <title>Beneath the Bleeding</title>
+          <description>Sed laudantium iste maxime.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -69,15 +69,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '163'
+      - '153'
     body:
       encoding: UTF-8
       string: |
         <package name="my_package" project="home:tom">
-          <title>Unweaving the Rainbow</title>
-          <description>Assumenda rerum tenetur dignissimos.</description>
+          <title>Beneath the Bleeding</title>
+          <description>Sed laudantium iste maxime.</description>
         </package>
-  recorded_at: Fri, 31 Jul 2020 14:58:44 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:47 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22my_package%22%20and%20linkinfo/@project=%22home:tom%22%20and%20@project=%22home:tom%22)
@@ -111,7 +111,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Fri, 31 Jul 2020 14:58:44 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:home:tom/_meta?user=tom
@@ -151,16 +151,16 @@ http_interactions:
           <description>This project was created for package my_package via attribute OBS:Maintained</description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Fri, 31 Jul 2020 14:58:44 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:47 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:branches:home:tom/new_package_name/_meta?user=tom
+    uri: http://backend:5352/source/home:tom:branches:home:tom/my_package/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
-        <package name="new_package_name" project="home:tom:branches:home:tom">
-          <title>Unweaving the Rainbow</title>
-          <description>Assumenda rerum tenetur dignissimos.</description>
+        <package name="my_package" project="home:tom:branches:home:tom">
+          <title>Beneath the Bleeding</title>
+          <description>Sed laudantium iste maxime.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -181,18 +181,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '187'
+      - '171'
     body:
       encoding: UTF-8
       string: |
-        <package name="new_package_name" project="home:tom:branches:home:tom">
-          <title>Unweaving the Rainbow</title>
-          <description>Assumenda rerum tenetur dignissimos.</description>
+        <package name="my_package" project="home:tom:branches:home:tom">
+          <title>Beneath the Bleeding</title>
+          <description>Sed laudantium iste maxime.</description>
         </package>
-  recorded_at: Fri, 31 Jul 2020 14:58:44 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:47 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:tom:branches:home:tom/new_package_name?cmd=branch&noservice=1&opackage=my_package&oproject=home:tom&user=tom
+    uri: http://backend:5352/source/home:tom:branches:home:tom/my_package?cmd=branch&noservice=1&opackage=my_package&oproject=home:tom&user=tom
     body:
       encoding: UTF-8
       string: ''
@@ -221,24 +221,24 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2" vrev="2">
-          <srcmd5>49bd231e56677e1dfd80e906f4f5dbe4</srcmd5>
+        <revision rev="3" vrev="3">
+          <srcmd5>83a26953292465b9db7b73e54859d7e0</srcmd5>
           <version>unknown</version>
-          <time>1596207524</time>
+          <time>1596207527</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 31 Jul 2020 14:58:44 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:47 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:branches:home:tom/new_package_name/_meta?user=tom
+    uri: http://backend:5352/source/home:tom:branches:home:tom/my_package/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
-        <package name="new_package_name" project="home:tom:branches:home:tom">
-          <title>Unweaving the Rainbow</title>
-          <description>Assumenda rerum tenetur dignissimos.</description>
+        <package name="my_package" project="home:tom:branches:home:tom">
+          <title>Beneath the Bleeding</title>
+          <description>Sed laudantium iste maxime.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -259,18 +259,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '187'
+      - '171'
     body:
       encoding: UTF-8
       string: |
-        <package name="new_package_name" project="home:tom:branches:home:tom">
-          <title>Unweaving the Rainbow</title>
-          <description>Assumenda rerum tenetur dignissimos.</description>
+        <package name="my_package" project="home:tom:branches:home:tom">
+          <title>Beneath the Bleeding</title>
+          <description>Sed laudantium iste maxime.</description>
         </package>
-  recorded_at: Fri, 31 Jul 2020 14:58:44 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:47 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:tom:branches:home:tom/new_package_name
+    uri: http://backend:5352/source/home:tom:branches:home:tom/my_package
     body:
       encoding: US-ASCII
       string: ''
@@ -293,18 +293,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '426'
+      - '420'
     body:
       encoding: UTF-8
       string: |
-        <directory name="new_package_name" rev="2" vrev="2" srcmd5="49bd231e56677e1dfd80e906f4f5dbe4">
-          <linkinfo project="home:tom" package="my_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="0a2e3813e4d7ad4b6b72066efa8587cc" lsrcmd5="49bd231e56677e1dfd80e906f4f5dbe4"/>
-          <entry name="_link" md5="324a67e2c9fe0d6cdc38c625b1c416f5" size="137" mtime="1596207431"/>
+        <directory name="my_package" rev="3" vrev="3" srcmd5="83a26953292465b9db7b73e54859d7e0">
+          <linkinfo project="home:tom" package="my_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="c688657843e10f988f2fb32c79413ce4" lsrcmd5="83a26953292465b9db7b73e54859d7e0"/>
+          <entry name="_link" md5="702b2f782cb222a3f9124aa00cdb6bf4" size="116" mtime="1596207360"/>
         </directory>
-  recorded_at: Fri, 31 Jul 2020 14:58:44 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:47 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:tom:branches:home:tom/new_package_name?view=info
+    uri: http://backend:5352/source/home:tom:branches:home:tom/my_package?view=info
     body:
       encoding: US-ASCII
       string: ''
@@ -327,18 +327,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '329'
+      - '323'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="new_package_name" rev="2" vrev="2" srcmd5="0a2e3813e4d7ad4b6b72066efa8587cc" lsrcmd5="49bd231e56677e1dfd80e906f4f5dbe4" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
+        <sourceinfo package="my_package" rev="3" vrev="3" srcmd5="c688657843e10f988f2fb32c79413ce4" lsrcmd5="83a26953292465b9db7b73e54859d7e0" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="home:tom" package="my_package"/>
         </sourceinfo>
-  recorded_at: Fri, 31 Jul 2020 14:58:44 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:47 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:tom:branches:home:tom/new_package_name
+    uri: http://backend:5352/source/home:tom:branches:home:tom/my_package
     body:
       encoding: US-ASCII
       string: ''
@@ -361,18 +361,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '426'
+      - '420'
     body:
       encoding: UTF-8
       string: |
-        <directory name="new_package_name" rev="2" vrev="2" srcmd5="49bd231e56677e1dfd80e906f4f5dbe4">
-          <linkinfo project="home:tom" package="my_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="0a2e3813e4d7ad4b6b72066efa8587cc" lsrcmd5="49bd231e56677e1dfd80e906f4f5dbe4"/>
-          <entry name="_link" md5="324a67e2c9fe0d6cdc38c625b1c416f5" size="137" mtime="1596207431"/>
+        <directory name="my_package" rev="3" vrev="3" srcmd5="83a26953292465b9db7b73e54859d7e0">
+          <linkinfo project="home:tom" package="my_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="c688657843e10f988f2fb32c79413ce4" lsrcmd5="83a26953292465b9db7b73e54859d7e0"/>
+          <entry name="_link" md5="702b2f782cb222a3f9124aa00cdb6bf4" size="116" mtime="1596207360"/>
         </directory>
-  recorded_at: Fri, 31 Jul 2020 14:58:44 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:47 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:tom:branches:home:tom/new_package_name?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    uri: http://backend:5352/source/home:tom:branches:home:tom/my_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
     body:
       encoding: UTF-8
       string: ''
@@ -397,21 +397,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '346'
+      - '334'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="c7ffe26cb047167f4060511e479109d9">
-          <old project="home:tom:branches:home:tom" package="new_package_name" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:tom:branches:home:tom" package="new_package_name" rev="2" srcmd5="49bd231e56677e1dfd80e906f4f5dbe4"/>
+        <sourcediff key="066d72b329a296606082cb5153b948ad">
+          <old project="home:tom:branches:home:tom" package="my_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="home:tom:branches:home:tom" package="my_package" rev="3" srcmd5="83a26953292465b9db7b73e54859d7e0"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Fri, 31 Jul 2020 14:58:44 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:47 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:tom:branches:home:tom/new_package_name?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
+    uri: http://backend:5352/source/home:tom:branches:home:tom/my_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
     body:
       encoding: UTF-8
       string: ''
@@ -431,23 +431,21 @@ http_interactions:
     headers:
       Content-Type:
       - text/xml
-      Content-Length:
-      - '384'
       Cache-Control:
       - no-cache
       Connection:
       - close
+      Content-Length:
+      - '355'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="08ba20ab5b2558f61bc8787701f7de3d">
+        <sourcediff key="cfd8c7a8066dcbd43b2ad2f21933b9a3">
           <old project="home:tom" package="my_package" rev="d41d8cd98f00b204e9800998ecf8427e" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:tom:branches:home:tom" package="new_package_name" rev="0a2e3813e4d7ad4b6b72066efa8587cc" srcmd5="0a2e3813e4d7ad4b6b72066efa8587cc"/>
+          <new project="home:tom:branches:home:tom" package="my_package" rev="c688657843e10f988f2fb32c79413ce4" srcmd5="c688657843e10f988f2fb32c79413ce4"/>
           <files/>
-          <issues>
-          </issues>
         </sourcediff>
-  recorded_at: Fri, 31 Jul 2020 14:58:44 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:home:tom/_meta?user=tom
@@ -493,5 +491,5 @@ http_interactions:
             <disable/>
           </publish>
         </project>
-  recorded_at: Fri, 31 Jul 2020 14:58:44 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:47 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Webui_Packages_BranchesController/POST_create/with_default_parameters/redirects_to_the_branched_package.yml
+++ b/src/api/spec/cassettes/Webui_Packages_BranchesController/POST_create/with_default_parameters/redirects_to_the_branched_package.yml
@@ -39,8 +39,7 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:52 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/my_package/_meta?user=tom
@@ -48,8 +47,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="my_package" project="home:tom">
-          <title>Unweaving the Rainbow</title>
-          <description>Ut et omnis in.</description>
+          <title>The Wings of the Dove</title>
+          <description>Tenetur ut voluptas quo.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,16 +69,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '142'
+      - '151'
     body:
       encoding: UTF-8
       string: |
         <package name="my_package" project="home:tom">
-          <title>Unweaving the Rainbow</title>
-          <description>Ut et omnis in.</description>
+          <title>The Wings of the Dove</title>
+          <description>Tenetur ut voluptas quo.</description>
         </package>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:52 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:47 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22my_package%22%20and%20linkinfo/@project=%22home:tom%22%20and%20@project=%22home:tom%22)
@@ -113,8 +111,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:52 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:home:tom/_meta?user=tom
@@ -154,17 +151,16 @@ http_interactions:
           <description>This project was created for package my_package via attribute OBS:Maintained</description>
           <person userid="tom" role="maintainer"/>
         </project>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:52 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:47 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:branches:home:tom/new_package_name/_meta?user=tom
+    uri: http://backend:5352/source/home:tom:branches:home:tom/my_package/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
-        <package name="new_package_name" project="home:tom:branches:home:tom">
-          <title>Unweaving the Rainbow</title>
-          <description>Ut et omnis in.</description>
+        <package name="my_package" project="home:tom:branches:home:tom">
+          <title>The Wings of the Dove</title>
+          <description>Tenetur ut voluptas quo.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -185,19 +181,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '166'
+      - '169'
     body:
       encoding: UTF-8
       string: |
-        <package name="new_package_name" project="home:tom:branches:home:tom">
-          <title>Unweaving the Rainbow</title>
-          <description>Ut et omnis in.</description>
+        <package name="my_package" project="home:tom:branches:home:tom">
+          <title>The Wings of the Dove</title>
+          <description>Tenetur ut voluptas quo.</description>
         </package>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:52 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:47 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:tom:branches:home:tom/new_package_name?cmd=branch&noservice=1&opackage=my_package&oproject=home:tom&user=tom
+    uri: http://backend:5352/source/home:tom:branches:home:tom/my_package?cmd=branch&noservice=1&opackage=my_package&oproject=home:tom&user=tom
     body:
       encoding: UTF-8
       string: ''
@@ -226,25 +221,24 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1" vrev="1">
-          <srcmd5>49bd231e56677e1dfd80e906f4f5dbe4</srcmd5>
+        <revision rev="4" vrev="4">
+          <srcmd5>83a26953292465b9db7b73e54859d7e0</srcmd5>
           <version>unknown</version>
-          <time>1589466832</time>
+          <time>1596207527</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:52 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:47 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:branches:home:tom/new_package_name/_meta?user=tom
+    uri: http://backend:5352/source/home:tom:branches:home:tom/my_package/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
-        <package name="new_package_name" project="home:tom:branches:home:tom">
-          <title>Unweaving the Rainbow</title>
-          <description>Ut et omnis in.</description>
+        <package name="my_package" project="home:tom:branches:home:tom">
+          <title>The Wings of the Dove</title>
+          <description>Tenetur ut voluptas quo.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -265,19 +259,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '166'
+      - '169'
     body:
       encoding: UTF-8
       string: |
-        <package name="new_package_name" project="home:tom:branches:home:tom">
-          <title>Unweaving the Rainbow</title>
-          <description>Ut et omnis in.</description>
+        <package name="my_package" project="home:tom:branches:home:tom">
+          <title>The Wings of the Dove</title>
+          <description>Tenetur ut voluptas quo.</description>
         </package>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:52 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:47 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:tom:branches:home:tom/new_package_name
+    uri: http://backend:5352/source/home:tom:branches:home:tom/my_package
     body:
       encoding: US-ASCII
       string: ''
@@ -300,19 +293,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '426'
+      - '420'
     body:
       encoding: UTF-8
       string: |
-        <directory name="new_package_name" rev="1" vrev="1" srcmd5="49bd231e56677e1dfd80e906f4f5dbe4">
-          <linkinfo project="home:tom" package="my_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="0a2e3813e4d7ad4b6b72066efa8587cc" lsrcmd5="49bd231e56677e1dfd80e906f4f5dbe4"/>
-          <entry name="_link" md5="324a67e2c9fe0d6cdc38c625b1c416f5" size="137" mtime="1589466832"/>
+        <directory name="my_package" rev="4" vrev="4" srcmd5="83a26953292465b9db7b73e54859d7e0">
+          <linkinfo project="home:tom" package="my_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="c688657843e10f988f2fb32c79413ce4" lsrcmd5="83a26953292465b9db7b73e54859d7e0"/>
+          <entry name="_link" md5="702b2f782cb222a3f9124aa00cdb6bf4" size="116" mtime="1596207360"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:52 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:47 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:tom:branches:home:tom/new_package_name?view=info
+    uri: http://backend:5352/source/home:tom:branches:home:tom/my_package?view=info
     body:
       encoding: US-ASCII
       string: ''
@@ -335,19 +327,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '329'
+      - '323'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="new_package_name" rev="1" vrev="1" srcmd5="0a2e3813e4d7ad4b6b72066efa8587cc" lsrcmd5="49bd231e56677e1dfd80e906f4f5dbe4" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
+        <sourceinfo package="my_package" rev="4" vrev="4" srcmd5="c688657843e10f988f2fb32c79413ce4" lsrcmd5="83a26953292465b9db7b73e54859d7e0" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="home:tom" package="my_package"/>
         </sourceinfo>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:52 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:47 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:tom:branches:home:tom/new_package_name
+    uri: http://backend:5352/source/home:tom:branches:home:tom/my_package
     body:
       encoding: US-ASCII
       string: ''
@@ -370,19 +361,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '426'
+      - '420'
     body:
       encoding: UTF-8
       string: |
-        <directory name="new_package_name" rev="1" vrev="1" srcmd5="49bd231e56677e1dfd80e906f4f5dbe4">
-          <linkinfo project="home:tom" package="my_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="0a2e3813e4d7ad4b6b72066efa8587cc" lsrcmd5="49bd231e56677e1dfd80e906f4f5dbe4"/>
-          <entry name="_link" md5="324a67e2c9fe0d6cdc38c625b1c416f5" size="137" mtime="1589466832"/>
+        <directory name="my_package" rev="4" vrev="4" srcmd5="83a26953292465b9db7b73e54859d7e0">
+          <linkinfo project="home:tom" package="my_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="c688657843e10f988f2fb32c79413ce4" lsrcmd5="83a26953292465b9db7b73e54859d7e0"/>
+          <entry name="_link" md5="702b2f782cb222a3f9124aa00cdb6bf4" size="116" mtime="1596207360"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:52 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:48 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:tom:branches:home:tom/new_package_name?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    uri: http://backend:5352/source/home:tom:branches:home:tom/my_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
     body:
       encoding: UTF-8
       string: ''
@@ -407,22 +397,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '346'
+      - '334'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="1a713416959d63bc720116f7a5ffe6dd">
-          <old project="home:tom:branches:home:tom" package="new_package_name" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:tom:branches:home:tom" package="new_package_name" rev="1" srcmd5="49bd231e56677e1dfd80e906f4f5dbe4"/>
+        <sourcediff key="38794fd5375e0e53700b2476ad153250">
+          <old project="home:tom:branches:home:tom" package="my_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="home:tom:branches:home:tom" package="my_package" rev="4" srcmd5="83a26953292465b9db7b73e54859d7e0"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:52 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:48 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:tom:branches:home:tom/new_package_name?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
+    uri: http://backend:5352/source/home:tom:branches:home:tom/my_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
     body:
       encoding: UTF-8
       string: ''
@@ -447,19 +436,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '384'
+      - '355'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="08ba20ab5b2558f61bc8787701f7de3d">
+        <sourcediff key="cfd8c7a8066dcbd43b2ad2f21933b9a3">
           <old project="home:tom" package="my_package" rev="d41d8cd98f00b204e9800998ecf8427e" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:tom:branches:home:tom" package="new_package_name" rev="0a2e3813e4d7ad4b6b72066efa8587cc" srcmd5="0a2e3813e4d7ad4b6b72066efa8587cc"/>
+          <new project="home:tom:branches:home:tom" package="my_package" rev="c688657843e10f988f2fb32c79413ce4" srcmd5="c688657843e10f988f2fb32c79413ce4"/>
           <files/>
-          <issues>
-          </issues>
         </sourcediff>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:52 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:48 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:home:tom/_meta?user=tom
@@ -505,6 +491,5 @@ http_interactions:
             <disable/>
           </publish>
         </project>
-    http_version: null
-  recorded_at: Thu, 14 May 2020 14:33:52 GMT
-recorded_with: VCR 5.1.0
+  recorded_at: Fri, 31 Jul 2020 14:58:48 GMT
+recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Webui_Packages_BranchesController/POST_create/with_target_package_name/1_1_9_1.yml
+++ b/src/api/spec/cassettes/Webui_Packages_BranchesController/POST_create/with_target_package_name/1_1_9_1.yml
@@ -39,7 +39,7 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Fri, 31 Jul 2020 14:58:44 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:45 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/my_package/_meta?user=tom
@@ -47,8 +47,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="my_package" project="home:tom">
-          <title>Unweaving the Rainbow</title>
-          <description>Assumenda rerum tenetur dignissimos.</description>
+          <title>The Last Temptation</title>
+          <description>Dicta et qui natus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -69,15 +69,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '163'
+      - '144'
     body:
       encoding: UTF-8
       string: |
         <package name="my_package" project="home:tom">
-          <title>Unweaving the Rainbow</title>
-          <description>Assumenda rerum tenetur dignissimos.</description>
+          <title>The Last Temptation</title>
+          <description>Dicta et qui natus.</description>
         </package>
-  recorded_at: Fri, 31 Jul 2020 14:58:44 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:45 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22my_package%22%20and%20linkinfo/@project=%22home:tom%22%20and%20@project=%22home:tom%22)
@@ -111,7 +111,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Fri, 31 Jul 2020 14:58:44 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:45 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:home:tom/_meta?user=tom
@@ -151,7 +151,7 @@ http_interactions:
           <description>This project was created for package my_package via attribute OBS:Maintained</description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Fri, 31 Jul 2020 14:58:44 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:45 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:home:tom/new_package_name/_meta?user=tom
@@ -159,8 +159,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="new_package_name" project="home:tom:branches:home:tom">
-          <title>Unweaving the Rainbow</title>
-          <description>Assumenda rerum tenetur dignissimos.</description>
+          <title>The Last Temptation</title>
+          <description>Dicta et qui natus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -181,15 +181,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '187'
+      - '168'
     body:
       encoding: UTF-8
       string: |
         <package name="new_package_name" project="home:tom:branches:home:tom">
-          <title>Unweaving the Rainbow</title>
-          <description>Assumenda rerum tenetur dignissimos.</description>
+          <title>The Last Temptation</title>
+          <description>Dicta et qui natus.</description>
         </package>
-  recorded_at: Fri, 31 Jul 2020 14:58:44 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:45 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:home:tom/new_package_name?cmd=branch&noservice=1&opackage=my_package&oproject=home:tom&user=tom
@@ -221,15 +221,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2" vrev="2">
+        <revision rev="3" vrev="3">
           <srcmd5>49bd231e56677e1dfd80e906f4f5dbe4</srcmd5>
           <version>unknown</version>
-          <time>1596207524</time>
+          <time>1596207525</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 31 Jul 2020 14:58:44 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:45 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:home:tom/new_package_name/_meta?user=tom
@@ -237,8 +237,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="new_package_name" project="home:tom:branches:home:tom">
-          <title>Unweaving the Rainbow</title>
-          <description>Assumenda rerum tenetur dignissimos.</description>
+          <title>The Last Temptation</title>
+          <description>Dicta et qui natus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -259,15 +259,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '187'
+      - '168'
     body:
       encoding: UTF-8
       string: |
         <package name="new_package_name" project="home:tom:branches:home:tom">
-          <title>Unweaving the Rainbow</title>
-          <description>Assumenda rerum tenetur dignissimos.</description>
+          <title>The Last Temptation</title>
+          <description>Dicta et qui natus.</description>
         </package>
-  recorded_at: Fri, 31 Jul 2020 14:58:44 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:45 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:home:tom/new_package_name
@@ -297,11 +297,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="new_package_name" rev="2" vrev="2" srcmd5="49bd231e56677e1dfd80e906f4f5dbe4">
+        <directory name="new_package_name" rev="3" vrev="3" srcmd5="49bd231e56677e1dfd80e906f4f5dbe4">
           <linkinfo project="home:tom" package="my_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="0a2e3813e4d7ad4b6b72066efa8587cc" lsrcmd5="49bd231e56677e1dfd80e906f4f5dbe4"/>
           <entry name="_link" md5="324a67e2c9fe0d6cdc38c625b1c416f5" size="137" mtime="1596207431"/>
         </directory>
-  recorded_at: Fri, 31 Jul 2020 14:58:44 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:45 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:home:tom/new_package_name?view=info
@@ -331,11 +331,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="new_package_name" rev="2" vrev="2" srcmd5="0a2e3813e4d7ad4b6b72066efa8587cc" lsrcmd5="49bd231e56677e1dfd80e906f4f5dbe4" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
+        <sourceinfo package="new_package_name" rev="3" vrev="3" srcmd5="0a2e3813e4d7ad4b6b72066efa8587cc" lsrcmd5="49bd231e56677e1dfd80e906f4f5dbe4" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="home:tom" package="my_package"/>
         </sourceinfo>
-  recorded_at: Fri, 31 Jul 2020 14:58:44 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:45 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:home:tom/new_package_name
@@ -365,11 +365,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="new_package_name" rev="2" vrev="2" srcmd5="49bd231e56677e1dfd80e906f4f5dbe4">
+        <directory name="new_package_name" rev="3" vrev="3" srcmd5="49bd231e56677e1dfd80e906f4f5dbe4">
           <linkinfo project="home:tom" package="my_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="0a2e3813e4d7ad4b6b72066efa8587cc" lsrcmd5="49bd231e56677e1dfd80e906f4f5dbe4"/>
           <entry name="_link" md5="324a67e2c9fe0d6cdc38c625b1c416f5" size="137" mtime="1596207431"/>
         </directory>
-  recorded_at: Fri, 31 Jul 2020 14:58:44 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:45 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:home:tom/new_package_name?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -401,14 +401,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="c7ffe26cb047167f4060511e479109d9">
+        <sourcediff key="7bd9bdc12dea0e56f2a5f9ea2429f778">
           <old project="home:tom:branches:home:tom" package="new_package_name" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:tom:branches:home:tom" package="new_package_name" rev="2" srcmd5="49bd231e56677e1dfd80e906f4f5dbe4"/>
+          <new project="home:tom:branches:home:tom" package="new_package_name" rev="3" srcmd5="49bd231e56677e1dfd80e906f4f5dbe4"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Fri, 31 Jul 2020 14:58:44 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:45 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:home:tom/new_package_name?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -447,7 +447,7 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Fri, 31 Jul 2020 14:58:44 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:45 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:home:tom/_meta?user=tom
@@ -493,5 +493,5 @@ http_interactions:
             <disable/>
           </publish>
         </project>
-  recorded_at: Fri, 31 Jul 2020 14:58:44 GMT
+  recorded_at: Fri, 31 Jul 2020 14:58:45 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/controllers/webui/packages/branches_controller_spec.rb
+++ b/src/api/spec/controllers/webui/packages/branches_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Webui::Packages::BranchesController, vcr: true do
 
     it 'shows an error if source package does not exist' do
       post :create, params: { linked_project: source_project, linked_package: 'does_not_exist' }
-      expect(flash[:error]).to eq('Failed to branch: Package does not exist.')
+      expect(flash[:error]).to eq('Failed to branch: Package not found: home:tom/does_not_exist')
       expect(response).to redirect_to(root_path)
     end
 
@@ -26,7 +26,7 @@ RSpec.describe Webui::Packages::BranchesController, vcr: true do
 
     it 'shows an error if source project does not exist' do
       post :create, params: { linked_project: 'does_not_exist', linked_package: source_package }
-      expect(flash[:error]).to eq('Failed to branch: Package does not exist.')
+      expect(flash[:error]).to eq('Failed to branch: Project not found: does_not_exist')
       expect(response).to redirect_to(root_path)
     end
 

--- a/src/api/spec/features/beta/webui/projects_spec.rb
+++ b/src/api/spec/features/beta/webui/projects_spec.rb
@@ -131,16 +131,6 @@ RSpec.describe 'Projects', type: :feature, js: true do
       expect(page).to have_text('You have already branched this package')
       expect(page).to have_current_path('/package/show/home:Jane/branch_test_package')
     end
-
-    it 'a non-existing package' do
-      fill_in('linked_project', with: 'non-existing_package')
-      fill_in('linked_package', with: package_of_another_project.name)
-
-      click_button('Branch')
-
-      expect(page).to have_text('Failed to branch: Package does not exist.')
-      expect(page).to have_current_path(project_new_packages_branch_path('home:Jane'))
-    end
   end
 
   describe 'maintenance projects' do

--- a/src/api/spec/features/webui/projects_spec.rb
+++ b/src/api/spec/features/webui/projects_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe 'Projects', type: :feature, js: true do
 
   describe 'branching', vcr: true do
     let(:other_user) { create(:confirmed_user, :with_home, login: 'other_user') }
-    let!(:package_of_another_project) { create(:package_with_file, name: 'branch_test_package', project: other_user.home_project) }
+    let(:package_of_another_project) { create(:package_with_file, name: 'branch_test_package', project: other_user.home_project) }
 
     before do
       login user
@@ -106,29 +106,6 @@ RSpec.describe 'Projects', type: :feature, js: true do
       click_button('Branch')
 
       expect(page).to have_text('Successfully branched package')
-      expect(page).to have_current_path('/package/show/home:Jane/branch_test_package')
-    end
-
-    it 'an existing package, but chose a different target package name' do
-      fill_in('linked_project', with: other_user.home_project_name)
-      fill_in('linked_package', with: package_of_another_project.name)
-      fill_in('Branch package name', with: 'some_different_name')
-      # This needs global write through
-      click_button('Branch')
-
-      expect(page).to have_text('Successfully branched package')
-      expect(page).to have_current_path("/package/show/#{user.home_project_name}/some_different_name", ignore_query: true)
-    end
-
-    it 'an existing package were the target package already exists' do
-      create(:package_with_file, name: package_of_another_project.name, project: user.home_project)
-
-      fill_in('linked_project', with: other_user.home_project_name)
-      fill_in('linked_package', with: package_of_another_project.name)
-      # This needs global write through
-      click_button('Branch')
-
-      expect(page).to have_text('You have already branched this package')
       expect(page).to have_current_path('/package/show/home:Jane/branch_test_package')
     end
   end

--- a/src/api/spec/features/webui/projects_spec.rb
+++ b/src/api/spec/features/webui/projects_spec.rb
@@ -131,16 +131,6 @@ RSpec.describe 'Projects', type: :feature, js: true do
       expect(page).to have_text('You have already branched this package')
       expect(page).to have_current_path('/package/show/home:Jane/branch_test_package')
     end
-
-    it 'a non-existing package' do
-      fill_in('linked_project', with: 'non-existing_package')
-      fill_in('linked_package', with: package_of_another_project.name)
-
-      click_button('Branch')
-
-      expect(page).to have_text('Failed to branch: Package does not exist.')
-      expect(page).to have_current_path(project_new_packages_branch_path('home:Jane'))
-    end
   end
 
   describe 'maintenance projects' do


### PR DESCRIPTION
Package::UnknownObjectError and Project::UnknownObjectError also
have nice error messages that tell you exactly what is not found.

Show that to people, instead of a generic message.

Makes #9970 a bit more clear

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
