### PR TITLE
[backend] support memory per job constraint

### DIFF
--- a/docs/api/api/constraints.rng
+++ b/docs/api/api/constraints.rng
@@ -117,6 +117,11 @@
              </element>
             </optional>
             <optional>
+             <element name="memoryperjob">
+               <ref name="size-unit"/>
+             </element>
+            </optional>
+            <optional>
              <element name="physicalmemory">
                <ref name="size-unit"/>
              </element>

--- a/src/backend/BSDispatcher/Constraints.pm
+++ b/src/backend/BSDispatcher/Constraints.pm
@@ -111,6 +111,7 @@ sub oracle {
     my $memory = ($worker->{'hardware'}->{'memory'} || 0);
     my $swap = ($worker->{'hardware'}->{'swap'} || 0);
     return 0 if $constraints->{'hardware'}->{'memory'} && getmbsize($constraints->{'hardware'}->{'memory'}) > ( $memory + $swap );
+    return 0 if $constraints->{'hardware'}->{'memoryperjob'} && getmbsize($constraints->{'hardware'}->{'memoryperjob'} * ($worker->{'hardware'}->{'jobs'} || 1)) > ( $memory + $swap );
     return 0 if $constraints->{'hardware'}->{'physicalmemory'} && getmbsize($constraints->{'hardware'}->{'physicalmemory'}) > $memory;
     if ($constraints->{'hardware'}->{'cpu'}) {
       return 0 unless $worker->{'hardware'}->{'cpu'};

--- a/src/backend/BSXML.pm
+++ b/src/backend/BSXML.pm
@@ -1758,6 +1758,7 @@ our @constraint = (
 	    'jobs',
 	  [ 'disk' => $size ],
 	  [ 'memory' => $size ],
+	  [ 'memoryperjob' => $size ],
 	  [ 'physicalmemory' => $size ],
       ]
 );

--- a/src/backend/testdata/test_dispatcher
+++ b/src/backend/testdata/test_dispatcher
@@ -131,6 +131,10 @@ td sandbox24 true  "kernel" i586 medium sandbox_secure  enforce_kvm
 td sandbox25 true  "kernel" i586 large  sandbox         enforce_kvm
 td sandbox26 true  "kernel" i586 large  sandbox_secure  enforce_kvm
 
+# combined constraints for sandbox
+td perjob21 false "chromium" i586 small  kernel
+td perjob22 true "chromium" i586 large  kernel
+
 echo
 
 if [ -n "$FAILS" ]; then


### PR DESCRIPTION
To increase the memory need per used job on the worker. This can be
potentionally racy, because parallel builds may happened on different
times so the need of memory might differ depending on build speed.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
