### PR TITLE
[backend] introduce publish flag to publish tracking report files

### DIFF
--- a/ReleaseNotes-2.11
+++ b/ReleaseNotes-2.11
@@ -49,6 +49,7 @@ Intentional changes:
 Backend:
  * .sha256 files get gpg signed in detached mode now
  * Switched from OR to AND when checking CPU flags in _constraints file
+ * internal .packages files are not published anymore
 
 Webui:
   Features enabled by default:

--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -2153,12 +2153,15 @@ sub publish {
           $kiwimedium = "$arch/$1" if !$2 && -e "$r/$1.packages";
 	  $p = mapsleimage($sleimagedata, "$reporoot/$prp/$arch/:repo", $rbin, $p) if $sleimagedata;
         } elsif ($bin =~ /\.packages$/) {
+          # FIXME2.11: to be removed
+	  next unless $config->{'publishflags:withreports'};
           $p = $bin;
 	  $p = mapsleimage($sleimagedata, "$reporoot/$prp/$arch/:repo", $rbin, $p) if $sleimagedata;
         } elsif ($bin =~ /^(.*)\.report$/) {
 	  # collect reports
 	  $kiwireport{"$arch/$1"} = readxml("$r/$rbin", $BSXML::report, 1) if $do_packtrack || $do_sourcepublish;
-	  next;
+	  next unless $config->{'publishflags:withreports'};
+	  $p = $bin;
 	} elsif ($bin =~ /^(.*)\.index$/) {
 	  # collect virt-builder index parts
 	  $kiwiindex .= readstr("$r/$bin", 1) . "\n";


### PR DESCRIPTION
RepoType: withreports   will also publish OBS internal .report files.

We will also keep publishing .packages files for now with that flag,
but we plan to remove that part when testing infrastructure has been adapted.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
