### PR TITLE
[api] fix place sourcediff in request diffing

### DIFF
--- a/src/api/app/controllers/request_controller.rb
+++ b/src/api/app/controllers/request_controller.rb
@@ -187,7 +187,7 @@ class RequestController < ApplicationController
         builder = Nokogiri::XML::Builder.new
         action.render_xml(builder)
         xml_request.add_child(builder.doc.root.to_xml)
-        xml_request.at_css('action').add_child(action_diff)
+        xml_request.at_xpath("//request/action[last()]").add_child(action_diff)
       else
         diff_text += action_diff
       end

--- a/src/api/app/controllers/request_controller.rb
+++ b/src/api/app/controllers/request_controller.rb
@@ -187,7 +187,7 @@ class RequestController < ApplicationController
         builder = Nokogiri::XML::Builder.new
         action.render_xml(builder)
         xml_request.add_child(builder.doc.root.to_xml)
-        xml_request.at_xpath("//request/action[last()]").add_child(action_diff)
+        xml_request.at_xpath('//request/action[last()]').add_child(action_diff)
       else
         diff_text += action_diff
       end

--- a/src/api/test/functional/maintenance_test.rb
+++ b/src/api/test/functional/maintenance_test.rb
@@ -510,6 +510,13 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     assert_xml_tag tag: 'old', attributes:  { package: 'pack2.linked' }
     assert_match(/-&lt;link package="pack2"/, @response.body)
     assert_match(/\+&lt;link package="pack2.ServicePack_Update"/, @response.body)
+    # two seperate sourcediffs in each action included
+    assert_xml_tag child: { tag: 'old', attributes: { project: 'ServicePack:Update', package: 'pack2' } },
+                   sibling: { tag: 'target', attributes: { project: 'ServicePack:Update', package: 'pack2.100' } },
+                   tag: 'sourcediff'
+    assert_xml_tag child: { tag: 'old', attributes: { project: 'ServicePack:Update', package: 'pack2.linked' } },
+                   sibling: { tag: 'target', attributes: { project: 'ServicePack:Update', package: 'pack2.linked.100' } },
+                   tag: 'sourcediff'
 
     # revoke to unlock the source
     post "/request/#{reqid}?cmd=changestate&newstate=revoked"


### PR DESCRIPTION
The sourcediff need to be part of the action where they belong to.

Not only the very fist action item.

(jsc#OBS-71)

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
