### PR TITLE
Encapsulate responsive-ux styles

### DIFF
--- a/src/api/app/assets/stylesheets/webui/responsive_ux/responsive_ux.scss
+++ b/src/api/app/assets/stylesheets/webui/responsive_ux/responsive_ux.scss
@@ -4,9 +4,11 @@ $top-navigation-height: 3.5625rem;
 $bottom-navigation-height: 3.5rem;
 $left-navigation-width: 16rem;
 
-@import 'build-result';
-@import 'grid';
-@import 'layout';
-@import 'navbar';
-@import 'sponsors';
-@import 'tabs';
+body.responsive-ux {
+  @import 'build-result';
+  @import 'grid';
+  @import 'layout';
+  @import 'navbar';
+  @import 'sponsors';
+  @import 'tabs';
+}

--- a/src/api/app/helpers/webui/webui_helper.rb
+++ b/src/api/app/helpers/webui/webui_helper.rb
@@ -346,6 +346,7 @@ module Webui::WebuiHelper
 
   def feature_css_class
     css_classes = []
+    css_classes << 'responsive-ux' if feature_enabled?(:responsive_ux)
     css_classes << 'notifications-redesign' if feature_enabled?(:notifications_redesign)
     css_classes.join(' ')
   end


### PR DESCRIPTION
Reverting the change in `feature_css_class` from #10007

This fixes issues which were caused by CSS rules leaking out of the responsive-ux layout when they are targeting elements not specific to this layout.

Before:
_Flash messages_
![flash-message-before](https://user-images.githubusercontent.com/1102934/90399719-b46fcd00-e09b-11ea-95cb-d36ef9101819.png)
_Footer_
![footer-before](https://user-images.githubusercontent.com/1102934/90399810-d9fcd680-e09b-11ea-97b0-439b7631fda8.png)

After:
_Flash messages_
![flash-message-after](https://user-images.githubusercontent.com/1102934/90399718-b3d73680-e09b-11ea-842c-58c1af7cfb8a.png)
_Footer_
![footer-after](https://user-images.githubusercontent.com/1102934/90399805-d8cba980-e09b-11ea-8432-ba76d85c1302.png)