### PR TITLE
Fix worker status data inserted in status_history table, used in system status graphic in main page

### DIFF
--- a/src/api/app/models/worker_status.rb
+++ b/src/api/app/models/worker_status.rb
@@ -1,4 +1,6 @@
 class WorkerStatus
+  WORKER_STATUS = ['building', 'idle', 'dead', 'down', 'away'].freeze
+
   class << self
     def hidden
       mydata = Rails.cache.read('workerstatus')
@@ -94,7 +96,7 @@ class WorkerStatus
     allworkers = {}
     workers = {}
 
-    ['building', 'idle', 'dead', 'down', 'away'].each do |state|
+    WORKER_STATUS.each do |state|
       wdata.search("//#{state}").each do |e|
         worker_id = e.attributes['workerid'].value
         # building+idle worker
@@ -102,11 +104,7 @@ class WorkerStatus
 
         workers[worker_id] = 1
         hostarch = e.attributes['hostarch'].value
-        allworkers["building_#{hostarch}"] ||= 0
-        allworkers["idle_#{hostarch}"] ||= 0
-        allworkers["away_#{hostarch}"] ||= 0
-        allworkers["dead_#{hostarch}"] ||= 0
-        allworkers["down_#{hostarch}"] ||= 0
+        WORKER_STATUS.each { |local_state| allworkers["#{local_state}_#{hostarch}"] ||= 0 }
         key = generic_key_generation([state, hostarch])
         allworkers[key] += 1
       end

--- a/src/api/app/models/worker_status.rb
+++ b/src/api/app/models/worker_status.rb
@@ -91,7 +91,7 @@ class WorkerStatus
   end
 
   def parse_worker_infos(wdata)
-    allworkers = Hash.new(0)
+    allworkers = {}
     workers = {}
 
     ['building', 'idle', 'dead', 'down', 'away'].each do |state|
@@ -101,7 +101,13 @@ class WorkerStatus
         next if workers.key?(worker_id)
 
         workers[worker_id] = 1
-        key = generic_key_generation([state, e.attributes['hostarch'].value])
+        hostarch = e.attributes['hostarch'].value
+        allworkers["building_#{hostarch}"] ||= 0
+        allworkers["idle_#{hostarch}"] ||= 0
+        allworkers["away_#{hostarch}"] ||= 0
+        allworkers["dead_#{hostarch}"] ||= 0
+        allworkers["down_#{hostarch}"] ||= 0
+        key = generic_key_generation([state, hostarch])
         allworkers[key] += 1
       end
     end

--- a/src/api/spec/models/worker_status_spec.rb
+++ b/src/api/spec/models/worker_status_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe WorkerStatus do
 
     subject { WorkerStatus.new.update_workerstatus_cache }
 
-    it { expect { subject }.to change(StatusHistory, :count).from(0).to(20) }
+    it { expect { subject }.to change(StatusHistory, :count).from(0).to(23) }
 
     context 'it change the Architecture to active' do
       before do


### PR DESCRIPTION
A previous code refactoring introduced a change in the amount of registers inserted to be used in the system status graphic. This change made the graphic not to update correctly. See 1bde603dd744325de326e501bc27151ca65d5f37.

Revert part of this refactoring, to ensure that '0' values are inserted. This way the `resample` helper will work again with datasets with the same time limits.

Fixes #10517.