### PR TITLE
[backend] container publishing: support oci fat manifests as well

### DIFF
--- a/src/backend/bs_regpush
+++ b/src/backend/bs_regpush
@@ -53,6 +53,7 @@ my $delete_except_mode;
 my $list_mode;
 my @tags;
 my $blobdir;
+my $oci;
 
 my $registryserver;
 my $repository;
@@ -459,6 +460,9 @@ while (@ARGV) {
   } elsif ($ARGV[0] eq '-B') {
     $blobdir = $ARGV[1];
     splice(@ARGV, 0, 2);
+  } elsif ($ARGV[0] eq '--oci') {
+    $oci = 1;
+    shift @ARGV;
   } else {
     last;
   }
@@ -538,6 +542,9 @@ if ($use_image_tags && @tarfiles > 1) {
   }
   $use_image_tags = 0;
 }
+
+# use oci types if we have a helm chart
+$oci = 1 if grep {/\.helminfo$/} @tarfiles;
 
 my @multimanifests;
 my %multiplatforms;
@@ -629,18 +636,19 @@ for my $tarfile (@tarfiles) {
   }
   close $tarfd if $tarfd;
 
+  my $mediaType = $oci ? 'application/vnd.oci.image.manifest.v1+json' : 'application/vnd.docker.distribution.manifest.v2+json';
   my $mani = {
     'schemaVersion' => 2,
-    'mediaType' => 'application/vnd.docker.distribution.manifest.v2+json',
+    'mediaType' => $mediaType,
     'config' => $config_data,
     'layers' => \@layer_data,
   };
   my $mani_json = BSContar::create_dist_manifest($mani);
 
   if ($multiarch) {
-    manifest_upload($mani_json, undef);		# upload anonymous image
+    manifest_upload($mani_json, undef, $mediaType);	# upload anonymous image
     my $multimani = {
-      'mediaType' => 'application/vnd.docker.distribution.manifest.v2+json',
+      'mediaType' => $mediaType,
       'size' => length($mani_json),
       'digest' => 'sha256:'.Digest::SHA::sha256_hex($mani_json),
       'platform' => {'architecture' => $goarch, 'os' => $goos},
@@ -648,18 +656,18 @@ for my $tarfile (@tarfiles) {
     $multimani->{'platform'}->{'variant'} = $govariant if $govariant;
     push @multimanifests, $multimani;
   } else {
-    manifest_upload_tags($mani_json, \@tags);
+    manifest_upload_tags($mani_json, \@tags, $mediaType);
   }
 }
 
 if ($multiarch) {
-  my $ct = 'application/vnd.docker.distribution.manifest.list.v2+json';
+  my $mediaType = $oci ? 'application/vnd.oci.image.index.v1+json' : 'application/vnd.docker.distribution.manifest.list.v2+json';
   my $mani = {
     'schemaVersion' => 2,
-    'mediaType' => $ct,
+    'mediaType' => $mediaType,
     'manifests' => \@multimanifests,
   };
   my $mani_json = BSContar::create_dist_manifest_list($mani);
-  manifest_upload_tags($mani_json, \@tags, $ct);
+  manifest_upload_tags($mani_json, \@tags, $mediaType);
 }
 


### PR DESCRIPTION
<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
