### PR TITLE
[backend] enable network access for node_modules

### DIFF
--- a/src/backend/call-service-in-container
+++ b/src/backend/call-service-in-container
@@ -51,7 +51,7 @@ create_dir "$LOGDIR"
 
 shift
 case "$COMMAND" in
-  */download_url|*/download_src_package|*/update_source|*/download_files|*/generator_pom|*/snapcraft|*/kiwi_import|*/appimage)
+  */download_url|*/download_src_package|*/update_source|*/download_files|*/generator_pom|*/snapcraft|*/kiwi_import|*/appimage|*/node_modules)
     WITH_NET="1"
     ;;
   */bundle_gems)

--- a/src/backend/call-service-in-docker.sh
+++ b/src/backend/call-service-in-docker.sh
@@ -45,7 +45,7 @@ create_dir "$LOGDIR"
 
 shift
 case "$COMMAND" in
-  */download_url|*/download_src_package|*/update_source|*/download_files|*/generator_pom|*/snapcraft|*/kiwi_import|*/appimage)
+  */download_url|*/download_src_package|*/update_source|*/download_files|*/generator_pom|*/snapcraft|*/kiwi_import|*/appimage/*/node_modules)
     WITH_NET="1"
     ;;
   */bundle_gems)


### PR DESCRIPTION
This patch should enable network access for the node_modules service
in containers (docker/podman).

service passed audit successfully, SEE

https://bugzilla.suse.com/show_bug.cgi?id=1177576
