### PR TITLE
[api] maintenance_release request action default reviewer change

### DIFF
--- a/src/api/app/controllers/request_controller.rb
+++ b/src/api/app/controllers/request_controller.rb
@@ -146,6 +146,7 @@ class RequestController < ApplicationController
       @req.set_add_revision       if params[:addrevision].present?
       @req.set_ignore_delegate    if params[:ignore_delegate].present?
       @req.set_ignore_build_state if params[:ignore_build_state].present?
+      @req.enforce_branching      if params[:enforce_branching].present?
       @req.save!
       Suse::Validator.validate(:request, @req.render_xml)
     end

--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -299,6 +299,10 @@ class BsRequest < ApplicationRecord
     @ignore_delegate = true
   end
 
+  def enforce_branching
+    @enforce_branching = true
+  end
+
   def sanitize?
     !@skip_sanitize
   end
@@ -920,6 +924,8 @@ class BsRequest < ApplicationRecord
 
     check_bs_request_actions!
 
+    modify_sources
+
     # Autoapproval? Is the creator allowed to accept it?
     permission_check_change_state!(newstate: 'accepted') if accept_at
 
@@ -1028,6 +1034,12 @@ class BsRequest < ApplicationRecord
       actions << action
     end
     actions
+  end
+
+  def modify_sources
+    bs_request_actions.each do |action|
+      action.modify_sources(@enforce_branching)
+    end
   end
 
   def expand_targets

--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -742,6 +742,10 @@ class BsRequestAction < ApplicationRecord
     self.target_project = tpkg.project.update_instance.name
   end
 
+  def modify_sources(force_branching)
+    # only used in incidents so far
+  end
+
   def source_access_check!
     sp = Package.find_by_project_and_name(source_project, source_package)
     if sp.nil?

--- a/src/api/app/models/bs_request_action_maintenance_incident.rb
+++ b/src/api/app/models/bs_request_action_maintenance_incident.rb
@@ -103,6 +103,35 @@ class BsRequestActionMaintenanceIncident < BsRequestAction
     super(ignore_build_state, ignore_delegate)
   end
 
+  def modify_sources(force_branching)
+    # is branch enforcement a policy?
+    maintenance_project = Project.find_by_name(target_project)
+    return if force_branching.nil? && Attrib.find_by_container_and_fullname(maintenance_project, 'OBS:EnforceIncidentRequestStaging').nil?
+
+    title = 'Enforce branch project for maintenance incident request'
+    description = ''
+    stage_project = nil
+    Project.transaction do
+      # enforce a request number and use this as branch area
+      bs_request.assign_number
+      stage_project = Project.create(name: User.session!.branch_project_name("MAINTENANCE_REQUEST:#{bs_request.number}"),
+                                     title: title, description: description)
+      stage_project.relationships.build(user: User.session!, role: Role.find_by_title!('maintainer'))
+      stage_project.store
+      # autocleanup attribute in case request gets not accepted?
+    end
+
+    # create package
+    pkg = _merge_pkg_into_maintenance_incident(stage_project)
+    # create channels
+    pkg.add_channels
+    # adapt request action
+    self.source_package = pkg.name
+    self.source_project = stage_project.name
+    # create patchinfo
+    Patchinfo.new.create_patchinfo_from_request(stage_project, bs_request)
+  end
+
   private
 
   def _merge_pkg_into_maintenance_incident(incident_project)
@@ -140,11 +169,11 @@ class BsRequestActionMaintenanceIncident < BsRequestAction
 
       branch_params = { target_project: incident_project.name,
                         olinkrev: 'base',
-                        requestid: bs_request.number,
                         maintenance: 1,
                         force: 1,
                         comment: 'Initial new branch from specified release project',
                         project: target_releaseproject, package: package_name }
+      branch_params[:requestid] = bs_request.number if bs_request.number
       # accept branching from former update incidents or GM (for kgraft case)
       linkprj = Project.find_by_name(linkinfo['project']) if linkinfo
       if defined?(linkprj) && linkprj
@@ -166,11 +195,11 @@ class BsRequestActionMaintenanceIncident < BsRequestAction
 
       branch_params = { target_project: incident_project.name,
                         olinkrev: 'base',
-                        requestid: bs_request.number,
                         maintenance: 1,
                         force: 1,
                         comment: 'Initial new branch',
                         project: linked_project, package: linked_package }
+      branch_params[:requestid] = bs_request.number if bs_request.number
       ret = BranchPackage.new(branch_params).branch
       new_pkg = Package.get_by_project_and_name(ret[:data][:targetproject], ret[:data][:targetpackage])
     elsif linkinfo && linkinfo['package'] # a new package for all targets
@@ -188,16 +217,18 @@ class BsRequestActionMaintenanceIncident < BsRequestAction
 
     # backend copy of submitted sources, but keep link
     cp_params = {
-      requestid: bs_request.number,
       keeplink: 1,
       expand: 1,
-      withacceptinfo: 1,
       comment: "Maintenance incident copy from project #{source_project}"
     }
+    if bs_request.number
+      cp_params[:requestid] = bs_request.number
+      cp_params[:withacceptinfo] = 1
+    end
     cp_params[:orev] = source_rev if source_rev
     response = Backend::Api::Sources::Package.copy(incident_project.name, new_pkg.name, source_project, source_package, User.session!.login, cp_params)
     result = Xmlhash.parse(response)
-    set_acceptinfo(result['acceptinfo'])
+    set_acceptinfo(result['acceptinfo']) if bs_request.number
 
     new_pkg.sources_changed
     new_pkg

