### PR TITLE
Improve repository status descriptions

### DIFF
--- a/src/api/app/helpers/webui/webui_helper.rb
+++ b/src/api/app/helpers/webui/webui_helper.rb
@@ -72,9 +72,9 @@ module Webui::WebuiHelper
     'published' => 'Repository has been published',
     'publishing' => 'Repository is being created right now',
     'unpublished' => 'Build finished, but repository publishing is disabled',
-    'building' => 'Build jobs exist',
+    'building' => 'Build jobs exist for the repository',
     'finished' => 'Build jobs have been processed, new repository is not yet created',
-    'blocked' => 'No build possible atm, waiting for jobs in other repositories',
+    'blocked' => 'No build possible at the moment, waiting for jobs in other repositories',
     'broken' => 'The repository setup is broken, build or publish not possible',
     'scheduling' => 'The repository state is being calculated right now'
   }.freeze


### PR DESCRIPTION
Even before @lnussel mentioned this in a comment in #10842, it was clear that some of the repository status descriptions are quite cryptic. This is hopefully a bit better now.

Example with the description (as for how this is all displayed in the build status details, see #10842):
![example](https://user-images.githubusercontent.com/1102934/110487373-cf646600-80ed-11eb-907e-7b02de8aa7de.png)