### PR TITLE
Replace `require_login` with Pundit in Webui::Users::NotificationsCon…

### DIFF
--- a/src/api/app/controllers/webui/users/notifications_controller.rb
+++ b/src/api/app/controllers/webui/users/notifications_controller.rb
@@ -2,9 +2,12 @@ class Webui::Users::NotificationsController < Webui::WebuiController
   MAX_PER_PAGE = 300
   VALID_NOTIFICATION_TYPES = ['read', 'reviews', 'comments', 'requests', 'unread'].freeze
 
-  before_action :require_login
+  # TODO: Remove this when we'll refactor kerberos_auth
+  before_action :kerberos_auth
   before_action :check_param_type, :check_param_project, only: :index
   before_action :check_feature_toggle
+
+  after_action :verify_policy_scoped
 
   def index
     @notifications = paginated_notifications

--- a/src/api/app/policies/notification_policy.rb
+++ b/src/api/app/policies/notification_policy.rb
@@ -1,5 +1,11 @@
 class NotificationPolicy < ApplicationPolicy
   class Scope < Scope
+    def initialize(user, scope)
+      raise Pundit::NotAuthorizedError, reason: ApplicationPolicy::ANONYMOUS_USER if user.nil? || user.is_nobody?
+
+      super(user, scope)
+    end
+
     def resolve
       NotificationsFinder.new(scope).for_subscribed_user(user)
     end

--- a/src/api/spec/policies/notification_policy_spec.rb
+++ b/src/api/spec/policies/notification_policy_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe NotificationPolicy do
+  describe NotificationPolicy::Scope do
+    let(:user_nobody) { build(:user_nobody) }
+
+    it "doesn't permit anonymous user" do
+      expect { described_class.new(user_nobody, Notification.none) }
+        .to raise_error(an_instance_of(Pundit::NotAuthorizedError).and(having_attributes(reason: :anonymous_user)))
+    end
+  end
+end


### PR DESCRIPTION
This is a PR of a series which replaces `require_login` with `Pundit`.
You can find further relevant info in #10083.

Tackles `Webui::Users::NotificationsController`

Ref #10083

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
