### PR TITLE
Truncate multi-line notification excerpts to the first line

### DIFF
--- a/src/api/app/presenters/notification_presenter.rb
+++ b/src/api/app/presenters/notification_presenter.rb
@@ -1,4 +1,7 @@
 class NotificationPresenter < SimpleDelegator
+  TRUNCATION_LENGTH = 100
+  TRUNCATION_ELLIPSIS_LENGTH = 3 # `...` is the default ellipsis for String#truncate
+
   def initialize(model)
     @model = model
     super(@model)
@@ -26,6 +29,12 @@ class NotificationPresenter < SimpleDelegator
     end
   end
 
+  def truncate_to_first_new_line(text)
+    first_new_line_index = text.index("\n")
+    truncation_index = !first_new_line_index.nil? && first_new_line_index < TRUNCATION_LENGTH ? first_new_line_index + TRUNCATION_ELLIPSIS_LENGTH : TRUNCATION_LENGTH
+    text.truncate(truncation_index)
+  end
+
   def excerpt
     text =  case @model.notifiable_type
             when 'BsRequest'
@@ -37,7 +46,7 @@ class NotificationPresenter < SimpleDelegator
             else
               ''
             end
-    text.to_s.truncate(100)
+    truncate_to_first_new_line(text.to_s)
   end
 
   def kind_of_request


### PR DESCRIPTION
In case of multi-line descriptions of notifications, joining the first lines of notifications' descriptions is confusing.

Truncate the excerpt to the first line, showing three dots at the end of the excerpt. This provides a more understandable message.