### PR TITLE
removed-gendered-terms

### DIFF
--- a/docs/api/api/api.txt
+++ b/docs/api/api/api.txt
@@ -151,7 +151,7 @@ XmlResult: status
 
 Parameters:
   cmd: change_password
-  cmd: lock             # will lock the user and his home projects
+  cmd: lock             # will lock the user and their home projects
   cmd: delete           # will mark the user as deleted and remove her home projects
 
 GET /person/<userid>/token
@@ -1683,7 +1683,7 @@ GET /search/owner
 Parameters:
 
   binary: specify the binary package to search for
-  user: specify a user login name to list his packages
+  user: specify a user login name to list their packages
   group: specify a group title name to list their packages
 
   devel: true/false: include devel package definitions?

--- a/docs/ichain.txt
+++ b/docs/ichain.txt
@@ -60,7 +60,7 @@ authenticated but is not yet, the webapp redirects to a special page.
 The iChain system is configured in the way that accessing this special
 page requires authentication and thus iChain displays the Novell
 standard login page. The user provides the credentials and after the
-login was successfull, the user is redirected to his initial requested
+login was successfull, the user is redirected to their initial requested
 page.
 
 

--- a/src/api/app/helpers/webui/user_helper.rb
+++ b/src/api/app/helpers/webui/user_helper.rb
@@ -58,7 +58,7 @@ module Webui::UserHelper
   end
 
   def requester_str(creator, requester_user, requester_group)
-    # we don't need to show the requester if he is the same as the creator
+    # we don't need to show the requester if they are the same as the creator
     return if creator == requester_user
 
     if requester_user

--- a/src/api/app/lib/suse/permission.rb
+++ b/src/api/app/lib/suse/permission.rb
@@ -17,8 +17,8 @@ module Suse
     end
 
     def project_change?(project = nil)
-      # one is project admin if he has the permission Project_Admin or if he
-      # is the owner of the project
+      # one is project admin if they have the permission Project_Admin or if they
+      # are the owner of the project
       logger.debug "User #{@user.login} wants to change the project"
 
       case project

--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -751,7 +751,7 @@ class BsRequestAction < ApplicationRecord
     if sp.nil?
       # either not there or read permission problem
       if Package.exists_on_backend?(source_package, source_project)
-        # user is not allowed to read the source, but when he can write
+        # user is not allowed to read the source, but when they can write
         # the target, the request creator (who must have permissions to read source)
         # wanted the target owner to review it
         tprj = Project.find_by_name(target_project)

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -172,7 +172,7 @@ class User < ApplicationRecord
   end
 
   # This static method tries to find a user with the given login and password
-  # in the database. Returns the user or nil if he could not be found
+  # in the database. Returns the user or nil if they could not be found
   def self.find_with_credentials(login, password)
     return find_with_credentials_via_ldap(login, password) if CONFIG['ldap_mode'] == :on
 

--- a/src/api/spec/controllers/webui/users/notifications_controller_spec.rb
+++ b/src/api/spec/controllers/webui/users/notifications_controller_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe Webui::Users::NotificationsController do
       let(:action) { :index }
     end
 
-    context 'when a user marks one of his unread notifications as read' do
+    context 'when a user marks one of their unread notifications as read' do
       subject! do
         login user_to_log_in
         put :update, params: { notification_ids: [state_change_notification.id], user_login: user_to_log_in.login }, xhr: true
@@ -213,7 +213,7 @@ RSpec.describe Webui::Users::NotificationsController do
       end
     end
 
-    context 'when a user marks one of his read notifications as unread' do
+    context 'when a user marks one of their read notifications as unread' do
       subject! do
         login user_to_log_in
         put :update, params: { notification_ids: [read_notification.id], type: 'read', user_login: user_to_log_in.login }, xhr: true

--- a/src/api/spec/helpers/webui/user_helper_spec.rb
+++ b/src/api/spec/helpers/webui/user_helper_spec.rb
@@ -11,11 +11,11 @@ RSpec.describe Webui::UserHelper do
   describe '#requester_str' do
     let(:requester) { create(:user, login: 'Ana') }
 
-    it 'do not show the requester if he is the same as the creator' do
+    it 'do not show the requester if they are the same as the creator' do
       expect(requester_str(creator.login, creator.login, nil)).to be(nil)
     end
 
-    it 'show the requester if he is different as the creator' do
+    it 'show the requester if they are different from the creator' do
       expect(requester_str(creator.login, requester.login, nil)).to include('user', requester.login)
     end
 

--- a/src/api/spec/helpers/webui/webui_helper_spec.rb
+++ b/src/api/spec/helpers/webui/webui_helper_spec.rb
@@ -137,11 +137,11 @@ RSpec.describe Webui::WebuiHelper do
   end
 
   describe '#creator_intentions' do
-    it 'do not show the requester if he is the same as the creator' do
+    it 'do not show the requester if they are the same as the creator' do
       expect(creator_intentions(nil)).to eq('become bugowner (previous bugowners will be deleted)')
     end
 
-    it 'show the requester if he is different as the creator' do
+    it 'show the requester if they are different from the creator' do
       expect(creator_intentions('bugowner')).to eq('get the role bugowner')
     end
   end

--- a/src/api/spec/models/package_spec.rb
+++ b/src/api/spec/models/package_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Package, vcr: true do
   describe '#maintainers' do
     it 'returns an array with user objects to all maintainers for a package' do
       # first of all, we add a user who is not a maintainer but a bugowner
-      # he/she should not be recognized by package.maintainers
+      # they should not be recognized by package.maintainers
       create(:relationship_package_user_as_bugowner, user: other_user2, package: package)
 
       # we expect both users to be in that returning array

--- a/src/api/spec/policies/comment_policy_spec.rb
+++ b/src/api/spec/policies/comment_policy_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe CommentPolicy do
       expect(subject).not_to permit(admin_user, comment)
     end
 
-    it 'a user can update his own comments' do
+    it 'a user can update their own comments' do
       expect(subject).to permit(comment_author, comment)
     end
 

--- a/src/api/test/fixtures/bs_requests.yml
+++ b/src/api/test/fixtures/bs_requests.yml
@@ -1,7 +1,7 @@
 bs_requests_1000:
   id: 9991000
   number: 1000
-  description: want to see his reaction
+  description: want to see their reaction
   creator: tom
   state: review
   commenter: tom

--- a/src/api/test/functional/comments_controller_test.rb
+++ b/src/api/test/functional/comments_controller_test.rb
@@ -101,7 +101,7 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     get comments_request_path(request_number: 2)
     assert_xml_tag tag: 'comment', attributes: { who: 'adrian' }, content: 'Hallo'
 
-    # just check if adrian gets the mail too - he's a commenter now
+    # just check if adrian gets the mail too - they're a commenter now
     login_dmayr
     SendEventEmailsJob.new.perform
     assert_difference('ActionMailer::Base.deliveries.size', +1) do

--- a/src/api/test/functional/maintenance_test.rb
+++ b/src/api/test/functional/maintenance_test.rb
@@ -1238,7 +1238,7 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     assert_response :success
     assert_xml_tag parent: { tag: 'update', attributes: { from: 'maintenance_coord', status: 'stable', type: 'security', version: '1' } }, tag: 'id', content: nil
 
-    # let's say the maintenance guy wants to publish it now
+    # let's say the maintenance person wants to publish it now
     get "/source/#{incident_project}/_meta"
     assert_response :success
     maintenance_project_meta = REXML::Document.new(@response.body)

--- a/src/api/test/functional/person_controller_test.rb
+++ b/src/api/test/functional/person_controller_test.rb
@@ -75,7 +75,7 @@ class PersonControllerTest < ActionDispatch::IntegrationTest
     prepare_request_valid_user
 
     get '/person/tom'
-    # should see his watchlist
+    # should see their watchlist
     assert_xml_tag tag: 'person', child: { tag: 'watchlist' }
 
     get '/person/fred'
@@ -280,7 +280,7 @@ class PersonControllerTest < ActionDispatch::IntegrationTest
     user_xml = "<person>
   <login>lost_guy</login>
   <email>lonely_person@universe.com</email>
-  <realname>The Other Guy</realname>
+  <realname>The Other Person</realname>
   <owner userid='adrian'/>
 </person>"
 

--- a/src/api/test/functional/request_controller_test.rb
+++ b/src/api/test/functional/request_controller_test.rb
@@ -84,7 +84,7 @@ class RequestControllerTest < ActionDispatch::IntegrationTest
         assert_select 'review', state: 'new', by_package: 'apache2', by_project: 'Apache'
         assert_select 'review', state: 'new', by_user: 'adrian'
         assert_select 'review', state: 'new', by_group: 'test_group'
-        assert_select 'description', 'want to see his reaction'
+        assert_select 'description', 'want to see their reaction'
       end
     end
 
@@ -114,7 +114,7 @@ class RequestControllerTest < ActionDispatch::IntegrationTest
         assert_select 'review', state: 'new', by_user: 'adrian'
         assert_select 'review', state: 'new', by_user: 'tom'
         assert_select 'review', state: 'new', by_group: 'test_group'
-        assert_select 'description', 'want to see his reaction'
+        assert_select 'description', 'want to see their reaction'
       end
       # Should find requests of groups adrian belongs to
       assert_select 'request', id: 4 do
@@ -3565,7 +3565,7 @@ class RequestControllerTest < ActionDispatch::IntegrationTest
     assert_response 400
     assert_xml_tag tag: 'summary', content: 'Package is used by following packages as devel package: BaseDistro:Update/pack2'
 
-    # but he should be able to add reviewers
+    # but they should be able to add reviewers
     post "/request/#{id}?cmd=addreview&by_user=tom"
     assert_response :success
 

--- a/src/api/test/functional/search_controller_test.rb
+++ b/src/api/test/functional/search_controller_test.rb
@@ -407,7 +407,7 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
         assert_select 'review', state: 'new', by_user: 'adrian'
         assert_select 'review', state: 'new', by_user: 'tom'
         assert_select 'review', state: 'new', by_group: 'test_group'
-        assert_select 'description', 'want to see his reaction'
+        assert_select 'description', 'want to see their reaction'
       end
       # XPath search is not expected to find requests of groups adrian belongs to
       assert_select "request[id='4']", false
@@ -664,7 +664,7 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     assert_no_xml_tag tag: 'owner', attributes: { project: 'TEMPORARY', package: 'pack' }
     assert_no_xml_tag tag: 'owner', attributes: { project: 'home:coolo:test' }
     assert_no_xml_tag tag: 'group', attributes: { name: 'test_group', role: 'bugowner' }
-    # disable a user and check that he disappears
+    # disable a user and check that they disappears
     u = User.find_by_login('Iggy')
     u.state = 'unconfirmed'
     u.save!

--- a/src/api/test/functional/source_controller_test.rb
+++ b/src/api/test/functional/source_controller_test.rb
@@ -2652,12 +2652,12 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     assert_response 403
     assert_xml_tag tag: 'status', attributes: { code: 'cmd_execution_no_permission' }
 
-    # but he can use the token
+    # but they can use the token
     reset_auth
     post '/trigger/release', headers: { 'Authorization' => "Token #{token}" }
     assert_response :success
 
-    # and he can release it to own space
+    # and they can release it to own space
     login_Iggy
     post '/source/home:Iggy/TestPack?cmd=release&target_project=home:Iggy'
     assert_response 400


### PR DESCRIPTION
Replacing gendered terms 'he', 'his', 'guy' and 'he/she' with 'they', 'their' and 'person'. 

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
