### PR TITLE
Keep the filter when marking a notification read or unread 

### DIFF
--- a/src/api/app/controllers/webui/users/notifications_controller.rb
+++ b/src/api/app/controllers/webui/users/notifications_controller.rb
@@ -8,9 +8,8 @@ class Webui::Users::NotificationsController < Webui::WebuiController
 
   def index
     @notifications = fetch_notifications
-    @projects_for_filter = projects_for_filter
-    @notifications_count = notifications_count
     @filtered_project = Project.find_by(name: params[:project])
+    @notifications_filter = notifications_filter
   end
 
   def update
@@ -27,8 +26,7 @@ class Webui::Users::NotificationsController < Webui::WebuiController
       format.js do
         render partial: 'update', locals: {
           notifications: fetch_notifications,
-          projects_for_filter: projects_for_filter,
-          notifications_count: notifications_count
+          notifications_filter: notifications_filter
         }
       end
     end
@@ -84,5 +82,12 @@ class Webui::Users::NotificationsController < Webui::WebuiController
                       NotificationsFinder.new(notifications_for_subscribed_user).for_notifiable_type(params[:type])
                     end
     params['show_all'] ? show_all(notifications) : notifications.page(params[:page])
+  end
+
+  def notifications_filter
+    NotificationsFilterPresenter.new(projects_for_filter,
+                                     notifications_count,
+                                     params[:type],
+                                     params[:project])
   end
 end

--- a/src/api/app/helpers/webui/notification_helper.rb
+++ b/src/api/app/helpers/webui/notification_helper.rb
@@ -9,10 +9,10 @@ module Webui::NotificationHelper
     end
   end
 
-  def filter_notification_link(link_text, amount, filter_item)
-    link_to(my_notifications_path(filter_item), class: filter_css(filter_item)) do
+  def filter_notification_link(link_text, amount, filter_item, selected_filter)
+    link_to(my_notifications_path(filter_item), class: css_for_filter_link(filter_item, selected_filter)) do
       concat(link_text)
-      concat(tag.span(amount, class: "badge #{badge_color(filter_item)} align-text-top ml-2")) if amount && amount.positive?
+      concat(tag.span(amount, class: "badge #{badge_color(filter_item, selected_filter)} align-text-top ml-2")) if amount && amount.positive?
     end
   end
 
@@ -33,23 +33,23 @@ module Webui::NotificationHelper
 
   private
 
-  def filter_css(filter_item)
+  def css_for_filter_link(filter_item, selected_filter)
     css_class = 'list-group-item list-group-item-action'
-    css_class += ' active' if notification_filter_active?(filter_item)
+    css_class += ' active' if notification_filter_matches(filter_item, selected_filter)
     css_class
   end
 
-  def notification_filter_active?(filter_item)
-    if params[:project].present?
-      filter_item[:project] == params[:project]
-    elsif params[:type].present?
-      filter_item[:type] == params[:type]
+  def notification_filter_matches(filter_item, selected_filter)
+    if selected_filter[:project].present?
+      filter_item[:project] == selected_filter[:project]
+    elsif selected_filter[:type].present?
+      filter_item[:type] == selected_filter[:type]
     else
       filter_item[:type] == 'unread'
     end
   end
 
-  def badge_color(filter_item)
-    notification_filter_active?(filter_item) ? 'badge-light' : 'badge-primary'
+  def badge_color(filter_item, selected_filter)
+    notification_filter_matches(filter_item, selected_filter) ? 'badge-light' : 'badge-primary'
   end
 end

--- a/src/api/app/presenters/notifications_filter_presenter.rb
+++ b/src/api/app/presenters/notifications_filter_presenter.rb
@@ -1,0 +1,11 @@
+class NotificationsFilterPresenter
+  attr_reader :selected_filter, :selected_project, :selected_type, :count, :projects_for_filter
+
+  def initialize(projects_for_filter, notifications_count, selected_type, selected_project)
+    @projects_for_filter = projects_for_filter
+    @count = notifications_count
+    @selected_type = selected_type
+    @selected_project = selected_project
+    @selected_filter = { type: selected_type, project: selected_project }
+  end
+end

