### PR TITLE
Move "Create User" from Manage Users tab to the bottom of the users list

### DIFF
--- a/src/api/app/views/webui/users/index.html.haml
+++ b/src/api/app/views/webui/users/index.html.haml
@@ -3,11 +3,7 @@
 .card.mb-3
   = render partial: 'webui/configuration/tabs'
   .card-body
-    %h3
-      = @pagetitle
-      - if feature_enabled?(:responsive_ux)
-        = link_to(new_user_path(pagetitle: 'create user', submit_btn_text: 'create'), title: 'Create User') do
-          %i.fas.fa-xs.fa-plus-circle.text-primary
+    %h3= @pagetitle
     %table.responsive.table.table-sm.table-bordered.table-hover#user-table{ data: { source: users_path } }
       %thead
         %tr
@@ -21,11 +17,10 @@
             Actions
       %tbody
 
-    - unless feature_enabled?(:responsive_ux)
-      .pt-4
-        = link_to(new_user_path(pagetitle: 'create user', submit_btn_text: 'create')) do
-          %i.fas.fa-plus-circle.text-primary
-          Create User
+    .pt-4
+      = link_to(new_user_path(pagetitle: 'create user', submit_btn_text: 'create', title: 'Create User')) do
+        %i.fas.fa-plus-circle.text-primary
+        Create User
 
 - content_for :ready_function do
   initializeUserConfigurationDatatable("#{::Configuration.ldap_enabled?}");


### PR DESCRIPTION
We move the "Create User" action next to the users list because both elements
are related to each other, so they should be next to each other.

Here is a screenshot of how it looks:

**Before**
<img width="714" alt="Screenshot 2020-11-25 at 15 40 09" src="https://user-images.githubusercontent.com/2650/100245499-62f79980-2f38-11eb-9d3f-d506eb8ade50.png">

**After**
<img width="851" alt="Screenshot 2020-11-25 at 16 06 45" src="https://user-images.githubusercontent.com/2650/100245524-68ed7a80-2f38-11eb-8f4f-f0f94a395dc0.png">
