### PR TITLE
Change Notifications#id to unsigned int

### DIFF
--- a/src/api/app/models/notification.rb
+++ b/src/api/app/models/notification.rb
@@ -46,7 +46,7 @@ end
 #
 # Table name: notifications
 #
-#  id                         :integer          not null, primary key
+#  id                         :integer          unsigned, not null, primary key
 #  bs_request_oldstate        :string(255)
 #  bs_request_state           :string(255)
 #  delivered                  :boolean          default(FALSE)

--- a/src/api/db/migrate/20210128173145_change_notification_id_to_unsigned.rb
+++ b/src/api/db/migrate/20210128173145_change_notification_id_to_unsigned.rb
@@ -1,0 +1,9 @@
+class ChangeNotificationIdToUnsigned < ActiveRecord::Migration[6.0]
+  def up
+    safety_assured { change_column :notifications, :id, :int, null: false, unique: true, auto_increment: true, unsigned: true }
+  end
+
+  def down
+    safety_assured { change_column :notifications, :id, :int, null: false, unique: true, auto_increment: true, unsigned: false }
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_09_105103) do
+ActiveRecord::Schema.define(version: 2021_01_28_173145) do
 
   create_table "architectures", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false, collation: "utf8_general_ci"
@@ -657,7 +657,7 @@ ActiveRecord::Schema.define(version: 2020_12_09_105103) do
     t.index ["user_id"], name: "user"
   end
 
-  create_table "notifications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "notifications", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "event_type", null: false, collation: "utf8_general_ci"
     t.text "event_payload", null: false
     t.string "subscription_receiver_role", null: false, collation: "utf8_general_ci"


### PR DESCRIPTION
To avoid the integers wrapping soon, change it from int(11) to unsigned int(10)

I added the DO NOT MIGRATE since it should migrated just in our maintenance window. 

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [X] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature
