### PR TITLE
[dist] changed required service name from mysql to mariadb

### DIFF
--- a/dist/t/0060-check_required_services.ts
+++ b/dist/t/0060-check_required_services.ts
@@ -8,13 +8,13 @@ my $tests    = 14;
 my $max_wait = 300;
 
 my @daemons = qw/obsdispatcher.service  obspublisher.service    obsrepserver.service
-                 obsscheduler.service   obssrcserver.service    /;
+                 obsscheduler.service   obssrcserver.service    mariadb.service/;
 
 my $os = get_distribution();
 if ($os eq "suse") {
-  push @daemons, "apache2.service", "mysql.service";
+  push @daemons, "apache2.service";
 } elsif ($os eq 'rh') {
-  push @daemons, "httpd.service", "mariadb.service";
+  push @daemons, "httpd.service";
 } else {
   die "Could not determine distribution!\n";
 }


### PR DESCRIPTION
new version of systemd on Tumbleweed returns "alias" instead of "enabled" when running "systemctl is-enabled mysql.service
