### PR TITLE
Capitalize select-all-label properly in the JavaScript code

### DIFF
--- a/src/api/app/assets/javascripts/webui/notification.js
+++ b/src/api/app/assets/javascripts/webui/notification.js
@@ -15,7 +15,7 @@ function setCheckboxCounterAndSubmitButton() {
 
   if(amountBoxesChecked <= 0) {
     $('#done-button').prop('disabled', true);
-    $('#select-all-label').text('Select all');
+    $('#select-all-label').text('Select All');
   } else {
     $('#done-button').prop('disabled', false);
     $('#select-all-label').text(amountBoxesChecked + ' selected');


### PR DESCRIPTION
Without this change, the word "all" flickers since it's first rendered as "All", then replaced by "all" in the JavaScript code.

Just something I've noticed while working on something else... see for yourself below in this recording of the notifications overview page refreshing:
![capitalization-change](https://user-images.githubusercontent.com/1102934/111164130-0b8c4080-859e-11eb-9ce0-d636898ef094.gif)