### PR TITLE
Replace `require_login` with Pundit in Webui::Users::TasksController

### DIFF
--- a/src/api/app/controllers/webui/users/tasks_controller.rb
+++ b/src/api/app/controllers/webui/users/tasks_controller.rb
@@ -1,7 +1,11 @@
 module Webui
   module Users
     class TasksController < WebuiController
-      before_action :require_login
+      # TODO: Remove this when we'll refactor kerberos_auth
+      before_action :kerberos_auth
+      before_action -> { authorize([:users, :task]) }
+
+      after_action :verify_authorized
     end
   end
 end

--- a/src/api/app/policies/users/task_policy.rb
+++ b/src/api/app/policies/users/task_policy.rb
@@ -1,0 +1,11 @@
+module Users
+  class TaskPolicy < ApplicationPolicy
+    def initialize(user, record, opts = {})
+      super(user, record, opts.merge(ensure_logged_in: true))
+    end
+
+    def index?
+      true
+    end
+  end
+end

--- a/src/api/spec/controllers/webui/users/tasks_controller_spec.rb
+++ b/src/api/spec/controllers/webui/users/tasks_controller_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe Webui::Users::TasksController do
+  describe 'GET #index' do
+    it_behaves_like 'require logged in user' do
+      let(:method) { :get }
+      let(:action) { :index }
+    end
+  end
+end

--- a/src/api/spec/policies/users/task_policy_spec.rb
+++ b/src/api/spec/policies/users/task_policy_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe Users::TaskPolicy do
+  let(:user) { create(:user) }
+  let(:user_nobody) { build(:user_nobody) }
+
+  subject { described_class }
+
+  permissions :index? do
+    it { is_expected.to permit(user, [:users, :task]) }
+  end
+
+  it "doesn't permit anonymous user" do
+    expect { described_class.new(user_nobody, [:users, :task]) }
+      .to raise_error(an_instance_of(Pundit::NotAuthorizedError).and(having_attributes(reason: :anonymous_user)))
+  end
+end


### PR DESCRIPTION
This is a PR of a series which replaces `require_login` with `Pundit`.
You can find further relevant info in #10083.

Tackles `Webui::Users::TasksController`

Ref #10083

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
