### PR TITLE
Remove markdown tags in notifications' excerpts

### DIFF
--- a/src/api/app/helpers/webui/markdown_helper.rb
+++ b/src/api/app/helpers/webui/markdown_helper.rb
@@ -7,8 +7,6 @@ module Webui::MarkdownHelper
                                            autolink: true,
                                            no_intra_emphasis: true,
                                            fenced_code_blocks: true, disable_indented_code_blocks: true)
-    # rubocop:disable Rails/OutputSafety
-    @md_parser.render(content.to_s).html_safe
-    # rubocop:enable Rails/OutputSafety
+    ActionController::Base.helpers.sanitize(@md_parser.render(content.to_s))
   end
 end

--- a/src/api/app/presenters/notification_presenter.rb
+++ b/src/api/app/presenters/notification_presenter.rb
@@ -1,3 +1,5 @@
+require 'redcarpet/render_strip'
+
 class NotificationPresenter < SimpleDelegator
   TRUNCATION_LENGTH = 100
   TRUNCATION_ELLIPSIS_LENGTH = 3 # `...` is the default ellipsis for String#truncate
@@ -42,7 +44,7 @@ class NotificationPresenter < SimpleDelegator
             when 'Review'
               @model.notifiable.reason
             when 'Comment'
-              @model.notifiable.body
+              render_without_markdown(@model.notifiable.body)
             else
               ''
             end
@@ -69,5 +71,13 @@ class NotificationPresenter < SimpleDelegator
     else
       @model.notifiable.reviews.in_state_new.map(&:reviewed_by) + User.where(login: @model.notifiable.creator)
     end
+  end
+
+  private
+
+  def render_without_markdown(content)
+    # Initializes a Markdown parser, if needed
+    @remove_markdown_parser ||= Redcarpet::Markdown.new(Redcarpet::Render::StripDown)
+    ActionController::Base.helpers.sanitize(@remove_markdown_parser.render(content.to_s))
   end
 end

--- a/src/api/spec/helpers/webui/markdown_helper_spec.rb
+++ b/src/api/spec/helpers/webui/markdown_helper_spec.rb
@@ -4,34 +4,34 @@ RSpec.describe Webui::MarkdownHelper do
   describe '#render_as_markdown' do
     it 'renders markdown links to html links' do
       expect(render_as_markdown('[my link](https://github.com/openSUSE/open-build-service/issues/5091)')).to eq(
-        "<p><a href='https://github.com/openSUSE/open-build-service/issues/5091'>my link</a></p>\n"
+        "<p><a href=\"https://github.com/openSUSE/open-build-service/issues/5091\">my link</a></p>\n"
       )
     end
 
     it 'adds the OBS domain to relative links' do
       expect(render_as_markdown('[my link](/here)')).to eq(
-        "<p><a href='#{::Configuration.obs_url}/here'>my link</a></p>\n"
+        "<p><a href=\"#{::Configuration.obs_url}/here\">my link</a></p>\n"
       )
     end
 
     it 'detects all the mentions to users' do
       expect(render_as_markdown('@alfie @milo and @Admin, please review. Also you, @test1.')).to eq(
-        "<p><a href='https://unconfigured.openbuildservice.org/users/alfie'>@alfie</a> \
-<a href='https://unconfigured.openbuildservice.org/users/milo'>@milo</a> \
-and <a href='https://unconfigured.openbuildservice.org/users/Admin'>@Admin</a>, \
-please review. Also you, <a href='https://unconfigured.openbuildservice.org/users/test1'>@test1</a>.</p>\n"
+        "<p><a href=\"https://unconfigured.openbuildservice.org/users/alfie\">@alfie</a> \
+<a href=\"https://unconfigured.openbuildservice.org/users/milo\">@milo</a> \
+and <a href=\"https://unconfigured.openbuildservice.org/users/Admin\">@Admin</a>, \
+please review. Also you, <a href=\"https://unconfigured.openbuildservice.org/users/test1\">@test1</a>.</p>\n"
       )
     end
 
     it "doesn't render users inside the text of html links" do
       expect(render_as_markdown('Group [openSUSE Leap 15.0 Incidents@DVD-Incidents](https://openqa.opensuse.org/tests/overview)')).to eq(
-        "<p>Group <a href='https://openqa.opensuse.org/tests/overview'>openSUSE Leap 15.0 Incidents@DVD-Incidents</a></p>\n"
+        "<p>Group <a href=\"https://openqa.opensuse.org/tests/overview\">openSUSE Leap 15.0 Incidents@DVD-Incidents</a></p>\n"
       )
     end
 
     it 'does not crash due to invalid URIs' do
       expect(render_as_markdown("anbox[400000+22d000]\r\n(the number)")).to eq(
-        "<p>anbox<a href='the number'>400000+22d000</a></p>\n"
+        "<p>anbox<a href=\"the%20number\">400000+22d000</a></p>\n"
       )
     end
 
