### PR TITLE
Introduce group measurements

### DIFF
--- a/src/api/app/jobs/measurements_job.rb
+++ b/src/api/app/jobs/measurements_job.rb
@@ -1,0 +1,7 @@
+class MeasurementsJob < ApplicationJob
+  queue_as :quick
+
+  def perform
+    RabbitmqBus.send_to_bus('metrics', "group count=#{Group.count}")
+  end
+end

--- a/src/api/config/clock.rb
+++ b/src/api/config/clock.rb
@@ -27,6 +27,10 @@ module Clockwork
     SendEventEmailsJob.perform_later
   end
 
+  every(5.minutes, 'measurements') do
+    MeasurementsJob.perform_later
+  end
+
   every(49.minutes, 'rescale history') do
     StatusHistoryRescalerJob.perform_later
   end


### PR DESCRIPTION
Measure the number of groups ~every time a group is created or destroyed~, ~hourly~, each five minutes.

Tḧe number of groups changes not so often. However, we need to measure frequently to avoid graphic panels with "No data" in Grafana.

Co-authored-by: Saray Cabrera Padrón <scabrerapadron@suse.de>