### PR TITLE
Use an up to date distribution name

### DIFF
--- a/dist/t/spec/features/0030_project_spec.rb
+++ b/dist/t/spec/features/0030_project_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Project" do
     end
     click_link('Repositories')
     click_link('Add from a Distribution')
-    check('repo_openSUSE_Leap_15_1', allow_label_click: true)
-    expect(page).to have_content("Successfully added repository 'openSUSE_Leap_15.1'")
+    check('repo_openSUSE_Leap_15_3', allow_label_click: true)
+    expect(page).to have_content("Successfully added repository 'openSUSE_Leap_15.3'")
   end
 end


### PR DESCRIPTION
This is a backport of https://github.com/openSUSE/open-build-service/pull/10622 to the 2.10 version

See [OpenQA for 2.10](https://openqa.opensuse.org/group_overview/63)