### PR TITLE
Document the person login action

### DIFF
--- a/src/api/public/apidocs-new/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs-new/OBS-v2.10.50.yaml
@@ -38,6 +38,9 @@ paths:
   /person:
     $ref: 'paths/person.yaml'
 
+  /person/{user_login}/login:
+    $ref: 'paths/person_login.yaml'
+
 components:
   securitySchemes:
     basic_authentication:

--- a/src/api/public/apidocs-new/components/parameters/user_login.yaml
+++ b/src/api/public/apidocs-new/components/parameters/user_login.yaml
@@ -1,0 +1,7 @@
+in: path
+name: user_login
+schema:
+  type: string
+required: true
+description: User login
+example: admin

--- a/src/api/public/apidocs-new/paths/person_login.yaml
+++ b/src/api/public/apidocs-new/paths/person_login.yaml
@@ -1,0 +1,18 @@
+post:
+  summary: Perform a login for some person
+  description: >
+    This is a fake login endpoint (it always responds back with an ok).
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/user_login.yaml'
+  responses:
+    '200':
+      description: >
+        OK. The request has succeeded.
+
+        XML Schema used for body validation: [status.xsd](../schema/status.xsd)
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+  tags:
+    - Person


### PR DESCRIPTION
The OpenAPI documentation for the `person#login` action.

You can test it in [our review-app](https://obs-reviewlab.opensuse.org/danidoni-document-person-login-action/apidocs-new/#/Person/post_person__user_login__login)

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
