### PR TITLE
Replace `require_login` with Pundit in Webui::StatusMessagesController

### DIFF
--- a/src/api/app/policies/webui/status_message_policy.rb
+++ b/src/api/app/policies/webui/status_message_policy.rb
@@ -1,0 +1,21 @@
+class Webui::StatusMessagePolicy < ApplicationPolicy
+  def initialize(user, record, opts = {})
+    super(user, record, opts.merge(ensure_logged_in: true))
+  end
+
+  def create?
+    user.is_admin? || user.is_staff?
+  end
+
+  def new?
+    create?
+  end
+
+  def destroy?
+    create?
+  end
+
+  def acknowledge?
+    true
+  end
+end

--- a/src/api/spec/controllers/webui/status_messages_controller_spec.rb
+++ b/src/api/spec/controllers/webui/status_messages_controller_spec.rb
@@ -4,7 +4,22 @@ RSpec.describe Webui::StatusMessagesController do
   let(:user) { create(:confirmed_user) }
   let(:admin_user) { create(:admin_user) }
 
+  describe 'GET new' do
+    it_behaves_like 'require logged in user' do
+      let(:method) { :get }
+      let(:action) { :new }
+    end
+  end
+
   describe 'POST create' do
+    it_behaves_like 'require logged in user' do
+      let(:method) { :post }
+      let(:action) { :create }
+      let(:opts) do
+        { params: { status_message: { message: 'Some message' } } }
+      end
+    end
+
     it 'create a status message' do
       login(admin_user)
 
@@ -76,6 +91,14 @@ RSpec.describe Webui::StatusMessagesController do
   describe 'DELETE destroy' do
     let!(:message) { create(:status_message, user: admin_user) }
 
+    it_behaves_like 'require logged in user' do
+      let(:method) { :delete }
+      let(:action) { :destroy }
+      let(:opts) do
+        { params: { id: message.id } }
+      end
+    end
+
     context 'as an admin' do
       before do
         login(admin_user)
@@ -101,6 +124,14 @@ RSpec.describe Webui::StatusMessagesController do
 
   describe 'POST acknowledge' do
     let(:message) { create(:status_message, user: admin_user) }
+
+    it_behaves_like 'require logged in user' do
+      let(:method) { :post }
+      let(:action) { :acknowledge }
+      let(:opts) do
+        { params: { id: message.id } }
+      end
+    end
 
     context 'when the status message is not yet acknowledged' do
       before do

--- a/src/api/spec/policies/webui/status_message_policy_spec.rb
+++ b/src/api/spec/policies/webui/status_message_policy_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe Webui::StatusMessagePolicy do
+  let(:user_nobody) { create(:user_nobody) }
+  let(:user) { create(:confirmed_user) }
+  let(:staff_user) { create(:staff_user) }
+  let(:admin_user) { create(:admin_user) }
+  let(:status_message) { create(:status_message) }
+
+  subject { described_class }
+
+  # rubocop:disable RSpec/RepeatedExample
+  # This cop is currently not recognizing the permissions block as separate test
+  permissions :acknowledge? do
+    it { is_expected.to permit(user, status_message) }
+    it { is_expected.to permit(staff_user, status_message) }
+    it { is_expected.to permit(admin_user, status_message) }
+  end
+
+  permissions :new?, :create?, :destroy? do
+    it { is_expected.not_to permit(user, status_message) }
+    it { is_expected.to permit(staff_user, status_message) }
+    it { is_expected.to permit(admin_user, status_message) }
+  end
+  # rubocop:enable RSpec/RepeatedExample
+
+  it "doesn't permit anonymous user" do
+    expect { described_class.new(user_nobody, status_message) }
+      .to raise_error(an_instance_of(Pundit::NotAuthorizedError).and(having_attributes(reason: ApplicationPolicy::ANONYMOUS_USER)))
+  end
+end


### PR DESCRIPTION
This is a PR of a series which replaces `require_login` with `Pundit`.
You can find further relevant info in #10083.

Tackles `Webui::StatusMessagesController`

Ref #10083

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
