### PR TITLE
Do not "humanize" group titles in subscriptions#index view

### DIFF
--- a/src/api/app/views/webui/users/subscriptions/index.html.haml
+++ b/src/api/app/views/webui/users/subscriptions/index.html.haml
@@ -12,7 +12,7 @@
           .custom-control.custom-checkbox.custom-control-inline
             = check_box_tag group_user.group, '1', group_user.email, class: 'custom-control-input', id: "checkbox-#{group_user.group}",
               data: { url: update_my_subscriptions_path, method: :put, remote: true }
-            = label_tag group_user.group.title, nil, class: 'custom-control-label', for: "checkbox-#{group_user.group}"
+            = label_tag nil, group_user.group.title, class: 'custom-control-label', for: "checkbox-#{group_user.group}"
             %i.fas.fa-spinner.invisible
   .card-body
     %h4.card-title Events


### PR DESCRIPTION
A small thing I've noticed while we talked about the notifications this morning. Without the changes from this PR, the group titles are "humanized" (with [humanize](https://api.rubyonrails.org/classes/String.html#method-i-humanize)) in the _subscriptions#index_ view.

In the example below, the HTML stays the same: `<label class="custom-control-label" for="checkbox-group_1">`. The group is the following:
```
#<Group:0x000055d9652a7738 id: 1, created_at: Mon, 18 Jan 2021 15:45:19 UTC +00:00, updated_at: Mon, 18 Jan 2021 15:45:24 UTC +00:00, title: "group_1", parent_id: nil, email: "duane@jaskolski-nitzsche.co">
```

Before:
![before](https://user-images.githubusercontent.com/1102934/105985915-75a75f80-609c-11eb-81db-79564c5b78ec.png)

After:
![after](https://user-images.githubusercontent.com/1102934/105985696-1cd7c700-609c-11eb-9938-e38e6b07ec69.png)

Notes: Documentation for [label_tag](https://api.rubyonrails.org/classes/ActionView/Helpers/FormTagHelper.html#method-i-label_tag) if you are like me and don't remember all those parameters by heart. :wink: We can also see in the [source](https://github.com/rails/rails/blob/5f3ff60084ab5d5921ca3499814e4697f8350ee7/actionview/lib/action_view/helpers/form_tag_helper.rb#L224) that the _name_ parameter is [humanized](https://api.rubyonrails.org/classes/String.html#method-i-humanize) (`name.to_s.humanize`). This is why the order of the parameter is important.