### PR TITLE
Fix pagination links after marking a notification as read

### DIFF
--- a/src/api/app/views/webui/users/notifications/_notifications_list.html.haml
+++ b/src/api/app/views/webui/users/notifications/_notifications_list.html.haml
@@ -41,4 +41,4 @@
               = render partial: 'notification_avatars', locals: { avatar_objects: notification.avatar_objects }
               %span.d-inline-block.text-nowrap.ml-2 #{time_ago_in_words(notification.created_at)} ago
 
-      = paginate notifications, views_prefix: 'webui', window: 2
+      = paginate notifications, views_prefix: 'webui', window: 2, params: { action: 'index', id: nil }


### PR DESCRIPTION
After marking a notification as read, the pagination links point to the update URL. This commit makes sure that the pagination links always create notification index links.

Fixes #10171.