### PR TITLE
Make involved packages/projects search case-insensitive

### DIFF
--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -986,7 +986,7 @@ class User < ApplicationRecord
     related_items = project_or_package_class.related_to_user(id).where(relationships: { role_id: roles_to_filter }).or(
       project_or_package_class.related_to_group(group_ids).where(relationships: { role_id: roles_to_filter })
     )
-    related_items = related_items.where('name LIKE ?', "%#{filters[:search_text]}%") if filters[:search_text].present?
+    related_items = related_items.where('LOWER(name) LIKE ?', "%#{filters[:search_text].downcase}%") if filters[:search_text].present?
     related_items
   end
 end


### PR DESCRIPTION
A case-sensitivity in the search create overhead since the
user needs to remember the exact case/capitalization of
packages/projects in order to find them.

Fixes #10833

**NOTE**: I considered directly using `Arel` to do the query since this way it is possible to get the default behavior of the `LIKE` query which is case-insensitve. Although the collation of our database is set to `utf8mb4_unicode_ci` (so case-insensitve) the `:name` column of project/package is `utf8_bin` (so case-sensitive) on the DB level. I would not change it for now, since this might introduce side-effects in other parts of OBS. I don't expect any performance issues with the provided solution, so I would avoid to use the sledgehammer to crack a nut;