### PR TITLE
Disable buttons properly and show spinner on submit in notifications list

### DIFF
--- a/src/api/app/assets/javascripts/webui/notification.js
+++ b/src/api/app/assets/javascripts/webui/notification.js
@@ -14,10 +14,10 @@ function setCheckboxCounterAndSubmitButton() {
   });
 
   if(amountBoxesChecked <= 0) {
-    $('#done-button').addClass('disabled');
+    $('#done-button').prop('disabled', true);
     $('#select-all-label').text('Select all');
   } else {
-    $('#done-button').removeClass('disabled');
+    $('#done-button').prop('disabled', false);
     $('#select-all-label').text(amountBoxesChecked + ' selected');
   }
 }

--- a/src/api/app/assets/javascripts/webui/notification.js
+++ b/src/api/app/assets/javascripts/webui/notification.js
@@ -29,4 +29,3 @@ function handleNotificationCheckboxSelection() { // jshint ignore:line
     setCheckboxCounterAndSubmitButton();
   });
 }
-

--- a/src/api/app/views/webui/users/notifications/_notification_action_bar.html.haml
+++ b/src/api/app/views/webui/users/notifications/_notification_action_bar.html.haml
@@ -6,5 +6,5 @@
           = check_box_tag('select-all-notifications', 1, false, class: 'custom-control-input')
           %label.custom-control-label.align-middle.mr-4#select-all-label{ for: 'select-all-notifications' } Select All
           - button_text = type == 'read' ? "Mark as 'Unread'" : "Mark as 'Read'"
-          = button_tag(type: 'submit', class: 'btn btn-sm btn-outline-success px-3 disabled', id: 'done-button') do
+          = button_tag(type: 'submit', class: 'btn btn-sm btn-outline-success px-3', id: 'done-button', disabled: 'disabled') do
             = button_text

--- a/src/api/app/views/webui/users/notifications/_notification_action_bar.html.haml
+++ b/src/api/app/views/webui/users/notifications/_notification_action_bar.html.haml
@@ -5,6 +5,9 @@
         .custom-control.custom-checkbox
           = check_box_tag('select-all-notifications', 1, false, class: 'custom-control-input')
           %label.custom-control-label.align-middle.mr-4#select-all-label{ for: 'select-all-notifications' } Select All
-          - button_text = type == 'read' ? "Mark as 'Unread'" : "Mark as 'Read'"
-          = button_tag(type: 'submit', class: 'btn btn-sm btn-outline-success px-3', id: 'done-button', disabled: 'disabled') do
+          :ruby
+            button_text = type == 'read' ? "Mark as 'Unread'" : "Mark as 'Read'"
+            disable_with_content = button_text + tag.i(class: 'fas fa-spinner fa-spin ml-2')
+          = button_tag(type: 'submit', class: 'btn btn-sm btn-outline-success px-3', id: 'done-button', disabled: 'disabled',
+                       'data-disable-with': disable_with_content) do
             = button_text

--- a/src/api/app/views/webui/users/notifications/_notifications_list.html.haml
+++ b/src/api/app/views/webui/users/notifications/_notifications_list.html.haml
@@ -43,12 +43,14 @@
                         = link_to(notification.notifiable_link[:text], notification.notifiable_link[:path], class: 'mx-1')
                         %small.text-nowrap #{time_ago_in_words(notification.created_at)} ago
                     .col-auto.actions.ml-auto.align-self-end.align-self-md-start
-                      - title, icon = notification.unread? ? ['Mark as "Read"', 'fa-check'] : ['Mark as "Unread"', 'fa-undo']
-                      - update_path = my_notifications_path(notification_ids: [notification.id], type: selected_filter[:type],
+                      :ruby
+                        title, icon = notification.unread? ? ['Mark as "Read"', 'fa-check'] : ['Mark as "Unread"', 'fa-undo']
+                        update_path = my_notifications_path(notification_ids: [notification.id], type: selected_filter[:type],
                                                             project: selected_filter[:project], page: params[:page],
                                                             show_all: params[:show_all])
                       = link_to(update_path, id: format('update-notification-%d', notification.id),
-                                method: :put, class: 'btn btn-sm btn-outline-success px-3', title: title, remote: true) do
+                                method: :put, class: 'btn btn-sm btn-outline-success px-3', title: title,
+                                data: { remote: true, 'disable-with': tag.i(class: 'fas fa-spinner fa-spin') }) do
                         %i.fas{ class: "#{icon}" }
                   .row.mt-1.pl-sm-4
                     .col-auto.pr-0


### PR DESCRIPTION
The button on the notification page was disabled through
a CSS class, which only lead to a disabled look, but still
allowed to submit the form.

Fixes #10248

There was no feedback to the user when marking notifications
as read and unread. When marking a bigger amount of notifications
it can take a bit to update the view, which might lead to additional
submit attempts. By showing a spinner and disabling the button
we can prevent this from happening.



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
