### PR TITLE
Use an up to date distribution name

### DIFF
--- a/dist/t/spec/features/0030_project_spec.rb
+++ b/dist/t/spec/features/0030_project_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Project" do
     end
     click_link('Repositories')
     click_link('Add from a Distribution')
-    check('repo_openSUSE_Leap_15_1')
-    expect(page).to have_content("Successfully added repository 'openSUSE_Leap_15.1'")
+    check('repo_openSUSE_Leap_15_3')
+    expect(page).to have_content("Successfully added repository 'openSUSE_Leap_15.3'")
   end
 end


### PR DESCRIPTION
OpenQA tests were failing because we no longer have openSUSE Leap 15.1 in the
Repositories to add from.

See [OpenQA tests for Unstable](https://openqa.opensuse.org/group_overview/62)