### PR TITLE
Add Pagination for WebUI::UsersController#show involved items

### DIFF
--- a/src/api/app/controllers/webui/users_controller.rb
+++ b/src/api/app/controllers/webui/users_controller.rb
@@ -13,6 +13,7 @@ class Webui::UsersController < Webui::WebuiController
   end
 
   def show
+    max_items_per_page = 25
     @groups = @displayed_user.groups
 
     if Flipper.enabled?(:user_profile_redesign, User.possibly_nobody)
@@ -21,7 +22,7 @@ class Webui::UsersController < Webui::WebuiController
 
       filters = adjust_filters
 
-      @involved_items = @displayed_user.involved_items(filters)
+      @involved_items = Kaminari.paginate_array(@displayed_user.involved_items(filters)).page(params[:page]).per(max_items_per_page)
       @involved_items_as_owner = @displayed_user.involved_items_as_owner(filters) if @owner_root_project_exists
     else
       @iprojects = @displayed_user.involved_projects.pluck(:name, :title)

--- a/src/api/app/views/webui/user/user_profile_redesign/_involvement.html.haml
+++ b/src/api/app/views/webui/user/user_profile_redesign/_involvement.html.haml
@@ -75,6 +75,7 @@
                 -# TODO: Deal with multiline, or long descriptions
                 %p.mb-0= involved_item.description
 
+      = paginate involved_items, window: 2, views_prefix: 'webui'
 - content_for :ready_function do
   :plain
     $('.dropdown-menu.keep-open').on('click', function(e) {


### PR DESCRIPTION
Fix P2: #10332 

An aftermath from #10313, calls to `User#involved_items` or `User#involved_items_as_owner` could be probably cached.

Pagination looks like:

![Screenshot_2020-10-22_13-33-36](https://user-images.githubusercontent.com/37418/96866610-d60a7d80-146b-11eb-8adc-d827184fced8.png)
