### PR TITLE
[backend] bs_srcserver allow tuning maxchilds via config

### DIFF
--- a/src/backend/BSConfig.pm.template
+++ b/src/backend/BSConfig.pm.template
@@ -62,6 +62,8 @@ our $servicedir = "/usr/lib/obs/service/";
 #our $servicetempdir = "/srv/obs/service";
 #our $serviceroot = "/opt/obs/MyServiceSystem";
 
+# Maximum number of concurrent jobs for source server
+#our $srcserver_maxchild = 20;
 # Maximum number of concurrent jobs for source service
 #our $service_maxchild = 20;
 

--- a/src/backend/BSSched/ProjPacks.pm
+++ b/src/backend/BSSched/ProjPacks.pm
@@ -834,7 +834,7 @@ sub setup_projects {
 
   my $t1 = Time::HiRes::time();
   my $projids_todo_cnt = scalar(@{$projids_todo || []});
-  undef $projids_todo if $projids_todo_cnt > 1000;	# removing old stuff takes too long
+  undef $projids_todo if $projids_todo_cnt > 200;	# removing old stuff takes too long
 
   my @projids_todo;
   if ($projids_todo) {

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -7169,6 +7169,10 @@ my $aconf = {
   'dispatches' => $dispatches_ajax,
 };
 
+if ($BSConfig::srcserver_maxchild) {
+  $conf->{'maxchild'} = $BSConfig::srcserver_maxchild;
+}
+
 if ($BSConfig::workersrcserver) {
   my $wport = $port;
   $wport = $1 if $BSConfig::workersrcserver =~ /:(\d+)$/;


### PR DESCRIPTION
<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
