### PR TITLE
Improve how build status details are displayed

### DIFF
--- a/src/api/app/views/webui/package/responsive_ux/_buildstatus.html.haml
+++ b/src/api/app/views/webui/package/responsive_ux/_buildstatus.html.haml
@@ -53,8 +53,8 @@
                     %i.fas.fa-clock.text-warning
                     This result is outdated
                 - if result.details
-                  %div
-                    %strong #{result.code}:
+                  .pt-1.mt-3
+                    %strong{ class: "build-state-#{result.code}" } #{result.code}:
                     %span= result.details
 
         - previous_repo = result.repository


### PR DESCRIPTION
Add a bit of spacing to separate different information and use colors to highlight important information about the build state.

Fixes #10837

Before:
![before](https://user-images.githubusercontent.com/1102934/110474487-029ff880-80e0-11eb-8f77-6c14c4f12f97.png)

Now:
![after](https://user-images.githubusercontent.com/1102934/110474483-02076200-80e0-11eb-8cf2-119624fd0d5c.png)