### PR TITLE
Track some metrics about notifications

### DIFF
--- a/src/api/app/jobs/measurements_job.rb
+++ b/src/api/app/jobs/measurements_job.rb
@@ -5,36 +5,49 @@ class MeasurementsJob < ApplicationJob
     return unless CONFIG['amqp_options']
 
     RabbitmqBus.send_to_bus('metrics', "group count=#{Group.count}")
-    RabbitmqBus.send_to_bus('metrics', "user #{user_fields}")
+    RabbitmqBus.send_to_bus('metrics', "user #{measurements_to_fields(users_measurements)}")
+    RabbitmqBus.send_to_bus('metrics', "notification #{measurements_to_fields(notifications_measurements)}")
   end
 
   private
 
-  def user_fields
-    user_measures.map { |k, v| "#{k}=#{v}" }.join(',')
+  def measurements_to_fields(measurements)
+    measurements.map { |k, v| "#{k}=#{v}" }.join(',')
   end
 
-  def user_measures
+  def users_measurements
     {
       in_beta: User.in_beta.count,
       in_rollout: User.in_rollout.count,
       count: User.count
     }
-      .merge(role_fields)
-      .merge(state_fields)
+      .merge(roles_measurements)
+      .merge(states_measurements)
   end
 
-  def role_fields
+  def roles_measurements
     Role.global.pluck(:title).each_with_object({}) do |role_title, fields|
       fields[role_title.downcase.to_sym] = Role.find_by(title: role_title).users.count
       fields
     end
   end
 
-  def state_fields
+  def states_measurements
     User::STATES.each_with_object({}) do |state, fields|
       fields[state.to_sym] = User.where(state: state).count
       fields
     end
+  end
+
+  def notifications_measurements
+    {
+      count: Notification.count,
+      for_web: Notification.for_web.count,
+      for_rss: Notification.for_rss.count,
+      read: NotificationsFinder.new.read.count,
+      unread: NotificationsFinder.new.unread.count,
+      about_comments: Notification.where(notifiable_type: 'Comment').count,
+      about_requests: Notification.where(notifiable_type: 'BsRequest').count
+    }
   end
 end

--- a/src/api/app/models/notification.rb
+++ b/src/api/app/models/notification.rb
@@ -10,6 +10,8 @@ class Notification < ApplicationRecord
 
   serialize :event_payload, JSON
 
+  after_create :track_notification_creation
+
   scope :for_web, -> { where(web: true) }
   scope :for_rss, -> { where(rss: true) }
 
@@ -39,6 +41,13 @@ class Notification < ApplicationRecord
 
   def unread_date
     last_seen_at || created_at
+  end
+
+  private
+
+  def track_notification_creation
+    RabbitmqBus.send_to_bus('metrics',
+                            "notification.create,notifiable_type=#{notifiable_type},web=#{web},rss=#{rss} value=1")
   end
 end
 


### PR DESCRIPTION
Every newly created notification is tracked _in situ_.
Some other metrics like the amount of different kind of notifications are tracked every 5 minutes.

MeasurementsJob has been slightly refactored.

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
