### PR TITLE
Move the Create Status Message back to the News box

### DIFF
--- a/src/api/app/views/webui/main/_status_messages.html.haml
+++ b/src/api/app/views/webui/main/_status_messages.html.haml
@@ -2,6 +2,9 @@
   .card-header.d-flex.justify-content-between
     %h5
       News
+      - if feature_enabled?(:responsive_ux) && policy(StatusMessage.new).create?
+        = link_to(new_status_message_path, title: 'Create Status Message') do
+          %i.fas.fa-xs.fa-plus-circle.text-primary
     .float-right
       = link_to(news_feed_path(format: 'rss'), title: 'RSS Feed') do
         %i.fa.fa-rss

--- a/src/api/app/views/webui/main/responsive_ux/_index_actions.html.haml
+++ b/src/api/app/views/webui/main/responsive_ux/_index_actions.html.haml
@@ -1,9 +1,4 @@
 - content_for :actions do
-  - if policy(StatusMessage.new).create?
-    %li.nav-item
-      = link_to(new_status_message_path, class: 'nav-link', title: 'Create Status Message') do
-        %i.fas.fa-plus-circle.fa-lg.mr-2
-        %span.nav-item-name Create Status Message
   %li.nav-item
     = link_to(new_project_path, class: 'nav-link', title: 'Create Project') do
       %i.fas.fa-plus-circle.fa-lg.mr-2


### PR DESCRIPTION
The Create Status Message action is best placed near its context, the News box,
where the status messages live.

This is how it looked like before:

![image](https://user-images.githubusercontent.com/2650/95999613-5b6fab80-0e36-11eb-9446-d16f357b423c.png)

And this is how it looks like now:

![image](https://user-images.githubusercontent.com/2650/96152662-136f8800-0f0d-11eb-9256-ab2f8037e6b6.png)

