### PR TITLE
Hide Projects filter when it is empty

### DIFF
--- a/src/api/app/views/webui/users/notifications/_notifications_filter.html.haml
+++ b/src/api/app/views/webui/users/notifications/_notifications_filter.html.haml
@@ -5,7 +5,8 @@
   %h5.ml-3 Filter
   = filter_notification_link('Comments', filter.count['Comment'], { type: 'comments' }, filter.selected_filter)
   = filter_notification_link('Requests', filter.count['BsRequest'], { type: 'requests' }, filter.selected_filter)
-.row.list-group-flush.mt-5
-  %h5.ml-3 Projects
-  - filter.projects_for_filter.each_pair do |project_name, amount|
-    = filter_notification_link(project_name, amount, { project: project_name }, filter.selected_filter)
+- unless filter.projects_for_filter.empty?
+  .row.list-group-flush.mt-5
+    %h5.ml-3 Projects
+    - filter.projects_for_filter.each_pair do |project_name, amount|
+      = filter_notification_link(project_name, amount, { project: project_name }, filter.selected_filter)


### PR DESCRIPTION
Projects filter title was shown even if there were no unread
notifications. That was confusing.

The commit adds the behavior to hide the filter when there are no unread
notifications.

Fixes #9461

To verify the feature:
1. Generate notifications:
   - SSH into running _frontend_ container;
   - Execute `bundle exec rake ts:start`;
   - Then run `bundle exec rake dev:notifications:data[2]`.
2. Log in to the application;
3. Go to Notifications Page (e.g. click on the bell in the top-right or proceed by the link: http://localhost:3000/my/notifications);
4. Focus on the Projects filter, it should show several projects, as there are unread notifications;
5. Mark all the notifications as "Read";
6. Focus on the Projects fitler.

Expected result:
Projects filter disappears when there are no unread notifications. It will also appear if mark any notification as "Unread" again.

| Before | After |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/37581072/93569734-40725e80-f992-11ea-9184-1c509d557a0d.png) | ![after](https://user-images.githubusercontent.com/37581072/93570338-271de200-f993-11ea-81b7-5409fa8d9774.png)|
