### PR TITLE
[backend] also log when processing 'built' events

### DIFF
--- a/src/backend/BSSched/EventQueue.pm
+++ b/src/backend/BSSched/EventQueue.pm
@@ -112,6 +112,7 @@ sub process_events {
 
   $ectx->order() if @{$ectx->{_events}};
 
+  my $numbuilt = 0;
   my @delayed;
   while (@{$ectx->{_events}}) {
     my $ev = shift @{$ectx->{_events}};
@@ -127,7 +128,9 @@ sub process_events {
     }
 
     # log event info
-    if ($ev->{'type'} ne 'built') {
+    if ($ev->{'type'} eq 'built') {
+      BSUtil::printlog("event built\n") if !$numbuilt++;	# only log the first
+    } else {
       my $estr = $ev->{'evfilename'} ? 'event' : 'remote event';
       for (qw{type project repository arch package}) {
 	$estr .= " $ev->{$_}" if $ev->{$_};

--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -2141,7 +2141,7 @@ sub receivekiwitree {
 }
 
 sub notify_jobresult {
-  my ($info, $jobstatus, $prpa) = @_;
+  my ($job, $info, $jobstatus, $prpa) = @_;
 
   # create notification info
   my %ninfo;
@@ -2152,6 +2152,7 @@ sub notify_jobresult {
   $ninfo{'endtime'} = $jobstatus->{'endtime'};
   $ninfo{'workerid'} = $jobstatus->{'workerid'};
   $ninfo{'previouslyfailed'} = 1 if -e "$reporoot/$prpa/:logfiles.fail/$info->{'package'}";
+  print "job statistics: $job $prpa $jobstatus->{'result'} $ninfo{'readytime'}-$ninfo{'starttime'}-$ninfo{'endtime'} $jobstatus->{'workerid'}\n";
   if ($jobstatus->{'result'} eq 'unchanged') {
     BSNotify::notify('BUILD_UNCHANGED', \%ninfo);
   } elsif ($jobstatus->{'result'} eq 'succeeded') {
@@ -2340,7 +2341,7 @@ sub putjob {
   $code = 'failed' if $code ne 'succeeded' && $code ne 'failed' && $code ne 'unchanged' && $code ne 'genbuildreqs';
   $jobstatus->{'result'} = $code;
 
-  notify_jobresult($info, $jobstatus, "$projid/$repoid/$arch");
+  notify_jobresult($job, $info, $jobstatus, "$projid/$repoid/$arch");
 
   my $bininfo = {};
 
@@ -4063,7 +4064,7 @@ sub failjob {
   my $now = time();
   my $jobstatus = { code => 'finished', result => 'failed', starttime => $now, endtime => $now,
                     workerid => 'dispatcher', 'hostarch' => '' };
-  notify_jobresult($info, $jobstatus, "$projid/$repoid/$arch");
+  notify_jobresult($job, $info, $jobstatus, "$projid/$repoid/$arch");
   my $ev = {'type' => 'built', 'arch' => $arch, 'job' => $job};
   writexml("$jobsdir/$arch/.$job:status", "$jobsdir/$arch/$job:status", $jobstatus, $BSXML::jobstatus);
   updateredisjobstatus($arch, $job, $info, 'finished');


### PR DESCRIPTION
<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
