### PR TITLE
Repoinfo search interface

### DIFF
--- a/docs/api/api/api.txt
+++ b/docs/api/api/api.txt
@@ -1556,6 +1556,21 @@ GET /search/published/binary/id
 Parameters:
 
   match: xpath predicate, mandatory
+  limit: override limit of entries, optional
+  withdownloadurl: bool, add download url entries as well, optional
+
+XmlResult: collection
+
+
+GET /search/published/repoinfo/id
+
+  Search for currenlty available repositories in the publish area.
+
+Parameters:
+
+  match: xpath predicate, mandatory
+  limit: override limit of entries, optional
+  withdownloadurl: bool, add download url entries as well, optional
 
 XmlResult: collection
 
@@ -1567,6 +1582,8 @@ GET /search/published/pattern/id
 Parameters:
 
   match: xpath predicate, mandatory
+  limit: override limit of entries, optional
+  withdownloadurl: bool, add download url entries as well, optional
 
 XmlResult: collection
 

--- a/src/api/config/routes/api_routes.rb
+++ b/src/api/config/routes/api_routes.rb
@@ -135,9 +135,8 @@ OBSApi::Application.routes.draw do
     ### /search
 
     controller :search do
-      # ACL(/search/published/binary/id) TODO: direct passed call to  "pass_to_backend'
       match 'search/published/binary/id' => :pass_to_backend, via: [:get, :post]
-      # ACL(/search/published/pattern/id) TODO: direct passed call to  'pass_to_backend'
+      match 'search/published/repoinfo/id' => :pass_to_backend, via: [:get, :post]
       match 'search/published/pattern/id' => :pass_to_backend, via: [:get, :post]
       match 'search/channel/binary/id' => :channel_binary_id, via: [:get, :post]
       match 'search/channel/binary' => :channel_binary, via: [:get, :post]

--- a/src/api/script/start_test_backend
+++ b/src/api/script/start_test_backend
@@ -332,7 +332,6 @@ scheduler_thread = nil
 
 at_exit do
   scheduler_thread.join if scheduler_thread
-
   system("cd #{backend_config}; exec ./bs_srcserver --stop")
   system("cd #{backend_config}; exec ./bs_repserver --stop")
 
@@ -353,8 +352,8 @@ at_exit do
   servicesrv_out.close
   servicesrv_out = nil
   servicesrv.join
-  #  FileUtils.rm_rf("#{backend_data}")
-  #  FileUtils.rm_rf("#{backend_config}")
+  FileUtils.rm_rf(backend_data)
+  FileUtils.rm_rf(backend_config)
   File.delete(schedulerdone_file) if File.exist?(schedulerdone_file)
 end
 

--- a/src/api/test/functional/channel_maintenance_test.rb
+++ b/src/api/test/functional/channel_maintenance_test.rb
@@ -552,6 +552,14 @@ class ChannelMaintenanceTests < ActionDispatch::IntegrationTest
                                                 filename: 'package-1.0-1.i586.rpm',
                                                 filepath: 'My:/Maintenance:/0/BaseDistro3Channel/rpm/i586/package-1.0-1.i586.rpm',
                                                 baseproject: 'BaseDistro3Channel', type: 'rpm' }
+    get "/search/published/repoinfo/id?match=project='" + incident_project + "'"
+    assert_response :success
+    assert_xml_tag tag: 'collection', attributes: { matches: '3' }
+    assert_xml_tag tag: 'repoinfo', attributes: { repository: 'channel_repo', project: 'BaseDistro3Channel' }
+    get '/search/published/repoinfo/id?withdownloadurl=1&match=starts-with(project,"My:Maintenance:")'
+    assert_response :success
+    assert_xml_tag tag: 'collection', attributes: { matches: '3' }
+    assert_xml_tag tag: 'repoinfo', attributes: { repository: 'channel_repo', project: 'BaseDistro3Channel' }
 
     # create release request
     post '/request?cmd=create', params: '<request>

--- a/src/backend/BSConfig.pm.template
+++ b/src/backend/BSConfig.pm.template
@@ -131,6 +131,10 @@ our $nosharedtrees = 2;
 # enable binary release tracking by default for release projects
 our $packtrack = [];
 
+# use the more efficient sqlite database for new installations by default
+our $source_db_sqlite = 1;
+our $published_db_sqlite = 1;
+
 # optional: limit visibility of projects for some architectures
 #our $limit_projects = {
 # "ppc" => [ "openSUSE:Factory", "FATE" ],

--- a/src/backend/BSXML.pm
+++ b/src/backend/BSXML.pm
@@ -1227,6 +1227,13 @@ our $pattern_id = [
 	'downloadurl',
 ];
 
+our $repoinfo_id = [
+     'repoinfo' =>
+	'project',
+	'repository',
+	'downloadurl',
+];
+
 our $sourcediff = [
     'sourcediff' =>
 	'key',
@@ -1389,6 +1396,7 @@ our $collection = [
       [ $pack ],
       [ $binary_id ],
       [ $pattern_id ],
+      [ $repoinfo_id ],
       [ 'value' ],
 ];
 

--- a/src/backend/bs_check_consistency
+++ b/src/backend/bs_check_consistency
@@ -386,6 +386,7 @@ if (-d "$dbroot" && $check_db) {
   closedir(DIR);
   for my $dbdir (sort(@dbdir_a)) {
     next if $dbdir =~ /^\./;
+    next if $dbdir eq 'sqlite';
     if ($dbdir eq "published" || $dbdir eq "source") { # request db dir is obsolete
       print "PROGRESS: checking $dbdir db\n";
       if (-d "$dbroot/$dbdir") {

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -5219,6 +5219,48 @@ sub search_published_binary_name {
   return search_published_binary_id($cgi, $match, 1);
 }
 
+sub published_repoinfo_projectindexfunc {
+  my ($db, $path, $value) = @_;
+  $db->{'_allkeys'} ||= [ $db->keys() ];
+  if (!defined($value)) {
+    my %projids;
+    $projids{(split('/', $_, 2))[0]} = 1 for @{$db->{'_allkeys'}};
+    return sort keys %projids;
+  }
+  return grep {/^\Q$value\E\//} @{$db->{'_allkeys'}};
+}
+
+sub search_published_repoinfo_id {
+  my ($cgi, $match) = @_;
+  my $repoinfodb;
+  if ($BSConfig::published_db_sqlite) {
+    $repoinfodb = BSSrcServer::SQLite::opendb($extrepodb, 'repoinfo');
+    $repoinfodb->{'allkeyspath'} = sub {die("413 refusing to get all keys\n")};
+  } else {
+    $repoinfodb = BSDB::opendb($extrepodb, 'repoinfo');
+    $repoinfodb->{'indexfunc'} = {'project' => \&published_repoinfo_projectindexfunc };
+  }
+  my $limit = defined($cgi->{'limit'}) ? $cgi->{'limit'} : 1000;
+  my $rootnode = BSXPathKeys::node($repoinfodb, '', $limit && $limit < 10 ? 1000 : $limit * 100);
+  my $matches = BSXPath::match($rootnode, $match) || [];
+  my $res = {};
+  my @data;
+  for my $d (@$matches) {
+    if ($cgi->{'withdownloadurl'}) {
+      my $du = BSUrlmapper::get_downloadurl("$d->{'base'}->{'project'}/$d->{'base'}->{'repository'}");
+      $d->{'base'}->{'downloadurl'} = $du if $du;
+    }
+    push @data, $d->{'base'};
+  }
+  $res->{'matches'} = @data;
+  if ($limit && @data > $limit) {
+    $res->{'limited'} = 'true';
+    splice(@data, $limit);
+  }
+  $res->{'repoinfo'} = \@data;
+  return ($res, $BSXML::collection);
+}
+
 sub search_published_pattern_id {
   my ($cgi, $match) = @_;
   my $patterndb;
@@ -7047,6 +7089,7 @@ my $dispatches = [
   '/search/published/binary/id $match: limit:num? withdownloadurl:bool?' => \&search_published_binary_id,
   '/search/published/binary/name $match: limit:num?' => \&search_published_binary_name,
   '/search/published/pattern/id $match: limit:num? withdownloadurl:bool?' => \&search_published_pattern_id,
+  '/search/published/repoinfo/id $match: limit:num? withdownloadurl:bool?' => \&search_published_repoinfo_id,
 
   # service interface, just for listing for now
   '/service' => \&listservices,


### PR DESCRIPTION
also enabling sqlite database on by default for new installations.

_Replace this line with a description of your changes. Please follow the suggestions in the comment below._

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
