### PR TITLE
Append ThinkingSphinx callbacks to Package and Project models

### DIFF
--- a/src/api/app/mixins/populate_sphinx.rb
+++ b/src/api/app/mixins/populate_sphinx.rb
@@ -1,7 +1,0 @@
-module PopulateSphinx
-  def populate_sphinx
-    ThinkingSphinx::RealTime::Callbacks::RealTimeCallbacks.new(
-      self.class.name.underscore.to_sym
-    ).after_save(self)
-  end
-end

--- a/src/api/app/models/concerns/append_sphinx_callbacks.rb
+++ b/src/api/app/models/concerns/append_sphinx_callbacks.rb
@@ -1,0 +1,14 @@
+module AppendSphinxCallbacks
+  extend ActiveSupport::Concern
+
+  included do
+    ThinkingSphinx::Callbacks.append(self, behaviours: [:real_time]) do |record|
+      # Index record only if its name, title or description changed
+      if record.name_previously_changed? || record.title_previously_changed? || record.description_previously_changed?
+        [record]
+      else
+        []
+      end
+    end
+  end
+end

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -4,6 +4,7 @@ require 'rexml/document'
 
 # rubocop: disable Metrics/ClassLength
 class Package < ApplicationRecord
+  include AppendSphinxCallbacks
   include FlagHelper
   include Flag::Validations
   include CanRenderModel
@@ -11,7 +12,6 @@ class Package < ApplicationRecord
   include Package::Errors
   include HasRatings
   include HasAttributes
-  include PopulateSphinx
   include PackageSphinx
 
   BINARY_EXTENSIONS = ['.0', '.bin', '.bin_mid', '.bz', '.bz2', '.ccf', '.cert',
@@ -69,7 +69,6 @@ class Package < ApplicationRecord
   before_destroy :remove_devel_packages
 
   after_save :write_to_backend
-  after_save :populate_sphinx, if: -> { name_previously_changed? || title_previously_changed? || description_previously_changed? }
   after_rollback :reset_cache
 
   # The default scope is necessary to exclude the forbidden projects.

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -1,5 +1,6 @@
 # rubocop:disable Metrics/ClassLength
 class Project < ApplicationRecord
+  include AppendSphinxCallbacks
   include FlagHelper
   include Flag::Validations
   include CanRenderModel
@@ -7,7 +8,6 @@ class Project < ApplicationRecord
   include HasRatings
   include HasAttributes
   include MaintenanceHelper
-  include PopulateSphinx
   include ProjectSphinx
   include Project::Errors
   include StagingProject
@@ -20,7 +20,6 @@ class Project < ApplicationRecord
   after_destroy_commit :delete_on_backend
 
   after_save :discard_cache
-  after_save :populate_sphinx, if: -> { name_previously_changed? || title_previously_changed? || description_previously_changed? }
   after_rollback :reset_cache
   after_rollback :discard_cache
 

--- a/src/api/spec/models/full_text_search_spec.rb
+++ b/src/api/spec/models/full_text_search_spec.rb
@@ -11,14 +11,37 @@ RSpec.describe FullTextSearch do
     context 'for a non-existent project' do
       let(:search_params) { { text: 'non-existent-project' } }
 
-      it { expect(subject).to be_empty }
+      it { is_expected.to be_empty }
     end
 
     context 'for an existing package' do
       let(:package) { create(:package, name: 'test_package', project: project, title: '', description: '') }
       let(:search_params) { { text: package.name } }
 
-      it { expect(subject).to eql([package]) }
+      it { is_expected.to eql([package]) }
+
+      context 'which is deleted' do
+        before do
+          package.destroy
+        end
+
+        it { is_expected.to be_empty }
+      end
+    end
+
+    context 'for an existing project' do
+      let!(:some_project) { create(:project) }
+      let(:search_params) { { text: some_project.name } }
+
+      it { is_expected.to eql([some_project]) }
+
+      context 'which is deleted' do
+        before do
+          some_project.destroy
+        end
+
+        it { is_expected.to be_empty }
+      end
     end
 
     context 'specifying classes' do


### PR DESCRIPTION
Deleted packages/projects are now removed from Sphinx indices. Before, we were missing the `after_destroy` callback from
`ThinkingSphinx::ActiveRecord::Callbacks::DeleteCallbacks`. This resulted in having deleted packages/projects in our Sphinx indices. The error was `ThinkingSphinx::Search::StaleIdsException` with the message `Record IDs found by Sphinx but not by ActiveRecord : 123, 456, 789`.

See upstream:
https://github.com/pat/thinking-sphinx/blob/df2746b5679c8009527ac87b761357d536d48c05/lib/thinking_sphinx/callbacks.rb#L10
https://github.com/pat/thinking-sphinx/blob/7622e5e40fe8a79a3329ddc78d54390cfe7a7f02/lib/thinking_sphinx/callbacks/appender.rb#L16

This fixes #9436.

**TODO after merging this PR:**
We will have to cleanup the indices and to do so, we need to rebuild them.
```shell
# We need to remove the existing indices
cd to_our_application
rm tmp/binlog db/sphinx
run_in_api bundle exec rake ts:rt:rebuild 
```