### PR TITLE
User profile page redesign

### DIFF
--- a/src/api/app/controllers/webui/users_controller.rb
+++ b/src/api/app/controllers/webui/users_controller.rb
@@ -80,7 +80,7 @@ class Webui::UsersController < Webui::WebuiController
     end
 
     if @configuration.accounts_editable?(@displayed_user)
-      @displayed_user.assign_attributes(params[:user].slice(:realname, :email).permit!)
+      @displayed_user.assign_attributes(params[:user].slice(:realname, :email, :biography).permit!)
       @displayed_user.toggle(:in_beta) if params[:user][:in_beta]
     end
 

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -7,6 +7,7 @@ class User < ApplicationRecord
   # Keep in sync with states defined in db/schema.rb
   STATES = ['unconfirmed', 'confirmed', 'locked', 'deleted', 'subaccount'].freeze
   NOBODY_LOGIN = '_nobody_'.freeze
+  MAX_BIOGRAPHY_LENGTH_ALLOWED = 250
 
   # disable validations because there can be users which don't have a bcrypt
   # password yet. this is for backwards compatibility
@@ -102,6 +103,7 @@ class User < ApplicationRecord
   validate :password_validation
   validates :password, length: { minimum: 6, maximum: ActiveModel::SecurePassword::MAX_PASSWORD_LENGTH_ALLOWED }, allow_nil: true
   validates :password, confirmation: true, allow_blank: true
+  validates :biography, length: { maximum: MAX_BIOGRAPHY_LENGTH_ALLOWED }
 
   before_save :send_metric_for_beta_change, if: :in_beta_changed?
   after_create :create_home_project, :track_create

--- a/src/api/app/views/webui/user/_edit_dialog.html.haml
+++ b/src/api/app/views/webui/user/_edit_dialog.html.haml
@@ -12,5 +12,11 @@
           .form-group
             = f.label(:email, 'Email:')
             = f.text_field(:email, required: true, email: true, class: 'form-control')
+          - if feature_enabled?(:user_profile_redesign)
+            .form-group
+              = f.label(:biography) do
+                Biography:
+                %small.form-text Max. #{User::MAX_BIOGRAPHY_LENGTH_ALLOWED} characters.
+              = f.text_area(:biography, rows: 6, class: 'form-control', maxlength: User::MAX_BIOGRAPHY_LENGTH_ALLOWED)
         .modal-footer
           = render partial: 'webui/shared/dialog_action_buttons', locals: { submit_tag_text: 'Update' }

--- a/src/api/app/views/webui/user/user_profile_redesign/_info.html.haml
+++ b/src/api/app/views/webui/user/user_profile_redesign/_info.html.haml
@@ -1,0 +1,66 @@
+.card.mb-3
+  .card-body
+    .row.mb-3.mb-md-0
+      .col-4.col-sm-2.col-md-12.text-center
+        = image_tag_for(user, size: 200)
+      .col-8.col-sm-10.col-md-12.pl-0.p-md-3
+        %h4#home-realname
+          = user.realname
+        %h5.text-muted#home-login
+          = user.login
+
+    - role_titles.each do |title|
+      %span.badge.badge-secondary
+        = title.upcase
+
+    .mt-4
+      - if User.session
+        = mail_to(user.email, title: "Send mail to #{user.name}", class: 'd-block') do
+          %i.fas.fa-envelope.mr-1
+          = user.email
+
+      - if policy(user).see_rss?
+        = link_to(user_rss_notifications_path(token: user.rss_token.string, format: 'rss'),
+                                              title: 'RSS Feed for Notifications', class: 'd-block') do
+          %i.fas.fa-rss.mr-1
+          RSS for Notifications
+
+    - if groups.any?
+      .h5.mt-4.mb-0 Member of the #{'group'.pluralize(groups.size)}
+      %ul.list-group.list-group-flush
+        - groups.each do |group|
+          %li.list-group-item.d-flex.justify-content-between.align-items-center.p-2
+            = link_to(group.title, group_show_path(group))
+            %span.badge.badge-primary
+              #{group.tasks} #{'task'.pluralize(group.tasks)}
+
+    - if is_user
+      .mt-4
+        = form_tag(user_path, id: 'beta-form', method: :patch) do
+          .custom-control.custom-switch
+            = hidden_field_tag 'user[in_beta]', false
+            = check_box_tag('user[in_beta]', !user.in_beta, user.in_beta, class: 'custom-control-input', id: 'beta-switch')
+            = label_tag 'Public Beta Program', nil, class: 'custom-control-label', for: 'beta-switch'
+            = hidden_field_tag('user[login]', user.login)
+            %i.fa.fa-question-circle.text-info{ data: { placement: 'top', toggle: 'popover', html: 'true',
+                                                        content: 'Join the <strong>beta program</strong> to try the latest ' + |
+                                                                 'features we develop and give us feedback on them before they go live.' } } |
+
+      .mt-4
+        - if configuration.accounts_editable?(user)
+          = render partial: 'webui/user/edit_account', locals: { account_edit_link: account_edit_link }
+        - if configuration.passwords_changable?(user)
+          = render partial: 'webui/user/change_password'
+        - if feature_enabled?(:responsive_ux)
+          - content_for :actions do
+            %li.nav-item
+              = link_to(my_subscriptions_path, class: 'nav-link', title: 'Change Your Notifications') do
+                %i.fas.fa-lg.mr-2.fa-bell
+                %span.nav-item-name Change Your Notifications
+        - else
+          = link_to(my_subscriptions_path, class: 'd-block') do
+            %i.fas.fa-bell
+            Change Your Notifications
+
+:javascript
+  switchBeta();

