### PR TITLE
Fix strange behaviour in image tabs

### DIFF
--- a/src/api/app/assets/javascripts/webui/kiwi_editor.js
+++ b/src/api/app/assets/javascripts/webui/kiwi_editor.js
@@ -325,6 +325,7 @@ function initializeTabs() { // jshint ignore:line
   $("#kiwi-details-trigger").click(function() {
     $("#kiwi-preferences").removeClass('d-none');
     $(".detailed-info").removeClass('d-none');
+    $("#link-edit-details").removeClass('d-none');
     $("#kiwi-image-profiles-section").addClass('d-none');
     $("#kiwi-image-repositories-section").addClass('d-none');
     $("#kiwi-image-packages-section").addClass('d-none');
@@ -338,6 +339,7 @@ function initializeTabs() { // jshint ignore:line
     $("#kiwi-image-packages-section").removeClass('d-none');
     $("#kiwi-preferences").addClass('d-none');
     $(".detailed-info").addClass('d-none');
+    $("#link-edit-details").addClass('d-none');
     $("#kiwi-software-trigger").addClass("active");
     $("#kiwi-details-trigger").removeClass("active");
   });

--- a/src/api/app/assets/javascripts/webui/kiwi_editor.js
+++ b/src/api/app/assets/javascripts/webui/kiwi_editor.js
@@ -323,7 +323,6 @@ function kiwiRepositoriesSetupAutocomplete(fields) {
 
 function initializeTabs() { // jshint ignore:line
   $("#kiwi-details-trigger").click(function() {
-    $("#kiwi-image-details-section").removeClass('d-none');
     $("#kiwi-preferences").removeClass('d-none');
     $(".detailed-info").removeClass('d-none');
     $("#kiwi-image-profiles-section").addClass('d-none');
@@ -339,7 +338,6 @@ function initializeTabs() { // jshint ignore:line
     $("#kiwi-image-packages-section").removeClass('d-none');
     $("#kiwi-preferences").addClass('d-none');
     $(".detailed-info").addClass('d-none');
-    $("#kiwi-image-details-section").addClass('d-none');
     $("#kiwi-software-trigger").addClass("active");
     $("#kiwi-details-trigger").removeClass("active");
   });

--- a/src/api/app/views/webui/kiwi/images/_base_info.html.haml
+++ b/src/api/app/views/webui/kiwi/images/_base_info.html.haml
@@ -1,17 +1,15 @@
 #kiwi-description
   .nested-fields
-    %h2#image-name
-      = image.name
-    %p.detailed-info{ class: "#{'d-none' if is_edit_software_action}" }
-      %span.fill{ data: { tag: 'specification' } }
-        = description
-    %ul.list-inline{ class: "#{'d-none' unless is_edit_details_action}" }
-      %li.list-inline-item
-        %strong Author:
-        %span.fill{ data: { tag: 'author' } }= author
-      %li.list-inline-item
-        %strong Contact:
-        %span.fill{ data: { tag: 'contact' } }= contact
+    %h2#image-name= image.name
+    %p.fill{ data: { tag: 'specification' } }= description
+    .detailed-info{ class: "#{'d-none' unless is_edit_details_action}" }
+      %ul.list-inline
+        %li.list-inline-item
+          %strong Author:
+          %span.fill{ data: { tag: 'author' } }= author
+        %li.list-inline-item
+          %strong Contact:
+          %span.fill{ data: { tag: 'contact' } }= contact
     - if feature_enabled?(:responsive_ux)
       = render partial: 'webui/kiwi/images/responsive_ux/actions',
                locals: { package: package, is_edit_details_action: is_edit_details_action }

--- a/src/api/app/views/webui/kiwi/images/responsive_ux/_actions.html.haml
+++ b/src/api/app/views/webui/kiwi/images/responsive_ux/_actions.html.haml
@@ -3,7 +3,7 @@
     = link_to(package_show_path(package.project, package), class: 'nav-link', title: 'View Package') do
       %i.fa.fa-archive.fa-lg.mr-2
       %span.nav-item-name View Package
-  %li.nav-item{ class: "#{'d-none' unless is_edit_details_action}" }
+  %li.nav-item#link-edit-details{ class: "#{'d-none' unless is_edit_details_action}" }
     = link_to('#', class: 'nav-link', data: { 'target': '#description-edit', 'toggle': 'modal' }, title: 'Edit Details') do
       %i.fa.fa-edit.fa-lg.mr-2
       %span.nav-item-name Edit Details


### PR DESCRIPTION
Fixes an strange behaviour of showing different description elements. This happened not when the Details section was accessed directly with an URL, but when it was accessed clicking in the Details tab after clicking the Software tab.

Now this behaviour is assured:
- Show always the description (specification) of an image.
- Show Author and Contact fields only in Details tab.