### PR TITLE
[backend] do not treat a commit to _project as project config change

### DIFF
--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -568,6 +568,7 @@ sub addrev {
     die("403 package '$packid' is read-only if a '_product' package exists\n") if -e "$projectsdir/$projid.pkg/_product.xml";
   }
   die("403 package '$packid' is read-only\n") if $packid =~ /(?<!^_product)(?<!^_patchinfo):./;
+  die("_project must not be a link\n") if $packid eq '_project' && $files->{'_link'};
   my $user = $cgi->{'user'};
   my $comment = $cgi->{'comment'};
   my $requestid = $cgi->{'requestid'};
@@ -677,8 +678,11 @@ sub addrev {
       $acceptinfo->{'srcmd5'} = $rev->{'srcmd5'};
       $rev->{'acceptinfo'} = $acceptinfo;
     }
-    notify_repservers('project', $projid);
-    notify("SRCSRV_UPDATE_PROJECT_CONFIG", { "project" => $projid, "files" => $filestr, "comment" => $comment, "sender" => $user });
+    # check if the commit included a project config change
+    if (($files_old->{'_config'} || '') ne ($files->{'_config'} || '')) {
+      notify_repservers('project', $projid);
+      notify("SRCSRV_UPDATE_PROJECT_CONFIG", { "project" => $projid, "files" => $filestr, "comment" => $comment, "sender" => $user });
+    }
     return $rev;
   }
 


### PR DESCRIPTION
Our release managers store information in _project/_staging_workflow,
which led to everything doing a deep check for the project.

Check if the config changed or stayed the same.

Also forbid a _link file in _project.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
