### PR TITLE
Move "Add Group Member" action next to heading of group#show page.

### DIFF
--- a/src/api/app/views/webui/groups/_group_members.html.haml
+++ b/src/api/app/views/webui/groups/_group_members.html.haml
@@ -1,11 +1,12 @@
 - write_access = policy(group).update?
 
 - if write_access
-  %ul.list-inline
-    %li.list-inline-item
-      = link_to('#', class: 'nav-link', data: { toggle: 'modal', target: '#add-group-user-modal' }) do
-        %i.fas.fa-plus-circle.text-primary
-        Add Member
+  - unless feature_enabled?(:responsive_ux)
+    %ul.list-inline
+      %li.list-inline-item
+        = link_to('#', class: 'nav-link', data: { toggle: 'modal', target: '#add-group-user-modal' }) do
+          %i.fas.fa-plus-circle.text-primary
+          Add Member
   = render partial: 'add_group_user_modal', locals: { group: group }
 
 - if group.users.blank?

--- a/src/api/app/views/webui/groups/show.html.haml
+++ b/src/api/app/views/webui/groups/show.html.haml
@@ -32,7 +32,11 @@
   .card-body
     .tab-content
       .tab-pane.show.active#group-members{ aria: { controls: 'group-members' }, role: 'tabpanel' }
-        %h3 Group Members
+        %h3
+          Group Members
+          - if feature_enabled?(:responsive_ux)
+            = link_to('#', data: { toggle: 'modal', target: '#add-group-user-modal' }, title: 'Add Member') do
+              %i.fas.fa-xs.fa-plus-circle.text-primary
         = render(partial: 'group_members', locals: { group: @group })
 
       .tab-pane#reviews-in{ aria: { controls: 'reviews-in' }, role: 'tabpanel' }


### PR DESCRIPTION
While managing members of a group, this is how it looked like before:

![ksnip_20201013-144105](https://user-images.githubusercontent.com/2650/95863118-1a0ecb80-0d64-11eb-94d3-2331f9a49975.png)

And this is how it looks like now:
![image](https://user-images.githubusercontent.com/2650/96137099-88869180-0efc-11eb-9a5e-c5d368bffc9d.png)