### PR TITLE
[api][backend] support an explicit marker to generate diffs from usin…

### DIFF
--- a/docs/api/api/obs.rng
+++ b/docs/api/api/obs.rng
@@ -110,6 +110,7 @@
       <value>manual</value>        <!-- only on manual commands the release gets started -->
  <!-- no yet supported <value>allsucceeded</value> -->  <!-- Release when the repository has finished building and all jobs were successfull -->
       <value>maintenance</value>   <!-- Release just once on maintenance release event. This attribute get removed at the same time -->
+      <value>obsgendiff</value>    <!-- Define the release target to generate the diff against -->
     </choice>
   </define>
 

--- a/src/api/app/controllers/request_controller.rb
+++ b/src/api/app/controllers/request_controller.rb
@@ -187,7 +187,7 @@ class RequestController < ApplicationController
         builder = Nokogiri::XML::Builder.new
         action.render_xml(builder)
         xml_request.add_child(builder.doc.root.to_xml)
-        xml_request.at_css('action').add_child(action_diff)
+        xml_request.at_xpath("//request/action[last()]").add_child(action_diff)
       else
         diff_text += action_diff
       end

--- a/src/api/app/controllers/request_controller.rb
+++ b/src/api/app/controllers/request_controller.rb
@@ -187,7 +187,7 @@ class RequestController < ApplicationController
         builder = Nokogiri::XML::Builder.new
         action.render_xml(builder)
         xml_request.add_child(builder.doc.root.to_xml)
-        xml_request.at_xpath("//request/action[last()]").add_child(action_diff)
+        xml_request.at_xpath('//request/action[last()]').add_child(action_diff)
       else
         diff_text += action_diff
       end

--- a/src/api/db/data_schema.rb
+++ b/src/api/db/data_schema.rb
@@ -1,2 +1,2 @@
 # encoding: UTF-8
-DataMigrate::Data.define(version: 20201112083506)
+DataMigrate::Data.define(version: 20201209105103)

--- a/src/api/db/migrate/20200831110429_obsgendiff_trigger.rb
+++ b/src/api/db/migrate/20200831110429_obsgendiff_trigger.rb
@@ -1,0 +1,9 @@
+class ObsgendiffTrigger < ActiveRecord::Migration[6.0]
+  def up
+    safety_assured { execute 'ALTER TABLE release_targets modify column `trigger` enum("manual","allsucceeded","maintenance","obsgendiff")' }
+  end
+
+  def down
+    safety_assured { execute 'ALTER TABLE release_targets modify column `trigger` enum("manual","allsucceeded","maintenance")' }
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_14_105103) do
+ActiveRecord::Schema.define(version: 2020_12_09_105103) do
 
   create_table "architectures", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false, collation: "utf8_general_ci"
@@ -833,7 +833,7 @@ ActiveRecord::Schema.define(version: 2020_10_14_105103) do
   create_table "release_targets", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "repository_id", null: false
     t.integer "target_repository_id", null: false
-    t.column "trigger", "enum('manual','allsucceeded','maintenance')", collation: "utf8_general_ci"
+    t.column "trigger", "enum('manual','allsucceeded','maintenance','obsgendiff')"
     t.index ["repository_id"], name: "repository_id_index"
     t.index ["target_repository_id"], name: "index_release_targets_on_target_repository_id"
   end

--- a/src/api/test/functional/maintenance_test.rb
+++ b/src/api/test/functional/maintenance_test.rb
@@ -510,6 +510,13 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     assert_xml_tag tag: 'old', attributes:  { package: 'pack2.linked' }
     assert_match(/-&lt;link package="pack2"/, @response.body)
     assert_match(/\+&lt;link package="pack2.ServicePack_Update"/, @response.body)
+    # two seperate sourcediffs in each action included
+    assert_xml_tag child: { tag: 'old', attributes: { project: 'ServicePack:Update', package: 'pack2' } },
+                   sibling: { tag: 'target', attributes: { project: 'ServicePack:Update', package: 'pack2.100' } },
+                   tag: 'sourcediff'
+    assert_xml_tag child: { tag: 'old', attributes: { project: 'ServicePack:Update', package: 'pack2.linked' } },
+                   sibling: { tag: 'target', attributes: { project: 'ServicePack:Update', package: 'pack2.linked.100' } },
+                   tag: 'sourcediff'
 
     # revoke to unlock the source
     post "/request/#{reqid}?cmd=changestate&newstate=revoked"

--- a/src/backend/BSSched/BuildJob.pm
+++ b/src/backend/BSSched/BuildJob.pm
@@ -1187,7 +1187,10 @@ sub create {
     $binfo->{'logidlelimit'} = $bconf->{'buildflags:logidlelimit'} if $bconf->{'buildflags:logidlelimit'};
     $binfo->{'genbuildreqs'} = $genbuildreqs->[0] if $genbuildreqs;
     if ($bconf->{'buildflags:obsgendiff'} && @{$ctx->{'repo'}->{'releasetarget'} || []}) {
-       my $releasetarget = $ctx->{'repo'}->{'releasetarget'}->[0];
+       # use the first obsgendiff marked release target or the first with any trigger one as fallback
+       my @gendifftargets = grep {$_->{'trigger'} && $_->{'trigger'} eq 'obsgendiff'} @{$ctx->{'repo'}->{'releasetarget'}};
+       my $releasetarget = @gendifftargets ? $gendifftargets[0] : $ctx->{'repo'}->{'releasetarget'}->[0];
+
        $binfo->{'obsgendiff'} = { 'project' => $releasetarget->{'project'},
                                   'repository' => $releasetarget->{'repository'} };
 

--- a/src/backend/BSXML.pm
+++ b/src/backend/BSXML.pm
@@ -266,6 +266,8 @@ our $patchinfo = [
 
 our $channel = [
     'channel' =>
+      [],
+      'disabled',
       [ 'product' =>
             'project',
             'name',


### PR DESCRIPTION
…g obsgendiff

release targets may have a trigger="obsgendiff" to specify the final
release area. This will be used as base to generate the diffs (aka
ChangeLogs) from.

The typical use case is a setup like

 Build Area => Candidate Area => Final Release Area

The Build Area would have a release target with trigger=manual pointing
to Candidate Area. And another release target pointing to Final Release
Area using trigger=obsgendiff

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
