### PR TITLE
Document person get_userinfo action

### DIFF
--- a/src/api/public/apidocs-new/components/responses/person/not_found.yaml
+++ b/src/api/public/apidocs-new/components/responses/person/not_found.yaml
@@ -5,7 +5,7 @@ description: |
 content:
   application/xml; charset=utf-8:
     schema:
-      $ref: '../schemas/api_response.yaml'
+      $ref: '../../schemas/api_response.yaml'
     example:
       code: not_found
       summary: "Couldn't find User with login = <login>"

--- a/src/api/public/apidocs-new/components/schemas/person.yaml
+++ b/src/api/public/apidocs-new/components/schemas/person.yaml
@@ -1,0 +1,22 @@
+type: object
+properties:
+  login:
+    type: string
+    example: user_1
+  email:
+    type: string
+    example: unconfigured@openbuildservice.org
+  realname:
+    type: string
+    example: User1
+  state:
+    type: string
+    example: confirmed
+  globalrole:
+    type: string
+  ignore_auth_services:
+    type: boolean
+  watchlist:
+    $ref: 'watchlist.yaml'
+xml:
+  name: person

--- a/src/api/public/apidocs-new/components/schemas/watchlist.yaml
+++ b/src/api/public/apidocs-new/components/schemas/watchlist.yaml
@@ -1,0 +1,13 @@
+type: array
+items:
+  type: object
+  properties:
+    project:
+      type: object
+      properties:
+        name:
+          type: string
+          xml:
+            attribute: true
+xml:
+  name: watchlist

--- a/src/api/public/apidocs-new/paths/person_login.yaml
+++ b/src/api/public/apidocs-new/paths/person_login.yaml
@@ -1,3 +1,36 @@
+get:
+  summary: Get details about a person
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/login.yaml'
+  responses:
+    '200':
+      description: >
+        OK. The request has succeeded.
+
+        XML Schema used for body validation: [user.rng](../schema/user.rng)
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/person.yaml'
+          example:
+            login: Admin
+            email: root@localhost
+            realname: OBS Instance Superuser
+            state: confirmed
+            globalrole: Admin
+            ignore_auth_services: false
+            watchlist:
+              - project:
+                  name: "home:Admin"
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '404':
+      $ref: '../components/responses/person/not_found.yaml'
+  tags:
+    - Person
+
 post:
   summary: Perform changes on a registered person
   security:
@@ -36,6 +69,6 @@ post:
     '403':
       $ref: '../components/responses/update_user_not_authorized.yaml'
     '404':
-      $ref: '../components/responses/not_found.yaml'
+      $ref: '../components/responses/person/not_found.yaml'
   tags:
     - Person


### PR DESCRIPTION
The OpenAPI documentation for the `person#get_userinfo` action.

_Replace this line with a description of your changes. Please follow the suggestions in the comment below._

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
