### PR TITLE
Fix patchinfo stack icons for bottom navigation

### DIFF
--- a/src/api/app/assets/stylesheets/webui/layout.scss
+++ b/src/api/app/assets/stylesheets/webui/layout.scss
@@ -55,6 +55,19 @@
   z-index: $zindex-fixed;
 }
 
+#left-navigation-area, #bottom-navigation-area {
+  .fa-stack {
+    width: 1.9rem;
+
+    .top-icon {
+      font-size: 0.9rem;
+      padding-left: 1rem;
+      padding-top: 0.5rem;
+      text-shadow: -1.5px 0 $dark, 0 1.5px $dark, 1.5px 0 $dark, 0 -1.5px $dark;
+    }
+  }
+}
+
 // BREADCRUMBS
 
 .breadcrumb {

--- a/src/api/app/assets/stylesheets/webui/sidebar-collapsible.scss
+++ b/src/api/app/assets/stylesheets/webui/sidebar-collapsible.scss
@@ -41,19 +41,4 @@
   }
 
   i { width: 1.5rem; }
-
-  .fa-stack {
-    width: 1.9rem;
-
-    .top-icon {
-      font-size: 0.9rem;
-      padding-left: 1rem;
-      padding-top: 0.5rem;
-      text-shadow: -1.5px 0 $dark, 0 1.5px $dark, 1.5px 0 $dark, 0 -1.5px $dark;
-    }
-
-    .fa-warehouse {
-      font-size: 0.7rem;
-    }
-  }
 }


### PR DESCRIPTION
The specific CSS for the stack icons now affects both left and bottom navigation.

![Screenshot_2021-03-17 home scp](https://user-images.githubusercontent.com/2581944/111470740-79fd0a00-8728-11eb-8e86-2d33037c3d78.png)


The rule for fa-warehouse is removed since that icon is no longer used.

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
