### PR TITLE
[backend] implement limit_projects in a sane way

### DIFF
--- a/src/backend/BSXML.pm
+++ b/src/backend/BSXML.pm
@@ -301,6 +301,7 @@ our $projpack = [
 	    'name',
 	    'kind',
 	     [],
+	    'error',
 	    'title',
 	    'description',
 	    'config',

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -1030,17 +1030,20 @@ sub getprojpack {
       push @$projids, $projid;
     }
   }
+
+  my $limit_projids;
   if ($BSConfig::limit_projects && $BSConfig::limit_projects->{$arch}) {
     my $limit = $BSConfig::limit_projects->{$arch};
     if ($BSConfig::limit_projects_use_regex || $BSConfig::limit_projects_use_regex) {
+      $limit_projids = {};
       for my $projid (splice @$projids) {
-        push @$projids, $projid if grep {$projid =~ /^$_$/} @$limit;
+	$limit_projids->{$projid} = 1 if grep {$projid =~ /^$_$/} @$limit;
       }
     } else {
-      my %limit_projids = map {$_ => 1} @$limit;
-      $projids = [ grep {$limit_projids{$_}} @$projids ];
+      $limit_projids = { map {$_ => 1} @$limit };
     }
   }
+
   $repoids = { map {$_ => 1} @$repoids } if $repoids;
   $packids = { map {$_ => 1} @$packids } if $packids;
   my $bconf = Build::read_config($arch);
@@ -1090,6 +1093,9 @@ sub getprojpack {
       $jinfo->{$_} = $proj->{$_} if exists $proj->{$_};
     }
 
+    my $is_limited;
+    $is_limited = 1 if $limit_projids && !$limit_projids->{$projid};
+
     my %expandedrepos;
 
     if ($cgi->{'withrepos'}) {
@@ -1110,7 +1116,7 @@ sub getprojpack {
 	  $repo->{'path'} = \@prps;
 	  $repo->{'base'} = $base;
 	}
-      } elsif ($remotemap) {
+      } elsif ($remotemap && !$is_limited) {
 	# we always need the expanded search path with the configs so that
 	# we know about the publishfilter
 	for my $repo (@{$jinfo->{'repository'}}) {
@@ -1152,7 +1158,7 @@ sub getprojpack {
       }
     }
 
-    if ($remotemap) {
+    if ($remotemap && !$is_limited) {
       for my $lprojid (map {$_->{'project'}} @{$proj->{'link'} || []}) {
         my $lproj = BSSrcServer::Remote::remoteprojid($lprojid);
 	eval {
@@ -1184,7 +1190,7 @@ sub getprojpack {
       };
     }
     my @packages;
-    if ($cgi->{'nopackages'}) {
+    if ($cgi->{'nopackages'} || $is_limited) {
       @packages = ();
     } elsif ($proj->{'remoteurl'}) {
       @packages = @{$cgi->{'package'}} if $cgi->{'package'} && $cgi->{'parseremote'};
@@ -1255,6 +1261,10 @@ sub getprojpack {
       @packages = ();
     }
     @packages = () if $cgi->{'nopackages'};
+    if ($is_limited) {
+      @packages = ();
+      $jinfo->{'error'} = 'forbidden for this architecture';
+    }
     my @pinfo;
     my %bconfs;
 


### PR DESCRIPTION
The old implementation made projects not in the limit list
look like not existing projects leading to all kinds of
hard to debug issues.

We now return the project but with an error status.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
