### PR TITLE
Move "Add Group" to the bottom of the group list

### DIFF
--- a/src/api/app/views/webui/groups/index.html.haml
+++ b/src/api/app/views/webui/groups/index.html.haml
@@ -5,9 +5,6 @@
   .card-body
     %h3
       = @pagetitle
-      - if feature_enabled?(:responsive_ux)
-        = link_to(group_new_path, title: 'Create Group') do
-          %i.fas.fa-xs.fa-plus-circle.text-primary
     %table.responsive.table.table-sm.table-bordered.table-hover.w-100#manage-groups-table
       %thead
         %tr
@@ -21,11 +18,10 @@
             %td
               = safe_join(group.users.map { |user| link_to(truncate(user.login, length: 20), user_path(user), title: user.login) }, ', ')
 
-    - unless feature_enabled?(:responsive_ux)
-      .pt-4
-        = link_to(group_new_path) do
-          %i.fas.fa-plus-circle.text-primary
-          Create Group
+    .pt-4
+      = link_to(group_new_path, title: 'Create Group') do
+        %i.fas.fa-plus-circle.text-primary
+        Create Group
 
 - content_for :ready_function do
   initializeDataTable('#manage-groups-table', { columnDefs: [{ orderable: false, searchable: false, targets: -1 }] });


### PR DESCRIPTION
We are moving the "Add Group" action next to the group list because both
elements are related, so they should be next to each other.

Here is a screenshot of how it looks:

**Before**
<img width="862" alt="Screenshot 2020-11-25 at 15 13 25" src="https://user-images.githubusercontent.com/2650/100238751-d9909900-2f30-11eb-9efd-0b99fa0eb4ad.png">


**After**
<img width="862" alt="Screenshot 2020-11-25 at 15 11 12" src="https://user-images.githubusercontent.com/2650/100238555-a221ec80-2f30-11eb-8e11-65ed5b17e2de.png">

