### PR TITLE
Restrict status messages showing on the rss feed

### DIFF
--- a/src/api/app/controllers/webui/feeds_controller.rb
+++ b/src/api/app/controllers/webui/feeds_controller.rb
@@ -5,7 +5,7 @@ class Webui::FeedsController < Webui::WebuiController
   before_action :set_project, only: [:commits]
 
   def news
-    @news = StatusMessage.newest.messages_for_me.includes(:user).limit(5)
+    @news = StatusMessage.newest.for_current_user.includes(:user).limit(5)
   end
 
   def latest_updates

--- a/src/api/app/controllers/webui/feeds_controller.rb
+++ b/src/api/app/controllers/webui/feeds_controller.rb
@@ -5,7 +5,7 @@ class Webui::FeedsController < Webui::WebuiController
   before_action :set_project, only: [:commits]
 
   def news
-    @news = StatusMessage.order('created_at DESC').includes(:user).limit(5)
+    @news = StatusMessage.newest.messages_for_me.includes(:user).limit(5)
   end
 
   def latest_updates

--- a/src/api/app/controllers/webui/main_controller.rb
+++ b/src/api/app/controllers/webui/main_controller.rb
@@ -4,7 +4,7 @@ class Webui::MainController < Webui::WebuiController
   skip_before_action :check_anonymous, only: [:index]
 
   def index
-    @status_messages = StatusMessage.newest.messages_for_me.includes(:user).limit(4)
+    @status_messages = StatusMessage.newest.for_current_user.includes(:user).limit(4)
     @workerstatus = Rails.cache.fetch('workerstatus_hash', expires_in: 10.minutes) do
       Xmlhash.parse(WorkerStatus.hidden.to_xml)
     end

--- a/src/api/app/controllers/webui/main_controller.rb
+++ b/src/api/app/controllers/webui/main_controller.rb
@@ -4,7 +4,7 @@ class Webui::MainController < Webui::WebuiController
   skip_before_action :check_anonymous, only: [:index]
 
   def index
-    @status_messages = StatusMessage.order('created_at DESC').where(communication_scope: StatusMessage.communication_scopes_for_current_user).includes(:user).limit(4)
+    @status_messages = StatusMessage.newest.messages_for_me.includes(:user).limit(4)
     @workerstatus = Rails.cache.fetch('workerstatus_hash', expires_in: 10.minutes) do
       Xmlhash.parse(WorkerStatus.hidden.to_xml)
     end

--- a/src/api/app/models/status_message.rb
+++ b/src/api/app/models/status_message.rb
@@ -6,6 +6,8 @@ class StatusMessage < ApplicationRecord
   validates :user, :severity, :message, presence: true
 
   scope :announcements, -> { order('created_at DESC').where(severity: 'announcement') }
+  scope :messages_for_me, -> { where(communication_scope: communication_scopes_for_current_user) }
+  scope :newest, -> { order('created_at DESC') }
 
   enum severity: { information: 0, green: 1, yellow: 2, red: 3, announcement: 4 }
   enum communication_scope: { all_users: 0, logged_in_users: 1, admin_users: 2, in_beta_users: 3, in_rollout_users: 4 }

--- a/src/api/app/models/status_message.rb
+++ b/src/api/app/models/status_message.rb
@@ -6,7 +6,7 @@ class StatusMessage < ApplicationRecord
   validates :user, :severity, :message, presence: true
 
   scope :announcements, -> { order('created_at DESC').where(severity: 'announcement') }
-  scope :messages_for_me, -> { where(communication_scope: communication_scopes_for_current_user) }
+  scope :for_current_user, -> { where(communication_scope: communication_scopes_for_current_user) }
   scope :newest, -> { order('created_at DESC') }
 
   enum severity: { information: 0, green: 1, yellow: 2, red: 3, announcement: 4 }

--- a/src/api/spec/factories/status_message.rb
+++ b/src/api/spec/factories/status_message.rb
@@ -4,5 +4,9 @@ FactoryBot.define do
     severity { :green }
     communication_scope { 'all_users' }
     user
+
+    trait :admins_only do
+      communication_scope { 'admin_users' }
+    end
   end
 end


### PR DESCRIPTION
The RSS feed is showing all status messages, ignoring its scope, so
everybody sees everything. This PR enforces the propper roles so the
RSS feed shows appropriate content to each user.

Fixes #9926