### PR TITLE
Show download link for files that exceed 4 megabytes

### DIFF
--- a/src/api/app/views/webui/package/_file.html.haml
+++ b/src/api/app/views/webui/package/_file.html.haml
@@ -13,9 +13,8 @@
   / limit download for anonymous user to avoid getting killed by crawlers
   - unless nobody
     %td.text-center
-      - if file[:size].to_i < 4.megabytes
-        = link_to(file_url(project.name, package.name, file[:name], file[:srcmd5]), title: 'Download file') do
-          %i.fas.fa-download.text-secondary
+      = link_to(file_url(project.name, package.name, file[:name], file[:srcmd5]), title: 'Download file') do
+        %i.fas.fa-download.text-secondary
       - if can_be_removed
         = link_to('#', data: { toggle: 'modal', target: '#delete-file-modal', title: 'Delete file',
           filename: file[:name], action: url_for(action: :remove_file, project: project, package: package, filename: file[:name]) }) do


### PR DESCRIPTION
In the past we showed the download link for files with
a size of less than 4 megabytes also to non authenticated users.
Now we show the link only to authenticated users no matter which
sizes the file has. A forgotten if statement led to the problem
that we didn't showed the download link to anyone anymore when
the file exceeds the 4 megabytes.

Fixes #10096

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
