### PR TITLE
Reduce padding for notifications list on small viewports

### DIFF
--- a/src/api/app/views/webui/users/notifications/_notifications_list.html.haml
+++ b/src/api/app/views/webui/users/notifications/_notifications_list.html.haml
@@ -17,7 +17,7 @@
       .list-group.list-group-flush.mt-3
         - notifications.each do |n|
           - notification = NotificationPresenter.new(n)
-          .list-group-item.px-2.notifications-grid-container
+          .list-group-item.px-0.px-md-2.notifications-grid-container
             .notifiable
               - if notification.notifiable_type == 'BsRequest'
                 = image_tag('icons/request-icon.svg', height: 18, title: 'Request notification')

--- a/src/api/app/views/webui/users/notifications/index.html.haml
+++ b/src/api/app/views/webui/users/notifications/index.html.haml
@@ -4,7 +4,7 @@
   end
 
 .row
-  .col-md-4.col-lg-3.sticky-top#notifications-filter-desktop
+  .col-md-4.col-lg-3.px-0.px-md-3.sticky-top#notifications-filter-desktop
     .card.mb-3
       %strong.d-block.d-md-none.p-3{ data: { toggle: 'collapse', target: '#filters' },
                                   aria: { expanded: true, controls: 'filters' } }
@@ -12,5 +12,5 @@
         %i.float-right.mt-1.fa.fa-chevron-down#notifications-dropdown-trigger
       .card-body.collapse#filters
         = render partial: 'notifications_filter', locals: { filter: @notifications_filter }
-  .col-md-8.col-lg-9#notifications-list
+  .col-md-8.col-lg-9.px-0.px-md-3#notifications-list
     = render partial: 'notifications_list', locals: { notifications: @notifications, selected_filter: @notifications_filter.selected_filter }


### PR DESCRIPTION
Currently we have the same padding both on small and big
viewports. By reducing the padding on small viewports, we
save up a lot of valuable space.

Co-authored-by: Eduardo Navarro <enavarro@suse.com>

**Before**
![Screenshot_2020-09-28 Open Build Service(1)](https://user-images.githubusercontent.com/22001671/94441573-370fa000-01a3-11eb-8e48-db553617a5eb.png)

**After**
![Screenshot_2020-09-28 Open Build Service](https://user-images.githubusercontent.com/22001671/94441602-3e36ae00-01a3-11eb-998d-c031ffe89c33.png)


<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
