### PR TITLE
Return back raw_type attr in HistoryElement Base

### DIFF
--- a/src/api/app/models/history_element/base.rb
+++ b/src/api/app/models/history_element/base.rb
@@ -5,7 +5,7 @@ module HistoryElement
     self.table_name = 'history_elements'
 
     class << self
-      attr_accessor :description, :comment, :created_at
+      attr_accessor :description, :comment, :created_at, :raw_type
     end
 
     def color


### PR DESCRIPTION
The commit returns back the attr, that was mistakenly removed in #10247
