### PR TITLE
[backend] bump vrev when undeleting a package

### DIFF
--- a/src/backend/BSRevision.pm
+++ b/src/backend/BSRevision.pm
@@ -398,14 +398,18 @@ sub undelete_rev {
   my $user = defined($cgi->{'user'}) ? str2utf8xml($cgi->{'user'}) : 'unknown';
   my $comment = defined($cgi->{'comment'}) ? str2utf8xml($cgi->{'comment'}) : '';
   my $nrev = { 'srcmd5' => $rev->{'srcmd5'}, 'time' => time(), 'user' => $user, 'comment' => $comment, 'requestid' => $cgi->{'requestid'} };
-  $nrev->{'version'} = $rev->{'version'} if $rev && defined $rev->{'version'};
-  $nrev->{'vrev'} = $rev->{'vrev'} if $rev && defined $rev->{'vrev'};
+  $nrev->{'vrev'} = $rev->{'vrev'} if defined $rev->{'vrev'};
+  $nrev->{'version'} = $rev->{'version'} if defined $rev->{'version'};
+  if (defined($rev->{'version'}) && defined($rev->{'vrev'}) && $rev->{'vrev'} ne '') {
+    # bump vrev
+    $rev->{'vrev'} = $1 . ($2 + 1) if $rev->{'vrev'} =~ /^(.*?)(\d+)$/;
+  }
   $nrev->{'rev'} = $rev->{'rev'} + 1;
   if ($cgi->{'time'}) {
     if ($cgi->{'time'} == 1) {
-      $nrev->{'time'} = $rev->{'time'} if $rev && $rev->{'time'};
+      $nrev->{'time'} = $rev->{'time'} if $rev->{'time'};
     } else {
-      die("specified time is less than time in last commit\n") if $rev && $rev->{'time'} > $cgi->{'time'};
+      die("specified time is less than time in last commit\n") if $rev->{'time'} > $cgi->{'time'};
       $nrev->{'time'} = $cgi->{'time'};
     }
   }

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -1172,8 +1172,9 @@ sub move_entry_into_cache {
   my $cachefile = "$cachedir/".substr($cacheid, 0, 2)."/$cacheid";
   mkdir_p("$cachedir/".substr($cacheid, 0, 2));
   unlink("$cachefile.$$");
-  return 0 unless link($path, "$cachefile.$$");
+  return 0 unless link_or_copy($path, "$cachefile.$$");
   rename("$cachefile.$$", $cachefile) || die("500 rename $cachefile.$$ $cachefile: $!\n");
+  unlink("$cachefile.$$");
   my $mpath = "$path.meta";
   $mpath = "$1.meta" if $path =~ /^(.*)\.(?:$binsufsre)$/;
   if (-s $mpath) {


### PR DESCRIPTION
When a package is deleted, all build results are lost including
the rebuild counter. So we habe to bump the vrev to make sure that
new builds get a higher revision.

_Replace this line with a description of your changes. Please follow the suggestions in the comment below._

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
