### PR TITLE
[backend] try to use sha256 when the default signkey is used

### DIFF
--- a/src/backend/bs_signer
+++ b/src/backend/bs_signer
@@ -198,7 +198,7 @@ sub signisofiles {
       if ($e->[0] =~ /\.key$/i && $e->[2] == 8192) {
 	my $signfile = readblk($fd, $e->[1]);
 	next if substr($signfile, 0, 8) ne "sIGnMeP\n";
-	$pubkey = BSUtil::xsystem(undef, $BSConfig::sign, @signargs, '-p') unless $pubkey;
+	$pubkey ||= BSUtil::xsystem(undef, $BSConfig::sign, @signargs, '-p');
 	die("pubkey is not available\n") unless $pubkey;
 	die("pubkey is too big\n") if length($pubkey) > 8192;
 	# replace old content
@@ -441,27 +441,35 @@ sub getsignkey {
   push @args, "autoextend=1" if $needpubkey;
   push @args, "withalgo=1";
   my $signkey = BSRPC::rpc($param, undef, @args);
-  my $algo;
-  $algo = $1 if $signkey && $signkey =~ s/^(\S+)://;
   my $pubkey;
+  my $algo;
   if ($signkey) {
     ($signkey, $pubkey) = split("\n", $signkey, 2) if $needpubkey;
-    undef $pubkey unless $pubkey && length($pubkey) > 2;       # not a valid pubkey
-    if ($needpubkey && !$pubkey) {
-      if ($BSConfig::sign_project && $BSConfig::sign) {
-	my @signargs;
-	push @signargs, '--project', $projid;
-	local *S;
-	open(S, '-|', $BSConfig::sign, @signargs, '-p') || die("$BSConfig::sign: $!\n");;
-	$pubkey = ''; 
-	1 while sysread(S, $pubkey, 4096, length($pubkey));
-	if (!close(S)) {
-	  print "sign -p failed: $?\n";
-	  $pubkey = undef;
-	}
+    undef $signkey unless $signkey && length($signkey) > 10;
+    undef $pubkey unless $pubkey && length($pubkey) > 10;
+  }
+  $algo = $1 if $signkey && $signkey =~ s/^(\S+)://;
+  if (($needpubkey || !$algo) && !$pubkey) {
+    if ($BSConfig::sign_project && $BSConfig::sign) {
+      my @signargs;
+      push @signargs, '--project', $projid;
+      local *S;
+      open(S, '-|', $BSConfig::sign, @signargs, '-p') || die("$BSConfig::sign: $!\n");;
+      $pubkey = ''; 
+      1 while sysread(S, $pubkey, 4096, length($pubkey));
+      if (!close(S)) {
+	print "sign -p failed: $?\n";
+	$pubkey = undef;
       }
+    } elsif ($BSConfig::keyfile) {
+      $pubkey = readstr($BSConfig::keyfile, 1);
     }
-    die("returned pubkey is empty\n") if $needpubkey && length($pubkey || '') <= 2 && length($signkey) > 2;
+    undef $pubkey unless $pubkey && length($pubkey) > 10;
+    die("pubkey is empty\n") if $needpubkey && !$pubkey;
+  }
+  if ($pubkey && !$algo) {
+    # try to get algo from public key
+    eval { $algo = BSPGP::pk2algo(BSPGP::unarmor($pubkey)) };
   }
   my $cert;
   if ($needcert) {


### PR DESCRIPTION
We already changed the publisher to do this, but forgot about
the signer.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
