### PR TITLE
Run the job that tracks the amount of user log ins once a day

### DIFF
--- a/src/api/app/jobs/daily_user_activity_measurement_job.rb
+++ b/src/api/app/jobs/daily_user_activity_measurement_job.rb
@@ -1,0 +1,21 @@
+class DailyUserActivityMeasurementJob < ApplicationJob
+  queue_as :quick
+
+  def perform
+    return unless CONFIG['amqp_options']
+
+    RabbitmqBus.send_to_bus('metrics', "user #{user_fields}")
+  end
+
+  private
+
+  def user_fields
+    user_measures.map { |k, v| "#{k}=#{v}" }.join(',')
+  end
+
+  def user_measures
+    {
+      seen: User.seen_since(1.day.ago).count
+    }
+  end
+end

--- a/src/api/app/jobs/measurements_job.rb
+++ b/src/api/app/jobs/measurements_job.rb
@@ -18,8 +18,7 @@ class MeasurementsJob < ApplicationJob
     {
       in_beta: User.in_beta.count,
       in_rollout: User.in_rollout.count,
-      count: User.count,
-      seen: active_users_since(5.minutes.ago)
+      count: User.count
     }
       .merge(role_fields)
       .merge(state_fields)
@@ -37,9 +36,5 @@ class MeasurementsJob < ApplicationJob
       fields[state.to_sym] = User.where(state: state).count
       fields
     end
-  end
-
-  def active_users_since(a_datetime)
-    User.seen_since(a_datetime).count
   end
 end

--- a/src/api/config/clock.rb
+++ b/src/api/config/clock.rb
@@ -31,7 +31,7 @@ module Clockwork
     MeasurementsJob.perform_later
   end
 
-  every(1.day, 'measurements') do
+  every(1.day, 'daily user activity measurements') do
     DailyUserActivityMeasurementJob.perform_later
   end
 

--- a/src/api/config/clock.rb
+++ b/src/api/config/clock.rb
@@ -31,10 +31,6 @@ module Clockwork
     MeasurementsJob.perform_later
   end
 
-  every(1.day, 'daily user activity measurements') do
-    DailyUserActivityMeasurementJob.perform_later
-  end
-
   every(49.minutes, 'rescale history') do
     StatusHistoryRescalerJob.perform_later
   end
@@ -70,6 +66,10 @@ module Clockwork
   every(1.day, 'create cleanup requests', at: '06:00') do
     User.session = User.get_default_admin
     ProjectCreateAutoCleanupRequestsJob.perform_later
+  end
+
+  every(1.day, 'daily user activity measurements') do
+    DailyUserActivityMeasurementJob.perform_later
   end
 
   # check for new breakages between api and backend due to dull code

--- a/src/api/config/clock.rb
+++ b/src/api/config/clock.rb
@@ -31,6 +31,10 @@ module Clockwork
     MeasurementsJob.perform_later
   end
 
+  every(1.day, 'measurements') do
+    DailyUserActivityMeasurementJob.perform_later
+  end
+
   every(49.minutes, 'rescale history') do
     StatusHistoryRescalerJob.perform_later
   end


### PR DESCRIPTION
As the `last_logged_in_at` user's field does not track the time, measuring this
every 5 minutes makes no sense.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
