### PR TITLE
[backend] bs_worker: support the new --vmdisk-filesystem-options para…

### DIFF
--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -165,7 +165,7 @@ BuildRequires:  perl(Test::Simple) > 1
 PreReq:         /usr/sbin/useradd /usr/sbin/groupadd
 BuildArch:      noarch
 Requires(pre):  obs-common
-Requires:       %{__obs_build_package_name} >= 20200110
+Requires:       %{__obs_build_package_name} >= 20201211
 Requires:       perl-BSSolv >= 0.36
 Requires:       perl(Date::Parse)
 # Required by source server

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -87,6 +87,7 @@ my $vm_worker_instance;
 my $vmdisk_rootsize;
 my $vmdisk_swapsize;
 my $vmdisk_filesystem;
+my $vmdisk_filesystem_options;
 my $vmdisk_mount_options;
 my $vmdisk_clean;
 my $emulator_script;
@@ -528,6 +529,11 @@ while (@ARGV) {
   if ($ARGV[0] eq '--vmdisk-filesystem') {
     shift @ARGV;
     $vmdisk_filesystem = shift @ARGV;
+    next;
+  }
+  if ($ARGV[0] eq '--vmdisk-filesystem-options') {
+    shift @ARGV;
+    $vmdisk_filesystem_options = shift @ARGV;
     next;
   }
   if ($ARGV[0] eq '--vmdisk-mount-options') {
@@ -3242,6 +3248,7 @@ sub dobuild {
   if ($vm =~ /(xen|kvm|zvm|emulator|pvm)/) {
     # allow overriding the filesystem type via the build config
     my $filesystemtype = $bconf->{'buildflags:vmfstype'} || $vmdisk_filesystem;
+    my $filesystemoptions = $bconf->{'buildflags:vmfsoptions'} || $vmdisk_filesystem_options;
     mkdir("$buildroot/.mount") unless -d "$buildroot/.mount";
     push @args, '--root', "$buildroot/.mount";
     push @args, '--vm-type', $vm;
@@ -3259,6 +3266,7 @@ sub dobuild {
     push @args, '--vmdisk-rootsize', $vmdisk_rootsize if $vmdisk_rootsize;
     push @args, '--vmdisk-swapsize', $vmdisk_swapsize if $vmdisk_swapsize;
     push @args, '--vmdisk-filesystem', $filesystemtype if $filesystemtype;
+    push @args, '--vmdisk-filesystem-options', $filesystemoptions if $filesystemoptions;
     push @args, "--vmdisk-mount-options=$vmdisk_mount_options" if $vmdisk_mount_options;
     push @args, '--vmdisk-clean'if $vmdisk_clean;
     push @args, '--hugetlbfs', $hugetlbfs if $hugetlbfs;


### PR DESCRIPTION
…meter

_Replace this line with a description of your changes. Please follow the suggestions in the comment below._

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
