### PR TITLE
Move the actions present in the user's profile page to the left menu

### DIFF
--- a/src/api/app/views/webui/user/_change_password.html.haml
+++ b/src/api/app/views/webui/user/_change_password.html.haml
@@ -1,0 +1,6 @@
+- if feature_enabled?(:responsive_ux)
+  = render partial: 'webui/user/index_actions'
+- else
+  = link_to('#', data: { toggle: 'modal', target: '#password-modal' }, class: 'd-block') do
+    %i.fas.fa-key
+    Change your password

--- a/src/api/app/views/webui/user/_edit_account.html.haml
+++ b/src/api/app/views/webui/user/_edit_account.html.haml
@@ -1,0 +1,20 @@
+- if feature_enabled?(:responsive_ux)
+  - content_for :actions do
+    - if account_edit_link.present?
+      %li.nav-item
+        = link_to(account_edit_link, class: 'nav-link') do
+          %i.fas.fa-lg.mr-2.fa-user-edit
+          Edit your account
+    - else
+      %li.nav-item
+        = link_to('#', data: { toggle: 'modal', target: '#edit-modal' }, class: 'nav-link') do
+          %i.fas.fa-lg.mr-2.fa-user-edit
+          Edit your account
+- elsif account_edit_link.present?
+  = link_to(account_edit_link, class: 'd-block') do
+    %i.fas.fa-user-edit
+    Edit your account
+- else
+  = link_to('#', data: { toggle: 'modal', target: '#edit-modal' }, class: 'd-block') do
+    %i.fas.fa-user-edit
+    Edit your account

--- a/src/api/app/views/webui/user/_index_actions.html.haml
+++ b/src/api/app/views/webui/user/_index_actions.html.haml
@@ -1,0 +1,5 @@
+- content_for :actions do
+  %li.nav-item
+    = link_to('#', data: { toggle: 'modal', target: '#password-modal' }, class: 'nav-link') do
+      %i.fas.fa-lg.mr-2.fa-plus-square
+      Change your password

--- a/src/api/app/views/webui/user/_info.html.haml
+++ b/src/api/app/views/webui/user/_info.html.haml
@@ -38,21 +38,19 @@
                                                                  'features we develop and give us feedback on them before they go live.' } } |
       .mt-4
         - if configuration.accounts_editable?(user)
-          - if account_edit_link.present?
-            = link_to(account_edit_link, class: 'd-block') do
-              %i.fas.fa-user-edit
-              Edit your account
-          - else
-            = link_to('#', data: { toggle: 'modal', target: '#edit-modal' }, class: 'd-block') do
-              %i.fas.fa-user-edit
-              Edit your account
+          = render partial: 'webui/user/edit_account', locals: { account_edit_link: account_edit_link }
         - if configuration.passwords_changable?(user)
-          = link_to('#', data: { toggle: 'modal', target: '#password-modal' }, class: 'd-block') do
-            %i.fas.fa-key
-            Change your password
-        = link_to(my_subscriptions_path, class: 'd-block') do
-          %i.fas.fa-bell
-          Change your notifications
+          = render partial: 'webui/user/change_password'
+        - if feature_enabled?(:responsive_ux)
+          - content_for :actions do
+            %li.nav-item
+              = link_to(my_subscriptions_path, class: 'nav-link') do
+                %i.fas.fa-lg.mr-2.fa-bell
+                Change your notifications
+        - else
+          = link_to(my_subscriptions_path, class: 'd-block') do
+            %i.fas.fa-bell
+            Change your notifications
         - if user.rss_token
           = link_to(user_rss_notifications_path(token: user.rss_token.string, format: 'rss'),
                                                 title: 'RSS Feed for Notifications', class: 'd-block') do

--- a/src/api/spec/features/beta/webui/users/user_home_page_spec.rb
+++ b/src/api/spec/features/beta/webui/users/user_home_page_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe "User's home project creation", type: :feature, js: true do
       expect(page).to have_css('#home-realname', text: 'Jim Knopf')
       expect(page).to have_css("a[href='mailto:jim.knopf@puppenkiste.com']", text: 'jim.knopf@puppenkiste.com')
 
+      within('#bottom-navigation-area') { click_link('Actions') } if mobile?
       expect(page).to have_text('Edit your account')
       expect(page).to have_text('Change your password')
 
@@ -49,7 +50,7 @@ RSpec.describe "User's home project creation", type: :feature, js: true do
 
       expect(page).to have_link('Incoming Requests')
       # TODO: Remove this line if the dropdown is changed to a scrollable tab, and responsive_ux is out of beta.
-      find('.nav-link.dropdown-toggle').click if mobile?
+      within('#requests') { find('.nav-link.dropdown-toggle').click } if mobile?
       expect(page).to have_link('Outgoing Requests')
       expect(page).to have_link('Declined Requests')
       expect(page).to have_link('All Requests')
@@ -58,7 +59,12 @@ RSpec.describe "User's home project creation", type: :feature, js: true do
     end
 
     it 'edit account information' do
-      click_link('Edit your account')
+      if mobile?
+        within('#bottom-navigation-area') { click_link('Actions') }
+        within('#bottom-navigation-area') { click_link('Edit your account') }
+      else
+        click_link('Edit your account')
+      end
 
       fill_in('user_realname', with: 'John Doe')
       fill_in('user_email', with: 'john.doe@opensuse.org')


### PR DESCRIPTION
We want to move all user's profile page action links into the left menu, inside the Actions area.

Those actions are, **Edit your account** and **Change your password**

This is how it looks like on small screens:
![Peek 2020-10-08 17-30](https://user-images.githubusercontent.com/2650/95480396-25d94700-098c-11eb-8ccf-be6ce25c5b8e.gif)

This is how it looks like on large screens:
![image](https://user-images.githubusercontent.com/2650/95480140-d85cda00-098b-11eb-94ba-05ad6cfd217e.png)

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
