### PR TITLE
Mark properties of the /about route as required

### DIFF
--- a/src/api/public/apidocs-new/components/schemas/about.yaml
+++ b/src/api/public/apidocs-new/components/schemas/about.yaml
@@ -1,4 +1,8 @@
 type: object
+required:
+  - title
+  - description
+  - revision
 properties:
   title:
     type: string


### PR DESCRIPTION
The title, description and revision elements are always present according to https://build.opensuse.org/schema/about.xsd, so I've marked them as such.