### PR TITLE
Allow inline edition for user profile page

### DIFF
--- a/src/api/app/views/webui/user/_edit_account.html.haml
+++ b/src/api/app/views/webui/user/_edit_account.html.haml
@@ -1,6 +1,12 @@
 - if feature_enabled?(:responsive_ux)
   - content_for :actions do
-    - if account_edit_link.present?
+    - if feature_enabled?(:user_profile_redesign)
+      -# Behind a proxy or not, with this Feature Flag `user_profile_redesign` we go to the edit account form.
+      %li.nav-item
+        = link_to(edit_account_user_path(user), class: 'nav-link', remote: true, title: 'Edit Your Account') do
+          %i.fas.fa-lg.mr-2.fa-user-edit
+          %span.nav-item-name Edit Your Account
+    - elsif account_edit_link.present?
       %li.nav-item
         = link_to(account_edit_link, class: 'nav-link', title: 'Edit Your Account') do
           %i.fas.fa-lg.mr-2.fa-user-edit
@@ -10,7 +16,7 @@
         = link_to('#', data: { toggle: 'modal', target: '#edit-modal' }, class: 'nav-link', title: 'Edit Your Account') do
           %i.fas.fa-lg.mr-2.fa-user-edit
           %span.nav-item-name Edit Your Account
-- elsif account_edit_link.present?
+- elsif account_edit_link.present? # Feature Flag `responsive_ux` is disabled
   = link_to(account_edit_link, class: 'd-block') do
     %i.fas.fa-user-edit
     Edit your account

--- a/src/api/app/views/webui/user/user_profile_redesign/_basic_info.html.haml
+++ b/src/api/app/views/webui/user/user_profile_redesign/_basic_info.html.haml
@@ -1,0 +1,20 @@
+.basic-info{ class: feature_enabled?(:user_profile_redesign) ? 'in-place-editing' : '' }
+  .row.mb-3.mb-md-0
+    .col-4.col-sm-2.col-md-12.text-center
+      = image_tag_for(user, size: 200)
+    .col-8.col-sm-10.col-md-12.pl-0.p-md-3
+      %h4#home-realname
+        = user.realname
+      %h5.text-muted#home-login
+        = user.login
+
+  - role_titles.each do |title|
+    %span.badge.badge-secondary
+      = title.upcase
+  %p= render_as_markdown(user.biography)
+
+  .mt-4
+    - if User.session
+      = mail_to(user.email, title: "Send mail to #{user.name}", class: 'd-block') do
+        %i.fas.fa-envelope.mr-1
+        = user.email

--- a/src/api/app/views/webui/user/user_profile_redesign/_edit_account_form.html.haml
+++ b/src/api/app/views/webui/user/user_profile_redesign/_edit_account_form.html.haml
@@ -1,0 +1,28 @@
+- behind_proxy = account_edit_link.present?
+
+= form_for(displayed_user, url: user_path(displayed_user), method: :patch, remote: true) do |f|
+  = f.hidden_field(:login, id: 'user')
+
+  .mb-3.text-center= image_tag_for(displayed_user, size: 200)
+  .form-group
+    = f.text_field(:realname, readonly: behind_proxy, placeholder: 'Name', class: 'form-control')
+  .form-group
+    = f.text_field(:login, readonly: true, class: 'form-control')
+  .form-group
+    - role_titles.each do |title|
+      %span.badge.badge-secondary
+        = title.upcase
+  .form-group
+    = f.text_area(:biography, rows: 6, placeholder: 'Biography', maxlength: User::MAX_BIOGRAPHY_LENGTH_ALLOWED, class: 'form-control')
+    = f.label(:biography, class: 'd-block text-right') do
+      %small.form-text Max. #{User::MAX_BIOGRAPHY_LENGTH_ALLOWED} characters.
+  .form-group
+    = f.text_field(:email, required: true, email: true, placeholder: 'Email', readonly: behind_proxy, class: 'form-control')
+  .form-group
+  - if behind_proxy
+    %p
+      You are behind a proxy. You can modify other data related to your profile by
+      = link_to(' this link.', account_edit_link)
+  .form-group.text-right
+    = link_to 'Cancel', user_path(displayed_user), class: 'cancel btn btn-outline-danger px-4', remote: true
+    = submit_tag('Update', class: 'btn btn-primary px-4')

--- a/src/api/app/views/webui/user/user_profile_redesign/_info.html.haml
+++ b/src/api/app/views/webui/user/user_profile_redesign/_info.html.haml
@@ -1,31 +1,12 @@
 .card.mb-3
   .card-body
-    .row.mb-3.mb-md-0
-      .col-4.col-sm-2.col-md-12.text-center
-        = image_tag_for(user, size: 200)
-      .col-8.col-sm-10.col-md-12.pl-0.p-md-3
-        %h4#home-realname
-          = user.realname
-        %h5.text-muted#home-login
-          = user.login
+    = render partial: 'webui/user/user_profile_redesign/basic_info', locals: { user: user, role_titles: role_titles }
 
