### PR TITLE
Add 403 response to person register endpoint OpenAPI docs

### DIFF
--- a/src/api/public/apidocs-new/paths/person_register.yaml
+++ b/src/api/public/apidocs-new/paths/person_register.yaml
@@ -14,5 +14,16 @@ post:
       $ref: '../components/responses/succeeded.yaml'
     '401':
       $ref: '../components/responses/unauthorized.yaml'
+    '403':
+      description: Forbidden
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          example:
+            code: permission_denied
+            summary: |
+              User accounts can not be registered via OBS when in LDAP mode. Please refer
+              to your LDAP server to create new users.
   tags:
     - Person


### PR DESCRIPTION
Just realized while reviewing another PR that the 403 response is missing