### PR TITLE
Use real-time specific Sphinx Rake tasks

### DIFF
--- a/ReleaseNotes-2.11
+++ b/ReleaseNotes-2.11
@@ -29,8 +29,8 @@ Features
 Generic:
  * Search was improved: New and updated projects/packages are indexed directly instead
    of once every hour. As configuration files for Thinking Sphinx were changed, running
-   a 'ts:rebuild' task is needed after deployment, as user wwwrun:
-   'chroot --userspec=wwwrun:www / /bin/bash -c "cd /srv/www/obs/api/ && /usr/bin/bundle.ruby2.5 exec rails ts:rebuild RAILS_ENV=production"'
+   a 'ts:rt:rebuild' task is needed after deployment, as user wwwrun:
+   'chroot --userspec=wwwrun:www / /bin/bash -c "cd /srv/www/obs/api/ && /usr/bin/bundle.ruby2.5 exec rails ts:rt:rebuild RAILS_ENV=production"'
 
 User Interface:
  * Colors were adjusted to improve contrast thus improving readability

--- a/contrib/Procfile.ha
+++ b/contrib/Procfile.ha
@@ -1,4 +1,4 @@
 web: bundle exec rails server -P tmp/pids/server$NODE_NUMBER.pid
 delayed: bundle exec script/delayed_job.api.rb run
 clock: bundle exec clockworkd --log-dir=log -l -c config/clock.rb run
-search: bundle exec rake ts:rebuild NODETACH=true
+search: bundle exec rake ts:rt:rebuild NODETACH=true

--- a/dist/README.UPDATERS
+++ b/dist/README.UPDATERS
@@ -306,7 +306,7 @@ use port 443 now.
     also to call the following once to have a working search:
 
     # cd /srv/www/obs/api/
-    # RAILS_ENV="production" rails ts:index
+    # RAILS_ENV="production" rails ts:rt:index
 
 For Updaters to OBS 2.4 from OBS 2.3
 ====================================

--- a/src/api/db/migrate/20150623063641_reindex_sphinx_db.rb
+++ b/src/api/db/migrate/20150623063641_reindex_sphinx_db.rb
@@ -2,7 +2,7 @@ class ReindexSphinxDb < ActiveRecord::Migration[4.2]
   def self.up
     rake = 'rake'
     # we do not use ThinkingSphinx class, since searchd might not be able to startup
-    system("cd #{Rails.root}; rm -rf tmp/binlog; exec #{rake} ts:index")
+    system("cd #{Rails.root}; rm -rf tmp/binlog; exec #{rake} ts:rt:index")
   end
 
   def self.down; end

--- a/src/api/lib/tasks/sphinx.rake
+++ b/src/api/lib/tasks/sphinx.rake
@@ -3,7 +3,7 @@ namespace :sphinx do
   task start: :environment do
     if index_to_build?
       puts 'Index does not exist, creating it...'
-      Rake::Task['ts:rebuild'].invoke
+      Rake::Task['ts:rt:rebuild'].invoke
     else
       Rake::Task['ts:start'].invoke
     end
@@ -12,7 +12,7 @@ namespace :sphinx do
   desc 'Start the sphinx daemon for the development environment'
   task start_for_development: :environment do
     if index_to_build?
-      Rake::Task['ts:clear'].invoke
+      Rake::Task['ts:rt:clear'].invoke
       Rake::Task['ts:configure'].invoke
       t = Thread.new do
         retries = 0


### PR DESCRIPTION
The generic tasks are also dealing with SQL-backed indices, which we don't use.

We'll have to be sure that SQL-backed indices are really gone from our reference server / IBS.