--- a/src/api/app/views/webui/user/user_profile_redesign/_info.html.haml
+++ b/src/api/app/views/webui/user/user_profile_redesign/_info.html.haml
@@ -19,7 +19,7 @@
           %i.fas.fa-envelope.mr-1
           = user.email
 
-      - if policy(user).see_rss?
+      - if user.rss_token && is_user
         = link_to(user_rss_notifications_path(token: user.rss_token.string, format: 'rss'),
                                               title: 'RSS Feed for Notifications', class: 'd-block') do
           %i.fas.fa-rss.mr-1

--- a/src/api/app/views/webui/user/user_profile_redesign/_info.html.haml
+++ b/src/api/app/views/webui/user/user_profile_redesign/_info.html.haml
@@ -13,6 +13,8 @@
       %span.badge.badge-secondary
         = title.upcase
 
+    %p= render_as_markdown(user.biography)
+
     .mt-4
       - if User.session
         = mail_to(user.email, title: "Send mail to #{user.name}", class: 'd-block') do

--- a/src/api/app/views/webui/users/show.html.haml
+++ b/src/api/app/views/webui/users/show.html.haml
@@ -5,19 +5,26 @@
   content_for(:meta_image, gravatar_url(@displayed_user.email))
 
 .row
-  .col-12.col-md-4.col-lg-3
-    = render partial: 'webui/user/info', locals: { user: @displayed_user,
-                                                          is_user: @is_displayed_user,
-                                                          groups: @groups,
-                                                          role_titles: @role_titles,
-                                                          configuration: @configuration,
-                                                          account_edit_link: @account_edit_link }
   - if feature_enabled?('user_profile_redesign')
-    .col-12.col-md-8.col-lg-9
+    .col-12.col-md-4.col-xxl-3
+      = render partial: 'webui/user/user_profile_redesign/info', locals: { user: @displayed_user,
+                                                                           is_user: @is_displayed_user,
+                                                                           groups: @groups,
+                                                                           role_titles: @role_titles,
+                                                                           configuration: @configuration,
+                                                                           account_edit_link: @account_edit_link }
+    .col-12.col-md-8.col-xxl-9.pl-md-0
       - locals = { user: @displayed_user, owned: @owned, involved_projects: @iprojects, involved_packages: @ipackages }
       - locals.merge!({ activity_hash: @activity_hash, first_day: @first_day, last_day: @last_day }) unless CONFIG['contribution_graph'] == :off
       = render partial: 'webui/user/user_profile_redesign/involvement_and_activity', locals: locals
   - else
+    .col-12.col-md-4.col-lg-3
+      = render partial: 'webui/user/info', locals: { user: @displayed_user,
+                                                            is_user: @is_displayed_user,
+                                                            groups: @groups,
+                                                            role_titles: @role_titles,
+                                                            configuration: @configuration,
+                                                            account_edit_link: @account_edit_link }
     .col-12.col-md-8.col-lg-9
       - unless CONFIG['contribution_graph'] == :off
         = render partial: 'webui/user/activity', locals: { activity_hash: @activity_hash,


### PR DESCRIPTION
This time we try to improve the user profile page adjusting positions, margins/paddings and sizes of the different elements. Paying special attention to the avatar and displaying related information together.

The Contribution Graph is now embedded in a tab.
The same happens with the list(s) of projects/packages where the user is involved. How we display this list(s) is going to be changed, but not in this PR.

![Screenshot_2020-10-13 Profile of Admin(1)](https://user-images.githubusercontent.com/2581944/95901384-8a811100-0d93-11eb-8706-50c32c3df49d.png)

**Before:**

![user_profile_before](https://user-images.githubusercontent.com/2581944/95901469-adabc080-0d93-11eb-9da5-41b99608990a.gif)

**After:**

![user_profile_redesign_info_2](https://user-images.githubusercontent.com/2581944/96008319-bce84800-0e3f-11eb-831d-5735fa4d927d.gif)

The animation shows the user biography, however, the field will be really added to this PR as soon as [this one](https://github.com/openSUSE/open-build-service/pull/10292) is merged.

TODO:

- [x] Add the real `biography` field to the view, allowing markdown on it.
- [x] Merge this PR with the one that redesigns the `Involved Projects/Packages` tab content.


- Make fields like `biography`, `name` and `email` editable inline when that's possible. In another PR.


**NOTE:** This PR requires to enable the feature flag in production and IBS. Running `Flipper.enable(:user_profile_redesign, :beta) in Rails console.` 