### PR TITLE
Replace `require_login` with Pundit in Webui::UsersController

### DIFF
--- a/src/api/app/controllers/webui/users_controller.rb
+++ b/src/api/app/controllers/webui/users_controller.rb
@@ -1,9 +1,13 @@
 class Webui::UsersController < Webui::WebuiController
-  before_action :require_login, only: [:index, :edit, :destroy, :update, :change_password, :edit_account]
+  # TODO: Remove this when we'll refactor kerberos_auth
+  before_action :kerberos_auth, only: [:index, :edit, :destroy, :update, :change_password, :edit_account]
+  before_action :authorize_user, only: [:index, :edit, :destroy, :update, :change_password, :edit_account]
   before_action :require_admin, only: [:index, :edit, :destroy]
   before_action :check_displayed_user, only: [:show, :edit, :update, :edit_account]
   before_action :role_titles, only: [:show, :edit_account, :update]
   before_action :account_edit_link, only: [:show, :edit_account, :update]
+
+  after_action :verify_authorized, only: [:index, :edit, :destroy, :update, :change_password, :edit_account]
 
   def index
     respond_to do |format|
@@ -177,6 +181,10 @@ class Webui::UsersController < Webui::WebuiController
     filter_keys.each do |filter|
       filters[filter] = 1
     end
+  end
+
+  def authorize_user
+    authorize([:webui, User])
   end
 
   def create_params

--- a/src/api/app/policies/webui/user_policy.rb
+++ b/src/api/app/policies/webui/user_policy.rb
@@ -1,0 +1,13 @@
+class Webui::UserPolicy < ApplicationPolicy
+  def initialize(user, record, opts = {})
+    super(user, record, opts.merge(ensure_logged_in: true))
+  end
+
+  # This is a stub: right now the authorization logic lives in Webui::UsersController.
+  # TODO: move here the authorization logic from Webui::UsersController.
+  [:index?, :edit?, :destroy?, :update?, :change_password?, :edit_account?].each do |action|
+    define_method action do
+      true
+    end
+  end
+end

--- a/src/api/spec/controllers/webui/users_controller_spec.rb
+++ b/src/api/spec/controllers/webui/users_controller_spec.rb
@@ -8,6 +8,11 @@ RSpec.describe Webui::UsersController do
   let!(:non_admin_user_request) { create(:set_bugowner_request, priority: 'critical', creator: non_admin_user) }
 
   describe 'GET #index' do
+    it_behaves_like 'require logged in user' do
+      let(:method) { :get }
+      let(:action) { :index }
+    end
+
     context 'as admin' do
       before do
         login admin_user
@@ -28,12 +33,32 @@ RSpec.describe Webui::UsersController do
   end
 
   describe 'GET #edit' do
-    before do
-      login admin_user
-      get :edit, params: { login: user.login }
+    it_behaves_like 'require logged in user' do
+      let(:method) { :get }
+      let(:action) { :edit }
+      let(:opts) do
+        { params: { login: user.login } }
+      end
     end
 
-    it { expect(response).to have_http_status(:ok) }
+    context 'for logged in user' do
+      before do
+        login admin_user
+        get :edit, params: { login: user.login }
+      end
+
+      it { expect(response).to have_http_status(:ok) }
+    end
+  end
+
+  describe 'GET #edit_account' do
+    it_behaves_like 'require logged in user' do
+      let(:method) { :get }
+      let(:action) { :edit_account }
+      let(:opts) do
+        { params: { login: user.login } }
+      end
+    end
   end
 
   describe 'GET #show' do
@@ -200,6 +225,14 @@ RSpec.describe Webui::UsersController do
   end
 
   describe 'DELETE #destroy' do
+    it_behaves_like 'require logged in user' do
+      let(:method) { :delete }
+      let(:action) { :destroy }
+      let(:opts) do
+        { params: { login: user.login } }
+      end
+    end
+
     context 'called by an admin user' do
       before do
         login(admin_user)
@@ -228,6 +261,14 @@ RSpec.describe Webui::UsersController do
   end
 
   describe 'POST #update' do
+    it_behaves_like 'require logged in user' do
+      let(:method) { :post }
+      let(:action) { :update }
+      let(:opts) do
+        { params: { login: user.login } }
+      end
+    end
+
     context 'when user is updating its own profile' do
       context 'with valid data' do
         before do
@@ -450,6 +491,14 @@ RSpec.describe Webui::UsersController do
   end
 
   describe 'POST #change_password' do
+    it_behaves_like 'require logged in user' do
+      let(:method) { :post }
+      let(:action) { :change_password }
+      let(:opts) do
+        { params: { login: user.login } }
+      end
+    end
+
     context 'LDAP mode on' do
       before do
         login non_admin_user

--- a/src/api/spec/policies/webui/user_policy_spec.rb
+++ b/src/api/spec/policies/webui/user_policy_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe Webui::UserPolicy do
+  let(:user) { create(:confirmed_user) }
+  let(:other_user) { create(:confirmed_user) }
+  let(:user_nobody) { build(:user_nobody) }
+
+  subject { described_class }
+
+  permissions :index?, :edit?, :destroy?, :update?, :change_password?, :edit_account? do
+    it { expect(subject).to permit(user, other_user) }
+  end
+
+  it "doesn't permit anonymous user" do
+    expect { described_class.new(user_nobody, user) }
+      .to raise_error(an_instance_of(Pundit::NotAuthorizedError).and(having_attributes(reason: :anonymous_user)))
+  end
+end


### PR DESCRIPTION
This is a PR of a series which replaces `require_login` with `Pundit`.
You can find further relevant info in #10083.

Tackles `Webui::UsersController`

Ref #10083

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
