### PR TITLE
Remove mentions of openFATE on error pages

### DIFF
--- a/src/api/public/402.html
+++ b/src/api/public/402.html
@@ -96,7 +96,7 @@
         <div class="col-md-4">
           <h4>...we better ourselves</h4>
           <p>
-            You have an idea how to make OBS better, faster, stronger? Those ideas we call <em>feature</em> and we track them in <a href="https://features.opensuse.org/feature/new">openFATE</a>.
+            You have an idea how to make OBS better, faster, stronger? Those ideas we call <em>feature</em> and we track them on <a href="https://github.com/openSUSE/open-build-service/issues" target="_blank">GitHub</a>.
           </p>
         </div>
       </div>

--- a/src/api/public/403.html
+++ b/src/api/public/403.html
@@ -96,7 +96,7 @@
         <div class="col-md-4">
           <h4>...we better ourselves</h4>
           <p>
-            You have an idea how to make OBS better, faster, stronger? Those ideas we call <em>feature</em> and we track them in <a href="https://features.opensuse.org/feature/new">openFATE</a>.
+            You have an idea how to make OBS better, faster, stronger? Those ideas we call <em>feature</em> and we track them on <a href="https://github.com/openSUSE/open-build-service/issues" target="_blank">GitHub</a>.
           </p>
         </div>
       </div>

--- a/src/api/public/404.html
+++ b/src/api/public/404.html
@@ -108,7 +108,7 @@
         <div class="col-md-4">
           <h4>...we better ourselves</h4>
           <p>
-            You have an idea how to make OBS better, faster, stronger? Those ideas we call <em>feature</em> and we track them in <a href="https://features.opensuse.org/feature/new">openFATE</a>.
+            You have an idea how to make OBS better, faster, stronger? Those ideas we call <em>feature</em> and we track them on <a href="https://github.com/openSUSE/open-build-service/issues" target="_blank">GitHub</a>.
           </p>
         </div>
       </div>

--- a/src/api/public/408.html
+++ b/src/api/public/408.html
@@ -96,7 +96,7 @@
         <div class="col-md-4">
           <h4>...we better ourselves</h4>
           <p>
-            You have an idea how to make OBS better, faster, stronger? Those ideas we call <em>feature</em> and we track them in <a href="https://features.opensuse.org/feature/new">openFATE</a>.
+            You have an idea how to make OBS better, faster, stronger? Those ideas we call <em>feature</em> and we track them on <a href="https://github.com/openSUSE/open-build-service/issues" target="_blank">GitHub</a>.
           </p>
         </div>
       </div>

--- a/src/api/public/500.html
+++ b/src/api/public/500.html
@@ -108,7 +108,7 @@
         <div class="col-md-4">
           <h4>...we better ourselves</h4>
           <p>
-            You have an idea how to make OBS better, faster, stronger? Those ideas we call <em>feature</em> and we track them in <a href="https://features.opensuse.org/feature/new">openFATE</a>.
+            You have an idea how to make OBS better, faster, stronger? Those ideas we call <em>feature</em> and we track them on <a href="https://github.com/openSUSE/open-build-service/issues" target="_blank">GitHub</a>.
           </p>
         </div>
       </div>

--- a/src/api/public/503.html
+++ b/src/api/public/503.html
@@ -96,7 +96,7 @@
         <div class="col-md-4">
           <h4>...we better ourselves</h4>
           <p>
-            You have an idea how to make OBS better, faster, stronger? Those ideas we call <em>feature</em> and we track them in <a href="https://features.opensuse.org/feature/new">openFATE</a>.
+            You have an idea how to make OBS better, faster, stronger? Those ideas we call <em>feature</em> and we track them on <a href="https://github.com/openSUSE/open-build-service/issues" target="_blank">GitHub</a>.
           </p>
         </div>
       </div>


### PR DESCRIPTION
openFATE has been discontinued and should no longer be linked to as
there is no archive.

This commit is replacing the outdated references with the same text as
used in https://github.com/openSUSE/obs-landing/pull/276 referencing
github issues as the correct place for features as well as used for
issue reports.

Fixes #10566