### PR TITLE
Adjust the rollout tasks

### DIFF
--- a/src/api/lib/tasks/rollout.rake
+++ b/src/api/lib/tasks/rollout.rake
@@ -1,35 +1,29 @@
 # rubocop:disable Rails/SkipsModelValidations
+
+# Follow the recommendations for the rollout in:
+# https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles#steps-for-rolling-out
+
 namespace :rollout do
   desc 'Move all the users to rollout program'
   task all_on: :environment do
     User.all_without_nobody
-        .not_staff
         .where(in_rollout: false).in_batches.update_all(in_rollout: true)
   end
 
   desc 'Move all the users out of the rollout program'
   task all_off: :environment do
     User.all_without_nobody
-        .not_staff
         .where(in_rollout: true).in_batches.update_all(in_rollout: false)
   end
 
   desc 'Move the users already in beta to rollout program'
   task from_beta: :environment do
-    User.not_staff
-        .where(in_beta: true, in_rollout: false).in_batches.update_all(in_rollout: true)
-  end
-
-  desc 'Move the members of groups to rollout program'
-  task from_groups: :environment do
-    User.not_staff
-        .where(in_rollout: false).joins(:groups_users).distinct.in_batches.update_all(in_rollout: true)
+    User.where(in_beta: true, in_rollout: false).in_batches.update_all(in_rollout: true)
   end
 
   desc 'Move the users with recent activity to rollout program'
   task recently_logged_users: :environment do
     User.all_without_nobody
-        .not_staff
         .where(in_rollout: false, last_logged_in_at: Time.zone.today.prev_month(3)..Time.zone.today)
         .in_batches.update_all(in_rollout: true)
   end
@@ -37,9 +31,13 @@ namespace :rollout do
   desc 'Move the users without recent activity to rollout program'
   task non_recently_logged_users: :environment do
     User.all_without_nobody
-        .not_staff
         .where.not(in_rollout: true).where.not(last_logged_in_at: Time.zone.today.prev_month(3)..Time.zone.today)
         .in_batches.update_all(in_rollout: true)
+  end
+
+  desc 'Move the members of groups to rollout program'
+  task from_groups: :environment do
+    User.where(in_rollout: false).joins(:groups_users).distinct.in_batches.update_all(in_rollout: true)
   end
 
   desc 'Move Staff users to rollout program'
@@ -52,6 +50,18 @@ namespace :rollout do
   task staff_off: :environment do
     User.staff
         .where(in_rollout: true).in_batches.update_all(in_rollout: false)
+  end
+
+  desc 'Move the anonymous user to the rollout program'
+  task anonymous_on: :environment do
+    user = User.find_by(login: '_nobody_', in_rollout: false)
+    user&.update_column(:in_rollout, true)
+  end
+
+  desc 'Move the anonymous user out of the rollout program'
+  task anonymous_off: :environment do
+    user = User.find_by(login: '_nobody_', in_rollout: true)
+    user&.update_column(:in_rollout, false)
   end
 end
 # rubocop:enable Rails/SkipsModelValidations


### PR DESCRIPTION
Most of the rollout tasks like "all_on" or "from_beta" excluded the staff users. Semantically speaking it was confusing. As we no longer need that restriction, the staff are not excluded anymore.

We also add tasks to move the anonymous user (_nobody_) into or out of the rollout program. Something that is usually needed at the beginning or end of the rollout process.

This PR comes with an update of the developer documentation: [Steps for Rolling Out](https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-(Flipper)#steps-for-rolling-out)

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [x] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

