### PR TITLE
Use correct css class for edit account link in collapsible nav

### DIFF
--- a/src/api/app/views/webui/user/_edit_account.html.haml
+++ b/src/api/app/views/webui/user/_edit_account.html.haml
@@ -2,9 +2,9 @@
   - content_for :actions do
     - if account_edit_link.present?
       %li.nav-item
-        = link_to(account_edit_link, class: 'nav-link') do
+        = link_to(account_edit_link, class: 'nav-link', title: 'Edit Your Account') do
           %i.fas.fa-lg.mr-2.fa-user-edit
-          Edit your account
+          %span.nav-item-name Edit your account
     - else
       %li.nav-item
         = link_to('#', data: { toggle: 'modal', target: '#edit-modal' }, class: 'nav-link', title: 'Edit Your Account') do


### PR DESCRIPTION
The link shows still shows the text when the navigation
is collapsed

![Screenshot_2020-10-16 Profile of krauselukas](https://user-images.githubusercontent.com/22001671/96253817-93046200-0fb4-11eb-8141-4a343cf15212.png)


<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
