### PR TITLE
Document '/attribute' API routes with OpenAPI

### DIFF
--- a/src/api/public/apidocs-new/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs-new/OBS-v2.10.50.yaml
@@ -7,6 +7,8 @@ tags:
   - name: General Information
   - name: Groups
   - name: Person
+  - name: Attribute Namespaces
+  - name: Attributes
 
 info:
   description: Open Build Service API
@@ -25,13 +27,23 @@ paths:
 
   /architectures:
     $ref: 'paths/architectures.yaml'
-
   /architectures/{architecture_name}:
     $ref: 'paths/architectures_architecture_name.yaml'
 
+  /attribute:
+    $ref: 'paths/attribute.yaml'
+  /attribute/{namespace}:
+    $ref: 'paths/attribute_namespace.yaml'
+  /attribute/{namespace}/_meta:
+    $ref: 'paths/attribute_namespace_meta.yaml'
+
+  /attribute/{namespace}/{attribute_name}:
+    $ref: 'paths/attribute_namespace_attribute_name.yaml'
+  /attribute/{namespace}/{attribute_name}/_meta:
+    $ref: 'paths/attribute_namespace_attribute_name_meta.yaml'
+
   /group:
     $ref: 'paths/group.yaml'
-
   /group/{group_title}:
     $ref: 'paths/group_group_title.yaml'
 

--- a/src/api/public/apidocs-new/components/parameters/attribute_name.yaml
+++ b/src/api/public/apidocs-new/components/parameters/attribute_name.yaml
@@ -1,0 +1,7 @@
+in: path
+name: attribute_name
+schema:
+  type: string
+required: true
+description: The name of the attribute
+example: OwnerRootProjectTest

--- a/src/api/public/apidocs-new/components/parameters/namespace.yaml
+++ b/src/api/public/apidocs-new/components/parameters/namespace.yaml
@@ -1,0 +1,7 @@
+in: path
+name: namespace
+schema:
+  type: string
+required: true
+description: The namespace
+example: OBS_TEST

--- a/src/api/public/apidocs-new/components/schemas/attribute.yaml
+++ b/src/api/public/apidocs-new/components/schemas/attribute.yaml
@@ -1,0 +1,40 @@
+type: object
+properties:
+  name:
+    type: string
+    example: 'OBS_TEST'
+    xml:
+      attribute: true
+  namespace:
+    type: string
+    example: 'OwnerRootProjectTest'
+    xml:
+      attribute: true
+  description:
+    type: string
+    example: 'An example description for an attribute.'
+  allowed:
+    type: object
+    properties:
+      value:
+        type: array
+        items:
+          type: string
+        example:
+          - 'DisableDevelTest'
+          - 'BugownerOnlyTest'
+  count:
+    type: integer
+    example: 0
+  modifiable_by:
+    type: array
+    items:
+      type: object
+      properties:
+        user:
+          type: string
+          example: 'user_login_name'
+          xml:
+            attribute: true
+xml:
+  name: definition

--- a/src/api/public/apidocs-new/components/schemas/namespace.yaml
+++ b/src/api/public/apidocs-new/components/schemas/namespace.yaml
@@ -1,0 +1,19 @@
+type: object
+properties:
+  name:
+    type: string
+    example: 'OBS_TEST'
+    xml:
+      attribute: true
+  modifiable_by:
+    type: array
+    items:
+      type: object
+      properties:
+        user:
+          type: string
+          example: 'user_login_name'
+          xml:
+            attribute: true
+xml:
+  name: namespace

--- a/src/api/public/apidocs-new/paths/attribute.yaml
+++ b/src/api/public/apidocs-new/paths/attribute.yaml
@@ -1,0 +1,24 @@
+get:
+  summary: List all attribute namespaces.
+  description: List all attribute namespaces.
+  security:
+    - basic_authentication: []
+  responses:
+    '200':
+      description: |
+        OK. The request has succeeded.
+
+        XML Schema used for body validation: [directory.xsd](../schema/directory.xsd)
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/directory.yaml'
+          example:
+            count: '2'
+            entry:
+              - name: 'OBS'
+              - name: 'openSUSE'
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+  tags:
+    - Attribute Namespaces

