### PR TITLE
Syncronize UI and API measurement tags

### DIFF
--- a/src/api/app/controllers/application_controller.rb
+++ b/src/api/app/controllers/application_controller.rb
@@ -379,8 +379,7 @@ class ApplicationController < ActionController::Base
     InfluxDB::Rails.current.tags = {
       beta: User.possibly_nobody.in_beta?,
       anonymous: !User.session,
-      interface: :api,
-      controller_location: "#{self.class.name}#{action_name}"
+      interface: :api
     }
   end
 end

--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -17,7 +17,6 @@ class Webui::WebuiController < ActionController::Base
   before_action :setup_view_path
   before_action :check_user
   before_action :check_anonymous
-  before_action :set_influxdb_additional_tags
   before_action :require_configuration
   before_action :current_announcement
   after_action :clean_cache
@@ -268,16 +267,9 @@ class Webui::WebuiController < ActionController::Base
 
   def set_influxdb_data
     InfluxDB::Rails.current.tags = {
+      beta: User.possibly_nobody.in_beta?,
+      anonymous: !User.session,
       interface: :webui
     }
-  end
-
-  def set_influxdb_additional_tags
-    tags = {
-      beta: User.possibly_nobody.in_beta?,
-      anonymous: !User.session
-    }
-
-    InfluxDB::Rails.current.tags = InfluxDB::Rails.current.tags.merge(tags)
   end
 end


### PR DESCRIPTION
If they report the same things with the same tag names and content,
it's easier to visualize things that go across namespaces.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
