### PR TITLE
[api] add branch trigger call

### DIFF
--- a/docs/api/api/obs.rng
+++ b/docs/api/api/obs.rng
@@ -461,6 +461,7 @@
 
   <define ns="" name="token-kind">
     <choice>
+      <value>branch</value>
       <value>rss</value>
       <value>rebuild</value>
       <value>release</value>

--- a/docs/api/api/tokenlist.rng
+++ b/docs/api/api/tokenlist.rng
@@ -68,6 +68,7 @@
        <a:documentation>
         This attribute specifies which actions can be performed via this token.
         - rss: used to retrieve the notification RSS feed
+        - branch: branches a package and stores a http payload from the server in _branch_request
         - rebuild: trigger rebuilds of packages
         - release: trigger project releases
         - runservice: run a service via the POST /trigger/runservice route

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -111,7 +111,7 @@ class Package < ApplicationRecord
   has_one :backend_package, foreign_key: :package_id, dependent: :destroy, inverse_of: :package # rubocop:disable Rails/RedundantForeignKey
   has_one :token, class_name: 'Token::Service', dependent: :destroy
 
-  has_many :tokens, class_name: 'Token::Service', dependent: :destroy, inverse_of: :package
+  has_many :tokens, dependent: :destroy, inverse_of: :package
 
   def self.check_access?(package)
     return false if package.nil?

--- a/src/api/app/models/token/branch.rb
+++ b/src/api/app/models/token/branch.rb
@@ -1,27 +1,6 @@
-class Token < ApplicationRecord
-  belongs_to :user
-  belongs_to :package, inverse_of: :tokens
-
-  has_secure_token :string
-
-  validates :user, presence: true
-
-  def token_name
-    self.class.token_name
-  end
-
-  def self.token_type(action)
-    case action
-    when 'branch'
-      Token::Branch
-    when 'rebuild'
-      Token::Rebuild
-    when 'release'
-      Token::Release
-    else
-      # default is Token::Service
-      Token::Service
-    end
+class Token::Branch < Token
+  def self.token_name
+    'branch'
   end
 end
 

--- a/src/api/config/routes/api_routes.rb
+++ b/src/api/config/routes/api_routes.rb
@@ -64,6 +64,7 @@ OBSApi::Application.routes.draw do
     resources :architectures, only: [:index, :show, :update] # create,delete currently disabled
 
     ### /trigger
+    post 'trigger/branch' => 'trigger#branch'
     post 'trigger/rebuild' => 'trigger#rebuild'
     post 'trigger/release' => 'trigger#release'
     post 'trigger/runservice' => 'trigger#runservice'

--- a/src/api/test/functional/trigger_controller_test.rb
+++ b/src/api/test/functional/trigger_controller_test.rb
@@ -56,4 +56,193 @@ class TriggerControllerTest < ActionDispatch::IntegrationTest
     delete '/source/home:tom/test'
     assert_response :success
   end
+
+  def test_branch_via_token
+    login_tom
+    put '/source/home:tom/test/_meta', params: "<package project='home:tom' name='test'> <title /> <description /> </package>"
+    assert_response :success
+
+    post '/person/tom/token?cmd=create&project=home:tom&package=test&operation=branch'
+    assert_response :success
+    doc = REXML::Document.new(@response.body)
+    token = doc.elements['//data'].text
+    assert_equal 24, token.length
+
+    # ANONYMOUS
+    reset_auth
+    post '/trigger/branch'
+    assert_response 403
+    assert_xml_tag tag: 'status', attributes: { code: 'permission_denied' }
+    assert_match(/No valid token found/, @response.body)
+
+    # call with a gitlab payload. based on documentation example
+    payload = '
+{
+  "object_kind": "merge_request",
+  "user": {
+    "id": 1,
+    "name": "Administrator",
+    "username": "root",
+    "avatar_url": "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=40\u0026d=identicon",
+    "email": "admin@example.com"
+  },
+  "project": {
+    "id": 1,
+    "name":"Gitlab Test",
+    "description":"Aut reprehenderit ut est.",
+    "web_url":"http://example.com/gitlabhq/gitlab-test",
+    "avatar_url":null,
+    "git_ssh_url":"git@example.com:gitlabhq/gitlab-test.git",
+    "git_http_url":"http://example.com/gitlabhq/gitlab-test.git",
+    "namespace":"GitlabHQ",
+    "visibility_level":20,
+    "path_with_namespace":"gitlabhq/gitlab-test",
+    "default_branch":"master",
+    "homepage":"http://example.com/gitlabhq/gitlab-test",
+    "url":"http://example.com/gitlabhq/gitlab-test.git",
+    "ssh_url":"git@example.com:gitlabhq/gitlab-test.git",
+    "http_url":"http://example.com/gitlabhq/gitlab-test.git"
+  },
+  "repository": {
+    "name": "Gitlab Test",
+    "url": "http://example.com/gitlabhq/gitlab-test.git",
+    "description": "Aut reprehenderit ut est.",
+    "homepage": "http://example.com/gitlabhq/gitlab-test"
+  },
+  "object_attributes": {
+    "id": 99,
+    "target_branch": "master",
+    "source_branch": "ms-viewport",
+    "source_project_id": 14,
+    "author_id": 51,
+    "assignee_id": 6,
+    "title": "MS-Viewport",
+    "created_at": "2013-12-03T17:23:34Z",
+    "updated_at": "2013-12-03T17:23:34Z",
+    "milestone_id": null,
+    "state": "opened",
+    "merge_status": "unchecked",
+    "target_project_id": 14,
+    "iid": 1,
+    "description": "",
+    "source": {
+      "name":"Awesome Project",
+      "description":"Aut reprehenderit ut est.",
+      "web_url":"http://example.com/awesome_space/awesome_project",
+      "avatar_url":null,
+      "git_ssh_url":"git@example.com:awesome_space/awesome_project.git",
+      "git_http_url":"http://example.com/awesome_space/awesome_project.git",
+      "namespace":"Awesome Space",
+      "visibility_level":20,
+      "path_with_namespace":"awesome_space/awesome_project",
+      "default_branch":"master",
+      "homepage":"http://example.com/awesome_space/awesome_project",
+      "url":"http://example.com/awesome_space/awesome_project.git",
+      "ssh_url":"git@example.com:awesome_space/awesome_project.git",
+      "http_url":"http://example.com/awesome_space/awesome_project.git"
+    },
+    "target": {
+      "name":"Awesome Project",
+      "description":"Aut reprehenderit ut est.",
+      "web_url":"http://example.com/awesome_space/awesome_project",
+      "avatar_url":null,
+      "git_ssh_url":"git@example.com:awesome_space/awesome_project.git",
+      "git_http_url":"http://example.com/awesome_space/awesome_project.git",
+      "namespace":"Awesome Space",
+      "visibility_level":20,
+      "path_with_namespace":"awesome_space/awesome_project",
+      "default_branch":"master",
+      "homepage":"http://example.com/awesome_space/awesome_project",
+      "url":"http://example.com/awesome_space/awesome_project.git",
+      "ssh_url":"git@example.com:awesome_space/awesome_project.git",
+      "http_url":"http://example.com/awesome_space/awesome_project.git"
+    },
+    "last_commit": {
+      "id": "da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
+      "message": "fixed readme",
+      "timestamp": "2012-01-03T23:36:29+02:00",
+      "url": "http://example.com/awesome_space/awesome_project/commits/da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
+      "author": {
+        "name": "GitLab dev user",
+        "email": "gitlabdev@dv6700.(none)"
+      }
+    },
+    "work_in_progress": false,
+    "url": "http://example.com/diaspora/merge_requests/1",
+    "action": "open",
+    "assignee": {
+      "name": "User1",
+      "username": "user1",
+      "avatar_url": "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=40\u0026d=identicon"
+    }
+  },
+  "labels": [{
+    "id": 206,
+    "title": "API",
+    "color": "#ffffff",
+    "project_id": 14,
+    "created_at": "2013-12-03T17:15:43Z",
+    "updated_at": "2013-12-03T17:15:43Z",
+    "template": false,
+    "description": "API related issues",
+    "type": "ProjectLabel",
+    "group_id": 41
+  }],
+  "changes": {
+    "updated_by_id": {
+      "previous": null,
+      "current": 1
+    },
+    "updated_at": {
+      "previous": "2017-09-15 16:50:55 UTC",
+      "current":"2017-09-15 16:52:00 UTC"
+    },
+    "labels": {
+      "previous": [{
+        "id": 206,
+        "title": "API",
+        "color": "#ffffff",
+        "project_id": 14,
+        "created_at": "2013-12-03T17:15:43Z",
+        "updated_at": "2013-12-03T17:15:43Z",
+        "template": false,
+        "description": "API related issues",
+        "type": "ProjectLabel",
+        "group_id": 41
+      }],
+      "current": [{
+        "id": 205,
+        "title": "Platform",
+        "color": "#123123",
+        "project_id": 14,
+        "created_at": "2013-12-03T17:15:43Z",
+        "updated_at": "2013-12-03T17:15:43Z",
+        "template": false,
+        "description": "Platform related issues",
+        "type": "ProjectLabel",
+        "group_id": 41
+      }]
+    }
+  }
+}'
+    post('/trigger/branch', headers: { 'Authorization' => "Token #{token}" }, params: payload)
+    # backend output ignored atm :/
+    assert_response :success
+
+    login_tom
+    get '/source/home:tom:MERGE:home:tom:test:1/test/_branch_request'
+    assert_response :success
+
+    # cleanup
+    get '/person/tom/token'
+    assert_response :success
+    assert_xml_tag tag: 'entry', attributes: { project: 'home:tom', package: 'test', kind: 'branch' }
+    delete '/source/home:tom:MERGE:home:tom:test:1'
+    assert_response :success
+    delete '/source/home:tom/test'
+    assert_response :success
+    get '/person/tom/token'
+    assert_response :success
+    assert_no_xml_tag tag: 'entry', attributes: { project: 'home:tom', package: 'test', kind: 'branch' }
+  end
 end


### PR DESCRIPTION
It also stores the payload into the new branched package. This allows
the service tooling to get the resource.

This allows integration of merge requests from gitlab.

This is the unfinished stuff from quite some time ago to allow to use OBS as CI tool directly without the need to run external bots.
What is missing:
- gitlab/github view integration to see the current state in pull/merge requests
- tracking of branch updates in the git repos

This requires also a new obs_scm tooling, will submit this as well later today.

Two ways to use it 
1) Register a "branch" token which bound to a concrete package
2) Configure as web hook for gitlab merge requests https://api.opensuse.org/trigger/branch

Or with generic token:
1) Register a "branch" token not bound to a package
2) Configure as web hook for gitlab merge requests https://api.opensuse.org/trigger/branch?project=$PROJECT\&package=$PACKAGE

I am not sure that I tested the github hook back then.
