### PR TITLE
Remove no longer needed Rails.cache 'shared' option

### DIFF
--- a/src/api/app/services/monitor_controller_service/status_history_fetcher.rb
+++ b/src/api/app/services/monitor_controller_service/status_history_fetcher.rb
@@ -6,7 +6,7 @@ module MonitorControllerService
     end
 
     def call
-      Rails.cache.fetch(custom_cache_key, expires_in: (@range.to_i * 3600) / 150, shared: true) do
+      Rails.cache.fetch(custom_cache_key, expires_in: (@range.to_i * 3600) / 150) do
         status_history
       end
     end


### PR DESCRIPTION
The 'shared' option for Rails.cache was introduced in 8d02d03c with the DomainCacheStore definition, but in f5435b14 that definition was removed. So the 'shared' option cannot be used any longer.