### PR TITLE
WIP: Support forwarding of multi-package requests

### DIFF
--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -257,27 +257,21 @@ class Webui::RequestController < Webui::WebuiController
   end
 
   def change_state(newstate, params)
-    request = BsRequest.find_by_number(params[:number])
-    if request.nil?
-      flash[:error] = 'Unable to load request'
-    else
-      # FIXME: make force optional, it hides warnings!
-      opts = {
-        newstate: newstate,
-        force: true,
-        user: User.session!.login,
-        comment: params[:reason]
-      }
-      begin
-        request.change_state(opts)
-        flash[:success] = "Request #{newstate}!"
-        return true
-      rescue APIError => e
-        flash[:error] = "Failed to change state: #{e.message}!"
-        return false
-      end
+    # FIXME: make force optional, it hides warnings!
+    opts = {
+      newstate: newstate,
+      force: true,
+      user: User.session!.login,
+      comment: params[:reason]
+    }
+    begin
+      @bs_request.change_state(opts)
+      flash[:success] = "Request #{newstate}!"
+      return true
+    rescue APIError => e
+      flash[:error] = "Failed to change state: #{e.message}!"
+      return false
     end
-
     false
   end
 

--- a/src/api/app/services/bs_request_action_service/forwardable.rb
+++ b/src/api/app/services/bs_request_action_service/forwardable.rb
@@ -1,0 +1,33 @@
+module BsRequestActionService
+  class Forwardable
+    def initialize(bs_request_action)
+      @bs_request_action = bs_request_action
+    end
+
+    def create(fwd_target_prj, fwd_target_pkg)
+      previous_action = @bs_request_action
+      rev = Directory.hashed(project: previous_action.target_project,
+                             package: previous_action.target_package)['rev']
+
+      BsRequestAction.new(source_project: previous_action.target_project,
+                          source_package: previous_action.target_package,
+                          source_rev: rev,
+                          target_project: fwd_target_prj,
+                          target_package: fwd_target_pkg,
+                          type: previous_action.type)
+    end
+
+    def possible_targets
+      target_package = @bs_request_action.target_package_object
+      forwarding_targets = target_package.developed_packages
+      linkinfo = target_package.linkinfo
+
+      return forwarding_targets unless linkinfo
+
+      unless forwarding_targets.any? { |t| t.name == linkinfo['package'] && t.project.name == linkinfo['project'] }
+        forwarding_targets.append(Package.find_by_project_and_name(linkinfo['project'], linkinfo['package']))
+      end
+      forwarding_targets
+    end
+  end
+end

--- a/src/api/app/services/bs_request_service/action_forwarder.rb
+++ b/src/api/app/services/bs_request_service/action_forwarder.rb
@@ -1,0 +1,29 @@
+module BsRequestService
+  class ActionForwarder
+    def initialize(bs_request)
+      @bs_request = bs_request
+      @bs_request_actions = bs_request.bs_request_actions
+    end
+
+    def forwarding_options
+      forwarding_options = []
+      @bs_request_actions.each do |action|
+        forwarding_options.append(Hash[action.id, BsRequestActionService::Forwardable.new(action).possible_targets])
+      end
+      forwarding_options
+    end
+
+    def forward_actions_in_single_request(fwd_targets)
+      new_request = BsRequest.new
+      BsRequest.transaction do
+        fwd_targets.each do |target|
+          bs_request_action = @bs_request_actions.where(id: target['req_action_id']).first
+          new_request.bs_request_actions << BsRequestActionService::Forwardable.new(bs_request_action)
+                                                                               .create(target['tgt_prj'], target['tgt_pkg'])
+        end
+        new_request.save!
+      end
+      new_request
+    end
+  end
+end

--- a/src/api/app/views/webui/request/_decision_tab.html.haml
+++ b/src/api/app/views/webui/request/_decision_tab.html.haml
@@ -2,19 +2,24 @@
   = hidden_field_tag(:number, request_number)
   %p
     = text_area_tag(:reason, nil, placeholder: 'Please add a comment', rows: 4, class: 'w-100 form-control')
-  - if single_action_request && is_target_maintainer && state.in?(['new', 'review'])
-    - if !action[:creator_is_target_maintainer] && action[:type] == :submit
-      .custom-control.custom-checkbox
-        = check_box_tag('add_submitter_as_maintainer_0', "#{action[:tprj]}_#_#{action[:tpkg]}", false, class: 'custom-control-input')
-        %label.custom-control-label{ for: 'add_submitter_as_maintainer_0' }
-          Add #{link_to(request_creator, user_path(request_creator))} as maintainer for
-          #{project_or_package_link(project: action[:tprj], package: action[:tpkg], short: true)}
-    - (action[:forward] || []).each_with_index do |forward, index|
-      .custom-control.custom-checkbox
-        = check_box_tag("forward-#{index}", "#{forward[:project]}_#_#{forward[:package]}", true, class: 'custom-control-input')
-        %label.custom-control-label{ for: "forward-#{index}" }
-          Forward submit request to
-          #{project_or_package_link(project: forward[:project], package: forward[:package], short: true)}
+  - if is_target_maintainer && state.in?(['new', 'review'])
+    - if single_action_request
+      - if !action[:creator_is_target_maintainer] && action[:type] == :submit
+        .custom-control.custom-checkbox
+          = check_box_tag('add_submitter_as_maintainer_0', "#{action[:tprj]}_#_#{action[:tpkg]}", false, class: 'custom-control-input')
+          %label.custom-control-label{ for: 'add_submitter_as_maintainer_0' }
+            Add #{link_to(request_creator, user_path(request_creator))} as maintainer for
+            #{project_or_package_link(project: action[:tprj], package: action[:tpkg], short: true)}
+    - if forwarding_options.any?
+      - forwarding_options.each do |targets|
+        - targets.each do |action_id, target_packages|
+          - target_packages.each_with_index do |target_package, index|
+            .custom-control.custom-checkbox
+              = check_box_tag("forward-#{action_id}-#{index}", "#{action_id}_#_#{target_package.project.name}_#_#{target_package.name}",
+                              true, class: 'custom-control-input')
+              %label.custom-control-label{ for: "forward-#{action_id}-#{index}" }
+                Forward submit request to
+                #{project_or_package_link(project: target_package.project.name, package: target_package.name, short: true)}
     %hr
   - if is_author && state.in?(['new', 'review', 'declined'])
     = submit_tag 'Revoke request', name: 'revoked', class: 'btn btn-danger mr-2'

--- a/src/api/app/views/webui/request/show.html.haml
+++ b/src/api/app/views/webui/request/show.html.haml
@@ -71,7 +71,8 @@
               .tab-pane.fade.show.active{ id: 'decision' }
                 = render('decision_tab', request_number: @bs_request.number, request_creator: @bs_request.creator,
                          is_target_maintainer: @is_target_maintainer, state: @bs_request.state.to_s,
-                         is_author: @is_author, single_action_request: @actions.count == 1, action: @actions.first)
+                         is_author: @is_author, single_action_request: @actions.count == 1, action: @actions.first,
+                         forwarding_options: @forwarding_options)
             - if @can_add_reviews
               - @my_open_reviews.each_with_index do |review, index|
                 .tab-pane.fade.show{ id: "review-#{index}", class: ('active' if index.zero? && !@can_handle_request) }


### PR DESCRIPTION
The PR is in state WIP, since a couple of code parts are not adapted yet, more refactoring is needed and adjustment of tests are required.

Fixes #890 

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
