### PR TITLE
Add role removal rake task

### DIFF
--- a/src/api/lib/tasks/make_user_an_admin.rake
+++ b/src/api/lib/tasks/make_user_an_admin.rake
@@ -1,20 +1,32 @@
-namespace :user do
-  desc 'Give admin permissions to existing user'
-  task give_admin_rights: :environment do
-    login = ARGV[1]
+require 'tasks/user_admin_rights'
 
-    user = User.where(login: login).first
-    if user
-      if user.roles.exists?(title: 'Admin')
-        puts "Nothing to do here. User '#{user.login}' already is an admin."
-      else
-        puts "Making user '#{login}' an admin"
-        user.roles << Role.global.where(title: 'Admin').first
+class MakeUserAnAdminTask
+  # See https://supergood.software/dont-step-on-a-rake/
+  include Rake::DSL
+
+  attr_reader :user
+
+  def initialize
+    namespace(:user) do
+      desc 'Give admin permissions to existing user'
+      task toggle_admin_rights: :environment do
+        login = ARGV[1]
+
+        user = User.where(login: login).first
+
+        UserAdminRights.new(user).toggle!
+
+        admin_rights = user.is_admin? ? 'has' : 'does not have'
+
+        puts "User '#{login}' #{admin_rights} admin rights from now on"
+
+        exit
+      rescue NotFoundError
+        abort("User '#{login}' does not exist. Aborting.")
       end
-    else
-      puts "Couldn't find user '#{login}'"
     end
-
-    exit
   end
 end
+
+# Instantiate the class to define the task
+MakeUserAnAdminTask.new

--- a/src/api/lib/tasks/user_admin_rights.rb
+++ b/src/api/lib/tasks/user_admin_rights.rb
@@ -1,0 +1,25 @@
+class UserAdminRights
+  attr_reader :user
+
+  def initialize(user)
+    @user = user
+  end
+
+  def toggle!
+    raise NotFoundError unless user
+
+    if user.roles.exists?(title: 'Admin')
+      RolesUser.where(user: user, role: admin_role).first.destroy
+    else
+      user.roles << admin_role
+    end
+
+    user
+  end
+
+  private
+
+  def admin_role
+    Role.global.where(title: 'Admin').first
+  end
+end

--- a/src/api/spec/lib/tasks/user_admin_rights_spec.rb
+++ b/src/api/spec/lib/tasks/user_admin_rights_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+require 'tasks/user_admin_rights'
+
+RSpec.describe UserAdminRights do
+  let(:user) { create(:confirmed_user) }
+  let(:admin_role) { Role.global.where(title: 'Admin').first }
+
+  subject do
+    UserAdminRights.new(user).toggle!
+  end
+
+  context 'when user has no admin rights' do
+    it 'grants the admin rights' do
+      expect(subject.roles).to contain_exactly(admin_role)
+    end
+  end
+
+  context 'when the user already has admin rights' do
+    before do
+      user.roles << admin_role
+    end
+
+    it 'removes the admin rights' do
+      expect(subject.reload.roles).to be_empty
+    end
+  end
+
+  context 'when there is no user' do
+    let(:user) { nil }
+
+    it 'fails with an error' do
+      expect { subject.roles }.to raise_error(NotFoundError)
+    end
+  end
+end


### PR DESCRIPTION
In order to avoid repeating some mistakes made previously when dealing with data
on production, we've automated the process of granting and removing admin rights
to some specific user.

Fixes #10524

