### PR TITLE
Opt out of suggestions for rubocop-minitest

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,6 +16,9 @@ AllCops:
     # These files are RPM spec files
     - 'dist/*.spec'
     - 'dist/t/spec/fixtures/hello_world.spec'
+  SuggestExtensions:
+    # We don't want extra cops for minitest since we want to migrate those tests to RSpec
+    rubocop-minitest: false
 
 #################### Layout ###########################
 

--- a/src/api/.rubocop.yml
+++ b/src/api/.rubocop.yml
@@ -20,6 +20,9 @@ AllCops:
     - 'db/data_schema.rb'
     # this file will be deleted as soon as app/jobs/consistency_check_job.rb is validated
     - 'app/jobs/old/consistency_check_job.rb'
+  SuggestExtensions:
+    # We don't want extra cops for minitest since we want to migrate those tests to RSpec
+    rubocop-minitest: false
 
 #################### Style ###########################
 


### PR DESCRIPTION
This removes the following output when running RuboCop:

> Tip: Based on detected gems, the following RuboCop extension libraries might be helpful:
>   * rubocop-minitest (http://github.com/rubocop-hq/rubocop-minitest)
> 
> You can opt out of this message by adding the following to your config (see https://docs.rubocop.org/rubocop/extensions.html#extension-suggestions for more options):
>   AllCops:
>     SuggestExtensions: false