### PR TITLE
Auto-correct RuboCop Performance cops offenses for `src/api/`

### DIFF
--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -593,12 +593,6 @@ Performance/StringInclude:
     - 'test/functional/webui/spider_test.rb'
     - 'test/functional/zzz_post_consistency_test.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-Performance/StringReplacement:
-  Exclude:
-    - 'app/controllers/webui/monitor_controller.rb'
-
 # Offense count: 61
 RSpec/AnyInstance:
   Exclude:

--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -564,14 +564,6 @@ Performance/InefficientHashSearch:
   Exclude:
     - 'app/models/user.rb'
 
-# Offense count: 2
-# Cop supports --auto-correct.
-# Configuration parameters: MaxKeyValuePairs.
-Performance/RedundantMerge:
-  Exclude:
-    - 'app/helpers/webui/notification_helper.rb'
-    - 'app/views/staging/staging_projects/_staging_project_item.xml.builder'
-
 # Offense count: 41
 # Cop supports --auto-correct.
 Performance/RegexpMatch:

--- a/src/api/app/controllers/webui/monitor_controller.rb
+++ b/src/api/app/controllers/webui/monitor_controller.rb
@@ -24,7 +24,7 @@ class Webui::MonitorController < Webui::WebuiController
         end
       end
       workers_list.each do |bid, barch|
-        hostname, subid = bid.gsub(/:/, '/').split('/')
+        hostname, subid = bid.tr(':', '/').split('/')
         id = bid.gsub(%r{[:./]}, '_')
         workers[hostname] ||= {}
         workers[hostname]['_arch'] = barch

--- a/src/api/app/helpers/webui/notification_helper.rb
+++ b/src/api/app/helpers/webui/notification_helper.rb
@@ -4,7 +4,7 @@ module Webui::NotificationHelper
     if params['show_all'] # already showing all
       link_to('Show less', my_notifications_path(parameters), class: 'btn btn-sm btn-secondary ml-2')
     else
-      parameters.merge!({ show_all: 1 })
+      parameters[:show_all] = 1
       link_to('Show all', my_notifications_path(parameters), class: 'btn btn-sm btn-secondary ml-2')
     end
   end

--- a/src/api/app/views/staging/staging_projects/_staging_project_item.xml.builder
+++ b/src/api/app/views/staging/staging_projects/_staging_project_item.xml.builder
@@ -1,5 +1,5 @@
 attributes = { name: staging_project.name }
-attributes.merge!(state: staging_project.overall_state) if options[:status]
+attributes[:state] = staging_project.overall_state if options[:status]
 
 builder.staging_project(attributes) do
   if options[:requests]


### PR DESCRIPTION
Auto-correct only those RuboCop Performance cops that are marked as safe auto-correct.

Follow-up to #10120.

