### PR TITLE
Replace `require_login` with Pundit in Webui::Staging::WorkflowsController

### DIFF
--- a/src/api/app/controllers/webui/staging/workflows_controller.rb
+++ b/src/api/app/controllers/webui/staging/workflows_controller.rb
@@ -1,19 +1,21 @@
 class Webui::Staging::WorkflowsController < Webui::WebuiController
   VALID_STATES_WITH_REQUESTS = [:acceptable, :accepting, :review, :testing, :building, :failed, :unacceptable].freeze
 
-  before_action :require_login, except: [:show]
+  # TODO: Remove this when we'll refactor kerberos_auth
+  before_action :kerberos_auth, except: [:show]
   before_action :set_project, only: [:new, :create]
   before_action :set_workflow_project, except: [:new, :create]
   before_action :set_staging_workflow, except: [:new, :create]
-  after_action :verify_authorized, except: [:show, :new]
+  after_action :verify_authorized, except: [:show]
 
   def new
     if @project.staging
+      authorize @project.staging
       redirect_to staging_workflow_path(@project)
       return
     end
 
-    @staging_workflow = @project.build_staging
+    @staging_workflow = authorize @project.build_staging
   end
 
   def create

--- a/src/api/app/policies/staging/workflow_policy.rb
+++ b/src/api/app/policies/staging/workflow_policy.rb
@@ -1,6 +1,10 @@
 class Staging::WorkflowPolicy < ApplicationPolicy
-  def initialize(user, record)
-    super(user, record, user_optional: true)
+  def initialize(user, record, opts = {})
+    super(user, record, opts.reverse_merge(ensure_logged_in: true))
+  end
+
+  def new?
+    create?
   end
 
   def create?

--- a/src/api/app/views/webui/project/_tabs.html.haml
+++ b/src/api/app/views/webui/project/_tabs.html.haml
@@ -24,7 +24,7 @@
         = tab_link('Staging', staging_workflow_path(project.staging_workflow.project), false, 'scrollable-tab-link')
       - elsif project.staging&.persisted?
         = tab_link('Staging', staging_workflow_path(project), active, 'scrollable-tab-link')
-      - elsif policy(Staging::Workflow.new(project: project)).create?
+      - elsif Staging::WorkflowPolicy.new(pundit_user, Staging::Workflow.new(project: project), ensure_logged_in: false).create?
         = tab_link('Staging', new_staging_workflow_path(project: project), active, 'scrollable-tab-link')
 - else
   .bg-light
@@ -70,7 +70,7 @@
             It will be persisted if the project is really a staging workflow project.
           %li.nav-item
             = tab_link('Staging', staging_workflow_path(project), active)
-        - elsif policy(Staging::Workflow.new(project: project)).create?
+        - elsif Staging::WorkflowPolicy.new(pundit_user, Staging::Workflow.new(project: project), ensure_logged_in: false).create?
           %li.nav-item
             = tab_link('Staging', new_staging_workflow_path(project: project), active)
       %li.nav-item.dropdown

--- a/src/api/spec/controllers/webui/staging/workflows_controller_spec.rb
+++ b/src/api/spec/controllers/webui/staging/workflows_controller_spec.rb
@@ -7,13 +7,18 @@ RSpec.describe Webui::Staging::WorkflowsController do
   let(:project) { user.home_project }
   let(:staging_workflow) { create(:staging_workflow, project: project, managers_group: managers_group) }
 
-  before do
-    login(user)
-  end
-
   describe 'GET #new' do
+    it_behaves_like 'require logged in user' do
+      let(:method) { :get }
+      let(:action) { :new }
+      let(:opts) do
+        { params: { project: project.name } }
+      end
+    end
+
     context 'non existent staging_workflow for project' do
       before do
+        login(user)
         get :new, params: { project: project.name }
       end
 
@@ -24,6 +29,7 @@ RSpec.describe Webui::Staging::WorkflowsController do
 
     context 'with an existent staging_workflow for project' do
       before do
+        login(user)
         staging_workflow
         get :new, params: { project: project.name }
       end
@@ -34,8 +40,17 @@ RSpec.describe Webui::Staging::WorkflowsController do
   end
 
   describe 'POST #create' do
+    it_behaves_like 'require logged in user' do
+      let(:method) { :post }
+      let(:action) { :create }
+      let(:opts) do
+        { params: { project: project.name } }
+      end
+    end
+
     context 'a staging_workflow and staging_projects' do
       before do
+        login(user)
         post :create, params: { project: project.name, managers_title: managers_group.title }
       end
 
@@ -53,6 +68,7 @@ RSpec.describe Webui::Staging::WorkflowsController do
       let!(:staging_b) { create(:project, name: "#{project}:Staging:B") }
 
       before do
+        login(user)
         post :create, params: { project: project.name, managers_title: managers_group.title }
       end
 
@@ -69,6 +85,7 @@ RSpec.describe Webui::Staging::WorkflowsController do
       let(:params) { { project_name: project.name, managers_title: 'ItDoesNotExist' } }
 
       before do
+        login(user)
         post :create, params: params
       end
 
@@ -78,6 +95,7 @@ RSpec.describe Webui::Staging::WorkflowsController do
 
     context 'when it fails to save the staging workflow' do
       before do
+        login(user)
         allow_any_instance_of(Staging::Workflow).to receive(:save).and_return(false)
         post :create, params: { project: project.name, managers_title: managers_group.title }
       end
@@ -102,9 +120,19 @@ RSpec.describe Webui::Staging::WorkflowsController do
   end
 
   describe 'GET #edit' do
+    before { staging_workflow }
+
+    it_behaves_like 'require logged in user' do
+      let(:method) { :get }
+      let(:action) { :edit }
+      let(:opts) do
+        { params: { workflow_project: project } }
+      end
+    end
+
     context 'with an existent staging_workflow for project' do
       before do
-        staging_workflow
+        login(user)
         get :edit, params: { workflow_project: project }
       end
 
@@ -117,8 +145,17 @@ RSpec.describe Webui::Staging::WorkflowsController do
   describe 'DELETE #destroy' do
     let!(:staging_workflow) { create(:staging_workflow, project: project) }
 
+    it_behaves_like 'require logged in user' do
+      let(:method) { :delete }
+      let(:action) { :destroy }
+      let(:opts) do
+        { params: { workflow_project: project, staging_project_ids: project.staging.staging_projects.ids, format: :js } }
+      end
+    end
+
     context 'a staging workflow and staging projects' do
       before do
+        login(user)
         params = { workflow_project: project, staging_project_ids: project.staging.staging_projects.ids, format: :js }
         delete :destroy, params: params
       end
@@ -134,6 +171,7 @@ RSpec.describe Webui::Staging::WorkflowsController do
 
     context 'a staging workflow and one staging project' do
       before do
+        login(user)
         params = { workflow_project: project, staging_project_ids: project.staging.staging_projects.ids.first, format: :js }
         delete :destroy, params: params
       end
@@ -149,6 +187,7 @@ RSpec.describe Webui::Staging::WorkflowsController do
 
     context 'a staging workflow unsuccessful' do
       before do
+        login(user)
         allow_any_instance_of(Staging::Workflow).to receive(:destroy).and_return(false)
         params = { workflow_project: project, staging_project_ids: project.staging.staging_projects.ids, format: :js }
         delete :destroy, params: params
@@ -160,12 +199,21 @@ RSpec.describe Webui::Staging::WorkflowsController do
   end
 
   describe 'PUT #update' do
+    subject { staging_workflow.reload }
+
+    it_behaves_like 'require logged in user' do
+      let(:method) { :put }
+      let(:action) { :update }
+      let(:opts) do
+        { params: { workflow_project: staging_workflow.project, managers_title: other_managers_group.title } }
+      end
+    end
+
     context 'without any problem' do
       before do
+        login(user)
         put :update, params: { workflow_project: staging_workflow.project, managers_title: other_managers_group.title }
       end
-
-      subject { staging_workflow.reload }
 
       it { expect(subject.managers_group).to eq(other_managers_group) }
 
@@ -181,12 +229,10 @@ RSpec.describe Webui::Staging::WorkflowsController do
 
     context 'with a failing save for staging workflow' do
       before do
-        staging_workflow
+        login(user)
         allow_any_instance_of(Staging::Workflow).to receive(:save).and_return(false)
         put :update, params: { workflow_project: staging_workflow.project, managers_title: other_managers_group.title }
       end
-
-      subject { staging_workflow.reload }
 
       it { expect(subject.managers_group).to eq(managers_group) }
 

--- a/src/api/spec/policies/staging/workflow_policy_spec.rb
+++ b/src/api/spec/policies/staging/workflow_policy_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe Staging::WorkflowPolicy do
+  let(:admin) { create(:admin_user) }
+  let(:user_nobody) { build(:user_nobody) }
+  let(:unauthorized_user) { build(:confirmed_user, login: 'Jerry') }
+  let(:staging_workflow) { build(:staging_workflow_with_staging_projects) }
+
+  subject { Staging::WorkflowPolicy }
+
+  permissions :new? do
+    it { is_expected.not_to permit(unauthorized_user, staging_workflow) }
+    it { is_expected.to permit(admin, staging_workflow) }
+  end
+
+  it "doesn't permit anonymous user by default" do
+    expect { described_class.new(user_nobody, staging_workflow) }
+      .to raise_error(an_instance_of(Pundit::NotAuthorizedError).and(having_attributes(reason: ApplicationPolicy::ANONYMOUS_USER)))
+  end
+
+  it 'permits anonymous user when ensure_logged_in == false' do
+    expect { described_class.new(user_nobody, staging_workflow, ensure_logged_in: false) }.not_to raise_error
+  end
+end


### PR DESCRIPTION
This is a PR of a series which replaces require_login with Pundit.
You can find further relevant info in #10083.

Tackles `Webui::Staging::WorkflowsController`

Ref #10083

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
