### PR TITLE
Remove unneeded path parameter for creating an issue tracker from apidocs documentation

### DIFF
--- a/docs/api/api/api.txt
+++ b/docs/api/api/api.txt
@@ -47,6 +47,12 @@ XmlResult: issue_trackers
 
 <name>: Issue tracker name
 
+POST /issue_trackers
+
+  Create an issue tracker.
+
+XmlResult: status
+
 GET /issue_trackers/<name>
 
   Read issue tracker data.
@@ -56,12 +62,6 @@ XmlResult: issue_tracker
 PUT /issue_trackers/<name>
 
   Update issue tracker data.
-
-XmlResult: status
-
-POST /issue_trackers/<name>
-
-  Create new issue tracker.
 
 XmlResult: status
 

--- a/src/api/app/controllers/issue_trackers_controller.rb
+++ b/src/api/app/controllers/issue_trackers_controller.rb
@@ -38,8 +38,8 @@ class IssueTrackersController < ApplicationController
 
   # GET /issue_trackers/<name>
   def show
-    @issue_tracker = IssueTracker.find_by_name(params[:id])
-    render_error(status: 404, errorcode: 'not_found', message: "Unable to find issue tracker '#{params[:id]}'") && return unless @issue_tracker
+    @issue_tracker = IssueTracker.find_by_name(params[:name])
+    render_error(status: 404, errorcode: 'not_found', message: "Unable to find issue tracker '#{params[:name]}'") && return unless @issue_tracker
 
     respond_to do |format|
       format.xml  { render xml: @issue_tracker.to_xml(IssueTracker::DEFAULT_RENDER_PARAMS) }
@@ -62,7 +62,7 @@ class IssueTrackersController < ApplicationController
       attribs[:enable_fetch] = xml.xpath('enable-fetch[1]/text()').to_s unless xml.xpath('enable-fetch[1]/text()').empty?
       attribs[:show_url] = xml.xpath('show-url[1]/text()').to_s unless xml.xpath('show-url[1]/text()').empty?
 
-      issue_tracker = IssueTracker.find_by_name(params[:id])
+      issue_tracker = IssueTracker.find_by_name(params[:name])
       if issue_tracker
         issue_tracker.update(attribs)
       else
@@ -74,8 +74,8 @@ class IssueTrackersController < ApplicationController
 
   # DELETE /issue_trackers/<name>
   def destroy
-    @issue_tracker = IssueTracker.find_by_name(params[:id])
-    render_error(status: 404, errorcode: 'not_found', message: "Unable to find issue tracker '#{params[:id]}'") && return unless @issue_tracker
+    @issue_tracker = IssueTracker.find_by_name(params[:name])
+    render_error(status: 404, errorcode: 'not_found', message: "Unable to find issue tracker '#{params[:name]}'") && return unless @issue_tracker
 
     @issue_tracker.destroy
 

--- a/src/api/app/controllers/issue_trackers_controller.rb
+++ b/src/api/app/controllers/issue_trackers_controller.rb
@@ -15,16 +15,6 @@ class IssueTrackersController < ApplicationController
     end
   end
 
-  # GET /issue_trackers/<id>
-  def show
-    @issue_tracker = IssueTracker.find_by_name(params[:id])
-    render_error(status: 404, errorcode: 'not_found', message: "Unable to find issue tracker '#{params[:id]}'") && return unless @issue_tracker
-
-    respond_to do |format|
-      format.xml  { render xml: @issue_tracker.to_xml(IssueTracker::DEFAULT_RENDER_PARAMS) }
-    end
-  end
-
   # POST /issue_trackers
   def create
     xml = Nokogiri::XML(request.raw_post, &:strict).root
@@ -46,7 +36,17 @@ class IssueTrackersController < ApplicationController
     end
   end
 
-  # PUT /issue_trackers/bnc
+  # GET /issue_trackers/<name>
+  def show
+    @issue_tracker = IssueTracker.find_by_name(params[:id])
+    render_error(status: 404, errorcode: 'not_found', message: "Unable to find issue tracker '#{params[:id]}'") && return unless @issue_tracker
+
+    respond_to do |format|
+      format.xml  { render xml: @issue_tracker.to_xml(IssueTracker::DEFAULT_RENDER_PARAMS) }
+    end
+  end
+
+  # PUT /issue_trackers/<name>
   def update
     respond_to do |format|
       xml = Nokogiri::XML(request.raw_post, &:strict).root
@@ -72,7 +72,7 @@ class IssueTrackersController < ApplicationController
     end
   end
 
-  # DELETE /issue_trackers/bnc
+  # DELETE /issue_trackers/<name>
   def destroy
     @issue_tracker = IssueTracker.find_by_name(params[:id])
     render_error(status: 404, errorcode: 'not_found', message: "Unable to find issue tracker '#{params[:id]}'") && return unless @issue_tracker

--- a/src/api/app/controllers/issues_controller.rb
+++ b/src/api/app/controllers/issues_controller.rb
@@ -1,6 +1,4 @@
 class IssuesController < ApplicationController
-  before_action :require_admin, only: [:create, :update, :destroy]
-
   def show
     required_parameters :id, :issue_tracker_name
 

--- a/src/api/app/controllers/issues_controller.rb
+++ b/src/api/app/controllers/issues_controller.rb
@@ -2,10 +2,9 @@ class IssuesController < ApplicationController
   before_action :require_admin, only: [:create, :update, :destroy]
 
   def show
-    required_parameters :id, :issue_tracker_id
+    required_parameters :id, :issue_tracker_name
 
-    # NOTE: issue_tracker_id is here actually the name
-    issue = Issue.find_or_create_by_name_and_tracker(params[:id], params[:issue_tracker_id], params[:force_update])
+    issue = Issue.find_or_create_by_name_and_tracker(params[:id], params[:issue_tracker_name], params[:force_update])
 
     render xml: issue.render_axml
   end

--- a/src/api/config/routes/api_routes.rb
+++ b/src/api/config/routes/api_routes.rb
@@ -71,8 +71,8 @@ OBSApi::Application.routes.draw do
     post 'trigger/webhook' => 'services/webhooks#create'
 
     ### /issue_trackers
-    resources :issue_trackers, only: [:index, :show, :create, :update, :destroy] do
-      resources :issues, only: [:show] # Nested route
+    resources :issue_trackers, only: [:index, :show, :create, :update, :destroy], param: :name do
+      resources :issues, only: [:show]
     end
 
     ### /statistics


### PR DESCRIPTION
The `POST` route for issue trackers doesn't require an issue tracker id in path parameters. And the `create` method in the controller doesn't make use of any path parameters.

This is how issue_trackers routes looks like now:

```
issue_tracker_issue GET    /issue_trackers/:issue_tracker_id/issues/:id(.:format) issues#show                                                            
     issue_trackers GET    /issue_trackers(.:format)                              issue_trackers#index                                                   
                    POST   /issue_trackers(.:format)                              issue_trackers#create                                                  
      issue_tracker GET    /issue_trackers/:id(.:format)                          issue_trackers#show                                                    
                    PATCH  /issue_trackers/:id(.:format)                          issue_trackers#update                                                  
                    PUT    /issue_trackers/:id(.:format)                          issue_trackers#update                                                  
                    DELETE /issue_trackers/:id(.:format)                          issue_trackers#destroy                                                 
```

Also replace `bnc` as an example of ids with `<id>`, in the comments, for the description of the route related to the controller method.

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature
