### PR TITLE
Fix RuboCop offenses for Rails/PluckInWhere

### DIFF
--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -1105,14 +1105,10 @@ Rails/OutputSafety:
     - 'app/helpers/webui/user_helper.rb'
     - 'app/helpers/webui/webui_helper.rb'
 
-# Offense count: 8
+# Offense count: 2
 # Cop supports --auto-correct.
 Rails/PluckInWhere:
   Exclude:
-    - 'app/models/group.rb'
-    - 'app/models/package.rb'
-    - 'app/models/review.rb'
-    - 'app/queries/open_requests_finder.rb'
     - 'db/data/20181214100207_remove_duplicated_flags.rb'
     - 'db/data/20200528135241_dump_announcements_into_status_messages.rb'
 

--- a/src/api/app/models/group.rb
+++ b/src/api/app/models/group.rb
@@ -146,7 +146,7 @@ class Group < ApplicationRecord
 
   # returns the users that actually want email for this group's notifications
   def email_users
-    User.where(id: groups_users.where(email: true).pluck(:user_id))
+    User.where(id: groups_users.where(email: true).select(:user_id))
   end
 
   def display_name

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -817,13 +817,13 @@ class Package < ApplicationRecord
     # rubocop:disable Layout/LineLength
     rel = rel.where('(bs_request_actions.source_project = ? and bs_request_actions.source_package = ?) or (bs_request_actions.target_project = ? and bs_request_actions.target_package = ?)', project.name, name, project.name, name)
     # rubocop:enable Layout/LineLength
-    BsRequest.where(id: rel.pluck('bs_requests.id'))
+    BsRequest.where(id: rel.select('bs_requests.id'))
   end
 
   def open_requests_with_by_package_review
     rel = BsRequest.where(state: [:new, :review])
     rel = rel.joins(:reviews).where("reviews.state = 'new' and reviews.by_project = ? and reviews.by_package = ? ", project.name, name)
-    BsRequest.where(id: rel.pluck('bs_requests.id'))
+    BsRequest.where(id: rel.select('bs_requests.id'))
   end
 
   def self.extended_name(project, package)

--- a/src/api/app/models/review.rb
+++ b/src/api/app/models/review.rb
@@ -190,7 +190,7 @@ class Review < ApplicationRecord
 
     relationships = obj.relationships
     roles = relationships.where(role: Role.hashed['maintainer'])
-    User.where(id: roles.users.pluck(:user_id)) + Group.where(id: roles.groups.pluck(:group_id))
+    User.where(id: roles.users.select(:user_id)) + Group.where(id: roles.groups.select(:group_id))
   end
 
   def users_and_groups_for_review

--- a/src/api/app/queries/open_requests_finder.rb
+++ b/src/api/app/queries/open_requests_finder.rb
@@ -6,7 +6,7 @@ class OpenRequestsFinder
   end
 
   def call
-    BsRequest.where(id: requests_finder.pluck('bs_requests.id'))
+    BsRequest.where(id: requests_finder.select('bs_requests.id'))
   end
 
   def requests_finder


### PR DESCRIPTION
<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
