### PR TITLE
Show request action name in the page title if only one action exists

### DIFF
--- a/src/api/app/views/webui/request/show.html.haml
+++ b/src/api/app/views/webui/request/show.html.haml
@@ -2,6 +2,8 @@
   content_for(:meta_title, "Request #{@bs_request.number} (#{@bs_request.state})")
   content_for(:meta_description, @bs_request.description)
   content_for(:meta_image, gravatar_url(User.find_by_login(@bs_request.creator).email))
+  @pagetitle = "Request #{@bs_request.number}"
+  @pagetitle += ": #{@actions.first[:name]}" if @actions.count == 1
 
 - if @not_full_diff && User.session
   = render partial: 'webui/shared/truncated_diff_hint', locals: { path: request_show_path(number: @bs_request.number, full_diff: true) }
@@ -10,7 +12,6 @@
                                                      number: @bs_request.number,
                                                      diff_to_superseded: @diff_to_superseded,
                                                      superseding: @bs_request.superseding }
-- @pagetitle = "Request #{@bs_request.number}"
 .card.mb-3
   .card-header.d-flex.justify-content-between
     %h5


### PR DESCRIPTION
This changes the title that gets displayed for a request to include the action name if only one action exists for that request. Otherwise it only displays the request number.

Fixes #1655

To verify this feature:
1. Start sphinx `bundle exec rake ts:start`
2. Create development test data `bundle exec rake dev:development_testdata:create`
3. Open rails console `bundle exec rails c`
4. Create another action for a request e.g. like this `BsRequestAction.create(bs_request_id: 7, type: "submit", target_project: Project.first, target_package: Package.first, source_project: Project.second, source_package: Package.second)`
5. Start the rails server `bundle exec rails s -b 0.0.0.0`
6. Visit the requests page to see one with multiple actions (http://localhost:3000/request/show/7) and another without multiple actions (e.g. http://localhost:3000/request/show/8)

Before with single action:
![before_single](https://user-images.githubusercontent.com/54934253/98842418-db932c00-2449-11eb-91d7-fc6677515d9a.png)

After with single action:
![after_single](https://user-images.githubusercontent.com/54934253/98842447-ea79de80-2449-11eb-9aa5-cbefa8c0abd6.png)

After with multiple actions:
![after_multiple](https://user-images.githubusercontent.com/54934253/98842483-f2d21980-2449-11eb-8ce6-92c242948505.png)