### PR TITLE
Show obs-down.png image when Apache is in MAINTENANCE mode

### DIFF
--- a/dist/obs-apache2.conf
+++ b/dist/obs-apache2.conf
@@ -54,6 +54,7 @@ LimitRequestFieldsize 20000
           ErrorDocument 503 /503.html
           RewriteEngine on
           RewriteCond %{REQUEST_URI} !=/503.html
+          RewriteCond %{REQUEST_URI} !=/obs-down.png
           RewriteRule ^ - [R=503,L]
         </IfDefine>
 

--- a/dist/obs-apache24.conf
+++ b/dist/obs-apache24.conf
@@ -54,6 +54,7 @@ LimitRequestFieldsize 20000
           ErrorDocument 503 /503.html
           RewriteEngine on
           RewriteCond %{REQUEST_URI} !=/503.html
+          RewriteCond %{REQUEST_URI} !=/obs-down.png
           RewriteRule ^ - [R=503,L]
         </IfDefine>
 


### PR DESCRIPTION
When Apache enters MAINTENANCE mode, the `/503.html` page is rendered. This page contains an image, that until now could not be rendered because of the Apache configuration. This pull request fixes this behaviour.

Apache MAINTENANCE mode is described in detail in our development wiki, as a step of deployments with migrations: https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org

To verify the fix:
- Download an OBS appliance.
- Inside the appliance:
  - Set apache in maintenance mode: edit the `/etc/sysconfig/apache2` file and modify the line with the apache server flags to have: `APACHE_SERVER_FLAGS="SSL MAINTENANCE"`
  - Modify the `/etc/apache2/vhosts.d/obs.conf` adding the line `RewriteCond %{REQUEST_URI} !=/obs-down.png`.
  - Restart apache: `systemctl restart apache2`.
- Open the OBS appliance URL in your browser and check.

*Before:*

![Screenshot from 2021-03-04 14-21-28](https://user-images.githubusercontent.com/24919/109970101-f806ed00-7cf4-11eb-9936-9fd712c2629e.png)

*After:*

![Screenshot from 2021-03-04 14-20-50](https://user-images.githubusercontent.com/24919/109970137-005f2800-7cf5-11eb-95f6-5bfc55b0e510.png)

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature
