### PR TITLE
Add statistics for backend Workers

### DIFF
--- a/src/api/app/jobs/backend_measurements_job.rb
+++ b/src/api/app/jobs/backend_measurements_job.rb
@@ -1,0 +1,27 @@
+class BackendMeasurementsJob < ApplicationJob
+  queue_as :quick
+
+  def perform
+    return unless CONFIG['amqp_options']
+
+    RabbitmqBus.send_to_bus('metrics', "workers #{worker_status_fields}")
+
+    worker_jobs = WorkerStatusService::JobsStatisticsFetcher.call
+    worker_jobs[:waiting].each do |wj|
+      RabbitmqBus.send_to_bus('metrics', "waiting_jobs,#{jobs_fields(wj)}")
+    end
+    worker_jobs[:blocked].each do |wj|
+      RabbitmqBus.send_to_bus('metrics', "blocked_jobs,#{jobs_fields(wj)}")
+    end
+  end
+
+  private
+
+  def worker_status_fields
+    WorkerStatus.statistics.map { |k, v| "#{k}=#{v}" }.join(',')
+  end
+
+  def jobs_fields(job_line)
+    job_line.map { |k, v| "#{k}=#{v}" }.join(' ')
+  end
+end

--- a/src/api/app/models/worker_status.rb
+++ b/src/api/app/models/worker_status.rb
@@ -7,6 +7,10 @@ class WorkerStatus
       hidden_projects(ws)
     end
 
+    def statistics
+      WorkerStatusService::WorkerStatisticsFetcher.call
+    end
+
     private
 
     def hidden_projects(worker_status_root)

--- a/src/api/app/services/worker_status_service/jobs_statistics_fetcher.rb
+++ b/src/api/app/services/worker_status_service/jobs_statistics_fetcher.rb
@@ -1,0 +1,33 @@
+module WorkerStatusService
+  class JobsStatisticsFetcher
+    attr_reader :worker_status
+
+    class << self
+      def call
+        new.statistics
+      end
+    end
+
+    def initialize
+      @worker_status = Hash.from_xml(backend_worker_status)
+    end
+
+    def waiting
+      @worker_status['workerstatus']['waiting']
+    end
+
+    def blocked
+      @worker_status['workerstatus']['blocked']
+    end
+
+    def statistics
+      { waiting: waiting, blocked: blocked }
+    end
+
+    private
+
+    def backend_worker_status
+      Rails.cache.read('workerstatus') || Backend::Api::BuildResults::Worker.status
+    end
+  end
+end

--- a/src/api/app/services/worker_status_service/worker_statistics_fetcher.rb
+++ b/src/api/app/services/worker_status_service/worker_statistics_fetcher.rb
@@ -1,0 +1,37 @@
+module WorkerStatusService
+  class WorkerStatisticsFetcher
+    attr_reader :worker_status
+
+    class << self
+      def call
+        new.statistics
+      end
+    end
+
+    def initialize
+      @worker_status = Nokogiri::XML(backend_worker_status)
+    end
+
+    def statistics
+      { building: building, idle: idle, total: total }
+    end
+
+    def total
+      building + idle
+    end
+
+    def building
+      worker_status.search('//building').size
+    end
+
+    def idle
+      worker_status.search('//idle').size
+    end
+
+    private
+
+    def backend_worker_status
+      Rails.cache.read('workerstatus') || Backend::Api::BuildResults::Worker.status
+    end
+  end
+end

--- a/src/api/config/clock.rb
+++ b/src/api/config/clock.rb
@@ -27,6 +27,10 @@ module Clockwork
     SendEventEmailsJob.perform_later
   end
 
+  every(1.minute, 'backend_measurements') do
+    BackendMeasurementsJob.perform_later
+  end
+
   every(5.minutes, 'measurements') do
     MeasurementsJob.perform_later
   end

--- a/src/api/spec/models/worker_status_spec.rb
+++ b/src/api/spec/models/worker_status_spec.rb
@@ -124,4 +124,58 @@ RSpec.describe WorkerStatus do
       it { expect { subject }.to change { Architecture.available.count }.by(3) }
     end
   end
