### PR TITLE
Add preview for the comment markdown

### DIFF
--- a/src/api/app/assets/javascripts/webui/comment.js
+++ b/src/api/app/assets/javascripts/webui/comment.js
@@ -56,4 +56,26 @@ $(document).ready(function(){
     if (!closest.hasClass('collapsed'))
       closest.trigger('click');
   });
+
+  $('.comments-list').on('click', '.preview-comment-tab:not(.active)', function (e) {
+      var commentContainer = $(e.target).closest('[class*="-comment-form"]');
+      var commentBody = commentContainer.find('.comment-field').val();
+      var commentPreview = commentContainer.find('.comment-preview');
+      if (commentBody) {
+        $.ajax({
+          method: 'POST',
+          url: commentContainer.data('previewCommentUrl'),
+          dataType: 'json',
+          data: { 'comment[body]': commentBody },
+          success: function(data) {
+            commentPreview.html(data.markdown);
+          },
+          error: function() {
+            commentPreview.html('Error loading markdown preview');
+          }
+        });
+      } else {
+        commentPreview.html('Nothing to preview');
+      }
+  });
 });

--- a/src/api/app/assets/javascripts/webui/comment.js
+++ b/src/api/app/assets/javascripts/webui/comment.js
@@ -14,7 +14,17 @@ function updateCommentCounter(selector, count) {
   $(selector).text(parseInt(oldValue) + count);
 }
 
+function validateForm(e) {
+  var submitButton = $(e.target).closest('[class*="-comment-form"]').find('input[type="submit"]');
+  submitButton.prop('disabled', !$(e.target).val());
+}
+
 $(document).ready(function(){
+  // Disable submit button if textarea is empty and enable otherwise
+  $('.comments-list').on('keyup', '.comment-field', function(e) {
+    validateForm(e);
+  });
+
   $('.comments-list').on('keyup click', '.comment-field', function() {
     resizeTextarea(this);
   });

--- a/src/api/app/assets/stylesheets/webui/comments.scss
+++ b/src/api/app/assets/stylesheets/webui/comments.scss
@@ -14,3 +14,7 @@
     code { line-height: 1.5rem; }
   }
 }
+
+.comment-preview {
+  min-height: 6.9rem;
+}

--- a/src/api/app/controllers/webui/comments_controller.rb
+++ b/src/api/app/controllers/webui/comments_controller.rb
@@ -54,6 +54,13 @@ class Webui::CommentsController < Webui::WebuiController
     end
   end
 
+  def preview
+    markdown = helpers.render_as_markdown(permitted_params[:body])
+    respond_to do |format|
+      format.json { render json: { markdown: markdown } }
+    end
+  end
+
   private
 
   def permitted_params

--- a/src/api/app/views/webui/comment/_comment_field.html.haml
+++ b/src/api/app/views/webui/comment/_comment_field.html.haml
@@ -1,11 +1,25 @@
-= form_for(comment, method: form_method, remote: true, html: { class: "#{form_method}-comment-form" }) do |f|
-  = hidden_field_tag :commentable_type, commentable.class.name
-  = hidden_field_tag :commentable_id, commentable.id
-  = f.hidden_field :parent_id, value: comment.parent_id
-  ~ f.text_area :body, rows: '4', placeholder: 'Write your comment here... (Markdown markup is supported)', required: true,
-    class: 'w-100 mb-3 form-control comment-field'
-  - case form_method
-  - when :post
-    = f.submit 'Add comment', class: 'btn btn-primary', data: { disable_with: 'Creating comment...' }
-  - when :put
-    = f.submit 'Update comment', class: 'btn btn-primary', data: { disable_with: 'Updating comment...' }
+= form_for(comment, method: form_method, remote: true, html: { id: "#{element_suffix}_form",
+class: "#{form_method}-comment-form" }, data: { preview_comment_url: preview_comments_path }) do |f|
+  = hidden_field_tag :commentable_type, commentable.class.name, { id: "#{element_suffix}_commentable_type" }
+  = hidden_field_tag :commentable_id, commentable.id, { id: "#{element_suffix}_commentable_id" }
+  = f.hidden_field :parent_id, value: comment.parent_id, id: "#{element_suffix}_parent_id"
+  .card
+    %ul.nav.nav-tabs.bg-light.px-3.pt-2{ role: 'tablist' }
+      %li.nav-item
+        = link_to('Write', "#write_#{element_suffix}", class: 'nav-link active', data: { toggle: 'tab' }, role: 'tab',
+        aria: { controls: 'write-comment-tab', selected: 'true' })
+      %li.nav-item
+        = link_to('Preview', "#preview_#{element_suffix}", class: 'nav-link preview-comment-tab', data: { toggle: 'tab' },
+        role: 'tab', aria: { controls: 'preview-comment-tab', selected: 'false' })
+    .tab-content.px-3
+      .tab-pane.fade.show.active.my-3{ id: "write_#{element_suffix}", role: 'tabpanel', 'aria-labelledby': 'write-comment-tab' }
+        ~ f.text_area :body, id: "#{element_suffix}_body", rows: '4',
+        placeholder: 'Write your comment here... (Markdown markup is supported)', required: true,
+        class: 'w-100 form-control comment-field'
+      .tab-pane.fade{ id: "preview_#{element_suffix}", role: 'tabpanel', 'aria-labelledby': 'preview-comment-tab' }
+        .comment-preview.border-bottom.border-gray-300.my-3
+      - case form_method
+      - when :post
+        = f.submit 'Add comment', class: 'btn btn-primary mb-3', data: { disable_with: 'Creating comment...' }, disabled: true
+      - when :put
+        = f.submit 'Update comment', class: 'btn btn-primary mb-3', data: { disable_with: 'Updating comment...' }

