### PR TITLE
Check if the user exist prior to check for user write policies

### DIFF
--- a/src/api/app/controllers/person_controller.rb
+++ b/src/api/app/controllers/person_controller.rb
@@ -263,6 +263,6 @@ class PersonController < ApplicationController
   private
 
   def set_user
-    @user = User.find_by(login: params[:login])
+    @user = User.find_by!(login: params[:login])
   end
 end

--- a/src/api/spec/controllers/person_controller_spec.rb
+++ b/src/api/spec/controllers/person_controller_spec.rb
@@ -72,6 +72,16 @@ RSpec.describe PersonController do
       login user
     end
 
+    context 'when asking for a non-existing login' do
+      before do
+        post :post_userinfo, params: { login: 'nonexistent', cmd: 'change_password', format: :xml }
+      end
+
+      it 'does not change the password' do
+        expect(old_password_digest).to eq(user.reload.password_digest)
+      end
+    end
+
     context 'when using default authentication' do
       before do
         request.env['RAW_POST_DATA'] = 'password_has_changed'


### PR DESCRIPTION
If we send a non-existent user, it's write policy check fail because we don't have the `@user` filled in.

Moving the policy check a bit down, we're covered by the user existence check.
