### PR TITLE
Feature: saved replies

### DIFF
--- a/src/api/app/controllers/webui/comment_snippets_controller.rb
+++ b/src/api/app/controllers/webui/comment_snippets_controller.rb
@@ -3,7 +3,7 @@ class Webui::CommentSnippetsController < Webui::WebuiController
   before_action :check_displayed_user
 
   def index
-    @comment_snippets = CommentSnippet.limit(10).all
+    @comment_snippets = User.session.comment_snippets.limit(10).all
     render :index
   end
 

--- a/src/api/app/controllers/webui/comment_snippets_controller.rb
+++ b/src/api/app/controllers/webui/comment_snippets_controller.rb
@@ -3,22 +3,76 @@ class Webui::CommentSnippetsController < Webui::WebuiController
   before_action :check_displayed_user
 
   def index
-    @comment_snippets = User.session.comment_snippets.limit(10).all
-    render :index
+    comment_snippets = User.session.comment_snippets.limit(10).all
+
+    render :index, locals: { comment_snippets: comment_snippets }
   end
 
   def create
-    @comment_snippet = CommentSnippet.new(permitted_params)
-    User.session!.comment_snippets << @comment_snippet
+    comment_snippet = CommentSnippet.new(permitted_params)
+    User.session!.comment_snippets << comment_snippet
+    comment_snippets = User.session.comment_snippets
 
-    status = if @comment_snippet.save
-               flash.now[:success] = 'Comment snippet created successfully.'
+    status = if comment_snippet.save
+               flash.now[:success] = 'Reply created successfully.'
                :ok
              else
-               flash.now[:error] = "Failed to create comment snippet: #{comment.errors.full_messages.to_sentence}."
+               flash.now[:error] = "Failed to create reply: #{comment_snippet.errors.full_messages.to_sentence}."
                :unprocessable_entity
              end
-    render(partial: 'webui/comment_snippets/comment_snippets_list')
+
+    respond_to do |format|
+      format.html do
+        render(partial: 'webui/comment_snippets/comment_snippets_list',
+               locals: { comment_snippets: comment_snippets },
+               status: status)
+      end
+    end
+  end
+
+  def update
+    comment_snippet = CommentSnippet.find(params[:id])
+    authorize comment_snippet, :update?
+    comment_snippet.assign_attributes(permitted_params)
+    comment_snippets = User.session.comment_snippets
+
+    status = if comment_snippet.save
+               flash.now[:success] = 'Reply updated successfully.'
+               :ok
+             else
+               flash.now[:error] = "Failed to update reply: #{comment_snippet.errors.full_messages.to_sentence}."
+               :unprocessable_entity
+             end
+
+    respond_to do |format|
+      format.html do
+        render(partial: 'webui/comment_snippets/comment_snippets_list',
+               locals: { comment_snippets: comment_snippets },
+               status: status)
+      end
+    end
+  end
+
+  def destroy
+    comment_snippet = CommentSnippet.find(params[:id])
+    authorize comment_snippet, :destroy?
+    comment_snippets = User.session.comment_snippets
+
+    status = if comment_snippet.destroy
+               flash.now[:success] = 'Reply deleted successfully.'
+               :ok
+             else
+               flash.now[:error] = "Failed to delete reply: #{comment_snippet.errors.full_messages.to_sentence}."
+               :unprocessable_entity
+             end
+
+    respond_to do |format|
+      format.html do
+        render(partial: 'webui/comment_snippets/comment_snippets_list',
+               locals: { comment_snippets: comment_snippets },
+               status: status)
+      end
+    end
   end
 
   private

--- a/src/api/app/controllers/webui/comment_snippets_controller.rb
+++ b/src/api/app/controllers/webui/comment_snippets_controller.rb
@@ -1,0 +1,29 @@
+class Webui::CommentSnippetsController < Webui::WebuiController
+  before_action :require_login
+  before_action :check_displayed_user
+
+  def index
+    @comment_snippets = CommentSnippet.limit(10).all
+    render :index
+  end
+
+  def create
+    @comment_snippet = CommentSnippet.new(permitted_params)
+    User.session!.comment_snippets << @comment_snippet
+
+    status = if @comment_snippet.save
+               flash.now[:success] = 'Comment snippet created successfully.'
+               :ok
+             else
+               flash.now[:error] = "Failed to create comment snippet: #{comment.errors.full_messages.to_sentence}."
+               :unprocessable_entity
+             end
+    render(partial: 'webui/comment_snippets/comment_snippets_list')
+  end
+
+  private
+
+  def permitted_params
+    params.require(:comment_snippet).permit(:title, :body)
+  end
+end

--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -105,6 +105,8 @@ class Webui::PackageController < Webui::WebuiController
     @comments = @package.comments.includes(:user)
     @comment = Comment.new
 
