### PR TITLE
[backend] global timeout for services

### DIFF
--- a/src/backend/bs_service
+++ b/src/backend/bs_service
@@ -116,7 +116,10 @@ sub rm_rf {
 }
 
 sub run_source_update {
-  my ($cgi, $projid, $packid) = @_;
+  my ($cgi, $projid, $packid, $timeout) = @_;
+
+  # just as fallback for older servicedispatchers
+  $timeout ||= $BSConfig::service_timeout;
 
   # chdir into a clean temp directory
   my $myworkdir = "$tempdir/$$";
@@ -199,10 +202,9 @@ sub run_source_update {
 	die "500 timeout while execution of $name\n";
       };
 
-      # Wait $BSConfig::service_timeout or per default 7200 sec (2 hours) for
-      # service to finish
-      BSUtil::printlog("Waiting $BSConfig::service_timeout for service($child_pid) to finish\n") if $verbose;
-      alarm($BSConfig::service_timeout);
+      # Wait given timeout or $BSConfig::service_timeout for service to finish
+      BSUtil::printlog("Waiting $timeout for service($child_pid) to finish\n") if $verbose;
+      alarm($timeout);
 
       # collect output
       my $output = '';
@@ -305,7 +307,7 @@ my $dispatches = [
 
   '/service' => \&list_service,
   '/serverstatus' => \&BSStdServer::serverstatus,
-  '!- POST:/sourceupdate/$project/$package' => \&run_source_update,
+  '!- POST:/sourceupdate/$project/$package $timeout:num?' => \&run_source_update,
   # configuration
   'PUT:/configuration' => \&putconfiguration,
 ];

--- a/src/backend/bs_servicedispatch
+++ b/src/backend/bs_servicedispatch
@@ -96,7 +96,7 @@ sub getrev {
 sub runservice {
   my ($projid, $packid, $servicemark, $srcmd5, $revid, $lxservicemd5, $projectservicesmd5, $oldsrcmd5) = @_;
 
-  BSUtil::printlog("dispatching service $projid/$packid $servicemark $srcmd5");
+  BSUtil::printlog("dispatching service (timeout: $BSConfig::service_timeout) $projid/$packid $servicemark $srcmd5");
   # get revision and file list
   my $rev;
   if ($revid) {
@@ -153,7 +153,7 @@ sub runservice {
       'timeout'   => $BSConfig::service_timeout,
       'withmd5'   => 1,
       'receiver' => \&BSHTTP::cpio_receiver,
-    }, undef);
+    }, undef, "timeout=$BSConfig::service_timeout");
   };
   my $error = $@;
 


### PR DESCRIPTION
This patch ensures that the BSConfig::service_timeout confiured on the
src_server is also used by servicedispatcher and service server.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
