### PR TITLE
[backend] make sure that the local dod package matches our expectations

### DIFF
--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -127,6 +127,23 @@ sub jobname {
   return $job;
 }
 
+sub is_wanted_dodbinary {
+  my ($pool, $p, $path, $doverify) = @_;
+  my $q;
+  eval { $q = Build::query($path, 'evra' => 1) };
+  return 0 unless $q;
+  my $data = $pool->pkg2data($p);
+  $data->{'release'} = '__undef__' unless defined $data->{'release'};
+  $q->{'release'} = '__undef__' unless defined $q->{'release'};
+  return 0 if $data->{'name'} ne $q->{'name'} ||
+	      ($data->{'arch'} || '') ne ($q->{'arch'} || '') ||
+	      ($data->{'epoch'} || 0) != ($q->{'epoch'} || 0) ||
+	      $data->{'version'} ne $q->{'version'} ||
+	      $data->{'release'} ne $q->{'release'};
+  BSVerify::verify_nevraquery($q) if $doverify;		# just in case
+  return 1;
+}
+
 sub fetchdodbinary {
   my ($pool, $repo, $p, $arch, $maxredirects, $handoff) = @_;
 
@@ -143,7 +160,10 @@ sub fetchdodbinary {
   BSVerify::verify_filename($pkgname);
   BSVerify::verify_simple($pkgname);
   my $localname = "$reporoot/$reponame/$arch/:full/$pkgname";
-  return $localname if -e $localname;
+  if (-e $localname) {
+    # package exists, why are we called? verify that it matches our expectations
+    return $localname if is_wanted_dodbinary($pool, $p, $localname);
+  }
   # we really need to download, handoff to ajax if not already done
   BSHandoff::handoff(@$handoff) if $handoff && !$BSStdServer::isajax;
   my $url = $repo->dodurl();
@@ -166,16 +186,7 @@ sub fetchdodbinary {
     # verify the checksum if we know it
     die("checksum error for $tmp, expected $checksum\n") if $checksum && !$pool->verifypkgchecksum($p, $tmp);
     # also make sure that the evra matches what we want
-    my $q = Build::query($tmp, 'evra' => 1);
-    my $data = $pool->pkg2data($p);
-    $data->{'release'} = '__undef__' unless defined $data->{'release'};
-    $q->{'release'} = '__undef__' unless defined $q->{'release'};
-    die("downloaded package is not the one we want\n") if $data->{'name'} ne $q->{'name'} ||
-	      ($data->{'arch'} || '') ne ($q->{'arch'} || '') ||
-	      ($data->{'epoch'} || 0) != ($q->{'epoch'} || 0) ||
-	      $data->{'version'} ne $q->{'version'} ||
-	      $data->{'release'} ne $q->{'release'};
-    BSVerify::verify_nevraquery($q);	# just in case...
+    die("downloaded package is not the one we want\n") unless is_wanted_dodbinary($pool, $p, $tmp, 1);
   };
   if ($@) {
     unlink($tmp);


### PR DESCRIPTION
It can be different if the metadata changes in weird ways, e.g.
if a package is moved into a module.

_Replace this line with a description of your changes. Please follow the suggestions in the comment below._

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
