### PR TITLE
Remove 'Add Attribute' action from sidebar

### DIFF
--- a/src/api/app/views/webui/attribute/index.html.haml
+++ b/src/api/app/views/webui/attribute/index.html.haml
@@ -1,7 +1,6 @@
 - @pagetitle = "Attributes of #{@package ? "#{@package} (Project #{@project})" : "Project #{@project}"}"
 - can_update_container = policy(@container).update?
-- if can_update_container && feature_enabled?(:responsive_ux)
-  = render partial: 'webui/attribute/responsive_ux/index_actions', locals: { project: @project, package: @package }
+
 .card
   = render(partial: "webui/#{@container.model_name.singular}/tabs", locals: { project: @project, package: @package })
 
@@ -39,9 +38,10 @@
       %p
         %em No attributes set
 
-    - if can_update_container && !feature_enabled?(:responsive_ux)
-      %p
-        = link_to(new_attribs_path(project: @project.name, package: @package), title: 'Add Attribute') do
-          %i.fas.fa-plus-circle.text-primary
-          Add Attribute
+    - if can_update_container
+      %ul.list-inline
+        %li.list-inline-item
+          = link_to(new_attribs_path(project: @project.name, package: @package), title: 'Add Attribute', class: 'nav-link') do
+            %i.fas.fa-plus-circle.text-primary
+            Add Attribute
     = render(partial: 'delete_dialog')

--- a/src/api/app/views/webui/attribute/responsive_ux/_index_actions.html.haml
+++ b/src/api/app/views/webui/attribute/responsive_ux/_index_actions.html.haml
@@ -1,5 +1,0 @@
-- content_for :actions do
-  %li.nav-item
-    = link_to(new_attribs_path(project: project.name, package: package), title: 'Add Attribute', class: 'nav-link') do
-      %i.fas.fa-plus-circle.fa-lg.mr-2
-      %span.nav-item-name Add Attribute

--- a/src/api/spec/features/beta/webui/attributes_spec.rb
+++ b/src/api/spec/features/beta/webui/attributes_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'Attributes', type: :feature, js: true do
         login user
 
         visit index_attribs_path(project: user.home_project_name)
-        desktop? ? click_link('Add Attribute') : click_menu_link('Actions', 'Add Attribute')
+        click_link('Add Attribute')
         find('select#attrib_attrib_type_id').select('OBS:VeryImportantProject')
         click_button('Add')
         expect(page).to have_content('Sorry, you are not authorized to create this Attrib.')

--- a/src/api/spec/features/beta/webui/projects_spec.rb
+++ b/src/api/spec/features/beta/webui/projects_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe 'Projects', type: :feature, js: true do
       visit project_show_path(project)
 
       click_link('Attributes')
-      desktop? ? click_link('Add Attribute') : click_menu_link('Actions', 'Add Attribute')
+      click_link('Add Attribute')
       select('OBS:MaintenanceProject')
       click_button('Add')
 

--- a/src/api/spec/support/features/features_attribute.rb
+++ b/src/api/spec/support/features/features_attribute.rb
@@ -1,7 +1,7 @@
 module FeaturesAttribute
   def add_attribute_with_values(package = nil)
     visit index_attribs_path(project: user.home_project_name, package: package.try(:name))
-    desktop? ? click_link('Add Attribute') : click_menu_link('Actions', 'Add Attribute')
+    click_link('Add Attribute')
     expect(page).to have_text('Add Attribute')
     find('select#attrib_attrib_type_id').select("#{attribute_type.attrib_namespace}:#{attribute_type.name}", match: :first)
     click_button('Add')


### PR DESCRIPTION
Before (responsive_ux)
![before](https://user-images.githubusercontent.com/1102934/100247065-393f7200-2f3a-11eb-83c1-cb9c317c54dc.png)

Now (responsive_ux)
![now](https://user-images.githubusercontent.com/1102934/100247071-3b093580-2f3a-11eb-9012-98452951dc33.png)

Now (without responsive_ux, nothing changed beside using an inline list instead of a paragraph)
![non-responsive-ux](https://user-images.githubusercontent.com/1102934/100247068-3a709f00-2f3a-11eb-9721-6c88fc9a9566.png)