### PR TITLE
Add user_profile_redesign flag to beta features' tests 

### DIFF
--- a/src/api/spec/features/beta/webui/users/user_contributions_spec.rb
+++ b/src/api/spec/features/beta/webui/users/user_contributions_spec.rb
@@ -1,13 +1,24 @@
 require 'browser_helper'
 
+RSpec.shared_examples 'a contribution graph' do
+  before do
+    visit user_path(login: user.login)
+  end
+
+  it 'shows contribution graph, only on desktop' do
+    if desktop?
+      expect(page).to have_text('Contributions')
+    else
+      expect(page).not_to have_text('Contributions')
+    end
+  end
+end
+
 RSpec.describe 'Bootstrap_User Contributions', type: :feature, js: true do
   let!(:user) { create(:confirmed_user) }
 
   context 'without contribution graph option' do
-    it 'shows the contribution graph' do
-      visit user_path(login: user.login)
-      expect(page).to have_css('#contributors-table')
-    end
+    it_behaves_like 'a contribution graph'
   end
 
   context 'with contribution graph disabled' do
@@ -17,7 +28,7 @@ RSpec.describe 'Bootstrap_User Contributions', type: :feature, js: true do
 
     it 'does not show the contribution table' do
       visit user_path(login: user.login)
-      expect(page).not_to have_css('#contributors-table')
+      expect(page).not_to have_text('Contributions')
     end
   end
 
@@ -26,15 +37,14 @@ RSpec.describe 'Bootstrap_User Contributions', type: :feature, js: true do
       stub_const('CONFIG', CONFIG.merge('contribution_graph' => :on))
     end
 
-    it 'shows the contribution graph' do
-      visit user_path(login: user.login)
-      expect(page).to have_css('#contributors-table')
-    end
+    it_behaves_like 'a contribution graph'
 
     context 'no contributions' do
       it 'shows 0' do
-        visit user_path(login: user.login)
+        skip_on_mobile
 
+        visit user_path(login: user.login)
+        click_link('Contributions')
         expect(page).to have_text('0 contributions')
       end
     end
@@ -45,7 +55,10 @@ RSpec.describe 'Bootstrap_User Contributions', type: :feature, js: true do
       let!(:review) { create(:review, bs_request: request, reviewer: user, by_user: user, state: :accepted) }
 
       it 'shows 3' do
+        skip_on_mobile
+
         visit user_path(login: user.login)
+        click_link('Contributions')
         expect(page).to have_text('3 contributions')
       end
     end

--- a/src/api/spec/support/beta.rb
+++ b/src/api/spec/support/beta.rb
@@ -1,5 +1,6 @@
 RSpec.configure do |config|
   config.before(:example, beta: true) do
     Flipper.enable(:notifications_redesign)
+    Flipper.enable(:user_profile_redesign)
   end
 end


### PR DESCRIPTION
This feature flag is already enabled in the beta program. Let's enable it in the tests for beta features.

Only tests for the contribution graph had to be adapted.

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature
