### PR TITLE
Create data migration to remove role "User"

### DIFF
--- a/src/api/app/models/role.rb
+++ b/src/api/app/models/role.rb
@@ -65,7 +65,7 @@ class Role < ApplicationRecord
   end
 
   def self.global_roles
-    ['Admin', 'User']
+    ['Admin']
   end
 
   def self.ids_with_permission(perm_string)

--- a/src/api/db/data/20201112083506_remove_role_user.rb
+++ b/src/api/db/data/20201112083506_remove_role_user.rb
@@ -1,0 +1,10 @@
+class RemoveRoleUser < ActiveRecord::Migration[6.0]
+  def up
+    Role.destroy_by(title: 'User')
+  end
+
+  def down
+    # While we can recreate the role, we cannot recreate associations between users and the role "User" (so records in RolesUser)
+    Role.create(title: 'User', global: true)
+  end
+end

--- a/src/api/db/data_schema.rb
+++ b/src/api/db/data_schema.rb
@@ -1,2 +1,2 @@
 # encoding: UTF-8
-DataMigrate::Data.define(version: 20200528135241)
+DataMigrate::Data.define(version: 20201112083506)

--- a/src/api/spec/models/role_spec.rb
+++ b/src/api/spec/models/role_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Role do
   end
 
   describe '::global_roles' do
-    let(:expected_global_roles) { ['Admin', 'User'] }
+    let(:expected_global_roles) { ['Admin'] }
 
     it 'returns an array with all global role titles' do
       expect(Role.global_roles).to match_array(expected_global_roles)


### PR DESCRIPTION
At the commit https://github.com/openSUSE/open-build-service/commit/4204a68c21941b477b61dbfaa6ba6ac330d2a4d4 in the database seeds, the role "User" is associated to the "Admin" user, but not to the "nobody" user.
From this, I'm guessing that this role was used only on "real" users. We can also see that in the commit https://github.com/openSUSE/open-build-service/commit/e523b55785b0714fa658868fee629056b64c1bf7. Users are created, then are assigned the role "User".

In the commit https://github.com/openSUSE/open-build-service/commit/ae9bba8076117282e03bc47665d26c92e9e23c70, the role "User" was commented out in the database seeds.
Why? I don't know, but it might be related to the next paragraph.

In the commit https://github.com/openSUSE/open-build-service/commit/5ae5084e9e63469c9303d6f1baf1af0d7a9f72e7, the role "User" was completely removed from the database seeds.
According to Adrian in the [issue 820](https://github.com/openSUSE/open-build-service/issues/820), the role "User" was dropped.

With all this in mind, I believe we can safely remove the role "User" from our production database.