### PR TITLE
[backend] allow to get buildinfo for linked projects #10751

### DIFF
--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -1315,8 +1315,9 @@ sub getprojpack {
       } else {
         $pack = BSRevision::readpack_local($projid, $packid, 1);
       }
-      ($pack) = getpackage({}, $projid, $packid) if $proj->{'remoteurl'} && $cgi->{'parseremote'};
-      $pack ||= {} if $proj->{'link'};
+      if (($proj->{'remoteurl'} && $cgi->{'parseremote'}) || ($proj->{'link'} && !defined $pack)) {
+        ($pack) = getpackage({}, $projid, $packid);
+      }
       if (!$pack) {
 	$pinfo->{'error'} = 'package does not exist';
 	next;


### PR DESCRIPTION
Hey Friends,

This PR allow control package build  when link project. Fixes #10751

To verify this feature

- Enable interconnect with openSUSE.org
- Create the project `donor` with meta:
```
<project name="donor">
  <title/>
  <description/>
  <person userid="Admin" role="maintainer"/>
  <repository name="openSUSE_Leap_15.2">
    <path project="openSUSE.org:openSUSE:Leap:15.2" repository="standard"/>
    <arch>x86_64</arch>
  </repository>
  <repository name="disabled_repo">
    <path project="openSUSE.org:openSUSE:Leap:15.2" repository="standard"/>
    <arch>x86_64</arch>
  </repository>
</project>
```
- Create package `simple_enabled` into donor project with meta:
```
<package name="simple_enabled" project="donor">
  <title/>
  <description/>
  <build>
    <disable/>
    <enable arch="x86_64" repository="openSUSE_Leap_15.2"/>
  </build>
</package>
```
- Add file `some.spec` into package `simple_enabled` with content:
```
Name:           simple_enabled
License:        GPLv2+
Group:          Development/Tools/Building
AutoReqProv:    on
Summary:        Test Package
Version:        1.0
Release:        1
Requires:       bash
Conflicts:      something
Provides:       myself

%description

%prep

%build

%install
mkdir -p $RPM_BUILD_ROOT
echo "CONTENT" > $RPM_BUILD_ROOT/my_packaged_file

%files
%defattr(-,root,root)
/my_packaged_file

%changelog
```
- Create home:Admin project with meta:
```
<project name="home:Admin">
  <title/>
  <description/>
  <link project="donor"/>
  <person userid="Admin" role="maintainer"/>
  <repository name="openSUSE_Leap_15.2" block="all" linkedbuild="all">
    <path project="donor" repository="openSUSE_Leap_15.2"/>
    <arch>x86_64</arch>
  </repository>
  <repository name="disabled_repo" block="all" linkedbuild="all">
    <path project="donor" repository="disabled_repo"/>
    <arch>x86_64</arch>
  </repository>
</project>
```
**Monitor page of donor project:**
![donor monitor before](https://user-images.githubusercontent.com/74910851/111634366-7e4c2480-8807-11eb-9861-b8f02fbf0d68.png)

**Monitor page of home:Admin Before:**
![home monitor before](https://user-images.githubusercontent.com/74910851/111634480-9d4ab680-8807-11eb-85c0-3b2b51958cdd.png)

**Monitor page of home:Admin After:**
![home monitor after](https://user-images.githubusercontent.com/74910851/111634567-b3f10d80-8807-11eb-83a9-e129876812f0.png)
