### PR TITLE
Correct Rubocop Style/RegexpLiteral in various files

### DIFF
--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -1380,22 +1380,6 @@ Style/OptionalBooleanParameter:
     - 'app/policies/package_policy.rb'
     - 'lib/xpath_engine.rb'
 
-# Offense count: 87
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, AllowInnerSlashes.
-# SupportedStyles: slashes, percent_r, mixed
-Style/RegexpLiteral:
-  Exclude:
-    - 'app/helpers/webui/webui_helper.rb'
-    - 'app/mixins/build_log_support.rb'
-    - 'app/services/package_service/file_verifier.rb'
-    - 'app/services/trigger_controller_service/token_extractor.rb'
-    - 'config/routes/webui_routes.rb'
-    - 'lib/api_error.rb'
-    - 'lib/tasks/coverage.rake'
-    - 'lib/tasks/extract.rake'
-    - 'lib/tasks/test_webui.rake'
-
 # Offense count: 23
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.

--- a/src/api/app/helpers/webui/webui_helper.rb
+++ b/src/api/app/helpers/webui/webui_helper.rb
@@ -167,7 +167,7 @@ module Webui::WebuiHelper
     text.force_encoding('UTF-8')
     text = 'The file you look at is not valid UTF-8 text. Please convert the file.' unless text.valid_encoding?
     # Ged rid of stuff that shouldn't be part of PCDATA:
-    text.gsub(/([^a-zA-Z0-9&;<>\/\n \t()])/) do
+    text.gsub(%r{([^a-zA-Z0-9&;<>/\n \t()])}) do
       if Regexp.last_match(1)[0].getbyte(0) < 32
         ''
       else
@@ -266,7 +266,7 @@ module Webui::WebuiHelper
 
   def replace_jquery_meta_characters(input)
     # The stated characters are c&p from https://api.jquery.com/category/selectors/
