### PR TITLE
Change measurement of the number of beta users

### DIFF
--- a/src/api/app/jobs/measurements_job.rb
+++ b/src/api/app/jobs/measurements_job.rb
@@ -3,5 +3,6 @@ class MeasurementsJob < ApplicationJob
 
   def perform
     RabbitmqBus.send_to_bus('metrics', "group count=#{Group.count}")
+    RabbitmqBus.send_to_bus('metrics', "user in_beta=#{User.in_beta.count},count=#{User.count}")
   end
 end

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -105,7 +105,6 @@ class User < ApplicationRecord
   validates :password, confirmation: true, allow_blank: true
   validates :biography, length: { maximum: MAX_BIOGRAPHY_LENGTH_ALLOWED }
 
-  before_save :send_metric_for_beta_change, if: :in_beta_changed?
   after_create :create_home_project, :track_create
 
   alias flipper_id id
@@ -898,11 +897,6 @@ class User < ApplicationRecord
     end
 
     save
-  end
-
-  def send_metric_for_beta_change
-    channel = (in_beta? ? 'joined_beta' : 'left_beta')
-    RabbitmqBus.send_to_bus('metrics', "user.#{channel} value=1")
   end
 
   def run_as


### PR DESCRIPTION
Before we measured if a user left or joined the beta program, that didn't provide the total amount of beta users.

Co-authored-by: Saray Cabrera Padrón <scabrerapadron@suse.de>