@@ -58,9 +58,9 @@ please review. Also you, <a href='https://unconfigured.openbuildservice.org/user
     end
 
     it 'does remove dangerous html from inside the links' do
-      # rubocop:disable Layout/LineLength
-      expect(render_as_markdown('[<script></script>](https://build.opensuse.org)')).to eq("<p><a href='https://build.opensuse.org'>&amp;lt;script&amp;gt;&amp;lt;/script&amp;gt;</a></p>\n")
-      # rubocop:enable Layout/LineLength
+      expect(render_as_markdown('[<script></script>](https://build.opensuse.org)')).to eq(
+        "<p><a href=\"https://build.opensuse.org\">&amp;lt;script&amp;gt;&amp;lt;/script&amp;gt;</a></p>\n"
+      )
     end
   end
 end

--- a/src/api/spec/mailers/event_mailer_spec.rb
+++ b/src/api/spec/mailers/event_mailer_spec.rb
@@ -78,8 +78,8 @@ RSpec.describe EventMailer, vcr: true do
       end
 
       it 'renders links absolute' do
-        expected_html = "<p>Hey <a href='https://build.example.com/users/#{receiver.login}'>@#{receiver.login}</a> "
-        expected_html += "how are things? Look at <a href='https://build.example.com/project/show/apache'>bug</a> please."
+        expected_html = "<p>Hey <a href=\"https://build.example.com/users/#{receiver.login}\">@#{receiver.login}</a> "
+        expected_html += 'how are things? Look at <a href="https://build.example.com/project/show/apache">bug</a> please.'
         expect(mail.html_part.to_s).to include(expected_html)
       end
 
@@ -112,7 +112,7 @@ RSpec.describe EventMailer, vcr: true do
         let!(:comment) { create(:comment_project, body: "I ❤️ @#{vip.login}!") }
 
         it { expect(mail.text_part.body.encoded).to include("I ❤️ [@#{vip.login}](https://build.example.com/users/") }
-        it { expect(mail.html_part.to_s).to include("I =E2=9D=A4=EF=B8=8F <a href=3D'https://build.example.com/users/") }
+        it { expect(mail.html_part.to_s).to include('I =E2=9D=A4=EF=B8=8F <a href=3D"https://build.example.com/users/') }
       end
     end
 


### PR DESCRIPTION
Use a render that strips the markdown tags. This way, we show a more understandable excerpt in the list of notifications.

**Before:**
![Screenshot from 2020-09-23 16-29-18](https://user-images.githubusercontent.com/24919/94026573-1ec20e80-fdba-11ea-9d1a-80ceb9a5607a.png)

**After:**
![Screenshot from 2020-09-23 16-28-06](https://user-images.githubusercontent.com/24919/94026598-241f5900-fdba-11ea-9c42-5bce763e8596.png)

To verify the changes, I will setup a couple of examples in the review-app.