### PR TITLE
 [backend] speed up repoinfo search, support repository searches

### DIFF
--- a/src/api/test/functional/channel_maintenance_test.rb
+++ b/src/api/test/functional/channel_maintenance_test.rb
@@ -555,11 +555,11 @@ class ChannelMaintenanceTests < ActionDispatch::IntegrationTest
     get "/search/published/repoinfo/id?match=project='" + incident_project + "'"
     assert_response :success
     assert_xml_tag tag: 'collection', attributes: { matches: '3' }
-    assert_xml_tag tag: 'repoinfo', attributes: { repository: 'channel_repo', project: 'BaseDistro3Channel' }
+    assert_xml_tag tag: 'repoinfo', attributes: { repository: 'BaseDistro3Channel', project: incident_project }
     get '/search/published/repoinfo/id?withdownloadurl=1&match=starts-with(project,"My:Maintenance:")'
     assert_response :success
     assert_xml_tag tag: 'collection', attributes: { matches: '3' }
-    assert_xml_tag tag: 'repoinfo', attributes: { repository: 'channel_repo', project: 'BaseDistro3Channel' }
+    assert_xml_tag tag: 'repoinfo', attributes: { repository: 'BaseDistro3Channel', project: incident_project }
 
     # create release request
     post '/request?cmd=create', params: '<request>

--- a/src/backend/BSXPathKeys.pm
+++ b/src/backend/BSXPathKeys.pm
@@ -39,6 +39,7 @@ use strict;
 #   db->{"fetch_$key"}      super-fast select_path_from_key function
 #   db->{'noindex'}->{$path}
 #   db->{'noindexdatall'}
+#   db->{'indexfunc'}
 #
 
 
@@ -218,7 +219,8 @@ sub boolop {
       #die("413 search limit reached\n") if $v1->{'limit'} && @k > $v1->{'limit'};
       $negpol = 0;
     } else {
-      my $noindex = ($db->{'noindex'} && $db->{'noindex'}->{$v1->{'path'}}) || $db->{'noindexatall'};
+      my $noindex = $db->{'noindexatall'} && !($db->{'indexfunc'} && $db->{'indexfunc'}->{$v1->{'path'}}) ? 1 : 0;
+      $noindex = 1 if $db->{'noindex'} && $db->{'noindex'}->{$v1->{'path'}};
       $noindex = 1 if !$v1->{'keys'} && $op == \&boolop_not_helper;
       my @values;
       if (!$noindex) {
@@ -287,7 +289,8 @@ sub boolop {
       #die("413 search limit reached\n") if $v2->{'limit'} && @k > $v2->{'limit'};
       $negpol = 0;
     } else {
-      my $noindex = ($db->{'noindex'} && $db->{'noindex'}->{$v2->{'path'}}) || $db->{'noindexatall'};
+      my $noindex = $db->{'noindexatall'} && !($db->{'indexfunc'} && $db->{'indexfunc'}->{$v2->{'path'}}) ? 1 : 0;
+      $noindex = 1 if $db->{'noindex'} && $db->{'noindex'}->{$v2->{'path'}};
       my @values;
       if (!$noindex) {
         for my $vv ($db->values($v2->{'path'}, $v2->{'keys'}, $hint, $v1)) {

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -5219,15 +5219,49 @@ sub search_published_binary_name {
   return search_published_binary_id($cgi, $match, 1);
 }
 
+sub published_repoinfo_keys2prps {
+  my (@k) = @_;
+  return @k unless $BSConfig::published_db_sqlite;
+  for (@k) {
+    my @p = split('/', $_); 
+    splice(@p, 0, 2, "$p[0]$p[1]") while @p > 1 && $p[0] =~ /:$/;
+    my $projid = shift @p;
+    splice(@p, 0, 2, "$p[0]$p[1]") while @p > 1 && $p[0] =~ /:$/;
+    my $repoid = shift @p;
+    $_ = "$projid/$repoid";
+  }    
+  return @k;
+}
+
 sub published_repoinfo_projectindexfunc {
-  my ($db, $path, $value) = @_;
-  $db->{'_allkeys'} ||= [ $db->keys() ];
+  my ($db, $path, $value, $lkeys, $hint, $hintval) = @_;
+  if ($BSConfig::published_db_sqlite) {
+    return $db->rawkeys($path, $value) if defined $value;
+    return $db->rawvalues($path, $hint, $hintval);
+  }
+  $db->{'_allkeys'} ||= [ $db->rawkeys() ] unless $lkeys;
   if (!defined($value)) {
     my %projids;
-    $projids{(split('/', $_, 2))[0]} = 1 for @{$db->{'_allkeys'}};
+    $projids{(split('/', $_, 2))[0]} = 1 for @{$lkeys || $db->{'_allkeys'}};
     return sort keys %projids;
   }
-  return grep {/^\Q$value\E\//} @{$db->{'_allkeys'}};
+  return grep {/^\Q$value\E\//} @{$lkeys || $db->{'_allkeys'}};
+}
+
+sub published_repoinfo_repositoryindexfunc {
+  my ($db, $path, $value, $lkeys, $hint, $hintval) = @_;
+  $db->{'_allkeys'} ||= [ $db->rawkeys() ] unless $lkeys;
+  my @k = published_repoinfo_keys2prps(@{$lkeys || $db->{'_allkeys'}});
+  if (!defined($value)) {
+    my %repoids;
+    $repoids{(split('/', $_, 2))[1]} = 1 for @k;
+    return sort keys %repoids;
+  }
+  @k = grep {/\/\Q$value\E$/} @k;
+  if ($BSConfig::published_db_sqlite) {
+    s/:/:\//g for @k;
+  }
+  return @k;
 }
 
 sub search_published_repoinfo_id {
@@ -5235,29 +5269,29 @@ sub search_published_repoinfo_id {
   my $repoinfodb;
   if ($BSConfig::published_db_sqlite) {
     $repoinfodb = BSSrcServer::SQLite::opendb($extrepodb, 'repoinfo');
-    $repoinfodb->{'allkeyspath'} = sub {die("413 refusing to get all keys\n")};
   } else {
     $repoinfodb = BSDB::opendb($extrepodb, 'repoinfo');
-    $repoinfodb->{'indexfunc'} = {'project' => \&published_repoinfo_projectindexfunc };
   }
+  $repoinfodb->{'allkeyspath'} = sub {die("413 refusing to get all keys\n")};
+  $repoinfodb->{'indexfunc'} = {'project' => \&published_repoinfo_projectindexfunc, 'repository' => \&published_repoinfo_repositoryindexfunc };
+  $repoinfodb->{'noindexatall'} = 1;
   my $limit = defined($cgi->{'limit'}) ? $cgi->{'limit'} : 1000;
   my $rootnode = BSXPathKeys::node($repoinfodb, '', $limit && $limit < 10 ? 1000 : $limit * 100);
-  my $matches = BSXPath::match($rootnode, $match) || [];
-  my $res = {};
-  my @data;
-  for my $d (@$matches) {
+  my $matches = $rootnode->keymatch($match) || [];
+  @$matches = published_repoinfo_keys2prps(@$matches);
+  for (@$matches) {
+    my ($projid, $repoid) = split('/', $_, 2);
+    $_ = { 'project' => $projid, 'repository' => $repoid };
     if ($cgi->{'withdownloadurl'}) {
-      my $du = BSUrlmapper::get_downloadurl("$d->{'base'}->{'project'}/$d->{'base'}->{'repository'}");
-      $d->{'base'}->{'downloadurl'} = $du if $du;
+      my $du = BSUrlmapper::get_downloadurl("$projid/$repoid");
+      $_->{'downloadurl'} = $du if $du;
     }
-    push @data, $d->{'base'};
   }
-  $res->{'matches'} = @data;
-  if ($limit && @data > $limit) {
+  my $res = { 'matches' => scalar(@$matches), 'repoinfo' => $matches };
+  if ($limit && @$matches > $limit) {
     $res->{'limited'} = 'true';
-    splice(@data, $limit);
+    splice(@$matches, $limit);
   }
-  $res->{'repoinfo'} = \@data;
   return ($res, $BSXML::collection);
 }
 


### PR DESCRIPTION
_Replace this line with a description of your changes. Please follow the suggestions in the comment below._

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
