### PR TITLE
Wrap sidebar links with span.nav-item-name

### DIFF
--- a/src/api/app/views/webui/user/_edit_account.html.haml
+++ b/src/api/app/views/webui/user/_edit_account.html.haml
@@ -7,9 +7,9 @@
           Edit your account
     - else
       %li.nav-item
-        = link_to('#', data: { toggle: 'modal', target: '#edit-modal' }, class: 'nav-link') do
+        = link_to('#', data: { toggle: 'modal', target: '#edit-modal' }, class: 'nav-link', title: 'Edit Your Account') do
           %i.fas.fa-lg.mr-2.fa-user-edit
-          Edit your account
+          %span.nav-item-name Edit Your Account
 - elsif account_edit_link.present?
   = link_to(account_edit_link, class: 'd-block') do
     %i.fas.fa-user-edit

--- a/src/api/app/views/webui/user/_index_actions.html.haml
+++ b/src/api/app/views/webui/user/_index_actions.html.haml
@@ -1,5 +1,5 @@
 - content_for :actions do
   %li.nav-item
-    = link_to('#', data: { toggle: 'modal', target: '#password-modal' }, class: 'nav-link') do
+    = link_to('#', data: { toggle: 'modal', target: '#password-modal' }, class: 'nav-link', title: 'Change Your Password') do
       %i.fas.fa-lg.mr-2.fa-exchange-alt
-      Change your password
+      %span.nav-item-name Change Your Password

--- a/src/api/app/views/webui/user/_info.html.haml
+++ b/src/api/app/views/webui/user/_info.html.haml
@@ -44,18 +44,18 @@
         - if feature_enabled?(:responsive_ux)
           - content_for :actions do
             %li.nav-item
-              = link_to(my_subscriptions_path, class: 'nav-link') do
+              = link_to(my_subscriptions_path, class: 'nav-link', title: 'Change Your Notifications') do
                 %i.fas.fa-lg.mr-2.fa-bell
-                Change your notifications
+                %span.nav-item-name Change Your Notifications
         - else
           = link_to(my_subscriptions_path, class: 'd-block') do
             %i.fas.fa-bell
-            Change your notifications
+            Change Your Notifications
         - if user.rss_token
           = link_to(user_rss_notifications_path(token: user.rss_token.string, format: 'rss'),
                                                 title: 'RSS Feed for Notifications', class: 'd-block') do
             %i.fas.fa-rss-square
-            RSS for notifications
+            RSS for Notifications
 
 :javascript
   switchBeta();

--- a/src/api/spec/features/beta/webui/users/user_home_page_spec.rb
+++ b/src/api/spec/features/beta/webui/users/user_home_page_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe "User's home project creation", type: :feature, js: true do
       expect(page).to have_css('#home-realname', text: 'Jim Knopf')
       expect(page).not_to have_css("a[href='mailto:jim.knopf@puppenkiste.com']", text: 'jim.knopf@puppenkiste.com')
 
-      expect(page).not_to have_text('Edit your account')
-      expect(page).not_to have_text('Change your password')
+      expect(page).not_to have_text('Edit Your account')
+      expect(page).not_to have_text('Change Your password')
 
       expect(page).to have_link('Involved Packages')
       expect(page).to have_link('Involved Projects')
@@ -37,8 +37,8 @@ RSpec.describe "User's home project creation", type: :feature, js: true do
       expect(page).to have_css("a[href='mailto:jim.knopf@puppenkiste.com']", text: 'jim.knopf@puppenkiste.com')
 
       within('#bottom-navigation-area') { click_link('Actions') } if mobile?
-      expect(page).to have_text('Edit your account')
-      expect(page).to have_text('Change your password')
+      expect(page).to have_text('Edit Your Account')
+      expect(page).to have_text('Change Your Password')
 
       expect(page).to have_link('Involved Packages')
       expect(page).to have_link('Involved Projects')
@@ -61,9 +61,9 @@ RSpec.describe "User's home project creation", type: :feature, js: true do
     it 'edit account information' do
       if mobile?
         within('#bottom-navigation-area') { click_link('Actions') }
-        within('#bottom-navigation-area') { click_link('Edit your account') }
+        within('#bottom-navigation-area') { click_link('Edit Your Account') }
       else
-        click_link('Edit your account')
+        click_link('Edit Your Account')
       end
 
       fill_in('user_realname', with: 'John Doe')


### PR DESCRIPTION
The PR #10263 moved links for account managing to sidebar. Since sidebar
became collapsible in #10293, those links have to be wrapped into
span.nav-item-name. Also, title should be specified for them.

The commit adds those missing wrappers and titles, and also capitalizes
the links to make them consistent with the other links in sidebar.

Here are the screenshots of how it looks:

**Before**
![actions_collapsed_before](https://user-images.githubusercontent.com/37581072/96125453-245fcf80-0ef4-11eb-91e8-240c4d3b28ba.png)   ![actions_expanded_before](https://user-images.githubusercontent.com/37581072/96125460-24f86600-0ef4-11eb-876d-ea6ba4803b31.png)


**After**
![actions_collapsed_after](https://user-images.githubusercontent.com/37581072/96125528-29bd1a00-0ef4-11eb-94e7-1654669a1006.png)   ![actions_expanded_after](https://user-images.githubusercontent.com/37581072/96125537-2a55b080-0ef4-11eb-8bdb-1567bf00a449.png)

