### PR TITLE
Remove notifications for missing notifiables

### DIFF
--- a/src/api/db/data/20210205131609_remove_notifications_for_missing_notifiables.rb
+++ b/src/api/db/data/20210205131609_remove_notifications_for_missing_notifiables.rb
@@ -1,0 +1,12 @@
+class RemoveNotificationsForMissingNotifiables < ActiveRecord::Migration[6.0]
+  def up
+    Notification.where(notifiable_type: 'Comment')
+                .joins('LEFT OUTER JOIN comments ON notifiable_id = comments.id')
+                .where(comments: { id: nil })
+                .destroy_all
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/src/api/spec/db/data/remove_notifications_for_missing_notifiables_spec.rb
+++ b/src/api/spec/db/data/remove_notifications_for_missing_notifiables_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+require Rails.root.join('db/data/20210205131609_remove_notifications_for_missing_notifiables.rb')
+RSpec.describe RemoveNotificationsForMissingNotifiables, type: :migration do
+  describe 'up' do
+    let!(:notification1) { create(:notification, :comment_for_request) }
+    let!(:notification2) { create(:notification, :comment_for_request) }
+
+    before do
+      # Simulate the wrong behaviour we had before. When a BsRequest was removed,
+      # all the comments were removed as well, but not their associated notifications.
+      # That happened because of a wrong association, dependent option: `delete_all` instead of `destroy`.
+      notification2.notifiable.delete
+    end
+
+    it 'removes notification with non-existent notifiables' do
+      expect { RemoveNotificationsForMissingNotifiables.new.up }.to change(Notification, :all)
+        .from([notification1, notification2])
+        .to([notification1])
+    end
+  end
+end


### PR DESCRIPTION
Add a data migration to remove dangling notifications that should have been removed when their associated comments where removed.

This is a follow-up of PR #10735.

**NOTE:** This PR contains a data migration but it won't cause any inconsistency or downtime.

Co-authored-by: Eduardo Navarro <enavarro@suse.com>

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
