### PR TITLE
[backend] support moduleinfo data returned by the modules.yaml parser

### DIFF
--- a/src/backend/BSSched/DoD.pm
+++ b/src/backend/BSSched/DoD.pm
@@ -47,12 +47,25 @@ sub readparsed {
   return 'could not retrieve pre-parsed metadata' unless $data;
   my $baseurl = delete $data->{'/url'};
   return 'baseurl missing in data' unless $baseurl;
+  my $moduleinfo = delete $data->{'/moduleinfo'};
   for (values %$data) {
     $_->{'id'} = 'dod';
     $_->{'hdrmd5'} = 'd0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0';
   }
   $data->{'/url'} = $baseurl;
   $data->{'/dodcookie'} = $cookie;
+  # add pseudo buildservice:modules packages for every module info entry
+  for my $mi (@{$moduleinfo || []}) {
+    my $m = { 'name' => 'buildservice:modules',
+              'version' => "$mi->{'name'}\@$mi->{'context'}",
+              'arch' => 'src',		# so that it is ignored in create_considered
+              'provides' => [ "$mi->{'name'}" ],
+            };
+    $m->{'requires'} = $mi->{'requires'} if @{$mi->{'requires'} || []};
+    $m->{'id'} = 'dod';
+    $m->{'hdrmd5'} = 'd0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0';
+    $data->{"buildservice:modules:$m"} = $m;	# use perl object id as differentiator
+  }
   return $data;
 }
 

--- a/src/backend/bs_dodup
+++ b/src/backend/bs_dodup
@@ -425,6 +425,7 @@ sub parsemetadata {
   Build::Repo::parse($doddata->{'repotype'}, $file, sub { addpkg($cache, $_[0], $archfilter, $moduleinfo) }, 'addselfprovides' => 1, 'normalizedeps' => 1, 'withchecksum' => 1, 'testcaseformat' => 1);
   $baseurl =~ s/\/$//;
   $cache->{'/url'} = $baseurl;
+  $cache->{'/moduleinfo'} = $moduleinfo->{"/moduleinfo"} if $moduleinfo->{"/moduleinfo"};
   BSUtil::store("$file.parsed", $file, $cache);
 }
 


### PR DESCRIPTION
This data will be used by perl-BSSolv.

_Replace this line with a description of your changes. Please follow the suggestions in the comment below._

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
