### PR TITLE
Fix indentation and add missing nav-link class of "Add Attribute" link

### DIFF
--- a/src/api/app/views/webui/attribute/responsive_ux/_index_actions.html.haml
+++ b/src/api/app/views/webui/attribute/responsive_ux/_index_actions.html.haml
@@ -1,5 +1,5 @@
 - content_for :actions do
   %li.nav-item
-  = link_to(new_attribs_path(project: project.name, package: package), title: 'Add Attribute') do
-    %i.fas.fa-plus-circle.fa-lg.mr-2
-    Add Attribute
+    = link_to(new_attribs_path(project: project.name, package: package), title: 'Add Attribute', class: 'nav-link') do
+      %i.fas.fa-plus-circle.fa-lg.mr-2
+      Add Attribute


### PR DESCRIPTION
I've found this inconsistency while working on something else. It's only a bit different, but it's now consistent with the other action links.

Before:
![before](https://user-images.githubusercontent.com/1102934/89811513-0fa33c00-db3f-11ea-947f-d1a4c24d7aac.png)

After:
![fix](https://user-images.githubusercontent.com/1102934/89811516-10d46900-db3f-11ea-9a8f-8c8be7e3466b.png)