+    @comment_snippets = User.session.comment_snippets
+
     @current_notification = NotificationsFinder.new.for_subscribed_user_by_id(params[:notification_id])
 
     @services = @files.any? { |file| file[:name] == '_service' }

--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -105,7 +105,7 @@ class Webui::PackageController < Webui::WebuiController
     @comments = @package.comments.includes(:user)
     @comment = Comment.new
 
-    @comment_snippets = User.session.comment_snippets
+    @comment_snippets = User.session.comment_snippets if User.session.present?
 
     @current_notification = NotificationsFinder.new.for_subscribed_user_by_id(params[:notification_id])
 

--- a/src/api/app/models/comment_snippet.rb
+++ b/src/api/app/models/comment_snippet.rb
@@ -4,7 +4,7 @@ class CommentSnippet < ApplicationRecord
 
   validates :title, :body, :user, presence: true
   validates :title, length: { maximum: 255 }
-  validates :body, length: { maximum: 16.megabytes - 1 }
+  validates :body, length: { maximum: 65_535 }
   validates :body, format: { with: /\A[^\u0000]*\Z/,
                              message: 'must not contain null characters' }
 end
@@ -14,7 +14,7 @@ end
 # Table name: comment_snippets
 #
 #  id         :integer          not null, primary key
-#  body       :text(16777215)   not null
+#  body       :text(65535)      not null
 #  title      :string(255)      not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/src/api/app/models/comment_snippet.rb
+++ b/src/api/app/models/comment_snippet.rb
@@ -1,0 +1,30 @@
+# This class represents saved replies you can use when writing a comment
+class CommentSnippet < ApplicationRecord
+  belongs_to :user, inverse_of: :comment_snippets
+
+  validates :title, :body, :user, presence: true
+  validates :title, length: { maximum: 255 }
+  validates :body, length: { maximum: 16.megabytes - 1 }
+  validates :body, format: { with: /\A[^\u0000]*\Z/,
+                             message: 'must not contain null characters' }
+end
+
+# == Schema Information
+#
+# Table name: comment_snippets
+#
+#  id         :integer          not null, primary key
+#  body       :text(16777215)   not null
+#  title      :string(255)      not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :integer          not null, indexed
+#
+# Indexes
+#
+#  index_comment_snippets_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -18,6 +18,7 @@ class User < ApplicationRecord
   has_many :relationships, inverse_of: :user, dependent: :destroy
 
   has_many :comments, dependent: :destroy, inverse_of: :user
+  has_many :comment_snippets, dependent: :destroy, inverse_of: :user
   has_many :status_messages
   has_many :messages
   has_many :tokens, class_name: 'Token', dependent: :destroy, inverse_of: :user

--- a/src/api/app/policies/comment_snippet_policy.rb
+++ b/src/api/app/policies/comment_snippet_policy.rb
@@ -1,0 +1,19 @@
+class CommentSnippetPolicy < ApplicationPolicy
+  def initialize(user, record)
+    super(user, record, user_optional: true)
+  end
+
+  def create
+    update?
+  end
+
+  def destroy?
+    update?
+  end
+
+  def update?
+    return false if user.blank? || user.is_nobody?
+
+    user == record.user
+  end
+end

--- a/src/api/app/policies/comment_snippet_policy.rb
+++ b/src/api/app/policies/comment_snippet_policy.rb
@@ -3,10 +3,6 @@ class CommentSnippetPolicy < ApplicationPolicy
     super(user, record, user_optional: true)
   end
 
-  def create
-    update?
-  end
-
   def destroy?
     update?
   end

--- a/src/api/app/views/layouts/webui/responsive_ux/_top_navigation.html.haml
+++ b/src/api/app/views/layouts/webui/responsive_ux/_top_navigation.html.haml
@@ -22,6 +22,10 @@
                 = image_tag_for(User.session, size: 20, custom_class: 'rounded-circle bg-light mr-2')
                 Your profile
             .dropdown-item
+              = link_to(my_comment_snippets_path, class: 'nav-link text-light p-0 w-100') do
+                %i.fas.fa-comment.fa-lg.mr-2
+                Saved replies
+            .dropdown-item
               = link_to(session_path, method: :delete, id: 'logout-link', class: 'nav-link text-light p-0 w-100') do
                 %i.fas.fa-sign-out-alt.fa-lg.mr-2
                 Logout

--- a/src/api/app/views/layouts/webui/responsive_ux/_top_navigation.html.haml
+++ b/src/api/app/views/layouts/webui/responsive_ux/_top_navigation.html.haml
@@ -22,7 +22,7 @@
                 = image_tag_for(User.session, size: 20, custom_class: 'rounded-circle bg-light mr-2')
                 Your profile
             .dropdown-item
-              = link_to(my_comment_snippets_path, class: 'nav-link text-light p-0 w-100') do
+              = link_to(comment_snippets_path, id: 'saved-replies-link', class: 'nav-link text-light p-0 w-100') do
                 %i.fas.fa-comment.fa-lg.mr-2
                 Saved replies
             .dropdown-item

--- a/src/api/app/views/webui/comment/_new.html.haml
+++ b/src/api/app/views/webui/comment/_new.html.haml
@@ -6,7 +6,7 @@
       or
       = link_to('signup', new_user_url)
     in order to comment
-- else 
+- else
   = render(partial: 'webui/comment_snippets/comment_snippets_dropdown')
   = render(partial: 'webui/comment/comment_field',
    locals: { form_method: :post, comment: Comment.new, commentable: commentable })

--- a/src/api/app/views/webui/comment/_new.html.haml
+++ b/src/api/app/views/webui/comment/_new.html.haml
@@ -6,6 +6,7 @@
       or
       = link_to('signup', new_user_url)
     in order to comment
-- else
+- else 
+  = render(partial: 'webui/comment_snippets/comment_snippets_dropdown')
   = render(partial: 'webui/comment/comment_field',
    locals: { form_method: :post, comment: Comment.new, commentable: commentable })

--- a/src/api/app/views/webui/comment_snippets/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui/comment_snippets/_breadcrumb_items.html.haml
@@ -1,0 +1,4 @@
+= render partial: 'webui/main/breadcrumb_items'
+
+%li.breadcrumb-item.active{ 'aria-current' => 'page' }
+  = @pagetitle

--- a/src/api/app/views/webui/comment_snippets/_comment_snippet_form.html.haml
+++ b/src/api/app/views/webui/comment_snippets/_comment_snippet_form.html.haml
@@ -1,0 +1,9 @@
+= form_with( model: @comment_snippet, method: form_method, remote: true, html: { class: "#{form_method}-comment-snippet-form" }) do |f|
+  ~ f.text_field('comment_snippet[title]', placeholder: 'Saved reply title', autocomplete: 'off', class: 'form-control', required: true)
+  ~ f.text_area 'comment_snippet[body]', rows: '4', placeholder: 'Write your saved reply here... (Markdown markup is supported)', required: true,
+    class: 'w-100 mb-3 form-control comment-field'
+  - case form_method
+  - when :post
+    = f.submit 'Add saved reply', class: 'btn btn-primary', data: { disable_with: 'Creating saved reply...' }
+  - when :put
+    = f.submit 'Update saved reply', class: 'btn btn-primary', data: { disable_with: 'Updating saved_reply...' }

--- a/src/api/app/views/webui/comment_snippets/_comment_snippet_form.html.haml
+++ b/src/api/app/views/webui/comment_snippets/_comment_snippet_form.html.haml
@@ -1,9 +1,5 @@
-= form_with( model: @comment_snippet, method: form_method, remote: true, html: { class: "#{form_method}-comment-snippet-form" }) do |f|
+= form_with(model: @comment_snippet, method: form_method, remote: true, html: { class: "#{form_method}-comment-snippet-form" }) do |f|
   ~ f.text_field('comment_snippet[title]', placeholder: 'Saved reply title', autocomplete: 'off', class: 'form-control', required: true)
-  ~ f.text_area 'comment_snippet[body]', rows: '4', placeholder: 'Write your saved reply here... (Markdown markup is supported)', required: true,
+  ~ f.text_area 'comment_snippet[body]', rows: '4', placeholder: 'Write your reply here... (Markdown markup is supported)', required: true,
     class: 'w-100 mb-3 form-control comment-field'
-  - case form_method
-  - when :post
-    = f.submit 'Add saved reply', class: 'btn btn-primary', data: { disable_with: 'Creating saved reply...' }
-  - when :put
-    = f.submit 'Update saved reply', class: 'btn btn-primary', data: { disable_with: 'Updating saved_reply...' }
+  = f.submit 'Add saved reply', class: 'btn btn-primary', data: { disable_with: 'Creating saved reply...' }

--- a/src/api/app/views/webui/comment_snippets/_comment_snippet_update_form.html.haml
+++ b/src/api/app/views/webui/comment_snippets/_comment_snippet_update_form.html.haml
@@ -1,0 +1,7 @@
+= form_with(model: @comment_snippet, url: comment_snippet_path(comment_snippet), method: form_method,
+  remote: true, html: { class: "#{form_method}-comment-snippet-form" }) do |f|
+  ~ f.text_field('comment_snippet[title]', placeholder: 'Saved reply title',
+    autocomplete: 'off', class: 'form-control', required: true, value: comment_snippet.title)
+  ~ f.text_area 'comment_snippet[body]', rows: '4', placeholder: 'Write your reply here... (Markdown markup is supported)', required: true,
+    class: 'w-100 mb-3 form-control comment-field', value: comment_snippet.body
+  = f.submit 'Update saved reply', class: 'btn btn-primary', data: { disable_with: 'Updating saved_reply...' }

