### PR TITLE
Add confirmation dialog to group members delete

### DIFF
--- a/src/api/app/controllers/webui/groups/users_controller.rb
+++ b/src/api/app/controllers/webui/groups/users_controller.rb
@@ -29,11 +29,12 @@ module Webui
         authorize @group, :update?
 
         if @group.remove_user(@user)
-          flash.now[:success] = "Removed user from group '#{@group}'"
-          render 'flash', status: :ok
+          flash[:success] = "Removed user '#{@user}' from group '#{@group}'"
         else
-          render 'flash', status: :bad_request
+          flash[:error] = "Couldn't remove user '#{@user}' from group '#{@group}'"
         end
+
+        redirect_to group_show_path(@group)
       end
 
       def update

--- a/src/api/app/views/webui/groups/_group_members.html.haml
+++ b/src/api/app/views/webui/groups/_group_members.html.haml
@@ -18,9 +18,10 @@
       - group.users.each do |user|
         .card.m-1.p-2.group-user
           - if write_access
-            = link_to(group_user_path(group_title: group.title, user_login: user.login), data: { method: :delete, remote: true },
-              id: user.login, class: 'group-member-removal text-right', title: 'Remove member from group') do
-              %i.fas.fa-sm.fa-times-circle.text-danger
+            = render(partial: 'webui/groups/group_members_delete_dialog', locals: { user: user, group: group })
+            = link_to('#', data: { toggle: 'modal', target: "#delete-group-members-modal-#{user}" }, title: 'Remove member from group') do
+              .float-right
+                %i.fas.fa-sm.fa-times-circle.text-danger
           .row.no-gutters
             .col-md-3
               = image_tag_for(user, size: 80, custom_class: 'align-self-center')

--- a/src/api/app/views/webui/groups/_group_members_delete_dialog.html.haml
+++ b/src/api/app/views/webui/groups/_group_members_delete_dialog.html.haml
@@ -1,0 +1,15 @@
+.modal.fade{ id: "delete-group-members-modal-#{user}", tabindex: -1, role: 'dialog',
+             aria: { labelledby: 'delete-group-members-modal-label', hidden: true } }
+  .modal-dialog.modal-dialog-centered{ role: 'document' }
+    .modal-content
+      .modal-header
+        %h5.modal-title
+          Delete group member?
+      .modal-body
+        %p Please confirm deletion of '#{user}' from this group
+
+        = form_tag(group_user_path(group_title: group.title, user_login: user.login), method: :delete, class: 'delete-group-members-form') do
+          .modal-footer
+            %a.btn.btn-sm.btn-outline-secondary.px-4{ data: { dismiss: 'modal' } }
+              Cancel
+            = submit_tag('Delete', class: 'btn btn-sm btn-danger px-4')

--- a/src/api/spec/controllers/webui/groups/users_controller_spec.rb
+++ b/src/api/spec/controllers/webui/groups/users_controller_spec.rb
@@ -76,8 +76,8 @@ RSpec.describe Webui::Groups::UsersController do
       end
 
       it 'removes the user from the group' do
-        expect(response).to have_http_status(:success)
-        expect(flash[:success]).to eq("Removed user from group '#{group}'")
+        expect(response).to redirect_to(group_show_path(title: group.title))
+        expect(flash[:success]).to eq("Removed user '#{user}' from group '#{group}'")
         expect(group.users.where(groups_users: { user_id: user })).not_to exist
       end
     end

--- a/src/api/spec/features/beta/webui/groups_spec.rb
+++ b/src/api/spec/features/beta/webui/groups_spec.rb
@@ -61,7 +61,8 @@ RSpec.describe 'Groups', type: :feature, js: true do
       click_link('Remove member from group')
     end
 
-    expect(page).to have_content("Removed user from group '#{group_1}'")
+    expect { click_button('Delete') }.to change { group_1.users.count }.by(-1)
+    expect(page).to have_content("Removed user '#{admin}' from group '#{group_1}'")
     expect(group_1.reload.users.map(&:login)).to eq([user_1.login])
   end
 

--- a/src/api/spec/features/webui/groups_spec.rb
+++ b/src/api/spec/features/webui/groups_spec.rb
@@ -59,7 +59,8 @@ RSpec.describe 'Groups', type: :feature, js: true do
       click_link('Remove member from group')
     end
 
-    expect(page).to have_content("Removed user from group '#{group_1}'")
+    expect { click_button('Delete') }.to change { group_1.users.count }.by(-1)
+    expect(page).to have_content("Removed user '#{admin}' from group '#{group_1}'")
     expect(group_1.reload.users.map(&:login)).to eq([user_1.login])
   end
 


### PR DESCRIPTION
Add a confirmation dialog when you delete a user from a group

Fixes #10316

To verify this feature

 1. Log into admin account
 2. Go to a group (Configuration -> Manage Group -> go to group or create a new one)
 3. Delete a member of the group (first add a user if none is present)

You should now see this dialog:
![dialog](https://user-images.githubusercontent.com/54934253/98146920-336ee780-1ecc-11eb-8464-60d34dfb02f9.png)

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
