### PR TITLE
[backend] implement signing of helm charts

### DIFF
--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -2053,6 +2053,11 @@ sub publish {
 	    $containerinfo->{'publishfile'} = "$extrep/$p";
 	    $containers{$p} = $containerinfo;
 	  }
+	} elsif ($bin =~ /(.*)\.tgz.prov$/ && -e "$r/$1.helminfo") {
+          eval {
+	    BSPublisher::Helm::readhelminfo($r, "$1.helminfo");
+	    $p = $bin;
+          };
 	} elsif ($bin =~ /\.containerinfo$/) {
 	  # handle the case where there is a containerinfo with no tar file
 	  my @s = stat("$r/$bin");
@@ -2265,6 +2270,7 @@ sub publish {
 	link($bins{$p}, $tmpfile) || die("link $bins{$p} $tmpfile: $!\n");
 	$containerinfo->{'publishfile'} = $tmpfile;
       }
+      next if ($containerinfo->{'type'} || '') eq 'helm';	# keep helm charts
       delete $bins{$p};
       delete $bins{"$p.sha256"};
       delete $binaryorigins->{$p};

--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -2411,7 +2411,7 @@ sub putjob {
 
   my $ev = {'type' => 'built', 'arch' => $arch, 'job' => $job};
 
-  if ($BSConfig::sign && (@{$kiwitree_tosign || []} || grep {$_->{'name'} =~ /\.(?:d?rpm|sha256|iso|pkg\.tar\.gz|pkg\.tar.xz|AppImage|deb|appx)$/} @$uploaded)) {
+  if ($BSConfig::sign && (@{$kiwitree_tosign || []} || grep {$_->{'name'} =~ /\.(?:d?rpm|sha256|iso|pkg\.tar\.gz|pkg\.tar.xz|AppImage|deb|appx|helminfo)$/} @$uploaded)) {
     # write jobstatus and free lock
     if (@{$kiwitree_tosign || []}) {
       my $c = '';

--- a/src/backend/bs_signer
+++ b/src/backend/bs_signer
@@ -35,6 +35,7 @@ use Digest::MD5 ();
 use XML::Structured ':bytes';
 use Build;
 use Storable;
+use JSON::XS ();
 
 use BSConfiguration;
 use BSRPC ':https';
@@ -367,6 +368,39 @@ sub signappx {
   die($@) if $@;
 }
 
+sub signhelm {
+  my ($signfile, $jobdir, @signargs) = @_;
+  my $chart = $signfile;
+  $chart =~ s/.*\///;
+  return unless $chart =~ s/\.helminfo$/\.tgz/;
+  return unless -s "$jobdir/$chart";
+  # read helminfo
+  my $helminfo_json;
+  my $helminfo;
+  return unless -e $signfile && -s _ < 1000000;
+  $helminfo_json = readstr($signfile);
+  eval { $helminfo = JSON::XS::decode_json($helminfo_json) };
+  return unless $helminfo && ref($helminfo) eq 'HASH';
+  my $config_yaml = $helminfo->{'config_yaml'};
+  my $chart_sha256 = $helminfo->{'chart_sha256'};
+  return unless $config_yaml && ref($config_yaml) eq '';
+  return unless $chart_sha256 && ref($chart_sha256) eq '' && $chart_sha256 =~ /^[0-9a-f]{64}$/s;
+  # escape filename
+  if ($chart =~ /[\x00-\x1f\x7f-\x9f\']/) {
+    $chart =~ s/\\/\\\\/g;
+    $chart =~ s/\"/\\\"/g;
+    $chart =~ s/[\x00-\x1f\x7f-\x9f]/'\x'.sprintf("%X",ord($1))/ge;
+    $chart = "\"$chart\"";
+  } elsif ($chart =~ /(?:^[~!@#%&*|>?:,'"`{}\[\]]|^-+$|\s|:\z)/) {
+    $chart = "'$chart'";
+  }
+  # generate provenance file and clearsign it
+  my $prov = "$config_yaml\n...\nfiles:\n  $chart: sha256:$chart_sha256\n";
+  splice(@signargs, $BSConfig::sign_project ? 2 : 0, 0, '--signtype', 'helm') if $BSConfig::sign_type;
+  my $prov_signed = BSUtil::xsystem($prov, $BSConfig::sign, @signargs, '-c');
+  writestr("$jobdir/$chart.prov", undef, $prov_signed);
+}
+
 sub fixup_sha256_checksum {
   my ($jobdir, $shafile, $isofile) = @_;
   return if ((-s "$jobdir/$shafile") || 0) > 65536;
@@ -505,7 +539,7 @@ sub signjob {
   my $info = readxml("$jobsdir/$arch/$job", $BSXML::buildinfo);
   my $projid = $info->{'project'};
   my @files = sort(ls($jobdir));
-  my @signfiles = grep {/\.(?:d?rpm|sha256|iso|pkg\.tar\.gz|pkg\.tar\.xz|rsasign|AppImage|appx)$/} @files;
+  my @signfiles = grep {/\.(?:d?rpm|sha256|iso|pkg\.tar\.gz|pkg\.tar\.xz|rsasign|AppImage|appx|helminfo)$/} @files;
   my $needpubkey;
   if (grep {$_ eq '.kiwitree_tosign'} @files) {
     for my $f (split("\n", readstr("$jobdir/.kiwitree_tosign"))) {
@@ -553,6 +587,10 @@ sub signjob {
 
     eval {
       for my $signfile (@signfiles) {
+	if ($signfile =~ /\.helminfo$/) {
+	  signhelm("$jobdir/$signfile", $jobdir, @signargs);
+	  next;
+	}
 	if ($signfile =~ /\.appx$/) {
 	  signappx("$jobdir/$signfile", $jobdir, $projid, $signkey, $cert, @signargs);
 	  next;


### PR DESCRIPTION
This generates provenance files for the charts.
We also no longer remove helm charts from the publish area if
a registry is configured. Helm charts are small and do not
contain layers from the blobstore like containers.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
