### PR TITLE
Remove remaining show JS view file

### DIFF
--- a/src/api/app/views/webui/users/show.js.erb
+++ b/src/api/app/views/webui/users/show.js.erb
@@ -1,8 +1,0 @@
-$('.in-place-editing').animate({
-  opacity: 0.25
-}, 400, function() {
-  scrollToInPlace();
-  $('.in-place-editing').html("<%= escape_javascript(render(partial: 'webui/user/user_profile_redesign/basic_info', locals: { user: @displayed_user, role_titles: @role_titles })) %>");
-  setCollapsible();
-  $('.in-place-editing').animate({ opacity: 1 }, 400);
-});


### PR DESCRIPTION
This file  (_app/views/webui/users/show.js.erb_) should have been removed when the inline editing was modified and the cancel button no longer redirected to show.js.erb.

Moreover, the show.js.erb called a partial but one of the locals was missing.

Keeping this file causes errors when bots try to visit the former URL.

Co-authored-by: Daniel Donisa <daniel.donisa@suse.com>
Co-authored-by: Eduardo Navarro <enavarro@suse.com>

Fixes: #10934 