### PR TITLE
Add characters count for User Biography

### DIFF
--- a/src/api/app/assets/javascripts/webui/user_profile.js
+++ b/src/api/app/assets/javascripts/webui/user_profile.js
@@ -5,3 +5,16 @@ function moveInvolvementToContainer() { // jshint ignore:line
 
   container.prepend($('#involvement'));
 }
+
+function updateCharactersCount(e) { // jshint ignore:line
+  var maxLength = $(e.target).attr('maxlength');
+  var currentLength = $(e.target).val().length;
+  var remainingCount = maxLength - currentLength;
+
+  // Change font color to "danger" when low amount of characters left
+  $('#bio-chars-counter').toggleClass('text-danger', remainingCount < 10);
+
+  // Make text singular or plural based on the amount of characters
+  var plural = (remainingCount === 1) ? '' : 's';
+  $('#bio-chars-counter').css("visibility", "visible").text(remainingCount + " character" + plural + " remaining");
+}

--- a/src/api/app/assets/stylesheets/webui/user.scss
+++ b/src/api/app/assets/stylesheets/webui/user.scss
@@ -32,3 +32,7 @@
     text-decoration: none;
   }
 }
+
+#bio-chars-counter {
+  min-height: 1.2rem;
+}

--- a/src/api/app/views/webui/user/_edit_dialog.html.haml
+++ b/src/api/app/views/webui/user/_edit_dialog.html.haml
@@ -16,7 +16,7 @@
             .form-group
               = f.label(:biography) do
                 Biography:
-                %small.form-text Max. #{User::MAX_BIOGRAPHY_LENGTH_ALLOWED} characters.
               = f.text_area(:biography, rows: 6, class: 'form-control', maxlength: User::MAX_BIOGRAPHY_LENGTH_ALLOWED)
+              %small.form-text.float-right#bio-chars-counter
         .modal-footer
           = render partial: 'webui/shared/dialog_action_buttons', locals: { submit_tag_text: 'Update' }

--- a/src/api/app/views/webui/user/user_profile_redesign/_edit_account_form.html.haml
+++ b/src/api/app/views/webui/user/user_profile_redesign/_edit_account_form.html.haml
@@ -15,7 +15,7 @@
   .form-group
     = f.text_area(:biography, rows: 6, placeholder: 'Biography', maxlength: User::MAX_BIOGRAPHY_LENGTH_ALLOWED, class: 'form-control')
     = f.label(:biography, class: 'd-block text-right') do
-      %small.form-text Max. #{User::MAX_BIOGRAPHY_LENGTH_ALLOWED} characters.
+      %small.form-text#bio-chars-counter
   .form-group
     = f.text_field(:email, required: true, email: true, placeholder: 'Email', readonly: behind_proxy, class: 'form-control')
   .form-group

--- a/src/api/app/views/webui/users/show.html.haml
+++ b/src/api/app/views/webui/users/show.html.haml
@@ -25,6 +25,16 @@
                         date: @date,
                         activities_per_day: @activities_per_day }) if contribution_graph?
       = render partial: 'webui/user/user_profile_redesign/involvement_and_activity', locals: locals
+    - content_for :ready_function do
+      :plain
+          // Show biography characters counter
+          $('body').on('focus keyup keydown', '#user_biography', function(e) {
+            updateCharactersCount(e);
+          });
+          // Hide biography characters counter
+          $('body').on('focusout', '#user_biography', function() {
+            $('#bio-chars-counter').css("visibility", "hidden");
+          });
   - else
     .col-12.col-md-4.col-lg-3
       = render partial: 'webui/user/info', locals: { user: @displayed_user,


### PR DESCRIPTION
There is a limit of characters that can be typed in Biography textarea.
After the limit is reached, no characters can be entered. But there is
no visual hint on how many characters remaining.

The commit adds a counter that updates in real-time to show to the user
on how many characters remaining.

How to test the feature:

1. Login to the application;
2. Go to User Profile Page;
3. Press "Edit Your Account" in sidebar menu;
4. Type any characters to Biography textarea.

Expected result:
Once textarea become in focus, the counter is appeared in the bottom-right corner of the textarea. It shows how many characters remaining when typing.

Here is a screenshot of how it looks:

**When responsive_ux is disabled**
![old_dialog](https://user-images.githubusercontent.com/37581072/99809209-3ca1ba80-2b42-11eb-9b12-602b4a50e818.png)

**When responsive_ux is enabled**
![new_dialog](https://user-images.githubusercontent.com/37581072/99809244-49261300-2b42-11eb-90b3-afd6372d4136.png)

