### PR TITLE
Add ability to mark multiple notifications as read/unread

### DIFF
--- a/src/api/app/assets/javascripts/webui/application.js
+++ b/src/api/app/assets/javascripts/webui/application.js
@@ -52,3 +52,4 @@
 //= require webui/kiwi_editor.js
 //= require webui/monitor.js
 //= require webui/responsive_ux
+//= require webui/notification.js

--- a/src/api/app/assets/javascripts/webui/notification.js
+++ b/src/api/app/assets/javascripts/webui/notification.js
@@ -1,0 +1,32 @@
+function setSelectAllCheckbox() {
+  $('#select-all-notifications').change(function() {
+    var checkboxes = $(this).closest('form').find('input[type=checkbox]');
+    checkboxes.prop('checked', $(this).is(':checked'));
+  });
+}
+
+function setCheckboxCounterAndSubmitButton() {
+  var amountBoxesChecked = 0;
+  $("input[id^='notification_ids_']").each(function() {
+    if($(this).is(':checked')){
+      amountBoxesChecked += 1;
+    }
+  });
+
+  if(amountBoxesChecked <= 0) {
+    $('#done-button').addClass('disabled');
+    $('#select-all-label').text('Select all');
+  } else {
+    $('#done-button').removeClass('disabled');
+    $('#select-all-label').text(amountBoxesChecked + ' selected');
+  }
+}
+
+function handleNotificationCheckboxSelection() { // jshint ignore:line
+  setCheckboxCounterAndSubmitButton();
+  setSelectAllCheckbox();
+  $('input[type="checkbox"]').change(function() {
+    setCheckboxCounterAndSubmitButton();
+  });
+}
+

--- a/src/api/app/assets/stylesheets/webui/notifications_redesign/notifications.scss
+++ b/src/api/app/assets/stylesheets/webui/notifications_redesign/notifications.scss
@@ -1,5 +1,6 @@
 // TODO: As soon as notifications_redesign feature is 100% rolled out,
 // all the 'body.notifications-redesign' wrappers can be removed.
