### PR TITLE
Use history icon for 'Job History' link

### DIFF
--- a/src/api/app/views/webui/package/binaries/_show_statistics_job_history_build_reason.html.haml
+++ b/src/api/app/views/webui/package/binaries/_show_statistics_job_history_build_reason.html.haml
@@ -9,9 +9,9 @@
 
 %li.list-inline-item
   = link_to(index_package_job_history_path(project: project, package_name: package, repository: repository, arch: result[:arch]),
-  title: 'Job history', class: 'nav-link') do
-    %i.fas.fa-list
-    Job history
+  title: 'Job History', class: 'nav-link') do
+    %i.fas.fa-history
+    Job History
 
 %li.list-inline-item
   = link_to(index_package_build_reason_path(project: project, package_name: package, repository: repository, arch: result[:arch]),


### PR DESCRIPTION
This is to avoid using the same `fa-list` icon as the `All Projects` link in the `Places` links.

Before:
![before](https://user-images.githubusercontent.com/1102934/96018925-1fdfdc00-0e4c-11eb-80e6-3ef090df185d.png)

Now:
![now](https://user-images.githubusercontent.com/1102934/96018928-21110900-0e4c-11eb-886c-1eb2277f155f.png)