### PR TITLE
Add default value to Channel#disabled, to avoid the three-state boolean

### DIFF
--- a/src/api/db/data/20210112091948_add_channel_default.rb
+++ b/src/api/db/data/20210112091948_add_channel_default.rb
@@ -1,0 +1,11 @@
+class AddChannelDefault < ActiveRecord::Migration[6.0]
+  def up
+    # rubocop:disable Rails/SkipsModelValidations
+    Channel.where(disabled: nil).update_all(disabled: false)
+    # rubocop:enable Rails/SkipsModelValidations
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/src/api/db/migrate/20210112091454_change_channel_disabled_default.rb
+++ b/src/api/db/migrate/20210112091454_change_channel_disabled_default.rb
@@ -1,0 +1,7 @@
+class ChangeChannelDisabledDefault < ActiveRecord::Migration[6.0]
+  # rubocop:disable Rails/ReversibleMigration
+  def change
+    change_column_default :channels, :disabled, false
+  end
+  # rubocop:enable Rails/ReversibleMigration
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_09_105103) do
+ActiveRecord::Schema.define(version: 2021_01_12_091454) do
 
   create_table "architectures", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false, collation: "utf8_general_ci"
@@ -257,7 +257,7 @@ ActiveRecord::Schema.define(version: 2020_12_09_105103) do
 
   create_table "channels", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "package_id", null: false
-    t.boolean "disabled"
+    t.boolean "disabled", default: false
     t.index ["package_id"], name: "index_unique", unique: true
   end
 

--- a/src/api/spec/models/channel_spec.rb
+++ b/src/api/spec/models/channel_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe Channel do
+  let(:channel) { create(:channel) }
+
+  describe '#disabled?' do
+    it { expect(channel).not_to be_disabled }
+  end
+end


### PR DESCRIPTION

We have the issue of [Three-state boolean](https://thoughtbot.com/blog/avoid-the-threestate-boolean-problem) in different places of our database. We should address them with:

- database migration adding a default
- data migration to handle production
- a test case if necessary


-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
