### PR TITLE
[backend] repserver: also dirty repos for project/package events

### DIFF
--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -471,6 +471,8 @@ class BsRequestAction < ApplicationRecord
         results = pkg.project.build_results
         raise BuildNotFinished, "The project'#{pkg.project.name}' has no building repositories" unless results
 
+        found_patchinfo = check_patchinfo(pkg)
+
         versrel = {}
         results.each do |result|
           repo = result.attributes['repository']
@@ -494,7 +496,6 @@ class BsRequestAction < ApplicationRecord
             versrel[repo][package] ||= vrel
           end
         end
-        found_patchinfo = check_patchinfo(pkg)
       end
 
       # re-route (for the kgraft case building against GM or former incident)

--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -2692,9 +2692,11 @@ sub forwardevent {
     # those events stack - we must not overwrite them. randomize somewhat.
     $evname = "type:::$$-".Digest::MD5::md5_hex("$$/$evname".time());
   }
-  mkdir_p("$eventdir/$arch") if $arch;
   if ($arch) {
-    dirty($projid, $repoid, $arch) unless !defined($repoid) || $arch eq 'dispatch' || $arch eq 'publish';
+    mkdir_p("$eventdir/$arch");
+    if ($arch ne 'dispatch' && $arch ne 'publish') {
+      dirty($projid, $repoid, $arch) if defined($repoid) || $type eq 'project' || $type eq 'package';
+    }
     writexml("$eventdir/$arch/.$evname.$$", "$eventdir/$arch/$evname", $ev, $BSXML::event);
     BSUtil::ping("$eventdir/$arch/.ping");
   } else {
@@ -2711,7 +2713,7 @@ sub forwardevent {
     for my $a (@archs) {
       eval {
         mkdir_p("$eventdir/$a");
-        dirty($projid, $repoid, $a) if defined $repoid;
+        dirty($projid, $repoid, $a) if defined($repoid) || $type eq 'project' || $type eq 'package';
         writexml("$eventdir/$a/.$evname.$$", "$eventdir/$a/$evname", $ev, $BSXML::event);
         BSUtil::ping("$eventdir/$a/.ping");
       };


### PR DESCRIPTION
<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
