### PR TITLE
Make staging muted delete icon a popover

### DIFF
--- a/src/api/app/views/webui/staging/workflows/_staging_project.html.haml
+++ b/src/api/app/views/webui/staging/workflows/_staging_project.html.haml
@@ -16,7 +16,8 @@
               = link_to('#', data: { toggle: 'modal', target: "#confirm-modal-#{staging_project.id}" }, title: "Delete #{staging_project}") do
                 %i.fas.fa-times-circle.text-danger
             - else
-              %i.fas.fa-times-circle.text-muted{ title: 'This project can not be deleted because it has staged requests' }
+              %i.fas.fa-times-circle.text-muted{ data: { toggle: 'popover', placement: 'bottom',
+                                                content: 'This project can not be deleted because it has staged requests' } }
     .card-body.p-2.text-muted
       %small.d-block
         state:


### PR DESCRIPTION
Make the staging muted delete icon a popover so the reason why it isn't available stays readable. Works better for mobile.

Fixes #10302

To verify this feature

1. Create a staging workflow with `bundle exec rake dev:staging:data`
2. Start the application with `bundle exec rails s -b 0.0.0.0`
3. Go to http://localhost:3000/staging_workflows/name-of-project-created-in-step-1/edit
4. Click on delete icon and a popover should appear which explains why it is disabled

![after](https://user-images.githubusercontent.com/54934253/98709007-17fb5500-2382-11eb-97d0-f31b615c0a9c.png)


<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
