### PR TITLE
Move Add Maintenance Incidents actions next to the Maintenance Incidents Header

### DIFF
--- a/src/api/app/views/webui/projects/maintenance_incidents/index.html.haml
+++ b/src/api/app/views/webui/projects/maintenance_incidents/index.html.haml
@@ -1,5 +1,12 @@
 - @pagetitle = 'Maintenance Incidents'
 
+- if policy(@project).create? && feature_enabled?(:responsive_ux)
+  - content_for :actions do
+    %li.nav-item
+      = link_to(project_maintenance_incidents_path(@project.name), method: :post, title: 'Create Maintenance Incident', class: 'nav-link') do
+        %i.fas.fa-lg.mr-2.fa-plus-circle
+        %span.nav-item-name Create Incident
+
 .card.mb-3
   = render partial: 'webui/project/tabs', locals: { project: @project }
   .card-body
@@ -7,10 +14,6 @@
       Maintenance incidents
       %span.badge.badge-primary
         = @incidents.count
-      - if policy(@project).create? && feature_enabled?(:responsive_ux)
-        = link_to(project_maintenance_incidents_path(@project.name), method: :post, title: 'Create Maintenance Incident') do
-          %i.fas.fa-xs.fa-plus-circle.text-primary
-
     -# haml-lint:disable MultilinePipe
     %table.w-100.responsive.table.table-sm.table-bordered.table-hover#incident-table{ data: { |
     source: project_maintenance_incidents_path(project_name: @project.name) } } |

--- a/src/api/app/views/webui/projects/maintenance_incidents/index.html.haml
+++ b/src/api/app/views/webui/projects/maintenance_incidents/index.html.haml
@@ -7,6 +7,9 @@
       Maintenance incidents
       %span.badge.badge-primary
         = @incidents.count
+      - if policy(@project).create? && feature_enabled?(:responsive_ux)
+        = link_to(project_maintenance_incidents_path(@project.name), method: :post, title: 'Create Maintenance Incident') do
+          %i.fas.fa-xs.fa-plus-circle.text-primary
 
     -# haml-lint:disable MultilinePipe
     %table.w-100.responsive.table.table-sm.table-bordered.table-hover#incident-table{ data: { |
@@ -25,7 +28,7 @@
           %th
             Release Targets
       %tbody
-    - if policy(@project).create?
+    - if policy(@project).create? && !feature_enabled?(:responsive_ux)
       .pt-4
         %ul.list-inline
           %li.list-inline-item

--- a/src/api/spec/features/beta/webui/projects_spec.rb
+++ b/src/api/spec/features/beta/webui/projects_spec.rb
@@ -148,7 +148,12 @@ RSpec.describe 'Projects', type: :feature, js: true do
 
       visit project_show_path(maintenance_project)
       click_link('Incidents')
-      click_link('Create Maintenance Incident')
+      if mobile?
+        within('#bottom-navigation-area') { click_link('Actions') }
+        within('#bottom-navigation-area') { click_link('Create Incident') }
+      else
+        click_link('Create Incident')
+      end
       expect(page).to have_css('#flash', text: "Created maintenance incident project #{project.name}:maintenance_project:0")
 
       # We can not create this via the Bootstrap UI, except by adding plain XML to the meta editor


### PR DESCRIPTION
## How it looked like before?
![2020-11-19_15-08](https://user-images.githubusercontent.com/2650/99678250-e74ea600-2a7a-11eb-9393-07d51b174baa.png)

## How it looks like now?
![image](https://user-images.githubusercontent.com/2650/99796848-78cb2000-2b2e-11eb-8105-c688de69cb0d.png)