### PR TITLE
Document person register endpoint

### DIFF
--- a/src/api/public/apidocs-new/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs-new/OBS-v2.10.50.yaml
@@ -58,7 +58,8 @@ paths:
 
   /person:
     $ref: 'paths/person.yaml'
-
+  /person/register:
+    $ref: 'paths/person_register.yaml'
   /person/{login}/token:
     $ref: 'paths/person_login_token.yaml'
 

--- a/src/api/public/apidocs-new/components/schemas/unregisteredperson.yaml
+++ b/src/api/public/apidocs-new/components/schemas/unregisteredperson.yaml
@@ -1,0 +1,16 @@
+type: object
+properties:
+  login:
+    type: string
+  realname:
+    type: string
+  email:
+    type: string
+  password:
+    type: string
+  note:
+    type: string
+  state:
+    type: string
+xml:
+  name: unregisteredperson

--- a/src/api/public/apidocs-new/paths/person.yaml
+++ b/src/api/public/apidocs-new/paths/person.yaml
@@ -2,8 +2,6 @@ get:
   summary: List all people.
   description: >
     List all people.
-  security:
-    - basic_authentication: []
   parameters:
     - in: query
       name: prefix
@@ -34,7 +32,5 @@ get:
               - name: 'user_2'
               - name: 'user_3'
               - name: 'Requestor'
-    '401':
-      $ref: '../components/responses/unauthorized.yaml'
   tags:
     - Person


### PR DESCRIPTION
The OpenAPI documentation for the `person#register` action.

You can test it in [our review-app](https://obs-reviewlab.opensuse.org/danidoni-document-person-register-endpoint/apidocs-new/#/Person/post_person_register)

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature