### PR TITLE
Fix system status graphic in main page, again

### DIFF
--- a/src/api/app/controllers/webui/main_controller.rb
+++ b/src/api/app/controllers/webui/main_controller.rb
@@ -32,8 +32,8 @@ class Webui::MainController < Webui::WebuiController
   def gather_busy
     busy = []
     starttime = (Time.now.utc - 7.days).to_i
-    Architecture.available.select(:name).distinct.each do |arch|
-      rel = StatusHistory.where("time >= ? AND \`key\` = ?", starttime, 'building_' + arch.worker)
+    Architecture.available.map(&:worker).uniq.each do |arch|
+      rel = StatusHistory.where("time >= ? AND \`key\` = ?", starttime, 'building_' + arch)
       values = rel.pluck(:time, :value).collect { |time, value| [time.to_i, value.to_f] }
       values = StatusHelper.resample(values, 400)
       busy = if busy.empty?

--- a/src/api/app/controllers/webui/main_controller.rb
+++ b/src/api/app/controllers/webui/main_controller.rb
@@ -36,7 +36,11 @@ class Webui::MainController < Webui::WebuiController
       rel = StatusHistory.where("time >= ? AND \`key\` = ?", starttime, 'building_' + arch.worker)
       values = rel.pluck(:time, :value).collect { |time, value| [time.to_i, value.to_f] }
       values = StatusHelper.resample(values, 400)
-      busy = busy.empty? ? values : add_arrays(busy, values)
+      busy = if busy.empty?
+               values
+             elsif values.present?
+               add_arrays(busy, values)
+             end
     end
     busy
   end


### PR DESCRIPTION
Add missing section of reverting changes of 1bde603. The method `add_arrays` should not be called if one of the arrays is empty. This can happen when there aren't any workers defined for a certain architecture.

Also revert a refactoring in the architecture loop, in the same commit, preventing a duplication of the data retrieved for architectures that return the same value for the `Architecture#worker` method (for example: `x86_64` and `i586`).

Fixes #10517, again.