### PR TITLE
Add explicit format constraints to show, edit and update package

### DIFF
--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -52,13 +52,15 @@ OBSApi::Application.routes.draw do
     resources :package, only: [:index], controller: 'webui/package', constraints: cons
 
     controller 'webui/package' do
-      get 'package/edit/:project/:package' => :edit, constraints: cons, as: 'edit_package'
-      patch 'package/update' => :update, constraints: cons
-      get 'package/show/:project/:package' => :show, as: 'package_show', constraints: cons
+      defaults format: 'js' do
+        get 'package/edit/:project/:package' => :edit, constraints: cons, as: 'edit_package'
+        patch 'package/update' => :update, constraints: cons
+      end
     end
 
     defaults format: 'html' do
       controller 'webui/package' do
+        get 'package/show/:project/:package' => :show, as: 'package_show', constraints: cons
         get 'package/branch_diff_info/:project/:package' => :branch_diff_info, as: 'package_branch_diff_info', constraints: cons
         get 'package/dependency/:project/:package' => :dependency, constraints: cons, as: 'package_dependency'
         get 'package/binary/:project/:package/:repository/:arch/:filename' => :binary, constraints: cons, as: 'package_binary'

--- a/src/api/spec/cassettes/Packages/Viewing_a_package_that/has_a_mime_like_suffix_in_it_s_name.yml
+++ b/src/api/spec/cassettes/Packages/Viewing_a_package_that/has_a_mime_like_suffix_in_it_s_name.yml
@@ -2,47 +2,6 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/home:package_test_user/_meta?user=package_test_user
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:package_test_user">
-          <title/>
-          <description/>
-          <person userid="package_test_user" role="maintainer"/>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '157'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:package_test_user">
-          <title></title>
-          <description></description>
-          <person userid="package_test_user" role="maintainer" />
-        </project>
-    http_version: 
-  recorded_at: Thu, 30 Aug 2018 16:32:56 GMT
-- request:
-    method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=_nobody_
     body:
       encoding: UTF-8
@@ -78,7 +37,6 @@ http_interactions:
           <title>The Wives of Bath</title>
           <description>Recusandae eum alias ut.</description>
         </package>
-    http_version: 
   recorded_at: Thu, 30 Aug 2018 16:32:57 GMT
 - request:
     method: put
@@ -117,126 +75,6 @@ http_interactions:
           <title>The Wives of Bath</title>
           <description>Recusandae eum alias ut.</description>
         </package>
-    http_version: 
-  recorded_at: Thu, 30 Aug 2018 16:32:57 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:package_test_user/test_package/_config
-    body:
-      encoding: UTF-8
-      string: Cupiditate consequatur dolorum. Et iste voluptas. Aut qui facilis.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '209'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="13" vrev="13">
-          <srcmd5>43b73dcd401538920575e4db43f2cc75</srcmd5>
-          <version>unknown</version>
-          <time>1535646777</time>
-          <user>unknown</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-    http_version: 
-  recorded_at: Thu, 30 Aug 2018 16:32:57 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:package_test_user/test_package/somefile.txt
-    body:
-      encoding: UTF-8
-      string: Officiis dicta blanditiis. Est error et. Repudiandae est ipsam.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '209'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="14" vrev="14">
-          <srcmd5>6cee80377576d47cb35a1168ddf08686</srcmd5>
-          <version>unknown</version>
-          <time>1535646777</time>
-          <user>unknown</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-    http_version: 
-  recorded_at: Thu, 30 Aug 2018 16:32:57 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:other_package_test_user/_meta?user=other_package_test_user
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:other_package_test_user">
-          <title/>
-          <description/>
-          <person userid="other_package_test_user" role="maintainer"/>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '169'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:other_package_test_user">
-          <title></title>
-          <description></description>
-          <person userid="other_package_test_user" role="maintainer" />
-        </project>
-    http_version: 
   recorded_at: Thu, 30 Aug 2018 16:32:57 GMT
 - request:
     method: put
@@ -275,7 +113,6 @@ http_interactions:
           <title>Consider Phlebas</title>
           <description>Fuga ut reprehenderit minima.</description>
         </package>
