### PR TITLE
Prevent content from breaking the responsive-ux layout

### DIFF
--- a/src/api/app/assets/stylesheets/webui/responsive_ux/grid.scss
+++ b/src/api/app/assets/stylesheets/webui/responsive_ux/grid.scss
@@ -51,6 +51,12 @@
       }
     }
 
+    // This prevents content from breaking the layout by overflowing outside the viewport
+    #content {
+      // 2rem is the sum of the left and right padding for the content
+      max-width: calc(100vw - (#{$left-navigation-width} + 2rem));
+    }
+
     #bottom-navigation-area {
       display: none;
     }

--- a/src/api/app/assets/stylesheets/webui/responsive_ux/tabs.scss
+++ b/src/api/app/assets/stylesheets/webui/responsive_ux/tabs.scss
@@ -17,11 +17,3 @@
     }
   }
 }
-
-@include media-breakpoint-up(xl) {
-  // This prevents tabs from breaking the layout by overflowing outside the viewport
-  .scrollable-tabs {
-    // 2rem is the sum of the left and right padding for the scrollable tabs
-    max-width: calc(100vw - (#{$left-navigation-width} + 2rem));
-  }
-}


### PR DESCRIPTION
This is something which was somewhat addressed in #10007. The tabs didn't break the layout anymore, but other elements still do. Limiting the width of specific elements could turn out to be a long process. It's better and simpler to tackle this issue for the content container.

Just like before, tabs are not overflowing:
![tabs](https://user-images.githubusercontent.com/1102934/90612207-033a7580-e208-11ea-9807-d0104e7a6c70.png)

As for the other elements, like the diffs on the request show page, they were overflowing. It's now fixed.
Before:
![request-show-before](https://user-images.githubusercontent.com/1102934/90612273-1b11f980-e208-11ea-8958-a8cc31df311b.png)
After:
![request-show-after](https://user-images.githubusercontent.com/1102934/90612270-1a796300-e208-11ea-8c08-21f810668606.png)