### PR TITLE
[backend] publisher: implement repotype 'helm'

### DIFF
--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -794,6 +794,27 @@ sub createrepo_virtbuilder {
   }
 }
 
+sub createrepo_helm {
+  my ($extrep, $projid, $repoid, $data, $options, $containers) = @_;
+  print "    generating helm chart index\n";
+  my $downloadurl = BSUrlmapper::get_downloadurl("$projid/$repoid");
+  unlink("$extrep/index.yaml");
+  my %entries;
+  for my $p (sort keys %$containers) {
+    next unless ($containers->{$p}->{'type'} || '') eq 'helm';
+    my $helminfo = $containers->{$p};
+    my $entry = BSPublisher::Helm::mkindexentry($helminfo, $downloadurl ? "${downloadurl}$p" : undef);
+    push @{$entries{$helminfo->{'name'}}}, $entry if $entry;
+  }
+  my $index_yaml = BSPublisher::Helm::mkindex_yaml(\%entries);
+  writestr("$extrep/index.yaml", undef, $index_yaml);
+}
+
+sub deleterepo_helm {
+  my ($extrep, $projid) = @_;
+  unlink("$extrep/index.yaml");
+}
+
 sub createrepo_hdlist2 {
   my ($extrep, $projid, $repoid, $data, $options) = @_;
 
@@ -2885,6 +2906,9 @@ sub publish {
     createrepo_zyppservice($extrep, $projid, $xrepoid, $data, $repotype{'zyppservice'});
   } else {
     deleterepo_zyppservice($extrep, $projid, $xrepoid, $data);
+  }
+  if ($repotype{'helm'}) {
+    createrepo_helm($extrep, $projid, $xrepoid, $data, $repotype{'helm'}, \%containers);
   }
 
   if ($patterntype{'ymp'}) {


### PR DESCRIPTION
This generates a helm chart index from all published charts.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
