### PR TITLE
Only use GET for search index endpoint

### DIFF
--- a/src/api/app/views/layouts/webui/_search.html.haml
+++ b/src/api/app/views/layouts/webui/_search.html.haml
@@ -1,2 +1,2 @@
-= form_tag(search_path(project: 1, package: 1, name: 1), class: 'form-inline') do
+= form_tag(search_path(project: 1, package: 1, name: 1), method: :get, class: 'form-inline') do
   %input.form-control.w-100{ 'aria-label': 'Search', name: 'search_text', placeholder: 'Search', type: 'text' }/

--- a/src/api/app/views/layouts/webui/responsive_ux/_top_navigation_search.html.haml
+++ b/src/api/app/views/layouts/webui/responsive_ux/_top_navigation_search.html.haml
@@ -1,2 +1,2 @@
-= form_tag(search_path(project: 1, package: 1, name: 1), class: 'form-inline') do
+= form_tag(search_path(project: 1, package: 1, name: 1), method: :get, class: 'form-inline') do
   %input.form-control.w-100{ 'aria-label': 'Search', name: 'search_text', placeholder: 'Search', type: 'text' }/

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -287,7 +287,7 @@ OBSApi::Application.routes.draw do
     end
 
     controller 'webui/search' do
-      match 'search' => :index, via: [:get, :post]
+      get 'search' => :index
       get 'search/owner' => :owner
       get 'search/issue' => :issue
     end

--- a/src/api/public/404.html
+++ b/src/api/public/404.html
@@ -4,7 +4,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Error 404</title>
-  
+
   <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.1.0/css/bootstrap.min.css">
   <style type="text/css">
     html,
@@ -34,7 +34,7 @@
       #error-text {
         padding-top: 90px;
       }
-    }   
+    }
 
     #error-img {
       padding-top: 0;
@@ -43,12 +43,12 @@
       #error-img {
         padding-top: 130px;
       }
-    }  
+    }
     @media all and (min-width: 1171px) {
       #error-img {
         padding-top: 85px;
       }
-    } 
+    }
   </style>
   <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
@@ -67,7 +67,7 @@
         Sorry but the page you are looking for does not exist. It might be that the page just has been moved, we think it's best if you try to search what you where looking for below or start again from the <a href="/">home page</a>.
         </p>
         <p>
-          <form method="post" action="/search" accept-charset="UTF-8">
+          <form method="get" action="/search" accept-charset="UTF-8">
             <input type="hidden" value="✓" name="utf8">
             <div class="input-group input-group-lg">
               <span class="input-group-btn">
@@ -96,7 +96,7 @@
         <div class="col-md-4">
           <h4>...we help each other out</h4>
           <p>
-            On <a href="irc://irc.freenode.net/openSUSE-buildservice" rel="nofollow">IRC</a> and on the <a href="mailto:opensuse-buildservice+subscribe@opensuse.org" rel="nofollow">mailing list</a> there is a vibrant community of developers, admins and users that <em>support</em> each other.  
+            On <a href="irc://irc.freenode.net/openSUSE-buildservice" rel="nofollow">IRC</a> and on the <a href="mailto:opensuse-buildservice+subscribe@opensuse.org" rel="nofollow">mailing list</a> there is a vibrant community of developers, admins and users that <em>support</em> each other.
           </p>
         </div>
         <div class="col-md-4">


### PR DESCRIPTION
The search#index endpoint doesnt modify or
store and any data. Therefore we shouldn't allow
or use POST request to access the resource.
This will also prevent issues with our 404 page
which is a static html file that doesn't include a
CSRF token (which would be require for POST).

Fixes #10196

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
