### PR TITLE
[api][backend] add linkedbuild=alldirect functionality

### DIFF
--- a/docs/api/api/obs.rng
+++ b/docs/api/api/obs.rng
@@ -100,7 +100,8 @@
     <choice>
       <value>off</value>       <!-- DEFAULT: do not build packages from project links -->
       <value>localdep</value>  <!-- only build project linked packages if they depend on a local package -->
-      <value>all</value>       <!-- treat packages from project links like local packages -->
+      <value>alldirect</value> <!-- treat packages from project links like local packages, only direct linked projects -->
+      <value>all</value>       <!-- treat packages from project links like local packages, includes also indirect linked projects -->
     </choice>
   </define>
 

--- a/src/api/db/migrate/20210201105103_linkedbuild_alldirect.rb
+++ b/src/api/db/migrate/20210201105103_linkedbuild_alldirect.rb
@@ -1,0 +1,9 @@
+class LinkedbuildAlldirect < ActiveRecord::Migration[4.2]
+  def self.up
+    safety_assured { execute "alter table repositories modify column linkedbuild enum('off','localdep','all','alldirect');" }
+  end
+
+  def self.down
+    safety_assured { execute "alter table repositories modify column linkedbuild enum('off','localdep','all');" }
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_09_105103) do
+ActiveRecord::Schema.define(version: 2021_02_01_105103) do
 
   create_table "architectures", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false, collation: "utf8_general_ci"
@@ -845,7 +845,7 @@ ActiveRecord::Schema.define(version: 2020_12_09_105103) do
     t.string "remote_project_name", default: "", null: false, collation: "utf8_bin"
     t.column "rebuild", "enum('transitive','direct','local')", collation: "utf8_general_ci"
     t.column "block", "enum('all','local','never')", collation: "utf8_general_ci"
-    t.column "linkedbuild", "enum('off','localdep','all')", collation: "utf8_general_ci"
+    t.column "linkedbuild", "enum('off','localdep','all','alldirect')", collation: "utf8_general_ci"
     t.integer "hostsystem_id"
     t.string "required_checks"
     t.index ["db_project_id", "name", "remote_project_name"], name: "projects_name_index", unique: true

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -1094,7 +1094,7 @@ sub getprojpack {
       }
     }
     next unless $proj;
-    for (qw{kind}) {
+    for (qw{kind link}) {
       $jinfo->{$_} = $proj->{$_} if exists $proj->{$_};
     }
 


### PR DESCRIPTION
To allow rebuilds from directly linked projects only, excluding package
sources from indirect linked projects.

This is for example required to rebuild ServicePack layers only.

_Replace this line with a description of your changes. Please follow the suggestions in the comment below._

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
