### PR TITLE
Disallow '/source/*' routes for web robots

### DIFF
--- a/src/api/public/robots.txt
+++ b/src/api/public/robots.txt
@@ -1,4 +1,4 @@
-# See http://www.robotstxt.org/wc/norobots.html for documentation on how to use the robots.txt file
+# See http://www.robotstxt.org/ for documentation on how to use the robots.txt file
 User-agent: *
 Disallow: /package/live_build_log
 Disallow: /ICSLogin
@@ -10,6 +10,7 @@ Disallow: /project/buildstatus
 Disallow: /project/status
 Disallow: /stage
 Disallow: /project/rebuild_time
+Disallow: /source/
 
 # unfortunately the sitemap needs to be full URL,
 # so it needs to be adopted for other anonymous


### PR DESCRIPTION
Web robots try to access these routes, causing a bunch of auth request errors (401).

Update also the link to the documentation page in the comment.