--- a/src/api/db/attribute_descriptions.rb
+++ b/src/api/db/attribute_descriptions.rb
@@ -26,6 +26,7 @@ def update_all_attrib_type_descriptions
     'EmbargoDate' => 'A timestamp until outgoing requests can not get accepted.',
     'PlannedReleaseDate' => 'A timestamp for the planned release date of an incident.',
     'MakeOriginOlder' => 'Initialize packages by making the build results newer then updated ones',
+    'EnforceIncidentRequestStaging' => 'Will create new projects to submit maintenance incidents requests',
     'DelegateRequestTarget' => 'Delegate the target project of requests even when target_project is specified',
     'AllowSubmitToMaintenanceRelease' => 'Allow submit requests to maintenance release projects'
   }

--- a/src/api/db/seeds.rb
+++ b/src/api/db/seeds.rb
@@ -150,6 +150,8 @@ at = ans.attrib_types.where(name: 'IncidentPriority').first_or_create(value_coun
 at.attrib_type_modifiable_bies.where(user_id: admin.id).first_or_create
 at = ans.attrib_types.where(name: 'EmbargoDate').first_or_create(value_count: 1)
 at.attrib_type_modifiable_bies.where(role_id: maintainer_role.id).first_or_create
+at = ans.attrib_types.where(name: 'EnforceIncidentRequestStaging').first_or_create(value_count: 0)
+at.attrib_type_modifiable_bies.where(role_id: maintainer_role.id).first_or_create
 at = ans.attrib_types.where(name: 'DelegateRequestTarget').first_or_create
 at.attrib_type_modifiable_bies.where(user_id: maintainer_role.id).first_or_create
 at = ans.attrib_types.where(name: 'AllowSubmitToMaintenanceRelease').first_or_create

--- a/src/api/test/fixtures/attrib_types.yml
+++ b/src/api/test/fixtures/attrib_types.yml
@@ -131,3 +131,9 @@ OBS_DelegateRequestTarget:
   value_count: 0
   attrib_namespace_id: 9
   issue_list: 0
+OBS_EnforceIncidentRequestStaging:
+  id: 83
+  name: EnforceIncidentRequestStaging
+  value_count: 0
+  attrib_namespace_id: 9
+  issue_list: 0

--- a/src/api/test/functional/attributes_test.rb
+++ b/src/api/test/functional/attributes_test.rb
@@ -32,7 +32,7 @@ class AttributeControllerTest < ActionDispatch::IntegrationTest
 
     get '/attribute/OBS'
     assert_response :success
-    count = 22
+    count = 23
     assert_xml_tag tag: 'directory', attributes: { count: count }
     assert_xml_tag children: { count: count }
     assert_xml_tag child: { tag: 'entry', attributes: { name: 'Maintained' } }
@@ -276,7 +276,7 @@ ription</description>
 
     get '/attribute/OBS'
     assert_response :success
-    count = 22
+    count = 23
     assert_xml_tag tag: 'directory', attributes: { count: count }
     assert_xml_tag children: { count: count }
     assert_xml_tag child: { tag: 'entry', attributes: { name: 'Maintained' } }

--- a/src/api/test/functional/maintenance_test.rb
+++ b/src/api/test/functional/maintenance_test.rb
@@ -352,6 +352,44 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  def test_maintenance_request_enforce_branching
+    login_king
+    # special kdelibs
+    put '/source/BaseDistro2.0:LinkedUpdateProject/kdelibs/_meta', params: "<package name='kdelibs'><title/><description/></package>"
+    assert_response :success
+    put '/source/BaseDistro2.0:LinkedUpdateProject/kdelibs/empty', params: 'NOOP'
+    assert_response :success
+
+    login_tom
+    # create maintenance request for one package from a unrelated project
+    post '/request?cmd=create&enforce_branching=1', params: '<request>
+                                   <action type="maintenance_incident">
+                                     <source project="kde4" package="kdelibs" />
+                                     <target project="My:Maintenance" releaseproject="BaseDistro2.0:LinkedUpdateProject" />
+                                   </action>
+                                   <description>To fix my bug</description>
+                                   <state name="new" />
+                                 </request>'
+    assert_response :success
+    node = Xmlhash.parse(@response.body)
+    assert node['id']
+    reqid = node['id']
+    branch_project = "home:tom:branches:MAINTENANCE_REQUEST:#{reqid}"
+    assert_xml_tag(tag: 'target', attributes: { project: 'My:Maintenance', releaseproject: 'BaseDistro2.0:LinkedUpdateProject' })
+    assert_xml_tag(tag: 'source', attributes: { project: branch_project, package: 'kdelibs.BaseDistro2.0_LinkedUpdateProject' })
+
+    get "/source/#{branch_project}"
+    assert_response :success
+    assert_xml_tag(tag: 'directory', attributes: { count: '2' })
+    get "/source/#{branch_project}/kdelibs.BaseDistro2.0_LinkedUpdateProject/_link"
+    assert_response :success
+    assert_xml_tag(tag: 'link', attributes: {project: 'BaseDistro2.0:LinkedUpdateProject', package: 'kdelibs'})
+
+    # cleanup
+    delete "/source/#{branch_project}"
+    assert_response :success
+  end
+
   def test_OBS_BranchTarget
     login_king
     put '/source/ServicePack/_meta', params: "<project name='ServicePack'><title/><description/><link project='kde4'/></project>"


### PR DESCRIPTION
maintenance_release request actions takes default reviewers only from package
and update project. Not from GA project anymore.

patch from adrian, applied in IBS since July 2019