### PR TITLE
Fix login modal redirection

### DIFF
--- a/src/api/app/views/layouts/webui/responsive_ux/_login_form.html.haml
+++ b/src/api/app/views/layouts/webui/responsive_ux/_login_form.html.haml
@@ -4,7 +4,6 @@
     = hidden_field_tag(:context, 'default')
     = hidden_field_tag(:proxypath, 'reserve')
     = hidden_field_tag(:message, 'Please log in')
-    = hidden_field_tag(:url, return_to_location)
   .form-group
     = text_field_tag(:username, nil, required: true, class: 'form-control', placeholder: 'Username')
   .form-group


### PR DESCRIPTION
Do not redirect from the login modal. You are already on the page
you want to be on. Fixes #10654

