### PR TITLE
Implement new z-index hierarchy

### DIFF
--- a/src/api/app/assets/stylesheets/webui/flash.scss
+++ b/src/api/app/assets/stylesheets/webui/flash.scss
@@ -1,5 +1,5 @@
 .flash-and-announcement.sticky-top {
-  z-index: 1030;
+  z-index: $zindex-fixed;
 
   &.sticking {
     .alert { margin-bottom: 0; }

--- a/src/api/app/assets/stylesheets/webui/personal-navigation.scss
+++ b/src/api/app/assets/stylesheets/webui/personal-navigation.scss
@@ -16,10 +16,6 @@
         color: $white !important;
     }
 
-    .top-of-flash {
-      z-index: 1031;
-    }
-
     #login-form {
       width: 300px;
     }

--- a/src/api/app/assets/stylesheets/webui/project-monitor.scss
+++ b/src/api/app/assets/stylesheets/webui/project-monitor.scss
@@ -1,5 +1,5 @@
 #project-monitor-repositories-dropdown, #project-monitor-architectures-dropdown, #project-monitor-status-dropdown {
     .dropdown-menu {
-        z-index: 1031;
+        z-index: $zindex-modal;
     }
 }

--- a/src/api/app/assets/stylesheets/webui/responsive_ux/layout.scss
+++ b/src/api/app/assets/stylesheets/webui/responsive_ux/layout.scss
@@ -38,6 +38,23 @@
   }
 }
 
+#top-navigation-area {
+  .fixed-top {
+    z-index: calc(#{$zindex-modal} - 5);
+  }
+}
+
+#bottom-navigation-area {
+  z-index: calc(#{$zindex-modal} - 5);
+  .fixed-bottom {
+    z-index: calc(#{$zindex-modal} - 5);
+  }
+}
+
+.watchlist-collapse {
+  z-index: $zindex-fixed;
+}
+
 // BREADCRUMBS
 
 .breadcrumb {

--- a/src/api/app/assets/stylesheets/webui/responsive_ux/navbar.scss
+++ b/src/api/app/assets/stylesheets/webui/responsive_ux/navbar.scss
@@ -34,7 +34,6 @@
         visibility: visible;
         -webkit-transform: translateX(-100%);
         transform: translateX(-100%);
-        z-index: calc(#{$zindex-fixed} - 1); // To not overlap fixed elements
       }
 
       button.navbar-toggler {

--- a/src/api/app/assets/stylesheets/webui/responsive_ux/tabs.scss
+++ b/src/api/app/assets/stylesheets/webui/responsive_ux/tabs.scss
@@ -2,7 +2,6 @@
   overflow: auto;
   white-space: nowrap;
   padding: 0.5rem 1rem 0rem 1rem;
-  z-index: 990;
 
   a.scrollable-tab-link {
     display: inline-block;

--- a/src/api/app/assets/stylesheets/webui/tabs-component.scss
+++ b/src/api/app/assets/stylesheets/webui/tabs-component.scss
@@ -16,8 +16,4 @@ ul.nav.nav-tabs li.nav-item {
       }
     }
   }
-
-  .dropdown-menu {
-    z-index: 1050;
-  }
 }

--- a/src/api/app/assets/stylesheets/webui/watchlist.scss
+++ b/src/api/app/assets/stylesheets/webui/watchlist.scss
@@ -1,9 +1,5 @@
 #global-navigation {
-  ul {
-    .dropdown-menu.dropdown-menu-right {
-      z-index: 1050;
-    }
-  }
+  z-index: calc(#{$zindex-modal} - 5);
 
   #watchlist {
     color: $gray-400;

--- a/src/api/app/views/layouts/webui/_login_form.html.haml
+++ b/src/api/app/views/layouts/webui/_login_form.html.haml
@@ -4,7 +4,7 @@
 %li.nav-item.dropdown#login-form-dropdown
   = link_to('#', id: 'login-trigger', class: 'nav-link dropdown-toggle', 'data-toggle': 'dropdown') do
     Log In
-  .dropdown-menu.dropdown-menu-right.shadow-lg.bg-dark.top-of-flash{ 'aria-labelledby': 'dropdownMenuButton' }
+  .dropdown-menu.dropdown-menu-right.shadow-lg.bg-dark{ 'aria-labelledby': 'dropdownMenuButton' }
     .px-4.py-3#login-form
       = render partial: 'webui/session/form', locals: { label_css: 'text-light',
                                                         button_css: 'float-right',


### PR DESCRIPTION
We have issues with components, overlapping each other in the wrong way.

This pull request changes the z-index hierarchy of the navigation bars and side panels, using default values provided by Bootstrap, and removing z-index changes that were considered unnecessary.

In the case of the old UI, only the watchlist panel was changed, to use a z-index lower than the one used by default in Bootstrap for modals.

In the case of the new responsive UI:
- fixed elements (fixed-top and fixed-bottom) in the top navigation bar and the bottom navigation bar were overwritten to a z-index lower than the one used by default in Bootstrap for modals.
- the watchlist panel z-index has a even lower value, to allow to show at the same time the user dropdown, located at the upper-right corner.

The value of a z-index lower than the one used by default in Bootstrap's modals was chosen because we use modals for the login and sign-up forms. We want these modals to be shown over the top and bottom navigation bars.

This pull request was based on the work done by @danidoni in #10204.

Fixes #9363.
