### PR TITLE
Prevent exception on empty URL in markdown text

### DIFF
--- a/src/api/lib/obsapi/markdown_renderer.rb
+++ b/src/api/lib/obsapi/markdown_renderer.rb
@@ -30,6 +30,10 @@ module OBSApi
 
     # unfortunately we can't call super (into C) - see vmg/redcarpet#51
     def link(link, title, content)
+      # A return value of nil will not output any data
+      # the contents of the span will be copied verbatim
+      return nil if link.blank?
+
       title = " title='#{title}'" if title.present?
       begin
         link = URI.join(::Configuration.obs_url, link)

--- a/src/api/spec/helpers/webui/markdown_helper_spec.rb
+++ b/src/api/spec/helpers/webui/markdown_helper_spec.rb
@@ -62,5 +62,11 @@ please review. Also you, <a href=\"https://unconfigured.openbuildservice.org/use
         "<p><a href=\"https://build.opensuse.org\">&amp;lt;script&amp;gt;&amp;lt;/script&amp;gt;</a></p>\n"
       )
     end
+
+    it 'just returns the original content on empty URIs' do
+      expect(render_as_markdown('installed_ver = self.core.version_func[deps_info[6]]()')).to eq(
+        "<p>installed_ver = self.core.version_func[deps_info[6]]()</p>\n"
+      )
+    end
   end
 end


### PR DESCRIPTION
An empty URL part in markdown text leads to an exception
in the mardown renderer. When a comment
includes such an empty URL string, it ends up with a
code 500. This happens when people post code examples
which contain the same syntax as a markdown link.
Instead of throwing an exception, we can just render
the original content incase of an empty URL part.

Kudos to @eduardoj

Fixes #10259

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
