### PR TITLE
[backend] try to use sha256 when the default signkey is used

### DIFF
--- a/src/backend/BSPublisher/Container.pm
+++ b/src/backend/BSPublisher/Container.pm
@@ -81,7 +81,7 @@ sub get_notary_pubkey {
   push @signargs, @{$signargs || []};
 
   # ask the sign tool for the correct pubkey if we do not have a sign key
-  if (!@$signargs && $BSConfig::sign_project && $BSConfig::sign) {
+  if (!(@$signargs && $signargs->[0] eq '-P') && $BSConfig::sign_project && $BSConfig::sign) {
     local *S;
     open(S, '-|', $BSConfig::sign, @signargs, '-p') || die("$BSConfig::sign: $!\n");;
     $pubkey = '';

--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -334,18 +334,17 @@ sub getsigndata {
   push @args, "autoextend=1" if $BSConfig::sign;
   my $signkey = BSRPC::rpc("$BSConfig::srcserver/getsignkey", undef, "project=$projid", @args);
   my $pubkey;
+  my $algo;
   if ($signkey) {
     ($signkey, $pubkey) = split("\n", $signkey, 2);
     undef $signkey unless $signkey && length($signkey) > 10;	# not a valid signkey
     undef $pubkey unless $pubkey && length($pubkey) > 10;	# not a valid pubkey
-    if ($signkey) {
-      my $algo;
-      $algo = $1 if $signkey && $signkey =~ s/^(\S+)://;
-      mkdir_p("$uploaddir");
-      writestr("$uploaddir/publisher.$$", undef, $signkey);
-      $signargs = [ '-P', "$uploaddir/publisher.$$" ];
-      push @$signargs, '-h', 'sha256' if $algo && $algo eq 'rsa';
-    }
+  }
+  if ($signkey) {
+    $algo = $1 if $signkey && $signkey =~ s/^(\S+)://;
+    mkdir_p("$uploaddir");
+    writestr("$uploaddir/publisher.$$", undef, $signkey);
+    $signargs = [ '-P', "$uploaddir/publisher.$$" ];
   }
   if (!$pubkey) {
     if ($BSConfig::sign_project && $BSConfig::sign) {
@@ -365,6 +364,11 @@ sub getsigndata {
       }
     }
   }
+  if ($pubkey && !$algo) {
+    # try to get algo from public key
+    eval { $algo = BSPGP::pk2algo(BSPGP::unarmor($pubkey)) };
+  }
+  push @$signargs, '-h', 'sha256' if $algo && $algo eq 'rsa';
   return ($pubkey, $signargs);
 }
 
@@ -2559,7 +2563,7 @@ sub publish {
     };
     if ($@) {
       clean_blobdir($blobdir);
-      unlink("$uploaddir/publisher.$$") if @$signargs;
+      unlink("$uploaddir/publisher.$$") if @$signargs && $signargs->[0] eq '-P';
       die($@);
     }
   }
@@ -2936,7 +2940,7 @@ sub publish {
   db_store($patterninfodb, $dbgsplit ? "$prp$dbgsplit" : $prp, %{$data->{'patterninfo'}} ? $data->{'patterninfo'} : undef) if $patterninfodb;
 
 publishprog_done:
-  unlink("$uploaddir/publisher.$$") if @$signargs;
+  unlink("$uploaddir/publisher.$$") if @$signargs && $signargs->[0] eq '-P';
 
   # post process step: create directory listing for poor YaST
   if ($repotype{'suse'}) {


### PR DESCRIPTION
We already switched to sha256 if the project contains a RSA key.
This does not work for the default signkey, as we do not get
the pubkey algorithm in this case.
We now derive the algo from the pubkey if the default signkey
is used.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
