### PR TITLE
Move the 'Add Member' action to the bottom of the group members list

### DIFF
--- a/src/api/app/views/webui/groups/_group_members.html.haml
+++ b/src/api/app/views/webui/groups/_group_members.html.haml
@@ -1,14 +1,5 @@
 - write_access = policy(group).update?
 
-- if write_access
-  - unless feature_enabled?(:responsive_ux)
-    %ul.list-inline
-      %li.list-inline-item
-        = link_to('#', class: 'nav-link', data: { toggle: 'modal', target: '#add-group-user-modal' }) do
-          %i.fas.fa-plus-circle.text-primary
-          Add Member
-  = render partial: 'add_group_user_modal', locals: { group: group }
-
 - if group.users.blank?
   %p
     This group does not have members.
@@ -37,6 +28,15 @@
                   %label.custom-control-label{ for: "maintainer_#{user.login}" }
                     Maintainer
                   %i.fas.fa-spinner.fa-spin.d-none
+
+- if write_access
+  .pt-4
+    %ul.list-inline
+      %li.list-inline-item
+        = link_to('#', class: 'nav-link', data: { toggle: 'modal', target: '#add-group-user-modal', title: 'Add Member' }) do
+          %i.fas.fa-plus-circle.text-primary
+          Add Member
+  = render partial: 'add_group_user_modal', locals: { group: group }
 
 - content_for :ready_function do
   :plain

--- a/src/api/app/views/webui/groups/show.html.haml
+++ b/src/api/app/views/webui/groups/show.html.haml
@@ -34,9 +34,6 @@
       .tab-pane.show.active#group-members{ aria: { controls: 'group-members' }, role: 'tabpanel' }
         %h3
           Group Members
-          - if policy(@group).update? && feature_enabled?(:responsive_ux)
-            = link_to('#', data: { toggle: 'modal', target: '#add-group-user-modal' }, title: 'Add Member') do
-              %i.fas.fa-xs.fa-plus-circle.text-primary
         = render(partial: 'group_members', locals: { group: @group })
 
       .tab-pane#reviews-in{ aria: { controls: 'reviews-in' }, role: 'tabpanel' }


### PR DESCRIPTION
As we're moving contextual actions close to their context, the 'Add Member'
action should go below the members list.

Here is a screenshot of how it looks:

**Before**
![2020-11-24_17-13](https://user-images.githubusercontent.com/2650/100120688-8824d300-2e78-11eb-91e7-bff969dd487a.png)

**After**
![2020-11-24_17-11](https://user-images.githubusercontent.com/2650/100120703-8d821d80-2e78-11eb-9534-8292cb235918.png)