--- a/src/api/app/views/webui/comment_snippets/_comment_snippets_dropdown.html.haml
+++ b/src/api/app/views/webui/comment_snippets/_comment_snippets_dropdown.html.haml
@@ -1,18 +1,18 @@
 - if @comment_snippets.present?
-  %button.btn.btn-link.dropdown-toggle#comment_snippets{ aria: { expanded: false, haspopup: false }, data: { toggle: 'dropdown', offset: 150 } }
+  %button.btn.btn-link.dropdown-toggle#comment-snippets{ aria: { expanded: false, haspopup: false }, data: { toggle: 'dropdown', offset: 150 } }
     Saved replies
-  .dropdown-menu#snippets_list{ aria: { labelledby: 'comment_snippets' } }
+  .dropdown-menu#snippets-list{ aria: { labelledby: 'comment_snippets' } }
     - @comment_snippets.each do |comment_snippet|
       %a.dropdown-item
         %p
           = comment_snippet.title
-        %p#snippet_body
+        %p#snippet-body
           = comment_snippet.body
 
 :javascript
-  $('#snippets_list a').on('click', function(){
+  $('#snippets-list a').on('click', function(){
     {
-      $('#comment_body').val($('#snippet_body', this).text())
+      $('#comment_body').val($('#snippet-body', this).text())
     }
   });
 

--- a/src/api/app/views/webui/comment_snippets/_comment_snippets_dropdown.html.haml
+++ b/src/api/app/views/webui/comment_snippets/_comment_snippets_dropdown.html.haml
@@ -1,0 +1,18 @@
+- if @comment_snippets.present?
+  %button.btn.btn-link.dropdown-toggle#comment_snippets{ aria: { expanded: false, haspopup: false }, data: { toggle: 'dropdown', offset: 150 } }
+    Saved replies
+  .dropdown-menu#snippets_list{ aria: { labelledby: 'comment_snippets' } }
+    - @comment_snippets.each do |comment_snippet|
+      %a.dropdown-item
+        %p
+          = comment_snippet.title
+        %p#snippet_body
+          = comment_snippet.body
+
+:javascript
+  $('#snippets_list a').on('click', function(){
+    {
+      $('#comment_body').val($('#snippet_body', this).text())
+    }
+  });
+

--- a/src/api/app/views/webui/comment_snippets/_comment_snippets_list.html.haml
+++ b/src/api/app/views/webui/comment_snippets/_comment_snippets_list.html.haml
@@ -7,11 +7,14 @@
       = link_to('signup', new_user_url)
     in order to comment
 - else
-  - @comment_snippets.each do |comment_snippet|
-    %p
-      = comment_snippet.title
-    = render_as_markdown(comment_snippet.body)
-
+  - comment_snippets.each do |comment_snippet|
+    %hr
+    .media
+      .media-body
+        %p
+          = comment_snippet.title
+        = render_as_markdown(comment_snippet.body)
+        = render partial: 'webui/comment_snippets/edit', locals: { comment_snippet: comment_snippet }
   .comment_new.mt-3
     = render partial: 'webui/comment_snippets/new'
 

--- a/src/api/app/views/webui/comment_snippets/_comment_snippets_list.html.haml
+++ b/src/api/app/views/webui/comment_snippets/_comment_snippets_list.html.haml
@@ -1,0 +1,17 @@
+- if !User.session
+  .alert.alert-warning{ role: 'alert' }
+    Login required, please
+    = link_to('login', new_session_url)
+    - if can_register?
+      or
+      = link_to('signup', new_user_url)
+    in order to comment
+- else
+  - @comment_snippets.each do |comment_snippet|
+    %p
+      = comment_snippet.title
+    = render_as_markdown(comment_snippet.body)
+
+  .comment_new.mt-3
+    = render partial: 'webui/comment_snippets/new'
+

--- a/src/api/app/views/webui/comment_snippets/_delete_dialog.html.haml
+++ b/src/api/app/views/webui/comment_snippets/_delete_dialog.html.haml
@@ -1,0 +1,16 @@
+.modal.fade{ id: "delete-comment-modal-#{comment_snippet.id}", tabindex: -1, role: 'dialog',
+             aria: { labelledby: 'delete-comment-modal-label', hidden: true } }
+  .modal-dialog.modal-dialog-centered{ role: 'document' }
+    .modal-content
+      .modal-header
+        %h5.modal-title
+          Delete reply?
+      .modal-body
+        %p Please confirm deletion of reply
+
+        = form_tag(comment_snippet_path(comment_snippet), method: :delete,
+          remote: true, class: 'delete-comment-form', data: { comment_snippet_id: comment_snippet.id }) do
+          .modal-footer
+            %a.btn.btn-sm.btn-outline-secondary.px-4{ data: { dismiss: 'modal' } }
+              Cancel
+            = submit_tag('Delete', class: 'btn btn-sm btn-danger px-4')

--- a/src/api/app/views/webui/comment_snippets/_edit.html.haml
+++ b/src/api/app/views/webui/comment_snippets/_edit.html.haml
@@ -1,0 +1,16 @@
+%ul.list-inline
+  - if policy(comment_snippet).update?
+    %li.list-inline-item
+      %button.btn.btn-outline-secondary.collapsed{ id: "edit_button_of_#{comment_snippet.id}",
+       data: { toggle: 'collapse', target: "#edit_form_of_#{comment_snippet.id}" } }
+        Edit
+  - if policy(comment_snippet).destroy?
+    %li.list-inline-item
+      = render(partial: 'webui/comment_snippets/delete_dialog', locals: { comment_snippet: comment_snippet })
+      = link_to('#', data: { toggle: 'modal', target: "#delete-comment-modal-#{comment_snippet.id}" },
+                class: 'delete_link btn btn-outline-danger', title: 'Delete reply') do
+        Delete
+
+- if policy(comment_snippet).update?
+  .collapse{ id: "edit_form_of_#{comment_snippet.id}" }
+    = render(partial: 'webui/comment_snippets/comment_snippet_update_form', locals: { form_method: :patch, comment_snippet: comment_snippet })

--- a/src/api/app/views/webui/comment_snippets/_new.html.haml
+++ b/src/api/app/views/webui/comment_snippets/_new.html.haml
@@ -1,0 +1,2 @@
+= render(partial: 'webui/comment_snippets/comment_snippet_form',
+  locals: { form_method: :post })

--- a/src/api/app/views/webui/comment_snippets/_new.html.haml
+++ b/src/api/app/views/webui/comment_snippets/_new.html.haml
@@ -1,2 +1,2 @@
 = render(partial: 'webui/comment_snippets/comment_snippet_form',
-  locals: { form_method: :post })
+  locals: { form_method: :post, comment_snippet: CommentSnippet.new })

--- a/src/api/app/views/webui/comment_snippets/index.html.haml
+++ b/src/api/app/views/webui/comment_snippets/index.html.haml
@@ -1,6 +1,8 @@
 :ruby
   - @pagetitle = "Saved replies #{User.session!}"
 
-.card
-  .card_body
-    = render partial: 'webui/comment_snippets/comment_snippets_list'
+.overview
+  .comments
+    .card#comments-list
+      .card-body#comments
+      = render(partial: 'webui/comment_snippets/comment_snippets_list', locals: { comment_snippets: comment_snippets })

--- a/src/api/app/views/webui/comment_snippets/index.html.haml
+++ b/src/api/app/views/webui/comment_snippets/index.html.haml
@@ -1,0 +1,6 @@
+:ruby
+  - @pagetitle = "Saved replies #{User.session!}"
+
+.card
+  .card_body
+    = render partial: 'webui/comment_snippets/comment_snippets_list'

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -324,7 +324,7 @@ OBSApi::Application.routes.draw do
       post 'rss_tokens' => :create, controller: 'webui/users/rss_tokens', as: :my_rss_token
       post 'status_messages/:id' => :acknowledge, controller: 'webui/status_messages', as: :acknowledge_status_message
 
-      resources :comment_snippets, controller: 'webui/comment_snippets', as: :my_comment_snippets
+      resources :comment_snippets, only: [:create, :destroy, :update, :index], controller: 'webui/comment_snippets', as: :comment_snippets
     end
 
     get 'home', to: 'webui/webui#home', as: :home

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -323,6 +323,8 @@ OBSApi::Application.routes.draw do
 
       post 'rss_tokens' => :create, controller: 'webui/users/rss_tokens', as: :my_rss_token
       post 'status_messages/:id' => :acknowledge, controller: 'webui/status_messages', as: :acknowledge_status_message
+
+      resources :comment_snippets, controller: 'webui/comment_snippets', as: :my_comment_snippets
     end
 
     get 'home', to: 'webui/webui#home', as: :home

--- a/src/api/db/migrate/20201004141110_create_comment_snippets.rb
+++ b/src/api/db/migrate/20201004141110_create_comment_snippets.rb
@@ -2,7 +2,7 @@ class CreateCommentSnippets < ActiveRecord::Migration[6.0]
   def change
     create_table :comment_snippets, id: :integer do |t|
       t.string :title, charset: 'utf8', null: false
-      t.text :body, limit: 16.megabytes - 1, null: false
+      t.text :body, null: false
       t.references :user, type: :integer, null: false, foreign_key: true
 
       t.timestamps

--- a/src/api/db/migrate/20201004141110_create_comment_snippets.rb
+++ b/src/api/db/migrate/20201004141110_create_comment_snippets.rb
@@ -1,0 +1,11 @@
+class CreateCommentSnippets < ActiveRecord::Migration[6.0]
+  def change
+    create_table :comment_snippets, id: :integer do |t|
+      t.string :title, charset: 'utf8', null: false
+      t.text :body, limit: 16.megabytes - 1, null: false
+      t.references :user, type: :integer, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -290,7 +290,7 @@ ActiveRecord::Schema.define(version: 2020_10_04_141110) do
 
   create_table "comment_snippets", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "title", null: false, collation: "utf8_general_ci"
-    t.text "body", size: :medium, null: false
+    t.text "body", null: false
     t.integer "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_03_110429) do
+ActiveRecord::Schema.define(version: 2020_10_04_141110) do
 
   create_table "architectures", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false, collation: "utf8_general_ci"
@@ -286,6 +286,15 @@ ActiveRecord::Schema.define(version: 2020_07_03_110429) do
     t.datetime "updated_at", null: false
     t.index ["job_id"], name: "index_cloud_user_upload_jobs_on_job_id", unique: true
     t.index ["user_id"], name: "index_cloud_user_upload_jobs_on_user_id"
+  end
+
+  create_table "comment_snippets", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "title", null: false, collation: "utf8_general_ci"
+    t.text "body", size: :medium, null: false
+    t.integer "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_comment_snippets_on_user_id"
   end
 
   create_table "comments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
@@ -1087,6 +1096,7 @@ ActiveRecord::Schema.define(version: 2020_07_03_110429) do
   add_foreign_key "channel_targets", "channels", name: "channel_targets_ibfk_1"
   add_foreign_key "channel_targets", "repositories", name: "channel_targets_ibfk_2"
   add_foreign_key "channels", "packages", name: "channels_ibfk_1"
+  add_foreign_key "comment_snippets", "users"
   add_foreign_key "comments", "comments", column: "parent_id", name: "comments_ibfk_4"
   add_foreign_key "comments", "users", name: "comments_ibfk_1"
   add_foreign_key "download_repositories", "repositories", name: "download_repositories_ibfk_1"

--- a/src/api/spec/cassettes/Comment_snippets/can_be_created.yml
+++ b/src/api/spec/cassettes/Comment_snippets/can_be_created.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/build/_workerstatus
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '1461'
+    body:
+      encoding: UTF-8
+      string: |
+        <workerstatus clients="2">
+          <idle workerid="790cab1dad27:1" hostarch="x86_64"/>
+          <building workerid="790cab1dad27:2" hostarch="x86_64" project="home:Admin" repository="openSUSE_Tumbleweed" package="hello_world" arch="x86_64" starttime="1602065097"/>
+          <waiting arch="i586" jobs="0"/>
+          <waiting arch="x86_64" jobs="0"/>
+          <blocked arch="i586" jobs="0"/>
+          <blocked arch="x86_64" jobs="1"/>
+          <buildavg arch="i586" buildavg="1200"/>
+          <buildavg arch="x86_64" buildavg="1200"/>
+          <partition>
+            <daemon type="srcserver" state="running" starttime="1602064959"/>
+            <daemon type="servicedispatch" state="running" starttime="1602064963"/>
+            <daemon type="service" state="running" starttime="1602064963"/>
+            <daemon type="clouduploadserver" state="running" starttime="1602064963"/>
+            <daemon type="clouduploadworker" state="running" starttime="1602064963"/>
+            <daemon type="scheduler" arch="i586" state="running" starttime="1602064963">
+              <queue high="0" med="0" low="0" next="0"/>
+            </daemon>
+            <daemon type="scheduler" arch="x86_64" state="running" starttime="1602064963">
+              <queue high="0" med="0" low="0" next="0"/>
+            </daemon>
+            <daemon type="repserver" state="running" starttime="1602064961"/>
+            <daemon type="dispatcher" state="running" starttime="1602064963"/>
+            <daemon type="publisher" state="running" starttime="1602064963"/>
+            <daemon type="signer" state="running" starttime="1602064965"/>
+          </partition>
+        </workerstatus>
+  recorded_at: Wed, 07 Oct 2020 12:58:56 GMT
+recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Comments/with_comment_snippet/creates_a_comment_from_comment_snippet.yml
+++ b/src/api/spec/cassettes/Comments/with_comment_snippet/creates_a_comment_from_comment_snippet.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/build/home:burdenski/_result?code=unresolvable&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home burdenski' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '156'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:burdenski' does not exist</summary>
+          <details>404 project 'home:burdenski' does not exist</details>
+        </status>
+  recorded_at: Wed, 07 Oct 2020 12:34:15 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:burdenski/_keyinfo?donotcreatecert=1&withsslcert=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '11'
+    body:
+      encoding: UTF-8
+      string: "<keyinfo/>\n"
+  recorded_at: Wed, 07 Oct 2020 12:34:15 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:burdenski/_result?view=summary
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home burdenski' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '156'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:burdenski' does not exist</summary>
+          <details>404 project 'home:burdenski' does not exist</details>
+        </status>
+  recorded_at: Wed, 07 Oct 2020 12:34:15 GMT
+recorded_with: VCR 6.0.0

--- a/src/api/spec/controllers/webui/comment_snippets_controller_spec.rb
+++ b/src/api/spec/controllers/webui/comment_snippets_controller_spec.rb
@@ -1,0 +1,145 @@
+require 'rails_helper'
+
+RSpec.describe Webui::CommentSnippetsController, type: :controller do
+  let(:user) { create(:confirmed_user, login: 'luck') }
+
+  before do
+    login user
+  end
+
+  describe 'POST #create' do
+    context 'saving a comment snippet' do
+      before do
+        params = {
+          comment_snippet: {
+            title: 'Appreciation reply',
+            body: 'Thank you for your contribution.'
+          }
+        }
+        post :create, params: params
+      end
+
+      it { expect(flash[:success]).to eq('Reply created successfully.') }
+      it { expect(user.comment_snippets.first.title).to eq('Appreciation reply') }
+      it { expect(user.comment_snippets.first.body).to eq('Thank you for your contribution.') }
+    end
+
+    context 'saving a comment snippet without title' do
+      before do
+        params = {
+          comment_snippet: {
+            title: '',
+            body: 'Thank you for your contribution.'
+          }
+        }
+        post :create, params: params
+      end
+
+      it { expect(flash[:error]).to eq("Failed to create reply: Title can't be blank.") }
+      it { expect(user.comment_snippets.count).to eq(0) }
+    end
+
+    context 'saving a comment snippet without body' do
+      before do
+        params = {
+          comment_snippet: {
+            title: 'Appreciation reply',
+            body: ''
+          }
+        }
+        post :create, params: params
+      end
+
+      it { expect(flash[:error]).to eq("Failed to create reply: Body can't be blank.") }
+      it { expect(user.comment_snippets.count).to eq(0) }
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    let(:comment_snippet) { create(:comment_snippet, user: user) }
+    let(:other_comment_snippet) { create(:comment_snippet) }
+
+    context 'can destroy own comments' do
+      before do
+        delete :destroy, params: { id: comment_snippet.id }
+      end
+
+      it { expect(flash[:success]).to eq('Reply deleted successfully.') }
+      it { expect(CommentSnippet.where(id: comment_snippet.id)).to eq([]) }
+    end
+
+    context 'cannot destroy comment snippet of somebody else' do
+      before do
+        delete :destroy, params: { id: other_comment_snippet.id }
+      end
+
+      it { expect(flash[:success]).to eq(nil) }
+      it { expect(CommentSnippet.where(id: other_comment_snippet.id)).to eq([other_comment_snippet]) }
+    end
+  end
+
+  describe 'EDIT update' do
+    let(:comment_snippet) { create(:comment_snippet, user: user) }
+    let(:other_comment_snippet) { create(:comment_snippet) }
+
+    context 'with a valid comment snippet' do
+      let(:params) do
+        {
+          id: comment_snippet.id,
+          comment_snippet: { title: 'Reply of disgust', body: '... and stay out!' }
+        }
+      end
+
+      before do
+        put :update, params: params
+      end
+
+      it { expect(flash[:success]).to eq('Reply updated successfully.') }
+      it { expect(comment_snippet.reload.title).to eq('Reply of disgust') }
+      it { expect(comment_snippet.reload.body).to eq('... and stay out!') }
+
+      it 'responds to html requests' do
+        put :update, params: params, format: :html
+        expect(response.header['Content-Type']).to include 'text/html'
+      end
+
+      it 'does not respond to other json requests' do
+        expect { put :update, params: params, format: :json }.to raise_error(ActionController::UnknownFormat)
+      end
+
+      it 'does not respond to xml requests' do
+        expect { put :update, params: params, format: :xml }.to raise_error(ActionController::UnknownFormat)
+      end
+    end
+
+    context 'updating a comment snippet without title' do
+      before do
+        params = {
+          id: comment_snippet.id,
+          comment_snippet: {
+            title: '',
+            body: '... and stay out!'
+          }
+        }
+        put :update, params: params
+      end
+
+      it { expect(flash[:error]).to eq("Failed to update reply: Title can't be blank.") }
+    end
+
+    context 'updating a comment snippet without body' do
+      before do
+        params = {
+          id: comment_snippet.id,
+          comment_snippet: {
+            title: 'Reply of disgust',
+            body: ''
+          }
+        }
+        put :update, params: params
+      end
+
+      it { expect(flash[:error]).to eq("Failed to update reply: Body can't be blank.") }
+    end
+  end
+end

--- a/src/api/spec/factories/comment_snippets.rb
+++ b/src/api/spec/factories/comment_snippets.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :comment_snippet do
+    title { Faker::Lorem.sentence(word_count: 3) }
+    body { Faker::Lorem.paragraph }
+    user
+  end
+end

--- a/src/api/spec/features/webui/comment_snippets_spec.rb
+++ b/src/api/spec/features/webui/comment_snippets_spec.rb
@@ -1,0 +1,32 @@
+require 'browser_helper'
+
+RSpec.describe 'Comment snippets', type: :feature, js: true do
+  let(:user) { create(:confirmed_user, :with_home, login: 'burdenski') }
+
+  # rubocop:disable RSpec/ExampleLength
+  it 'can be created' do
+    login user
+    visit comment_snippets_path
+    fill_in 'comment_snippet[title]', with: 'Appreciation reply'
+    fill_in 'comment_snippet[body]', with: 'Thank you for your contribution.'
+    find_button('Add saved reply').click
+    visit comment_snippets_path
+
+    expect(page).to have_text('Appreciation reply')
+    expect(page).to have_text('Thank you for your contribution.')
+  end
+
+  it 'can be deleted' do
+    create(:comment_snippet, user: user)
+    login user
+    visit comment_snippets_path
+    click_link('Delete')
+
+    expect(page).to have_text('Please confirm deletion of reply')
+    click_button('Delete')
+
+    visit comment_snippets_path
+    expect(page).not_to have_text('Appreciation reply')
+  end
+  # rubocop:enable RSpec/ExampleLength
+end

--- a/src/api/spec/models/comment_snippet_spec.rb
+++ b/src/api/spec/models/comment_snippet_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe CommentSnippet, type: :model do
+  let(:comment_snippet) { create(:comment_snippet) }
+
+  describe 'has a valid Factory' do
+    it { expect(comment_snippet).to be_valid }
+  end
+
+  describe 'save' do
+    it 'stores emoji' do
+      comment_snippet.title = 'Thank you for your contribution'
+      comment_snippet.body = '😁'
+      comment_snippet.save
+    end
+  end
+
+  describe 'associations' do
+    it { is_expected.to belong_to(:user).inverse_of(:comment_snippets) }
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:title) }
+    it { is_expected.to validate_presence_of(:body) }
+    it { is_expected.to validate_presence_of(:user) }
+  end
+end