-    http_version: 
   recorded_at: Thu, 30 Aug 2018 16:32:57 GMT
 - request:
     method: put
@@ -314,85 +151,6 @@ http_interactions:
           <title>Consider Phlebas</title>
           <description>Fuga ut reprehenderit minima.</description>
         </package>
-    http_version: 
-  recorded_at: Thu, 30 Aug 2018 16:32:57 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_config
-    body:
-      encoding: UTF-8
-      string: Omnis laudantium rem. Et sunt inventore. Accusamus repellat nostrum.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '209'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="35" vrev="35">
-          <srcmd5>517500ad3d0732529d6b16e2d8c70b90</srcmd5>
-          <version>unknown</version>
-          <time>1535646777</time>
-          <user>unknown</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-    http_version: 
-  recorded_at: Thu, 30 Aug 2018 16:32:57 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/somefile.txt
-    body:
-      encoding: UTF-8
-      string: Quasi unde maiores. Sit nihil voluptatem. Eos et nemo.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '209'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="36" vrev="36">
-          <srcmd5>5bf925c6d6d656cbb8f93c340183602a</srcmd5>
-          <version>unknown</version>
-          <time>1535646777</time>
-          <user>unknown</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-    http_version: 
   recorded_at: Thu, 30 Aug 2018 16:32:57 GMT
 - request:
     method: put
@@ -431,7 +189,6 @@ http_interactions:
           <title>The Little Foxes</title>
           <description>A package with a mime type suffix</description>
         </package>
-    http_version: 
   recorded_at: Thu, 30 Aug 2018 16:32:57 GMT
 - request:
     method: put
@@ -470,7 +227,6 @@ http_interactions:
           <title>The Little Foxes</title>
           <description>A package with a mime type suffix</description>
         </package>
-    http_version: 
   recorded_at: Thu, 30 Aug 2018 16:32:57 GMT
 - request:
     method: get
@@ -503,7 +259,6 @@ http_interactions:
       string: |
         <directory name="test.json" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-    http_version: 
   recorded_at: Thu, 30 Aug 2018 16:32:57 GMT
 - request:
     method: get
@@ -536,7 +291,6 @@ http_interactions:
       string: |
         <directory name="test.json" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-    http_version: 
   recorded_at: Thu, 30 Aug 2018 16:32:57 GMT
 - request:
     method: get
@@ -571,7 +325,6 @@ http_interactions:
           <summary>_service: no such file</summary>
           <details>404 _service: no such file</details>
         </status>
-    http_version: 
   recorded_at: Thu, 30 Aug 2018 16:32:57 GMT
 - request:
     method: get
@@ -606,6 +359,447 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000" />
 
 '
-    http_version: 
   recorded_at: Thu, 30 Aug 2018 16:32:57 GMT
