### PR TITLE
Use goarch instead of the scheduler arch when collecting containers

### DIFF
--- a/src/backend/BSPublisher/Container.pm
+++ b/src/backend/BSPublisher/Container.pm
@@ -196,15 +196,17 @@ sub upload_all_containers {
     for my $p (sort keys %$containers) {
       my $containerinfo = $containers->{$p};
       my $arch = $containerinfo->{'arch'};
+      my $goarch = $containerinfo->{'goarch'};
+      $goarch .= ":$containerinfo->{'govariant'}" if $containerinfo->{'govariant'};
       my @tags = $mapper->($registry, $containerinfo, $projid, $repoid, $arch);
       for my $tag (@tags) {
 	my ($reponame, $repotag) = ($tag, 'latest');
 	($reponame, $repotag) = ($1, $2) if $tag =~ /^(.*):([^:\/]+)$/;
-	if ($uploads{$reponame}->{$repotag}->{$arch}) {
-	  my $otherinfo = $containers->{$uploads{$reponame}->{$repotag}->{$arch}};
+	if ($uploads{$reponame}->{$repotag}->{$goarch}) {
+	  my $otherinfo = $containers->{$uploads{$reponame}->{$repotag}->{$goarch}};
 	  next if cmp_containerinfo($otherinfo, $containerinfo) > 0;
 	}
-	$uploads{$reponame}->{$repotag}->{$arch} = $p;
+	$uploads{$reponame}->{$repotag}->{$goarch} = $p;
       }
     }
 

--- a/src/backend/BSPublisher/Registry.pm
+++ b/src/backend/BSPublisher/Registry.pm
@@ -450,6 +450,7 @@ sub push_containers {
       next;
     }
     my $multiarchtag = $multiarch;
+    $multiarchtag = 1 if @{$tags->{$tag}} > 1;
     $multiarchtag = 0 if @{$tags->{$tag}} == 1 && ($tags->{$tag}->[0]->{'type'} || '') eq 'helm';
     die("must use multiarch if multiple containers are to be pushed\n") if @{$tags->{$tag}} > 1 && !$multiarchtag;
     my %multiplatforms;


### PR DESCRIPTION
<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
