### PR TITLE
Show notifications counter on top of bell icon

### DIFF
--- a/src/api/app/assets/stylesheets/webui/notifications_redesign/notifications.scss
+++ b/src/api/app/assets/stylesheets/webui/notifications_redesign/notifications.scss
@@ -69,3 +69,16 @@ body.notifications-redesign  {
     }
   }
 }
+
+.notifications-counter {
+  position: relative;
+  margin: 0 auto;
+  width: 6rem;
+  .badge {
+    position: absolute;
+    top: -0.4rem;
+    left: 3.1rem;
+    border: 0.1rem solid $dark;
+    padding: 0.1rem 0.3rem;
+  }
+}


### PR DESCRIPTION
Notifications counter badge shifted bell icon when appeared/disappeared
or when amount of digits was changed.

The commit adjusts CSS styles to show the badge on top of icon, so that
the position of icon is not changed when counter is updated.

How to test the changes:
1. Log in as any user that has notifications;
2. Proceed to the Notifications Page;
3. Mark several notifications as "Read", so that amount of digits in notifications counter badge is changed (or mark all as read o make the badge disappear);
4. Focus on the bell icon.

Expected result:
Bell icon does not change its position.

Here are screenshots of how it looks:

**Before**
![before_counter](https://user-images.githubusercontent.com/37581072/94939494-8707a300-04d2-11eb-8e52-01f8566a12a3.png)


**After**
![1_digit_counter](https://user-images.githubusercontent.com/37581072/94939574-a272ae00-04d2-11eb-9b97-cf7df76a64f6.png)

![2_digit_counter](https://user-images.githubusercontent.com/37581072/94939577-a272ae00-04d2-11eb-9096-8c82f98688f4.png)

![3_digit_counter](https://user-images.githubusercontent.com/37581072/94939579-a30b4480-04d2-11eb-876e-192c7b827b4c.png)

![4_digit_counter](https://user-images.githubusercontent.com/37581072/94939582-a30b4480-04d2-11eb-9255-1a63241dc29c.png)