-    input.gsub(/[!"#$%&'()*+,.\/:\\;<=>?@\[\]^`{|}~]/, '_')
+    input.gsub(%r{[!"#$%&'()*+,./:\\;<=>?@\[\]^`{|}~]}, '_')
   end
 
   def word_break(string, length = 80)

--- a/src/api/app/mixins/build_log_support.rb
+++ b/src/api/app/mixins/build_log_support.rb
@@ -7,7 +7,7 @@ module BuildLogSupport
   def get_log_chunk(project, package, repo, arch, start, theend)
     log = raw_log_chunk(project, package, repo, arch, start, theend)
     log.encode!(invalid: :replace, undef: :replace, cr_newline: true)
-    log.gsub(/([^a-zA-Z0-9&;<>\/\n\r \t()])/) do |c|
+    log.gsub(%r{([^a-zA-Z0-9&;<>/\n\r \t()])}) do |c|
       if c.ord < 32
         ''
       else

--- a/src/api/app/services/package_service/file_verifier.rb
+++ b/src/api/app/services/package_service/file_verifier.rb
@@ -27,7 +27,7 @@ module PackageService
     end
 
     def file_name_invalid?
-      @file_name.blank? || @file_name !~ /^[^.\/][^\/]+$/
+      @file_name.blank? || @file_name !~ %r{^[^./][^/]+$}
     end
 
     def service?

--- a/src/api/app/services/trigger_controller_service/token_extractor.rb
+++ b/src/api/app/services/trigger_controller_service/token_extractor.rb
@@ -19,7 +19,7 @@ module TriggerControllerService
     end
 
     def valid?
-      @auth_token.present? && @auth_token[0..4] == 'Token' && @auth_token[6..-1].match?(/^[A-Za-z0-9+\/]+$/)
+      @auth_token.present? && @auth_token[0..4] == 'Token' && @auth_token[6..-1].match?(%r{^[A-Za-z0-9+/]+$})
     end
 
     # it will return a Token subclass or raise ActiveRecord::RecordNotFound

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -337,18 +337,18 @@ OBSApi::Application.routes.draw do
     resource :session, only: [:new, :create, :destroy], controller: 'webui/session'
 
     controller 'webui/groups/bs_requests' do
-      get 'groups/(:title)/requests' => :index, constraints: { title: /[^\/]*/ }, as: 'group_requests'
+      get 'groups/(:title)/requests' => :index, constraints: { title: %r{[^/]*} }, as: 'group_requests'
     end
 
     controller 'webui/groups' do
       get 'groups' => :index
-      get 'group/show/:title' => :show, constraints: { title: /[^\/]*/ }, as: 'group_show'
+      get 'group/show/:title' => :show, constraints: { title: %r{[^/]*} }, as: 'group_show'
       get 'group/new' => :new
       post 'group/create' => :create
       get 'group/autocomplete' => :autocomplete, as: 'autocomplete_groups'
     end
 
-    resources :groups, only: [], param: :title, constraints: { title: /[^\/]*/ } do
+    resources :groups, only: [], param: :title, constraints: { title: %r{[^/]*} } do
       resources :user, only: [:create, :destroy, :update], constraints: cons, param: :user_login, controller: 'webui/groups/users'
     end
 

--- a/src/api/lib/api_error.rb
+++ b/src/api/lib/api_error.rb
@@ -26,7 +26,7 @@ class APIError < RuntimeError
 
     err = self.class.name.demodulize.underscore
     # if the class name stops with Error, strip that
-    err.gsub(%r{_error$}, '')
+    err.gsub(/_error$/, '')
   end
 
   def status

--- a/src/api/lib/tasks/coverage.rake
+++ b/src/api/lib/tasks/coverage.rake
@@ -29,11 +29,11 @@ namespace :ci do
     SimpleCov.merge_timeout 100_000
 
     SimpleCov.configure do
-      add_group('WebUI') { |file| file.filename =~ %r{webui} }
+      add_group('WebUI') { |file| file.filename =~ /webui/ }
       add_group('Jobs') { |file| file.filename =~ %r{jobs/} }
       add_group('Models') { |file| file.filename =~ %r{models/} }
-      add_group('Helpers') { |file| file.filename =~ %r{helpers/} && file.filename !~ %r{webui} }
-      add_group('API Controllers') { |file| file.filename =~ %r{controllers/} && file.filename !~ %r{webui} }
+      add_group('Helpers') { |file| file.filename =~ %r{helpers/} && file.filename !~ /webui/ }
+      add_group('API Controllers') { |file| file.filename =~ %r{controllers/} && file.filename !~ /webui/ }
     end
 
     # upload the result for all

--- a/src/api/lib/tasks/extract.rake
+++ b/src/api/lib/tasks/extract.rake
@@ -7,7 +7,7 @@ def local_to_yaml(hash, file)
   keys.each_with_index do |k, index| # <-- here's my addition (the 'sort')
     v = hash[k]
     k = "record_#{index}" if k.is_a?(Integer)
-    file.write({ k => v }.to_yaml(SortKeys: true, ExplicitTypes: true).gsub(%r{^---\s*}, ''))
+    file.write({ k => v }.to_yaml(SortKeys: true, ExplicitTypes: true).gsub(/^---\s*/, ''))
   end
 end
 

--- a/src/api/lib/tasks/test_webui.rake
+++ b/src/api/lib/tasks/test_webui.rake
@@ -5,7 +5,7 @@ Rake::TestTask.new do |t|
   t.libs << 'test'
   test_files = FileList['test/unit/*_test.rb']
   test_files += FileList['test/models/*_test.rb']
-  test_files += FileList['test/**/*_test.rb'].exclude(%r{webui}).exclude(%r{test/models}).exclude(%r{test/unit})
+  test_files += FileList['test/**/*_test.rb'].exclude(/webui/).exclude(%r{test/models}).exclude(%r{test/unit})
   t.test_files = test_files
   t.name = 'test:api'
   t.warning = false
@@ -46,7 +46,7 @@ end
 
 Rake::TestTask.new do |t|
   t.libs << 'test'
-  files = FileList['test/functional/**/*_test.rb'].exclude(%r{spider_test})
+  files = FileList['test/functional/**/*_test.rb'].exclude(/spider_test/)
   SAFE_TESTS.each do |file|
     files.exclude(file)
   end


### PR DESCRIPTION
Corrections in helpers, mixins, services, routes and libs.

Using // by default and %r{} just in case the regular expression
contains slashes.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
