### PR TITLE
Always use public path to logfile in webui

### DIFF
--- a/src/api/app/views/webui/package/_live_build_log_controls.html.haml
+++ b/src/api/app/views/webui/package/_live_build_log_controls.html.haml
@@ -5,21 +5,12 @@
   = link_to('#', class: 'stop_refresh live-link-action btn-dark') do
     %i.far.fa-pause-circle
     Stop refresh
-
-  - if !User.session
-    = link_to(public_build_path(package: @package, project: @project, arch: @arch, repository: @repo, filename: '_log'),
-              target: :_blank,
-              rel: 'noopener',
-              class: 'live-link-action btn-secondary') do
-      %i.fas.fa-download
-      Download logfile
-  - else
-    = link_to(raw_logfile_path(package: @package, project: @project, arch: @arch, repository: @repo),
-              target: :_blank,
-              rel: 'noopener',
-              class: 'live-link-action btn-secondary') do
-      %i.fas.fa-download
-      Download logfile
+  = link_to(public_build_path(package: @package, project: @project, arch: @arch, repository: @repo, filename: '_log'),
+            target: :_blank,
+            rel: 'noopener',
+            class: 'live-link-action btn-secondary') do
+    %i.fas.fa-download
+    Download logfile
   - if @can_modify
     = link_to(package_trigger_rebuild_path(project: @project, package: @package, arch: @arch, repository: @repo),
               class: 'link_trigger_rebuild live-link-action btn-warning d-none',


### PR DESCRIPTION
There is no benefit in using different routes to the log file,
for authenticated and non authenticated users in the webui,
since both deliver the exact same result.

Fixes #9880

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
