### PR TITLE
[backend] Add another ampere variant for aarch32 support

### DIFF
--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -805,6 +805,9 @@ if (open(FILE, "<", "/proc/cpuinfo")) {
       } elsif ($cpu_variant eq "0x1") {
         # APM X-Gene 2 supports aarch32
         $supports_aarch32 = 1;
+      } elsif ($cpu_variant eq "0x3") {
+        # Ampere eMAG supports aarch32
+        $supports_aarch32 = 1;
       }
     } elsif ($cpu_implementer eq "0x41") {
       # ARM Inc. - all variants support aarch32 compat for now


### PR DESCRIPTION
Based on feedback from the linked mailing list post.