-recorded_with: VCR 4.0.0
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:package_test_user">
+          <title/>
+          <description/>
+          <person userid="package_test_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '156'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:package_test_user">
+          <title></title>
+          <description></description>
+          <person userid="package_test_user" role="maintainer"/>
+        </project>
+  recorded_at: Mon, 10 Aug 2020 12:58:13 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=user_1
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:package_test_user">
+          <title>The Curious Incident of the Dog in the Night-Time</title>
+          <description>Autem voluptas rem beatae.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '197'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:package_test_user">
+          <title>The Curious Incident of the Dog in the Night-Time</title>
+          <description>Autem voluptas rem beatae.</description>
+        </package>
+  recorded_at: Mon, 10 Aug 2020 12:58:14 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/test_package/_config
+    body:
+      encoding: UTF-8
+      string: Mollitia nesciunt quam. Et sit aliquam. Et facere rerum.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="1" vrev="1">
+          <srcmd5>b9672cae9e62dfd974a8406eb2851690</srcmd5>
+          <version>unknown</version>
+          <time>1597064294</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Mon, 10 Aug 2020 12:58:14 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/test_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Laborum aut officiis. Iste culpa aut. Illo eius enim.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="2" vrev="2">
+          <srcmd5>fa61a4eab98444251d5da0ddd2353d14</srcmd5>
+          <version>unknown</version>
+          <time>1597064294</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Mon, 10 Aug 2020 12:58:14 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/_meta?user=other_package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:other_package_test_user">
+          <title/>
+          <description/>
+          <person userid="other_package_test_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '168'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:other_package_test_user">
+          <title></title>
+          <description></description>
+          <person userid="other_package_test_user" role="maintainer"/>
+        </project>
+  recorded_at: Mon, 10 Aug 2020 12:58:16 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=user_2
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>For a Breath I Tarry</title>
+          <description>Beatae quia mollitia impedit.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '184'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>For a Breath I Tarry</title>
+          <description>Beatae quia mollitia impedit.</description>
+        </package>
+  recorded_at: Mon, 10 Aug 2020 12:58:17 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_config
+    body:
+      encoding: UTF-8
+      string: Non velit vel. Vitae quia ut. Minima deleniti est.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="1" vrev="1">
+          <srcmd5>82e74247eab946d82305b35e3f3ae2b9</srcmd5>
+          <version>unknown</version>
+          <time>1597064297</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Mon, 10 Aug 2020 12:58:17 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Nisi quo molestias. Et et vel. Explicabo laudantium non.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="2" vrev="2">
+          <srcmd5>ef54745f29d5732282c9af53de061537</srcmd5>
+          <version>unknown</version>
+          <time>1597064298</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Mon, 10 Aug 2020 12:58:18 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/test.yaml/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test.yaml" project="home:package_test_user">
+          <title>Arms and the Man</title>
+          <description>A package with a mime type suffix</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '168'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test.yaml" project="home:package_test_user">
+          <title>Arms and the Man</title>
+          <description>A package with a mime type suffix</description>
+        </package>
+  recorded_at: Mon, 10 Aug 2020 12:58:18 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test.yaml
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '84'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test.yaml" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Mon, 10 Aug 2020 12:58:20 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test.yaml?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '84'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test.yaml" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Mon, 10 Aug 2020 12:58:20 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:package_test_user/_result?package=test.yaml&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Mon, 10 Aug 2020 12:58:20 GMT
+recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Packages/editing_a_package_s_details/updates_the_package_title_and_description.yml
+++ b/src/api/spec/cassettes/Packages/editing_a_package_s_details/updates_the_package_title_and_description.yml
@@ -1,0 +1,215 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '297'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" rev="2" vrev="2" srcmd5="fa61a4eab98444251d5da0ddd2353d14">
+          <entry name="_config" md5="ed2e5e174937e69e908256e3f39413f1" size="56" mtime="1597064294"/>
+          <entry name="somefile.txt" md5="cc07fe8287a77220d73ae7bc85fa4c89" size="53" mtime="1597064294"/>
+        </directory>
+  recorded_at: Mon, 10 Aug 2020 13:10:42 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package?expand=1&rev=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '297'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" rev="2" vrev="2" srcmd5="fa61a4eab98444251d5da0ddd2353d14">
+          <entry name="_config" md5="ed2e5e174937e69e908256e3f39413f1" size="56" mtime="1597064294"/>
+          <entry name="somefile.txt" md5="cc07fe8287a77220d73ae7bc85fa4c89" size="53" mtime="1597064294"/>
+        </directory>
+  recorded_at: Mon, 10 Aug 2020 13:10:42 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '297'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" rev="2" vrev="2" srcmd5="fa61a4eab98444251d5da0ddd2353d14">
+          <entry name="_config" md5="ed2e5e174937e69e908256e3f39413f1" size="56" mtime="1597064294"/>
+          <entry name="somefile.txt" md5="cc07fe8287a77220d73ae7bc85fa4c89" size="53" mtime="1597064294"/>
+        </directory>
+  recorded_at: Mon, 10 Aug 2020 13:10:42 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '297'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" rev="2" vrev="2" srcmd5="fa61a4eab98444251d5da0ddd2353d14">
+          <entry name="_config" md5="ed2e5e174937e69e908256e3f39413f1" size="56" mtime="1597064294"/>
+          <entry name="somefile.txt" md5="cc07fe8287a77220d73ae7bc85fa4c89" size="53" mtime="1597064294"/>
+        </directory>
+  recorded_at: Mon, 10 Aug 2020 13:10:42 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package/_history
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '395'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+          <revision rev="1" vrev="1">
+            <srcmd5>b9672cae9e62dfd974a8406eb2851690</srcmd5>
+            <version>unknown</version>
+            <time>1597064294</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="2" vrev="2">
+            <srcmd5>fa61a4eab98444251d5da0ddd2353d14</srcmd5>
+            <version>unknown</version>
+            <time>1597064294</time>
+            <user>unknown</user>
+          </revision>
+        </revisionlist>
+  recorded_at: Mon, 10 Aug 2020 13:10:42 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:package_test_user/_result?package=test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Mon, 10 Aug 2020 13:10:42 GMT
+recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Packages/editing_the_package_description/updated_the_package_description.yml
+++ b/src/api/spec/cassettes/Packages/editing_the_package_description/updated_the_package_description.yml
@@ -1,0 +1,479 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home package_test_user' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '172'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:package_test_user' does not exist</summary>
+          <details>404 project 'home:package_test_user' does not exist</details>
+        </status>
+  recorded_at: Mon, 10 Aug 2020 12:36:41 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home package_test_user' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '172'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:package_test_user' does not exist</summary>
+          <details>404 project 'home:package_test_user' does not exist</details>
+        </status>
+  recorded_at: Mon, 10 Aug 2020 12:36:41 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home package_test_user' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '172'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:package_test_user' does not exist</summary>
+          <details>404 project 'home:package_test_user' does not exist</details>
+        </status>
+  recorded_at: Mon, 10 Aug 2020 12:36:41 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package?expand=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home package_test_user' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '172'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:package_test_user' does not exist</summary>
+          <details>404 project 'home:package_test_user' does not exist</details>
+        </status>
+  recorded_at: Mon, 10 Aug 2020 12:36:41 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home package_test_user' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '172'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:package_test_user' does not exist</summary>
+          <details>404 project 'home:package_test_user' does not exist</details>
+        </status>
+  recorded_at: Mon, 10 Aug 2020 12:36:41 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home package_test_user' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '172'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:package_test_user' does not exist</summary>
+          <details>404 project 'home:package_test_user' does not exist</details>
+        </status>
+  recorded_at: Mon, 10 Aug 2020 12:36:41 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:package_test_user/_result?package=file_edit_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home package_test_user' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '172'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:package_test_user' does not exist</summary>
+          <details>404 project 'home:package_test_user' does not exist</details>
+        </status>
+  recorded_at: Mon, 10 Aug 2020 12:36:41 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home package_test_user' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '172'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:package_test_user' does not exist</summary>
+          <details>404 project 'home:package_test_user' does not exist</details>
+        </status>
+  recorded_at: Mon, 10 Aug 2020 12:43:22 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home package_test_user' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '172'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:package_test_user' does not exist</summary>
+          <details>404 project 'home:package_test_user' does not exist</details>
+        </status>
+  recorded_at: Mon, 10 Aug 2020 12:43:22 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home package_test_user' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '172'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:package_test_user' does not exist</summary>
+          <details>404 project 'home:package_test_user' does not exist</details>
+        </status>
+  recorded_at: Mon, 10 Aug 2020 12:43:22 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package?expand=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home package_test_user' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '172'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:package_test_user' does not exist</summary>
+          <details>404 project 'home:package_test_user' does not exist</details>
+        </status>
+  recorded_at: Mon, 10 Aug 2020 12:43:22 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home package_test_user' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '172'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:package_test_user' does not exist</summary>
+          <details>404 project 'home:package_test_user' does not exist</details>
+        </status>
+  recorded_at: Mon, 10 Aug 2020 12:43:22 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home package_test_user' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '172'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:package_test_user' does not exist</summary>
+          <details>404 project 'home:package_test_user' does not exist</details>
+        </status>
+  recorded_at: Mon, 10 Aug 2020 12:43:22 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:package_test_user/_result?package=file_edit_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home package_test_user' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '172'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:package_test_user' does not exist</summary>
+          <details>404 project 'home:package_test_user' does not exist</details>
+        </status>
+  recorded_at: Mon, 10 Aug 2020 12:43:23 GMT
+recorded_with: VCR 6.0.0

