### PR TITLE
Move relevant Staging Projects Management actions under the Actions section on the left menu

### DIFF
--- a/src/api/app/views/webui/staging/workflows/edit.html.haml
+++ b/src/api/app/views/webui/staging/workflows/edit.html.haml
@@ -1,24 +1,36 @@
 - @pagetitle = "Manage Staging Projects for #{@project}"
 
+- if feature_enabled?(:responsive_ux)
+  - content_for :actions do
+    %li.nav-item
+      = link_to('#', class: 'nav-link', data: { toggle: 'modal', target: '#staging-managers-group-modal' }, title: 'Change Managers') do
+        %i.fas.fa-lg.mr-2.fa-users
+        %span.nav-item-name Change Managers
+
 .row
   .col-xl-12
     .card.mb-3
       = render(partial: 'webui/project/tabs', locals: { project: @project })
       .card-body
-        %h3= @pagetitle
+        %h3
+          = @pagetitle
+          - if feature_enabled?(:responsive_ux)
+            = link_to('#', title: 'Create Staging Project', data: { toggle: 'modal', target: '#create-staging-projects-modal' }) do
+              %i.fas.fa-xs.fa-plus-circle.text-primary
+
         %ul.list-inline
-          %li.list-inline-item
-            = link_to('#', class: 'nav-link', data: { toggle: 'modal', target: '#create-staging-projects-modal' }) do
-              %i.fas.fa-plus-circle.text-success
-              Create Staging Project
-            = render partial: 'create_staging_project', locals: { staging_workflow: @staging_workflow }
-          %li.list-inline-item
-            = link_to('#', class: 'nav-link', data: { toggle: 'modal', target: '#staging-managers-group-modal' }) do
-              %i.fas.fa-users.text-warning
-              Change Managers
-            = render partial: 'staging_managers_group', locals: { staging_workflow: @staging_workflow }
+          - unless feature_enabled?(:responsive_ux)
+            %li.list-inline-item
+              = link_to('#', class: 'nav-link', data: { toggle: 'modal', target: '#create-staging-projects-modal' }) do
+                %i.fas.fa-plus-circle.text-success
+                Create Staging Project
+            %li.list-inline-item
+              = link_to('#', class: 'nav-link', data: { toggle: 'modal', target: '#staging-managers-group-modal' }) do
+                %i.fas.fa-users.text-warning
+                Change Managers
+        = render partial: 'create_staging_project', locals: { staging_workflow: @staging_workflow }
+        = render partial: 'staging_managers_group', locals: { staging_workflow: @staging_workflow }
 
         .row
           = render(partial: 'staging_project', collection: @staging_projects,
                                                locals: { staging_workflow: @staging_workflow })
-


### PR DESCRIPTION
While [editing a Staging Project](https://github.com/openSUSE/open-build-service/pull/10277), this is how it looked like before:

![before](https://user-images.githubusercontent.com/2650/95989289-59075480-0e2a-11eb-9915-f1136218ec3c.png)

And this is how it looks like now:

![image](https://user-images.githubusercontent.com/2650/96135165-bddeaf80-0efb-11eb-9fff-44e11505fec7.png)
