### PR TITLE
[api] allow to create submit requests to maintenance_release projects

### DIFF
--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -878,7 +878,8 @@ class BsRequestAction < ApplicationRecord
 
     tprj = Project.get_by_name(target_project)
     if tprj.is_a?(Project)
-      if tprj.is_maintenance_release? && action_type == :submit
+      if tprj.is_maintenance_release? && action_type == :submit &&
+         !tprj.find_attribute('OBS', 'AllowSubmitToMaintenanceRelease')
         raise SubmitRequestRejected, "The target project #{target_project} is a maintenance release project, " \
                                      'a submit self is not possible, please use the maintenance workflow instead.'
       end

--- a/src/api/db/attribute_descriptions.rb
+++ b/src/api/db/attribute_descriptions.rb
@@ -26,7 +26,8 @@ def update_all_attrib_type_descriptions
     'EmbargoDate' => 'A timestamp until outgoing requests can not get accepted.',
     'PlannedReleaseDate' => 'A timestamp for the planned release date of an incident.',
     'MakeOriginOlder' => 'Initialize packages by making the build results newer then updated ones',
-    'DelegateRequestTarget' => 'Delegate the target project of requests even when target_project is specified'
+    'DelegateRequestTarget' => 'Delegate the target project of requests even when target_project is specified',
+    'AllowSubmitToMaintenanceRelease' => 'Allow submit requests to maintenance release projects'
   }
   # rubocop:enable Layout/LineLength
 

--- a/src/api/db/data/20200922135426_allow_submit_to_maintenance_release.rb
+++ b/src/api/db/data/20200922135426_allow_submit_to_maintenance_release.rb
@@ -1,0 +1,20 @@
+require_relative '../attribute_descriptions'
+
+class AllowSubmitToMaintenanceRelease < ActiveRecord::Migration[6.0]
+  def self.up
+    ans = AttribNamespace.find_by_name('OBS')
+
+    AttribTypeModifiableBy.reset_column_information
+
+    at = AttribType.find_or_create_by(attrib_namespace: ans, name: 'AllowSubmitToMaintenanceRelease')
+
+    role = Role.find_by_title('maintainer')
+    AttribTypeModifiableBy.find_or_create_by(role_id: role.id, attrib_type_id: at.id)
+
+    update_all_attrib_type_descriptions
+  end
+
+  def self.down
+    AttribType.find_by_namespace_and_name('OBS', 'AllowSubmitToMaintenanceRelease').delete
+  end
+end

--- a/src/api/db/seeds.rb
+++ b/src/api/db/seeds.rb
@@ -152,6 +152,8 @@ at = ans.attrib_types.where(name: 'EmbargoDate').first_or_create(value_count: 1)
 at.attrib_type_modifiable_bies.where(role_id: maintainer_role.id).first_or_create
 at = ans.attrib_types.where(name: 'DelegateRequestTarget').first_or_create
 at.attrib_type_modifiable_bies.where(user_id: maintainer_role.id).first_or_create
+at = ans.attrib_types.where(name: 'AllowSubmitToMaintenanceRelease').first_or_create
+at.attrib_type_modifiable_bies.where(user_id: maintainer_role.id).first_or_create
 
 at = ans.attrib_types.where(name: 'OwnerRootProject').first_or_create
 at.attrib_type_modifiable_bies.where(user_id: admin.id).first_or_create


### PR DESCRIPTION
This makes almost never sense, except you have a project where
you want to mirror the requests to somehere else ... (SUSE:SLE-*Update)

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
