### PR TITLE
Add Cancel button to comment section

### DIFF
--- a/src/api/app/assets/javascripts/webui/comment.js
+++ b/src/api/app/assets/javascripts/webui/comment.js
@@ -67,6 +67,10 @@ $(document).ready(function(){
       closest.trigger('click');
   });
 
+  $('body').on('click', '.cancel-comment', function (e) {
+    $(e.target).closest('.collapse').collapse('hide');
+  });
+
   $('.comments-list').on('click', '.preview-comment-tab:not(.active)', function (e) {
       var commentContainer = $(e.target).closest('[class*="-comment-form"]');
       var commentBody = commentContainer.find('.comment-field').val();

--- a/src/api/app/assets/javascripts/webui/tabs.js
+++ b/src/api/app/assets/javascripts/webui/tabs.js
@@ -31,7 +31,7 @@ $.fn.hasOverflow = function() {
   return (element.offsetHeight < element.scrollHeight - 1) || (element.offsetWidth < element.scrollWidth - 1);
 };
 
-$.fn.collapse = function(){
+$.fn.collapseCollapsible = function(){
   var collapsibleElements = this;
   
   return collapsibleElements.each(function() {
@@ -43,5 +43,5 @@ $.fn.collapse = function(){
 };
 
 $(document).ready(function() {
-  $('ul.collapsible').collapse();
+  $('ul.collapsible').collapseCollapsible();
 });

--- a/src/api/app/views/webui/comment/_comment_field.html.haml
+++ b/src/api/app/views/webui/comment/_comment_field.html.haml
@@ -18,8 +18,12 @@ class: "#{form_method}-comment-form" }, data: { preview_comment_url: preview_com
         class: 'w-100 form-control comment-field'
       .tab-pane.fade{ id: "preview_#{element_suffix}", role: 'tabpanel', 'aria-labelledby': 'preview-comment-tab' }
         .comment-preview.border-bottom.border-gray-300.my-3
-      - case form_method
-      - when :post
-        = f.submit 'Add comment', class: 'btn btn-primary mb-3', data: { disable_with: 'Creating comment...' }, disabled: true
-      - when :put
-        = f.submit 'Update comment', class: 'btn btn-primary mb-3', data: { disable_with: 'Updating comment...' }
+      .comment-controls.mb-3
+        - case form_method
+        - when :post
+          = f.submit 'Add comment', class: 'btn btn-primary mr-2', data: { disable_with: 'Creating comment...' }, disabled: true
+        - when :put
+          = f.submit 'Update comment', class: 'btn btn-primary mr-2', data: { disable_with: 'Updating comment...' }
+        - if has_cancel
+          %a.cancel-comment.btn.btn-outline-secondary
+            Cancel

--- a/src/api/app/views/webui/comment/_new.html.haml
+++ b/src/api/app/views/webui/comment/_new.html.haml
@@ -1,6 +1,6 @@
 - if User.session
   = render(partial: 'webui/comment/comment_field',
-    locals: { form_method: :post, comment: Comment.new, commentable: commentable, element_suffix: 'new_comment' })
+    locals: { form_method: :post, comment: Comment.new, commentable: commentable, element_suffix: 'new_comment', has_cancel: false })
 - else
   .alert.alert-warning{ role: 'alert' }
     Login required, please

--- a/src/api/app/views/webui/comment/_reply.html.haml
+++ b/src/api/app/views/webui/comment/_reply.html.haml
@@ -18,8 +18,8 @@
 - if User.session
   .collapse{ id: "reply_form_of_#{comment.id}" }
     = render(partial: 'webui/comment/comment_field', locals: { form_method: :post,
-     comment: comment.children.new, commentable: commentable, element_suffix: "reply_for_#{comment.id}" })
+     comment: comment.children.new, commentable: commentable, element_suffix: "reply_for_#{comment.id}", has_cancel: true })
   - if policy(comment).update?
     .collapse{ id: "edit_form_of_#{comment.id}" }
       = render(partial: 'webui/comment/comment_field', locals: { form_method: :put,
-       comment: comment, commentable: commentable, element_suffix: "edit_#{comment.id}" })
+       comment: comment, commentable: commentable, element_suffix: "edit_#{comment.id}", has_cancel: true })


### PR DESCRIPTION
It is not clear how to collapse comment section once it is expanded
while editing or replying.

The PR adds "Cancel" button for this purpose.

To verify this feature

1. Log in to the application;
2. Go to any page, where comments section exists (e.g. select "Your Home Project" in the sidebar);
3. Create a comment if there are no ones;
4. Press "Reply" or "Edit" buttons;
5. When the comment section is expanded, press "Cancel" button.

Expected result:
Comment section is collapsed.

Here is a screenshot of how it looks:

**Before**
![comment_before](https://user-images.githubusercontent.com/37581072/99273438-4fa64900-2829-11eb-8158-a52e8ac17a94.png)


**After**
![after_comment](https://user-images.githubusercontent.com/37581072/99376577-67cba600-28c5-11eb-81fc-f04e8f5cd0de.png)


