### PR TITLE
Use update project on request delegation

### DIFF
--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -738,7 +738,7 @@ class BsRequestAction < ApplicationRecord
                                            { follow_project_links: true,
                                              follow_multibuild: true,
                                              check_update_project: true })
-    self.target_project = tpkg.project.name
+    self.target_project = tpkg.project.update_instance.name
   end
 
   def source_access_check!

--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -825,9 +825,12 @@ class BsRequestAction < ApplicationRecord
       # skip excluded patchinfos
       status = pkg.project.project_state.search("/resultlist/result[@repository='#{repo.name}' and @arch='#{firstarch.name}']").first
 
-      next if status && (s = status.search("status[@package='#{pkg.name}']").first) && s.attributes['code'].value == 'excluded'
+      if status
+        s = status.search("status[@package='#{pkg.name}']").first
+        next if s && s.attributes['code'].value == 'excluded'
 
-      raise BuildNotFinished, "patchinfo #{pkg.name} is broken" if s.attributes['code'].value == 'broken'
+        raise BuildNotFinished, "patchinfo #{pkg.name} is broken" if s && s.attributes['code'].value == 'broken'
+      end
 
       check_maintenance_release(pkg, repo, firstarch)
       true

--- a/src/api/test/functional/build_controller_test.rb
+++ b/src/api/test/functional/build_controller_test.rb
@@ -89,6 +89,11 @@ class BuildControllerTest < ActionDispatch::IntegrationTest
     assert_response 404
     get '/build/home:Iggy/10.2/i586/TestPack/package-1.0-1.i586.rpm'
     assert_response :success
+    get '/source/home:Iggy/TestPack/_meta'
+    assert_response :success
+    assert_xml_tag parent: { tag: 'build' }, tag: 'enable', attributes: { arch: 'i586', repository: '10.2' }
+    # ensure that current state got written
+    run_scheduler('i586')
     get '/build/home:Iggy/10.2/i586/TestPack/_status'
     assert_response :success
     assert_xml_tag tag: 'status', attributes: { package: 'TestPack', code: 'succeeded' }

--- a/src/api/test/unit/bs_request_test.rb
+++ b/src/api/test/unit/bs_request_test.rb
@@ -141,10 +141,13 @@ class BsRequestTest < ActiveSupport::TestCase
   end
 
   def test_if_delegate_works
+    # ensure that update project lacks the package to cover update_instance delegation as well
+    assert Package.find_by_project_and_name('BaseDistro:Update', 'pack1').nil?
+
     xml = '<request>
               <action type="submit">
                 <source project="BaseDistro3" package="pack2"/>
-                <target project="BaseDistro:SP1"/>
+                <target project="BaseDistro:SP1" package="pack1"/>
               </action>
               <state name="new" />
           </request>'


### PR DESCRIPTION
<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
