### PR TITLE
Show confirmation dialog on status message delete

### DIFF
--- a/src/api/app/views/webui/main/_status_message.html.haml
+++ b/src/api/app/views/webui/main/_status_message.html.haml
@@ -9,7 +9,8 @@
         #{time_ago_in_words(status_message.created_at)} ago
       - if policy(status_message).destroy?
         .float-right
-          = link_to(status_message_path(status_message), method: :delete, title: 'Remove status message') do
+          = render(partial: 'webui/main/status_message_delete_dialog', locals: { status_message: status_message })
+          = link_to('#', data: { toggle: 'modal', target: "#delete-status-message-modal-#{status_message.id}" }, title: 'Delete status message') do
             %i.fas.fa-times-circle.text-danger
       .mt-2.mb-0
         = render_as_markdown(status_message.message)

--- a/src/api/app/views/webui/main/_status_message_delete_dialog.html.haml
+++ b/src/api/app/views/webui/main/_status_message_delete_dialog.html.haml
@@ -1,0 +1,16 @@
+.modal.fade{ id: "delete-status-message-modal-#{status_message.id}", tabindex: -1, role: 'dialog',
+             aria: { labelledby: 'delete-status-message-modal-label', hidden: true } }
+  .modal-dialog.modal-dialog-centered{ role: 'document' }
+    .modal-content
+      .modal-header
+        %h5.modal-title
+          Delete status message?
+      .modal-body
+        %p Please confirm deletion of status message
+
+        = form_tag(status_message_path(status_message), method: :delete, class: 'delete-status-message-form',
+                   data: { status_message_id: status_message.id }) do
+          .modal-footer
+            %a.btn.btn-sm.btn-outline-secondary.px-4{ data: { dismiss: 'modal' } }
+              Cancel
+            = submit_tag('Delete', class: 'btn btn-sm btn-danger px-4')


### PR DESCRIPTION
There were no confirmation while removing a status message. To prevent
accidental removing, all the destructive actions should contain a
confirmation.

The commit adds the appropriate modal dialog.

Fixes #10087

To verify this feature

1. Log in to local instance of OBS;
2. Create new status message (if there are no existing ones on the Home Page);
3. Click 'X' (Delete status message) icon for the status message.

Expected result:
"Delete status message?" confirmation dialog is shown. After clicking "Delete", the dialog should disappear, status message should be deleted.

Here is the screenshot of how it looks:
![delete_status_message](https://user-images.githubusercontent.com/37581072/91875629-0740ab80-ec7c-11ea-86ad-afa5d6bee016.png)

