### PR TITLE
Correct Rubocop Style/RegexpLiteral offences in controllers

### DIFF
--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -1428,13 +1428,6 @@ Style/RedundantReturn:
 # SupportedStyles: slashes, percent_r, mixed
 Style/RegexpLiteral:
   Exclude:
-    - 'app/controllers/application_controller.rb'
-    - 'app/controllers/person_controller.rb'
-    - 'app/controllers/public_controller.rb'
-    - 'app/controllers/webui/monitor_controller.rb'
-    - 'app/controllers/webui/package_controller.rb'
-    - 'app/controllers/webui/sitemaps_controller.rb'
-    - 'app/controllers/webui/webui_controller.rb'
     - 'app/helpers/webui/webui_helper.rb'
     - 'app/mixins/build_log_support.rb'
     - 'app/models/cloud/ec2/configuration.rb'

--- a/src/api/app/controllers/application_controller.rb
+++ b/src/api/app/controllers/application_controller.rb
@@ -306,7 +306,7 @@ class ApplicationController < ActionController::Base
 
     request_format = request.format != 'json'
     response_status = response.status.to_s[0..2] == '200'
-    response_headers = response.headers['Content-Type'] !~ /.*\/json/i && response.headers['Content-Disposition'] != 'attachment'
+    response_headers = response.headers['Content-Type'] !~ %r{.*/json}i && response.headers['Content-Disposition'] != 'attachment'
 
     return unless request_format && response_status && response_headers
 

--- a/src/api/app/controllers/person_controller.rb
+++ b/src/api/app/controllers/person_controller.rb
@@ -193,7 +193,7 @@ class PersonController < ApplicationController
     render_ok
   rescue Exception => e
     # Strip passwords from request environment and re-raise exception
-    request.env['RAW_POST_DATA'] = request.env['RAW_POST_DATA'].sub(/<password>(.*)<\/password>/, '<password>STRIPPED<password>')
+    request.env['RAW_POST_DATA'] = request.env['RAW_POST_DATA'].sub(%r{<password>(.*)</password>}, '<password>STRIPPED<password>')
     raise e
   end
 

--- a/src/api/app/controllers/public_controller.rb
+++ b/src/api/app/controllers/public_controller.rb
@@ -168,8 +168,8 @@ class PublicController < ApplicationController
           # So we have to revert this here...
           filepath = b['filepath']
           # having both gsub! in one line can crash with some ruby builds
-          filepath.gsub!(/:\//, ':')
-          filepath.gsub!(/^[^\/]*\/[^\/]*\//, '')
+          filepath.gsub!(%r{:/}, ':')
+          filepath.gsub!(%r{^[^/]*/[^/]*/}, '')
 
           @binary_links[dist_id][:binary] << { type: binary_type, arch: b['arch'], url: repo.download_url(filepath) }
           if @binary_links[dist_id][:repository].blank?

--- a/src/api/app/controllers/webui/monitor_controller.rb
+++ b/src/api/app/controllers/webui/monitor_controller.rb
@@ -24,7 +24,7 @@ class Webui::MonitorController < Webui::WebuiController
         end
       end
       workers_list.each do |bid, barch|
-        hostname, subid = bid.gsub(%r{:}, '/').split('/')
+        hostname, subid = bid.gsub(/:/, '/').split('/')
         id = bid.gsub(%r{[:./]}, '_')
         workers[hostname] ||= {}
         workers[hostname]['_arch'] = barch

--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -473,7 +473,7 @@ class Webui::PackageController < Webui::WebuiController
       @log_chunk = ''
     rescue Backend::Error => e
       case e.summary
-      when %r{Logfile is not that big}
+      when /Logfile is not that big/
         @log_chunk = ''
       when /start out of range/
         # probably build compare has cut log and offset is wrong, reset offset

--- a/src/api/app/controllers/webui/sitemaps_controller.rb
+++ b/src/api/app/controllers/webui/sitemaps_controller.rb
@@ -16,7 +16,7 @@ class Webui::SitemapsController < Webui::WebuiController
 
     predication =
       case project_name
-      when %r{home}
+      when /home/
         projects_table[:name].matches("#{project_name}%")
       when 'opensuse'
         projects_table[:name].matches('openSUSE:%')

--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -27,7 +27,7 @@ class Webui::WebuiController < ActionController::Base
 
   def valid_xml_id(rawid)
     rawid = "_#{rawid}" if rawid !~ /^[A-Za-z_]/ # xs:ID elements have to start with character or '_'
-    CGI.escapeHTML(rawid.gsub(/[+&: .\/~()@#]/, '_'))
+    CGI.escapeHTML(rawid.gsub(%r{[+&: ./~()@#]}, '_'))
   end
 
   def home


### PR DESCRIPTION
Regular expresiones can be wrapped by // or %r{}.
Rubocop proposes to use only one of them and // is the preference.
Only if the regular expression contains any slash, it should use %r{}.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
