### PR TITLE
Remove configuration schedulers route for inexistent code

### DIFF
--- a/src/api/config/routes/api_routes.rb
+++ b/src/api/config/routes/api_routes.rb
@@ -6,7 +6,7 @@ OBSApi::Application.routes.draw do
 
     resources :about, only: :index
 
-    resource :configuration, only: [:show, :update, :schedulers]
+    resource :configuration, only: [:show, :update]
 
     resources :announcements, except: [:edit, :new]
 


### PR DESCRIPTION
In the commit d759517, schedulers was added to the configuration resource in the routes. Its corresponding action was never created in ConfigurationsController. It could also never work since schedulers is not one of the default RESTful actions. It cannot be simply passed to the `only` option like that.