+
+  describe '#statistics' do
+    subject { WorkerStatus.statistics }
+
+    context 'when the xml response is empty' do
+      let(:xml_response) { '<workerstatus clients="0"></workerstatus>' }
+
+      it { expect(subject).not_to be_nil }
+      it { expect(subject).to include(:building, :idle, :total) }
+    end
+
+    context 'it generates a json with count for building and queued jobs' do
+      let(:xml_response) do
+        <<-HEREDOC
+        <workerstatus clients="285">
+          <idle workerid="build24/7" hostarch="x86_64"/>
+          <building repository="openSUSE_11.3_Update" arch="x86_64" project="home:enzokiel" package="android-sdk" starttime="1289838671" workerid="build03/1" hostarch="x86_64"/>
+          <building repository="openSUSE_11.2" arch="i586" project="KDE:KDE3" package="desktoptext-config" starttime="1289899573" workerid="build03/2" hostarch="x86_64"/>
+          <building repository="openSUSE_11.1" arch="i586" project="home:frispete:gimp" package="xsane" starttime="1289918108" workerid="build03/3" hostarch="x86_64"/>
+          <waiting jobs="2160" arch="i586"/>
+          <waiting jobs="1" arch="local"/>
+          <waiting jobs="2013" arch="x86_64"/>
+          <blocked jobs="7215" arch="i586"/>
+          <blocked jobs="3" arch="local"/>
+          <blocked jobs="5855" arch="x86_64"/>
+          <buildavg arch="i586" buildavg="7853.49900157855"/>
+          <buildavg arch="local" buildavg="6706.03274513389"/>
+          <buildavg arch="x86_64" buildavg="6313.8886610886"/>
+          <partition>
+          <daemon type="scheduler" arch="i586" starttime="1288252359" state="running">
+          <queue med="68" high="4" next="9730" low="760"/>
+          </daemon>
+          <daemon type="scheduler" arch="local" starttime="1288252359" state="running">
+          <queue med="0" high="0" next="0" low="0"/>
+          </daemon>
+          <daemon type="scheduler" arch="x86_64" starttime="1288252359" state="running">
+          <queue med="69" high="0" next="7409" low="4690"/>
+          </daemon>
+          <daemon type="dispatcher" starttime="1289593678" state="running"/>
+          <daemon type="publisher" starttime="1287910270" state="running"/>
+          <daemon type="signer" starttime="1289913427" state="running"/>
+          <daemon type="warden" starttime="1287910269" state="running"/>
+          </partition>
+        </workerstatus>
+        HEREDOC
+      end
+
+      it { expect(subject).not_to be_nil }
+      it { expect(subject).to include(:building, :idle, :total) }
+      it { expect(subject[:building]).to eq(3) }
+      it { expect(subject[:idle]).to eq(1) }
+      it { expect(subject[:total]).to eq(4) }
+    end
+  end
 end

--- a/src/api/spec/services/worker_status_service/jobs_statistics_fetcher_spec.rb
+++ b/src/api/spec/services/worker_status_service/jobs_statistics_fetcher_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe WorkerStatusService::JobsStatisticsFetcher do
+  subject { described_class.call }
+
+  let(:xml_response) do
+    <<-HEREDOC
+          <workerstatus clients="1">
+          <building workerid="build01/2" hostarch="i586" project="foo" repository="nada" package="bdpack" arch="i586" starttime="0" />
+          <waiting arch="i586" jobs="1" />
+          <blocked arch="i586" jobs="1" />
+          <buildavg arch="i586" buildavg="1200" />
+          <partition>
+            <daemon type="scheduler" arch="i586" state="dead">
+            <queue high="0" med="0" low="3" next="0" />
+            </daemon>
+            <daemon type="publisher" state="dead" />
+          </partition>
+          </workerstatus>
+    HEREDOC
+  end
+
+  before do
+    allow(Backend::Api::BuildResults::Worker).to receive(:status).and_return(xml_response)
+  end
+
+  it { expect(subject).to include(:blocked, :waiting) }
+  it { expect(subject[:blocked]).to be_a(Hash) }
+  it { expect(subject[:waiting]).to be_a(Hash) }
+end


### PR DESCRIPTION
Add statistics for the workers, similar with what we have in the frontend but those are for Grafana

TODO:

- [x] Create metrics for backend workers
- [x] Create new metrics job
- [x] Test locally with local grafana

![Screenshot_2020-11-03_09-39-09](https://user-images.githubusercontent.com/37418/97964427-0d0c5780-1db9-11eb-9725-5074528795a4.png)

Tried locally using https://github.com/openSUSE/open-build-service/wiki/Site-Reliability#development-environment

Built locally some packages and could do it being updated on my local grafana instance