### PR TITLE
Remove authentication requirement from person POST OpenAPI docs

### DIFF
--- a/src/api/public/apidocs-new/paths/person.yaml
+++ b/src/api/public/apidocs-new/paths/person.yaml
@@ -43,8 +43,6 @@ post:
     Allows executing command on the person endpoint.
 
     As of now, the only command allowed is 'register'.
-  security:
-    - basic_authentication: []
   parameters:
     - in: query
       name: cmd


### PR DESCRIPTION
Overlooked in a previous PR that this endpoint skips
the authentication
