### PR TITLE
[api] Improve error message of /trigger/runservice route

### DIFF
--- a/src/api/app/controllers/trigger/errors.rb
+++ b/src/api/app/controllers/trigger/errors.rb
@@ -12,7 +12,7 @@ module Trigger::Errors
   class InvalidToken < APIError
     setup 'permission_denied',
           403,
-          'No valid token found "Authorization" header'
+          'No valid token found in the "Authorization" header'
   end
 
   class NoPermissionForPackage < APIError


### PR DESCRIPTION
The `/trigger/runservice` route will respond with an error if used with an improper authorization (e.g. plain http auth). The error message was not a complete sentence, which is now fixed.