### PR TITLE
Change user plain delete confirmation to use standard dialog

### DIFF
--- a/src/api/app/helpers/webui/user_helper.rb
+++ b/src/api/app/helpers/webui/user_helper.rb
@@ -8,8 +8,9 @@ module Webui::UserHelper
         mail_to(user.email) do
           tag.i(nil, class: 'fas fa-envelope text-secondary pr-1', title: 'Send Email to User')
         end,
-        link_to(user_path(user.login), method: :delete, data: { confirm: 'Are you sure?' }) do
-          tag.i(nil, class: 'fas fa-times-circle text-danger pr-1', title: 'Delete User')
+        render(partial: 'webui/users/delete_dialog.html.haml', locals: { user: user }),
+        link_to('#', data: { toggle: 'modal', target: "#delete-user-modal-#{user}" }, title: 'Delete User') do
+          tag.i(nil, class: 'fas fa-times-circle text-danger pr-1')
         end
       ]
     )

--- a/src/api/app/views/webui/users/_delete_dialog.html.haml
+++ b/src/api/app/views/webui/users/_delete_dialog.html.haml
@@ -1,0 +1,15 @@
+.modal.fade{ id: "delete-user-modal-#{user}", tabindex: -1, role: 'dialog',
+             aria: { labelledby: 'delete-user-modal-label', hidden: true } }
+  .modal-dialog.modal-dialog-centered{ role: 'document' }
+    .modal-content
+      .modal-header
+        %h5.modal-title
+          Delete User?
+      .modal-body
+        %p Please confirm deletion of '#{user}'
+
+        = form_tag(user_path(user.login), method: :delete, class: 'delete-user-form') do
+          .modal-footer
+            %button.btn.btn-sm.btn-outline-secondary.px-4{ data: { dismiss: 'modal' } }
+              Cancel
+            = submit_tag('Delete', class: 'btn btn-sm btn-danger px-4')

--- a/src/api/spec/features/beta/webui/users/admin_configuration_spec.rb
+++ b/src/api/spec/features/beta/webui/users/admin_configuration_spec.rb
@@ -29,9 +29,9 @@ RSpec.describe 'Admin user configuration page', type: :feature, js: true do
 
     within(find('td', text: /#{user.realname}/).ancestor('tr')) do
       expect(page).to have_css('td', text: 'confirmed')
-      page.find('a[data-method=delete]').click
+      page.find('a[title="Delete User"]').click
       # Accept the confirmation dialog
-      page.driver.browser.switch_to.alert.accept
+      click_button('Delete')
     end
     expect(page).to have_css('td', text: 'deleted')
   end

--- a/src/api/spec/features/webui/users/admin_configuration_spec.rb
+++ b/src/api/spec/features/webui/users/admin_configuration_spec.rb
@@ -25,9 +25,9 @@ RSpec.describe 'Admin user configuration page', type: :feature, js: true do
   it 'delete user' do
     within(find('td', text: /#{user.realname}/).ancestor('tr')) do
       expect(page).to have_css('td', text: 'confirmed')
-      page.find('a[data-method=delete]').click
+      page.find('a[title="Delete User"]').click
       # Accept the confirmation dialog
-      page.driver.browser.switch_to.alert.accept
+      click_button('Delete')
     end
     expect(page).to have_css('td', text: 'deleted')
   end


### PR DESCRIPTION
The confirmation for deleting a user was a plain `confirm()` . This changes it to use the standard confirmation dialog.

Fixes #10383

To verify this feature

1. Log into admin account
2. Go to manage users (Configuration -> Manage Users)
3. Delete a user

Before:
![before](https://user-images.githubusercontent.com/54934253/98547213-20776100-2298-11eb-8e33-42e30a4d745f.png)

After:
![after](https://user-images.githubusercontent.com/54934253/98547222-23725180-2298-11eb-984c-9992bf3b13c8.png)