### PR TITLE
Capture exceptions and send them to errbit

### DIFF
--- a/src/api/config/clock.rb
+++ b/src/api/config/clock.rb
@@ -4,6 +4,10 @@ require File.dirname(__FILE__) + '/environment'
 require 'clockwork'
 
 module Clockwork
+  error_handler do |error|
+    Airbrake.notify(error)
+  end
+
   on(:before_run) do |event|
     InfluxDB::Rails.current.tags = {
       interface: :clock,


### PR DESCRIPTION
We send all exceptions happening in the application to errbit. But we forgot to
capture exception in the Clockworkd service, and any exception not explicitly
handled is logged into the clockword.log only.

Fixes #10523 
