### PR TITLE
Prevent duplication for involved projects/packages

### DIFF
--- a/src/api/app/assets/javascripts/webui/application.js
+++ b/src/api/app/assets/javascripts/webui/application.js
@@ -54,3 +54,4 @@
 //= require webui/responsive_ux
 //= require webui/notification.js
 //= require webui/sidebar-menu.js
+//= require webui/user_profile.js

--- a/src/api/app/assets/javascripts/webui/user_profile.js
+++ b/src/api/app/assets/javascripts/webui/user_profile.js
@@ -1,0 +1,7 @@
+function moveInvolvementToContainer() { // jshint ignore:line
+  var container = $('#involvement-and-activity');
+  if ($('#involvement-and-activity > .tab-content:visible').length > 0)
+    container = $('.tab-pane#involved-projects-and-packages');
+
+  container.prepend($('#involvement'));
+}

--- a/src/api/app/views/webui/user/_involvement.html.haml
+++ b/src/api/app/views/webui/user/_involvement.html.haml
@@ -1,4 +1,4 @@
-.card.mb-3
+.card.mb-3#involvement
   - if feature_enabled?(:responsive_ux)
     = render partial: 'webui/user/responsive_ux/tabs_profile', locals: { involved_packages: involved_packages,
                                                                          involved_projects: involved_projects, owned: owned }

--- a/src/api/app/views/webui/user/user_profile_redesign/_involvement_and_activity.html.haml
+++ b/src/api/app/views/webui/user/user_profile_redesign/_involvement_and_activity.html.haml
@@ -1,38 +1,43 @@
-.card{ class: CONFIG['contribution_graph'] == :off ? 'd-block' : 'd-block d-md-none' }
+.card
   -# Header that replaces the tabs when the contribution graph is not displayed (in small viewports or when not enabled).
-  .card-header
+  .card-header{ class: CONFIG['contribution_graph'] == :off ? 'd-block' : 'd-block d-md-none' }
     %h5 Involved Projects and Packages
-  .card-body
-    = render partial: 'webui/user/involvement', locals: { user: user,
-                                                          owned: owned,
-                                                          involved_projects: involved_projects,
-                                                          involved_packages: involved_packages }
 
--# Displaying tabs in medium-large viewports when the Contribution Graph is enabled
-- unless CONFIG['contribution_graph'] == :off
-  .card.d-none.d-md-block
+  - unless CONFIG['contribution_graph'] == :off
     -# Tabs
-    .bg-light
+    .bg-light.d-none.d-md-block
       %ul.nav.nav-tabs.pt-2.px-3.flex-nowrap.collapsible{ 'role': 'tablist' }
         %li.nav-item
           = link_to('#involved-projects-and-packages', id: 'involved-projects-and-packages-tab', class: 'nav-link active text-nowrap',
                     data: { toggle: 'tab' }, role: 'tab', aria: { controls: 'involved-projects-and-packages', selected: true }) do
             Involved Projects/Packages
         %li.nav-item
-          = link_to('#contributions', id: 'contributions-tab', class: 'nav-link text-nowrap',
-                    data: { toggle: 'tab' }, role: 'tab', aria: { controls: 'contributions', selected: false }) do
+          = link_to('#activity', id: 'activity-tab', class: 'nav-link text-nowrap',
+                    data: { toggle: 'tab' }, role: 'tab', aria: { controls: 'activity', selected: false }) do
             Contributions
 
-    -# Tabs content
-    .card-body
-      .tab-content
-        .tab-pane.fade.show.active#involved-projects-and-packages{ role: 'tabpanel', aria: { labelledby: 'involved-projects-and-packages-tab' } }
-          = render partial: 'webui/user/involvement', locals: { user: user,
-                                                                owned: owned,
-                                                                involved_projects: involved_projects,
-                                                                involved_packages: involved_packages }
+  .card-body#involvement-and-activity
+    = render partial: 'webui/user/involvement', locals: { user: user,
+                                                          owned: owned,
+                                                          involved_projects: involved_projects,
+                                                          involved_packages: involved_packages }
 
-        .tab-pane.fade#contributions{ role: 'tabpanel', aria: { labelledby: 'contributions-tab' } }
+    -# Displaying tabs in medium-large viewports when the Contribution Graph is enabled
+    - unless CONFIG['contribution_graph'] == :off
+      .tab-content.d-none.d-md-block
+        .tab-pane.fade.show.active#involved-projects-and-packages{ role: 'tabpanel', aria: { labelledby: 'involved-projects-and-packages-tab' } }
+        -# Content to be injected by JavaScript
+        .tab-pane.fade#activity{ role: 'tabpanel', aria: { labelledby: 'activity-tab' } }
           = render partial: 'webui/user/activity', locals: { activity_hash: activity_hash,
                                                              first_day: first_day,
                                                              last_day: last_day }
+
+- content_for :ready_function do
+  :plain
+    // Move the involvement element in the right place.
+    moveInvolvementToContainer();
+
+    // Move the involvement element in the right place after each window resize.
+    $( window ).resize(function() {
+      moveInvolvementToContainer();
+    })


### PR DESCRIPTION
If the Contribution Graph is enabled, the 'Involved Projects/Packages' list can be displayed inside a simple card or inside a tab according to the viewport size.

Instead of rendering the same partial ('_involvement.html.haml') twice and using CSS to show/hide one or the other according to the viewport size, now we inject the content of the partial in the right place using JavaScript.

Preventing duplication is needed because it brings conflicts when selecting other elements in the view by JavaScript.

Follow-up of: #10271

Co-authored-by: Eduardo Navarro <enavarro@suse.com>