### PR TITLE
Move actions to sidebar on the configuration page

### DIFF
--- a/src/api/app/views/webui/groups/index.html.haml
+++ b/src/api/app/views/webui/groups/index.html.haml
@@ -17,10 +17,17 @@
             %td
               = safe_join(group.users.map { |user| link_to(truncate(user.login, length: 20), user_path(user), title: user.login) }, ', ')
 
-    .pt-4
-      = link_to(group_new_path) do
-        %i.fas.fa-plus-circle.text-primary
-        Create Group
+    - if feature_enabled?(:responsive_ux)
+      - content_for :actions do
+        %li.nav-item
+          = link_to(group_new_path, class: 'nav-link') do
+            %i.fas.fa-lg.mr-2.fa-plus-circle
+            Create Group
+    - else
+      .pt-4
+        = link_to(group_new_path) do
+          %i.fas.fa-plus-circle.text-primary
+          Create Group
 
 - content_for :ready_function do
   initializeDataTable('#manage-groups-table', { columnDefs: [{ orderable: false, searchable: false, targets: -1 }] });

--- a/src/api/app/views/webui/users/index.html.haml
+++ b/src/api/app/views/webui/users/index.html.haml
@@ -17,10 +17,17 @@
             Actions
       %tbody
 
-    .pt-4
-      = link_to(new_user_path(pagetitle: 'create user', submit_btn_text: 'create')) do
-        %i.fas.fa-plus-circle.text-primary
-        Create User
+    - if feature_enabled?(:responsive_ux)
+      - content_for :actions do
+        %li.nav-item
+          = link_to(new_user_path(pagetitle: 'create user', submit_btn_text: 'create'), class: 'nav-link') do
+            %i.fas.fa-lg.mr-2.fa-plus-circle
+            Create User
+    - else
+      .pt-4
+        = link_to(new_user_path(pagetitle: 'create user', submit_btn_text: 'create')) do
+          %i.fas.fa-plus-circle.text-primary
+          Create User
 
 - content_for :ready_function do
   initializeUserConfigurationDatatable("#{::Configuration.ldap_enabled?}");

--- a/src/api/spec/features/beta/webui/groups_spec.rb
+++ b/src/api/spec/features/beta/webui/groups_spec.rb
@@ -42,7 +42,12 @@ RSpec.describe 'Groups', type: :feature, js: true do
   it 'create a group' do
     visit groups_path
 
-    click_link('Create Group', href: group_new_path)
+    if mobile?
+      within('#bottom-navigation-area') { click_link('Actions') }
+      within('#bottom-navigation-area') { click_link('Create Group') }
+    else
+      click_link('Create Group', href: group_new_path)
+    end
 
     new_group_title = 'group_123'
     fill_in('group_title', with: new_group_title)

--- a/src/api/spec/features/beta/webui/users/admin_configuration_spec.rb
+++ b/src/api/spec/features/beta/webui/users/admin_configuration_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe 'Admin user configuration page', type: :feature, js: true do
 
   it 'create user' do
     expect(page).to have_text('5 records')
+    click_link('Actions') if mobile?
     click_link('Create User')
 
     fill_in 'Username:', with: 'tux'


### PR DESCRIPTION
**Create Users from the Actions menu**

![image](https://user-images.githubusercontent.com/2650/95580475-b02ab500-0a37-11eb-9fe7-3f422ee289d0.png)

**Create Groups from the Actions menu**

![image](https://user-images.githubusercontent.com/2650/95580631-f253f680-0a37-11eb-967e-7c0431f08744.png)

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
