### PR TITLE
Show Notification Toolbar when opening notification from Notifications List Page

### DIFF
--- a/src/api/app/assets/stylesheets/webui/application.scss
+++ b/src/api/app/assets/stylesheets/webui/application.scss
@@ -62,6 +62,7 @@
 
 @import 'responsive_ux/responsive_ux';
 @import 'notifications_redesign/notifications';
+@import 'notification_toolbar';
 
 html {
     overflow-y: scroll !important;

--- a/src/api/app/assets/stylesheets/webui/notification_toolbar.scss
+++ b/src/api/app/assets/stylesheets/webui/notification_toolbar.scss
@@ -1,0 +1,9 @@
+.notification-toolbar.sticky-top {
+  z-index: $zindex-fixed;
+  top: $top-navigation-height;
+}
+
+.notification-toolbar ~ .container-xxl .flash-and-announcement {
+  top: $top-navigation-height + $notification-toolbar-height + .25rem !important;
+  z-index: calc(#{$zindex-fixed} - 5);
+}

--- a/src/api/app/assets/stylesheets/webui/responsive_ux/responsive_ux.scss
+++ b/src/api/app/assets/stylesheets/webui/responsive_ux/responsive_ux.scss
@@ -3,6 +3,7 @@
 $top-navigation-height: 3.5625rem;
 $bottom-navigation-height: 3.5rem;
 $left-navigation-width: 16rem;
+$notification-toolbar-height: 3rem;
 
 body.responsive-ux {
   @import 'build-result';

--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -104,6 +104,9 @@ class Webui::PackageController < Webui::WebuiController
 
     @comments = @package.comments.includes(:user)
     @comment = Comment.new
+
+    @current_notification = NotificationsFinder.new.for_subscribed_user_by_id(params[:notification_id])
+
     @services = @files.any? { |file| file[:name] == '_service' }
 
     respond_to do |format|

--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -132,6 +132,9 @@ class Webui::ProjectController < Webui::WebuiController
     @has_patchinfo = @project.patchinfos.exists?
     @comments = @project.comments
     @comment = Comment.new
+
+    @current_notification = NotificationsFinder.new.for_subscribed_user_by_id(params[:notification_id])
+
     respond_to do |format|
       format.html
       format.js

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -117,6 +117,8 @@ class Webui::RequestController < Webui::WebuiController
     @comments = @bs_request.comments
     @comment = Comment.new
 
+    @current_notification = NotificationsFinder.new.for_subscribed_user_by_id(params[:notification_id])
+
     @actions = @bs_request.webui_actions(filelimit: diff_limit, tarlimit: diff_limit, diff_to_superseded: @diff_to_superseded, diffs: true)
     # print a hint that the diff is not fully shown (this only needs to be verified for submit actions)
     @not_full_diff = BsRequest.truncated_diffs?(@actions)

--- a/src/api/app/controllers/webui/users/notifications_controller.rb
+++ b/src/api/app/controllers/webui/users/notifications_controller.rb
@@ -23,6 +23,7 @@ class Webui::Users::NotificationsController < Webui::WebuiController
     end
 
     respond_to do |format|
+      format.html { redirect_to my_notifications_path }
       format.js do
         render partial: 'update', locals: {
           notifications: fetch_notifications,

--- a/src/api/app/helpers/webui/notification_helper.rb
+++ b/src/api/app/helpers/webui/notification_helper.rb
@@ -49,4 +49,14 @@ module Webui::NotificationHelper
   def badge_color(filter_item, selected_filter)
     notification_filter_matches(filter_item, selected_filter) ? 'badge-light' : 'badge-primary'
   end
+
+  def mark_as_read_or_unread_button(notification)
+    update_path = my_notification_path(id: notification.id)
+    title, icon = notification.unread? ? ['Mark as read', 'fa-check'] : ['Mark as unread', 'fa-undo']
+    link_to(update_path, id: "update-notification-#{notification.id}", method: :put,
+                         class: 'btn btn-sm btn-outline-success', title: title) do
+      concat(tag.i(class: "#{icon} fas"))
+      concat " #{title}"
+    end
+  end
 end

--- a/src/api/app/presenters/notification_presenter.rb
+++ b/src/api/app/presenters/notification_presenter.rb
@@ -13,18 +13,19 @@ class NotificationPresenter < SimpleDelegator
     case @model.event_type
     when 'Event::RequestStatechange', 'Event::RequestCreate', 'Event::ReviewWanted'
       { text: "Request ##{@model.notifiable.number}",
-        path: Rails.application.routes.url_helpers.request_show_path(@model.notifiable.number) }
+        path: Rails.application.routes.url_helpers.request_show_path(@model.notifiable.number, notification_id: @model.id) }
     when 'Event::CommentForRequest'
       { text: "Request ##{@model.notifiable.commentable.number}",
-        path: Rails.application.routes.url_helpers.request_show_path(@model.notifiable.commentable.number, anchor: 'comments-list') }
+        path: Rails.application.routes.url_helpers.request_show_path(@model.notifiable.commentable.number, notification_id: @model.id, anchor: 'comments-list') }
     when 'Event::CommentForProject'
       { text: @model.notifiable.commentable.name,
-        path: Rails.application.routes.url_helpers.project_show_path(@model.notifiable.commentable, anchor: 'comments-list') }
+        path: Rails.application.routes.url_helpers.project_show_path(@model.notifiable.commentable, notification_id: @model.id, anchor: 'comments-list') }
     when 'Event::CommentForPackage'
       commentable = @model.notifiable.commentable
       { text: "#{commentable.project.name} / #{commentable.name}",
         path: Rails.application.routes.url_helpers.package_show_path(package: @model.notifiable.commentable,
                                                                      project: @model.notifiable.commentable.project,
+                                                                     notification_id: @model.id,
                                                                      anchor: 'comments-list') }
     else
       {}

--- a/src/api/app/queries/notifications_finder.rb
+++ b/src/api/app/queries/notifications_finder.rb
@@ -44,4 +44,10 @@ class NotificationsFinder
   def for_project_name(project_name)
     unread.joins(:projects).where(projects: { name: project_name })
   end
+
+  def for_subscribed_user_by_id(notification_id)
+    return unless User.session && notification_id
+
+    self.class.new.for_subscribed_user.find_by(id: notification_id)
+  end
 end

--- a/src/api/app/views/layouts/webui/_notification_toolbar.html.haml
+++ b/src/api/app/views/layouts/webui/_notification_toolbar.html.haml
@@ -1,0 +1,5 @@
+.notification-toolbar.sticky-top.navbar.navbar-light.bg-light.border-bottom.border-gray-400
+  = link_to(my_notifications_path, class: 'btn btn-sm btn-outline-secondary', title: 'Back to notifications') do
+    %i.fas.fa-arrow-left
+    Back to notifications
+  = mark_as_read_or_unread_button(notification)

--- a/src/api/app/views/layouts/webui/responsive_ux.html.haml
+++ b/src/api/app/views/layouts/webui/responsive_ux.html.haml
@@ -45,6 +45,8 @@
       .bg-dark#left-navigation-area
         = render partial: 'layouts/webui/responsive_ux/left_navigation'
       .d-flex.flex-column#content-area
+        - if @current_notification
+          = render partial: 'layouts/webui/notification_toolbar', locals: { notification: @current_notification }
         .container-xxl.flex-grow-1.pb-3.border-bottom.border-gray-400
           .sticky-top.flash-and-announcement.text-break
             = render partial: 'layouts/webui/status_message_announcement', locals: { current_announcement: @current_announcement }


### PR DESCRIPTION
The PR adds a toolbar on the top of the page, which adds ability to mark notification as read from Request, Project and Package Pages.

The feature was requested in #9279

Steps to test the feature:
1. Log in as Admn that has notifications;
2. Proceed to the Notifications List Page;
3. Click on the title of any of the noifications;
4. When presented with the Request/Package/Project Page, focus on the top of the page.

Expected result:
Notification Toolbar is shown on the top, just below the Top Nav.

Here are the screenshots of how it looks:

**Desktop**
![2020-09-28_21-44](https://user-images.githubusercontent.com/37581072/94478664-e06e8a00-01d3-11eb-9699-015cc71039ff.png)

**Mobile**
![2020-09-28_21-43_1](https://user-images.githubusercontent.com/37581072/94478564-b9b05380-01d3-11eb-88e5-4a43b0eed978.png)