### PR TITLE
[backend] allow to blacklist packages from source publishing

### DIFF
--- a/src/backend/BSConfig.pm.template
+++ b/src/backend/BSConfig.pm.template
@@ -175,6 +175,8 @@ our $relsync_pool = {
 #our $sourcepublish_sync = 'rsync://127.0.0.1/sources';
 # optional filter to publish only some areas
 #our $sourcepublish_filter = [ "openSUSE:.*", "SUSE:.*" ];
+# optional filter to blacklist specific package names independend of the project
+#our $sourcepublish_blacklist = [ "flash-player", "binary-only-app" ];
 
 # Define your own global Macros
 #my $macro_packager = '<rpm@example.com>';

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -6402,6 +6402,20 @@ sub external_notification_sourcepublish {
       push @included, { 'project' => $iproject, 'package' => $ipackage, 'srcmd5' => $imd5 };
     }
 
+    if ($BSConfig::sourcepublish_blacklist) {
+      my $xml = readxml("$projectsdir/$project.xml", $BSXML::proj, 1);
+      die("400 Unable to parse $project.xml\n") unless $xml;
+      if ( {$xml->{'kind'} || ''} eq 'maintenance_release' ) {
+        if (grep {$package =~ /^$_\./} @$BSConfig::sourcepublish_blacklist) {
+          BSUtil::printlog("black list hit for $package in maintenance release project");
+          return;
+        }
+      } elsif (grep {$package eq $_} @$BSConfig::sourcepublish_blacklist) {
+        BSUtil::printlog("black list hit for $package");
+        return;
+      }
+    }
+
     my $evname = "${project}::${package}::${md5}";
     my $ev = { 'type' => "sourcepublish" };
     $ev->{'project'} = $project;


### PR DESCRIPTION
No way to specifiy this per project yet, not sure if there
is a usecase.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
