### PR TITLE
Remove wrapper from links that are not in sidebar

### DIFF
--- a/src/api/app/views/webui/groups/index.html.haml
+++ b/src/api/app/views/webui/groups/index.html.haml
@@ -25,9 +25,9 @@
             %span.nav-item-name Create Group
     - else
       .pt-4
-        = link_to(group_new_path, title: 'Create Group') do
+        = link_to(group_new_path) do
           %i.fas.fa-plus-circle.text-primary
-          %span.nav-item-name Create Group
+          Create Group
 
 - content_for :ready_function do
   initializeDataTable('#manage-groups-table', { columnDefs: [{ orderable: false, searchable: false, targets: -1 }] });

--- a/src/api/app/views/webui/project/index.html.haml
+++ b/src/api/app/views/webui/project/index.html.haml
@@ -36,9 +36,9 @@
                 %span.nav-item-name Create Project
         - else
           %li.list-inline-item
-            = link_to(new_project_path, title: 'Create Project') do
+            = link_to(new_project_path) do
               %i.fas.fa-plus-circle.text-primary
-              %span.nav-item-name Create Project
+              Create Project
 
     %table.responsive.table.table-sm.table-bordered.table-hover.w-100#projects-datatable{ data: { source: projects_path(format: :json),
                                                                                                   all: 'false' } }

--- a/src/api/app/views/webui/users/index.html.haml
+++ b/src/api/app/views/webui/users/index.html.haml
@@ -25,9 +25,9 @@
             %span.nav-item-name Create User
     - else
       .pt-4
-        = link_to(new_user_path(pagetitle: 'create user', submit_btn_text: 'create'), title: 'Create User') do
+        = link_to(new_user_path(pagetitle: 'create user', submit_btn_text: 'create')) do
           %i.fas.fa-plus-circle.text-primary
-          %span.nav-item-name Create User
+          Create User
 
 - content_for :ready_function do
   initializeUserConfigurationDatatable("#{::Configuration.ldap_enabled?}");


### PR DESCRIPTION
Some of wrappers for links were mistakenly added in the PR #10293. Since
the links are not used in sidebar, they do not need to be wrapped into
span.nav-item-name.

The commit removes the extra wrappers.
