### PR TITLE
Move the 'Add Project to Maintain' action to the left sidebar

### DIFF
--- a/src/api/app/views/webui/projects/maintained_projects/index.html.haml
+++ b/src/api/app/views/webui/projects/maintained_projects/index.html.haml
@@ -3,14 +3,17 @@
   update_policy = policy(@project).update?
   data_source = project_maintained_projects_path(@project, :json)
 
+- if update_policy && feature_enabled?(:responsive_ux)
+  - content_for :actions do
+    %li.nav-item
+      = link_to('#', data: { toggle: 'modal', target: '#new-maintenance-project-modal' }, title: 'Add Project to Maintain', class: 'nav-link') do
+        %i.fas.fa-lg.mr-2.fa-plus-circle
+        Add Project to Maintain
+
 .card
   = render partial: 'webui/project/tabs', locals: { project: @project }
   .card-body
-    %h3
-      Maintained Projects
-      - if update_policy && feature_enabled?(:responsive_ux)
-        = link_to('#', data: { toggle: 'modal', target: '#new-maintenance-project-modal' }, title: 'Add Project to Maintain') do
-          %i.fas.fa-xs.fa-plus-circle.text-primary
+    %h3 Maintained Projects
 
     .table-responsive
       %table.table.table-sm.table-striped.table-bordered.w-100#maintained-projects-datatable{ 'data-source': data_source }

--- a/src/api/spec/features/beta/webui/maintained_projects_spec.rb
+++ b/src/api/spec/features/beta/webui/maintained_projects_spec.rb
@@ -36,7 +36,12 @@ RSpec.describe 'MaintainedProjects', type: :feature, js: true do
         visit project_maintained_projects_path(project_name: maintenance_project.name)
 
         expect(page).to have_selector('#new-maintenance-project-modal', visible: :hidden)
-        click_link('Add Project to Maintain')
+        if mobile?
+          within('#bottom-navigation-area') { click_link('Actions') }
+          within('#bottom-navigation-area') { click_link('Add Project to Maintain') }
+        else
+          click_link('Add Project to Maintain')
+        end
 
         expect(page).to have_selector('#new-maintenance-project-modal', visible: :visible)
         expect(page).to have_selector('#delete-maintained-project-modal', visible: :hidden)


### PR DESCRIPTION
As this is a page action and not a contextual action it should be in the left Actions Sidebar.

## Before
![image](https://user-images.githubusercontent.com/2650/99796493-e1fe6380-2b2d-11eb-9eab-2a9884a24ed8.png)

## Now
![image](https://user-images.githubusercontent.com/2650/99796435-c85d1c00-2b2d-11eb-9413-3fa5422c1136.png)
