### PR TITLE
Proof of concept: two ways of documenting using OpenAPI

### DIFF
--- a/src/api/public/apidocs-new/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs-new/OBS-v2.10.50.yaml
@@ -10,6 +10,7 @@ tags:
   - name: Person
   - name: Attribute Namespaces
   - name: Attributes
+  - name: Attributes2
   - name: Request
 
 info:
@@ -54,6 +55,11 @@ paths:
     $ref: 'paths/attribute_namespace_attribute_name.yaml'
   /attribute/{namespace}/{attribute_name}/_meta:
     $ref: 'paths/attribute_namespace_attribute_name_meta.yaml'
+
+  /attribute2/{namespace}/{attribute_name}:
+    $ref: 'paths/attribute2_namespace_attribute_name.yaml'
+  /attribute2/{namespace}/{attribute_name}/_meta:
+    $ref: 'paths/attribute2_namespace_attribute_name_meta.yaml'
 
   /group:
     $ref: 'paths/group.yaml'

--- a/src/api/public/apidocs-new/paths/attribute2_namespace_attribute_name.yaml
+++ b/src/api/public/apidocs-new/paths/attribute2_namespace_attribute_name.yaml
@@ -1,0 +1,30 @@
+delete:
+  summary: Delete an attribute and all its values in projects or packages.
+  description: |
+    Delete an attribute and all its values in projects or packages.
+
+    This operation is the same as `DELETE /attribute2/{namespace}/{attribute_name}/_meta`.
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/namespace.yaml'
+    - $ref: '../components/parameters/attribute_name.yaml'
+  responses:
+    '200':
+      $ref: '../components/responses/succeeded.yaml'
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '404':
+      description: Not Found.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          examples:
+            namespace:
+              value:
+                code: not_found
+                summary: Couldn't find AttribNamespace
+              summary: Not Found (Namespace)
+  tags:
+    - Attributes2

--- a/src/api/public/apidocs-new/paths/attribute2_namespace_attribute_name_meta.yaml
+++ b/src/api/public/apidocs-new/paths/attribute2_namespace_attribute_name_meta.yaml
@@ -1,0 +1,103 @@
+get:
+  summary: Shows attribute.
+  description: Shows attribute.
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/namespace.yaml'
+    - $ref: '../components/parameters/attribute_name.yaml'
+  responses:
+    '200':
+      description: OK. The request has succeeded.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/attribute.yaml'
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '404':
+      description: Not Found.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          examples:
+            namespace:
+              value:
+                code: not_found
+                summary: Couldn't find AttribNamespace
+              summary: Not Found (Namespace)
+            unknown_attribute:
+              value:
+                code: unknown_attribute
+                summary: "Unknown attribute 'OBS_TEST':'OwnerRootProjectTest'"
+              summary: Unknown Attribute
+  tags:
+    - Attributes2
+
+post:
+  summary: Change attribute data. Create an attribute if it doesn't exist.
+  description: |
+    This endpoint can be used for both, creating an attribute and updating it:
+      * If the attribute passed as parameter doesn't exist, it will create the attribute.
+      * If the attribute passed as parameter already exists, it will update the attribute.
+
+    This operation is the same as `PUT`.
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/namespace.yaml'
+    - $ref: '../components/parameters/attribute_name.yaml'
+  requestBody:
+    description: Attribute definition.
+    required: true
+    content:
+      application/xml; charset=utf-8:
+        schema:
+          $ref: '../components/schemas/attribute.yaml'
+  responses:
+    '200':
+      $ref: '../components/responses/succeeded.yaml'
+    '400':
+      description: Validation Failed.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          examples:
+            empty_body:
+              value:
+                code: validation_failed
+                summary: Document is empty, not allowed for attrib_type
+              summary: Validation Failed (Empty Body)
+            wrong_xml_element:
+              value:
+                code: validation_failed
+                summary: 'attrib_type validation error: 1:0: ERROR: Element definition failed to validate attributes'
+              summary: Validation Failed (Wrong XML Attributes)
+            illegal_request:
+              value:
+                code: illegal_request
+                summary: 'Illegal request: PUT/POST /attribute/OBS_TEST/OwnerRootProjectTest/_meta: path does not match content'
+              summary: Illegal Request
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '404':
+      description: Not Found.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          examples:
+            namespace:
+              value:
+                code: not_found
+                summary: Couldn't find AttribNamespace
+              summary: Not Found (Namespace)
+            unknown_attribute:
+              value:
+                code: unknown_attribute
+                summary: "Unknown attribute 'OBS_TEST':'OwnerRootProjectTest'"
+              summary: Unknown Attribute
+  tags:
+    - Attributes2


### PR DESCRIPTION
This is a proof of concept of two ways of documenting the API using OpenAPI. Please, don't merge this pull request.

Two options are provided, with two examples:
- Group Attributes: define repeated endpoints, and reference inside them, in their descriptions, to the other one.
- Group Attributes2: define only an endpoint, and add a note in the description that there is another endpoint that can also be used.