### PR TITLE
Edit comments feature

### DIFF
--- a/src/api/app/assets/javascripts/webui/comment.js
+++ b/src/api/app/assets/javascripts/webui/comment.js
@@ -19,11 +19,17 @@ $(document).ready(function(){
     resizeTextarea(this);
   });
 
-  $('.comments-list').on('ajax:complete', '.new-comment-form', function(_, data) {
+  $('.comments-list').on('ajax:complete', '.post-comment-form', function(_, data) {
     var $commentsList = $(this).closest('.comments-list');
 
     $commentsList.html(data.responseText);
     updateCommentCounter($commentsList.data('comment-counter'), 1);
+  });
+
+  $('.comments-list').on('ajax:complete', '.put-comment-form', function(_, data) {
+    var $commentsList = $(this).closest('.comments-list');
+
+    $commentsList.html(data.responseText);
   });
 
   $('.comments-list').on('ajax:complete', '.delete-comment-form', function(_, data) {
@@ -37,5 +43,17 @@ $(document).ready(function(){
       updateCommentCounter($commentsList.data('comment-counter'), -1);
       $commentsList.html(data.responseText);
     });
+  });
+
+  $('body').on('click', 'button[id*="edit_button_of_"]', function (e) {
+    var closest = $(e.target).parent().parent().find('button[id*="reply_button_of_"]');
+    if (!closest.hasClass('collapsed'))
+      closest.trigger('click');
+  });
+
+  $('body').on('click', 'button[id*="reply_button_of_"]', function (e) {
+    var closest = $(e.target).parent().parent().find('button[id*="edit_button_of_"]');
+    if (!closest.hasClass('collapsed'))
+      closest.trigger('click');
   });
 });

--- a/src/api/app/controllers/webui/comments_controller.rb
+++ b/src/api/app/controllers/webui/comments_controller.rb
@@ -32,6 +32,28 @@ class Webui::CommentsController < Webui::WebuiController
     render(partial: 'webui/comment/comment_list', locals: { commentable: @commentable }, status: status)
   end
 
+  def update
+    comment = Comment.find(params[:id])
+    authorize comment, :update?
+    comment.assign_attributes(permitted_params)
+
+    status = if comment.save
+               flash.now[:success] = 'Comment updated successfully.'
+               :ok
+             else
+               flash.now[:error] = "Failed to update comment: #{comment.errors.full_messages.to_sentence}."
+               :unprocessable_entity
+             end
+
+    respond_to do |format|
+      format.html do
+        render(partial: 'webui/comment/comment_list',
+               locals: { commentable: comment.commentable },
+               status: status)
+      end
+    end
+  end
+
   private
 
   def permitted_params

--- a/src/api/app/policies/comment_policy.rb
+++ b/src/api/app/policies/comment_policy.rb
@@ -20,4 +20,10 @@ class CommentPolicy < ApplicationPolicy
       record.commentable.is_target_maintainer?(user)
     end
   end
+
+  def update?
+    return false if user.blank? || user.is_nobody?
+
+    user == record.user
+  end
 end

--- a/src/api/app/views/webui/comment/_comment_field.html.haml
+++ b/src/api/app/views/webui/comment/_comment_field.html.haml
@@ -1,7 +1,11 @@
-= form_for(comment, action: 'create', method: :post, remote: true, html: { class: 'new-comment-form' }) do |f|
+= form_for(comment, method: form_method, remote: true, html: { class: "#{form_method}-comment-form" }) do |f|
   = hidden_field_tag :commentable_type, commentable.class.name
   = hidden_field_tag :commentable_id, commentable.id
   = f.hidden_field :parent_id, value: comment.parent_id
-  ~ f.text_area :body, rows: '4', placeholder: 'Add a new comment (markdown markup supported)', required: true,
+  ~ f.text_area :body, rows: '4', placeholder: 'Write your comment here... (Markdown markup is supported)', required: true,
     class: 'w-100 mb-3 form-control comment-field'
-  = f.submit 'Add comment', class: 'btn btn-primary', data: { disable_with: 'Creating comment...' }
+  - case form_method
+  - when :post
+    = f.submit 'Add comment', class: 'btn btn-primary', data: { disable_with: 'Creating comment...' }
+  - when :put
+    = f.submit 'Update comment', class: 'btn btn-primary', data: { disable_with: 'Updating comment...' }

--- a/src/api/app/views/webui/comment/_new.html.haml
+++ b/src/api/app/views/webui/comment/_new.html.haml
@@ -7,4 +7,5 @@
       = link_to('signup', new_user_url)
     in order to comment
 - else
-  = render(partial: 'webui/comment/comment_field', locals: { comment: Comment.new, commentable: commentable })
+  = render(partial: 'webui/comment/comment_field',
+   locals: { form_method: :post, comment: Comment.new, commentable: commentable })

