### PR TITLE
Adjust margin and padding on edit links

### DIFF
--- a/src/api/app/views/webui/package/_basic_info.html.haml
+++ b/src/api/app/views/webui/package/_basic_info.html.haml
@@ -1,7 +1,7 @@
 .editing-form.d-none
   = render partial: 'edit', locals: { package: package, project: package.project }
 
-.basic-info.mb-3
+.basic-info
   %h3#package-title
     = package.title.presence || package.name
   - if package.url.present?
@@ -13,9 +13,10 @@
       = render partial: 'webui/shared/collapsible_text', locals: { text: package.description }
 
   - if policy(package).update?
-    = link_to('javascript:void(0);', id: 'toggle-in-place-editing', class: 'nav-link', title: 'Edit') do
-      %i.fas.fa-edit
-      %span.nav-item-name Edit
+    .pt-4
+      = link_to('javascript:void(0);', id: 'toggle-in-place-editing', class: 'nav-link pl-0', title: 'Edit') do
+        %i.fas.fa-edit
+        %span.nav-item-name Edit
 
 :javascript
   $('#toggle-in-place-editing').on('click', function () {

--- a/src/api/app/views/webui/project/_basic_info.html.haml
+++ b/src/api/app/views/webui/project/_basic_info.html.haml
@@ -14,6 +14,6 @@
 
   - if policy(project).update?
     .pt-4
-      = link_to(edit_project_path(project), class: 'nav-link', remote: true, title: 'Edit') do
+      = link_to(edit_project_path(project), class: 'nav-link pl-0', remote: true, title: 'Edit') do
         %i.fas.fa-edit.text-secondary
         %span.nav-item-name Edit

--- a/src/api/app/views/webui/user/user_profile_redesign/_basic_info.html.haml
+++ b/src/api/app/views/webui/user/user_profile_redesign/_basic_info.html.haml
@@ -6,7 +6,7 @@
   - if configuration.accounts_editable?(user)
     .d-flex.flex-row-reverse
       = link_to('javascript:void(0);', id: 'toggle-in-place-editing', class: 'nav-link', remote: true, title: 'Edit Your Account') do
-        %i.fas.mr-2.fa-user-edit
+        %i.fas.fa-user-edit
         %span.nav-item-name Edit
 
   .row.mb-3.mb-md-0


### PR DESCRIPTION
The links are now left-aligned with the rest of the elements, and there is not excessive space at the bottom nor between the icon and the text.

Follow-up of: #10905 

**Result:**

![Screenshot_2021-03-18 paquete](https://user-images.githubusercontent.com/2581944/111649376-9b332880-8804-11eb-934e-6450176c2b31.png)

![Screenshot_2021-03-18 Profile of Admin](https://user-images.githubusercontent.com/2581944/111649404-a1c1a000-8804-11eb-9441-ca91d7e1ad62.png)

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
