### PR TITLE
Merge the docker-compose AHM/APM setups

### DIFF
--- a/contrib/grafana-datasource.yml
+++ b/contrib/grafana-datasource.yml
@@ -1,0 +1,17 @@
+apiVersion: 1
+
+datasources:
+  - name: performance
+    type: influxdb
+    access: proxy
+    database: performance
+    user: grafana
+    password: grafana
+    url: http://influx:8086
+  - name: health
+    type: influxdb
+    access: proxy
+    database: health
+    user: grafana
+    password: grafana
+    url: http://influx:8086

--- a/contrib/influxdb-init.iql
+++ b/contrib/influxdb-init.iql
@@ -1,0 +1,2 @@
+CREATE DATABASE performance;
+CREATE DATABASE health;

--- a/contrib/telegraf.conf
+++ b/contrib/telegraf.conf
@@ -79,7 +79,7 @@
   # urls = ["udp://127.0.0.1:8089"] # UDP endpoint example
   urls = ["http://influx:8086"] # required
   ## The target database for metrics (telegraf will create it if not exists).
-  database = "telegraf" # required
+  database = "health" # required
 
   ## Name of existing retention policy to write to.  Empty string writes to
   ## the default retention policy.
@@ -90,8 +90,8 @@
   ## Write timeout (for the InfluxDB client), formatted as a string.
   ## If not provided, will default to 5s. 0s means no timeout (not recommended).
   timeout = "5s"
-  username = "telegraf"
-  password = "telegraf"
+  username = "root"
+  password = "root"
 
 ###############################################################################
 #                            SERVICE INPUT PLUGINS                            #

--- a/docker-compose.sre.yml
+++ b/docker-compose.sre.yml
@@ -1,13 +1,24 @@
 version: "2.1"
 services:
   influx:
-    image: influxdb
+    image: influxdb:1.7
     environment:
-      - INFLUXDB_DB=telegraf
-      - INFLUXDB_USER=telegraf
-      - INFLUXDB_USER_PASSWORD=telegraf
+      - INFLUXDB_ADMIN_USER=root
+      - INFLUXDB_ADMIN_PASSWORD=root
       - INFLUXDB_READ_USER=grafana
       - INFLUXDB_READ_USER_PASSWORD=grafana
+    volumes:
+      - ./contrib/influxdb-init.iql:/docker-entrypoint-initdb.d/influxdb-init.iql:ro
+      - influxdata:/var/lib/influxdb
+  grafana:
+    image: grafana/grafana:7.1.1
+    ports:
+      - "8000:3000"
+    depends_on:
+      - influx
+    volumes:
+      - grafanadata:/var/lib/grafana
+      - ./contrib/grafana-datasource.yml:/etc/grafana/provisioning/datasources/grafana-datasource.yml:ro
   rabbit:
     image: rabbitmq:3-management
     ports:
@@ -27,9 +38,7 @@ services:
         condition: service_healthy
     volumes:
       - ./contrib/telegraf.conf:/etc/telegraf/telegraf.conf:ro
-  grafana:
-    image: grafana/grafana
-    ports:
-      - "8000:3000"
-    depends_on:
-      - influx
+volumes:
+  influxdata:
+  grafanadata:
+

--- a/src/api/config/initializers/influxdb_rails.rb
+++ b/src/api/config/initializers/influxdb_rails.rb
@@ -5,7 +5,7 @@ if CONFIG['influxdb_hosts'].blank? # defaults to localhost otherwise
   return
 end
 InfluxDB::Rails.configure do |config|
-  config.client.database       = CONFIG['influxdb_database'] || 'rails'
+  config.client.database       = CONFIG['influxdb_database'] || 'performance'
   config.client.username       = CONFIG['influxdb_username'] || 'root'
   config.client.password       = CONFIG['influxdb_password'] || 'root'
   config.client.hosts          = CONFIG['influxdb_hosts']


### PR DESCRIPTION
This makes it possible to start an environment with all monitoring
services enabled. I think it make little sense to seperate AHM/APM.

`docker-compose -f docker-compose.yml -f docker-compose.sre.yml up`

