### PR TITLE
Replace `require_login` with Pundit in Webui::Users::RssTokensController

### DIFF
--- a/src/api/app/controllers/webui/users/rss_tokens_controller.rb
+++ b/src/api/app/controllers/webui/users/rss_tokens_controller.rb
@@ -1,18 +1,21 @@
 module Webui
   module Users
     class RssTokensController < WebuiController
-      before_action :require_login
+      # TODO: Remove this when we'll refactor kerberos_auth
+      before_action :kerberos_auth
+
+      after_action :verify_authorized
 
       def create
-        token = User.session!.rss_token
-        if token
+        token = authorize(Token::Rss.find_or_initialize_by(user: User.session))
+        if token.persisted?
           flash[:success] = 'Successfully re-generated your RSS feed url'
           token.regenerate_string
-          token.save
         else
           flash[:success] = 'Successfully generated your RSS feed url'
-          User.session!.create_rss_token
         end
+        token.save
+
         redirect_back(fallback_location: my_subscriptions_path)
       end
     end

--- a/src/api/app/policies/token/rss_policy.rb
+++ b/src/api/app/policies/token/rss_policy.rb
@@ -1,0 +1,11 @@
+class Token
+  class RssPolicy < ApplicationPolicy
+    def initialize(user, record, opts = {})
+      super(user, record, opts.merge(ensure_logged_in: true))
+    end
+
+    def create?
+      user == record.user
+    end
+  end
+end

--- a/src/api/spec/controllers/webui/users/rss_tokens_controller_spec.rb
+++ b/src/api/spec/controllers/webui/users/rss_tokens_controller_spec.rb
@@ -4,18 +4,20 @@ RSpec.describe Webui::Users::RssTokensController do
   describe 'POST #create' do
     let(:user) { create(:confirmed_user) }
 
-    before do
-      login(user)
+    it_behaves_like 'require logged in user' do
+      let(:method) { :post }
+      let(:action) { :create }
     end
 
     context 'with a user with an existent token' do
-      let(:last_token) { user.create_rss_token.string }
+      let!(:last_token) { user.create_rss_token.string }
 
       before do
+        login(user)
         post :create
       end
 
-      it { expect(flash[:success]).to eq('Successfully generated your RSS feed url') }
+      it { expect(flash[:success]).to eq('Successfully re-generated your RSS feed url') }
       it { is_expected.to redirect_to(my_subscriptions_path) }
       it { expect(user.reload.rss_token.string).not_to eq(last_token) }
     end
@@ -24,6 +26,7 @@ RSpec.describe Webui::Users::RssTokensController do
       let!(:last_token) { user.rss_token }
 
       before do
+        login(user)
         post :create
       end
 

--- a/src/api/spec/policies/token/rss_policy_spec.rb
+++ b/src/api/spec/policies/token/rss_policy_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe Token::RssPolicy do
+  let(:user) { create(:user) }
+  let(:other_user) { build(:user) }
+  let(:user_nobody) { build(:user_nobody) }
+  let(:rss_token_user) { create(:rss_token, user: user) }
+
+  subject { described_class }
+
+  permissions :create? do
+    it { is_expected.to permit(user, rss_token_user) }
+    it { is_expected.not_to permit(other_user, rss_token_user) }
+  end
+
+  it "doesn't permit anonymous user" do
+    expect { described_class.new(user_nobody, rss_token_user) }
+      .to raise_error(an_instance_of(Pundit::NotAuthorizedError).and(having_attributes(reason: :anonymous_user)))
+  end
+end


### PR DESCRIPTION
This is a PR of a series which replaces `require_login` with `Pundit`.
You can find further relevant info in #10083.

Tackles `Webui::Users::RssTokensController`

Ref #10083

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
