### PR TITLE
[backend] aggregate signing: reuse old rpms if the old signatures wer…

### DIFF
--- a/src/backend/bs_signer
+++ b/src/backend/bs_signer
@@ -445,6 +445,19 @@ sub getsignkey {
   return ($algo, $signkey, $pubkey, $cert);
 }
 
+sub getsigdata {
+  my ($rpm) = @_;
+  my $sigdata;
+  eval {
+    my %res = Build::Rpm::rpmq($rpm, 'SIGTAG_GPG', 'SIGTAG_PGP');
+    my $sig = $res{'SIGTAG_PGP'} || $res{'SIGTAG_GPG'};
+    $sig = $sig->[0] if $sig;
+    $sigdata = BSPGP::pk2sigdata($sig) if $sig;
+  };
+  warn("getsigdata $rpm: $@") if $@;
+  return $sigdata ? $sigdata : {};
+}
+
 sub signjob {
   my ($job, $arch) = @_;
 
@@ -530,21 +543,20 @@ sub signjob {
 	  rsasign("$jobdir/$signfile", $jobstatus, @signargs) if $followupfile;
 	  next;
 	}
-	my $signtime;
+	my $signfilefinal;
+	my ($signtime, $signissuer);
 	if ($info->{'file'} eq '_aggregate' && ($signfile =~ /\.d?rpm$/)) {
 	  # newer rpm versions sometimes do in-place signature replacement,
 	  # so create a copy first
 	  # (we should add a delsign option to our sign utility...)
-	  BSUtil::cp("$jobdir/$signfile", "$jobdir/.$signfile", "$jobdir/$signfile");
+	  BSUtil::cp("$jobdir/$signfile", "$jobdir/.$signfile");
+	  $signfilefinal = $signfile;
+	  $signfile = ".$signfile";
 	  # special aggregate handling: remove old sigs
 	  # but get old sig time first
-	  eval {
-	    my %res = Build::Rpm::rpmq("$jobdir/$signfile", 'SIGTAG_GPG', 'SIGTAG_PGP');
-	    my $sig = $res{'SIGTAG_PGP'} || $res{'SIGTAG_GPG'};
-	    $sig = $sig->[0] if $sig;
-	    $signtime = BSPGP::pk2signtime($sig) if $sig;
-	  };
-	  warn("get signtime: $@") if $@;
+	  my $sigdata = getsigdata("$jobdir/$signfile");
+	  $signtime = $sigdata->{'signtime'};
+	  $signissuer = $sigdata->{'issuer'};
 	  system('rpm', '--delsign', "$jobdir/$signfile") && warn("delsign $jobdir/$signfile failed: $?\n");
 	  print "using signtime $signtime\n" if $signtime;
 	}
@@ -582,7 +594,21 @@ sub signjob {
 	      $jobstatus->{'result'} = 'rebuild';
 	    }
 	  }
+	  unlink("$jobdir/$signfile") if $signfilefinal;	# delete tmp file
 	  die("sign $jobdir/$signfile failed\n");
+	}
+	if ($signfilefinal) {
+	  # check if the signed rpm has the same issuer
+	  my $sigdata = getsigdata("$jobdir/$signfile");
+	  if ($sigdata->{'issuer'} && $signissuer && $sigdata->{'issuer'} eq $signissuer) {
+	    # old rpm was already signed with the same issuer, reuse
+	    print "same issuer, reusing old rpm\n";
+	    unlink("$jobdir/$signfile");
+	  } else {
+	    rename("$jobdir/$signfile", "$jobdir/$signfilefinal");
+	  }
+	  $signfile = $signfilefinal;
+	  undef $signfilefinal;
 	}
 	if ($signfile =~ /\.AppImage$/ && -e "$jobdir/$signfile.zsync") {
 	  print("regenerating zsync file\n");


### PR DESCRIPTION
…e done by the same issuer

We do this to work around rpm --delsign having a bug that makes it
modify the lead.

It also saves some disk space because hard links are saved this way.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
