### PR TITLE
Toggle build info when {click,hover}ing on build state 

### DIFF
--- a/src/api/app/helpers/webui/buildresult_helper.rb
+++ b/src/api/app/helpers/webui/buildresult_helper.rb
@@ -5,16 +5,16 @@ module Webui::BuildresultHelper
     status_id = valid_xml_id("id-#{package_name}_#{repo}_#{arch}")
     link_title = status['details']
     code = ''
-    theclass = ' '
+    css_class = ' '
 
     if status['code']
       code = status['code']
-      theclass = "build-state-#{code}"
+      css_class = "build-state-#{code}"
       # special case for scheduled jobs with constraints limiting the workers a lot
-      theclass = 'text-warning' if code == 'scheduled' && link_title.present?
+      css_class = 'text-warning' if code == 'scheduled' && link_title.present?
     end
 
-    return build_state(code: code, css_class: theclass, package_name: package_name, status_id: status_id, repo: repo, arch: arch) if feature_enabled?(:responsive_ux)
+    return build_state(code: code, css_class: css_class, package_name: package_name, status_id: status_id, repo: repo, arch: arch) if feature_enabled?(:responsive_ux)
 
     capture do
       if enable_help && status['code']
@@ -22,11 +22,11 @@ module Webui::BuildresultHelper
                           data: { content: Buildresult.status_description(status['code']), placement: 'top', toggle: 'popover' }))
       end
       if code.in?(['-', 'unresolvable', 'blocked', 'excluded', 'scheduled'])
-        concat(link_to(code, 'javascript:void(0);', id: status_id, class: theclass, data: { content: link_title, placement: 'right', toggle: 'popover' }))
+        concat(link_to(code, 'javascript:void(0);', id: status_id, class: css_class, data: { content: link_title, placement: 'right', toggle: 'popover' }))
       else
         concat(link_to(code.gsub(/\s/, '&nbsp;'),
                        package_live_build_log_path(project: @project.to_s, package: package_name, repository: repo, arch: arch),
-                       data: { content: link_title, placement: 'right', toggle: 'popover' }, rel: 'nofollow', class: theclass))
+                       data: { content: link_title, placement: 'right', toggle: 'popover' }, rel: 'nofollow', class: css_class))
       end
     end
   end

--- a/src/api/app/helpers/webui/buildresult_helper.rb
+++ b/src/api/app/helpers/webui/buildresult_helper.rb
@@ -35,7 +35,7 @@ module Webui::BuildresultHelper
   def build_state(attr)
     capture do
       if attr[:code].in?(['-', 'unresolvable', 'blocked', 'excluded', 'scheduled'])
-        concat(link_to(attr[:code], 'javascript:void(0);', id: attr[:status_id], class: attr[:css_class]))
+        concat(tag.span(attr[:code], id: attr[:status_id], class: "#{attr[:css_class]} toggle-build-info", title: 'Click to keep it open'))
       else
         concat(link_to(attr[:code].gsub(/\s/, '&nbsp;'),
                        package_live_build_log_path(project: @project.to_s, package: attr[:package_name], repository: attr[:repo], arch: attr[:arch]),

--- a/src/api/app/helpers/webui/buildresult_helper.rb
+++ b/src/api/app/helpers/webui/buildresult_helper.rb
@@ -31,7 +31,7 @@ module Webui::BuildresultHelper
     end
   end
 
-  # NOTE: reponsive_ux
+  # NOTE: responsive_ux
   def build_state(attr)
     capture do
       if attr[:code].in?(['-', 'unresolvable', 'blocked', 'excluded', 'scheduled'])


### PR DESCRIPTION
Please refer to commits for details on the changes. This PR fixes #9936.

_Note: I didn't change this for the non-responsive_ux UI since this version isn't displayed anymore on our reference server._

Before:
![before-with-click-text](https://user-images.githubusercontent.com/1102934/107268330-4c95b000-6a48-11eb-9289-caf408a4c7d6.gif)

Now:
![now](https://user-images.githubusercontent.com/1102934/107268342-4f90a080-6a48-11eb-9c32-60480e94a1b2.gif)