--- a/src/api/spec/features/beta/webui/packages_spec.rb
+++ b/src/api/spec/features/beta/webui/packages_spec.rb
@@ -276,23 +276,25 @@ RSpec.describe 'Packages', type: :feature, js: true, vcr: true do
     expect(page).to have_text("Set the devel project to package #{third_project.name} / develpackage for package #{user.home_project} / develpackage")
   end
 
-  it 'editing a package' do
-    login user
-    visit package_show_path(package: package, project: user.home_project)
-    click_menu_link('Actions', 'Edit Package')
-    wait_for_ajax
+  describe "editing a package's details" do
+    it 'updates the package title and description' do
+      login user
+      visit package_show_path(package: package, project: user.home_project)
+      click_menu_link('Actions', 'Edit Package')
+      wait_for_ajax
 
-    within('#edit_package_details') do
-      fill_in('package_details[title]', with: 'test title')
-      fill_in('package_details[description]', with: 'test description')
-      fill_in('package_details[url]', with: 'https://test.url')
-      click_button('Update')
+      within('#edit_package_details') do
+        fill_in('package_details[title]', with: 'test title')
+        fill_in('package_details[description]', with: 'test description')
+        fill_in('package_details[url]', with: 'https://test.url')
+        click_button('Update')
+      end
+
+      expect(find('#flash')).to have_text('Package was successfully updated.')
+      expect(page).to have_text('test title')
+      expect(page).to have_text('test description')
+      expect(page).to have_text('https://test.url')
     end
-
-    expect(find('#flash')).to have_text('Package was successfully updated.')
-    expect(page).to have_text('test title')
-    expect(page).to have_text('test description')
-    expect(page).to have_text('https://test.url')
   end
 
   context 'meta configuration' do

--- a/src/api/spec/features/webui/packages_spec.rb
+++ b/src/api/spec/features/webui/packages_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Packages', type: :feature, js: true, vcr: true do
     let(:branching_data) { BranchPackage.new(project: user.home_project.name, package: package.name).branch }
     let(:branched_project) { Project.where(name: branching_data[:data][:targetproject]).first }
     let(:package_mime) do
-      create(:package, name: 'test.json', project: user.home_project, description: 'A package with a mime type suffix')
+      create(:package, name: 'test.yaml', project: user.home_project, description: 'A package with a mime type suffix')
     end
 
     before do
@@ -33,7 +33,7 @@ RSpec.describe 'Packages', type: :feature, js: true, vcr: true do
 
     it "has a mime like suffix in it's name" do
       visit package_show_path(project: user.home_project, package: package_mime)
-      expect(page).to have_text('test.json')
+      expect(page).to have_text('test.yaml')
       expect(page).to have_text('A package with a mime type suffix')
     end
 
@@ -75,6 +75,31 @@ RSpec.describe 'Packages', type: :feature, js: true, vcr: true do
 
       expect(page).to have_text("The file 'somefile.txt' has been successfully saved.")
       expect(file_edit_test_package.source_file('somefile.txt')).to eq('added some new text')
+    end
+  end
+
+  describe 'editing the package description' do
+    let(:file_edit_test_package) { create(:package_with_file, name: 'file_edit_test_package', project: user.home_project) }
+
+    before do
+      login(user)
+      visit package_show_path(project: user.home_project, package: file_edit_test_package)
+    end
+
+    it 'updated the package description' do
+      click_link('Edit description')
+      within('.modal-body') do
+        fill_in('Title:', with: 'Updated title')
+        fill_in('Description:', with: 'Updated description')
+      end
+      within('.modal-footer') do
+        click_on('Update')
+      end
+      expect(page).to have_text('was saved successfully')
+      within('.basic-info') do
+        expect(page).to have_text('Updated title')
+        expect(page).to have_text('Updated description')
+      end
     end
   end
 


### PR DESCRIPTION
While implementing the in-place editing for the packages, we removed
the explicit format constraints that allowed package names to have
extension-like names like `python-aspy.yaml`.

This PR brings those format constraints back.

How to test it:
- Create a package with a name like `ctris.yaml`
- You should be able to access the show page.

Fixes #9998 