### PR TITLE
Allow staff users to create/update/destroy status messages

### DIFF
--- a/src/api/app/controllers/status_messages_controller.rb
+++ b/src/api/app/controllers/status_messages_controller.rb
@@ -1,4 +1,5 @@
 class StatusMessagesController < ApplicationController
+  # TODO: Use Pundit StatusMessagePolicy instead of a mix of Pundit and custom policy code
   before_action :require_admin, only: [:create, :update, :destroy]
   before_action :set_status_message, except: [:index, :create]
 

--- a/src/api/app/policies/status_message_policy.rb
+++ b/src/api/app/policies/status_message_policy.rb
@@ -8,7 +8,11 @@ class StatusMessagePolicy < ApplicationPolicy
   end
 
   def create?
-    user.is_admin?
+    user.is_admin? || user.is_staff?
+  end
+
+  def new?
+    create?
   end
 
   def update?

--- a/src/api/app/views/webui/main/_status_message.html.haml
+++ b/src/api/app/views/webui/main/_status_message.html.haml
@@ -7,7 +7,7 @@
       wrote
       %u
         #{time_ago_in_words(status_message.created_at)} ago
-      - if User.admin_session?
+      - if policy(status_message).destroy?
         .float-right
           = link_to(status_message_path(status_message), method: :delete, title: 'Remove status message') do
             %i.fas.fa-times-circle.text-danger

--- a/src/api/app/views/webui/main/_status_messages.html.haml
+++ b/src/api/app/views/webui/main/_status_messages.html.haml
@@ -7,7 +7,7 @@
         %i.fa.fa-rss
   .list-group
     = render partial: 'status_message', collection: status_messages
-    - if User.admin_session?
+    - if policy(StatusMessage.new).create?
       - unless feature_enabled?(:responsive_ux)
         .card-footer
           = link_to(new_status_message_path, class: 'nav-link') do

--- a/src/api/app/views/webui/main/responsive_ux/_index_actions.html.haml
+++ b/src/api/app/views/webui/main/responsive_ux/_index_actions.html.haml
@@ -1,5 +1,5 @@
 - content_for :actions do
-  - if User.admin_session?
+  - if policy(StatusMessage.new).create?
     %li.nav-item
       = link_to(new_status_message_path, class: 'nav-link') do
         %i.fas.fa-plus-square.fa-lg.mr-2

--- a/src/api/spec/policies/status_message_policy_spec.rb
+++ b/src/api/spec/policies/status_message_policy_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe StatusMessagePolicy do
+  let(:anonymous_user) { create(:user_nobody) }
+  let(:user) { create(:confirmed_user) }
+  let(:staff_user) { create(:staff_user) }
+  let(:admin_user) { create(:admin_user) }
+  let(:status_message) { create(:status_message) }
+
+  subject { StatusMessagePolicy }
+
+  # rubocop:disable RSpec/RepeatedExample
+  # This cop is currently not recognizing the permissions block as separate test
+  permissions :index?, :show? do
+    it { is_expected.to permit(anonymous_user, status_message) }
+    it { is_expected.to permit(user, status_message) }
+    it { is_expected.to permit(staff_user, status_message) }
+    it { is_expected.to permit(admin_user, status_message) }
+  end
+
+  permissions :new?, :create?, :update?, :destroy? do
+    it { is_expected.not_to permit(anonymous_user, status_message) }
+    it { is_expected.not_to permit(user, status_message) }
+    it { is_expected.to permit(staff_user, status_message) }
+    it { is_expected.to permit(admin_user, status_message) }
+  end
+  # rubocop:enable RSpec/RepeatedExample
+end


### PR DESCRIPTION
We often have the need to create (and sometimes destroy) status messages on our reference server. Allowing staff users to do this is much better than turning everybody into an admin.