### PR TITLE
Add style for markdown block quotes

### DIFF
--- a/src/api/app/assets/stylesheets/webui/comments.scss
+++ b/src/api/app/assets/stylesheets/webui/comments.scss
@@ -13,6 +13,12 @@
     }
     code { line-height: 1.5rem; }
   }
+
+  blockquote {
+    color: $gray-500;
+    padding: 0 1rem;
+    border-left: .25rem solid $gray-300;
+  }
 }
 
 .comment-preview {


### PR DESCRIPTION
Block quotes are not styled in web ui markdown comments.

The commit adds the appropriate styles in scss.

Fixes #10645

How to test the fix:

1. Go to any request;
2. Make a comment using markdown block quotes, eg.:
`> this is a block quote`
3. Submit the comment / click on preview tab.

Here are the screenshots of how it looks:

**Before**
![2021-02-16_18-37](https://user-images.githubusercontent.com/37581072/108100506-4924a900-7086-11eb-972c-8a1ae0ff14af.png)

**After**
![2021-02-16_18-29](https://user-images.githubusercontent.com/37581072/108100519-4de95d00-7086-11eb-9ea3-f8f4a41dfeaf.png)