--- a/src/api/public/apidocs-new/paths/attribute_namespace.yaml
+++ b/src/api/public/apidocs-new/paths/attribute_namespace.yaml
@@ -1,0 +1,53 @@
+get:
+  summary: List all attributes below a namespace.
+  description: List all attributes under a given attribute namespace.
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/namespace.yaml'
+  responses:
+    '200':
+      description: |
+        OK. The request has succeeded.
+
+        XML Schema used for body validation: [directory.xsd](../schema/directory.xsd)
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/directory.yaml'
+          example:
+            count: '2'
+            entry:
+              - name: 'AutoCleanup'
+              - name: 'OwnerRootProject'
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '404':
+      description: Not Found.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          example:
+            code: not_found
+            summary: Couldn't find AttribNamespace
+  tags:
+    - Attribute Namespaces
+
+delete:
+  summary: Delete an attribute namespace and all attributes below.
+  description: |
+    Delete an attribute namespace and all attributes below.
+
+    This operation is the same as the one defined with [DELETE /attribute/{namespace}/_meta](#/Attributes/delete_attribute__namespace___meta).
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/namespace.yaml'
+  responses:
+    '200':
+      $ref: '../components/responses/succeeded.yaml'
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+  tags:
+    - Attribute Namespaces

--- a/src/api/public/apidocs-new/paths/attribute_namespace_attribute_name.yaml
+++ b/src/api/public/apidocs-new/paths/attribute_namespace_attribute_name.yaml
@@ -1,0 +1,30 @@
+delete:
+  summary: Delete an attribute and all its values in projects or packages.
+  description: |
+    Delete an attribute and all its values in projects or packages.
+
+    This operation is the same as the one defined with [DELETE /attribute/{namespace}/{attribute_name}/_meta](#/Attributes/delete_attribute__namespace___attribute_name___meta)
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/namespace.yaml'
+    - $ref: '../components/parameters/attribute_name.yaml'
+  responses:
+    '200':
+      $ref: '../components/responses/succeeded.yaml'
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '404':
+      description: Not Found.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          examples:
+            namespace:
+              value:
+                code: not_found
+                summary: Couldn't find AttribNamespace
+              summary: Not Found (Namespace)
+  tags:
+    - Attributes

--- a/src/api/public/apidocs-new/paths/attribute_namespace_attribute_name_meta.yaml
+++ b/src/api/public/apidocs-new/paths/attribute_namespace_attribute_name_meta.yaml
@@ -1,0 +1,203 @@
+get:
+  summary: Shows attribute.
+  description: Shows attribute.
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/namespace.yaml'
+    - $ref: '../components/parameters/attribute_name.yaml'
+  responses:
+    '200':
+      description: OK. The request has succeeded.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/attribute.yaml'
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '404':
+      description: Not Found.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          examples:
+            namespace:
+              value:
+                code: not_found
+                summary: Couldn't find AttribNamespace
+              summary: Not Found (Namespace)
+            unknown_attribute:
+              value:
+                code: unknown_attribute
+                summary: "Unknown attribute 'OBS_TEST':'OwnerRootProjectTest'"
+              summary: Unknown Attribute
+  tags:
+    - Attributes
+
+post:
+  # 'post' and 'put' operations must be in sync
+  summary: Change attribute data. Create an attribute if it doesn't exist.
+  description: |
+    This endpoint can be used for both, creating an attribute and updating it:
+      * If the attribute passed as parameter doesn't exist, it will create the attribute.
+      * If the attribute passed as parameter already exists, it will update the attribute.
+
+    This operation is the same as the one defined with [PUT](#/Attributes/put_attribute__namespace___attribute_name___meta).
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/namespace.yaml'
+    - $ref: '../components/parameters/attribute_name.yaml'
+  requestBody:
+    description: Attribute definition.
+    required: true
+    content:
+      application/xml; charset=utf-8:
+        schema:
+          $ref: '../components/schemas/attribute.yaml'
+  responses:
+    '200':
+      $ref: '../components/responses/succeeded.yaml'
+    '400':
+      description: Validation Failed.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          examples:
+            empty_body:
+              value:
+                code: validation_failed
+                summary: Document is empty, not allowed for attrib_type
+              summary: Validation Failed (Empty Body)
+            wrong_xml_element:
+              value:
+                code: validation_failed
+                summary: 'attrib_type validation error: 1:0: ERROR: Element definition failed to validate attributes'
+              summary: Validation Failed (Wrong XML Attributes)
+            illegal_request:
+              value:
+                code: illegal_request
+                summary: 'Illegal request: PUT/POST /attribute/OBS_TEST/OwnerRootProjectTest/_meta: path does not match content'
+              summary: Illegal Request
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '404':
+      description: Not Found.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          examples:
+            namespace:
+              value:
+                code: not_found
+                summary: Couldn't find AttribNamespace
+              summary: Not Found (Namespace)
+            unknown_attribute:
+              value:
+                code: unknown_attribute
+                summary: "Unknown attribute 'OBS_TEST':'OwnerRootProjectTest'"
+              summary: Unknown Attribute
+  tags:
+    - Attributes
+
+put:
+  # 'post' and 'put' operations must be in sync
+  summary: Change attribute data. Create an attribute if it doesn't exist.
+  description: |
+    This endpoint can be used for both, creating an attribute and updating it:
+      * If the attribute passed as parameter doesn't exist, it will create the attribute.
+      * If the attribute passed as parameter already exists, it will update the attribute.
+
+    This operation is the same as the one defined with [POST](#/Attributes/post_attribute__namespace___attribute_name___meta).
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/namespace.yaml'
+    - $ref: '../components/parameters/attribute_name.yaml'
+  requestBody:
+    description: Attribute definition.
+    required: true
+    content:
+      application/xml; charset=utf-8:
+        schema:
+          $ref: '../components/schemas/attribute.yaml'
+  responses:
+    '200':
+      $ref: '../components/responses/succeeded.yaml'
+    '400':
+      description: Validation Failed.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          examples:
+            empty_body:
+              value:
+                code: validation_failed
+                summary: Document is empty, not allowed for attrib_type
+              summary: Validation Failed (Empty Body)
+            wrong_xml_element:
+              value:
+                code: validation_failed
+                summary: 'attrib_type validation error: 1:0: ERROR: Element definition failed to validate attributes'
+              summary: Validation Failed (Wrong XML Attributes)
+            illegal_request:
+              value:
+                code: illegal_request
+                summary: 'Illegal request: PUT/POST /attribute/OBS_TEST/OwnerRootProjectTest/_meta: path does not match content'
+              summary: Illegal Request
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '404':
+      description: Not Found.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          examples:
+            namespace:
+              value:
+                code: not_found
+                summary: Couldn't find AttribNamespace
+              summary: Not Found (Namespace)
+            unknown_attribute:
+              value:
+                code: unknown_attribute
+                summary: "Unknown attribute 'OBS_TEST':'OwnerRootProjectTest'"
+              summary: Unknown Attribute
+  tags:
+    - Attributes
+
+delete:
+  summary: Delete an attribute and all its values in projects or packages.
+  description: |
+    Delete an attribute and all its values in projects or packages.
+
+    This operation is the same as the one defined with [DELETE /attribute/{namespace}/{attribute_name}](#/Attributes/delete_attribute__namespace___attribute_name_)
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/namespace.yaml'
+    - $ref: '../components/parameters/attribute_name.yaml'
+  responses:
+    '200':
+      $ref: '../components/responses/succeeded.yaml'
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '404':
+      description: Not Found.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          examples:
+            namespace:
+              value:
+                code: not_found
+                summary: Couldn't find AttribNamespace
+              summary: Not Found (Namespace)
+  tags:
+    - Attributes

--- a/src/api/public/apidocs-new/paths/attribute_namespace_meta.yaml
+++ b/src/api/public/apidocs-new/paths/attribute_namespace_meta.yaml
@@ -1,0 +1,178 @@
+get:
+  summary: Show attribute namespace.
+  description: Shows attribute namespace.
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/namespace.yaml'
+  responses:
+    '200':
+      description: |
+        OK. The request has succeeded.
+
+        XML Schema used for body validation: [attribute_namespace_meta.xsd](../schema/attribute_namespace_meta.xsd)
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/namespace.yaml'
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '404':
+      description: Not Found.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          example:
+            code: not_found
+            summary: Couldn't find AttribNamespace
+  tags:
+    - Attribute Namespaces
+
+post:
+  # 'post' and 'put' operations must be in sync
+  summary: Change attribute namespace. Create an attribute namespace if it doesn't exist.
+  description: |
+    This endpoint can be used for both, creating an attribute namespace and updating it:
+      * If the attribute namespace passed as parameter doesn't exist, it will create the attribute namespace.
+      * If the attribute namespace passed as parameter already exists, it will update the namespace attribute.
+
+    This operation is the same as the one defined with [PUT](#/Attributes/put_attribute__namespace___meta).
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/namespace.yaml'
+  requestBody:
+    description: |
+      Attribute namespace definition.
+
+      XML Schema used for body validation: [attribute_namespace_meta.xsd](../schema/attribute_namespace_meta.xsd)
+    required: true
+    content:
+      application/xml; charset=utf-8:
+        schema:
+          $ref: '../components/schemas/namespace.yaml'
+  responses:
+    '200':
+      $ref: '../components/responses/succeeded.yaml'
+    '400':
+      description: Validation Failed.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          examples:
+            empty_body:
+              value:
+                code: validation_failed
+                summary: Document is empty, not allowed for attribute_namespace_meta
+              summary: Validation Failed (Empty Body)
+            wrong_xml_element:
+              value:
+                code: validation_failed
+                summary: "attribute_namespace_meta validation error: 1:0: ERROR: Element 'foo': No matching global declaration available for the validation root."
+              summary: Validation Failed (Wrong XML Element)
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '404':
+      description: Not Found.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          examples:
+            namespace:
+              value:
+                code: not_found
+                summary: Couldn't find AttribNamespace
+              summary: Not Found (Namespace)
+            user:
+              value:
+                code: not_found
+                summary: Couldn't find User with login = user_login_name
+              summary: Not Found (User)
+  tags:
+    - Attribute Namespaces
+
+put:
+  # 'post' and 'put' operations must be in sync
+  summary: Change attribute namespace. Create an attribute namespace if it doesn't exist.
+  description: |
+    This endpoint can be used for both, creating an attribute namespace and updating it:
+      * If the attribute namespace passed as parameter doesn't exist, it will create the attribute namespace.
+      * If the attribute namespace passed as parameter already exists, it will update the namespace attribute.
+
+    This operation is the same as the one defined with [POST](#/Attributes/post_attribute__namespace___meta).
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/namespace.yaml'
+  requestBody:
+    description: |
+      Attribute namespace definition.
+
+      XML Schema used for body validation: [attribute_namespace_meta.xsd](../schema/attribute_namespace_meta.xsd)
+    required: true
+    content:
+      application/xml; charset=utf-8:
+        schema:
+          $ref: '../components/schemas/namespace.yaml'
+  responses:
+    '200':
+      $ref: '../components/responses/succeeded.yaml'
+    '400':
+      description: Validation Failed.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          examples:
+            empty_body:
+              value:
+                code: validation_failed
+                summary: Document is empty, not allowed for attribute_namespace_meta
+              summary: Validation Failed (Empty Body)
+            wrong_xml_element:
+              value:
+                code: validation_failed
+                summary: "attribute_namespace_meta validation error: 1:0: ERROR: Element 'foo': No matching global declaration available for the validation root."
+              summary: Validation Failed (Wrong XML Element)
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '404':
+      description: Not Found.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          examples:
+            namespace:
+              value:
+                code: not_found
+                summary: Couldn't find AttribNamespace
+              summary: Not Found (Namespace)
+            user:
+              value:
+                code: not_found
+                summary: Couldn't find User with login = user_login_name
+              summary: Not Found (User)
+  tags:
+    - Attribute Namespaces
+
+delete:
+  summary: Delete an attribute namespace and all attributes below.
+  description: |
+    Delete an attribute namespace and all attributes below.
+
+    This operation is the same as the one defined with [DELETE /attribute/{namespace}](#/Attributes/delete_attribute__namespace_).
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/namespace.yaml'
+  responses:
+    '200':
+      $ref: '../components/responses/succeeded.yaml'
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+  tags:
+    - Attribute Namespaces


### PR DESCRIPTION
Introduce the new "Attributes" group of operations. This group contains the documentation of all operations with API routes starting by '/attribute'.

To verify the documetation that has been introduced:
- Start the development environment
- Go to http://localhost:3000/apidocs-new/

![Screenshot from 2021-01-08 19-00-55](https://user-images.githubusercontent.com/24919/104048689-f680e300-51e3-11eb-890b-f62019e1bf46.png)

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

