### PR TITLE
Remove unneeded path for `render partial: ...` calls

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -539,11 +539,11 @@ class Webui::PackageController < Webui::WebuiController
       show_all = params[:show_all] == 'true'
       @index = params[:index]
       @buildresults = @package.buildresult(@project, show_all)
-      render partial: 'webui/package/buildstatus', locals: { buildresults: @buildresults,
-                                                             index: @index,
-                                                             project: @project,
-                                                             collapsed_packages: params.fetch(:collapsedPackages, []),
-                                                             collapsed_repositories: params.fetch(:collapsedRepositories, {}) }
+      render partial: 'buildstatus', locals: { buildresults: @buildresults,
+                                               index: @index,
+                                               project: @project,
+                                               collapsed_packages: params.fetch(:collapsedPackages, []),
+                                               collapsed_repositories: params.fetch(:collapsedRepositories, {}) }
     else
       render partial: 'no_repositories', locals: { project: @project }
     end

--- a/src/api/app/views/webui/kiwi/images/_base_info.html.haml
+++ b/src/api/app/views/webui/kiwi/images/_base_info.html.haml
@@ -10,7 +10,6 @@
         %li.list-inline-item
           %strong Contact:
           %span.fill{ data: { tag: 'contact' } }= contact
-    = render partial: 'webui/kiwi/images/actions',
-             locals: { package: package, is_edit_details_action: is_edit_details_action }
+    = render partial: 'actions', locals: { package: package, is_edit_details_action: is_edit_details_action }
     - if action_name == 'edit'
       = render partial: 'description_form', locals: { f: f }

--- a/src/api/app/views/webui/main/index.html.haml
+++ b/src/api/app/views/webui/main/index.html.haml
@@ -1,6 +1,6 @@
 :ruby
   @pagetitle = 'Welcome'
-  render partial: 'webui/main/index_actions'
+  render partial: 'index_actions'
 
 .row
   .col-md-8.col-lg-7

--- a/src/api/app/views/webui/package/show.html.haml
+++ b/src/api/app/views/webui/package/show.html.haml
@@ -5,16 +5,16 @@
   content_for(:meta_title, @package.title.presence || @package.name)
   content_for(:meta_description, @package.description)
 
-  render partial: 'webui/package/show_actions', locals: { bugowners_mail: @bugowners_mail,
-                                                  configuration: @configuration,
-                                                  revision: @revision,
-                                                  current_rev: @current_rev,
-                                                  spec_count: @spec_count,
-                                                  cleanup_source: @cleanup_source,
-                                                  services: @services,
-                                                  project: @project,
-                                                  package: @package,
-                                                  is_working: @forced_unexpand.blank? }
+  render partial: 'show_actions', locals: { bugowners_mail: @bugowners_mail,
+                                            configuration: @configuration,
+                                            revision: @revision,
+                                            current_rev: @current_rev,
+                                            spec_count: @spec_count,
+                                            cleanup_source: @cleanup_source,
+                                            services: @services,
+                                            project: @project,
+                                            package: @package,
+                                            is_working: @forced_unexpand.blank? }
 
 .card.mb-3
   = render partial: 'tabs', locals: { project: @project, package: @package }


### PR DESCRIPTION
@eduardoj, @saraycp and I realized that we forgot to remove this in some of the recent responsive_ux PRs.
