### PR TITLE
Show correct message when hovering build info elements

### DIFF
--- a/src/api/app/assets/javascripts/webui/buildresult.js
+++ b/src/api/app/assets/javascripts/webui/buildresult.js
@@ -76,7 +76,7 @@ function toggleBuildInfo() { // jshint ignore:line
     var infoContainer = $(this).parents('.toggle-build-info-parent').next();
     $(infoContainer).toggleClass('collapsed');
     $(infoContainer).removeClass('hover');
-    $(this).attr('title', replaceTitle);
+    $('.toggle-build-info').attr('title', replaceTitle);
   });
   $('.toggle-build-info').on('mouseover', function(){
     $(this).parents('.toggle-build-info-parent').next().addClass('hover');


### PR DESCRIPTION
After introducing another element with CSS class 'toggle-build-info' in a previous commit, clicking in one of this elements should change the title for all elements which have this class.

Prevent having one build info element with title 'Click to keep it open' and another element with title 'Click to close it' at the same time.

This is a follow-up of PR #10748.

**Before:**

![Peek 2021-02-09 11-58-Build-Info-error](https://user-images.githubusercontent.com/24919/107378433-46590f80-6aec-11eb-8da7-85f4143763de.gif)

**After:**

![Peek 2021-02-09 11-55-Build-Info-fixed](https://user-images.githubusercontent.com/24919/107378446-49ec9680-6aec-11eb-9f81-1b3f6c289ee5.gif)


-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature
