### PR TITLE
Prevent potential Cross-Site Scripting in markdown rendering

### DIFF
--- a/ReleaseNotes-2.10.8
+++ b/ReleaseNotes-2.10.8
@@ -1,0 +1,18 @@
+#
+# Open Build Service 2.10.8
+#
+
+Please read the README.md file for initial installation
+instructions or use the OBS Appliance from
+
+  http://openbuildservice.org/download/
+
+The dist/README.UPDATERS file has information for people updating
+from a previous OBS release.
+
+
+Bugfixes
+========
+
+* frontend:
+  - CVE-2020-8031: Potential Cross-Site Scripting in markdown rendering.

--- a/src/api/app/helpers/webui/markdown_helper.rb
+++ b/src/api/app/helpers/webui/markdown_helper.rb
@@ -7,8 +7,6 @@ module Webui::MarkdownHelper
                                            autolink: true,
                                            no_intra_emphasis: true,
                                            fenced_code_blocks: true, disable_indented_code_blocks: true)
-    # rubocop:disable Rails/OutputSafety
-    @md_parser.render(content.to_s).html_safe
-    # rubocop:enable Rails/OutputSafety
+    ActionController::Base.helpers.sanitize(@md_parser.render(content.to_s))
   end
 end

--- a/src/api/spec/helpers/webui/markdown_helper_spec.rb
+++ b/src/api/spec/helpers/webui/markdown_helper_spec.rb
@@ -4,28 +4,28 @@ RSpec.describe Webui::MarkdownHelper do
   describe '#render_as_markdown' do
     it 'renders markdown links to html links' do
       expect(render_as_markdown('[my link](https://github.com/openSUSE/open-build-service/issues/5091)')).to eq(
-        "<p><a href='https://github.com/openSUSE/open-build-service/issues/5091'>my link</a></p>\n"
+        "<p><a href=\"https://github.com/openSUSE/open-build-service/issues/5091\">my link</a></p>\n"
       )
     end
 
     it 'adds the OBS domain to relative links' do
       expect(render_as_markdown('[my link](/here)')).to eq(
-        "<p><a href='#{::Configuration.obs_url}/here'>my link</a></p>\n"
+        "<p><a href=\"#{::Configuration.obs_url}/here\">my link</a></p>\n"
       )
     end
 
-    it 'detects all the metions to users' do
-      expect(render_as_markdown('@alfie @milo and @Admin, please review.')).to eq(
-        "<p><a href='https://unconfigured.openbuildservice.org/user/show/alfie'>@alfie</a> \
-<a href='https://unconfigured.openbuildservice.org/user/show/milo'>@milo</a> \
-and <a href='https://unconfigured.openbuildservice.org/user/show/Admin'>@Admin</a>, \
-please review.</p>\n"
+    it 'detects all the mentions to users' do
+      expect(render_as_markdown('@alfie @milo and @Admin, please review. Also you, @test1.')).to eq(
+        "<p><a href=\"https://unconfigured.openbuildservice.org/user/show/alfie\">@alfie</a> \
+<a href=\"https://unconfigured.openbuildservice.org/user/show/milo\">@milo</a> \
+and <a href=\"https://unconfigured.openbuildservice.org/user/show/Admin\">@Admin</a>, \
+please review. Also you, <a href=\"https://unconfigured.openbuildservice.org/user/show/test1\">@test1</a>.</p>\n"
       )
     end
 
     it 'does not crash due to invalid URIs' do
       expect(render_as_markdown("anbox[400000+22d000]\r\n(the number)")).to eq(
-        "<p>anbox<a href='the number'>400000+22d000</a></p>\n"
+        "<p>anbox<a href=\"the%20number\">400000+22d000</a></p>\n"
       )
     end
 
@@ -34,7 +34,9 @@ please review.</p>\n"
     end
 
     it 'does remove dangerous html from inside the links' do
-      expect(render_as_markdown('[<script></script>](https://build.opensuse.org)')).to eq("<p><a href='https://build.opensuse.org'></a></p>\n")
+      expect(render_as_markdown('[<script></script>](https://build.opensuse.org)')).to eq(
+        "<p><a href=\"https://build.opensuse.org\"></a></p>\n"
+      )
     end
   end
 end

--- a/src/api/spec/mailers/event_mailer_spec.rb
+++ b/src/api/spec/mailers/event_mailer_spec.rb
@@ -75,8 +75,8 @@ RSpec.describe EventMailer, vcr: true do
       end
 
       it 'renders links absolute' do
-        expected_html = "<p>Hey <a href='https://build.example.com/user/show/#{receiver.login}'>@#{receiver.login}</a> "
-        expected_html += "how are things? Look at <a href='https://build.example.com/project/show/apache'>bug</a> please."
+        expected_html = "<p>Hey <a href=\"https://build.example.com/user/show/#{receiver.login}\">@#{receiver.login}</a> "
+        expected_html += 'how are things? Look at <a href="https://build.example.com/project/show/apache">bug</a> please.'
         expect(mail.html_part.to_s).to include(expected_html)
       end
 
@@ -109,7 +109,7 @@ RSpec.describe EventMailer, vcr: true do
         let!(:comment) { create(:comment_project, body: "I ❤️ @#{vip.login}!") }
 
         it { expect(mail.text_part.body.encoded).to include("I ❤️ [@#{vip.login}](https://build.example.com/user/show/") }
-        it { expect(mail.html_part.to_s).to include("I =E2=9D=A4=EF=B8=8F <a href=3D'https://build.example.com/user/sh=\now/#{vip.login}'>@#{vip.login}</a>") }
+        it { expect(mail.html_part.to_s).to include("I =E2=9D=A4=EF=B8=8F <a href=3D\"https://build.example.com/user/sh=\now/#{vip.login}\">@#{vip.login}</a>") }
       end
     end
   end


### PR DESCRIPTION
Displaying the user input in a comment is now safer, using sanitize helper to prevent potential Cross-Site Scripting.
Tests are adapted accordingly.

Added Release Notes for 2.10.8.

This PR is an adaptation of: https://github.com/openSUSE/open-build-service/commit/ae51b7cd507954b41ace6b2688b856e63d12e33a