--- a/src/api/spec/policies/comment_snippet_policy_spec.rb
+++ b/src/api/spec/policies/comment_snippet_policy_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe CommentSnippetPolicy do
+  let(:anonymous_user) { create(:user_nobody) }
+  let(:user) { create(:confirmed_user, login: 'tom') }
+  let(:other_user) { create(:confirmed_user, login: 'other_user') }
+  let(:comment_snippet) { create(:comment_snippet, user: user) }
+
+  subject { CommentSnippetPolicy }
+
+  # rubocop:disable RSpec/RepeatedExample
+  # This cop is currently not recognizing the permissions block as separate test
+  permissions :destroy? do
+    it 'Not logged users cannot destroy comment snippets' do
+      expect(subject).not_to permit(nil, comment_snippet)
+    end
+
+    it 'Users can destroy their own comment snippets' do
+      expect(subject).to permit(user, comment_snippet)
+    end
+
+    it 'User cannot destroy comment snippets of other user' do
+      expect(subject).not_to permit(other_user, comment_snippet)
+    end
+    # rubocop:enable RSpec/RepeatedExample
+  end
+
+  # rubocop:disable RSpec/RepeatedExample
+  # This cop is currently not recognizing the permissions block as separate test
+  permissions :update? do
+    it 'an anonymous user cannot update comment snippetss' do
+      expect(subject).not_to permit(nil, comment_snippet)
+    end
+
+    it 'a user can update his own comment snippets' do
+      expect(subject).to permit(user, comment_snippet)
+    end
+
+    it 'a user cannot update comment snippetss of other users' do
+      expect(subject).not_to permit(other_user, comment_snippet)
+    end
+  end
+  # rubocop:enable RSpec/RepeatedExample
+end


### PR DESCRIPTION
Hello everyone,

this PR introduces saved replies feature with functionality similar to [GitHub saved replies](https://docs.github.com/en/github/writing-on-github/working-with-saved-replies). A user can create/update/remove replies, and use any of those replies to fill any comment input field.

To verify this feature
- create sample data (including a project with packages, right now this feature only works there)
- go to the root page, click 'Saved replies' link
![Screenshot_2020-10-07 Open Build Service](https://user-images.githubusercontent.com/14862258/95389409-10b0d980-08f4-11eb-8e88-be721a4ff581.jpg)
- create several replies with title and body
- go to the package overview page
![Screenshot_2020-10-07 Alone on a Wide, Wide Sea](https://user-images.githubusercontent.com/14862258/95390435-b0bb3280-08f5-11eb-97a9-de51b81de2f2.jpg)
- click on the dropdown list and choose a reply you would like to fill the comment input field with. When you click it, reply text should appear in the input field.

This is a work in progress, so, at the moment, it looks ugly.