### PR TITLE
Allow limitation of buildresults to a specific package

### DIFF
--- a/src/api/app/lib/backend/api/build/project.rb
+++ b/src/api/app/lib/backend/api/build/project.rb
@@ -28,9 +28,12 @@ module Backend
         end
 
         # Returns the binaries of a project (used in patchinfo controller)
+        # Limit results to a specific package by providing a package name
         # @return [String]
-        def self.binarylist(project_name)
-          http_get(['/build/:project/_result', project_name], params: { view: 'binarylist' })
+        def self.binarylist(project_name, package_name: nil)
+          params = { view: 'binarylist' }
+          params[:package] = package_name if package_name
+          http_get(['/build/:project/_result', project_name], params: params)
         end
       end
     end


### PR DESCRIPTION
By passing the package name in additon to the project name to
the backend, we can limit the buildresults in the binarylist
to a specific package which saves us some processing on the
frontend side.

Required for PR#10752


How to check the PR:

* Easiest way is to build two small packages in the dev environment and afterwards to call, the API wrapper in the Rails Console
* Check once the result without providing the package name (`Xmlhash.parse(Backend::Api::Build::Project.binarylist(Project.first))`)
* Check once with the package name (`Xmlhash.parse(Backend::Api::Build::Project.binarylist(Project.first, Project.first.packages.first)`)
