### PR TITLE
Move 'Add Maintained Project' action next to Maintained Projects Header

### DIFF
--- a/src/api/app/views/webui/projects/maintained_projects/index.html.haml
+++ b/src/api/app/views/webui/projects/maintained_projects/index.html.haml
@@ -6,7 +6,12 @@
 .card
   = render partial: 'webui/project/tabs', locals: { project: @project }
   .card-body
-    %h3 Maintained Projects
+    %h3
+      Maintained Projects
+      - if update_policy && feature_enabled?(:responsive_ux)
+        = link_to('#', data: { toggle: 'modal', target: '#new-maintenance-project-modal' }, title: 'Add Project to Maintain') do
+          %i.fas.fa-xs.fa-plus-circle.text-primary
+
     .table-responsive
       %table.table.table-sm.table-striped.table-bordered.w-100#maintained-projects-datatable{ 'data-source': data_source }
         %thead
@@ -15,7 +20,7 @@
             %th Actions
         %tbody
 
-    - if update_policy
+    - if update_policy && !feature_enabled?(:responsive_ux)
       = link_to('#', data: { toggle: 'modal', target: '#new-maintenance-project-modal' }) do
         %i.fas.fa-plus-circle.text-primary
         Add Project to Maintain


### PR DESCRIPTION
**Before this change:**
![2020-11-19_12-20](https://user-images.githubusercontent.com/2650/99659930-ec532b80-2a61-11eb-9073-efb3e720b7bb.png)

**After this change:**
![2020-11-19_12-11](https://user-images.githubusercontent.com/2650/99659965-fa08b100-2a61-11eb-98c6-6d33929a609b.png)

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
