### PR TITLE
[backend] log if accepting getbinaries hangs

### DIFF
--- a/src/backend/bs_getbinariesproxy
+++ b/src/backend/bs_getbinariesproxy
@@ -160,7 +160,10 @@ sub getbinaries {
   my $nometa = $cgi->{'nometa'};
   my $metaonly = $cgi->{'metaonly'};
   die("nometa and metaonly?\n") if $nometa && $metaonly;
-
+  if ($cgi->{'now'}) {
+    my $waited = time() - $cgi->{'now'};
+    print "waited $waited seconds to accept call\n" if $waited > 60;
+  }
   mkdir_p($cachedir);
   mkdir_p($cachetmpdir);
   set_maxopen() unless defined $maxopen;
@@ -184,6 +187,7 @@ sub getbinaries {
   # get missing bvs from server
   if (@missingbvs) {
     print "missingbvs: @missingbvs\n";
+    my $callers_time = time();
     my @args;
     push @args, "project=$projid";
     push @args, "repository=$repoid";
@@ -191,6 +195,7 @@ sub getbinaries {
     push @args, "nometa" if $nometa;
     push @args, map {"module=$_"} @{$cgi->{'module'} || []};
     push @args, "binaries=".join(',', @missingbvs);
+    push @args, "now=$callers_time";
     my $bvl;
     eval {
       $bvl = BSRPC::rpc({
@@ -298,11 +303,13 @@ sub getbinaries {
     if ($downloadsizek * 1024 * 100 > $cachesize) {
       manage_cache($cachesize - $downloadsizek * 1024);
     }
+    my $callers_time = time();
     my @args;
     push @args, "project=$projid";
     push @args, "repository=$repoid";
     push @args, "arch=$arch";
     push @args, map {"module=$_"} @{$cgi->{'module'} || []};
+    push @args, "now=$callers_time";
     my $res;
     eval {
       $res = BSRPC::rpc({
@@ -361,7 +368,10 @@ sub getbinaries {
 
 sub getpreinstallimage {
   my ($cgi, $prpa, $hdrmd5) = @_;
-
+  if ($cgi->{'now'}) {
+    my $waited = time() - $cgi->{'now'};
+    print "waited $waited seconds to accept call\n" if $waited > 60;
+  }
   mkdir_p($cachedir);
   mkdir_p($cachetmpdir);
   set_maxopen() unless defined $maxopen;
@@ -417,8 +427,8 @@ sub hello {
 
 my $dispatches = [
   '/' => \&hello,
-  '/getbinaries $project $repository $arch binaries: nometa:bool? metaonly:bool? module* workerid? server:' => \&getbinaries,
-  '/getpreinstallimage $prpa $hdrmd5:md5 path: sizek:num? workerid? server:' => \&getpreinstallimage,
+  '/getbinaries $project $repository $arch binaries: nometa:bool? metaonly:bool? module* workerid? now:num? server:' => \&getbinaries,
+  '/getpreinstallimage $prpa $hdrmd5:md5 path: sizek:num? workerid? now:num? server:' => \&getpreinstallimage,
 ];
 
 my $conf = {

--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -241,6 +241,10 @@ sub getbinaryversions {
     die unless $cgi->{'view'} && $cgi->{'view'} eq 'binaryversions';
     @bins = @{$cgi->{'binary'} || []};
   }
+  if ($cgi->{'now'}) {
+    my $waited = time() - $cgi->{'now'};
+    print "waited $waited seconds to accept call\n" if $waited > 60;
+  }
   my $serial;
   $serial = BSWatcher::serialize("$reporoot/$projid/$repoid/$arch") if $BSStdServer::isajax;
   return if $BSStdServer::isajax && !defined $serial;
@@ -447,7 +451,10 @@ sub getbinaries {
   my ($cgi, $projid, $repoid, $arch) = @_;
   my $prp = "$projid/$repoid";
   my @bins = split(',', $cgi->{'binaries'} || '');
-
+  if ($cgi->{'now'}) {
+    my $waited = time() - $cgi->{'now'};
+    print "waited $waited seconds to accept call\n" if $waited > 60;
+  }
   my $serial;
   $serial = BSWatcher::serialize("$reporoot/$projid/$repoid/$arch") if $BSStdServer::isajax;
   return if $BSStdServer::isajax && !defined $serial;
@@ -4427,8 +4434,8 @@ my $dispatches = [
   '!worker /getworkercode' => \&getworkercode,
   '!worker POST:/putjob $arch $job $jobid $code:? now:num? kiwitree:bool? workerid?' => \&putjob,
   '!worker POST:/workerdispatched $arch $job $jobid hostarch:arch port workerid?' => \&workerdispatched,
-  '!worker /getbinaries $project $repository $arch binaries: nometa:bool? metaonly:bool? workerid? module*' => \&getbinaries,
-  '!worker /getbinaryversions $project $repository $arch binaries: nometa:bool? workerid? module*' => \&getbinaryversions,
+  '!worker /getbinaries $project $repository $arch binaries: nometa:bool? metaonly:bool? workerid? now:num? module*' => \&getbinaries,
+  '!worker /getbinaryversions $project $repository $arch binaries: nometa:bool? workerid? now:num? module*' => \&getbinaryversions,
   '!worker /getjobdata $arch $job $jobid workerid?' => \&getjobdata,
   '!worker /getpackagebinaryversionlist $project $repository $arch $package* withcode:bool? workerid?' => \&getpackagebinaryversionlist,
   '!worker /badpackagebinaryversionlist $project $repository $arch $package* workerid?' => \&badpackagebinaryversionlist,
@@ -4487,8 +4494,8 @@ my $dispatches_ajax = [
   '/build/$project/$repository/$arch/$package:package_repository view:? binary:filename* nosource:bool? module* withccache:bool?' => \&getbinarylist,
   '/build/$project/$repository/$arch/$package:package_repository/$filename view:? module*' => \&getbinary,
   '/_result $prpa+ oldstate:md5? package* code:* withbinarylist:bool? withstats:bool? summary:bool? withversrel:bool?' => \&getresult,
-  '/getbinaries $project $repository $arch binaries: nometa:bool? metaonly:bool? module*' => \&getbinaries,
-  '/getbinaryversions $project $repository $arch binaries: nometa:bool? module*' => \&getbinaryversions,
+  '/getbinaries $project $repository $arch binaries: nometa:bool? metaonly:bool? now:num? module*' => \&getbinaries,
+  '/getbinaryversions $project $repository $arch binaries: nometa:bool? now:num? module*' => \&getbinaryversions,
 ];
 
 my $conf = {

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -5638,6 +5638,7 @@ sub worker_getbinaries {
     push @args, "arch=$arch";
     push @args, "binaries=$cgi->{'binaries'}";
     push @args, map {"module=$_"} @{$cgi->{'module'} || []};
+    push @args, "now=$cgi->{'now'}" if $cgi->{'now'};
     BSHandoff::handoff('/getbinaries', undef, @args);
   }
   my @binaries = split(',', $cgi->{'binaries'});
@@ -5669,6 +5670,7 @@ sub worker_getbinaryversions {
     push @args, "binaries=$cgi->{'binaries'}";
     push @args, "nometa=1" if $cgi->{'nometa'};
     push @args, map {"module=$_"} @{$cgi->{'module'} || []};
+    push @args, "now=$cgi->{'now'}" if $cgi->{'now'};
     BSHandoff::handoff('/getbinaryversions', undef, @args);
   }
   my @binaries = split(',', $cgi->{'binaries'});
@@ -7019,8 +7021,8 @@ my $dispatches = [
   '/getsources $project $package $srcmd5:md5 workerid?' => \&getsources,
   '/getconfig $project $repository path:prp* workerid?' => \&getbuildconfig,
   '/getsslcert $project autoextend:bool? workerid? signtype:?' => \&getsslcert,
-  '/getbinaries $project $repository $arch binaries: nometa:bool? workerid? module*' => \&worker_getbinaries,
-  '/getbinaryversions $project $repository $arch binaries: nometa:bool? workerid? module*' => \&worker_getbinaryversions,
+  '/getbinaries $project $repository $arch binaries: nometa:bool? workerid? now:num? module*' => \&worker_getbinaries,
+  '/getbinaryversions $project $repository $arch binaries: nometa:bool? workerid? now:num? module*' => \&worker_getbinaryversions,
   '/getobsgendiffdata $project $repository $arch jobid? workerid?' => \&getobsgendiffdata,
 
   # publisher/signer calls
@@ -7139,8 +7141,8 @@ my $dispatches_ajax = [
   '/build/$project/$repository/$arch package* view:?' => \&getpackagelist_build,
   '/build/$project/$repository/$arch/$package/_log nostream:bool? last:bool? lastsucceeded:bool? start:intnum? end:num?' => \&getlogfile,
   '/build/$project/$repository/$arch/$package_repository view:? binary:filename* nometa:bool? nosource:bool? withmd5:bool? module* withccache:bool?' => \&getbinarylist,
-  '/getbinaries $project $repository $arch binaries: nometa:bool? raw:bool? module*' => \&worker_getbinaries,
-  '/getbinaryversions $project $repository $arch binaries: nometa:bool? module*' => \&worker_getbinaryversions,
+  '/getbinaries $project $repository $arch binaries: nometa:bool? raw:bool? now:num? module*' => \&worker_getbinaries,
+  '/getbinaryversions $project $repository $arch binaries: nometa:bool? now:num? module*' => \&worker_getbinaryversions,
   '/lastevents $filter:* start:num? obsname:?' => \&lastevents,
   '/lasteventsproxy $filter:* start:num? remoteurl: client:?' => \&lasteventsproxy,
   '/lastnotifications start:num? view:? block:bool?' => \&lastnotifications,

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -1246,6 +1246,7 @@ sub trygetbinariesproxy {
   my ($server, $dir, $bins, $bvs,  @args) = @_;
 
   return undef unless $getbinariesproxy;
+  my $callers_time = time();
   my @proxybins;
   for my $bin (@$bins) {
     my $bv = $bvs->{$bin};
@@ -1262,7 +1263,7 @@ sub trygetbinariesproxy {
       'directory' => $dir,
       'timeout' => $gettimeout,
       'receiver' => \&BSHTTP::cpio_receiver,
-    }, undef, "server=$server", @args, 'binaries='.join(',', @proxybins));
+    }, undef, "server=$server", @args, "now=$callers_time", 'binaries='.join(',', @proxybins));
   };
   if ($@) {
     warn($@);
@@ -1274,10 +1275,12 @@ sub trygetbinariesproxy {
 sub trygetbinariesproxy_preinstallimage {
   my ($server, $filename, $img) = @_;
   return undef unless $getbinariesproxy;
+  my $callers_time = time();
   my $res;
   my @args;
   push @args, "workerid=$workerid" if defined $workerid;
   push @args, "prpa=$img->{'prpa'}", "hdrmd5=$img->{'hdrmd5'}", "sizek=$img->{'sizek'}", "path=$img->{'path'}";
+  push @args, "now=$callers_time";
   eval {
     $res = BSRPC::rpc({
       'uri' => "$getbinariesproxy/getpreinstallimage",
@@ -1315,6 +1318,7 @@ sub getbinaries_cache {
     undef $bvl if grep {!$bv{$_}} @$bins;
   }
   if ($cachedir && !$bvl) {
+    my $callers_time = time();
     my @args;
     push @args, "workerid=$workerid" if defined $workerid;
     push @args, "project=$projid";
@@ -1323,6 +1327,7 @@ sub getbinaries_cache {
     push @args, "nometa" if $nometa;
     push @args, map {"module=$_"} @{$modules || []};
     push @args, "binaries=".join(',', @$bins);
+    push @args, "now=$callers_time";
     eval {
       $bvl = BSRPC::rpc({
         'uri' => "$server/getbinaryversions",
@@ -1406,12 +1411,14 @@ sub getbinaries_cache {
       # reserve space
       manage_cache($cachesize - $downloadsizek * 1024);
     }
+    my $callers_time = time();
     my @args;
     push @args, "workerid=$workerid" if defined $workerid;
     push @args, "project=$projid";
     push @args, "repository=$repoid";
     push @args, "arch=$arch";
     push @args, map {"module=$_"} @{$modules || []};
+    push @args, "now=$callers_time";
     my $res;
     $res = trygetbinariesproxy($server, $dir, \@downloadbins, \%bv, @args) if $getbinariesproxy;
     eval {
@@ -1881,6 +1888,8 @@ sub getpreinstallimage_metas {
   my $res;
   $res = trygetbinariesproxy($server, $dir, \@todo, $metas, @args) if $getbinariesproxy;
   eval {
+    my $callers_time = time();
+    push @args, "now=$callers_time";
     $res ||= BSRPC::rpc({
       'uri' => "$server/getbinaries",
       'directory' => $dir,
@@ -1937,6 +1946,7 @@ sub getpreinstallimage {
     my $server = $repo->{'server'} || $buildinfo->{'reposerver'};
     my $nometa = $repo->{'project'} ne $projid || $repo->{'repository'} ne $repoid ? 1 : 0;
     $nometa = 1 if $buildinfo->{'file'} eq '_preinstallimage';
+    my $callers_time = time();
     my @args;
     push @args, "project=$repo->{'project'}";
     push @args, "repository=$repo->{'repository'}";
@@ -1944,6 +1954,7 @@ sub getpreinstallimage {
     push @args, "nometa" if $nometa;
     push @args, map {"module=$_"} @{$buildinfo->{'module'} || []};
     push @args, "binaries=".join(',', @bins);
+    push @args, "now=$callers_time";
     my $bvl;
     eval {
       $bvl = BSRPC::rpc({
@@ -2179,6 +2190,7 @@ sub getbinaries_buildenv {
     # maybe we need to look at the full tree as well...
     for my $repo (@{$buildinfo->{'path'} || []}) {
       my $server = $repo->{'server'} || $buildinfo->{'reposerver'};
+      my $callers_time = time();
       my @args;
       push @args, "project=$repo->{'project'}";
       push @args, "repository=$repo->{'repository'}";
@@ -2186,6 +2198,7 @@ sub getbinaries_buildenv {
       push @args, 'nometa';
       push @args, map {"module=$_"} @{$buildinfo->{'module'} || []};
       push @args, "binaries=".join(',', @needed_names);
+      push @args, "now=$callers_time";
       my $bvl;
       eval {
         $bvl = BSRPC::rpc({
@@ -2453,11 +2466,13 @@ sub getbinaries {
       die("getbinaries: job has no container repository\n") unless $repo;
       my $ddir = "$srcdir/containers/$repo->{'project'}/$repo->{'repository'}";
       mkdir_p($ddir);
+      my $callers_time = time();
       my @args;
       push @args, "workerid=$workerid" if defined $workerid;
       push @args, "project=$repo->{'project'}";
       push @args, "repository=$repo->{'repository'}";
       push @args, "arch=$buildinfo->{'arch'}";
+      push @args, "now=$callers_time";
       my $server = $repo->{'server'} || $buildinfo->{'reposerver'};
       my $res = BSRPC::rpc({
 	'uri' => "$server/getbinaries",


### PR DESCRIPTION
log if the call stays in the queue for more than one minute

_Replace this line with a description of your changes. Please follow the suggestions in the comment below._

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
