### PR TITLE
Reintroduce CleanupNotifications job

### DIFF
--- a/src/api/app/jobs/cleanup_notifications_job.rb
+++ b/src/api/app/jobs/cleanup_notifications_job.rb
@@ -1,0 +1,5 @@
+class CleanupNotificationsJob < ApplicationJob
+  def perform
+    NotificationsFinder.new.stale.delete_all
+  end
+end

--- a/src/api/app/queries/notifications_finder.rb
+++ b/src/api/app/queries/notifications_finder.rb
@@ -48,4 +48,14 @@ class NotificationsFinder
 
     self.class.new.for_subscribed_user.find_by(id: notification_id)
   end
+
+  def stale
+    @relation.where('created_at < ?', notifications_lifetime.days.ago)
+  end
+
+  private
+
+  def notifications_lifetime
+    CONFIG['notifications_lifetime'] ||= 365
+  end
 end

--- a/src/api/config/clock.rb
+++ b/src/api/config/clock.rb
@@ -67,6 +67,10 @@ module Clockwork
     CleanupProjectLogEntries.perform_later
   end
 
+  every(1.day, 'cleanup notifications') do
+    CleanupNotificationsJob.perform_later
+  end
+
   every(1.day, 'create cleanup requests', at: '06:00') do
     User.session = User.get_default_admin
     ProjectCreateAutoCleanupRequestsJob.perform_later

--- a/src/api/config/options.yml.example
+++ b/src/api/config/options.yml.example
@@ -208,6 +208,10 @@ default: &default
   # Default: 2 days (172800 seconds).
   # maintenance_release_repositories_lifetime: 172800
 
+  # Lifetime for notifications.
+  # Default: 365 days (1 year).
+  notifications_lifetime: 365
+
 production:
   <<: *default
 
@@ -220,4 +224,3 @@ development:
   <<: *default
   source_host: backend
   memcached_host: cache
-

--- a/src/api/spec/factories/notification.rb
+++ b/src/api/spec/factories/notification.rb
@@ -6,6 +6,10 @@ FactoryBot.define do
     title { Faker::Lorem.sentence }
     delivered { false }
 
+    trait :stale do
+      created_at { 13.months.ago }
+    end
+
     trait :request_state_change do
       event_type { 'Event::RequestStatechange' }
       association :notifiable, factory: :bs_request_with_submit_action

--- a/src/api/spec/jobs/cleanup_notifications_job_spec.rb
+++ b/src/api/spec/jobs/cleanup_notifications_job_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe CleanupNotificationsJob, type: :job do
+  include ActiveJob::TestHelper
+
+  describe '#perform' do
+    it 'only deletes old notifications' do
+      create(:notification, :stale)
+      create(:notification)
+
+      expect { described_class.new.perform }.to change(Notification, :count).by(-1)
+    end
+  end
+end


### PR DESCRIPTION
Remove notifications older than a year with a daily job.

A `notifications_lifetime` config option can be set, to specify the number of days a notification persists before being removed.

Co-authored-by: Saray Cabrera Padrón <scabrerapadron@suse.de>

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [x] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
