### PR TITLE
Fix typo in issue types

### DIFF
--- a/src/api/app/views/webui/patchinfo/form/_issues.html.haml
+++ b/src/api/app/views/webui/patchinfo/form/_issues.html.haml
@@ -14,7 +14,7 @@
   %small.form-text.text-danger#ajax-error-message
 
   .list-group.mt-3#issues
-    - issue_types = ['issueid', 'issuetracker', 'issueurl', 'issuesumi']
+    - issue_types = ['issueid', 'issuetracker', 'issueurl', 'issuesum']
     - issues.to_a.each do |issue|
       - issue_name = "#{issue[1]}_#{issue[0]}"
       .list-group-item.flex-column.align-items-start.issue-element{ id: "issue_#{issue_name}" }


### PR DESCRIPTION
This typo was introduced in #10120 when we addressed a RuboCop offense

Fixes #10260

In the error message, you can see that `issuesum` is a permitted parameter, but `issuesumi` is not.
![error](https://user-images.githubusercontent.com/1102934/95217379-66518d00-07f3-11eb-861c-ad10e4214acc.png)