### PR TITLE
[backend] repserver: also log the build type of finished jobs

### DIFF
--- a/src/api/app/models/event/build.rb
+++ b/src/api/app/models/event/build.rb
@@ -3,7 +3,7 @@ module Event
     self.description = 'Package has finished building'
     self.abstract_class = true
     payload_keys :project, :package, :sender, :repository, :arch, :release, :readytime, :srcmd5,
-                 :rev, :reason, :bcnt, :verifymd5, :hostarch, :starttime, :endtime, :workerid, :versrel, :previouslyfailed, :successive_failcount
+                 :rev, :reason, :bcnt, :verifymd5, :hostarch, :starttime, :endtime, :workerid, :versrel, :previouslyfailed, :successive_failcount, :buildtype
 
     def custom_headers
       mid = my_message_id

--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -81,7 +81,6 @@ use BSRepServer::Registry;
 use BSRepServer::YMP;
 use BSDispatcher::Constraints;
 use BSCando;
-use Build;
 
 # configure Build module for buildinfo queries
 $Build::Rpm::unfilteredprereqs = 1 if defined $Build::Rpm::unfilteredprereqs;
@@ -2152,7 +2151,12 @@ sub notify_jobresult {
   $ninfo{'endtime'} = $jobstatus->{'endtime'};
   $ninfo{'workerid'} = $jobstatus->{'workerid'};
   $ninfo{'previouslyfailed'} = 1 if -e "$reporoot/$prpa/:logfiles.fail/$info->{'package'}";
-  print "job statistics: $job $prpa $jobstatus->{'result'} $ninfo{'readytime'}-$ninfo{'starttime'}-$ninfo{'endtime'} $jobstatus->{'workerid'}\n";
+  # calculate buildtype for the job statistics
+  my $buildtype;
+  $buildtype = $1 if $info->{'file'} =~ /\.(spec|dsc|kiwi|livebuild)$/;
+  $buildtype ||= Build::recipe2buildtype($info->{'file'}) || 'unknown';
+  $buildtype = $info->{'imagetype'} && ($info->{'imagetype'}->[0] || '') eq 'product' ? 'kiwi-product' : 'kiwi-image' if $buildtype eq 'kiwi';
+  print "job statistics: $job $prpa $jobstatus->{'result'} $ninfo{'readytime'}-$ninfo{'starttime'}-$ninfo{'endtime'} $jobstatus->{'workerid'} $buildtype\n";
   if ($jobstatus->{'result'} eq 'unchanged') {
     BSNotify::notify('BUILD_UNCHANGED', \%ninfo);
   } elsif ($jobstatus->{'result'} eq 'succeeded') {


### PR DESCRIPTION
<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
