### PR TITLE
Enable extended_backend_log in test environment

### DIFF
--- a/src/api/config/environments/test.rb
+++ b/src/api/config/environments/test.rb
@@ -98,3 +98,6 @@ CONFIG['sponsors'] = [
     url: '#'
   )
 ]
+
+# Making sure that Backend::Logger.info is fully executed to catch potential errors
+CONFIG['extended_backend_log'] = true


### PR DESCRIPTION
Following up on #10289