### PR TITLE
Change compression format in import_database script

### DIFF
--- a/src/api/config/options.yml.example
+++ b/src/api/config/options.yml.example
@@ -158,7 +158,7 @@ default: &default
   backup_server: foo.bar
   backup_user: tux
   backup_location: /home/tux
-  backup_filename: obs_production.sql.bz2
+  backup_filename: obs_production.sql.xz
   backup_port: 22
 
   # Rabbitmq based message bus

--- a/src/api/script/import_database.rb
+++ b/src/api/script/import_database.rb
@@ -83,7 +83,7 @@ def import_dump
   password = config[environment]['password']
   filename = @params[:path] || options[environment]['backup_filename']
 
-  cmds = ["bzcat #{File.join(@data_path, filename)}"]
+  cmds = ["xz -d #{File.join(@data_path, filename)}"]
   unless TABLES_TO_REMOVE.empty?
     cmds << TABLES_TO_REMOVE.map do |table|
       "sed '/-- Dumping data for table `#{table}`/,/-- Table structure for table/{//!d}'"


### PR DESCRIPTION
In our reference server we always have a daily dump of the database available. Its compression format has changed from .bz2 to .xz. So we adapt the import_database script and config/options.yml.example.

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature


