### PR TITLE
Move Create User action next to the heading of the Manage Users page

### DIFF
--- a/src/api/app/views/webui/users/index.html.haml
+++ b/src/api/app/views/webui/users/index.html.haml
@@ -3,7 +3,11 @@
 .card.mb-3
   = render partial: 'webui/configuration/tabs'
   .card-body
-    %h3= @pagetitle
+    %h3
+      = @pagetitle
+      - if feature_enabled?(:responsive_ux)
+        = link_to(new_user_path(pagetitle: 'create user', submit_btn_text: 'create'), title: 'Create User') do
+          %i.fas.fa-xs.fa-plus-circle.text-primary
     %table.responsive.table.table-sm.table-bordered.table-hover#user-table{ data: { source: users_path } }
       %thead
         %tr
@@ -17,13 +21,7 @@
             Actions
       %tbody
 
-    - if feature_enabled?(:responsive_ux)
-      - content_for :actions do
-        %li.nav-item
-          = link_to(new_user_path(pagetitle: 'create user', submit_btn_text: 'create'), class: 'nav-link', title: 'Create User') do
-            %i.fas.fa-lg.mr-2.fa-plus-circle
-            %span.nav-item-name Create User
-    - else
+    - unless feature_enabled?(:responsive_ux)
       .pt-4
         = link_to(new_user_path(pagetitle: 'create user', submit_btn_text: 'create'), title: 'Create User') do
           %i.fas.fa-plus-circle.text-primary

--- a/src/api/spec/features/beta/webui/users/admin_configuration_spec.rb
+++ b/src/api/spec/features/beta/webui/users/admin_configuration_spec.rb
@@ -38,7 +38,6 @@ RSpec.describe 'Admin user configuration page', type: :feature, js: true do
 
   it 'create user' do
     expect(page).to have_text('5 records')
-    click_link('Actions') if mobile?
     click_link('Create User')
 
     fill_in 'Username:', with: 'tux'


### PR DESCRIPTION
The action is now on the right of the Manage User's heading

This is how it looked like before:
![image](https://user-images.githubusercontent.com/2650/95580475-b02ab500-0a37-11eb-9fe7-3f422ee289d0.png)

This is how it looks like now:

![image](https://user-images.githubusercontent.com/2650/96138916-8f160880-0efe-11eb-909c-cab83d6c0153.png)

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