--- a/src/api/app/views/webui/comment/_reply.html.haml
+++ b/src/api/app/views/webui/comment/_reply.html.haml
@@ -1,8 +1,14 @@
 %ul.list-inline
   - if User.session
     %li.list-inline-item
-      %button.btn.btn-outline-secondary{ data: { toggle: 'collapse', target: "#reply_form_of_#{comment.id}" } }
+      %button.btn.btn-outline-success.collapsed{ id: "reply_button_of_#{comment.id}",
+      data: { toggle: 'collapse', target: "#reply_form_of_#{comment.id}" } }
         Reply
+    - if policy(comment).update?
+      %li.list-inline-item
+        %button.btn.btn-outline-secondary.collapsed{ id: "edit_button_of_#{comment.id}",
+         data: { toggle: 'collapse', target: "#edit_form_of_#{comment.id}" } }
+          Edit
   - if policy(comment).destroy?
     %li.list-inline-item
       = render(partial: 'webui/comment/delete_dialog', locals: { comment: comment })
@@ -11,4 +17,9 @@
         Delete
 - if User.session
   .collapse{ id: "reply_form_of_#{comment.id}" }
-    = render(partial: 'webui/comment/comment_field', locals: { comment: comment.children.new, commentable: commentable })
+    = render(partial: 'webui/comment/comment_field', locals: { form_method: :post,
+     comment: comment.children.new, commentable: commentable })
+  - if policy(comment).update?
+    .collapse{ id: "edit_form_of_#{comment.id}" }
+      = render(partial: 'webui/comment/comment_field', locals: { form_method: :put,
+       comment: comment, commentable: commentable })

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -352,7 +352,7 @@ OBSApi::Application.routes.draw do
       resources :user, only: [:create, :destroy, :update], constraints: cons, param: :user_login, controller: 'webui/groups/users'
     end
 
-    resources :comments, constraints: cons, only: [:create, :destroy], controller: 'webui/comments'
+    resources :comments, constraints: cons, only: [:create, :destroy, :update], controller: 'webui/comments'
 
     ### /apidocs
     get 'apidocs', to: redirect('/apidocs/index')

--- a/src/api/spec/controllers/webui/comments_controller_spec.rb
+++ b/src/api/spec/controllers/webui/comments_controller_spec.rb
@@ -106,4 +106,95 @@ RSpec.describe Webui::CommentsController, type: :controller do
       it { expect(Comment.where(id: other_comment.id)).to eq([]) }
     end
   end
+
+  describe 'EDIT update' do
+    let(:project) { create(:project) }
+    let(:package) { create(:package, project: project) }
+    let(:bs_request) { create(:set_bugowner_request) }
+    let(:admin_user) { create(:admin_user, login: 'Admin') }
+    let(:comment) { create(:comment_project, user: user) }
+    let(:other_comment) { create(:comment_project) }
+
+    context 'with invalid commentable_type' do
+      let(:comment_params) do
+        { comment: { body: 'This is AWESOME!' }, commentable_type: 'FOOBAR', commentable_id: 31_337 }
+      end
+
+      subject { post :create, params: comment_params }
+
+      it { expect(subject.request.flash[:success]).to be_nil }
+      it { expect(subject.request.flash[:error]).not_to(be_nil) }
+      it { expect(subject).to redirect_to(root_path) }
+    end
+
+    context 'with a valid comment' do
+      RSpec.shared_examples 'updating a comment' do
+        before do
+          params = { id: comment.id, comment: { body: "This #{commentable.model_name.singular} is AWFUL!" } }
+          put :update, params: params
+        end
+
+        it { expect(flash[:success]).to eq('Comment updated successfully.') }
+        it { expect(comment.reload.body).to eq("This #{commentable.model_name.singular} is AWFUL!") }
+      end
+
+      context 'only Http requests' do
+        let(:commentable) { project }
+
+        let(:params) do
+          { id: comment.id, comment: { body: "This #{commentable.model_name.singular} is AWFUL!" } }
+        end
+
+        it 'responds to html requests' do
+          put :update, params: params, format: :html
+          expect(response.header['Content-Type']).to include 'text/html'
+        end
+
+        it 'does not respond to other json requests' do
+          expect { put :update, params: params, format: :json }.to raise_error(ActionController::UnknownFormat)
+        end
+
+        it 'does not respond to xml requests' do
+          expect { put :update, params: params, format: :xml }.to raise_error(ActionController::UnknownFormat)
+        end
+      end
+
+      context 'of a project' do
+        let(:commentable) { project }
+
+        include_examples 'updating a comment'
+      end
+
+      context 'of a package' do
+        let(:commentable) { package }
+
+        include_examples 'updating a comment'
+      end
+
+      context 'of a bs_request' do
+        let(:commentable) { bs_request }
+
+        include_examples 'updating a comment'
+      end
+    end
+
+    context 'updating a comment without body' do
+      let(:commentable) { package }
+
+      before do
+        params = { id: comment.id, comment: { body: '' },
+                   commentable_type: commentable.class, commentable_id: commentable.id }
+        put :update, params: params
+      end
+
+      it { expect(flash[:error]).to eq("Failed to update comment: Body can't be blank.") }
+    end
+
+    context "does not allow to overwrite the comment's user" do
+      it 'raises an error' do
+        params = { id: comment.id, comment: { body: 'This project is AWESOME!', user_id: user }, commentable_type: project.class, commentable_id: project.id }
+        expect { put :update, params: params }.to raise_error(ActionController::UnpermittedParameters)
+      end
+    end
+  end
 end

