### PR TITLE
Remove unnecessary `includes` in requests query

### DIFF
--- a/src/api/app/controllers/request_controller.rb
+++ b/src/api/app/controllers/request_controller.rb
@@ -37,9 +37,9 @@ class RequestController < ApplicationController
     params[:ids] = params[:ids].split(',').map(&:to_i) if params[:ids]
 
     rel = BsRequest.find_for(params)
+    rel = BsRequest.where(id: rel.select(:id)).preload([{ bs_request_actions: :bs_request_action_accept_info, reviews: { history_elements: :user } }])
     rel = rel.limit(params[:limit].to_i) if params[:limit].to_i.positive?
 
-    rel = BsRequest.where(id: rel.select(:id)).preload([{ bs_request_actions: :bs_request_action_accept_info, reviews: { history_elements: :user } }])
     xml = Nokogiri::XML('<collection/>', &:strict).root
     matches = 0
     rel.each do |r|

--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -25,7 +25,7 @@ class BsRequest < ApplicationRecord
 
   scope :to_accept_by_time, -> { where(state: ['new', 'review']).where('accept_at < ?', Time.now) }
   # Scopes for collections
-  scope :with_actions, -> { includes(:bs_request_actions).references(:bs_request_actions).distinct.order(priority: :asc, id: :desc) }
+  scope :with_actions, -> { joins(:bs_request_actions).distinct.order(priority: :asc, id: :desc) }
   scope :with_involved_projects, ->(project_ids) { where(bs_request_actions: { target_project_id: project_ids }) }
   scope :with_involved_packages, ->(package_ids) { where(bs_request_actions: { target_package_id: package_ids }) }
 

--- a/src/api/app/models/bs_request/data_table/find_for_user_or_group_query.rb
+++ b/src/api/app/models/bs_request/data_table/find_for_user_or_group_query.rb
@@ -15,7 +15,7 @@ class BsRequest
           .offset(@params[:offset])
           .limit(@params[:limit])
           .reorder(@params[:sort])
-          .includes(:bs_request_actions)
+          .preload(:bs_request_actions)
       end
 
       def records_total


### PR DESCRIPTION
Sorting the requests by the Source, Target or Type columns led to missing results.

This was caused by a wrong DISTINCT clause, that was taking fields from two tables (`bs_request_actions` and `requests`) instead of one (`requests`). Those extra fields in the DISTINCT clause were introduced by an `includes` finder method.

The problem was fixed by replacing the `includes` in the `.with_action` scope with a `joins` finder method, so the fields from
`bs_requests_actions` are no longer part of the DISTINCT modifier in the SQL sentence.

Additionally, the `includes` in the BsRequest::DataTable::FindForUserOrGroup#requests method was redundant. We add `preload(:bs_request_actions)` instead.

Fixes #10950.

Co-authored-by: Saray Cabrera Padrón <scabrerapadron@suse.de>

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature
