### PR TITLE
Document person post_userinfo action

### DIFF
--- a/src/api/public/apidocs-new/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs-new/OBS-v2.10.50.yaml
@@ -71,6 +71,8 @@ paths:
     $ref: 'paths/person.yaml'
   /person/register:
     $ref: 'paths/person_register.yaml'
+  /person/{login}:
+    $ref: 'paths/person_login.yaml'
   /person/{login}/group:
     $ref: 'paths/person_login_group.yaml'
   /person/{login}/token:

--- a/src/api/public/apidocs-new/components/responses/bad_request_error.yaml
+++ b/src/api/public/apidocs-new/components/responses/bad_request_error.yaml
@@ -1,0 +1,16 @@
+description: |
+  Bad request.
+  XML Schema used for body validation: [status.xsd](../schema/status.xsd)
+content:
+  application/xml; charset=utf-8:
+    schema:
+      $ref: '../schemas/api_response.yaml'
+    examples:
+      Unknown Command:
+        value:
+          code: unknown_command
+          summary: "Allowed commands are '<some command>'."
+      Bad Request:
+        value:
+          code: err_register_save
+          summary: "Could not save the registration, details: Login is the name of an already existing user and Password can't be blank."

--- a/src/api/public/apidocs-new/components/responses/not_found.yaml
+++ b/src/api/public/apidocs-new/components/responses/not_found.yaml
@@ -1,0 +1,11 @@
+description: |
+  Not found.
+
+  XML Schema used for body validation: [status.xsd](../schema/status.xsd)
+content:
+  application/xml; charset=utf-8:
+    schema:
+      $ref: '../schemas/api_response.yaml'
+    example:
+      code: not_found
+      summary: "Couldn't find User with login = <login>"

--- a/src/api/public/apidocs-new/components/responses/update_user_not_authorized.yaml
+++ b/src/api/public/apidocs-new/components/responses/update_user_not_authorized.yaml
@@ -1,0 +1,13 @@
+description: |
+  Forbidden.
+
+  XML Schema used for body validation: [status.xsd](../schema/status.xsd)
+content:
+  application/xml; charset=utf-8:
+    schema:
+      $ref: '../schemas/api_response.yaml'
+    examples:
+      update_user_not_authorized:
+        value:
+          code: update_user_not_authorized
+          summary: 'You are not authorized to update this User.'

--- a/src/api/public/apidocs-new/paths/person_login.yaml
+++ b/src/api/public/apidocs-new/paths/person_login.yaml
@@ -1,0 +1,41 @@
+post:
+  summary: Perform changes on a registered person
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/login.yaml'
+    - in: query
+      name: cmd
+      schema:
+        type: string
+        enum: [change_password,lock,delete]
+      required: true
+      description: "The command to execute against the provided person."
+      example: change_password
+  requestBody:
+    description: "The password in plain text when the cmd param is 'change_password'."
+    required: false
+    content:
+      text/plain:
+        schema:
+          type: string
+  responses:
+    '200':
+      description: >
+        OK. The request has succeeded.
+
+        XML Schema used for body validation: [api_response.xsd](../schema/api_response.xsd)
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '400':
+      $ref: '../components/responses/bad_request_error.yaml'
+    '403':
+      $ref: '../components/responses/update_user_not_authorized.yaml'
+    '404':
+      $ref: '../components/responses/not_found.yaml'
+  tags:
+    - Person


### PR DESCRIPTION
Document `person#post_userinfo` action.

_Replace this line with a description of your changes. Please follow the suggestions in the comment below._

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
