### PR TITLE
[backend] speed up removal of old projpacks_linked data

### DIFF
--- a/src/backend/bs_sched
+++ b/src/backend/bs_sched
@@ -446,6 +446,7 @@ my $gctx = {
 
   # postprocessed project data
   'projpacks_linked' => {},		# data of all linked sources
+  'projpacks_linked_blks' => {},	# block offsets in projpacks_linked
   'linked_projids' => {},		# projid => [projid, projid] projects our packages link to
   'prps' => [],				# sorted list of all local prps (project repos)
   'project_prps' => {},			# projid => [ prp, prp ...]


### PR DESCRIPTION
We now maintain a new projpacks_linked_blks hash that stores
the size of the same-project blocks in the corresponding
projpacks_linked entry. Using this we can for one skip the
blocks much faster if the project does not match and we
also can remove the block with one single splice call.

This speeds up the removal phase considerably. It no
longer dominates the time used in setup_projects.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
