### PR TITLE
[backend] move mime type definitions into BSContar.pm

### DIFF
--- a/src/backend/BSContar.pm
+++ b/src/backend/BSContar.pm
@@ -33,6 +33,17 @@ use BSTar;
 
 use strict;
 
+our $mt_docker_manifest     = 'application/vnd.docker.distribution.manifest.v2+json';
+our $mt_docker_manifestlist = 'application/vnd.docker.distribution.manifest.list.v2+json';
+our $mt_oci_manifest        = 'application/vnd.oci.image.manifest.v1+json';
+our $mt_oci_index           = 'application/vnd.oci.image.index.v1+json';
+
+our $mt_docker_config       = 'application/vnd.docker.container.image.v1+json';
+our $mt_docker_layer_gzip   = 'application/vnd.docker.image.rootfs.diff.tar.gzip';
+our $mt_oci_config          = 'application/vnd.oci.image.config.v1+json';
+our $mt_oci_layer_gzip      = 'application/vnd.oci.image.layer.v1.tar+gzip';
+our $mt_helm_config         = 'application/vnd.cncf.helm.config.v1+json';
+
 sub checksum_entry {
   my ($ent, $ctx) = @_;
   my $offset = 0;
@@ -315,7 +326,7 @@ sub container_from_helm {
   }
   # create ent for the config
   my $config_ent = { 'name' => 'config.json', 'size' => length($config_json), 'data' => $config_json, 'mtime' => $mtime };
-  $config_ent->{'mimetype'} = 'application/vnd.cncf.helm.config.v1+json';
+  $config_ent->{'mimetype'} = $mt_helm_config;
   # create ent for the manifest
   my $manifest = { 
     'Layers' => [ $chartbasename ],

--- a/src/backend/BSPublisher/Registry.pm
+++ b/src/backend/BSPublisher/Registry.pm
@@ -516,7 +516,7 @@ sub push_containers {
       my $config_blobid = push_blob($repodir, $containerinfo, $config_ent);
       $knownblobs{$config_blobid} = 1;
       my $config_data = {
-	'mediaType' => $config_ent->{'mimetype'} || 'application/vnd.docker.container.image.v1+json',
+	'mediaType' => $config_ent->{'mimetype'} || ($oci ? $BSContar::mt_oci_config : $BSContar::mt_docker_config),
 	'size' => $config_ent->{'size'},
 	'digest' => $config_blobid,
       };
@@ -535,7 +535,7 @@ sub push_containers {
 	my $blobid = push_blob($repodir, $containerinfo, $layer_ent);
         $knownblobs{$blobid} = 1;
 	my $layer_data = {
-	  'mediaType' => $layer_ent->{'mimetype'} || 'application/vnd.docker.image.rootfs.diff.tar.gzip',
+	  'mediaType' => $layer_ent->{'mimetype'} || ($oci ? $BSContar::mt_oci_layer_gzip : $BSContar::mt_docker_layer_gzip),
 	  'size' => $layer_ent->{'size'},
 	  'digest' => $blobid,
 	};
@@ -545,7 +545,7 @@ sub push_containers {
       close $tarfd if $tarfd;
 
       # put manifest into repo
-      my $mediaType = $oci ? 'application/vnd.oci.image.manifest.v1+json' : 'application/vnd.docker.distribution.manifest.v2+json';
+      my $mediaType = $oci ? $BSContar::mt_oci_manifest : $BSContar::mt_docker_manifest;
       my $mani = { 
 	'schemaVersion' => 2,
 	'mediaType' => $mediaType,
@@ -596,8 +596,8 @@ sub push_containers {
     };
     my ($mani_id, $mani_size);
     if ($multiarchtag) {
-      my $mediaType = $oci ? 'application/vnd.oci.image.index.v1+json' : 'application/vnd.docker.distribution.manifest.list.v2+json';
       # create fat manifest
+      my $mediaType = $oci ? $BSContar::mt_oci_index : $BSContar::mt_docker_manifestlist;
       my $mani = {
         'schemaVersion' => 2,
         'mediaType' => $mediaType,

--- a/src/backend/bs_regpush
+++ b/src/backend/bs_regpush
@@ -163,7 +163,7 @@ sub blob_fetch {
 sub manifest_exists {
   my ($manifest, $tag, $content_type) = @_;
 
-  $content_type ||= 'application/vnd.docker.distribution.manifest.v2+json';
+  $content_type ||= $BSContar::mt_docker_manifest;
   my $maniid = 'sha256:'.Digest::SHA::sha256_hex($manifest);
   $tag = $maniid unless defined $tag;
   my $replyheaders;
@@ -189,9 +189,9 @@ sub manifest_upload {
 
   my $maniid = 'sha256:'.Digest::SHA::sha256_hex($manifest);
   return $maniid if manifest_exists($manifest, $tag, $content_type);
-  $content_type ||= 'application/vnd.docker.distribution.manifest.v2+json';
+  $content_type ||= $BSContar::mt_docker_manifest;
   my $fat = '';
-  $fat = 'fat ' if $content_type eq 'application/vnd.docker.distribution.manifest.list.v2+json' || $content_type eq 'application/vnd.oci.image.index.v1+json';
+  $fat = 'fat ' if $content_type eq $BSContar::mt_docker_manifestlist || $content_type eq $BSContar::mt_oci_index;
   if (!$quiet) {
     if (defined($tag)) {
       print "uploading ${fat}manifest $maniid for tag '$tag'... ";
@@ -284,7 +284,7 @@ sub get_manifest_for_tag {
   my $replyheaders;
   my $param = {
     'uri' => "$registryserver/v2/$repository/manifests/$tag",
-    'headers' => [ "Accept: application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.oci.image.index.v1+json" ],
+    'headers' => [ "Accept: $BSContar::mt_docker_manifest, $BSContar::mt_docker_manifestlist, $BSContar::mt_oci_manifest, $BSContar::mt_oci_index" ],
     'authenticator' => $registry_authenticator,
     'replyheaders' => \$replyheaders,
     'timeout' => $registry_timeout,
@@ -331,19 +331,19 @@ sub delete_tag {
 
 sub list_tag {
   my ($tag) = @_;
-  
+
   my ($mani, $maniid) = get_manifest_for_tag($tag);
   if (!$mani) {
     printf "%-20s -\n", $tag;
   } elsif (!$mani->{'mediaType'}) {
     printf "%-20s %s %s\n", $tag, $maniid, 'v1image';
-  } elsif ($mani->{'mediaType'} eq 'application/vnd.docker.distribution.manifest.list.v2+json') {
+  } elsif ($mani->{'mediaType'} eq $BSContar::mt_docker_manifestlist) {
     printf "%-20s %s %s\n", $tag, $maniid, 'list';
-  } elsif ($mani->{'mediaType'} eq 'application/vnd.docker.distribution.manifest.v2+json') {
+  } elsif ($mani->{'mediaType'} eq $BSContar::mt_docker_manifest) {
     printf "%-20s %s %s\n", $tag, $maniid, 'image';
-  } elsif ($mani->{'mediaType'} eq 'application/vnd.oci.image.manifest.v1+json') {
+  } elsif ($mani->{'mediaType'} eq $BSContar::mt_oci_manifest) {
     printf "%-20s %s %s\n", $tag, $maniid, 'ociimage';
-  } elsif ($mani->{'mediaType'} eq 'application/vnd.oci.image.index.v1+json') {
+  } elsif ($mani->{'mediaType'} eq $BSContar::mt_oci_index) {
     printf "%-20s %s %s\n", $tag, $maniid, 'ocilist';
   } else {
     printf "%-20s %s %s\n", $tag, $maniid, 'unknown';
@@ -366,7 +366,7 @@ sub tags_from_digestfile {
 }
 
 sub construct_container_tar {
-  my ($containerinfo) = @_; 
+  my ($containerinfo) = @_;
 
   die("Must specify a blobdir for containerinfos\n") unless $blobdir;
   my $manifest = $containerinfo->{'tar_manifest'};
@@ -571,7 +571,7 @@ for my $tarfile (@tarfiles) {
     $config_layers = $config->{'rootfs'}->{'diff_ids'};
     die("layer number mismatch\n") if @layers != @{$config_layers || []};
   }
-  
+
   my $goarch = $config->{'architecture'} || 'any';
   my $goos = $config->{'os'} || 'any';
   $govariant = $config->{'variant'} if $config->{'variant'};
@@ -591,14 +591,14 @@ for my $tarfile (@tarfiles) {
   # process config
   my $config_blobid = BSContar::blobid_entry($config_ent);
   # create layer data
-  my $config_data = { 
-    'mediaType' => $config_ent->{'mimetype'} || 'application/vnd.docker.container.image.v1+json',
+  my $config_data = {
+    'mediaType' => $config_ent->{'mimetype'} || ($oci ? $BSContar::mt_oci_config : $BSContar::mt_docker_config),
     'size' => $config_ent->{'size'},
     'digest' => $config_blobid,
-  }; 
+  };
   # upload to server
   blob_upload($config_blobid, $config_ent);
-  
+
   # process layers (compress if necessary)
   my %layer_datas;
   my @layer_data;
@@ -624,7 +624,7 @@ for my $tarfile (@tarfiles) {
 
     # create layer data
     my $layer_data = {
-      'mediaType' => $layer_ent->{'mimetype'} || 'application/vnd.docker.image.rootfs.diff.tar.gzip',
+      'mediaType' => $layer_ent->{'mimetype'} || ($oci ? $BSContar::mt_oci_layer_gzip : $BSContar::mt_docker_layer_gzip),
       'size' => $layer_ent->{'size'},
       'digest' => $blobid,
     };
@@ -636,7 +636,7 @@ for my $tarfile (@tarfiles) {
   }
   close $tarfd if $tarfd;
 
-  my $mediaType = $oci ? 'application/vnd.oci.image.manifest.v1+json' : 'application/vnd.docker.distribution.manifest.v2+json';
+  my $mediaType = $oci ? $BSContar::mt_oci_manifest : $BSContar::mt_docker_manifest;
   my $mani = {
     'schemaVersion' => 2,
     'mediaType' => $mediaType,
@@ -661,7 +661,7 @@ for my $tarfile (@tarfiles) {
 }
 
 if ($multiarch) {
-  my $mediaType = $oci ? 'application/vnd.oci.image.index.v1+json' : 'application/vnd.docker.distribution.manifest.list.v2+json';
+  my $mediaType = $oci ? $BSContar::mt_oci_index : $BSContar::mt_docker_manifestlist;
   my $mani = {
     'schemaVersion' => 2,
     'mediaType' => $mediaType,


### PR DESCRIPTION
Also use the oci mime types for the config/layers if
we're creating an oci manifest.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
