### PR TITLE
[backend] support exitstatus 4 as unrecoverable worker failure

### DIFF
--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -663,6 +663,8 @@ if ($exitrestart) {
   if ($state->{'state'} eq 'building' || $state->{'state'} eq 'killed' || $state->{'state'} eq 'discarded' || $state->{'state'} eq 'badhost') {
     $state->{'state'} = 'discarded';
     $state->{'nextstate'} = $exitrestart eq 'exit' ? 'exit' : 'rebooting';
+  } elsif ($state->{'state'} eq 'dead') {
+    die("worker is dead\n");
   } else {
     $state->{'state'} = $exitrestart eq 'exit' ? 'exit' : 'rebooting';
   }
@@ -1167,7 +1169,8 @@ sub manage_cache {
   my $content;
   if (-s F) {
     seek(F, 0, 0);
-    $content = Storable::fd_retrieve(\*F);
+    eval { $content = Storable::fd_retrieve(\*F) };
+    die("FATAL: cannot read cache content: $@") if $@;
   }
   $content ||= [];
   my %content = map {$_->[0] => $_->[1]} @$content;
@@ -3338,6 +3341,8 @@ sub dobuild {
     }
   } elsif ($ret == 3 * 256) {
     return 3;
+  } elsif ($ret == 4 * 256) {
+    return 4;
   } elsif ($ret == 9 * 256) {
     if ($vm =~ /(xen|kvm|zvm|emulator|pvm|openstack)/) {
       rm_rf("$buildroot/.build.packages");
@@ -3721,8 +3726,13 @@ sub periodic {
     $idlecnt = 0;
   }
 
-  if ($state->{'state'} eq 'exit') {
+  if ($state->{'state'} eq 'exit' || $state->{'state'} eq 'dead') {
     $state = lockstate();
+    if ($state->{'state'} eq 'dead') {
+      close RUNLOCK;
+      send_state('exit', $port, $hostarch);
+      exit(0);
+    }
     if ($state->{'state'} eq 'exit') {
       close RUNLOCK;
       $state = {'state' => 'idle'};
@@ -3934,6 +3944,7 @@ if ($@) {
   $ex = 3 if $@ =~ /^500 /;
   # catch disk full errors before the build script could be even started
   $ex = 3 if $@ =~ /No space left on device/;
+  $ex = 4 if $@ =~ /^FATAL:/;
   append_nonfatal("$buildroot/.build.log", $workerid ? "$@(worker was $workerid)\n" : $@);
   print $@;
 }
@@ -4138,6 +4149,10 @@ if (!$ex) {
       $code = 'failed';
     }
   }
+} elsif ($ex == 4) {
+  print "detected broken build host, exiting...\n";
+  $code = 'badhost';
+  $state->{'nextstate'} = 'dead';
 } elsif ($ex == 11) {
   print "build has different generated build requires\n";
   $code = 'genbuildreqs';


### PR DESCRIPTION
<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
