### PR TITLE
Make sidebar scrollable if it does not fit into viewport

### DIFF
--- a/src/api/app/assets/stylesheets/webui/responsive_ux/grid.scss
+++ b/src/api/app/assets/stylesheets/webui/responsive_ux/grid.scss
@@ -38,9 +38,12 @@
       display: block;
 
       #left-navigation {
-        position: fixed;
+        position: sticky;
         top: $top-navigation-height;
         left: 0;
+        max-height: calc(100vh - #{$top-navigation-height});
+        overflow-y: auto;
+        overflow-x: hidden;
 
         & a {
           color: $gray-300;


### PR DESCRIPTION
Sidebar items were hidden over the viewport boundaries when sidebar does
not fit into the screen.

The commit adds CSS styles to show scrollbar when the items in sidebar
go over the viewport boundaries.

To verify the feature:

1. Log in to the application;
2. Decrease browser's height, so that sidebar items go out of viewport boundaries;
3. Focus on the sidebar.

Expected result:
Scrollbar appears. All the previous behavior remains same (e.g. scrollbar is not moving when scrolling the content area).

Here are screenshots of how it looks:

**Before**
![before](https://user-images.githubusercontent.com/37581072/95345347-eabb1300-08ba-11eb-8ca8-7678325e8493.png)


**After**
![after](https://user-images.githubusercontent.com/37581072/95348136-04118e80-08be-11eb-9176-b02e1a1ec26c.png)

