### PR TITLE
[api] allow to disable entire channels

### DIFF
--- a/docs/api/api/channel.rng
+++ b/docs/api/api/channel.rng
@@ -9,6 +9,14 @@
 
   <define ns="" name="channel-element">
     <element name="channel">
+      <optional>
+        <element ns="" name="disabled">
+          <empty/>
+          <a:documentation>
+             For disabling the entire channel. The channel source won't be branched by default
+          </a:documentation>
+        </element>
+      </optional>
       <zeroOrMore>
         <ref name="channel-product-element"/>
       </zeroOrMore>
@@ -42,6 +50,9 @@
        <optional>
          <element ns="" name="disabled">
            <empty/>
+           <a:documentation>
+              For disabling the repository. The channel source will be branched but not build enabled by default
+           </a:documentation>
          </element>
        </optional>
      </element>

--- a/src/api/app/models/channel.rb
+++ b/src/api/app/models/channel.rb
@@ -42,6 +42,7 @@ class Channel < ApplicationRecord
   def update_from_xml(xmlhash)
     xmlhash = Xmlhash.parse(xmlhash) if xmlhash.is_a?(String)
 
+    self.disabled = xmlhash.key?('disabled')
     _update_from_xml_targets(xmlhash)
     _update_from_xml_binary_lists(xmlhash)
 
@@ -90,6 +91,8 @@ class Channel < ApplicationRecord
   end
 
   def is_active?
+    return false if disabled
+
     # no targets defined, the project has some
     return true if channel_targets.size.zero?
 
@@ -186,6 +189,7 @@ end
 # Table name: channels
 #
 #  id         :integer          not null, primary key
+#  disabled   :boolean
 #  package_id :integer          not null, indexed
 #
 # Indexes

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -1385,6 +1385,9 @@ class Package < ApplicationRecord
   end
 
   def _add_channel(mode, channel_binary, message)
+    # set to disabled
+    return if channel_binary.channel_binary_list.channel.disabled
+
     # add source container
     return if mode == :skip_disabled && !channel_binary.channel_binary_list.channel.is_active?
 

--- a/src/api/db/migrate/20201209105103_add_channel_disable_flag.rb
+++ b/src/api/db/migrate/20201209105103_add_channel_disable_flag.rb
@@ -1,0 +1,5 @@
+class AddChannelDisableFlag < ActiveRecord::Migration[6.0]
+  def change
+    add_column :channels, :disabled, :boolean
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_14_105103) do
+ActiveRecord::Schema.define(version: 2020_12_09_105103) do
 
   create_table "architectures", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false, collation: "utf8_general_ci"
@@ -257,6 +257,7 @@ ActiveRecord::Schema.define(version: 2020_10_14_105103) do
 
   create_table "channels", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "package_id", null: false
+    t.boolean "disabled"
     t.index ["package_id"], name: "index_unique", unique: true
   end
 


### PR DESCRIPTION
this disables the entire branching and not just skips repository
creation

_Replace this line with a description of your changes. Please follow the suggestions in the comment below._

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
