### PR TITLE
[api] fix runservice api docu via token

### DIFF
--- a/docs/api/api/api.txt
+++ b/docs/api/api/api.txt
@@ -1436,7 +1436,7 @@ POST /trigger/runservice
   This call needs a token to identify user and package which shall be updated
   via a source service. See the cmd=create in the /person/<userid>/token route.
 
-  The token itself must be delivered as HTTP header:
+  The token itself must be delivered as a HTTP header:
     Authorization: Token <TOKEN_STRING>
 
 Parameters

--- a/docs/api/api/api.txt
+++ b/docs/api/api/api.txt
@@ -1433,7 +1433,7 @@ XmlResult: buildinfo
 
 POST /trigger/runservice
 
-  This call needs a token to identify user and package which shall be updated
+  This call needs a token to identify the user and package which shall be updated
   via a source service. See the cmd=create in the /person/<userid>/token route.
 
   The token itself must be delivered as a HTTP header:

--- a/docs/api/api/api.txt
+++ b/docs/api/api/api.txt
@@ -1433,14 +1433,16 @@ XmlResult: buildinfo
 
 POST /trigger/runservice
 
-  This call needs a token created via "createtoken" command to identify user and
-  package which shall be updated via a source service. The token must be delivered
-  as HTTP header:
+  This call needs a token to identify user and package which shall be updated
+  via a source service. See the cmd=create in the /person/<userid>/token route.
+
+  The token itself must be delivered as HTTP header:
     Authorization: Token <TOKEN_STRING>
 
 Parameters
-  project: To be used together with "package" to identify the object.
-  package:
+  project: To be used together with "package" to identify the object. Must not be used
+           when the token is bound to a package.
+  package: see project parameter.
 
 XmlResult: status
 


### PR DESCRIPTION
fixes #10395

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