--- a/src/api/app/views/webui/users/notifications/_notifications_filter.html.haml
+++ b/src/api/app/views/webui/users/notifications/_notifications_filter.html.haml
@@ -1,11 +1,11 @@
 .row.list-group-flush
-  = filter_notification_link('Unread', notifications_count['unread'], type: 'unread')
-  = filter_notification_link('Read', nil, type: 'read')
+  = filter_notification_link('Unread', filter.count['unread'], { type: 'unread' }, filter.selected_filter)
+  = filter_notification_link('Read', nil, { type: 'read' }, filter.selected_filter)
 .row.list-group-flush.mt-5
   %h5.ml-3 Filter
-  = filter_notification_link('Comments', notifications_count['Comment'], type: 'comments')
-  = filter_notification_link('Requests', notifications_count['BsRequest'], type: 'requests')
+  = filter_notification_link('Comments', filter.count['Comment'], { type: 'comments' }, filter.selected_filter)
+  = filter_notification_link('Requests', filter.count['BsRequest'], { type: 'requests' }, filter.selected_filter)
 .row.list-group-flush.mt-5
   %h5.ml-3 Projects
-  - projects_for_filter.each_pair do |project_name, amount|
-    = filter_notification_link(project_name, amount, project: project_name)
+  - filter.projects_for_filter.each_pair do |project_name, amount|
+    = filter_notification_link(project_name, amount, { project: project_name }, filter.selected_filter)

--- a/src/api/app/views/webui/users/notifications/_notifications_list.html.haml
+++ b/src/api/app/views/webui/users/notifications/_notifications_list.html.haml
@@ -2,7 +2,7 @@
   .card-body
     - if notifications.empty?
       %p
-        - case params[:type]
+        - case selected_filter[:type]
         - when 'reviews', 'comments', 'requests'
           There are no notifications for this filter
         - when 'done'
@@ -29,7 +29,8 @@
                 = link_to(notification.notifiable_link[:text], notification.notifiable_link[:path], class: 'mx-1 text-word-break-all')
             .actions.ml-auto.align-self-end.align-self-md-start
               - title, icon = notification.unread? ? ['Mark as "Read"', 'fa-check'] : ['Mark as "Unread"', 'fa-undo']
