### PR TITLE
Address RuboCop TODOs

### DIFF
--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -434,11 +434,6 @@ Naming/AccessorMethodName:
     - 'app/models/user.rb'
     - 'test/functional/search_controller_test.rb'
 
-# Offense count: 1
-Naming/ConstantName:
-  Exclude:
-    - 'test/unit/issue_test.rb'
-
 # Offense count: 22
 # Configuration parameters: ForbiddenDelimiters.
 # ForbiddenDelimiters: (?-mix:(^|\s)(EO[A-Z]{1}|END)(\s|$))

--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -16,11 +16,6 @@ Lint/ConstantDefinitionInBlock:
     - 'spec/support/database_cleaner.rb'
 
 # Offense count: 1
-Lint/DuplicateMethods:
-  Exclude:
-    - 'app/models/history_element/base.rb'
-
-# Offense count: 1
 # Configuration parameters: AllowComments.
 Lint/EmptyFile:
   Exclude:

--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -6,12 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 2
-Lint/BinaryOperatorWithIdenticalOperands:
-  Exclude:
-    - 'app/models/bs_request.rb'
-    - 'spec/models/bs_request_action/differ/for_source_spec.rb'
-
 # Offense count: 7
 Lint/ConstantDefinitionInBlock:
   Exclude:

--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -15,12 +15,6 @@ Lint/ConstantDefinitionInBlock:
     - 'lib/tasks/statistics/github/pull_requests.rake'
     - 'spec/support/database_cleaner.rb'
 
-# Offense count: 1
-# Configuration parameters: AllowComments.
-Lint/EmptyFile:
-  Exclude:
-    - 'spec/models/bs_request/differ/query_builder.rb'
-
 # Offense count: 8
 # Configuration parameters: MaximumRangeSize.
 Lint/MissingCopEnableDirective:

--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -628,7 +628,7 @@ class BsRequest < ApplicationRecord
   end
 
   def assignreview(opts = {})
-    raise InvalidStateError, 'request is not in review state' unless state == :review || (state == :new && state == :new)
+    raise InvalidStateError, 'request is not in review state' unless state == :review || state == :new
 
     reviewer = User.find_by_login!(opts[:reviewer])
 

--- a/src/api/app/models/history_element/base.rb
+++ b/src/api/app/models/history_element/base.rb
@@ -5,7 +5,7 @@ module HistoryElement
     self.table_name = 'history_elements'
 
     class << self
-      attr_accessor :description, :raw_type, :comment, :raw_type, :created_at, :raw_type
+      attr_accessor :description, :comment, :created_at
     end
 
     def color

--- a/src/api/spec/models/bs_request_action/differ/for_source_spec.rb
+++ b/src/api/spec/models/bs_request_action/differ/for_source_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe BsRequestAction::Differ::ForSource, vcr: true do
           )
         end
 
-        it { expect(subject.perform).to eq(xml_response + xml_response) }
+        it { expect(subject.perform).to eq(xml_response * 2) }
       end
     end
   end

--- a/src/api/test/unit/issue_test.rb
+++ b/src/api/test/unit/issue_test.rb
@@ -4,7 +4,7 @@ class IssueTest < ActiveSupport::TestCase
   fixtures :all
 
   # rubocop:disable Layout/LineLength
-  BugGet0815 = "<?xml version=\"1.0\" ?><methodCall><methodName>Bug.get</methodName><params><param><value><struct><member><name>ids</name><value><array><data><value><string>1234</string></value><value><string>0815</string></value></data></array></value></member><member><name>permissive</name><value><i4>1</i4></value></member></struct></value></param></params></methodCall>\n".freeze
+  BUG_GET_0815 = "<?xml version=\"1.0\" ?><methodCall><methodName>Bug.get</methodName><params><param><value><struct><member><name>ids</name><value><array><data><value><string>1234</string></value><value><string>0815</string></value></data></array></value></member><member><name>permissive</name><value><i4>1</i4></value></member></struct></value></param></params></methodCall>\n".freeze
   # rubocop:enable Layout/LineLength
 
   def test_parse
@@ -15,7 +15,7 @@ class IssueTest < ActiveSupport::TestCase
 
   def test_create_and_destroy
     stub_request(:post, 'http://bugzilla.novell.com/xmlrpc.cgi')
-      .with(body: BugGet0815)
+      .with(body: BUG_GET_0815)
       .to_return(status: 200,
                  body: load_backend_file('bugzilla_get_0815.xml'),
                  headers: {})


### PR DESCRIPTION
The PR addresses RuboCop TODOs for:
- Lint/BinaryOperatorWithIdenticalOperands
- Lint/DuplicateMethods
- Lint/EmptyFile
- Naming/ConstantName