### PR TITLE
Use Date.parse instead of Time.now.parse to parse user controlled date

### DIFF
--- a/src/api/app/jobs/project_create_auto_cleanup_requests_job.rb
+++ b/src/api/app/jobs/project_create_auto_cleanup_requests_job.rb
@@ -56,7 +56,7 @@ Such requests get not created for projects with open requests or if you remove t
       attribute = prj.attribs.find_by_attrib_type_id(@cleanup_attribute.id)
       return unless attribute
 
-      time = Time.zone.parse(attribute.values.first.value)
+      time = Date.parse(attribute.values.first.value)
     rescue TypeError, ArgumentError
       # nil time raises TypeError
       return

--- a/src/api/spec/jobs/project_create_auto_cleanup_requests_job_spec.rb
+++ b/src/api/spec/jobs/project_create_auto_cleanup_requests_job_spec.rb
@@ -52,5 +52,23 @@ RSpec.describe ProjectCreateAutoCleanupRequestsJob, type: :job, vcr: true do
         expect(project.target_of_bs_request_actions.where(type: 'delete').count).to eq(0)
       end
     end
+
+    context 'with empty cleanup time' do
+      before do
+        attribute.values.first.value = ''
+        attribute.save
+      end
+
+      it { expect { subject }.not_to raise_error }
+    end
+
+    context 'with invalid cleanup time' do
+      before do
+        attribute.values.first.value = '200000'
+        attribute.save
+      end
+
+      it { expect { subject }.not_to raise_error }
+    end
   end
 end


### PR DESCRIPTION
Date.parse is more robust when dealing with empty strings or
out of the range dates

Some projects in production set an invalid value to the `OBS:AutoCleanup` to avoid being auto cleaned. Examples:

Project: home:mvdlinde_ger:tiefflieger
Project: home:lenovo-lico:lico-dep:5.1:el6
Project: home:Coollinux101:branches:openSUSE:Templates:Images:42.3
Project: home:maelhabashy
Project: home:taslim.tanim

