### PR TITLE
Update notifications counter in Top Nav with AJAX

### DIFF
--- a/src/api/app/views/layouts/webui/responsive_ux/_top_navigation.html.haml
+++ b/src/api/app/views/layouts/webui/responsive_ux/_top_navigation.html.haml
@@ -10,12 +10,8 @@
             %i.fas.fa-bookmark
             %span.d-block Watchlist
         - if feature_enabled?(:notifications_redesign)
-          .toggler.text-center.justify-content-center
-            = link_to(my_notifications_path, class: 'nav-link text-light p-0 w-100', alt: 'Notifications') do
-              %i.fas.fa-bell
-              - unless User.session.unread_notifications.zero?
-                %span.badge.badge-primary.align-text-top= User.session.unread_notifications
-              %span.d-block Notifications
+          .toggler.text-center.justify-content-center#notifications-counter
+            = render partial: 'layouts/webui/responsive_ux/unread_notifications_counter'
         .toggler.text-center.justify-content-center.nav-item.dropdown
           = link_to('#', class: 'nav-link dropdown-toggle text-light', id: 'top-navigation-profile-dropdown', role: 'button',
                     'data-toggle': 'dropdown', aria: { haspopup: true, expanded: false }) do

--- a/src/api/app/views/layouts/webui/responsive_ux/_unread_notifications_counter.html.haml
+++ b/src/api/app/views/layouts/webui/responsive_ux/_unread_notifications_counter.html.haml
@@ -1,0 +1,5 @@
+= link_to(my_notifications_path, class: 'nav-link text-light p-0 w-100', alt: 'Notifications') do
+  %i.fas.fa-bell
+  - unless User.session.unread_notifications.zero?
+    %span.badge.badge-primary.align-text-top= User.session.unread_notifications
+  %span.d-block Notifications

--- a/src/api/app/views/webui/users/notifications/_update.js.erb
+++ b/src/api/app/views/webui/users/notifications/_update.js.erb
@@ -1,3 +1,4 @@
 $('#filters').html("<%= j(render partial: 'notifications_filter', locals: { filter: notifications_filter }) %>");
 $('#notifications-list').html("<%= j(render partial: 'notifications_list', locals: { notifications: notifications, selected_filter: notifications_filter.selected_filter }) %>");
 $('#flash').html("<%= escape_javascript(render(layout: false, partial: 'layouts/webui/flash', object: flash)) %>");
+$('#notifications-counter').html("<%= escape_javascript(render partial: 'layouts/webui/responsive_ux/unread_notifications_counter') %>");


### PR DESCRIPTION
Notifications counter did not update in real-time, when marking a
notification as read/unread. Only when page was refreshed, it was
updated.

The commit changes the behavior to use AJAX and update the counter every
time when action on notification is performed, so that there is no need
to update the page to see the actual amount of unread notifications in
the counter.

Fixes #10169

To verify this feature

1. Generate notifications:
   - SSH into running _frontend_ container;
   - Execute `bundle exec rake ts:start`;
   - Then run `bundle exec rake dev:notifications:data[2]`.
2. Log in to the application;
3. Go to Notifications Page (e.g. click on the bell in the top-right or proceed by the link: http://localhost:3000/my/notifications);
4. Remember the number, that is shown in Notifications counter in the top-right;
5. Mark any notification as read;
6. Check the number in Notifications counter.

Expected result:
The notifications counter is updated.