### PR TITLE
[dist] drop rpath from mysql2.so and move operations to install

### DIFF
--- a/dist/obs-bundled-gems.spec
+++ b/dist/obs-bundled-gems.spec
@@ -43,6 +43,7 @@ BuildRequires:  openldap2-devel
 BuildRequires:  python-devel
 BuildRequires:  ruby2.5-devel
 BuildRequires:  rubygem(ruby:2.5.0:bundler)
+BuildRequires:  chrpath
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 
@@ -94,14 +95,18 @@ EOF
 
 cp %{S:0} %{S:1} .
 
-%build
 # copy gem files into cache
 mkdir -p vendor/cache
 cp %{_sourcedir}/vendor/cache/*.gem vendor/cache
+
+%build
+# emtpy since bundle does not decouple compile and install
+
+%install
+# all operations here since bundle does not decouple compile and install
 export GEM_HOME=~/.gems
 bundle config build.nokogiri --use-system-libraries
 
-%install
 bundle --local --path %{buildroot}%_libdir/obs-api/
 
 # test that the rake and rack macros is still matching our Gemfile
@@ -144,6 +149,10 @@ done
 find %{buildroot} -type f -print0 | xargs -0 grep -l /usr/bin/env | while read file; do
   chmod a-x $file
 done
+
+# remove the rpath entry from the shared lib in the mysql2 rubygem
+chrpath -d %{buildroot}%_libdir/obs-api/ruby/*/extensions/*/*/mysql2-*/mysql2/mysql2.so || true
+chrpath -d %{buildroot}%_libdir/obs-api/ruby/*/gems/mysql2-*/lib/mysql2/mysql2.so || true
 
 %files
 %_libdir/obs-api


### PR DESCRIPTION
After applying the changes to introduce the new minor release 2.10.8, we realized these changes introduced by Rüdiger Oertel are also necessary.

> Rework obs-bundled-gems.spec to do all compile and install in the install section of the specfile as future rpm versions
> will clean buildroot at the start of the install section and bundle does not properly decouple compile and install section.

Adaptation of 086e86379 by Rüdiger Oertel <ro@suse.de>. In the current version, we also needed to require `chrpath` for openSUSE 15.2.

Co-authored-by: Daniel Donisa <daniel.donisa@suse.com>