--- a/src/api/app/views/webui/comment/_new.html.haml
+++ b/src/api/app/views/webui/comment/_new.html.haml
@@ -1,6 +1,6 @@
 - if User.session
   = render(partial: 'webui/comment/comment_field',
-    locals: { form_method: :post, comment: Comment.new, commentable: commentable })
+    locals: { form_method: :post, comment: Comment.new, commentable: commentable, element_suffix: 'new_comment' })
 - else
   .alert.alert-warning{ role: 'alert' }
     Login required, please

--- a/src/api/app/views/webui/comment/_reply.html.haml
+++ b/src/api/app/views/webui/comment/_reply.html.haml
@@ -18,8 +18,8 @@
 - if User.session
   .collapse{ id: "reply_form_of_#{comment.id}" }
     = render(partial: 'webui/comment/comment_field', locals: { form_method: :post,
-     comment: comment.children.new, commentable: commentable })
+     comment: comment.children.new, commentable: commentable, element_suffix: "reply_for_#{comment.id}" })
   - if policy(comment).update?
     .collapse{ id: "edit_form_of_#{comment.id}" }
       = render(partial: 'webui/comment/comment_field', locals: { form_method: :put,
-       comment: comment, commentable: commentable })
+       comment: comment, commentable: commentable, element_suffix: "edit_#{comment.id}" })

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -360,7 +360,11 @@ OBSApi::Application.routes.draw do
       resources :user, only: [:create, :destroy, :update], constraints: cons, param: :user_login, controller: 'webui/groups/users'
     end
 
-    resources :comments, constraints: cons, only: [:create, :destroy, :update], controller: 'webui/comments'
+    resources :comments, constraints: cons, only: [:create, :destroy, :update], controller: 'webui/comments' do
+      collection do
+        post 'preview'
+      end
+    end
 
     ### /apidocs
     get 'apidocs', to: redirect('/apidocs/index')

--- a/src/api/spec/controllers/webui/comments_controller_spec.rb
+++ b/src/api/spec/controllers/webui/comments_controller_spec.rb
@@ -107,6 +107,23 @@ RSpec.describe Webui::CommentsController, type: :controller do
     end
   end
 
+  describe 'POST #preview' do
+    let(:comment_params) { { comment: { body: '#test comment header' } } }
+
+    before do
+      post :preview, params: comment_params, format: :json
+    end
+
+    it 'sends success HTTP status when markdown rendered successfully' do
+      expect(response).to have_http_status(:success)
+    end
+
+    it 'renders comment with Markdown properly' do
+      json = JSON.parse(response.body)
+      expect(json['markdown']).to eq("<h1>test comment header</h1>\n")
+    end
+  end
+
   describe 'EDIT update' do
     let(:project) { create(:project) }
     let(:package) { create(:package, project: project) }

--- a/src/api/spec/features/beta/webui/comments_spec.rb
+++ b/src/api/spec/features/beta/webui/comments_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Comments', type: :feature, js: true do
   it 'can be created' do
     login user
     visit project_show_path(user.home_project)
-    fill_in 'comment_body', with: 'Comment Body'
+    fill_in 'new_comment_body', with: 'Comment Body'
     find_button('Add comment').click
 
     expect(page).to have_text('Comment Body')

--- a/src/api/spec/features/webui/comments_spec.rb
+++ b/src/api/spec/features/webui/comments_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Comments', type: :feature, js: true do
   it 'can be created' do
     login user
     visit project_show_path(user.home_project)
-    fill_in 'comment_body', with: 'Comment Body'
+    fill_in 'new_comment_body', with: 'Comment Body'
     find_button('Add comment').click
 
     expect(page).to have_text('Comment Body')


### PR DESCRIPTION
It is easy for a MD formatted text to come out looking wrong due to a
typo.

The PR adds Preview tab for comment section, so that it is possible
to view the formatted with markdown comment before saving it.

Fixes #10019

To verify this feature

1. Log in to the application;
2. Go to any page, where comments section exists (e.g. select "Your Home Project" in the sidebar);
3. Type any comment with markdown in "Write" tab of comment section;
4. Select "Preview" Tab.

Expected result:
The comment is shown with rendered markdown. Please, see the GIF below on how it looks:
![Peek 2020-11-12 15-10](https://user-images.githubusercontent.com/37581072/98950414-418abc80-24f9-11eb-8600-f1cd5e6bc8d6.gif)


