### PR TITLE
Speed up removal of projpacks_linked entries in get_projpacks_postprocess_projects

### DIFF
--- a/src/backend/BSSched/EventHandler.pm
+++ b/src/backend/BSSched/EventHandler.pm
@@ -70,6 +70,7 @@ our %event_handlers = (
   'resumeproject'   => \&BSSched::EventHandler::event_resumeproject,
   'memstats'        => \&BSSched::EventHandler::event_memstats,
   'dumppmat'        => \&BSSched::EventHandler::event_dumppmat,
+  'projectstats'    => \&BSSched::EventHandler::event_projectstats,
   'dispatchdetails' => \&BSSched::EventHandler::event_dispatchdetails,
   'force_publish'   => \&BSSched::EventHandler::event_force_publish,
 );
@@ -682,6 +683,12 @@ sub event_dumppmat {
     Devel::MAT::Dumper::dump("$rundir/bs_sched.$myarch.pmat");
   };
   warn($@) if $@;
+}
+
+sub event_projectstats {
+  my ($ectx, $ev) = @_;
+  my $gctx = $ectx->{'gctx'};
+  BSSched::ProjPacks::print_project_stats($gctx);
 }
 
 sub event_dispatchdetails {

--- a/src/backend/bs_admin
+++ b/src/backend/bs_admin
@@ -230,6 +230,7 @@ Debug Options
 
  --dump-memstats <architecture> [what]
  --dump-pmat <architecture>
+ --dump-projectstats <architecture>
 
 Backend Configuration
 =====================
@@ -568,6 +569,11 @@ sub dump_memstats {
   write_event( undef, undef, $arch, 'memstats', undef, $job );
 }
 
+sub dump_projectstats {
+  my ($arch) = @_;
+  write_event( undef, undef, $arch, 'projectstats' );
+}
+
 sub dump_pmat {
   my ($arch) = @_;
   write_event( undef, undef, $arch, 'dumppmat' );
@@ -753,6 +759,10 @@ while (@ARGV) {
     die("ERROR: need architecture as argument!\n") if @ARGV < 1;
     my $arch = shift @ARGV;
     dump_pmat($arch);
+  } elsif ($arg eq "--dump-projectstats") {
+    die("ERROR: need architecture as argument!\n") if @ARGV < 1;
+    my $arch = shift @ARGV;
+    dump_projectstats($arch);
   } elsif ($arg eq "--dump-project-from-state") {
     die("ERROR: need project as argument!\n") if @ARGV < 1;
     my $project = shift @ARGV;


### PR DESCRIPTION
<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
