### PR TITLE
[archlinux] Update filename regexes to fix .pkg.tar.zst signing

### DIFF
--- a/src/backend/BSSched/Remote.pm
+++ b/src/backend/BSSched/Remote.pm
@@ -652,7 +652,7 @@ sub convertpackagebinarylist {
           $bins{$filename} = {'filename' => $filename, 'name' => $1, 'arch' => $2};
         } elsif ($filename =~ /^([^\/]+)_[^\/]*_([^\/]*)\.deb$/) {
           $bins{$filename} = {'filename' => $filename, 'name' => $1, 'arch' => $2};
-        } elsif ($filename =~ /^([^\/]+)-[^-]+-[^-]+-([a-zA-Z][^\/\.\-]*)\.pkg\.tar\..z$/) {
+        } elsif ($filename =~ /^([^\/]+)-[^-]+-[^-]+-([a-zA-Z][^\/\.\-]*)\.pkg\.tar\.(?:gz|xz|zst)$/) {
           $bins{$filename} = {'filename' => $filename, 'name' => $1, 'arch' => $2};
         } elsif ($filename eq '.nouseforbuild') {
           $bins{$filename} = {};

--- a/src/backend/BSSrcServer/SQLite.pm
+++ b/src/backend/BSSrcServer/SQLite.pm
@@ -173,7 +173,7 @@ sub binarypath2name {
   $path =~ s/.*\///;
   return $1 if $path =~ /^(.*)-[^-]+-[^-]+\.[^\.]+\.rpm$/;
   return $1 if $path =~ /^(.*)_[^_]+_[^_]+\.deb$/;
-  return $1 if $path =~ /^(.*)-[^-]+-[^-]+-[^-]+\.pkg\.tar\.(?:xz|gz|zstd)$/;
+  return $1 if $path =~ /^(.*)-[^-]+-[^-]+-[^-]+\.pkg\.tar\.(?:xz|gz|zst)$/;
   return undef;
 }
 

--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -2416,7 +2416,7 @@ sub putjob {
 
   my $ev = {'type' => 'built', 'arch' => $arch, 'job' => $job};
 
-  if ($BSConfig::sign && (@{$kiwitree_tosign || []} || grep {$_->{'name'} =~ /\.(?:d?rpm|sha256|iso|pkg\.tar\.gz|pkg\.tar.xz|AppImage|deb|appx|helminfo)$/} @$uploaded)) {
+  if ($BSConfig::sign && (@{$kiwitree_tosign || []} || grep {$_->{'name'} =~ /\.(?:d?rpm|sha256|iso|pkg\.tar\.gz|pkg\.tar\.xz|pkg\.tar\.zst|AppImage|deb|appx|helminfo)$/} @$uploaded)) {
     if (@{$kiwitree_tosign || []}) {
       my $c = '';
       $c .= BSHTTP::urlencode($_)."\n" for @$kiwitree_tosign;

--- a/src/backend/bs_signer
+++ b/src/backend/bs_signer
@@ -550,7 +550,7 @@ sub signjob {
   my $projid = $info->{'project'};
   $prpa_stats = "$projid/$info->{'repository'}/$arch";
   my @files = sort(ls($jobdir));
-  my @signfiles = grep {/\.(?:d?rpm|sha256|iso|pkg\.tar\.gz|pkg\.tar\.xz|rsasign|AppImage|appx|helminfo)$/} @files;
+  my @signfiles = grep {/\.(?:d?rpm|sha256|iso|pkg\.tar\.gz|pkg\.tar\.xz|pkg\.tar\.zst|rsasign|AppImage|appx|helminfo)$/} @files;
   my $needpubkey;
   if (grep {$_ eq '.kiwitree_tosign'} @files) {
     for my $f (split("\n", readstr("$jobdir/.kiwitree_tosign"))) {
@@ -634,7 +634,7 @@ sub signjob {
 	my @signmode;
 	@signmode = ('-r', '-T', $signtime) if $signtime;
 	@signmode = ('-r', '-T', 'buildtime') if $signfile =~ /\.drpm$/;
-	@signmode = ('-D') if $signfile =~ /\.pkg\.tar\.(?:gz|xz)$/;
+	@signmode = ('-D') if $signfile =~ /\.pkg\.tar\.(?:gz|xz|zst)$/;
 	@signmode = ('-a') if $signfile =~ /\.AppImage$/;
 	@signmode = ('-d') if $signfile =~ /\.sha256$/;
 	if ($signfile =~ /\.key$/s) {

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -5027,7 +5027,7 @@ sub binary_key_to_name {
   $key =~ s/.*\///;
   return $1 if $key =~ /^(.*)-[^-]+-[^-]+\.[^\.]+\.rpm$/;
   return $1 if $key =~ /^(.*)_[^_]+_[^_]+\.deb$/;
-  return $1 if $key =~ /^(.*)-[^-]+-[^-]+-[^-]+\.pkg\.tar\.(?:xz|gz|zstd)$/;
+  return $1 if $key =~ /^(.*)-[^-]+-[^-]+-[^-]+\.pkg\.tar\.(?:xz|gz|zst)$/;
   return ();
 }
 
@@ -5035,7 +5035,7 @@ sub binary_key_to_type {
   my ($db, $key) = @_;
   return 'rpm' if $key =~ /\.rpm$/;
   return 'deb' if $key =~ /\.deb$/;
-  return 'arch' if $key =~ /\.pkg\.tar\.(?:xz|gz|zstd)$/;
+  return 'arch' if $key =~ /\.pkg\.tar\.(?:xz|gz|zst)$/;
   return ();
 }
 
@@ -5049,7 +5049,7 @@ sub binary_key_to_data {
     $versrel = $1;
   } elsif ($name =~ s/_([^_]+)_[^_]+\.deb$//) {
     $versrel = $1;
-  } elsif ($name =~ s/-([^-]+-[^-]+)-[^-]+\.pkg\.tar\.(?:xz|gz|zstd)$//) {
+  } elsif ($name =~ s/-([^-]+-[^-]+)-[^-]+\.pkg\.tar\.(?:xz|gz|zst)$//) {
     $versrel = $1;
   }
   my ($version, $release) = ($versrel, undef);
@@ -5069,7 +5069,7 @@ sub binary_key_to_data {
   my $type;
   $type = 'rpm' if $binary =~ /\.rpm$/;
   $type = 'deb' if $binary =~ /\.deb$/;
-  $type = 'arch' if $binary =~ /\.pkg\.tar\.(?:xz|gz|zstd)$/;
+  $type = 'arch' if $binary =~ /\.pkg\.tar\.(?:xz|gz|zst)$/;
   my $res = {
     'name' => $name,
     'versrel' => $versrel,
@@ -5150,7 +5150,7 @@ sub published_binary_projectindexfunc {
       my $repoorigins = $prp_to_repoorigins{$prp} || prp_to_repoorigins($prp, $db);
       for (keys %{$repoorigins || {}}) {
 	# keep in sync with updatebinaryindex in bs_publish
-	next unless /\.(?:rpm|deb|pkg\.tar\.gz|pkg\.tar\.xz|pkg\.tar\.zstd)$/;
+	next unless /\.(?:rpm|deb|pkg\.tar\.gz|pkg\.tar\.xz|pkg\.tar\.zst)$/;
 	$bins{"$prp_ext/$_"} = 1;
       }
       last if defined $dbgsplit;
@@ -5415,7 +5415,7 @@ sub published_path {
       $p = "$1/$bin";
     } elsif ($bin =~ /\.exe$/) {
       $p = $bin;
-    } elsif ($bin =~ /\.pkg\.tar(?:\.gz|\.xz|\.zstd)$/) {
+    } elsif ($bin =~ /\.pkg\.tar(?:\.gz|\.xz|\.zst)$/) {
       $p = ($cgi->{'arch'} eq 'i586' ? 'i686' : $cgi->{'arch'})."/$bin";
     } elsif ($bin =~ /\.iso(?:\.report)$/) {
       $p = "iso/$bin";


### PR DESCRIPTION
This should fix the issue where `.pkg.tar.gz` and `.pkg.tar.xz` Arch Linux packages are signed, but `.pkg.tar.zst` packages are not.

I believe the root cause was that some regexes were missed when support for zstd-compressed packages was added, specifically in `src/backend/bs_signer`. I added `zst` where needed and fixed `zstd` -> `zst` in a few other places (`.pkg.tar.zst` is the official file extension: https://github.com/archlinux/svntogit-packages/blob/81c75751713eba68479dab00b7d598be99e5e024/trunk/makepkg.conf#L146).

This is an example of a repo I created that exhibits the problem: https://download.opensuse.org/repositories/home:/chenxiaolong:/test/Arch/x86_64/. The repo metadata is signed, but the packages are not (missing `.sig` file).

This is another 3rd party repo I found where the xz packages are signed, but the zstd packages are not: https://download.opensuse.org/repositories/home:/Minerva_W:/Science/Arch_Extra/x86_64/.

I don't think these changes should break anything, but I'd appreciate it if someone could take a close look as I'm not too familiar with the OBS code base.

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature