### PR TITLE
Prevent rendering of carriage return character in xml views

### DIFF
--- a/src/api/app/views/models/_package.xml.builder
+++ b/src/api/app/views/models/_package.xml.builder
@@ -1,6 +1,6 @@
 xml.package(name: my_model.name, project: my_model.project.name) do
   xml.title(my_model.title)
-  xml.description(my_model.description)
+  xml.description(my_model.description.gsub(/\r\n/, "\n"))
   xml.releasename(my_model.releasename) if my_model.releasename
 
   xml.devel(project: my_model.develpackage.project.name, package: my_model.develpackage.name) if my_model.develpackage

--- a/src/api/app/views/models/_project.xml.builder
+++ b/src/api/app/views/models/_project.xml.builder
@@ -4,7 +4,7 @@ project_attributes[:kind] = my_model.kind unless my_model.is_standard?
 
 xml.project(project_attributes) do
   xml.title(my_model.title)
-  xml.description(my_model.description)
+  xml.description(my_model.description.gsub(/\r\n/, "\n"))
 
   my_model.linking_to.each do |l|
     params = { project: l.linked_db_project ? l.linked_db_project.name : l.linked_remote_project_name }

--- a/src/api/app/views/source/package_meta.xml.builder
+++ b/src/api/app/views/source/package_meta.xml.builder
@@ -1,6 +1,6 @@
 xml.package('name' => @package.name) do
   xml.title @package.title
-  xml.description @package.description
+  xml.description @package.description.gsub(/\r\n/, "\n")
   @package.each_person do |p|
     xml.person('userid' => p.userid, 'role' => p.role)
   end

--- a/src/api/app/views/webui/image_templates/index.xml.builder
+++ b/src/api/app/views/webui/image_templates/index.xml.builder
@@ -5,7 +5,7 @@ xml.image_template_projects do
         xml.image_template_package do
           xml.name package.name
           xml.title package.title
-          xml.description package.description
+          xml.description package.description.gsub(/\r\n/, "\n")
         end
       end
     end


### PR DESCRIPTION
When editing the description of a package/project in the webui,
the text_area in the form add's a sequence of '\r\n' to indicate
a new line. The carriage return indicated by the '\r' gets
rendered in the corresponding xml output for example in the meta
view or through the API. In order to prevent this from happening
we can replace this sequence with a simple '\n' which is the
standard in most recent unix environments to indicate a new line.

Fixes #10272

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
