### PR TITLE
Only show log in option if no user is logged in

### DIFF
--- a/src/api/app/views/webui/shared/_sign_up.html.haml
+++ b/src/api/app/views/webui/shared/_sign_up.html.haml
@@ -24,5 +24,6 @@
         class: 'form-control', required: true)
     = hidden_field_tag 'register', 'true'
     = submit_tag submit_btn_text, class: 'btn btn-primary'
-    or
-    = link_to('Log In', new_session_path)
+    - unless User.session
+      or
+      = link_to('Log In', new_session_path)


### PR DESCRIPTION
Only show the "or Log In" option if no user is logged in

Fixes #10326 

Before Screenshot:
![before](https://user-images.githubusercontent.com/54934253/98015351-f8ea4980-1dfc-11eb-9053-5865e6d0b7ef.png)
After Screenshots:
![after](https://user-images.githubusercontent.com/54934253/98015413-0acbec80-1dfd-11eb-9119-d7142404d647.png)
![after_logged_out](https://user-images.githubusercontent.com/54934253/98015421-0dc6dd00-1dfd-11eb-9843-f12edb1c1d07.png)

