### PR TITLE
Document '/distributions' API routes with OpenAPI

### DIFF
--- a/src/api/app/controllers/distributions_controller.rb
+++ b/src/api/app/controllers/distributions_controller.rb
@@ -27,13 +27,13 @@ class DistributionsController < ApplicationController
     end
   end
 
-  # GET /distributions/opensuse-11.4
-  # GET /distributions/opensuse-11.4.xml
+  # GET /distributions/1234
+  # GET /distributions/1234.xml
   def show
     @distribution = Distribution.find(params[:id]).to_hash
 
     respond_to do |format|
-      format.xml  { render xml: @distribution }
+      format.xml
       format.json { render json: @distribution }
     end
   end

--- a/src/api/app/views/distributions/_distribution.xml.builder
+++ b/src/api/app/views/distributions/_distribution.xml.builder
@@ -1,0 +1,16 @@
+builder.distribution(vendor: distribution['vendor'], version: distribution['version'], id: distribution['id']) do
+  builder.name(distribution['name'])
+  builder.project(distribution['project'])
+  builder.reponame(distribution['reponame'])
+  builder.repository(distribution['repository'])
+  builder.link(distribution['link'])
+  distribution['icons'].each do |i|
+    attr = { url: i['url'] }
+    attr[:width] = i['width'] if i['width'].present?
+    attr[:height] = i['height'] if i['height'].present?
+    builder.icon(attr)
+  end
+  distribution['architectures'].each do |architecture|
+    builder.architecture(architecture.to_s)
+  end
+end

--- a/src/api/app/views/distributions/index.xml.builder
+++ b/src/api/app/views/distributions/index.xml.builder
@@ -1,20 +1,5 @@
 xml.distributions do
-  @distributions.each do |d|
-    xml.distribution(vendor: d['vendor'], version: d['version'], id: d['id']) do
-      xml.name(d['name'])
-      xml.project(d['project'])
-      xml.reponame(d['reponame'])
-      xml.repository(d['repository'])
-      xml.link(d['link'])
-      d['icons'].each do |i|
-        attr = { url: i['url'] }
-        attr[:width] = i['width'] if i['width'].present?
-        attr[:height] = i['height'] if i['height'].present?
-        xml.icon(attr)
-      end
-      d['architectures'].each do |a|
-        xml.architecture(a.to_s)
-      end
-    end
+  @distributions.each do |distribution|
+    render(partial: 'distributions/distribution', locals: { distribution: distribution, builder: xml })
   end
 end

--- a/src/api/app/views/distributions/show.xml.builder
+++ b/src/api/app/views/distributions/show.xml.builder
@@ -1,0 +1,1 @@
+render(partial: 'distributions/distribution', locals: { distribution: @distribution, builder: xml })

--- a/src/api/public/apidocs-new/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs-new/OBS-v2.10.50.yaml
@@ -12,6 +12,7 @@ tags:
   - name: Attributes
   - name: Request
   - name: Configuration
+  - name: Distributions
 
 info:
   description: |
@@ -58,6 +59,13 @@ paths:
 
   /configuration:
     $ref: 'paths/configuration.yaml'
+
+  /distributions:
+    $ref: 'paths/distributions.yaml'
+  /distributions/include_remotes:
+    $ref: 'paths/distributions_include_remotes.yaml'
+  /distributions/{distribution_id}:
+    $ref: 'paths/distributions_distribution_id.yaml'
 
   /group:
     $ref: 'paths/group.yaml'

--- a/src/api/public/apidocs-new/components/parameters/distribution_id.yaml
+++ b/src/api/public/apidocs-new/components/parameters/distribution_id.yaml
@@ -1,0 +1,7 @@
+in: path
+name: distribution_id
+schema:
+  type: integer
+required: true
+description: The id of the distribution
+example: 16626

--- a/src/api/public/apidocs-new/components/responses/distributions.yaml
+++ b/src/api/public/apidocs-new/components/responses/distributions.yaml
@@ -1,0 +1,62 @@
+description: |
+  OK. The request has succeeded.
+
+  XML Schema used for body validation: [distributions.rng](../schema/distributions.rng)
+content:
+  application/xml; charset=utf-8:
+    schema:
+      $ref: '../schemas/distributions.yaml'
+    example:
+      distribution:
+        - vendor: 'opensuse'
+          version: 'Tumbleweed'
+          id: 16626
+          name: 'openSUSE Tumbleweed'
+          project: 'openSUSE:Factory'
+          reponame: 'openSUSE_Tumbleweed'
+          repository: 'snapshot'
+          link: 'http://www.opensuse.org/'
+          icon:
+            - url: 'https://static.opensuse.org/distributions/logos/opensuse.png'
+              width: 8
+              height: 8
+            - url: 'https://static.opensuse.org/distributions/logos/opensuse.png'
+              width: 16
+              height: 16
+          architecture:
+            - 'i586'
+            - 'x86_64'
+        - vendor: 'openSUSE'
+          version: '15.3'
+          id: 16629
+          name: 'openSUSE Leap 15.3'
+          project: 'openSUSE:Leap:15.3'
+          reponame: 'openSUSE_Leap_15.3'
+          repository: 'standard'
+          link: 'http://www.opensuse.org/'
+          icon:
+            - url: 'https://static.opensuse.org/distributions/logos/opensuse.png'
+              width: 8
+              height: 8
+            - url: 'https://static.opensuse.org/distributions/logos/opensuse.png'
+              width: 16
+              height: 16
+          architecture: 'x86_64'
+        - vendor: 'Fedora'
+          version: '33'
+          id: 16731
+          name: 'Fedora 33'
+          project: 'Fedora:33'
+          reponame: 'Fedora_33'
+          repository: 'standard'
+          link: 'http://www.fedoraproject.org/'
+          icon:
+            - url: 'https://static.opensuse.org/distributions/logos/fedora.png'
+              width: 8
+              height: 8
+            - url: 'https://static.opensuse.org/distributions/logos/fedora.png'
+              width: 16
+              height: 16
+          architecture:
+            - 'i586'
+            - 'x86_64'

--- a/src/api/public/apidocs-new/components/schemas/distributions.yaml
+++ b/src/api/public/apidocs-new/components/schemas/distributions.yaml
@@ -1,0 +1,70 @@
+type: object
+properties:
+  distribution:
+    type: array
+    items:
+      type: object
+      properties:
+        id:
+          type: integer
+          example: 16626
+          xml:
+            attribute: true
+        vendor:
+          type: string
+          example: opensuse
+          xml:
+            attribute: true
+        version:
+          type: string
+          example: Tumbleweed
+          xml:
+            attribute: true
+        name:
+          type: string
+          example: openSUSE Tumbleweed
+        project:
+          type: string
+          example: 'openSUSE:Factory'
+        repository:
+          type: string
+          example: snapshot
+        reponame:
+          type: string
+          example: openSUSE_Tumbleweed
+        link:
+          type: string
+          example: 'http://www.opensuse.org/'
+        architecture:
+          type: array
+          example:
+            - i586
+            - x86_64
+          items:
+            type: string
+        icon:
+          type: array
+          example:
+            - width: 8
+              height: 8
+              url: 'https://static.opensuse.org/distributions/logos/opensuse.png'
+            - width: 16
+              height: 16
+              url: 'https://static.opensuse.org/distributions/logos/opensuse.png'
+          items:
+            type: object
+            properties:
+              width:
+                type: integer
+                xml:
+                  attribute: true
+              height:
+                type: integer
+                xml:
+                  attribute: true
+              url:
+                type: string
+                xml:
+                  attribute: true
+xml:
+  name: distributions

