### PR TITLE
Change the patchinfo icon

### DIFF
--- a/src/api/app/views/webui/project/side_links/_patchinfo_present.html.haml
+++ b/src/api/app/views/webui/project/side_links/_patchinfo_present.html.haml
@@ -1,4 +1,4 @@
 %li
-  %i.fa.fa-check-circle.text-success
+  %i.fa.fa-band-aid.text-success
   = link_to(show_patchinfo_path(project, 'patchinfo')) do
     Patchinfo present


### PR DESCRIPTION
To align with our pattern library.

Before:
![patchinfo-before](https://user-images.githubusercontent.com/1102934/100210705-940da500-2f0b-11eb-8cdb-e7f453fcc92d.png)

Now:
![patchinfo-new](https://user-images.githubusercontent.com/1102934/100210708-94a63b80-2f0b-11eb-96da-203427dc5786.png)
