### PR TITLE
[api] maintenance_release request action default reviewer change

### DIFF
--- a/ReleaseNotes-2.11
+++ b/ReleaseNotes-2.11
@@ -64,6 +64,8 @@ Webui:
     - /home/home_project
     - /home/list_my
 
+maintenance_release request actions takes default reviewers only from package
+and update project. Not from GA project anymore.
 
 Breaking API changes:
 =====================


### PR DESCRIPTION
maintenance_release request actions takes default reviewers only from package
and update project. Not from GA project anymore.

patch from adrian, applied in IBS since Jul 2019