-    - role_titles.each do |title|
-      %span.badge.badge-secondary
-        = title.upcase
-
-    %p= render_as_markdown(user.biography)
-
-    .mt-4
-      - if User.session
-        = mail_to(user.email, title: "Send mail to #{user.name}", class: 'd-block') do
-          %i.fas.fa-envelope.mr-1
-          = user.email
-
-      - if user.rss_token && is_user
-        = link_to(user_rss_notifications_path(token: user.rss_token.string, format: 'rss'),
-                                              title: 'RSS Feed for Notifications', class: 'd-block') do
-          %i.fas.fa-rss.mr-1
-          RSS for Notifications
+    - if user.rss_token && is_user
+      = link_to(user_rss_notifications_path(token: user.rss_token.string, format: 'rss'),
+                                            title: 'RSS Feed for Notifications', class: 'd-block') do
+        %i.fas.fa-rss.mr-1
+        RSS for Notifications
 
     - if groups.any?
       .h5.mt-4.mb-0 Member of the #{'group'.pluralize(groups.size)}
@@ -50,7 +31,7 @@
 
       .mt-4
         - if configuration.accounts_editable?(user)
-          = render partial: 'webui/user/edit_account', locals: { account_edit_link: account_edit_link }
+          = render partial: 'webui/user/edit_account', locals: { account_edit_link: account_edit_link, user: user }
         - if configuration.passwords_changable?(user)
           = render partial: 'webui/user/change_password'
         - if feature_enabled?(:responsive_ux)

--- a/src/api/app/views/webui/users/edit_account.js.erb
+++ b/src/api/app/views/webui/users/edit_account.js.erb
@@ -1,0 +1,10 @@
+$('#flash').empty();
+$('.in-place-editing').animate({
+  opacity: 0.25
+}, 400, function() {
+  scrollToInPlace();
+  $('.in-place-editing').html("<%= escape_javascript(render(partial: 'webui/user/user_profile_redesign/edit_account_form', locals: { displayed_user: @displayed_user, role_titles: @role_titles, account_edit_link: @account_edit_link})) %>");
+  $('.in-place-editing').animate({ opacity: 1 }, 400, function() {
+    $("form *[autofocus='autofocus']").focus();
+  });
+});

--- a/src/api/app/views/webui/users/show.js.erb
+++ b/src/api/app/views/webui/users/show.js.erb
@@ -1,0 +1,8 @@
+$('.in-place-editing').animate({
+  opacity: 0.25
+}, 400, function() {
+  scrollToInPlace();
+  $('.in-place-editing').html("<%= escape_javascript(render(partial: 'webui/user/user_profile_redesign/basic_info', locals: { user: @displayed_user, role_titles: @role_titles })) %>");
+  setCollapsible();
+  $('.in-place-editing').animate({ opacity: 1 }, 400);
+});

--- a/src/api/app/views/webui/users/update.js.haml
+++ b/src/api/app/views/webui/users/update.js.haml
@@ -1,0 +1,19 @@
+resetFormValidation();
+- if @displayed_user.errors.any?
+  - @displayed_user.errors.messages.each do |field, messages|
+    element = $("##{@displayed_user.class.name.underscore}_#{field}"); // Create strings like "user_email"
+    setFormValidation(element, "#{messages.to_sentence}");
+- else
+  - locals = { user: @displayed_user, role_titles: @role_titles }
+  :plain
+    $('.in-place-editing').animate({
+      opacity: 0.25
+    }, 400, function() {
+      scrollToInPlace();
+      $('.in-place-editing').html(
+        "#{escape_javascript(render(partial: 'webui/user/user_profile_redesign/basic_info', locals: locals))}");
+      setCollapsible();
+      $('.in-place-editing').animate({ opacity: 1 }, 400, function() {
+        $('#flash').html("#{escape_javascript(render(layout: false, partial: 'layouts/webui/flash', object: flash))}");
+      });
+    });

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -300,6 +300,7 @@ OBSApi::Application.routes.draw do
       end
       member do
         post 'change_password'
+        get 'edit_account'
       end
     end
 

--- a/src/api/spec/controllers/webui/users_controller_spec.rb
+++ b/src/api/spec/controllers/webui/users_controller_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe Webui::UsersController do
           user.reload
         end
 
-        it { expect(flash[:error]).to eq("Couldn't update user: Validation failed: Email must be a valid email address.") }
+        it { expect(flash[:error]).to eq("Couldn't update user: Email must be a valid email address.") }
         it { expect(user.realname).to eq(user.realname) }
         it { expect(user.email).to eq(user.email) }
         it { expect(user.state).to eq('confirmed') }


### PR DESCRIPTION
When the authentication is handled by a proxy, biography is the only attribute editable. Otherwise, biography, name and email can be edited.
    
**Without proxy:**

![wo_proxy](https://user-images.githubusercontent.com/2581944/96480656-d40da800-123a-11eb-881c-c9e25badab52.gif)

**With proxy:**

![with_proxt](https://user-images.githubusercontent.com/2581944/96480708-e4be1e00-123a-11eb-8db7-d0eb0bbc97bf.gif)

Co-authored-by: Oleksandr Orlov <oorlov@suse.com>


DO NOT MERGE until #10295 is merged.