### PR TITLE
Fix distributions POST endpoint

### DIFF
--- a/docs/api/api/distributions.rng
+++ b/docs/api/api/distributions.rng
@@ -13,9 +13,11 @@
   </define>
   <define ns="" name="distribution-element">
     <element name="distribution">
-      <attribute name="id">
-        <data type="string"/>
-      </attribute>
+      <optional>
+        <attribute name="id">
+          <data type="string"/>
+        </attribute>
+      </optional>
       <attribute name="vendor">
         <data type="string"/>
       </attribute>

--- a/src/api/app/controllers/distributions_controller.rb
+++ b/src/api/app/controllers/distributions_controller.rb
@@ -4,6 +4,7 @@ class DistributionsController < ApplicationController
 
   validate_action index: { method: :get, response: :distributions }
   validate_action upload: { method: :put, request: :distributions, response: :status }
+  validate_action create: { method: :post, request: :distributions }
 
   # GET /distributions
   # GET /distributions.xml
@@ -55,17 +56,9 @@ class DistributionsController < ApplicationController
   # POST /distributions
   # POST /distributions.xml
   def create
-    @distribution = Distribution.new(params[:distribution])
+    Distribution.parse(Xmlhash.parse(request.body.read), delete_current: false)
 
-    respond_to do |format|
-      if @distribution.save
-        format.xml  { render xml: @distribution, status: :created, location: @distribution }
-        format.json { render json: @distribution, status: :created, location: @distribution }
-      else
-        format.xml  { render xml: @distribution.errors, status: :unprocessable_entity }
-        format.json { render json: @distribution.errors, status: :unprocessable_entity }
-      end
-    end
+    render_ok
   end
 
   # DELETE /distributions/opensuse-11.4

--- a/src/api/app/models/distribution.rb
+++ b/src/api/app/models/distribution.rb
@@ -4,10 +4,12 @@ class Distribution < ApplicationRecord
   has_and_belongs_to_many :icons, -> { distinct }, class_name: 'DistributionIcon'
   has_and_belongs_to_many :architectures, -> { distinct }, class_name: 'Architecture'
 
-  def self.parse(xmlhash)
+  def self.parse(xmlhash, delete_current: true)
     Distribution.transaction do
-      Distribution.destroy_all
-      DistributionIcon.delete_all
+      if delete_current
+        Distribution.destroy_all
+        DistributionIcon.delete_all
+      end
       xmlhash.elements('distribution') do |d|
         db = Distribution.create(vendor: d['vendor'], version: d['version'], name: d['name'], project: d['project'],
                                  reponame: d['reponame'], repository: d['repository'], link: d['link'])

--- a/src/api/spec/controllers/distributions_controller_spec.rb
+++ b/src/api/spec/controllers/distributions_controller_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe DistributionsController do
+  let(:admin) { create(:admin_user) }
+  let(:user) { create(:confirmed_user) }
+
+  let(:distribution_xml) do
+    '<distributions>
+       <distribution vendor="opensuse" version="Tumbleweed">
+         <name>openSUSE Tumbleweed</name>
+         <project>openSUSE:Factory</project>
+         <reponame>openSUSE_Tumbleweed</reponame>
+         <repository>snapshot</repository>
+         <link>http://www.opensuse.org/</link>
+         <icon width="8" height="8" url="https://static.opensuse.org/distributions/logos/opensuse.png"/>
+         <icon width="16" height="16" url="https://static.opensuse.org/distributions/logos/opensuse.png"/>
+         <architecture>i586</architecture>
+         <architecture>x86_64</architecture>
+       </distribution>
+     </distributions>'
+  end
+
+  let(:invalid_distribution_xml) do
+    '<distribution>
+     </distribution>'
+  end
+
+  describe '#create' do
+    before do
+      login admin
+    end
+
+    subject { post :create, body: distribution_xml, format: :xml }
+
+    context 'when xml is valid' do
+      it { is_expected.to have_http_status(:ok) }
+      it { expect { subject }.to change(Distribution, :count).by(1) }
+    end
+
+    context 'when xml is invalid' do
+      subject { post :create, body: invalid_distribution_xml, format: :xml }
+
+      it { expect { subject }.not_to change(Distribution, :count) }
+      it { is_expected.to have_http_status(:bad_request) }
+    end
+
+    context 'when xml is empty' do
+      subject { post :create, format: :xml }
+
+      it { is_expected.to have_http_status(:bad_request) }
+    end
+
+    context 'when authenticating as a user' do
+      before do
+        login user
+      end
+
+      it { is_expected.to have_http_status(:forbidden) }
+    end
+  end
+end


### PR DESCRIPTION
This PR is related to #10695
It fixes the POST endpoint of /distributions
It also introduces a spec to test the endpoint

To verify this feature:
1. Start dev environment
2. Look at current distributions `curl --user Admin:opensuse http://api.localhost:3000/distributions`
3. Make use of the POST /distributions endpoint for example like this:
Write these contents into a file e.g. `post.yml`:
```
<distributions>
  <distribution vendor="opensuse" version="Tumbleweed">
    <name>openSUSE Tumbleweed</name>
    <project>openSUSE:Factory</project>
    <reponame>openSUSE_Tumbleweed</reponame>
    <repository>snapshot</repository>
    <link>http://www.opensuse.org/</link>
    <icon width="8" height="8" url="https://static.opensuse.org/distributions/logos/opensuse.png"/>
    <icon width="16" height="16" url="https://static.opensuse.org/distributions/logos/opensuse.png"/>
    <architecture>i586</architecture>
    <architecture>x86_64</architecture>
  </distribution>
</distributions>
```
After that:
`curl --user Admin:opensuse -X POST --data-binary @post.yml http://api.localhost:3000/distributions`

4. Look at the distributions again as described in step 2 and confirm a new one has been added.

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
