### PR TITLE
Improve erroring in smoke tests

### DIFF
--- a/dist/t/spec/features/0040_package_spec.rb
+++ b/dist/t/spec/features/0040_package_spec.rb
@@ -62,8 +62,8 @@ RSpec.describe "Package", type: :feature do
       # wait for the build results ajax call
       sleep(5)
       puts "Refreshed build results, #{counter} retries left."
-      succeed_build = page.all('a', class: 'build-state-succeeded')
-      break if succeed_build.length == 1
+      builds_in_final_state = page.all('a', class: /build-state-(succeeded|failed)/).length
+      break if builds_in_final_state.positive?
     end
   end
 end

--- a/dist/t/spec/features/0040_package_spec.rb
+++ b/dist/t/spec/features/0040_package_spec.rb
@@ -65,5 +65,6 @@ RSpec.describe "Package", type: :feature do
       builds_in_final_state = page.all('a', class: /build-state-(succeeded|failed)/).length
       break if builds_in_final_state.positive?
     end
+    expect(page).to have_link('succeeded')
   end
 end


### PR DESCRIPTION
The aim of this pull request is to provide more information when the smoke tests fail building a package.

Now, when the build does not return with `succeeded`, there is no log or screenshot generated.

This pull request makes the tests fail when building a package does not return a `succeded` state. So log files and the screenshot will be generated, and will give more information about what failed.

To verify the changes, for the `succeed` status:
- Run the smoke tests locally, using this branch instead of master
- Run the test suite once, with `bundle.ruby2.5 exec rspec`

For next runs of the tests:
- Modfy the `spec/features/0040_package_spec.rb` file, comenting all the tests sections but the last one: `"should be able to successfully build"`.
- Run only that test, with `bundle.ruby2.5 exec rspec spec/features/0040_package_spec.rb`

To verify the changes, for the `failed` status:
- Create another package, with fails to build, with your browser
- Modify the line `visit("/package/show/home:Admin/hello_world")` to point to your new package
- Run the test

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
