### PR TITLE
Notifications accurate redesign

### DIFF
--- a/src/api/app/assets/stylesheets/webui/notifications_redesign/notifications.scss
+++ b/src/api/app/assets/stylesheets/webui/notifications_redesign/notifications.scss
@@ -2,24 +2,6 @@
 // all the 'body.notifications-redesign' wrappers can be removed.
 
 body.notifications-redesign  {
-  .notifications-grid-container {
-    display: grid;
-    grid-template-columns: 1fr auto;
-    grid-template-rows: auto;
-    grid-template-areas:
-      "notifiable notifiable"
-      "content content"
-      "who-when action";
-    column-gap: 0.5rem;
-    row-gap: 0.25rem;
-    align-items: start;
-
-    .notifiable { grid-area: notifiable; }
-    .who-when { grid-area: who-when; }
-    .action { grid-area: action; }
-    .content { grid-area: content; }
-  }
-
   .avatars-counter, .simulated-avatar {
     display: inline-block;
     text-align: center;
@@ -50,14 +32,6 @@ body.notifications-redesign  {
   body.notifications-redesign {
     #notifications-filter-desktop {
       .collapse { display: block !important; }
-    }
-
-    .notifications-grid-container {
-      min-height: 6.25rem;
-      grid-template-columns: 1fr auto 3rem;
-      grid-template-areas:
-        "notifiable who-when action"
-        "content content content";
     }
   }
 }

--- a/src/api/app/helpers/webui/notification_helper.rb
+++ b/src/api/app/helpers/webui/notification_helper.rb
@@ -28,6 +28,28 @@ module Webui::NotificationHelper
     end
   end
 
+  def action_description(notification)
+    case notification.event_type
+    when 'Event::RequestStatechange', 'Event::RequestCreate', 'Event::ReviewWanted', 'Event::CommentForRequest'
+      source_and_target(notification)
+    when 'Event::CommentForProject'
+      "#{notification.notifiable.commentable.name}"
+    when 'Event::CommentForPackage'
+      commentable = notification.notifiable.commentable
+      "#{commentable.project.name} / #{commentable.name}"
+    end
+  end
+
+  def source_and_target(notification)
+    capture do
+      if notification.source.present?
+        concat(tag.span(notification.source))
+        concat(tag.i(nil, class: 'fas fa-long-arrow-alt-right text-info mx-2'))
+      end
+      concat(tag.span(notification.target))
+    end
+  end
+
   private
 
   def css_for_filter_link(filter_item, selected_filter)

--- a/src/api/app/views/webui/users/notifications/_notifications_list.html.haml
+++ b/src/api/app/views/webui/users/notifications/_notifications_list.html.haml
@@ -17,29 +17,32 @@
       .list-group.list-group-flush.mt-3
         - notifications.each do |n|
           - notification = NotificationPresenter.new(n)
-          .list-group-item.px-0.px-md-2.notifications-grid-container
-            .notifiable
-              - if notification.notifiable_type == 'BsRequest'
-                = image_tag('icons/request-icon.svg', height: 18, title: 'Request notification')
-                = link_to(notification.notifiable_link[:text], notification.notifiable_link[:path], class: 'mx-1 text-word-break-all')
-                %span.badge{ class: "badge badge-#{request_badge_color(notification.notifiable.state)}" }
-                  = notification.notifiable.state
-              - else
-                %i.fas.fa-comments{ title: 'Comment notification' }
-                = link_to(notification.notifiable_link[:text], notification.notifiable_link[:path], class: 'mx-1 text-word-break-all')
-            .actions.ml-auto.align-self-end.align-self-md-start
-              - title, icon = notification.unread? ? ['Mark as "Read"', 'fa-check'] : ['Mark as "Unread"', 'fa-undo']
-              - update_path = my_notification_path(id: notification, type: selected_filter[:type], project: selected_filter[:project],
-                page: params[:page], show_all: params[:show_all])
-              = link_to(update_path, id: format('update-notification-%d', notification.id),
-                        method: :put, class: 'btn btn-sm btn-outline-success px-3', title: title, remote: true) do
-                %i.fas{ class: "#{icon}" }
-            .content
-              - if notification.kind_of_request
-                %p.text-word-break-all.m-0.mb-2= notification.kind_of_request
-              %p.d-none.d-md-block.font-weight-light= notification.excerpt
-            %small.who-when.d-flex.align-self-center.align-self-md-start.justify-content-start.justify-content-md-end.font-weight-light
-              = render partial: 'notification_avatars', locals: { avatar_objects: notification.avatar_objects }
-              %span.d-inline-block.text-nowrap.ml-2 #{time_ago_in_words(notification.created_at)} ago
-
+          .list-group-item.px-0.px-md-1.py-3.container
+            .row
+              .col
+                - if notification.notifiable_type == 'BsRequest'
+                  = image_tag('icons/request-icon.svg', height: 18, title: 'Request notification')
+                  = link_to(notification.notifiable_link[:text], notification.notifiable_link[:path], class: 'mx-1')
+                  %small.text-nowrap #{time_ago_in_words(notification.created_at)} ago
+                  %span.badge.ml-1{ class: "badge badge-#{request_badge_color(notification.notifiable.state)}" }
+                    = notification.notifiable.state
+                - else
+                  %i.fas.fa-comments{ title: 'Comment notification' }
+                  = link_to(notification.notifiable_link[:text], notification.notifiable_link[:path], class: 'mx-1')
+                  %small.text-nowrap #{time_ago_in_words(notification.created_at)} ago
+              .col-auto.actions.ml-auto.align-self-end.align-self-md-start
+                - title, icon = notification.unread? ? ['Mark as "Read"', 'fa-check'] : ['Mark as "Unread"', 'fa-undo']
+                - update_path = my_notification_path(id: notification, type: selected_filter[:type], project: selected_filter[:project],
+                  page: params[:page], show_all: params[:show_all])
+                = link_to(update_path, id: format('update-notification-%d', notification.id),
+                          method: :put, class: 'btn btn-sm btn-outline-success px-3', title: title, remote: true) do
+                  %i.fas{ class: "#{icon}" }
+            .row.mt-1.pl-sm-4
+              .col-auto.pr-0
+                = render partial: 'notification_avatars', locals: { avatar_objects: notification.avatar_objects }
+              .col-auto.pl-xs-2
+                %span.text-word-break-all= action_description(notification)
+            .row.d-none.d-md-block.pl-4
+              .col
+                %p.mt-3.mb-0= notification.excerpt
       = paginate notifications, views_prefix: 'webui', window: 2, params: { action: 'index', id: nil }


### PR DESCRIPTION
In this new round of redesign, we've tried to avoid having the notifications' information spread all over the area. So we've put together the information which answers to these two questions respectively: Where does the notification happen? What is happening there? The goal is making it easier to understand at a glance.

**Improvements:**

- We ensure we display relevant information like source and target project/package when needed.
- Change the position of the elements to group them logically.
- Specify the kind of requests in the link's text. Example: _"Add Role Request # 222"_
- The link's text for comments is changed from project/package name or request Id to something more clear like: _"Comment on Package"_ or _"Comment on Add Role Request"_. Needed to distinguish where the comment happened, especially in comments on requests since the action summary is not as verbose as before.
- Less variety of font styles

**Before (desktop version)**

![desktop_before](https://user-images.githubusercontent.com/2581944/94435539-8baf1d00-019b-11eb-92a7-11a1e1758862.png)

**After (desktop version)**

![desktop_after](https://user-images.githubusercontent.com/2581944/94673273-c8535380-0316-11eb-9a72-6f433397db4e.png)

**Before (mobile version)**

![mobile_before](https://user-images.githubusercontent.com/2581944/94435597-9e295680-019b-11eb-9b83-33b506a0611f.png)

**After (mobile version)**

![mobile_after](https://user-images.githubusercontent.com/2581944/94673894-b0c89a80-0317-11eb-8451-725cb3e41260.png)