--- a/src/api/spec/features/beta/webui/comments_spec.rb
+++ b/src/api/spec/features/beta/webui/comments_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Comments', type: :feature, js: true do
 
     click_button('Reply')
     within('.media') do
-      fill_in(placeholder: 'Add a new comment (markdown markup supported)', with: 'Reply Body')
+      fill_in(placeholder: 'Write your comment here... (Markdown markup is supported)', with: 'Reply Body')
       click_button('Add comment')
     end
 

--- a/src/api/spec/features/webui/comments_spec.rb
+++ b/src/api/spec/features/webui/comments_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Comments', type: :feature, js: true do
 
     click_button('Reply')
     within('.media') do
-      fill_in(placeholder: 'Add a new comment (markdown markup supported)', with: 'Reply Body')
+      fill_in(placeholder: 'Write your comment here... (Markdown markup is supported)', with: 'Reply Body')
       click_button('Add comment')
     end
 

--- a/src/api/spec/policies/comment_policy_spec.rb
+++ b/src/api/spec/policies/comment_policy_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe CommentPolicy do
 
   subject { CommentPolicy }
 
+  # rubocop:disable RSpec/RepeatedExample
+  # This cop is currently not recognizing the permissions block as separate test
   permissions :destroy? do
     it 'Not logged users cannot destroy comments' do
       expect(subject).not_to permit(nil, comment)
@@ -36,6 +38,7 @@ RSpec.describe CommentPolicy do
     it 'User cannot destroy comments of other user' do
       expect(subject).not_to permit(user, comment)
     end
+    # rubocop:enable RSpec/RepeatedExample
 
     context 'with a comment of a Package' do
       before do
@@ -67,4 +70,39 @@ RSpec.describe CommentPolicy do
       it { expect(subject).not_to permit(other_user, comment_on_request) }
     end
   end
+
+  # rubocop:disable RSpec/RepeatedExample
+  # This cop is currently not recognizing the permissions block as separate test
+  permissions :update? do
+    it 'an anonymous user cannot update comments' do
+      expect(subject).not_to permit(nil, comment)
+    end
+
+    it 'an admin user cannot update other comments' do
+      expect(subject).not_to permit(admin_user, comment)
+    end
+
+    it 'a user can update his own comments' do
+      expect(subject).to permit(comment_author, comment)
+    end
+
+    it 'a user cannot update comments of other users' do
+      expect(subject).not_to permit(other_user, comment)
+    end
+
+    context 'with an anonymous user comment' do
+      it 'a normal user is unable to update an anonymous user comment' do
+        expect(subject).not_to permit(other_user, comment_deleted_user)
+      end
+
+      it 'an admin user is unable to update an anonymous user comment' do
+        expect(subject).not_to permit(admin_user, comment_deleted_user)
+      end
+
+      it 'an anonymous user is unable to update an anonymous user comment' do
+        expect(subject).not_to permit(anonymous_user, comment_deleted_user)
+      end
+    end
+  end
+  # rubocop:enable RSpec/RepeatedExample
 end


### PR DESCRIPTION
# Description
Hey everyone,

This Pull Request enables users to edit their comments on the webui namespace,  __not__ the api one.
The issue being addressed is #6674.

__NOTE:__ I know that the initial commit is a bit large, sorry for this :-(.

# Verify Feature
To verify the feature:

- Open a package, project, or any other commentable entity in the project
- If you have already made comments then you will see an __edit__ button now available on your comments
- Else add a comment and you will see the __edit__ button available on the comment that you made
- Click the edit button, a text area containing the previous comment should appear
- Edit the comment and click on the __Update comment__ button
- You should be able to see the new comment now

# Screenshots

## Edit Button Appearance
![Editable Comments](https://user-images.githubusercontent.com/407006/93140758-a8534b80-f6eb-11ea-97ba-f97c8b15640b.png)

## Editing Textarea
![Edited Comment Textarea](https://user-images.githubusercontent.com/407006/93140073-80afb380-f6ea-11ea-8d87-b4f1b78b84d3.png)

## Updated Comment
![Updated Comment](https://user-images.githubusercontent.com/407006/93137315-ed747f00-f6e5-11ea-80a3-2626649f58ad.png)
