### PR TITLE
Update autoprefixer-rails to 10.2.4.0

### DIFF
--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -78,7 +78,7 @@ GEM
       rake (>= 10.4, < 14.0)
     ansi (1.5.0)
     ast (2.4.2)
-    autoprefixer-rails (10.2.0.0)
+    autoprefixer-rails (10.2.4.0)
       execjs
     awesome_print (1.9.2)
     bcrypt (3.1.16)


### PR DESCRIPTION
To avoid having this bundled in a Depfu PR which is also updating Bootstrap (see #10825)