### PR TITLE
Handle dots in user logins for group members page/route

### DIFF
--- a/src/api/app/lib/routes_helper/routes_constraints.rb
+++ b/src/api/app/lib/routes_helper/routes_constraints.rb
@@ -16,6 +16,7 @@ module RoutesHelper
       service: %r{\w[^/]*},
       title: %r{[^/]*},
       user: %r{[^/]*},
+      user_login: %r{[^/]*},
       repository_publish_build_id: %r{[^/]*},
       workflow_project: %r{[^/]*},
       staging_project_name: %r{[^/]*},

--- a/src/api/app/views/webui/groups/_group_members.html.haml
+++ b/src/api/app/views/webui/groups/_group_members.html.haml
@@ -10,7 +10,8 @@
         .card.m-1.p-2.group-user
           - if write_access
             = render(partial: 'webui/groups/group_members_delete_dialog', locals: { user: user, group: group })
-            = link_to('#', data: { toggle: 'modal', target: "#delete-group-members-modal-#{user}" }, title: 'Remove member from group') do
+            = link_to('#', data: { toggle: 'modal', target: "#delete-group-members-modal-#{dom_id(user)}" },
+                      title: 'Remove member from group') do
               .float-right
                 %i.fas.fa-sm.fa-times-circle.text-danger
           .row.no-gutters

--- a/src/api/app/views/webui/groups/_group_members_delete_dialog.html.haml
+++ b/src/api/app/views/webui/groups/_group_members_delete_dialog.html.haml
@@ -1,4 +1,4 @@
-.modal.fade{ id: "delete-group-members-modal-#{user}", tabindex: -1, role: 'dialog',
+.modal.fade{ id: "delete-group-members-modal-#{dom_id(user)}", tabindex: -1, role: 'dialog',
              aria: { labelledby: 'delete-group-members-modal-label', hidden: true } }
   .modal-dialog.modal-dialog-centered{ role: 'document' }
     .modal-content

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -356,7 +356,7 @@ OBSApi::Application.routes.draw do
       get 'group/autocomplete' => :autocomplete, as: 'autocomplete_groups'
     end
 
-    resources :groups, only: [], param: :title, constraints: { title: %r{[^/]*} } do
+    resources :groups, only: [], param: :title, constraints: cons do
       resources :user, only: [:create, :destroy, :update], constraints: cons, param: :user_login, controller: 'webui/groups/users'
     end
 


### PR DESCRIPTION
Fixes #10955

Before, the `Delete group member` modal didn't appear for a user which has dots in their login.

The routes /groups/<group>/users/<user> were also not handling dots correctly, treating them as separators. Having a constraint for the user login solves this. This is documented in Rails, see https://guides.rubyonrails.org/routing.html#dynamic-segments