### PR TITLE
Adds a unique index on the name column on the status_checks table

### DIFF
--- a/src/api/app/models/status/check.rb
+++ b/src/api/app/models/status/check.rb
@@ -59,17 +59,18 @@ end
 # Table name: status_checks
 #
 #  id                :integer          not null, primary key
-#  name              :string(255)
+#  name              :string(255)      indexed => [status_reports_id]
 #  short_description :string(255)
 #  state             :string(255)
 #  url               :string(255)
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
-#  status_reports_id :integer          indexed
+#  status_reports_id :integer          indexed => [name], indexed
 #
 # Indexes
 #
-#  index_status_checks_on_status_reports_id  (status_reports_id)
+#  index_status_checks_on_name_and_status_reports_id  (name,status_reports_id) UNIQUE
+#  index_status_checks_on_status_reports_id           (status_reports_id)
 #
 # Foreign Keys
 #

--- a/src/api/db/migrate/20201210165142_add_unique_index_name_to_status_checks_table.rb
+++ b/src/api/db/migrate/20201210165142_add_unique_index_name_to_status_checks_table.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexNameToStatusChecksTable < ActiveRecord::Migration[6.0]
+  def change
+    add_index :status_checks, [:name, :status_reports_id], unique: true
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_09_105103) do
+ActiveRecord::Schema.define(version: 2020_12_10_165142) do
 
   create_table "architectures", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false, collation: "utf8_general_ci"
@@ -962,6 +962,7 @@ ActiveRecord::Schema.define(version: 2020_12_09_105103) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "status_reports_id"
+    t.index ["name", "status_reports_id"], name: "index_status_checks_on_name_and_status_reports_id", unique: true
     t.index ["status_reports_id"], name: "index_status_checks_on_status_reports_id"
   end
 


### PR DESCRIPTION
This PR addresses the [cop regarding an unique index missing](https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsuniquevalidationwithoutindex) detected by [this depfu PR](https://github.com/openSUSE/open-build-service/pull/10545)

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
