### PR TITLE
Generate 'Download package' links correctly

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -109,6 +109,23 @@ class Webui::PackageController < Webui::WebuiController
 
     @services = @files.any? { |file| file[:name] == '_service' }
 
+    download_name_candidates = []
+    binary_list = Xmlhash.parse(Backend::Api::Build::Project.binarylist(@project))
+
+    binary_list.elements('result') do |result|
+      result.elements('binarylist') do |list|
+        next unless list['package'] == @package.name
+
+        list.elements('binary') do |binary|
+          next unless binary['filename'].end_with?('.rpm')
+
+          download_name_candidates << binary['filename'].sub(/-[^-]*-[^-]*.rpm$/, '')
+        end
+      end
+    end
+
+    @download_name = download_name_candidates.uniq.min || ''
+
     respond_to do |format|
       format.html
       format.js

--- a/src/api/app/views/webui/package/_extra_actions.html.haml
+++ b/src/api/app/views/webui/package/_extra_actions.html.haml
@@ -1,4 +1,4 @@
-- if CONFIG['software_opensuse_url']
+- if CONFIG['software_opensuse_url'] && !package.empty?
   %li
     %i.fas.fa-download.text-secondary
-    = link_to('Download package', "#{CONFIG['software_opensuse_url']}/download.html?project=#{u project.name}&package=#{u package.name}")
+    = link_to('Download package', "#{CONFIG['software_opensuse_url']}/download.html?project=#{u project.name}&package=#{u package}")

--- a/src/api/app/views/webui/package/_side_links.html.haml
+++ b/src/api/app/views/webui/package/_side_links.html.haml
@@ -22,4 +22,4 @@
     = render partial: 'webui/package/side_links/show_linkinfo', locals: { package: package, project: project,
                                                                                   linkinfo: linkinfo, revision: revision }
 
-  = render partial: 'extra_actions', locals: { project: project, package: package }
+  = render partial: 'extra_actions', locals: { project: project, package: download_name }

--- a/src/api/app/views/webui/package/show.html.haml
+++ b/src/api/app/views/webui/package/show.html.haml
@@ -29,7 +29,8 @@
                                                   linkinfo: @linkinfo,
                                                   revision: @revision,
                                                   project: @project,
-                                                  package: @package }
+                                                  package: @package,
+                                                  download_name: @download_name }
       - unless feature_enabled?(:responsive_ux)
         = render partial: 'bottom_actions', locals: { bugowners_mail: @bugowners_mail,
                                                     configuration: @configuration,


### PR DESCRIPTION
This PR should fix #10572. Please see commit messages for more information.

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
