### PR TITLE
[backend] scheduler: do not always check linkers for delayedfetchproj…

### DIFF
--- a/src/backend/bs_getbinariesproxy
+++ b/src/backend/bs_getbinariesproxy
@@ -79,6 +79,35 @@ sub set_maxopen() {
   print "could open $maxopen file descriptors\n";
 }
 
+sub move_entry_into_cache {
+  my ($cacheid, $path) = @_;
+  my $cachefile = "$cachedir/".substr($cacheid, 0, 2)."/$cacheid";
+  mkdir_p("$cachedir/".substr($cacheid, 0, 2));
+  unlink("$cachefile.$$");
+  return 0 unless link($path, "$cachefile.$$");
+  rename("$cachefile.$$", $cachefile) || die("rename $cachefile.$$ $cachefile: $!\n");
+  my $mpath = "$path.meta";
+  $mpath = "$1.meta" if $path =~ /^(.*)\.(?:$binsufsre)$/;
+  if (-s $mpath) {
+    unlink("$cachefile.meta.$$");
+    if (link($mpath, "$cachefile.meta.$$")) {
+      rename("$cachefile.meta.$$", "$cachefile.meta") || die("rename $cachefile.meta.$$ $cachefile.meta: $!\n");
+    } else {
+      unlink("$cachefile.meta");
+    }
+  } else {
+    unlink("$cachefile.meta");
+  }
+  return 1;
+}
+
+sub remove_entry_from_cache {
+  my ($cacheid) = @_;
+  my $cachefile = "$cachedir/".substr($cacheid, 0, 2)."/$cacheid";
+  unlink($cachefile);
+  unlink("$cachefile.meta");
+}
+
 sub manage_cache {
   my ($prunesize, $cacheold, $cachenew) = @_;
   # get the lock
@@ -92,31 +121,10 @@ sub manage_cache {
   $content ||= [];
   my %content = map {$_->[0] => $_->[1]} @$content;
   # put cacheold, cachenew at the top
-  if ($cacheold && @$cacheold) {
-    splice(@$content, 0, 0, @$cacheold);
-    $content{$_->[0]} = $_->[1] for @$cacheold;
-  }
+  splice(@$content, 0, 0, @$cacheold) if $cacheold && @$cacheold;
   if ($cachenew) {
     for my $c (reverse @$cachenew) {
-      my $path = pop(@$c);
-      my $cacheid = $c->[0];
-      my $cachefile = "$cachedir/".substr($cacheid, 0, 2)."/$cacheid";
-      mkdir_p("$cachedir/".substr($cacheid, 0, 2));
-      unlink("$cachefile.$$");
-      next unless link($path, "$cachefile.$$");
-      rename("$cachefile.$$", $cachefile) || die("rename $cachefile.$$ $cachefile: $!\n");
-      my $mpath = "$path.meta";
-      $mpath = "$1.meta" if $path =~ /^(.*)\.(?:$binsufsre)$/;
-      if (-s $mpath) {
-	unlink("$cachefile.meta.$$");
-	if (link($mpath, "$cachefile.meta.$$")) {
-	  rename("$cachefile.meta.$$", "$cachefile.meta") || die("rename $cachefile.meta.$$ $cachefile.meta: $!\n");
-	} else {
-	  unlink("$cachefile.meta");
-	}
-      } else {
-	unlink("$cachefile.meta");
-      }
+      next unless move_entry_into_cache($c->[0], pop(@$c));
       unshift @$content, $c;
       $content{$c->[0]} = $c->[1];
     }
@@ -125,30 +133,20 @@ sub manage_cache {
   for my $c (@$content) {
     if (!defined delete $content{$c->[0]}) {
       $c = undef;
-      next;
-    }
-    $prunesize -= $c->[1];
-    if ($prunesize < 0) {
-      my $cacheid = $c->[0];
-      my $cachefile = "$cachedir/".substr($cacheid, 0, 2)."/$cacheid";
-      unlink($cachefile);
-      unlink("$cachefile.meta");
+    } elsif (($prunesize -= $c->[1]) < 0) {
+      remove_entry_from_cache($c->[0]);
       $c = undef;
-      next;
     }
   }
+  # store content
   @$content = grep {defined $_} @$content;
   eval {
     Storable::nstore($content, "$cachedir/content.new");
     rename("$cachedir/content.new", "$cachedir/content") || die("rename $cachedir/content.new $cachedir/content");
   };
   if ($@) {
-    for my $c (@$cachenew) {
-      my $cacheid = $c->[0];
-      my $cachefile = "$cachedir/".substr($cacheid, 0, 2)."/$cacheid";
-      unlink($cachefile);
-      unlink("$cachefile.meta");
-    }    
+    # could not update content, delete all new entries
+    remove_entry_from_cache($_->[0]) for @$cachenew;
     die($@);
   }
   close F;

--- a/src/backend/bs_sched
+++ b/src/backend/bs_sched
@@ -987,7 +987,7 @@ eval {
       while ($delayed = delete($gctx->{'delayedfetchprojpacks'}->{$projid})) {
         my $async;
         $async = {'_changeprp' => $prp, '_changetype' => $lookattype} if $gctx->{'asyncmode'};
-        $inprogress ||= !BSSched::ProjPacks::do_delayedprojpackfetches($gctx, $async, $projid, @$delayed);
+        $inprogress = 1 if !BSSched::ProjPacks::do_delayedprojpackfetches($gctx, $async, $projid, @$delayed);
       }
       next if $inprogress;	# async projpack fetch in progress...
     }

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -1167,6 +1167,35 @@ sub link_or_copy {
   return 1;
 }
 
+sub move_entry_into_cache {
+  my ($cacheid, $path) = @_;
+  my $cachefile = "$cachedir/".substr($cacheid, 0, 2)."/$cacheid";
+  mkdir_p("$cachedir/".substr($cacheid, 0, 2));
+  unlink("$cachefile.$$");
+  return 0 unless link($path, "$cachefile.$$");
+  rename("$cachefile.$$", $cachefile) || die("500 rename $cachefile.$$ $cachefile: $!\n");
+  my $mpath = "$path.meta";
+  $mpath = "$1.meta" if $path =~ /^(.*)\.(?:$binsufsre)$/;
+  if (-s $mpath) {
+    unlink("$cachefile.meta.$$");
+    if (link($mpath, "$cachefile.meta.$$")) {
+      rename("$cachefile.meta.$$", "$cachefile.meta") || die("500 rename $cachefile.meta.$$ $cachefile.meta: $!\n");
+    } else {
+      unlink("$cachefile.meta");
+    }
+  } else {
+    unlink("$cachefile.meta");
+  }
+  return 1;
+}
+
+sub remove_entry_from_cache {
+  my ($cacheid) = @_;
+  my $cachefile = "$cachedir/".substr($cacheid, 0, 2)."/$cacheid";
+  unlink($cachefile);
+  unlink("$cachefile.meta");
+}
+
 sub manage_cache {
   my ($prunesize, $cacheold, $cachenew) = @_;
   # get the lock
@@ -1181,33 +1210,10 @@ sub manage_cache {
   $content ||= [];
   my %content = map {$_->[0] => $_->[1]} @$content;
   # put cacheold, cachenew at the top
-  if ($cacheold && @$cacheold) {
-    splice(@$content, 0, 0, @$cacheold);
-    $content{$_->[0]} = $_->[1] for @$cacheold;
-  }
+  splice(@$content, 0, 0, @$cacheold) if $cacheold && @$cacheold;
   if ($cachenew) {
     for my $c (reverse @$cachenew) {
-      my $path = pop(@$c);
-      my $cacheid = $c->[0];
-      my $cachefile = "$cachedir/".substr($cacheid, 0, 2)."/$cacheid";
-      mkdir_p("$cachedir/".substr($cacheid, 0, 2));
-      unlink("$cachefile.$$");
-      next unless link_or_copy($path, "$cachefile.$$");
-      rename("$cachefile.$$", $cachefile) || die("500 rename $cachefile.$$ $cachefile: $!\n");
-      unlink("$cachefile.$$");
-      my $mpath = "$path.meta";
-      $mpath = "$1.meta" if $path =~ /^(.*)\.(?:$binsufsre)$/;
-      if (-s $mpath) {
-	unlink("$cachefile.meta.$$");
-	if (link_or_copy($mpath, "$cachefile.meta.$$")) {
-	  rename("$cachefile.meta.$$", "$cachefile.meta") || die("500 rename $cachefile.meta.$$ $cachefile.meta: $!\n");
-	  unlink("$cachefile.meta.$$");
-	} else {
-	  unlink("$cachefile.meta");
-	}
-      } else {
-	unlink("$cachefile.meta");
-      }
+      next unless move_entry_into_cache($c->[0], pop(@$c));
       unshift @$content, $c;
       $content{$c->[0]} = $c->[1];
     }
@@ -1217,19 +1223,12 @@ sub manage_cache {
   for my $c (@$content) {
     if (!defined delete $content{$c->[0]}) {
       $c = undef;	# already pruned
-      next;
-    }
-    $prunesize -= $c->[1];
-    if ($prunesize < 0) {
+    } elsif (($prunesize -= $c->[1]) < 0) {
       push @pruneids, $c->[0];
       $c = undef;
     }
   }
-  for my $cacheid (sort @pruneids) {
-    my $cachefile = "$cachedir/".substr($cacheid, 0, 2)."/$cacheid";
-    unlink($cachefile);
-    unlink("$cachefile.meta");
-  }
+  remove_entry_from_cache($_->[0]) for sort @pruneids;
   @$content = grep {defined $_} @$content;
   eval {
     Storable::nstore($content, "$cachedir/content.new");
@@ -1237,12 +1236,7 @@ sub manage_cache {
   };
   if ($@) {
     # could not update content, delete all new entries
-    for my $c (@$cachenew) {
-      my $cacheid = $c->[0];
-      my $cachefile = "$cachedir/".substr($cacheid, 0, 2)."/$cacheid";
-      unlink($cachefile);
-      unlink("$cachefile.meta");
-    }
+    remove_entry_from_cache($_->[0]) for @$cachenew;
     die($@);
   }
   close F;


### PR DESCRIPTION
…packs packages

We do not want check linkers for packages put on the delayedfetchprojpacks by
the linker check itself, as this is both not necessary and could lead to
endless package updates.

We now support a '/dolink' flag on the queue that enables linker checking.

_Replace this line with a description of your changes. Please follow the suggestions in the comment below._

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
