### PR TITLE
Stack action and corresponding resource icon

### DIFF
--- a/src/api/app/assets/stylesheets/webui/sidebar-collapsible.scss
+++ b/src/api/app/assets/stylesheets/webui/sidebar-collapsible.scss
@@ -40,5 +40,20 @@
     .nav-item-name, .collapse-button-name { display: none; }
   }
 
-  & i { width: 1.2rem; }
+  i { width: 1.5rem; }
+
+  .fa-stack {
+    width: 1.9rem;
+
+    .top-icon {
+      font-size: 0.9rem;
+      padding-left: 1rem;
+      padding-top: 0.5rem;
+      text-shadow: -1.5px 0 $dark, 0 1.5px $dark, 1.5px 0 $dark, 0 -1.5px $dark;
+    }
+
+    .fa-warehouse {
+      font-size: 0.7rem;
+    }
+  }
 }

--- a/src/api/app/views/webui/project/responsive_ux/show_actions/_patchinfo.html.haml
+++ b/src/api/app/views/webui/project/responsive_ux/show_actions/_patchinfo.html.haml
@@ -1,5 +1,7 @@
 - unless has_patchinfo
   %li.nav-item
     = link_to(patchinfo_path(project: project), method: :post, class: 'nav-link', title: 'Create Patchinfo') do
-      %i.fas.fa-plus-circle.fa-lg.mr-2
+      %span.fa-stack
+        %i.fas.fa-band-aid.fa-lg.fa-stack-1x
+        %i.fas.fa-plus-circle.fa-stack-1x.top-icon
       %span.nav-item-name Create Patchinfo

--- a/src/api/app/views/webui/repositories/responsive_ux/_index_actions.html.haml
+++ b/src/api/app/views/webui/repositories/responsive_ux/_index_actions.html.haml
@@ -2,16 +2,22 @@
   - if user_can_modify
     %li.nav-item
       = link_to(repositories_distributions_path(project: project), class: 'nav-link', title: 'Add from a Distribution') do
-        %i.fas.fa-plus-circle.fa-lg.mr-2
+        %span.fa-stack
+          %i.fas.fa-plus-circle.fa-lg.fa-stack-1x
+          %i.fas.fa-boxes.fa-stack-1x.top-icon
         %span.nav-item-name Add from a Distribution
 
     %li.nav-item
       = link_to('#', data: { toggle: 'modal', target: '#add-repository-from-project' }, class: 'nav-link', title: 'Add from a Project') do
-        %i.fas.fa-plus-circle.fa-lg.mr-2
+        %span.fa-stack
+          %i.fas.fa-plus-circle.fa-lg.fa-stack-1x
+          %i.fas.fa-cubes.fa-stack-1x.top-icon
         %span.nav-item-name Add from a Project
 
   - if User.admin_session?
     %li.nav-item
       = link_to('#', data: { toggle: 'modal', target: '#add-dod-repository-modal' }, class: 'nav-link', title: 'Add DoD Repository') do
-        %i.fas.fa-plus-circle.fa-lg.mr-2
+        %span.fa-stack
+          %i.fas.fa-plus-circle.fa-lg.fa-stack-1x
+          %i.fas.fa-warehouse.fa-stack-1x.top-icon
         %span.nav-item-name Add DoD Repository

--- a/src/api/app/views/webui/shared/user_or_groups_roles/responsive_ux/_actions.html.haml
+++ b/src/api/app/views/webui/shared/user_or_groups_roles/responsive_ux/_actions.html.haml
@@ -1,9 +1,13 @@
 - content_for :actions do
   %li.nav-item
     = link_to('#', data: { toggle: 'modal', target: '#add-user-role-modal' }, id: 'add-user', class: 'nav-link', title: 'Add User') do
-      %i.fas.fa-plus-circle.fa-lg.mr-2
+      %span.fa-stack
+        %i.fas.fa-user.fa-lg.fa-stack-1x
+        %i.fas.fa-plus-circle.fa-stack-1x.top-icon
       %span.nav-item-name Add User
   %li.nav-item
     = link_to('#', data: { toggle: 'modal', target: '#add-group-role-modal' }, id: 'add-group', class: 'nav-link', title: 'Add Group') do
-      %i.fas.fa-plus-circle.fa-lg.mr-2
+      %span.fa-stack
+        %i.fas.fa-users.fa-lg.fa-stack-1x
+        %i.fas.fa-plus-circle.fa-stack-1x.top-icon
       %span.nav-item-name Add Group


### PR DESCRIPTION
In some places we have multiple add/create actions in the
collapsible sidebar. In the collapsed state, there is no
distinction between the icons. Therefore we stacked
some icons to create a little more visiual separation
between them.

Co-authored-by: Oleksandr Orlov <oorlov@suse.com>

**Patchinfo**
![Screenshot_2020-11-24 official maintenance space](https://user-images.githubusercontent.com/22001671/100095124-5270f180-2e5a-11eb-918a-1476ed159aa5.png)

**Users/Groups**
![Screenshot_2020-11-24 Open Build Service(1)](https://user-images.githubusercontent.com/22001671/100095163-5f8de080-2e5a-11eb-8832-46485c113f2c.png)

**Repositories**
![Screenshot_2020-11-24 Open Build Service](https://user-images.githubusercontent.com/22001671/100095186-66b4ee80-2e5a-11eb-840c-7c49515e40cb.png)

Should we decide to go with the proposed solution, we will add this also to our pattern library


<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
