### PR TITLE
[backend] BSPublisher/Container.pm allow to specify repo

### DIFF
--- a/src/backend/BSConfig.pm.template
+++ b/src/backend/BSConfig.pm.template
@@ -285,11 +285,12 @@ our $container_registries = {
 };
 
 our $publish_containers = [
-#   # key:   regex to match projid
+#   # key:   regex to match projid or projid/repoid
 #   # value: ArrayRef with identifiers for registries configured in $container_registries
-#   'SUSE:.*'        => [ 'registry.example.com', 'hub.docker.com' ],
-#   '.*:branches:.*' => [ 'staging-registry.example.com' ],
-   '.*'             => ['local'],
+#   'SUSE:.*/containers' => [ 'myregistry.example.com', 'local' ],
+#   'SUSE:'              => [ 'registry.example.com', 'hub.docker.com' ],
+#   '.*:branches:'       => [ 'staging-registry.example.com' ],
+   '.*'                 => ['local'],
 ];
 
 # enable this to announce the X-Registry-Supports-Signatures extension

--- a/src/backend/BSPublisher/Container.pm
+++ b/src/backend/BSPublisher/Container.pm
@@ -54,7 +54,7 @@ sub registries_for_prp {
   my @s = @{$BSConfig::publish_containers};
   while (@s) {
     my ($k, $v) = splice(@s, 0, 2);
-    if ($projid =~ /^$k/) {
+    if ("$projid/$repoid" =~ /^$k/ || $projid =~ /^$k/) {
       $v = [ $v ] unless ref $v;
       @registries = @$v;
       last;


### PR DESCRIPTION
along with the project in BSConfig::publish_containers

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
