### PR TITLE
Add maintenance incidents actions next to the maintenance incidents heading

### DIFF
--- a/src/api/app/views/webui/projects/maintenance_incidents/index.html.haml
+++ b/src/api/app/views/webui/projects/maintenance_incidents/index.html.haml
@@ -1,12 +1,5 @@
 - @pagetitle = 'Maintenance Incidents'
 
-- if policy(@project).create? && feature_enabled?(:responsive_ux)
-  - content_for :actions do
-    %li.nav-item
-      = link_to(project_maintenance_incidents_path(@project.name), method: :post, title: 'Create Maintenance Incident', class: 'nav-link') do
-        %i.fas.fa-lg.mr-2.fa-plus-circle
-        %span.nav-item-name Create Incident
-
 .card.mb-3
   = render partial: 'webui/project/tabs', locals: { project: @project }
   .card-body
@@ -14,6 +7,10 @@
       Maintenance incidents
       %span.badge.badge-primary
         = @incidents.count
+      - if policy(@project).create? && feature_enabled?(:responsive_ux)
+        = link_to(project_maintenance_incidents_path(@project.name), method: :post, title: 'Create Maintenance Incident') do
+          %i.fas.fa-xs.fa-plus-circle.text-primary
+
     -# haml-lint:disable MultilinePipe
     %table.w-100.responsive.table.table-sm.table-bordered.table-hover#incident-table{ data: { |
     source: project_maintenance_incidents_path(project_name: @project.name) } } |


### PR DESCRIPTION
Here is a screenshot of how it looks:

**Before**
![image](https://user-images.githubusercontent.com/2650/99967917-be8b2100-2d98-11eb-889d-86db840b6e95.png)

**After**
![image](https://user-images.githubusercontent.com/2650/99967701-82f05700-2d98-11eb-960a-6c5ee089bc26.png)