### PR TITLE
[backend] also check the time to decide that the dispatcher loop need…

### DIFF
--- a/src/backend/bs_dispatch
+++ b/src/backend/bs_dispatch
@@ -348,7 +348,7 @@ sub assignjob {
   writexml("$workersdir/building/.$idlename", "$workersdir/building/$idlename", $worker, $BSXML::worker);
 
   if ($info->{'masterdispatched'}) {
-    # we did out job. delete job
+    # we did our job. delete job
     push @{$masterdispatched{"$info->{'project'}/$info->{'repository'}/$info->{'arch'}"}}, $jobstatus->{'starttime'};
     unlink("$jobsdir/$arch/$job");
     unlink("$jobsdir/$arch/$job:status");
@@ -1369,7 +1369,7 @@ while (1) {
       push @front, shift(@jobprpas) while @jobprpas && $scales{$jobprpas[0]} * $load->{$jobprpas[0]} < $newload;
       unshift @jobprpas, @front, $prpa;
     }
-    last if $assigned >= 50;
+    last if $assigned >= 50 && time() - $now > 60;
   }
 
   forwardevents();


### PR DESCRIPTION
…s restarting

We used to restart after 50 job assignments to account for freshly created
jobs. This leads to too many restarts, but increasing the limit is also bad
if assigning takes too long. So also take the time spent in job assigning
into account and only restart if at least one minute has passed.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
