### PR TITLE
Fix example of a not found response example, in issue trackers

### DIFF
--- a/src/api/public/apidocs-new/paths/issue_trackers_issue_tracker_name_issues_issue_name.yaml
+++ b/src/api/public/apidocs-new/paths/issue_trackers_issue_tracker_name_issues_issue_name.yaml
@@ -28,7 +28,6 @@ get:
             $ref: '../components/schemas/api_response.yaml'
           example:
             code: issue_tracker_not_found
-            summary: Error: Issue Tracker 'foo' not found.
+            summary: "Error: Issue Tracker 'foo' not found."
   tags:
     - Issue Trackers
-


### PR DESCRIPTION
Add double quotes to the sentence. This prevented the whole endpoint to be shown in the OpenAPI documetation.

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature
