### PR TITLE
Marking a notification as read: couple of fixes

### DIFF
--- a/src/api/app/controllers/webui/users/notifications_controller.rb
+++ b/src/api/app/controllers/webui/users/notifications_controller.rb
@@ -79,6 +79,7 @@ class Webui::Users::NotificationsController < Webui::WebuiController
                     else
                       NotificationsFinder.new(notifications_for_subscribed_user).for_notifiable_type(params[:type])
                     end
+    params[:page] = notifications.page(params[:page]).total_pages if notifications.page(params[:page]).out_of_range?
     params[:show_all] ? show_all(notifications) : notifications.page(params[:page])
   end
 

--- a/src/api/app/controllers/webui/users/notifications_controller.rb
+++ b/src/api/app/controllers/webui/users/notifications_controller.rb
@@ -79,7 +79,7 @@ class Webui::Users::NotificationsController < Webui::WebuiController
                     else
                       NotificationsFinder.new(notifications_for_subscribed_user).for_notifiable_type(params[:type])
                     end
-    params['show_all'] ? show_all(notifications) : notifications.page(params[:page])
+    params[:show_all] ? show_all(notifications) : notifications.page(params[:page])
   end
 
   def notifications_filter

--- a/src/api/app/helpers/webui/notification_helper.rb
+++ b/src/api/app/helpers/webui/notification_helper.rb
@@ -1,6 +1,6 @@
 module Webui::NotificationHelper
   def link_to_all
-    parameters = params.slice(:show_all, :type, :project, :page).permit!
+    parameters = params.slice(:show_all, :type, :project).permit!
     all_or_less = parameters[:show_all] ? 'less' : 'all'
     parameters[:show_all] = parameters[:show_all] ? nil : '1'
     link_to("Show #{all_or_less}", my_notifications_path(parameters), class: 'btn btn-sm btn-secondary ml-2')

--- a/src/api/app/views/webui/users/notifications/_notifications_list.html.haml
+++ b/src/api/app/views/webui/users/notifications/_notifications_list.html.haml
@@ -12,7 +12,7 @@
     - else
       .text-center
         %span.ml-3= page_entries_info notifications, entry_name: 'notification'
-        = link_to_all unless notifications.total_pages == 1 && params['show_all'].nil?
+        = link_to_all unless notifications.total_pages == 1 && params[:show_all].nil?
 
       .list-group.list-group-flush.mt-3
         - notifications.each do |n|
@@ -29,7 +29,8 @@
                 = link_to(notification.notifiable_link[:text], notification.notifiable_link[:path], class: 'mx-1 text-word-break-all')
             .actions.ml-auto.align-self-end.align-self-md-start
               - title, icon = notification.unread? ? ['Mark as "Read"', 'fa-check'] : ['Mark as "Unread"', 'fa-undo']
-              - update_path = my_notification_path(id: notification, type: selected_filter[:type], project: selected_filter[:project])
+              - update_path = my_notification_path(id: notification, type: selected_filter[:type], project: selected_filter[:project],
+                page: params[:page], show_all: params[:show_all])
               = link_to(update_path, id: format('update-notification-%d', notification.id),
                         method: :put, class: 'btn btn-sm btn-outline-success px-3', title: title, remote: true) do
                 %i.fas{ class: "#{icon}" }


### PR DESCRIPTION
Preserve `page` and `show_all` parameters after marking a notification as read. Fixes #10173 and fixes #10181.

Also related, take the user to the last pagination page, when the only notification of the last page is marked as read. Reported  in [#10173](https://github.com/openSUSE/open-build-service/issues/10173#issuecomment-696027112).

And last, after clicking in a page of several notifications (not the first page), and then clicking on the "Show all" button, show the first page of all the results. It makes no sense to preserve the `page` paramenter in the "Show all"/"Show less" button link.

I will setup a lot of notifications on the review-app instance, to make it easier to do a review.