### PR TITLE
Add Tasks link to the top navigation for users not in the beta program

### DIFF
--- a/src/api/app/assets/stylesheets/webui/notifications_redesign/notifications.scss
+++ b/src/api/app/assets/stylesheets/webui/notifications_redesign/notifications.scss
@@ -70,7 +70,8 @@ body.notifications-redesign  {
   }
 }
 
-.notifications-counter {
+// TODO Remove .tasks-counter once the notifications_redesign feature is rolled out
+.tasks-counter, .notifications-counter {
   position: relative;
   margin: 0 auto;
   width: 6rem;

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -804,7 +804,6 @@ class User < ApplicationRecord
     to_s
   end
 
-  # TODO: Remove once responsive_ux is out of beta
   def tasks
     Rails.cache.fetch("requests_for_#{cache_key_with_version}") do
       declined_requests.count +

--- a/src/api/app/views/layouts/webui/responsive_ux/_top_navigation.html.haml
+++ b/src/api/app/views/layouts/webui/responsive_ux/_top_navigation.html.haml
@@ -13,6 +13,15 @@
           .toggler.text-center.justify-content-center
             = link_to(my_notifications_path, id: 'top-notifications-counter', class: 'nav-link text-light p-0 w-100', alt: 'Notifications') do
               = render partial: 'layouts/webui/responsive_ux/unread_notifications_counter'
+        - else # TODO: Remove `else` block when the notifications_redesign is rolled out
+          .toggler.text-center.justify-content-center
+            - tasks = User.session!.tasks
+            = link_to(my_tasks_path, class: 'nav-link text-light p-0 w-100', alt: 'Tasks') do
+              .tasks-counter
+                %i.fas.fa-tasks
+                - unless tasks.zero?
+                  %span.badge.badge-primary.align-text-top= tasks
+                %span.d-block Tasks
         .toggler.text-center.justify-content-center.nav-item.dropdown
           = link_to('#', class: 'nav-link dropdown-toggle text-light', id: 'top-navigation-profile-dropdown', role: 'button',
                     'data-toggle': 'dropdown', aria: { haspopup: true, expanded: false }) do


### PR DESCRIPTION
This includes a counter. All of this is displayed when the notifications_redesign feature is not enabled, so for users not in the
beta program.

The Tasks link in the Places menu is not changed.

Fixes #10611

Example with a lot of tasks (so yes, it scales):
![it-scales](https://user-images.githubusercontent.com/1102934/104326799-6a740180-54ea-11eb-9618-2daa4742b531.png)