### PR TITLE
Move "Create Package" and "Branch Package" from Project overview into the Packages section

### DIFF
--- a/src/api/app/views/webui/project/_project_packages.html.haml
+++ b/src/api/app/views/webui/project/_project_packages.html.haml
@@ -10,7 +10,7 @@
   - else
     %p This project does not contain any packages
 
-  - if !feature_enabled?(:responsive_ux) && User.possibly_nobody.can_modify?(project) && show_package_actions?
+  - if User.possibly_nobody.can_modify?(project) && show_package_actions?
     .pt-4
       %ul.list-inline
         %li.list-inline-item

--- a/src/api/app/views/webui/project/responsive_ux/_show_actions.html.haml
+++ b/src/api/app/views/webui/project/responsive_ux/_show_actions.html.haml
@@ -21,12 +21,3 @@
     = link_to(image_templates_path, class: 'nav-link', title: 'New Image') do
       %i.fas.fa-compact-disc.fa-lg.mr-2
       %span.nav-item-name New Image
-  - if User.possibly_nobody.can_modify?(project) && show_package_actions?
-    %li.nav-item
-      = link_to(new_package_path(project), class: 'nav-link', title: 'Create Package') do
-        %i.fas.fa-plus-circle.fa-lg.mr-2
-        %span.nav-item-name Create Package
-    %li.nav-item
-      = link_to(project_new_packages_branch_path(project), class: 'nav-link', title: 'Branch Package') do
-        %i.fas.fa-code-branch.fa-lg.mr-2
-        %span.nav-item-name Branch Package

--- a/src/api/spec/features/beta/webui/projects_spec.rb
+++ b/src/api/spec/features/beta/webui/projects_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe 'Projects', type: :feature, js: true do
     before do
       login user
       visit project_show_path(project)
-      desktop? ? click_link('Branch Package') : click_menu_link('Actions', 'Branch Package')
+      click_link('Branch Package')
     end
 
     it 'an existing package' do


### PR DESCRIPTION
The "Create Package" and "Branch Package" are contextual actions.
This change moves close to the "Packages" list that is their context.

Here is a screenshot of how it looks:

**Before**
![2020-11-23_17-44](https://user-images.githubusercontent.com/2650/99992563-ca85db80-2db6-11eb-80bf-de8652504143.png)


**After**
![2020-11-23_17-45_1](https://user-images.githubusercontent.com/2650/99992577-ce196280-2db6-11eb-976a-35b15eb44cb1.png)


-->
