### PR TITLE
[dist] in obs-server.spec prereq shadow for system-user packages

### DIFF
--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -368,30 +368,24 @@ Summary: System user and group obsrun
 Group:    System/Fhs
 Provides: user(obsrun)
 Provides: group(obsrun)
+%if 0%{?suse_version:1}
+Requires(pre):  shadow
+%endif
 
 %description -n system-user-obsrun
 This package provides the system account and group 'obsrun'.
-
-%pre -n system-user-obsrun
-getent group obsrun >/dev/null || /usr/sbin/groupadd -r obsrun
-getent passwd obsrun >/dev/null || \
-    /usr/sbin/useradd -r -g obsrun -d /usr/lib/obs -s %{sbin}/nologin \
-    -c "User for build service backend" obsrun
-
 
 %package -n system-user-obsservicerun
 Summary:  System user obsservicerun
 Group:    System/Fhs
 Requires: group(obsrun)
 Provides: user(obsservicerun)
+%if 0%{?suse_version:1}
+Requires(pre):  shadow
+%endif
 
 %description -n system-user-obsservicerun
 This package provides the system account 'obsservicerun'
-
-%pre -n system-user-obsservicerun
-getent passwd obsservicerun >/dev/null || \
-    /usr/sbin/useradd -r -g obsrun -d %{obs_backend_data_dir}/service -s %{sbin}/nologin \
-    -c "" obsservicerun
 
 #--------------------------------------------------------------------------------
 %prep
@@ -598,6 +592,17 @@ exit 0
 %pre -n obs-cloud-uploader
 %service_add_pre obsclouduploadworker.service
 %service_add_pre obsclouduploadserver.service
+
+%pre -n system-user-obsrun
+getent group obsrun >/dev/null || /usr/sbin/groupadd -r obsrun
+getent passwd obsrun >/dev/null || \
+    /usr/sbin/useradd -r -g obsrun -d /usr/lib/obs -s %{sbin}/nologin \
+    -c "User for build service backend" obsrun
+
+%pre -n system-user-obsservicerun
+getent passwd obsservicerun >/dev/null || \
+    /usr/sbin/useradd -r -g obsrun -d %{obs_backend_data_dir}/service -s %{sbin}/nologin \
+    -c "" obsservicerun
 
 %preun
 %service_del_preun obsscheduler.service


### PR DESCRIPTION
Also move preinstall scripts to the same section in the
specfile where all other pre scripts are

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
