### PR TITLE
Migrate projects to only responsive, 3rd round

### DIFF
--- a/src/api/app/views/webui/project/_basic_info.html.haml
+++ b/src/api/app/views/webui/project/_basic_info.html.haml
@@ -1,4 +1,4 @@
-.basic-info.mb-3{ class: feature_enabled?(:responsive_ux) ? 'in-place-editing' : '' }
+.basic-info.in-place-editing.mb-3
   %h3#project-title
     = project.title.presence || project
   - if project.categories.any?

--- a/src/api/app/views/webui/project/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui/project/_breadcrumb_items.html.haml
@@ -1,39 +1,34 @@
 - if current_page?(projects_path) || current_page?(project_list_path) || current_page?(project_list_public_path)
   %li.breadcrumb-item.active{ 'aria-current' => 'page' }
     Projects
+- elsif current_page?(project_list_all_path)
+  %li.breadcrumb-item.active{ 'aria-current' => 'page' }
+    List of All Projects
+- elsif current_page?(new_project_path)
+  %li.breadcrumb-item.active{ 'aria-current' => 'page' }
+    = @namespace.nil? ? 'Create Project' : 'Create Subproject'
 - else
-  - unless feature_enabled?(:responsive_ux)
-    %li.breadcrumb-item
-      = link_to 'Projects', projects_path
-  - if current_page?(project_list_all_path)
+  %li.breadcrumb-item.text-word-break-all
+    %i.fa.fa-cubes
+    = link_to @project, project_show_path(@project)
+  - if current_page?(project_show_path(@project))
     %li.breadcrumb-item.active{ 'aria-current' => 'page' }
-      List of All Projects
-  - elsif current_page?(new_project_path)
+      Overview
+  - elsif current_page?(project_monitor_path(@project))
     %li.breadcrumb-item.active{ 'aria-current' => 'page' }
-      = @namespace.nil? ? 'Create Project' : 'Create Subproject'
-  - else
-    %li.breadcrumb-item.text-word-break-all
-      - if feature_enabled?(:responsive_ux)
-        %i.fa.fa-cubes
-      = link_to @project, project_show_path(@project)
-    - if current_page?(project_show_path(@project))
-      %li.breadcrumb-item.active{ 'aria-current' => 'page' }
-        Overview
-    - elsif current_page?(project_monitor_path(@project))
-      %li.breadcrumb-item.active{ 'aria-current' => 'page' }
-        Monitor
-    - elsif current_page?(project_requests_path(@project))
-      %li.breadcrumb-item.active{ 'aria-current' => 'page' }
-        Requests
-    - elsif current_page?(project_users_path(@project))
-      %li.breadcrumb-item.active{ 'aria-current' => 'page' }
-        Users
-    - elsif current_page?(project_config_path(@project))
-      %li.breadcrumb-item.active{ 'aria-current' => 'page' }
-        Configuration
-    - elsif current_page?(project_subprojects_path(@project))
-      %li.breadcrumb-item.active{ 'aria-current' => 'page' }
-        Subprojects
-    - elsif current_page?(project_release_request_path(@project))
-      %li.breadcrumb-item.active{ 'aria-current' => 'page' }
-        Create Maintenance Release Request
+      Monitor
+  - elsif current_page?(project_requests_path(@project))
+    %li.breadcrumb-item.active{ 'aria-current' => 'page' }
+      Requests
+  - elsif current_page?(project_users_path(@project))
+    %li.breadcrumb-item.active{ 'aria-current' => 'page' }
+      Users
+  - elsif current_page?(project_config_path(@project))
+    %li.breadcrumb-item.active{ 'aria-current' => 'page' }
+      Configuration
+  - elsif current_page?(project_subprojects_path(@project))
+    %li.breadcrumb-item.active{ 'aria-current' => 'page' }
+      Subprojects
+  - elsif current_page?(project_release_request_path(@project))
+    %li.breadcrumb-item.active{ 'aria-current' => 'page' }
+      Create Maintenance Release Request


### PR DESCRIPTION
Remove non-responsive code from the project basic_info partial and project breadcrumbs.

In project breadcrumbs, RuboCop complained with: "Style/IfInsideElse: Convert `if` nested inside `else` to `elsif`.". Moving the `if` clause inside the `else` to an `elsif`, fixed the linter.

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature
