### PR TITLE
Unescape carriage return char in nokogiri xml output

### DIFF
--- a/src/api/config/initializers/nokogiri_builder.rb
+++ b/src/api/config/initializers/nokogiri_builder.rb
@@ -10,8 +10,8 @@ module ActionView
       def call(template)
         'xml = ::Nokogiri::XML::Builder.new { |xml|' +
           template.source +
-          "}.to_xml :indent => 2, :encoding => 'UTF-8',
-            :save_with => Nokogiri::XML::Node::SaveOptions::NO_DECLARATION | Nokogiri::XML::Node::SaveOptions::FORMAT;"
+          "}.to_xml(:indent => 2, :encoding => 'UTF-8',
+            :save_with => Nokogiri::XML::Node::SaveOptions::NO_DECLARATION | Nokogiri::XML::Node::SaveOptions::FORMAT).gsub('&#13;', '\r')"
       end
     end
   end

--- a/src/api/spec/cassettes/SourceProjectPackageMetaController/GET_show/package_description_includes_carriage_return_characters/1_1_3_1.yml
+++ b/src/api/spec/cassettes/SourceProjectPackageMetaController/GET_show/package_description_includes_carriage_return_characters/1_1_3_1.yml
@@ -1,0 +1,156 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/project_3/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_3">
+          <title>Unweaving the Rainbow</title>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '150'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_3">
+          <title>Unweaving the Rainbow</title>
+          <description></description>
+          <person userid="tom" role="maintainer"/>
+        </project>
+  recorded_at: Wed, 14 Oct 2020 08:54:54 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_3/foo/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="foo" project="project_3">
+          <title>Beyond the Mexique Bay</title>
+          <description>Quo corporis delectus quia.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '149'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="foo" project="project_3">
+          <title>Beyond the Mexique Bay</title>
+          <description>Quo corporis delectus quia.</description>
+        </package>
+  recorded_at: Wed, 14 Oct 2020 08:54:54 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_3/foo/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="foo" project="project_3">
+          <title>Beyond the Mexique Bay</title>
+          <description>Quo corporis delectus quia.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '149'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="foo" project="project_3">
+          <title>Beyond the Mexique Bay</title>
+          <description>Quo corporis delectus quia.</description>
+        </package>
+  recorded_at: Wed, 14 Oct 2020 08:54:54 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_3/foo/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: "<package name=\"foo\" project=\"project_3\">\n  <title>Beyond the Mexique
+        Bay</title>\n  <description>%description\r\nctris is a colorized, small and
+        flexible Tetris(TM)-clone for the console.</description>\n</package>\n"
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="foo" project="project_3">
+          <title>Beyond the Mexique Bay</title>
+          <description>%description
+        ctris is a colorized, small and flexible Tetris(TM)-clone for the console.</description>
+        </package>
+  recorded_at: Wed, 14 Oct 2020 08:54:54 GMT
+recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/SourceProjectPackageMetaController/GET_show/package_do_not_exist/1_1_2_1.yml
+++ b/src/api/spec/cassettes/SourceProjectPackageMetaController/GET_show/package_do_not_exist/1_1_2_1.yml
@@ -1,0 +1,119 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/project_1/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_1">
+          <title>The Way of All Flesh</title>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '149'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_1">
+          <title>The Way of All Flesh</title>
+          <description></description>
+          <person userid="tom" role="maintainer"/>
+        </project>
+  recorded_at: Wed, 14 Oct 2020 08:54:53 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_1/foo/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="foo" project="project_1">
+          <title>Ego Dominus Tuus</title>
+          <description>Molestiae et accusamus atque.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '145'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="foo" project="project_1">
+          <title>Ego Dominus Tuus</title>
+          <description>Molestiae et accusamus atque.</description>
+        </package>
+  recorded_at: Wed, 14 Oct 2020 08:54:53 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_1/foo/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="foo" project="project_1">
+          <title>Ego Dominus Tuus</title>
+          <description>Molestiae et accusamus atque.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '145'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="foo" project="project_1">
+          <title>Ego Dominus Tuus</title>
+          <description>Molestiae et accusamus atque.</description>
+        </package>
+  recorded_at: Wed, 14 Oct 2020 08:54:53 GMT
+recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/SourceProjectPackageMetaController/GET_show/package_exist/1_1_1_1.yml
+++ b/src/api/spec/cassettes/SourceProjectPackageMetaController/GET_show/package_exist/1_1_1_1.yml
@@ -1,0 +1,119 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/project_2/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_2">
+          <title>Tirra Lirra by the River</title>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '153'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_2">
+          <title>Tirra Lirra by the River</title>
+          <description></description>
+          <person userid="tom" role="maintainer"/>
+        </project>
+  recorded_at: Wed, 14 Oct 2020 08:54:54 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_2/foo/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="foo" project="project_2">
+          <title>The Skull Beneath the Skin</title>
+          <description>Vel vel aperiam nostrum.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '150'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="foo" project="project_2">
+          <title>The Skull Beneath the Skin</title>
+          <description>Vel vel aperiam nostrum.</description>
+        </package>
+  recorded_at: Wed, 14 Oct 2020 08:54:54 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_2/foo/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="foo" project="project_2">
+          <title>The Skull Beneath the Skin</title>
+          <description>Vel vel aperiam nostrum.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '150'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="foo" project="project_2">
+          <title>The Skull Beneath the Skin</title>
+          <description>Vel vel aperiam nostrum.</description>
+        </package>
+  recorded_at: Wed, 14 Oct 2020 08:54:54 GMT
+recorded_with: VCR 6.0.0

--- a/src/api/spec/controllers/source_project_package_meta_controller_spec.rb
+++ b/src/api/spec/controllers/source_project_package_meta_controller_spec.rb
@@ -31,6 +31,18 @@ RSpec.describe SourceProjectPackageMetaController, vcr: true do
 
       it { expect(response).not_to have_http_status(:success) }
     end
+
+    context 'package description does not include escaped carriage return characters' do
+      before do
+        login user
+        project_with_package.packages.first.update(description: "%description\r\nctris is a colorized, small and flexible Tetris(TM)-clone for the console.")
+        project_with_package
+        get :show, params: { project: project_with_package.name,
+                             package: 'foo', format: :xml }
+      end
+
+      it { expect(response.body).not_to include('&#13;') }
+    end
   end
 
   describe 'PUT #update' do


### PR DESCRIPTION
The carriage return character '\r' gets escaped by
nokogiri/libxml which causes the character to be
rendered in the xml output.

https://github.com/sparklemotion/nokogiri/issues/1356

Since this is a valid xml char we can workaround this problem
by unescaping it again.

Fixes #10272

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
