### PR TITLE
Change Delayed::Worker.default_log_level to debug

### DIFF
--- a/src/api/config/environments/production.rb
+++ b/src/api/config/environments/production.rb
@@ -89,7 +89,7 @@ OBSApi::Application.configure do
 end
 
 # ActiveJob already logs everything we need
-Delayed::Worker.default_log_level = 'error'
+Delayed::Worker.default_log_level = 'debug'
 
 # disabled on production for performance reasons
 # CONFIG['response_schema_validation'] = true


### PR DESCRIPTION
We want DJ logs to only appear as debug logs. And ActiveJob logs
as info logs.