--- a/src/api/public/apidocs-new/paths/distributions.yaml
+++ b/src/api/public/apidocs-new/paths/distributions.yaml
@@ -1,0 +1,82 @@
+get:
+  summary: List all distributions.
+  description: |
+    List all distributions that can be build against.
+    This will not list distributions that are available via [interconnect](https://openbuildservice.org/help/manuals/obs-user-guide/cha.obs.concepts.html#id-1.5.10.3.5).
+    Check /distributions/include_remotes for this.
+  security:
+    - basic_authentication: []
+  responses:
+    '200':
+      $ref: '../components/responses/distributions.yaml'
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+  tags:
+    - Distributions
+
+# FIXME: This endpoint doesn't work. It should be fixed before we document it.
+#        It's not documented in the non-Swagger API documentation.
+#        PUT /distributions would do the same (while also deleting all existing distributions). This is confusing!
+#
+# post:
+#   summary: Create distributions.
+#   description: |
+#     Create one or more distributions.
+
+#     This is only for admins.
+#   security:
+#     - basic_authentication: []
+#   requestBody:
+#     description: Distribution definition
+#     content:
+#       application/xml; charset=utf-8:
+#         schema:
+#           $ref: '../components/schemas/distributions.yaml'
+#   responses:
+#     '200':
+#       $ref: '../components/responses/distributions.yaml'
+#     '401':
+#       $ref: '../components/responses/unauthorized.yaml'
+#   tags:
+#     - Distributions
+
+put:
+  summary: Create distributions while deleting all existing distributions.
+  description: |
+    Create one or more distributions. Existing distributions will be deleted.
+
+    This is only for admins.
+  security:
+    - basic_authentication: []
+  requestBody:
+    description: Distributions definition
+    content:
+      application/xml; charset=utf-8:
+        schema:
+          $ref: '../components/schemas/distributions.yaml'
+  responses:
+    '200':
+      description: |
+        OK. The Request has succeded.
+
+        XML Schema used for body validation: [distributions.rng](../schema/distributions.rng)
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          example:
+            code: 'ok'
+            summary: 'Ok'
+    '400':
+      description: Bad Request.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          example:
+            code: 'validation_failed'
+            summary: 'distributions validation error: 40:0: ERROR: Expecting an element name, got nothing'
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+  tags:
+    - Distributions

--- a/src/api/public/apidocs-new/paths/distributions_distribution_id.yaml
+++ b/src/api/public/apidocs-new/paths/distributions_distribution_id.yaml
@@ -1,0 +1,64 @@
+get:
+  summary: Show a distribution.
+  description: |
+    Show a distribution that can be build against.
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/distribution_id.yaml'
+  responses:
+    '200':
+      description: |
+        OK. The request has succeded.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/distributions.yaml'
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '404':
+      description: Not found.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          example:
+            code: 'not_found'
+            summary: "Couldn't find Distribution with 'id'=0"
+  tags:
+    - Distributions
+
+delete:
+  summary: Delete a distribution.
+  description: |
+    Delete a distribution.
+
+    This is only for admins.
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/distribution_id.yaml'
+  responses:
+    '200':
+      description: |
+        OK. The request has succeded.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          example:
+            code: 'ok'
+            summary: 'Ok'
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '404':
+      description: Not found.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          example:
+            code: 'not_found'
+            summary: "Couldn't find Distribution with 'id'=0"
+  tags:
+    - Distributions

--- a/src/api/public/apidocs-new/paths/distributions_include_remotes.yaml
+++ b/src/api/public/apidocs-new/paths/distributions_include_remotes.yaml
@@ -1,0 +1,13 @@
+get:
+  summary: List all distributions.
+  description: |
+    List all distributions that can be build against, including the ones provided by the interconnect.
+  security:
+    - basic_authentication: []
+  responses:
+    '200':
+      $ref: '../components/responses/distributions.yaml'
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+  tags:
+    - Distributions

--- a/src/api/test/functional/distributions_controller_test.rb
+++ b/src/api/test/functional/distributions_controller_test.rb
@@ -11,31 +11,7 @@ class DistributionsControllerTest < ActionDispatch::IntegrationTest
     login_tom
     get distribution_path(id: distributions(:two).to_param)
     assert_response :success
-    # the default XML renderer just s***s
-    assert_equal({ 'id' => { 'type' => 'integer', '_content' => '2' },
-                   'link' => 'http://www.openbuildservice.org/',
-                   'name' => 'OBS Base 2.0',
-                   'project' => 'BaseDistro2.0',
-                   'reponame' => 'Base_repo',
-                   'repository' => 'BaseDistro2_repo',
-                   'vendor' => 'OBS',
-                   'version' => 'Base',
-                   'architectures' =>
-                                      { 'type' => 'array',
-                                        'architecture' => ['i586', 'x86_64'] },
-                   'icons' =>
-                                      { 'type' => 'array',
-                                        'icon' =>
-                                                  [{ 'id' => { 'type' => 'integer', '_content' => '72' },
-                                                     'url' =>
-                                                                 'https://static.opensuse.org/distributions/logos/opensuse-Factory-8.png',
-                                                     'width' => { 'type' => 'integer', '_content' => '8' },
-                                                     'height' => { 'type' => 'integer', '_content' => '8' } },
-                                                   { 'id' => { 'type' => 'integer', '_content' => '73' },
-                                                     'url' =>
-                                                                 'https://static.opensuse.org/distributions/logos/opensuse-Factory-16.png',
-                                                     'width' => { 'type' => 'integer', '_content' => '16' },
-                                                     'height' => { 'type' => 'integer', '_content' => '16' } }] } }, Xmlhash.parse(@response.body))
+    assert_xml_tag tag: 'name', content: 'OBS Base 2.0'
   end
 
   def test_should_destroy_distribution


### PR DESCRIPTION
This adds the "distributions" group to the new OpenAPI documentation.
Note that I found the old documentation to be at times outdated. So I tried to also update the documentation with more up to date information.

To verify the new addition to the documentation:
- Start the development environment
- Go to http://localhost:3000/apidocs-new/

![distributions](https://user-images.githubusercontent.com/1102934/105719321-71573700-5f22-11eb-8a3d-0fec0ad2db8b.png)