### PR TITLE
Render flash message now in notifications#update

### DIFF
--- a/src/api/app/controllers/webui/users/notifications_controller.rb
+++ b/src/api/app/controllers/webui/users/notifications_controller.rb
@@ -17,9 +17,9 @@ class Webui::Users::NotificationsController < Webui::WebuiController
     authorize notification, policy_class: NotificationPolicy
 
     if notification.toggle(:delivered).save
-      flash[:success] = "Successfully marked the notification as #{notification.unread? ? 'unread' : 'read'}"
+      flash.now[:success] = "Successfully marked the notification as #{notification.unread? ? 'unread' : 'read'}"
     else
-      flash[:error] = "Couldn't mark the notification as #{notification.unread? ? 'read' : 'unread'}"
+      flash.now[:error] = "Couldn't mark the notification as #{notification.unread? ? 'read' : 'unread'}"
     end
 
     respond_to do |format|


### PR DESCRIPTION
Using `flash[:some_key]` will keep the flash for the next request, so this means that when we set the flash in an action called through an AJAX request, the flash will still be displayed when we reload the page.