### PR TITLE
Remove 'Create Maintenance Incident' from sidebar

### DIFF
--- a/src/api/app/views/webui/projects/maintenance_incidents/index.html.haml
+++ b/src/api/app/views/webui/projects/maintenance_incidents/index.html.haml
@@ -1,12 +1,5 @@
 - @pagetitle = 'Maintenance Incidents'
 
-- if policy(@project).create? && feature_enabled?(:responsive_ux)
-  - content_for :actions do
-    %li.nav-item
-      = link_to(project_maintenance_incidents_path(@project.name), method: :post, title: 'Create Maintenance Incident', class: 'nav-link') do
-        %i.fas.fa-lg.mr-2.fa-plus-circle
-        %span.nav-item-name Create Incident
-
 .card.mb-3
   = render partial: 'webui/project/tabs', locals: { project: @project }
   .card-body
@@ -31,13 +24,11 @@
           %th
             Release Targets
       %tbody
-    - if policy(@project).create? && !feature_enabled?(:responsive_ux)
+    - if policy(@project).create?
       .pt-4
-        %ul.list-inline
-          %li.list-inline-item
-            = link_to(project_maintenance_incidents_path(@project.name), method: :post, class: 'nav-link') do
-              %i.fas.fa-plus-circle.text-primary
-              Create Maintenance Incident
+        = link_to(project_maintenance_incidents_path(@project.name), method: :post) do
+          %i.fas.fa-plus-circle.text-primary
+          Create Maintenance Incident
 
 - content_for :ready_function do
   :plain

--- a/src/api/spec/features/beta/webui/projects_spec.rb
+++ b/src/api/spec/features/beta/webui/projects_spec.rb
@@ -148,12 +148,8 @@ RSpec.describe 'Projects', type: :feature, js: true do
 
       visit project_show_path(maintenance_project)
       click_link('Incidents')
-      if mobile?
-        within('#bottom-navigation-area') { click_link('Actions') }
-        within('#bottom-navigation-area') { click_link('Create Incident') }
-      else
-        click_link('Create Incident')
-      end
+      page.execute_script('window.scrollBy(0,50)')
+      click_link('Create Maintenance Incident')
       expect(page).to have_css('#flash', text: "Created maintenance incident project #{project.name}:maintenance_project:0")
 
       # We can not create this via the Bootstrap UI, except by adding plain XML to the meta editor


### PR DESCRIPTION
**Before (responsive_ux)**
![Screenshot_2020-11-25 Open Build Service(1)](https://user-images.githubusercontent.com/22001671/100251724-5e82af00-2f3f-11eb-9983-f1be62810743.png)

**After(responsive_ux)**
![Screenshot_2020-11-25 Open Build Service](https://user-images.githubusercontent.com/22001671/100251766-6a6e7100-2f3f-11eb-9415-81ed78619f33.png)


<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
