### PR TITLE
[backend] allow building helm chart

### DIFF
--- a/src/backend/BSPublisher/Registry.pm
+++ b/src/backend/BSPublisher/Registry.pm
@@ -542,9 +542,12 @@ sub push_containers {
       close $tarfd if $tarfd;
 
       # put manifest into repo
+      # helm has a static set of mediatypes supported
+      # https://github.com/helm/helm/blob/d6f6184351f7aecd9d0efdfb8aba7da5664031eb/internal/experimental/registry/constants.go
+      my $mediaType = "application/vnd.oci.image.manifest.v1+json" if (($containerinfo->{'type'} || '') eq 'helm');
       my $mani = { 
 	'schemaVersion' => 2,
-	'mediaType' => 'application/vnd.docker.distribution.manifest.v2+json',
+	'mediaType' => $mediaType || 'application/vnd.docker.distribution.manifest.v2+json',
 	'config' => $config_data,
 	'layers' => \@layer_data,
       };

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -865,6 +865,7 @@ sub findfile {
   return $files{'appimage.yml'} if $files{'appimage.yml'} && $ext eq 'appimage';
   return $files{'Dockerfile'} if $files{'Dockerfile'} && $ext eq 'docker';
   return $files{'fissile.yml'} if $files{'fissile.yml'} && $ext eq 'fissile';
+  return $files{'Chart.yaml'} if $files{'Chart.yaml'} && $ext eq 'helm';
 
   if ($ext eq 'arch') {
     return $files{'PKGBUILD'} if $files{'PKGBUILD'};

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -4051,6 +4051,7 @@ if ($ex == 0) {
   @d = ('KIWI') if $buildinfo->{'file'} =~ /\.kiwi$/;
   @d = ('DOCKER') if $buildinfo->{'file'} =~ /Dockerfile$/;
   @d = ('FISSILE') if $buildinfo->{'file'} =~ /fissile\.yml$/;
+  @d = ('HELM') if $buildinfo->{'file'} =~ /Chart\.yaml$/;
   push @d, 'OTHER';
   for my $d ('.', @d) {
     my @files = sort(ls("$buildroot/.build.packages/$d"));


### PR DESCRIPTION
the mediaType change is as expected by helm documented here:
https://helm.sh/docs/topics/registries/
and
https://github.com/helm/helm/blob/d6f6184351f7aecd9d0efdfb8aba7da5664031eb/internal/experimental/registry/constants.go

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
