### PR TITLE
Move "Add Projects to Maintain" below the list of maintained projects

### DIFF
--- a/src/api/app/views/webui/projects/maintained_projects/index.html.haml
+++ b/src/api/app/views/webui/projects/maintained_projects/index.html.haml
@@ -3,13 +3,6 @@
   update_policy = policy(@project).update?
   data_source = project_maintained_projects_path(@project, :json)
 
-- if update_policy && feature_enabled?(:responsive_ux)
-  - content_for :actions do
-    %li.nav-item
-      = link_to('#', data: { toggle: 'modal', target: '#new-maintenance-project-modal' }, title: 'Add Project to Maintain', class: 'nav-link') do
-        %i.fas.fa-lg.mr-2.fa-plus-circle
-        Add Project to Maintain
-
 .card
   = render partial: 'webui/project/tabs', locals: { project: @project }
   .card-body
@@ -23,10 +16,11 @@
             %th Actions
         %tbody
 
-    - if update_policy && !feature_enabled?(:responsive_ux)
-      = link_to('#', data: { toggle: 'modal', target: '#new-maintenance-project-modal' }) do
-        %i.fas.fa-plus-circle.text-primary
-        Add Project to Maintain
+    - if update_policy
+      .pt-4
+        = link_to('#', data: { toggle: 'modal', target: '#new-maintenance-project-modal' }, title: 'Add Project to Maintain') do
+          %i.fas.fa-plus-circle.text-primary
+          Add Project to Maintain
 
 - if update_policy
   = render partial: 'delete_dialog'

--- a/src/api/spec/features/beta/webui/maintained_projects_spec.rb
+++ b/src/api/spec/features/beta/webui/maintained_projects_spec.rb
@@ -36,12 +36,7 @@ RSpec.describe 'MaintainedProjects', type: :feature, js: true do
         visit project_maintained_projects_path(project_name: maintenance_project.name)
 
         expect(page).to have_selector('#new-maintenance-project-modal', visible: :hidden)
-        if mobile?
-          within('#bottom-navigation-area') { click_link('Actions') }
-          within('#bottom-navigation-area') { click_link('Add Project to Maintain') }
-        else
-          click_link('Add Project to Maintain')
-        end
+        click_link('Add Project to Maintain')
 
         expect(page).to have_selector('#new-maintenance-project-modal', visible: :visible)
         expect(page).to have_selector('#delete-maintained-project-modal', visible: :hidden)


### PR DESCRIPTION
We move the "Add Projects to Maintain" action next to the maintained projects
because they are closely related to each other.

Here is a screenshot of how it looks:

**Before**
<img width="712" alt="Screenshot 2020-11-25 at 17 10 26" src="https://user-images.githubusercontent.com/2650/100253262-2da37980-2f41-11eb-89a4-39d47875cee4.png">


**After**
<img width="790" alt="Screenshot 2020-11-25 at 17 09 05" src="https://user-images.githubusercontent.com/2650/100253140-09e03380-2f41-11eb-8cef-66f9d210d59d.png">