### PR TITLE
Fix clear filters link on profiles

### DIFF
--- a/src/api/app/helpers/webui/user_helper.rb
+++ b/src/api/app/helpers/webui/user_helper.rb
@@ -1,12 +1,13 @@
 module Webui::UserHelper
-  def display_applied_filters(filters)
+  def display_applied_filters(filters, user)
     tag.span(class: 'd-block ml-4 mb-3') do
-      link_to(User.session!) do
-        tag.i(class: 'fas fa-trash-alt') do
-          tag.b(class: 'pl-2') do
+      link_to(user) do
+        safe_join(
+          [
+            tag.i(class: 'fas fa-trash-alt pr-2'),
             "Clear current search #{display_filters(filters.keys).to_sentence}"
-          end
-        end
+          ]
+        )
       end
     end
   end

--- a/src/api/app/views/webui/user/user_profile_redesign/_involvement.html.haml
+++ b/src/api/app/views/webui/user/user_profile_redesign/_involvement.html.haml
@@ -51,7 +51,7 @@
             Apply Filter
 
     - if display_filters?(filters.keys)
-      = display_applied_filters(filters)
+      = display_applied_filters(filters, displayed_user)
   .card-body.pt-0
     - if involved_items.blank?
       This user is not involved in any project or package.


### PR DESCRIPTION
Fix the "Clear current search ..." link when looking at another user's profile.
Fixes #10604

To verify this feature:

1. Start dev environment and make sure to start sphinx with `rake ts:start`
2. Log in as Admin and make sure 'Public beta program' is activated
3. Create another user
4. Go to that user's profile
5. Apply a filter
6. Click the "Clear current search..." link and observe that it now links the correct profile

-----------------

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
