### PR TITLE
Fix misleading error message

### DIFF
--- a/src/api/app/controllers/person_controller.rb
+++ b/src/api/app/controllers/person_controller.rb
@@ -24,13 +24,12 @@ class PersonController < ApplicationController
     render_ok # just a dummy check for the webui to call (for now)
   end
 
-  # Returns a list of all users (that optionally start with a prefix)
   def command
     if params[:cmd] == 'register'
       internal_register
       return
     end
-    raise UnknownCommandError, "Allowed commands are 'change_password'"
+    raise UnknownCommandError, "Allowed command is 'register'"
   end
 
   def get_userinfo


### PR DESCRIPTION
This PR fixes the misleading error message thrown in [this endpoint](https://github.com/openSUSE/open-build-service/pull/10646)

_Replace this line with a description of your changes. Please follow the suggestions in the comment below._

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature