### PR TITLE
Migrate actions for Kiwi Images

### DIFF
--- a/src/api/app/views/webui/kiwi/images/_base_info.html.haml
+++ b/src/api/app/views/webui/kiwi/images/_base_info.html.haml
@@ -12,19 +12,23 @@
       %li.list-inline-item
         %strong Contact:
         %span.fill{ data: { tag: 'contact' } }= contact
-    %ul.list-inline.mb-0
-      %li.list-inline-item
-        = link_to(package_show_path(package.project, package)) do
-          %i.text-warning.fa.fa-archive
-          View package
-      %li.list-inline-item{ class: "#{'d-none' unless is_edit_details_action}" }
-        = link_to('#', data: { 'target': '#description-edit', 'toggle': 'modal' }) do
-          %i.fa.fa-edit.text-secondary
-          Edit details
-      - if User.session
+    - if feature_enabled?(:responsive_ux)
+      = render partial: 'webui/kiwi/images/responsive_ux/actions',
+               locals: { package: package, is_edit_details_action: is_edit_details_action }
+    - else
+      %ul.list-inline.mb-0
         %li.list-inline-item
-          = link_to(cloud_upload_index_path, id: 'cloud-upload') do
-            %i.fas.fa-cloud-upload-alt.text-secondary
-            Cloud upload
+          = link_to(package_show_path(package.project, package)) do
+            %i.text-warning.fa.fa-archive
+            View Package
+        %li.list-inline-item{ class: "#{'d-none' unless is_edit_details_action}" }
+          = link_to('#', data: { 'target': '#description-edit', 'toggle': 'modal' }) do
+            %i.fa.fa-edit.text-secondary
+            Edit Details
+        - if User.session
+          %li.list-inline-item
+            = link_to(cloud_upload_index_path, id: 'cloud-upload') do
+              %i.fas.fa-cloud-upload-alt.text-secondary
+              Cloud Upload
     - if action_name == 'edit'
       = render partial: 'description_form', locals: { f: f }

--- a/src/api/app/views/webui/kiwi/images/_package_fields.html.haml
+++ b/src/api/app/views/webui/kiwi/images/_package_fields.html.haml
@@ -7,7 +7,7 @@
           %small (#{f.object.arch})
     %span.btn.btn-link.kiwi_actions
       = link_to_remove_association f do
-        %i.fas.fa-times.text-danger
+        %i.fas.fa-times-circle.text-danger
 
   .modal.fade{ 'tabindex': '-1', role: 'dialog', id: "#{f.object.name.present? ? 'package-' + f.object.name : 'add-package'}",
                class: "#{'new_element' if f.object.new_record?}" }

--- a/src/api/app/views/webui/kiwi/images/_preferences.html.haml
+++ b/src/api/app/views/webui/kiwi/images/_preferences.html.haml
@@ -2,6 +2,9 @@
   .nested-fields
     %h5.card-header#image-name
       Preferences
+      - if feature_enabled?(:responsive_ux)
+        = link_to('#', data: { 'target': '#preferences-edit', 'toggle': 'modal' }, title: 'Edit Preferences') do
+          %i.fas.fa-edit.text-secondary.fa-xs
     .card-body
       - @image.preferences.each do |preference|
         %h6= preference.profile
@@ -20,7 +23,8 @@
               %strong Container config tag:
               %span.fill{ data: { tag: 'type_containerconfig_tag' } }= preference.type_containerconfig_tag
       %p
-        = link_to('#', data: { 'target': '#preferences-edit', 'toggle': 'modal' }) do
-          %i.fas.fa-edit.text-secondary
-          Edit Preferences
+        - unless feature_enabled?(:responsive_ux)
+          = link_to('#', data: { 'target': '#preferences-edit', 'toggle': 'modal' }) do
+            %i.fas.fa-edit.text-secondary
+            Edit Preferences
         = render partial: 'preferences_form', locals: { f: f }

--- a/src/api/app/views/webui/kiwi/images/responsive_ux/_actions.html.haml
+++ b/src/api/app/views/webui/kiwi/images/responsive_ux/_actions.html.haml
@@ -1,0 +1,14 @@
+- content_for :actions do
+  %li.nav-item
+    = link_to(package_show_path(package.project, package), class: 'nav-link', title: 'View Package') do
+      %i.fa.fa-archive.fa-lg.mr-2
+      %span.nav-item-name View Package
+  %li.nav-item{ class: "#{'d-none' unless is_edit_details_action}" }
+    = link_to('#', class: 'nav-link', data: { 'target': '#description-edit', 'toggle': 'modal' }, title: 'Edit Details') do
+      %i.fa.fa-edit.fa-lg.mr-2
+      %span.nav-item-name Edit Details
+  - if User.session
+    %li.nav-item
+      = link_to(cloud_upload_index_path, class: 'nav-link', id: 'cloud-upload', title: 'Cloud Upload') do
+        %i.fas.fa-cloud-upload-alt.fa-lg.mr-2
+        %span.nav-item-name Cloud Upload


### PR DESCRIPTION
Before:
![before](https://user-images.githubusercontent.com/1102934/99662204-3ab5f980-2a65-11eb-9731-42089c12f037.png)

After:
![after](https://user-images.githubusercontent.com/1102934/99662065-0f330f00-2a65-11eb-9b52-d65c55d72795.png)

In the screenshot below, the `Add package` link cannot be migrated next to the header `Packages` since it's depending on the data from `fields_for`: https://github.com/openSUSE/open-build-service/blob/3ce10d89bdefb05fa8ea6c75e12c2247c8905a4b/src/api/app/views/webui/kiwi/images/_packages.html.haml#L6
![cannot-be-migrated](https://user-images.githubusercontent.com/1102934/99662071-0fcba580-2a65-11eb-8f48-49b336f82dac.png)