+$notifications-filter-box-height: 3.5rem;
 
 body.notifications-redesign  {
   .avatars-counter, .simulated-avatar {
@@ -26,6 +27,9 @@ body.notifications-redesign  {
       &.show { border-top: 1px solid $gray-300;}
     }
   }
+  #notification-action-bar {
+    &.sticky-top { top: $top-navigation-height; }
+  }
 }
 
 @include media-breakpoint-up(md) {
@@ -41,12 +45,19 @@ body.notifications-redesign  {
     #notifications-filter-desktop {
       &.show { border-top: 1px solid $gray-300; }
       &.sticky-top { top: $top-navigation-height; }
+      height: $notifications-filter-box-height;
+      // To not overlap with the notification action bar
+      z-index: calc(#{$zindex-sticky} + 1);
+
       #filters {
         max-height: 100vw; overflow: auto;
         -webkit-box-shadow: 2px 3px 5px rgba(0,0,0,.2);
         -moz-box-shadow: 2px 3px 5px rgba(0,0,0,.2);
         box-shadow: 2px 3px 5px rgba(0,0,0,.2);
       }
+    }
+    #notification-action-bar {
+      &.sticky-top { top: calc(#{$top-navigation-height} + #{$notifications-filter-box-height}); }
     }
   }
 

--- a/src/api/app/helpers/webui/notification_helper.rb
+++ b/src/api/app/helpers/webui/notification_helper.rb
@@ -3,7 +3,7 @@ module Webui::NotificationHelper
     parameters = params.slice(:show_all, :type, :project).permit!
     all_or_less = parameters[:show_all] ? 'less' : 'all'
     parameters[:show_all] = parameters[:show_all] ? nil : '1'
-    link_to("Show #{all_or_less}", my_notifications_path(parameters), class: 'btn btn-sm btn-secondary ml-2')
+    link_to("Show #{all_or_less}", my_notifications_path(parameters))
   end
 
   def filter_notification_link(link_text, amount, filter_item, selected_filter)

--- a/src/api/app/helpers/webui/notification_helper.rb
+++ b/src/api/app/helpers/webui/notification_helper.rb
@@ -73,7 +73,7 @@ module Webui::NotificationHelper
   end
 
   def mark_as_read_or_unread_button(notification)
-    update_path = my_notification_path(id: notification.id)
+    update_path = my_notifications_path(notification_ids: [notification.id])
     title, icon = notification.unread? ? ['Mark as read', 'fa-check'] : ['Mark as unread', 'fa-undo']
     link_to(update_path, id: "update-notification-#{notification.id}", method: :put,
                          class: 'btn btn-sm btn-outline-success', title: title) do

--- a/src/api/app/policies/notification_policy.rb
+++ b/src/api/app/policies/notification_policy.rb
@@ -1,6 +1,7 @@
 class NotificationPolicy < ApplicationPolicy
-  def update?
-    return true if record.subscriber_type == 'User' && record.subscriber_id == user.id
-    return true if record.subscriber_type == 'Group' && record.subscriber_id.include?(user.groups.ids)
+  class Scope < Scope
+    def resolve
+      NotificationsFinder.new(scope).for_subscribed_user(user)
+    end
   end
 end

--- a/src/api/app/views/webui/users/notifications/_notification_action_bar.html.haml
+++ b/src/api/app/views/webui/users/notifications/_notification_action_bar.html.haml
@@ -1,0 +1,10 @@
+.card.sticky-top#notification-action-bar
+  .card-body.py-3
+    .row.px-0.px-md-1
+      .col
+        .custom-control.custom-checkbox
+          = check_box_tag('select-all-notifications', 1, false, class: 'custom-control-input')
+          %label.custom-control-label.align-middle.mr-4#select-all-label{ for: 'select-all-notifications' } Select All
+          - button_text = type == 'read' ? "Mark as 'Unread'" : "Mark as 'Read'"
+          = button_tag(type: 'submit', class: 'btn btn-sm btn-outline-success px-3 disabled', id: 'done-button') do
+            = button_text

--- a/src/api/app/views/webui/users/notifications/_notifications_list.html.haml
+++ b/src/api/app/views/webui/users/notifications/_notifications_list.html.haml
@@ -1,6 +1,6 @@
-.card
-  .card-body
-    - if notifications.empty?
+- if notifications.empty?
+  .card
+    .card-body
       %p
         - case selected_filter[:type]
         - when 'reviews', 'comments', 'requests'
@@ -9,40 +9,56 @@
           Mark notifications as "Read" and they'll appear here
         - else
           There are no notifications, but there's a world of opportunities!
-    - else
-      .text-center
-        %span.ml-3= page_entries_info notifications, entry_name: 'notification'
-        = link_to_all unless notifications.total_pages == 1 && params[:show_all].nil?
+- else
+  - update_path = my_notifications_path(type: selected_filter[:type], project: selected_filter[:project],
+                                       page: params[:page], show_all: params[:show_all])
+  = form_tag(update_path, method: :put, remote: true) do
+    = render partial: 'notification_action_bar', locals: { type: selected_filter[:type] }
+    .card
+      .card-body
+        .text-center
+          %span.ml-3= page_entries_info notifications, entry_name: 'notification'
+          = link_to_all unless notifications.total_pages == 1 && params['show_all'].nil?
+        .list-group.list-group-flush.mt-3
+          - notifications.each do |n|
+            - notification = NotificationPresenter.new(n)
+            .list-group-item.px-0.px-md-1.py-3
+              .row
+                .col-auto.pr-0
+                  .custom-control.custom-checkbox
+                    = check_box_tag('notification_ids[]', notification.id, false,
+                                    id: "notification_ids_#{notification.id}", class: 'custom-control-input')
+                    = label_tag("notification_ids_#{notification.id}", '', class: 'custom-control-label')
+                .col
+                  .row
+                    .col
+                      - if notification.notifiable_type == 'BsRequest'
+                        = image_tag('icons/request-icon.svg', height: 18, title: 'Request notification')
+                        = link_to(notification.notifiable_link[:text], notification.notifiable_link[:path], class: 'mx-1')
+                        %small.text-nowrap #{time_ago_in_words(notification.created_at)} ago
+                        %span.badge.ml-1{ class: "badge badge-#{request_badge_color(notification.notifiable.state)}" }
+                          = notification.notifiable.state
+                      - else
+                        %i.fas.fa-comments{ title: 'Comment notification' }
+                        = link_to(notification.notifiable_link[:text], notification.notifiable_link[:path], class: 'mx-1')
+                        %small.text-nowrap #{time_ago_in_words(notification.created_at)} ago
+                    .col-auto.actions.ml-auto.align-self-end.align-self-md-start
+                      - title, icon = notification.unread? ? ['Mark as "Read"', 'fa-check'] : ['Mark as "Unread"', 'fa-undo']
+                      - update_path = my_notifications_path(notification_ids: [notification.id], type: selected_filter[:type],
+                                                            project: selected_filter[:project], page: params[:page],
+                                                            show_all: params[:show_all])
+                      = link_to(update_path, id: format('update-notification-%d', notification.id),
+                                method: :put, class: 'btn btn-sm btn-outline-success px-3', title: title, remote: true) do
+                        %i.fas{ class: "#{icon}" }
+                  .row.mt-1.pl-sm-4
+                    .col-auto.pr-0
+                      = render partial: 'notification_avatars', locals: { avatar_objects: notification.avatar_objects }
+                    .col-auto.pl-xs-2
+                      %span.text-word-break-all= action_description(notification)
+                  .row.d-none.d-md-block.pl-4
+                    .col
+                      %p.mt-3.mb-0= notification.excerpt
+  = paginate notifications, views_prefix: 'webui', window: 2, params: { action: 'index', id: nil }
 
-      .list-group.list-group-flush.mt-3
-        - notifications.each do |n|
-          - notification = NotificationPresenter.new(n)
-          .list-group-item.px-0.px-md-1.py-3.container
-            .row
-              .col
-                - if notification.notifiable_type == 'BsRequest'
-                  = image_tag('icons/request-icon.svg', height: 18, title: 'Request notification')
-                  = link_to(notification.notifiable_link[:text], notification.notifiable_link[:path], class: 'mx-1')
-                  %small.text-nowrap #{time_ago_in_words(notification.created_at)} ago
-                  %span.badge.ml-1{ class: "badge badge-#{request_badge_color(notification.notifiable.state)}" }
-                    = notification.notifiable.state
-                - else
-                  %i.fas.fa-comments{ title: 'Comment notification' }
-                  = link_to(notification.notifiable_link[:text], notification.notifiable_link[:path], class: 'mx-1')
-                  %small.text-nowrap #{time_ago_in_words(notification.created_at)} ago
-              .col-auto.actions.ml-auto.align-self-end.align-self-md-start
-                - title, icon = notification.unread? ? ['Mark as "Read"', 'fa-check'] : ['Mark as "Unread"', 'fa-undo']
-                - update_path = my_notification_path(id: notification, type: selected_filter[:type], project: selected_filter[:project],
-                  page: params[:page], show_all: params[:show_all])
-                = link_to(update_path, id: format('update-notification-%d', notification.id),
-                          method: :put, class: 'btn btn-sm btn-outline-success px-3', title: title, remote: true) do
-                  %i.fas{ class: "#{icon}" }
-            .row.mt-1.pl-sm-4
-              .col-auto.pr-0
-                = render partial: 'notification_avatars', locals: { avatar_objects: notification.avatar_objects }
-              .col-auto.pl-xs-2
-                %span.text-word-break-all= action_description(notification)
-            .row.d-none.d-md-block.pl-4
-              .col
-                %p.mt-3.mb-0= notification.excerpt
-      = paginate notifications, views_prefix: 'webui', window: 2, params: { action: 'index', id: nil }
+- content_for :ready_function do
+  handleNotificationCheckboxSelection();

--- a/src/api/app/views/webui/users/notifications/_update.js.erb
+++ b/src/api/app/views/webui/users/notifications/_update.js.erb
@@ -2,3 +2,4 @@ $('#filters').html("<%= j(render partial: 'notifications_filter', locals: { filt
 $('#notifications-list').html("<%= j(render partial: 'notifications_list', locals: { notifications: notifications, selected_filter: notifications_filter.selected_filter }) %>");
 $('#flash').html("<%= escape_javascript(render(layout: false, partial: 'layouts/webui/flash', object: flash)) %>");
 $('#notifications-counter').html("<%= escape_javascript(render partial: 'layouts/webui/responsive_ux/unread_notifications_counter') %>");
+$(document).ready(function() { handleNotificationCheckboxSelection(); });

--- a/src/api/config/locales/kaminari.en.yml
+++ b/src/api/config/locales/kaminari.en.yml
@@ -11,8 +11,8 @@ en:
     page_entries_info:
       one_page:
         display_entries:
-          zero: "No %{entry_name} found."
-          one: "Displaying <b>1</b> %{entry_name}."
-          other: "Displaying <b>all %{count}</b> %{entry_name}."
+          zero: "No %{entry_name} found"
+          one: "Displaying <b>1</b>"
+          other: "Displaying <b>all %{count}</b>"
       more_pages:
-        display_entries: "Displaying %{entry_name} <b>%{first}&nbsp;-&nbsp;%{last}</b> of <b>%{total}</b>."
+        display_entries: "Displaying <b>%{first}&nbsp;-&nbsp;%{last}</b> of <b>%{total}</b>"

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -306,7 +306,14 @@ OBSApi::Application.routes.draw do
     scope :my do
       resources :tasks, only: [:index], controller: 'webui/users/tasks', as: :my_tasks
 
-      resources :notifications, only: [:index, :update], controller: 'webui/users/notifications', as: :my_notifications
+      resources :notifications, only: [:index], controller: 'webui/users/notifications', as: :my_notifications do
+        collection do
+          # We allow updating multiple notifications in a single HTTP request
+          put :update
+        end
+      end
+
+      resource :notification, only: [:update], controller: 'webui/users/notifications', as: :my_notification
 
       resources :subscriptions, only: [:index], controller: 'webui/users/subscriptions', as: :my_subscriptions do
         collection do

--- a/src/api/spec/controllers/webui/users/notifications_controller_spec.rb
+++ b/src/api/spec/controllers/webui/users/notifications_controller_spec.rb
@@ -88,17 +88,13 @@ RSpec.describe Webui::Users::NotificationsController do
   describe 'PUT #update' do
     context 'when a user marks one of his unread notifications as read' do
       subject! do
-        put :update, params: { id: state_change_notification.id, user_login: user_to_log_in.login }, xhr: true
+        put :update, params: { notification_ids: [state_change_notification.id], user_login: user_to_log_in.login }, xhr: true
       end
 
       let(:user_to_log_in) { user }
 
       it 'succeeds' do
         expect(response).to have_http_status(:ok)
-      end
-
-      it 'flashes a success message' do
-        expect(flash[:success]).to eql('Successfully marked the notification as read')
       end
 
       it 'sets the notification as delivered' do
@@ -108,18 +104,14 @@ RSpec.describe Webui::Users::NotificationsController do
 
     context 'when a user marks one of his read notifications as unread' do
       subject! do
-        put :update, params: { id: read_notification.id, user_login: user_to_log_in.login }, xhr: true
+        put :update, params: { notification_ids: [read_notification.id], type: 'read', user_login: user_to_log_in.login }, xhr: true
       end
 
-      let(:read_notification) { create(:web_notification, :request_state_change, subscriber: user, delivered: true) }
       let(:user_to_log_in) { user }
+      let(:read_notification) { create(:web_notification, :request_state_change, subscriber: user_to_log_in, delivered: true) }
 
       it 'succeeds' do
         expect(response).to have_http_status(:ok)
-      end
-
-      it 'flashes a success message' do
-        expect(flash[:success]).to eql('Successfully marked the notification as unread')
       end
 
       it 'sets the notification as not delivered' do


### PR DESCRIPTION
When dealing with a big amount of notifications, it is very
time consuming to mark them one by one.
Therefore a way to update multiple notifications at once
is required.

**Desktop**
![Peek 2020-09-30 15-23](https://user-images.githubusercontent.com/22001671/94691260-618f6380-0331-11eb-8e3a-25165c59824e.gif)

**Mobile**
![Peek 2020-09-30 15-24](https://user-images.githubusercontent.com/22001671/94691297-6bb16200-0331-11eb-8a49-9be86971dc9e.gif)


This PR is work in progress since I want to implement a way that enables the user to literally mark everything as read (not just the items that are paginated in the notification list)

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
