### PR TITLE
[backend] bs_worker: clean up getbinaries_cache

### DIFF
--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -1156,11 +1156,25 @@ sub link_or_copy {
     return undef;
   }
   my $buf;
-  while (sysread(F, $buf, 8192)) {
-    (syswrite(G, $buf) || 0) == length($buf) || die("$to write: $!\n");
+  while (1) {
+    my $r = sysread(F, $buf, 8192);
+    if (!defined($r)) {
+      warn("sysread $from: $!\n");
+      unlink($to);
+      close F;
+      return undef;
+    }
+    last unless $r;
+    if ((syswrite(G, $buf) || 0) != length($buf)) {
+      warn("syswrite $to: $!\n");
+      unlink($to);
+      close F;
+      return undef;
+    }
   }
   close(F);
   if (!close(G)) {
+    warn("close $to: $!\n");
     unlink($to);
     return undef;
   }
@@ -1294,6 +1308,16 @@ sub trygetbinariesproxy_preinstallimage {
   return $res;
 }
 
+sub checkmd5 {
+  my ($file, $md5) = @_;
+  local *F;
+  open(F, '<', $file) || return undef;
+  my $ctx = Digest::MD5->new;
+  $ctx->addfile(*F);
+  close F;
+  return $ctx->hexdigest() eq $md5 ? 1 : undef;
+}
+
 sub getbinaries_cache {
   my ($dir, $server, $projid, $repoid, $arch, $nometa, $bins, $modules, $bvl) = @_;
 
@@ -1354,49 +1378,40 @@ sub getbinaries_cache {
     next if $bv->{'error'};
     my $cacheid =  Digest::MD5::md5_hex("$projid/$repoid/$arch/$bv->{'hdrmd5'}");
     my $cachefile = "$cachedir/".substr($cacheid, 0, 2)."/$cacheid";
-    my $usecache = 0;
+    if (!link_or_copy($cachefile, "$dir/$bv->{'name'}")) {
+      push @downloadbins, $bin;
+      $downloadsizek += $bv->{'sizek'};
+      next;
+    }
+    my $usecache = 1;
     my $havemeta;
-    if (link_or_copy($cachefile, "$dir/$bv->{'name'}")) {
-      my @s = stat("$dir/$bv->{'name'}");
-      die unless @s;
-      if (!$nometa && $bv->{'hdrmd5'}) {
-	my $mn = $bv->{'name'};
-        $mn =~ s/\.(?:$binsufsre)/.meta/;
-        if (link_or_copy("$cachefile.meta", "$dir/$mn")) {
-	  local *F;
-	  open(F, '<', "$dir/$mn") || die;
-	  my $ctx = Digest::MD5->new;
-	  $ctx->addfile(*F);
-	  close F;
-	  if ($ctx->hexdigest() eq $bv->{'metamd5'}) {
-	    $usecache = 1;
-	    $havemeta = 1;
-	  } else {
-	    unlink("$dir/$mn");
-	  }
+    my @s = stat("$dir/$bv->{'name'}");
+    die unless @s;
+    if (!$nometa && $bv->{'metamd5'}) {
+      my $mn = $bv->{'name'};
+      $mn =~ s/\.(?:$binsufsre)/.meta/;
+      if (link_or_copy("$cachefile.meta", "$dir/$mn")) {
+	if (checkmd5("$dir/$mn", $bv->{'metamd5'})) {
+	  $havemeta = 1;
+	} else {
+	  unlink("$dir/$mn");
 	}
-      } else {
-	$usecache = 1;
       }
-      if ($usecache) {
-	# check hdrmd5 to be sure we got the right bin
-        my $id = Build::queryhdrmd5("$dir/$bv->{'name'}");
-	$usecache = 0 if ($id || '') ne $bv->{'hdrmd5'};
-      }
-      if (!$usecache) {
-	unlink("$dir/$bv->{'name'}");
-      } else {
-	push @cacheold, [$cacheid, $s[7]];
-      }
+      $usecache = 0 unless $havemeta;
+    }
+    if ($usecache) {
+      # check hdrmd5 to be sure we got the right bin
+      my $id = Build::queryhdrmd5("$dir/$bv->{'name'}");
+      $usecache = 0 if ($id || '') ne $bv->{'hdrmd5'};
     }
     if (!$usecache) {
+      unlink("$dir/$bv->{'name'}");
       push @downloadbins, $bin;
       $downloadsizek += $bv->{'sizek'};
     } else {
+      push @cacheold, [$cacheid, $s[7]];
       $ret{$bin} = {'name' => $bv->{'name'}, 'hdrmd5' => $bv->{'hdrmd5'}};
-      if (!$nometa && $havemeta) {
-        $ret{$bin}->{'meta'} = 1;
-      }
+      $ret{$bin}->{'meta'} = 1 if !$nometa && $havemeta;
     }
   }
   $binariescachehits += @cacheold;
@@ -1855,12 +1870,7 @@ sub getpreinstallimage_metas {
       my $cacheid =  Digest::MD5::md5_hex("$prpa/$bv->{'hdrmd5'}");
       my $cachefile = "$cachedir/".substr($cacheid, 0, 2)."/$cacheid";
       if (link_or_copy("$cachefile.meta", "$dir/$bin.meta")) {
-	local *F;
-	open(F, '<', "$dir/$bin.meta") || die;
-	my $ctx = Digest::MD5->new;
-	$ctx->addfile(*F);
-	close F;
-	next if $ctx->hexdigest() eq $bv->{'metamd5'};
+	next if checkmd5("$dir/$bin.meta", $bv->{'metamd5'});
 	unlink("$dir/$bin.meta");
       }
       push @todo, $bin;


### PR DESCRIPTION
Also use 'metamd5' instead of 'hdrmd5' when checking for the meta file.

_Replace this line with a description of your changes. Please follow the suggestions in the comment below._

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
