### PR TITLE
Replace `require_login` with Pundit in Webui::Users::SubscriptionsController

### DIFF
--- a/src/api/app/policies/event_subscription/form_policy.rb
+++ b/src/api/app/policies/event_subscription/form_policy.rb
@@ -1,0 +1,23 @@
+class EventSubscription
+  class FormPolicy < ApplicationPolicy
+    def initialize(user, record, opts = {})
+      super(user, record, opts.merge(ensure_logged_in: true))
+    end
+
+    def index?
+      user_is_subscriber?
+    end
+
+    def update?
+      user_is_subscriber?
+    end
+
+    private
+
+    def user_is_subscriber?
+      return true unless record.subscriber
+
+      user == record.subscriber
+    end
+  end
+end

--- a/src/api/spec/controllers/webui/users/subscriptions_controller_spec.rb
+++ b/src/api/spec/controllers/webui/users/subscriptions_controller_spec.rb
@@ -2,16 +2,22 @@ require 'rails_helper'
 
 RSpec.describe Webui::Users::SubscriptionsController do
   describe 'GET #index' do
-    let!(:user) { create(:confirmed_user) }
-
-    before do
-      login user
-      get :index
+    it_behaves_like 'require logged in user' do
+      let(:method) { :get }
+      let(:action) { :index }
     end
 
-    it { expect(response).to have_http_status(:success) }
-    it { expect(response).to render_template(:index) }
-    it { is_expected.to use_before_action(:require_login) }
+    context 'for logged in user' do
+      let!(:user) { create(:confirmed_user) }
+
+      before do
+        login user
+        get :index
+      end
+
+      it { expect(response).to have_http_status(:success) }
+      it { expect(response).to render_template(:index) }
+    end
   end
 
   describe 'PUT #update' do
@@ -19,14 +25,21 @@ RSpec.describe Webui::Users::SubscriptionsController do
 
     let(:params) { { subscriptions: subscription_params } }
 
-    before do
-      login user
-      put :update, params: params
+    it_behaves_like 'require logged in user' do
+      let(:method) { :put }
+      let(:action) { :update }
+      let(:opts) { { params: params } }
     end
 
-    it { expect(response).to redirect_to(action: :index) }
-    it { is_expected.to use_before_action(:require_login) }
+    context 'for logged in user' do
+      before do
+        login user
+        put :update, params: params
+      end
 
-    it_behaves_like 'a subscriptions form for subscriber'
+      it { expect(response).to redirect_to(action: :index) }
+
+      it_behaves_like 'a subscriptions form for subscriber'
+    end
   end
 end

--- a/src/api/spec/policies/event_subscription/form_policy_spec.rb
+++ b/src/api/spec/policies/event_subscription/form_policy_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe EventSubscription::FormPolicy do
+  let(:user) { create(:user_with_groups) }
+  let(:other_user) { create(:user_with_groups) }
+  let(:user_nobody) { build(:user_nobody) }
+  let(:event_subscription_form) { EventSubscription::Form.new }
+  let(:event_subscription_form_user) { EventSubscription::Form.new(user) }
+
+  subject { described_class }
+
+  permissions :index?, :update? do
+    it { is_expected.to permit(user, event_subscription_form_user) }
+    it { is_expected.to permit(other_user, event_subscription_form) }
+    it { is_expected.not_to permit(other_user, event_subscription_form_user) }
+  end
+
+  it "doesn't permit anonymous user" do
+    expect { described_class.new(user_nobody, event_subscription_form) }
+      .to raise_error(an_instance_of(Pundit::NotAuthorizedError).and(having_attributes(reason: :anonymous_user)))
+  end
+end


### PR DESCRIPTION
This is a PR of a series which replaces `require_login` with `Pundit`.
You can find further relevant info in #10083.

Tackles `Webui::Users::SubscriptionsController`

Ref #10083

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
