### PR TITLE
[backend] mergeconstraints: implement sandbox merging

### DIFF
--- a/src/backend/BSDispatcher/Constraints.pm
+++ b/src/backend/BSDispatcher/Constraints.pm
@@ -122,6 +122,22 @@ sub oracle {
   return 1;
 }
 
+=head2 mergeconstraints_sandbox - merge two sandbox constraints
+
+=cut
+
+sub mergeconstraints_sandbox {
+  my ($sb, $sb2) = @_;
+  return $sb unless $sb2 && $sb2->{'_content'};
+  return $sb2 unless $sb && $sb->{'_content'};
+  my $ex = $sb->{'exclude'} && $sb->{'exclude'} eq 'true' ? 1 : 0;
+  my $ex2 = $sb2->{'exclude'} && $sb2->{'exclude'} eq 'true' ? 1 : 0;
+  return $sb2 if $ex == $ex2;		# overwrite if both are of same type
+  ($sb, $sb2) = ($sb2, $sb) if $ex;	# include+exclude. bring include to front
+  return { '_content' => 'cannot_merge_sandbox' } if ($sb->{'_content'} eq 'secure' && $secure_sandboxes{$sb2->{'_content'}}) || $sb->{'_content'} eq $sb2->{'_content'};
+  return $sb;
+}
+
 =head2 mergeconstraints - merge two constraint files
 
   and return the merged constraints
@@ -137,7 +153,7 @@ sub mergeconstraints {
       $con->{'hostlabel'} = [ @{$con->{'hostlabel'} || []},  @{$con2->{'hostlabel'}} ];
     }
     if ($con2->{'sandbox'}) {
-      $con->{'sandbox'} = $con2->{'sandbox'};
+      $con->{'sandbox'} = mergeconstraints_sandbox($con->{'sandbox'}, $con2->{'sandbox'});
     }
     if ($con2->{'linux'}) {
       $con->{'linux'}->{'flavor'} = $con2->{'linux'}->{'flavor'} if $con2->{'linux'}->{'flavor'};

--- a/src/backend/testdata/test_dispatcher
+++ b/src/backend/testdata/test_dispatcher
@@ -125,8 +125,7 @@ td sandbox16 true  "kernel" i586 large  ""  enforce_kvm
 # combined constraints for sandbox
 td sandbox21 false "kernel" i586 small  sandbox         enforce_kvm
 td sandbox22 false "kernel" i586 small  sandbox_secure  enforce_kvm
-# package constraints are more important here
-td sandbox23 true  "kernel" i586 medium sandbox         enforce_kvm
+td sandbox23 false "kernel" i586 medium sandbox         enforce_kvm
 td sandbox24 true  "kernel" i586 medium sandbox_secure  enforce_kvm
 td sandbox25 true  "kernel" i586 large  sandbox         enforce_kvm
 td sandbox26 true  "kernel" i586 large  sandbox_secure  enforce_kvm


### PR DESCRIPTION
We try do something intelligent if we need to merge an include
and an exclude.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
