### PR TITLE
Remove unneeded code for notification.notifiable_type 'Review'

### DIFF
--- a/src/api/app/presenters/notification_presenter.rb
+++ b/src/api/app/presenters/notification_presenter.rb
@@ -30,8 +30,6 @@ class NotificationPresenter < SimpleDelegator
     text =  case @model.notifiable_type
             when 'BsRequest'
               @model.notifiable.description
-            when 'Review'
-              @model.notifiable.reason
             when 'Comment'
               @model.notifiable.body
             else

--- a/src/api/app/queries/notifications_finder.rb
+++ b/src/api/app/queries/notifications_finder.rb
@@ -30,8 +30,6 @@ class NotificationsFinder
     case type
     when 'read'
       notifications.read
-    when 'reviews'
-      notifications.unread.where(notifiable_type: 'Review')
     when 'comments'
       notifications.unread.where(notifiable_type: 'Comment')
     when 'requests'

--- a/src/api/app/services/notified_projects.rb
+++ b/src/api/app/services/notified_projects.rb
@@ -19,8 +19,6 @@ class NotifiedProjects
       when 'BsRequest'
         @notifiable.commentable.target_project_objects.distinct
       end
-    when 'Review'
-      @notifiable.bs_request.target_project_objects.distinct
     end
   end
 end

--- a/src/api/spec/controllers/webui/users/notifications_controller_spec.rb
+++ b/src/api/spec/controllers/webui/users/notifications_controller_spec.rb
@@ -61,16 +61,6 @@ RSpec.describe Webui::Users::NotificationsController do
       end
     end
 
-    context "when param type is 'reviews'" do
-      let(:params) { default_params.merge(type: 'reviews') }
-
-      it_behaves_like 'returning success'
-
-      it "sets @notifications to all undelivered notifications of 'review' type" do
-        expect(assigns[:notifications]).to include(review_notification)
-      end
-    end
-
     context "when param type is 'comments'" do
       let(:params) { default_params.merge(type: 'comments') }
 

--- a/src/api/spec/db/data/backfill_notified_projects_spec.rb
+++ b/src/api/spec/db/data/backfill_notified_projects_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe BackfillNotifiedProjects, type: :migration, vcr: true do
 
     before do
       create(:notification, :request_state_change, notifiable: bs_request_with_submit_action)
-      create(:notification, :review_wanted, notifiable: user_review)
+      create(:notification, :review_wanted, notifiable: user_review.bs_request)
       create(:notification, :comment_for_project, notifiable: comment_project)
       create(:notification, :comment_for_package, notifiable: comment_package)
       create(:notification, :comment_for_request, notifiable: comment_request)

--- a/src/api/spec/factories/notification.rb
+++ b/src/api/spec/factories/notification.rb
@@ -19,7 +19,7 @@ FactoryBot.define do
 
     trait :review_wanted do
       event_type { 'Event::ReviewWanted' }
-      association :notifiable, factory: :user_review
+      association :notifiable, factory: :bs_request_with_submit_action
     end
 
     trait :comment_for_project do


### PR DESCRIPTION
Notifications with the notifiable_type 'Review' and the event_type 'Event::ReviewWanted' were migrated to the notifiable_type 'BsRequest' in #9883. Code specific to the notifiable_type 'Review' is since then unneeded.