-              = link_to(my_notification_path(id: notification),
+              - update_path = my_notification_path(id: notification, type: selected_filter[:type], project: selected_filter[:project])
+              = link_to(update_path, id: format('update-notification-%d', notification.id),
                         method: :put, class: 'btn btn-sm btn-outline-success px-3', title: title, remote: true) do
                 %i.fas{ class: "#{icon}" }
             .content

--- a/src/api/app/views/webui/users/notifications/_update.js.erb
+++ b/src/api/app/views/webui/users/notifications/_update.js.erb
@@ -1,3 +1,3 @@
-$('#filters').html("<%= j(render partial: 'notifications_filter', locals: { projects_for_filter: projects_for_filter, notifications_count: notifications_count }) %>");
-$('#notifications-list').html("<%= j(render partial: 'notifications_list', locals: { notifications: notifications }) %>");
+$('#filters').html("<%= j(render partial: 'notifications_filter', locals: { filter: notifications_filter }) %>");
+$('#notifications-list').html("<%= j(render partial: 'notifications_list', locals: { notifications: notifications, selected_filter: notifications_filter.selected_filter }) %>");
 $('#flash').html("<%= escape_javascript(render(layout: false, partial: 'layouts/webui/flash', object: flash)) %>");

--- a/src/api/app/views/webui/users/notifications/index.html.haml
+++ b/src/api/app/views/webui/users/notifications/index.html.haml
@@ -9,8 +9,8 @@
       %strong.d-block.d-md-none.p-3{ data: { toggle: 'collapse', target: '#filters' },
                                   aria: { expanded: true, controls: 'filters' } }
         Filtered by: #{params[:type]&.humanize || @filtered_project || 'Unread'}
-        %i.float-right.mt-1.fa.fa-chevron-down
+        %i.float-right.mt-1.fa.fa-chevron-down#notifications-dropdown-trigger
       .card-body.collapse#filters
-        = render partial: 'notifications_filter', locals: { projects_for_filter: @projects_for_filter, notifications_count: @notifications_count }
+        = render partial: 'notifications_filter', locals: { filter: @notifications_filter }
   .col-md-8.col-lg-9#notifications-list
-    = render partial: 'notifications_list', locals: { notifications: @notifications }
+    = render partial: 'notifications_list', locals: { notifications: @notifications, selected_filter: @notifications_filter.selected_filter }

--- a/src/api/spec/features/beta/webui/users/notifications_controller_spec.rb
+++ b/src/api/spec/features/beta/webui/users/notifications_controller_spec.rb
@@ -1,0 +1,84 @@
+require 'browser_helper'
+
+RSpec.describe 'User notifications', type: :feature, js: true do
+  let!(:user) { create(:confirmed_user, :in_beta) }
+
+  describe 'when having no notifications' do
+    context 'when accessing the notifications page' do
+      before do
+        login user
+        visit my_notifications_path
+      end
+
+      it 'shows no notifications' do
+        expect(page).to have_text('There are no notifications')
+      end
+    end
+  end
+
+  describe 'when having notifications' do
+    let!(:notification_for_projects_comment) { create(:web_notification, :comment_for_package, subscriber: user) }
+    let!(:another_notification_for_projects_comment) { create(:web_notification, :comment_for_package, subscriber: user) }
+    let(:notifiable) { notification_for_projects_comment.notifiable }
+    let(:another_notifiable) { another_notification_for_projects_comment.notifiable }
+    let(:project) { notifiable.commentable.project }
+
+    context 'when clicking on the Comments filter' do
+      before do
+        login user
+        visit my_notifications_path
+      end
+
+      it 'shows all unread comment notifications' do
+        find('#notifications-dropdown-trigger').click if mobile?
+        within('#filters') { click_link('Comments') }
+        expect(page).to have_text(notifiable.commentable.name)
+      end
+
+      context 'when marking a comment notification as read' do # rubocop:todo RSpec/NestedGroups
+        before do
+          find('#notifications-dropdown-trigger').click if mobile?
+          within('#filters') { click_link('Comments') }
+          click_link("update-notification-#{notification_for_projects_comment.id}")
+        end
+
+        it 'keeps the Comments filter' do
+          wait_for_ajax
+
+          find('#notifications-dropdown-trigger').click if mobile?
+          expect(find('.list-group-item.list-group-item-action.active')).to have_text('Comment')
+        end
+      end
+    end
+
+    context 'when clicking on the project filter' do
+      before do
+        login user
+        project.notifications << notification_for_projects_comment
+        project.notifications << another_notification_for_projects_comment
+        visit my_notifications_path
+      end
+
+      it 'shows all unread project notifications' do
+        find('#notifications-dropdown-trigger').click if mobile?
+        within('#filters') { click_link(project.name) }
+        find('#notifications-dropdown-trigger').click if mobile?
+        expect(find('.list-group-item.list-group-item-action.active')).to have_text(project.name)
+      end
+
+      context 'when marking a project notification as read' do # rubocop:todo RSpec/NestedGroups
+        before do
+          find('#notifications-dropdown-trigger').click if mobile?
+          within('#filters') { click_link(project.name) }
+          find_link(id: format('update-notification-%d', notification_for_projects_comment.id)).click
+        end
+
+        it 'keeps the project filter' do
+          wait_for_ajax
+          find('#notifications-dropdown-trigger').click if mobile?
+          expect(find('.list-group-item.list-group-item-action.active')).to have_text(project.name)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Instead of picking the notification type from the `params` variable,
this PR makes the notification type explicitly available as a partial
local variable and function parameters.

Before this PR, the user was losing the selected notifiable type from the
notifications filter when marking a notification as 'read'.

This was due to the notifications/update remote partial not getting
the `params[:type]` when rendering.

![Peek 2020-08-07 13-02](https://user-images.githubusercontent.com/2650/89639768-7b22aa80-d8ae-11ea-8440-f36eb37cefda.gif)

It's also fixed in small devices

![Peek 2020-08-06 16-13](https://user-images.githubusercontent.com/2650/90007908-d59b7c80-dc9b-11ea-8aab-c8624481ce68.gif)

Fixes #9908