### PR TITLE
Display 'Add Group Members' link if the group can be updated

### DIFF
--- a/src/api/app/views/webui/groups/show.html.haml
+++ b/src/api/app/views/webui/groups/show.html.haml
@@ -34,7 +34,7 @@
       .tab-pane.show.active#group-members{ aria: { controls: 'group-members' }, role: 'tabpanel' }
         %h3
           Group Members
-          - if feature_enabled?(:responsive_ux)
+          - if policy(@group).update? && feature_enabled?(:responsive_ux)
             = link_to('#', data: { toggle: 'modal', target: '#add-group-user-modal' }, title: 'Add Member') do
               %i.fas.fa-xs.fa-plus-circle.text-primary
         = render(partial: 'group_members', locals: { group: @group })


### PR DESCRIPTION
Without this change, the `+` icon next to the `Group Members` heading would always be displayed in the responsive_ux UI. This is wrong when the currently logged-in user cannot update the group.

So the icon was still rendered, but clicking on it would do nothing since the modal was not rendered in the view, which is totally expected since the user shouldn't be able to see the icon in the first place.

The fix is to display the icon only when the user can update the group.

To reproduce that bug, visit https://build.opensuse.org/group/show/obs-developers and see the icon next to the `Group Members` heading. Click on it and nothing happens (unless you're allowed to update the group, it's not the case unless you're an admin or a maintainer in the group).