### PR TITLE
[backend] remove redirect from call-service-in-container

### DIFF
--- a/src/backend/call-service-in-container
+++ b/src/backend/call-service-in-container
@@ -3,9 +3,6 @@
 #set -x
 LOGDIR=/srv/obs/service/log/
 LOGFILE=$LOGDIR/`basename $0`.log
-exec 1>>$LOGFILE
-exec 2>&1
-
 
 function printlog {
   printf "%s %s %7s %s\n" `date +"%Y-%m-%d %H:%M:%S"` "[$$]" "$@" >> $LOGFILE


### PR DESCRIPTION
The redirect of STDOUT/STDERR in call-service-in-container causes an
error in bs_service like

refcnt: fd -1 < 0

This patch removes the redirection.
