### PR TITLE
Refactor event mailer

### DIFF
--- a/src/api/app/helpers/webui/markdown_helper.rb
+++ b/src/api/app/helpers/webui/markdown_helper.rb
@@ -7,6 +7,6 @@ module Webui::MarkdownHelper
                                            autolink: true,
                                            no_intra_emphasis: true,
                                            fenced_code_blocks: true, disable_indented_code_blocks: true)
-    ActionController::Base.helpers.sanitize(@md_parser.render(content.to_s))
+    ActionController::Base.helpers.sanitize(@md_parser.render(content.dup.to_s))
   end
 end

--- a/src/api/spec/mailers/event_mailer_spec.rb
+++ b/src/api/spec/mailers/event_mailer_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe EventMailer, vcr: true do
         let(:vip) { create(:confirmed_user) }
         let!(:comment) { create(:comment_project, body: "I ❤️ @#{vip.login}!") }
 
-        it { expect(mail.text_part.body.encoded).to include("I ❤️ [@#{vip.login}](https://build.example.com/users/") }
+        it { expect(mail.text_part.body.encoded).to include("I ❤️ @#{vip.login}") }
         it { expect(mail.html_part.to_s).to include('I =E2=9D=A4=EF=B8=8F <a href=3D"https://build.example.com/users/') }
       end
     end


### PR DESCRIPTION
After a long debugging section with @eduardoj and @krauselukas we were able to pin-point a problem: In the [SendEventEmailsJobs](https://github.com/openSUSE/open-build-service/blob/master/src/api/app/jobs/send_event_emails_job.rb#L9) the `send_mail` call was changing the value of the variable `event`. We found out that our custom Markdown Render is mutating a variable exactly here https://github.com/openSUSE/open-build-service/blob/master/src/api/lib/obsapi/markdown_renderer.rb#L14

Beside it, we fixed a wrong assumption in the `event_mailer_spec.rb`. The text part from the multipart email shouldnt have any rendered markdown present.  