### PR TITLE
Fix off-canvas menu for desktop

### DIFF
--- a/src/api/app/assets/stylesheets/webui/responsive_ux/navbar.scss
+++ b/src/api/app/assets/stylesheets/webui/responsive_ux/navbar.scss
@@ -56,3 +56,13 @@
     }
   }
 }
+
+@include media-breakpoint-up(xl) {
+  .navbar-dark.navbar-collapse {
+    &.watchlist-collapse, &.places-collapse, &.actions-collapse {
+      bottom: 0;
+
+      button.navbar-toggler { display: none; }
+    }
+  }
+}


### PR DESCRIPTION
Watchlist menu was displaying a close button that should be only
visible for small and medium viewports. And the menu didn't reach to
bottom of the page.

##### Before
![Screenshot_2020-08-18 openSUSE Build Service(2)](https://user-images.githubusercontent.com/1212806/90492952-0ff49600-e142-11ea-9363-0096a6ac17a8.png)



#### After
![Screenshot_2020-08-18 Open Build Service(3)](https://user-images.githubusercontent.com/1212806/90492895-f94e3f00-e141-11ea-86f1-84e2f5788df1.png)
