### PR TITLE
Publish build events to the metrics bus

### DIFF
--- a/src/api/app/models/event/build.rb
+++ b/src/api/app/models/event/build.rb
@@ -13,7 +13,40 @@ module Event
       h
     end
 
+    def metric_measurement
+      'build'
+    end
+
+    def metric_tags
+      {
+        namespace: payload['project'].split(':').first,
+        worker: payload['workerid'],
+        arch: payload['arch'],
+        reason: reason,
+        state: state
+      }
+    end
+
+    def metric_fields
+      {
+        duration: duration_in_seconds,
+        latency: latency_in_seconds
+      }
+    end
+
     private
+
+    def duration_in_seconds
+      payload['endtime'].to_i - payload['starttime'].to_i
+    end
+
+    def latency_in_seconds
+      payload['starttime'].to_i - payload['readytime'].to_i
+    end
+
+    def reason
+      payload['reason'].parameterize.underscore
+    end
 
     def my_message_id
       # we put the verifymd5 sum in the message id, so new checkins get new thread, but it doesn't have to be very correct

--- a/src/api/app/models/event/build_fail.rb
+++ b/src/api/app/models/event/build_fail.rb
@@ -23,6 +23,10 @@ module Event
       h
     end
 
+    def state
+      'fail'
+    end
+
     private
 
     def faillog

--- a/src/api/app/models/event/build_success.rb
+++ b/src/api/app/models/event/build_success.rb
@@ -2,6 +2,10 @@ module Event
   class BuildSuccess < Build
     self.message_bus_routing_key = 'package.build_success'
     self.description = 'Package has succeeded building'
+
+    def state
+      'success'
+    end
   end
 end
 

--- a/src/api/app/models/event/build_unchanged.rb
+++ b/src/api/app/models/event/build_unchanged.rb
@@ -2,6 +2,10 @@ module Event
   class BuildUnchanged < Build
     self.message_bus_routing_key = 'package.build_unchanged'
     self.description = 'Package has succeeded building with unchanged result'
+
+    def state
+      'unchanged'
+    end
   end
 end
 


### PR DESCRIPTION
There are also some interesting times and tags in the build events.
Let's measure them.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
