### PR TITLE
[api] raise a proper error on missconfigured update project

### DIFF
--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -531,7 +531,11 @@ class Project < ApplicationRecord
   def update_instance(namespace = 'OBS', name = 'UpdateProject')
     # check if a newer instance exists in a defined update project
     a = find_attribute(namespace, name)
-    return Project.find_by_name(a.values[0].value) if a && a.values[0]
+    if a && a.values[0]
+      update_instance = Project.find_by_name(a.values[0].value)
+      return update_instance if update_instance
+      raise Project::Errors::UnknownObjectError, "Update project configured in #{name} but not found: #{a.values[0].value}"
+    end
 
     self
   end

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -534,7 +534,7 @@ class Project < ApplicationRecord
     if a && a.values[0]
       update_instance = Project.find_by_name(a.values[0].value)
       return update_instance if update_instance
-      
+
       raise Project::Errors::UnknownObjectError, "Update project configured in #{name} but not found: #{a.values[0].value}"
     end
 

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -534,6 +534,7 @@ class Project < ApplicationRecord
     if a && a.values[0]
       update_instance = Project.find_by_name(a.values[0].value)
       return update_instance if update_instance
+      
       raise Project::Errors::UnknownObjectError, "Update project configured in #{name} but not found: #{a.values[0].value}"
     end
 


### PR DESCRIPTION
raise a proper error (not just crash with 500) when an update project
got configured, but does not exist.

Fixes #10116.