### PR TITLE
Implement new z-index hierarchy

### DIFF
--- a/src/api/app/assets/stylesheets/webui/application.scss
+++ b/src/api/app/assets/stylesheets/webui/application.scss
@@ -27,6 +27,7 @@
 @import 'breadcrumbs-component';
 @import 'tabs-component';
 @import 'personal-navigation';
+@import 'profile';
 @import 'list-group-item-integrated';
 @import 'kaminari';
 @import 'coderay';

--- a/src/api/app/assets/stylesheets/webui/flash.scss
+++ b/src/api/app/assets/stylesheets/webui/flash.scss
@@ -1,5 +1,5 @@
 .flash-and-announcement.sticky-top {
-  z-index: 1030;
+  z-index: 1031; // This is the third item in our hierarchy
 
   &.sticking {
     .alert { margin-bottom: 0; }

--- a/src/api/app/assets/stylesheets/webui/profile.scss
+++ b/src/api/app/assets/stylesheets/webui/profile.scss
@@ -1,0 +1,3 @@
+#top-navigation-profile-panel {
+    z-index: $zindex-popover;
+}

--- a/src/api/app/assets/stylesheets/webui/project-monitor.scss
+++ b/src/api/app/assets/stylesheets/webui/project-monitor.scss
@@ -1,5 +1,5 @@
 #project-monitor-repositories-dropdown, #project-monitor-architectures-dropdown, #project-monitor-status-dropdown {
     .dropdown-menu {
-        z-index: 1031;
+        z-index: 1030; // This is the fifth item in our hierarchy
     }
 }

--- a/src/api/app/assets/stylesheets/webui/responsive_ux/layout.scss
+++ b/src/api/app/assets/stylesheets/webui/responsive_ux/layout.scss
@@ -6,7 +6,7 @@
 // NAVIGATION
 
 #top-navigation-area {
-  .fixed-top { height: $top-navigation-height; }
+  .fixed-top { height: $top-navigation-height; } // This is our fourth item in our hierarchy, but it comes already pre-defined from Bootstrap
   .toggler {
     @extend .ml-2;
     @extend .d-none;

--- a/src/api/app/assets/stylesheets/webui/responsive_ux/navbar.scss
+++ b/src/api/app/assets/stylesheets/webui/responsive_ux/navbar.scss
@@ -24,6 +24,7 @@
       transition: visibility .3s ease-in-out, -webkit-transform .3s ease-in-out;
       transition: transform .3s ease-in-out, visibility .3s ease-in-out;
       transition: transform .3s ease-in-out, visibility .3s ease-in-out, -webkit-transform .3s ease-in-out;
+      z-index: calc(#{$zindex-fixed} + 3); // Collapsable navbars are the second element in our hierarchy
 
       & a {
         color: $gray-300;
@@ -34,7 +35,6 @@
         visibility: visible;
         -webkit-transform: translateX(-100%);
         transform: translateX(-100%);
-        z-index: calc(#{$zindex-fixed} - 1); // To not overlap fixed elements
       }
 
       button.navbar-toggler {

--- a/src/api/app/assets/stylesheets/webui/responsive_ux/tabs.scss
+++ b/src/api/app/assets/stylesheets/webui/responsive_ux/tabs.scss
@@ -2,7 +2,7 @@
   overflow: auto;
   white-space: nowrap;
   padding: 0.5rem 1rem 0rem 1rem;
-  z-index: 990;
+  z-index: $zindex-fixed;
 
   a.scrollable-tab-link {
     display: inline-block;

--- a/src/api/app/views/layouts/webui/responsive_ux/_top_navigation.html.haml
+++ b/src/api/app/views/layouts/webui/responsive_ux/_top_navigation.html.haml
@@ -20,7 +20,7 @@
           = link_to('#', class: 'nav-link dropdown-toggle text-light', id: 'top-navigation-profile-dropdown', role: 'button',
                     'data-toggle': 'dropdown', aria: { haspopup: true, expanded: false }) do
             = image_tag_for(User.session, size: 32, custom_class: 'rounded-circle bg-light mr-2')
-          .dropdown-menu.dropdown-menu-right{ 'aria-labelledby': 'top-navigation-profile-dropdown' }
+          .dropdown-menu.dropdown-menu-right#top-navigation-profile-panel{ 'aria-labelledby': 'top-navigation-profile-dropdown' }
             .dropdown-item
               = link_to(user_path(User.session!), id: 'link-to-user-home', class: 'nav-link text-light p-0 w-100') do
                 = image_tag_for(User.session, size: 20, custom_class: 'rounded-circle bg-light mr-2')


### PR DESCRIPTION
We have several issues with several component overlapping each other in
the wrong way.

This PR changes the z-index hierarchy to address those issues. This will
be the new hierarchy, elements at the top of the list are elements that
will show on top of the others.

1. Login dropdown
2. Collapsable menus
3. Flash messages
4. Status messages
5. Top nav bar
6. Architecture, Repository and Status dropdowns from Monitor page
7. The rest of UI elements stay as they are

Fixes #9363