### PR TITLE
User profile layout redesign

### DIFF
--- a/src/api/app/views/webui/user/user_profile_redesign/_involvement_and_activity.html.haml
+++ b/src/api/app/views/webui/user/user_profile_redesign/_involvement_and_activity.html.haml
@@ -1,0 +1,38 @@
+.card{ class: CONFIG['contribution_graph'] == :off ? 'd-block' : 'd-block d-md-none' }
+  -# Header that replaces the tabs when the contribution graph is not displayed (in small viewports or when not enabled).
+  .card-header
+    %h5 Involved Projects and Packages
+  .card-body
+    = render partial: 'webui/user/involvement', locals: { user: user,
+                                                          owned: owned,
+                                                          involved_projects: involved_projects,
+                                                          involved_packages: involved_packages }
+
+-# Displaying tabs in medium-large viewports when the Contribution Graph is enabled
+- unless CONFIG['contribution_graph'] == :off
+  .card.d-none.d-md-block
+    -# Tabs
+    .bg-light
+      %ul.nav.nav-tabs.pt-2.px-3.flex-nowrap.collapsible{ 'role': 'tablist' }
+        %li.nav-item
+          = link_to('#involved-projects-and-packages', id: 'involved-projects-and-packages-tab', class: 'nav-link active text-nowrap',
+                    data: { toggle: 'tab' }, role: 'tab', aria: { controls: 'involved-projects-and-packages', selected: true }) do
+            Involved Projects/Packages
+        %li.nav-item
+          = link_to('#contributions', id: 'contributions-tab', class: 'nav-link text-nowrap',
+                    data: { toggle: 'tab' }, role: 'tab', aria: { controls: 'contributions', selected: false }) do
+            Contributions
+
+    -# Tabs content
+    .card-body
+      .tab-content
+        .tab-pane.fade.show.active#involved-projects-and-packages{ role: 'tabpanel', aria: { labelledby: 'involved-projects-and-packages-tab' } }
+          = render partial: 'webui/user/involvement', locals: { user: user,
+                                                                owned: owned,
+                                                                involved_projects: involved_projects,
+                                                                involved_packages: involved_packages }
+
+        .tab-pane.fade#contributions{ role: 'tabpanel', aria: { labelledby: 'contributions-tab' } }
+          = render partial: 'webui/user/activity', locals: { activity_hash: activity_hash,
+                                                             first_day: first_day,
+                                                             last_day: last_day }

--- a/src/api/app/views/webui/users/show.html.haml
+++ b/src/api/app/views/webui/users/show.html.haml
@@ -12,15 +12,21 @@
                                                           role_titles: @role_titles,
                                                           configuration: @configuration,
                                                           account_edit_link: @account_edit_link }
-  .col-12.col-md-8.col-lg-9
-    - unless CONFIG['contribution_graph'] == :off
-      = render partial: 'webui/user/activity', locals: { activity_hash: @activity_hash,
-                                                                first_day: @first_day,
-                                                                last_day: @last_day }
-    = render partial: 'webui/user/involvement', locals: { user: @displayed_user,
-                                                                 owned: @owned,
-                                                                 involved_projects: @iprojects,
-                                                                 involved_packages: @ipackages }
+  - if feature_enabled?('user_profile_redesign')
+    .col-12.col-md-8.col-lg-9
+      - locals = { user: @displayed_user, owned: @owned, involved_projects: @iprojects, involved_packages: @ipackages }
+      - locals.merge!({ activity_hash: @activity_hash, first_day: @first_day, last_day: @last_day }) unless CONFIG['contribution_graph'] == :off
+      = render partial: 'webui/user/user_profile_redesign/involvement_and_activity', locals: locals
+  - else
+    .col-12.col-md-8.col-lg-9
+      - unless CONFIG['contribution_graph'] == :off
+        = render partial: 'webui/user/activity', locals: { activity_hash: @activity_hash,
+                                                           first_day: @first_day,
+                                                           last_day: @last_day }
+      = render partial: 'webui/user/involvement', locals: { user: @displayed_user,
+                                                            owned: @owned,
+                                                            involved_projects: @iprojects,
+                                                            involved_packages: @ipackages }
 
 = render partial: 'webui/user/password_dialog', locals: { user: @displayed_user }
 = render partial: 'webui/user/edit_dialog', locals: { user: @displayed_user }

--- a/src/api/lib/tasks/dev.rake
+++ b/src/api/lib/tasks/dev.rake
@@ -3,7 +3,7 @@
 require 'fileutils'
 require 'yaml'
 
-ENABLED_FEATURE_FLAGS = [:responsive_ux, :notifications_redesign].freeze
+ENABLED_FEATURE_FLAGS = [:responsive_ux, :notifications_redesign, :user_profile_redesign].freeze
 
 namespace :dev do
   task :prepare do


### PR DESCRIPTION
New layout for the user profile page. Distributing _Involved Projects/Packages_ and _Contribution Graph_ in tabs when both are present.

**No tabs when Contribution Graph is disabled:**

![Screenshot_2020-10-08 Profile of Admin](https://user-images.githubusercontent.com/2581944/95515658-491cea00-09be-11eb-88ba-be59f5f89f35.png)

**Tabs when Contribution Graph is enabled:**

![Screenshot_2020-10-08 Profile of Admin(2)](https://user-images.githubusercontent.com/2581944/95515794-78335b80-09be-11eb-9727-caf9d1fb2e51.png)

**No tabs on small viewports no matter if the Contribution Graph is desabled or enabled**

![Screenshot_2020-10-08 Profile of Admin(1)](https://user-images.githubusercontent.com/2581944/95515627-3d312800-09be-11eb-8a34-1e619c8e7079.png)
