### PR TITLE
[backend] allow calling the sign tool with a bad signkey

### DIFF
--- a/src/backend/BSPublisher/Container.pm
+++ b/src/backend/BSPublisher/Container.pm
@@ -72,6 +72,13 @@ sub registries_for_prp {
   return @registries;
 }
 
+sub have_good_project_signkey {
+  my ($signargs) = @_;
+  return 0 unless @{$signargs || []} >= 2;
+  return 0 if $signargs->[0] ne '-P';
+  return (-s $signargs->[1]) >= 10;
+}
+
 sub get_notary_pubkey {
   my ($projid, $pubkey, $signargs) = @_;
 
@@ -80,8 +87,8 @@ sub get_notary_pubkey {
   push @signargs, '--signtype', 'notary' if $BSConfig::sign_type || $BSConfig::sign_type;
   push @signargs, @{$signargs || []};
 
-  # ask the sign tool for the correct pubkey if we do not have a sign key
-  if (!(@$signargs && $signargs->[0] eq '-P') && $BSConfig::sign_project && $BSConfig::sign) {
+  # ask the sign tool for the correct pubkey if we do not have a good sign key
+  if ($BSConfig::sign_project && $BSConfig::sign && !have_good_project_signkey($signargs)) {
     local *S;
     open(S, '-|', $BSConfig::sign, @signargs, '-p') || die("$BSConfig::sign: $!\n");;
     $pubkey = '';

--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -329,7 +329,6 @@ sub getpatterns {
 sub getsigndata {
   my ($projid) = @_;
 
-  my $signargs = [];
   my @args = ("withpubkey=1", "withalgo=1");
   push @args, "autoextend=1" if $BSConfig::sign;
   my $signkey = BSRPC::rpc("$BSConfig::srcserver/getsignkey", undef, "project=$projid", @args);
@@ -337,14 +336,9 @@ sub getsigndata {
   my $algo;
   if ($signkey) {
     ($signkey, $pubkey) = split("\n", $signkey, 2);
-    undef $signkey unless $signkey && length($signkey) > 10;	# not a valid signkey
     undef $pubkey unless $pubkey && length($pubkey) > 10;	# not a valid pubkey
-  }
-  if ($signkey) {
     $algo = $1 if $signkey && $signkey =~ s/^(\S+)://;
-    mkdir_p("$uploaddir");
-    writestr("$uploaddir/publisher.$$", undef, $signkey);
-    $signargs = [ '-P', "$uploaddir/publisher.$$" ];
+    undef $algo if $algo && $algo eq '?';
   }
   if (!$pubkey) {
     if ($BSConfig::sign_project && $BSConfig::sign) {
@@ -367,6 +361,13 @@ sub getsigndata {
   if ($pubkey && !$algo) {
     # try to get algo from public key
     eval { $algo = BSPGP::pk2algo(BSPGP::unarmor($pubkey)) };
+  }
+  # setup sign arguments
+  my $signargs = [];
+  if ($signkey) {
+    mkdir_p($uploaddir);
+    writestr("$uploaddir/publisher.$$", undef, $signkey);
+    push @$signargs, '-P', "$uploaddir/publisher.$$";
   }
   push @$signargs, '-h', 'sha256' if $algo && $algo eq 'rsa';
   return ($pubkey, $signargs);

--- a/src/backend/bs_signer
+++ b/src/backend/bs_signer
@@ -445,10 +445,10 @@ sub getsignkey {
   my $algo;
   if ($signkey) {
     ($signkey, $pubkey) = split("\n", $signkey, 2) if $needpubkey;
-    undef $signkey unless $signkey && length($signkey) > 10;
     undef $pubkey unless $pubkey && length($pubkey) > 10;
+    $algo = $1 if $signkey && $signkey =~ s/^(\S+)://;
+    undef $algo if $algo && $algo eq '?';
   }
-  $algo = $1 if $signkey && $signkey =~ s/^(\S+)://;
   if (($needpubkey || !$algo) && !$pubkey) {
     if ($BSConfig::sign_project && $BSConfig::sign) {
       my @signargs;


### PR DESCRIPTION
The code used to be different in the publisher and the signer.
The publisher used to ignore bad signkeys (i.e. too small
signkeys), whereas the signer just used the keys. This was
changed in commit 27cfcb1aaffbf0e0ba2c0cf06ce87a0373c0a563
which made both versions of the code ignore bad signkeys.

It turned out that doing this has the disadvantage that we
do not catch configuration errors anymore which used to
result in the signer complaining about a bad signkey.
So this coomit changes the code in both the signer and the
publisher to again pass bad signkeys to the signer.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
