### PR TITLE
Add job to delay the published repositories cleanup

### DIFF
--- a/src/api/app/jobs/published_repositories_cleanup_job.rb
+++ b/src/api/app/jobs/published_repositories_cleanup_job.rb
@@ -1,0 +1,6 @@
+class PublishedRepositoriesCleanupJob < ApplicationJob
+  def perform(source_project_name)
+    # cleanup published binaries to save disk space on ftp server and mirrors
+    Backend::Api::Build::Project.wipe_published_locked(source_project_name)
+  end
+end

--- a/src/api/config/options.yml.example
+++ b/src/api/config/options.yml.example
@@ -204,6 +204,10 @@ default: &default
   #   icon: sponsor_abc
   #   url: https://www.example.com
 
+  # Lifetime for repositories published after accepting maintenance release requests.
+  # Default: 2 days (172800 seconds).
+  # maintenance_release_repositories_lifetime: 172800
+
 production:
   <<: *default
 

--- a/src/api/test/functional/maintenance_test.rb
+++ b/src/api/test/functional/maintenance_test.rb
@@ -901,6 +901,10 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
   end
 
   def test_create_maintenance_project_and_release_packages
+    # FIXME: https://github.com/rails/rails/issues/37270
+    (ActiveJob::Base.descendants << ActiveJob::Base).each(&:disable_test_adapter)
+    ActiveJob::Base.queue_adapter = :inline
+
     # Backup
     system("for i in #{Rails.root}/tmp/backend_data/projects/BaseDistro2.0.pkg/*.rev; do cp $i $i.backup; done")
     # the birthday of J.K.
@@ -1471,7 +1475,7 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     run_scheduler('i586')
     run_scheduler('x86_64')
     run_publisher
-    # published binaries from incident got removed?
+    # Check that the job removed the published binaries
     get "/published/#{incident_project}/BaseDistro3/i586/package-1.0-1.i586.rpm"
     assert_response 404
     get "/published/#{incident_project}/BaseDistro2.0_LinkedUpdateProject/x86_64/package-1.0-1.x86_64.rpm"


### PR DESCRIPTION
After accepting maintenance release requests, the corresponding published repositories were removed inmediately. This broke some automated maintenance tests because the repositories were removed before the tests finished.

We have moved the cleanup to a delayed job, so the repositories will be removed some specific time after they are published.

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature
