### PR TITLE
[backend] turn binarycache content file into sqlite db

### DIFF
--- a/src/backend/bs_getbinariesproxy
+++ b/src/backend/bs_getbinariesproxy
@@ -39,6 +39,7 @@ use Symbol;
 
 use BSConfiguration;
 use BSRPC ':https';
+use BSSQLite;
 use BSServer;
 use BSStdServer;
 use BSUtil;
@@ -56,14 +57,36 @@ my $proto = 'http';
 $port = $1 if $BSConfig::getbinariesproxyserver && $BSConfig::getbinariesproxyserver =~ /:(\d+)$/;
 $proto = $1 if $BSConfig::getbinariesproxyserver && $BSConfig::getbinariesproxyserver =~ /^(https):/;
 
-
 my $cachedir = "$BSConfig::bsdir/getbinariesproxycache";
 my $cachesize = 1024 * 1024 * 1024;	# default: 1G
 $cachesize = $BSConfig::getbinariesproxyserver_cachesize * 1024 * 1024 if $BSConfig::getbinariesproxyserver_cachesize;
 
+# content db init
+my $binarycachedbfile = "$cachedir/content.db";
+my $binarycachedb;
+
 my $cachetmpdir = "$cachedir/tmp";
 
 my $maxopen;	# max number of fds we can open
+
+sub init_db {
+  mkdir_p($cachedir);
+  $binarycachedb = BSSQLite::connectdb($binarycachedbfile);
+  my %dbtables = map {$_ => 1} BSSQLite::list_tables($binarycachedb);
+  if (!$dbtables{'binarycache'}) {
+    BSSQLite::dbdo($binarycachedb, <<'EOS');
+  CREATE TABLE IF NOT EXISTS binarycache(
+    md5 TEXT,
+    size INTEGER,
+    time TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    UNIQUE(md5)
+  )
+EOS
+  }
+  # create our global sum counter over all entries
+  BSSQLite::dbdo_bind($binarycachedb, 'INSERT OR IGNORE INTO binarycache(md5,size) VALUES("__sum__", 0)');
+#  BSSQLite::dbdo($binarycachedb, 'CREATE INDEX IF NOT EXISTS binarycache_idx on binarycache(md5)');
+}
 
 sub set_maxopen() {
   my $fd = POSIX::open('/dev/null', O_RDONLY);
@@ -116,8 +139,73 @@ sub remove_entry_from_cache {
   unlink("$cachefile.meta");
 }
 
+sub manage_cache_sqlite {
+  my ($prunesize, $cacheold, $cachenew) = @_;
+  # get the handle
+  my $h = $binarycachedb->{'sqlite'} || BSSQLite::connectdb($binarycachedbfile);
+  BSSQLite::begin_work($h);
+
+  # get current cache size
+  my @ary = BSSQLite::selectrow($h, "SELECT size FROM binarycache WHERE md5 = '__sum__'");
+  my $currentcachesize = $ary[0];
+
+  # update time stamp on hits
+  if ($cacheold && @$cacheold) {
+    # FIXME: turn this into a single call?
+    BSSQLite::dbdo_bind($h, 'UPDATE SET time = CURRENT_TIMESTAMP WHERE md5 = ?', $_->[0]) for @$cacheold;
+  }
+
+  # prune cache, oldest first
+  # do it by chunks to avoid to read entire database;
+  while ( $currentcachesize < $prunesize ) {
+    my $sth = $h->prepare("SELECT md5,size FROM binarycache WHERE md5 != '__sum__' ORDER BY time LIMIT 100");
+    $sth->execute();
+    while(my $row = $sth->fetch) {
+      BSSQLite::dbdo_bind($h, 'DELETE FROM binarycache WHERE md5 = ?', [ $row->[0] ]);
+      remove_entry_from_cache($row->[0]);
+      $prunesize -= $row->[1];
+      last if $currentcachesize > $prunesize;
+    }
+  }
+# alternative implementation without chunks
+# my $tobepruned = $currentcachesize - $prunesize;
+# if ( $tobepruned > 0 ) {
+#   my $sth = $h->prepare("SELECT md5,size FROM binarycache WHERE md5 != '__sum__' GROUP BY time HAVING SUM(size) > $tobepruned");
+#   $sth->execute();
+#   while(my $row = $sth->fetch) {
+#     BSSQLite::dbdo_bind($h, 'DELETE FROM binarycache WHERE md5 = ?', [ $row->[0] ]);
+#     $prunesize -= $row->[1];
+#     remove_entry_from_cache($row->[0]);
+#   }
+# }
+
+  # add new files
+  if ($cachenew) {
+    for my $c (reverse @$cachenew) {
+      next unless move_entry_into_cache($c->[0], pop(@$c));
+      eval {
+        BSSQLite::dbdo_bind($h, 'INSERT INTO binarycache(md5,size) VALUES(?,?)', [ $c->[0] ], [ $c->[1] ]);
+      };
+      if ($@ =~ /^UNIQUE constraint failed: binarycache.md5/) {
+        # another process was faster adding same file, that is fine
+      } elsif ($@) {
+        die($@);
+      } else {
+        $prunesize += $c->[1];
+      }
+    }
+  }
+
+  # update size counter, commit and close
+  BSSQLite::dbdo_bind($h, 'UPDATE binarycache SET size = ? WHERE md5 = "__sum__"', [ $currentcachesize + $prunesize ]);
+  BSSQLite::commit($h);
+}
+
 sub manage_cache {
   my ($prunesize, $cacheold, $cachenew) = @_;
+
+  return manage_cache_sqlite($prunesize, $cacheold, $cachenew) unless $BSConfig::use_nstore_cache_db;
+
   # get the lock
   local *F;
   BSUtil::lockopen(\*F, '+>>', "$cachedir/content", 1) || return;
@@ -467,6 +555,8 @@ my $conf = {
 };
 
 $conf->{'maxchild'} = $BSConfig::getbinariesproxyserver_maxchild if $BSConfig::getbinariesproxyserver_maxchild;
+
+init_db();
 
 BSStdServer::server('bs_getbinariesproxy', \@ARGV, $conf);
 

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -1278,6 +1278,18 @@ sub remove_entry_from_cache {
 
 sub manage_cache {
   my ($prunesize, $cacheold, $cachenew) = @_;
+  eval {
+    manage_cache_internal($prunesize, $cacheold, $cachenew);
+  };
+  if ($@) {
+    send_state('badhost', $port, $hostarch);
+    commitstate({ 'state' => 'dead' });
+    exit(0);
+  }
+}
+
+sub manage_cache_internal {
+  my ($prunesize, $cacheold, $cachenew) = @_;
   # get the lock
   local *F;
   BSUtil::lockopen(\*F, '+>>', "$cachedir/content", 1) || return;


### PR DESCRIPTION
should solve bottlenecks on large cache configurations

_Replace this line with a description of your changes. Please follow the suggestions in the comment below._

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
