### PR TITLE
Improve request history section

### DIFF
--- a/src/api/app/assets/stylesheets/webui/collapsible-text.scss
+++ b/src/api/app/assets/stylesheets/webui/collapsible-text.scss
@@ -36,6 +36,6 @@
   @include collapsible($maxHeight: 15em);
 }
 
-#request-history {
+#request-history .card-body {
   @include collapsible($maxHeight: 4.5em);
 }

--- a/src/api/app/assets/stylesheets/webui/requests.scss
+++ b/src/api/app/assets/stylesheets/webui/requests.scss
@@ -32,7 +32,7 @@
   @extend .text-danger;
 }
 
-#request-history {
+#request-history .card-body {
   .media .media-body {
     @extend .text-break;
   }

--- a/src/api/app/views/webui/request/_show_side_links.html.haml
+++ b/src/api/app/views/webui/request/_show_side_links.html.haml
@@ -7,7 +7,7 @@
   %li
     %i.fas.fa-info-circle.text-info
     In state
-    = link_to(bs_request.state, { anchor: 'request_history' }, style: "color: #{request_state_color(bs_request.state.to_s)};")
+    = link_to(bs_request.state, { anchor: 'request-history' }, style: "color: #{request_state_color(bs_request.state.to_s)};")
   - unless package_maintainers.empty?
     %li
       %i.fas.fa-info-circle.text-info

--- a/src/api/app/views/webui/request/_update.js.erb
+++ b/src/api/app/views/webui/request/_update.js.erb
@@ -1,4 +1,4 @@
-$('#request-history').html("<%= escape_javascript(render partial: 'request_history', locals: { bs_request: bs_request, history: history }) %>");
+$('#request-history .card-body').html("<%= escape_javascript(render partial: 'request_history', locals: { bs_request: bs_request, history: history }) %>");
 $('#overview').html("<%= escape_javascript(render partial: 'show_overview', locals: { bs_request: bs_request, can_add_reviews: can_add_reviews }) %>");
 $('#side-links').html("<%= escape_javascript(render partial: 'show_side_links', locals: { bs_request: bs_request, package_maintainers: package_maintainers }) %>");
 $('#flash').html("<%= escape_javascript(render partial: 'layouts/webui/flash') %>");

--- a/src/api/app/views/webui/request/show.html.haml
+++ b/src/api/app/views/webui/request/show.html.haml
@@ -58,11 +58,11 @@
                                                         actions: @actions }
 
   .col-md-4
-    .card
+    .card#request-history
       .card-header.d-flex.justify-content-between
         %h5
           Request History
-      .card-body#request-history
+      .card-body
         = render partial: 'request_history', locals: { bs_request: @bs_request, history: @history }
 
 - if User.session


### PR DESCRIPTION
See commits for details. Fixes #10840

Before (the first request history element is partially hidden):
![before](https://user-images.githubusercontent.com/1102934/110461026-3e7e9200-80cf-11eb-8560-52ddfa9ab3e8.gif)

Now (the first request history element is fully visible):
![now](https://user-images.githubusercontent.com/1102934/110461030-3fafbf00-80cf-11eb-9305-6b173d687ca5.gif)