### PR TITLE
Update BS Request with AJAX call

### DIFF
--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -125,6 +125,11 @@ class Webui::RequestController < Webui::WebuiController
     user = User.session # might be nil
     @my_open_reviews = reviews.select { |review| review.matches_user?(user) }
     @can_add_reviews = @bs_request.state.in?([:new, :review]) && (@is_author || @is_target_maintainer || @my_open_reviews.present?)
+
+    respond_to do |format|
+      format.html
+      format.js { render_request_update }
+    end
   end
 
   def sourcediff
@@ -336,5 +341,20 @@ class Webui::RequestController < Webui::WebuiController
     opt['role'] = params[:role]
     opt['type'] = type.to_s
     opt
+  end
+
+  def render_request_update
+    render partial: 'update', locals: {
+      is_target_maintainer: @is_target_maintainer,
+      is_author: @is_author,
+      bs_request: @bs_request,
+      history: @history,
+      can_add_reviews: @can_add_reviews,
+      package_maintainers: @package_maintainers,
+      can_handle_request: @can_handle_request,
+      my_open_reviews: @my_open_reviews,
+      show_project_maintainer_hint: @show_project_maintainer_hint,
+      actions: @actions
+    }
   end
 end

--- a/src/api/app/views/webui/request/_decision_tab.html.haml
+++ b/src/api/app/views/webui/request/_decision_tab.html.haml
@@ -1,4 +1,4 @@
-= form_tag({ action: 'changerequest' }, id: 'request_handle_form') do
+= form_tag({ action: 'changerequest' }, remote: true, id: 'request_handle_form') do
   = hidden_field_tag(:number, request_number)
   %p
     = text_area_tag(:reason, nil, placeholder: 'Please add a comment', rows: 4, class: 'w-100 form-control')

--- a/src/api/app/views/webui/request/_handle_request.html.haml
+++ b/src/api/app/views/webui/request/_handle_request.html.haml
@@ -1,0 +1,34 @@
+- if can_handle_request || (can_add_reviews && my_open_reviews.any?)
+  .card.mb-3#handle-request
+    .bg-light
+      %ul.nav.nav-tabs{ role: 'tablist' }
+        - if can_handle_request
+          %li.nav-item
+            %a.nav-link.text-nowrap.active{ href: '#decision', data: { toggle: 'tab' }, role: 'tab' }
+              My decision
+        - if can_add_reviews
+          - my_open_reviews.each_with_index do |review, index|
+            %li.nav-item
+              %a.nav-link.text-nowrap{ href: "#review-#{index}", data: { toggle: 'tab' }, role: 'tab',
+                  class: ('active' if index.zero? && !can_handle_request) }
+                Review for
+                - if review.by_package
+                  #{review.by_project}/#{review.by_package}
+                - else
+                  = review.by_user || review.by_group || review.by_project
+    .card-body
+      - if can_handle_request && show_project_maintainer_hint
+        .alert.alert-warning
+          You are a <strong>project maintainer</strong> but not a <strong>package maintainer</strong>. This package
+          has <strong>#{pluralize(package_maintainers.size, 'package maintainer')}</strong> assigned. Please keep
+          in mind that also package maintainers would like to review this request.
+      .tab-content
+        - if can_handle_request
+          .tab-pane.fade.show.active{ id: 'decision' }
+            = render('decision_tab', request_number: bs_request.number, request_creator: bs_request.creator,
+                       is_target_maintainer: is_target_maintainer, state: bs_request.state.to_s,
+                       is_author: is_author, single_action_request: actions.count == 1, action: actions.first)
+        - if can_add_reviews
+          - my_open_reviews.each_with_index do |review, index|
+            .tab-pane.fade.show{ id: "review-#{index}", class: ('active' if index.zero? && !can_handle_request) }
+              = render('review_tab', review: review, bs_request: bs_request)

--- a/src/api/app/views/webui/request/_update.js.erb
+++ b/src/api/app/views/webui/request/_update.js.erb
@@ -1,0 +1,14 @@
+$('#request-history').html("<%= escape_javascript(render partial: 'request_history', locals: { bs_request: bs_request, history: history }) %>");
+$('#overview').html("<%= escape_javascript(render partial: 'show_overview', locals: { bs_request: bs_request, can_add_reviews: can_add_reviews }) %>");
+$('#side-links').html("<%= escape_javascript(render partial: 'show_side_links', locals: { bs_request: bs_request, package_maintainers: package_maintainers }) %>");
+$('#flash').html("<%= escape_javascript(render partial: 'layouts/webui/flash') %>");
+$('#handle-request').replaceWith("<%= escape_javascript(render partial: 'handle_request', locals: {
+                     is_target_maintainer: is_target_maintainer,
+                     is_author: is_author,
+                     bs_request: bs_request,
+                     can_handle_request: can_handle_request,
+                     can_add_reviews: can_add_reviews,
+                     my_open_reviews: my_open_reviews,
+                     show_project_maintainer_hint: show_project_maintainer_hint,
+                     package_maintainers: package_maintainers,
+                     actions: actions }) %>");

--- a/src/api/app/views/webui/request/show.html.haml
+++ b/src/api/app/views/webui/request/show.html.haml
@@ -17,9 +17,9 @@
       Overview
   .card-body
     .row
-      .col-md-8
+      .col-md-8#overview
         = render partial: 'show_overview', locals: { bs_request: @bs_request, can_add_reviews: @can_add_reviews }
-      .col-md-4
+      .col-md-4#side-links
         = render partial: 'show_side_links', locals: { bs_request: @bs_request, package_maintainers: @package_maintainers }
       - if @can_add_reviews
         %ul.list-inline.mb-0
@@ -42,40 +42,15 @@
   .col-md-8
     .card.mb-3#comments-list
       = render partial: 'request_comments', locals: { comments: @comments, bs_request: @bs_request }
-    - if @can_handle_request || (@can_add_reviews && @my_open_reviews.any?)
-      .card.mb-3
-        .bg-light
-          %ul.nav.nav-tabs{ role: 'tablist' }
-            - if @can_handle_request
-              %li.nav-item
-                %a.nav-link.text-nowrap.active{ href: '#decision', data: { toggle: 'tab' }, role: 'tab' }
-                  My decision
-            - if @can_add_reviews
-              - @my_open_reviews.each_with_index do |review, index|
-                %li.nav-item
-                  %a.nav-link.text-nowrap{ href: "#review-#{index}", data: { toggle: 'tab' }, role: 'tab',
-                    class: ('active' if index.zero? && !@can_handle_request) }
-                    Review for
-                    - if review.by_package
-                      #{review.by_project}/#{review.by_package}
-                    - else
-                      = review.by_user || review.by_group || review.by_project
-        .card-body
-          - if @can_handle_request && @show_project_maintainer_hint
-            .alert.alert-warning
-              You are a <strong>project maintainer</strong> but not a <strong>package maintainer</strong>. This package
-              has <strong>#{pluralize(@package_maintainers.size, 'package maintainer')}</strong> assigned. Please keep
-              in mind that also package maintainers would like to review this request.
-          .tab-content
-            - if @can_handle_request
-              .tab-pane.fade.show.active{ id: 'decision' }
-                = render('decision_tab', request_number: @bs_request.number, request_creator: @bs_request.creator,
-                         is_target_maintainer: @is_target_maintainer, state: @bs_request.state.to_s,
-                         is_author: @is_author, single_action_request: @actions.count == 1, action: @actions.first)
-            - if @can_add_reviews
-              - @my_open_reviews.each_with_index do |review, index|
-                .tab-pane.fade.show{ id: "review-#{index}", class: ('active' if index.zero? && !@can_handle_request) }
-                  = render('review_tab', review: review, bs_request: @bs_request)
+    = render partial: 'handle_request', locals: { is_target_maintainer: @is_target_maintainer,
+                                                        is_author: @is_author,
+                                                        bs_request: @bs_request,
+                                                        can_handle_request: @can_handle_request,
+                                                        can_add_reviews: @can_add_reviews,
+                                                        my_open_reviews: @my_open_reviews,
+                                                        show_project_maintainer_hint: @show_project_maintainer_hint,
+                                                        package_maintainers: @package_maintainers,
+                                                        actions: @actions }
 
   .col-md-4
     .card


### PR DESCRIPTION
Update BS request with AJAX call
    
The commit introduces asynchronous update for BS Requests.
    
This was implemented in scope of adding notification toolbar feature (#10220).
Previously, when the request got updated (e.g. approved/rejected), the page was refreshed and notification toolbar was removed, because it relies on 'notification_id' query parameter, but that parameter got removed after action was made on BS request.

To test the feature:

1. Log in as user that has notifications;
2. Proceed to the Notifications List Page;
3. Open Request notification which is in "review" or "declined" state;
4. Scroll the Request Page to the bottom;
5. Press "Decline"/"Approve"/"Reopen" button.

Expected result:
The page is updated asynchronously.  (Overview, Decision, Request History sections are updated).