### PR TITLE
Use server-side pagination for the maintenance requests table on the user tasks page

### DIFF
--- a/src/api/app/controllers/webui/users/patchinfos_controller.rb
+++ b/src/api/app/controllers/webui/users/patchinfos_controller.rb
@@ -1,0 +1,13 @@
+module Webui
+  module Users
+    class PatchinfosController < WebuiController
+      def index
+        respond_to do |format|
+          format.json do
+            render json: TasksMaintenanceRequestsDatatable.new(current_user: User.session!, view_context: view_context)
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/api/app/datatables/tasks_maintenance_requests_datatable.rb
+++ b/src/api/app/datatables/tasks_maintenance_requests_datatable.rb
@@ -1,0 +1,39 @@
+class TasksMaintenanceRequestsDatatable < Datatable
+  def_delegators :@view_context, :elide_two, :link_to, :package_show_path, :project_monitor_path, :project_show_path, :safe_join, :tag
+
+  def initialize(current_user:, view_context:)
+    @current_user = current_user
+    @view_context = view_context
+    super
+  end
+
+  def view_columns
+    @view_columns ||= {
+      project: {},
+      package: {},
+      issues: {},
+      actions: {}
+    }
+  end
+
+  # rubocop:disable Naming/AccessorMethodName
+  def get_raw_records
+    @current_user.involved_patchinfos
+  end
+  # rubocop:enable Naming/AccessorMethodName
+
+  def data
+    records.map do |record|
+      project_name, package_name = elide_two(record.project.name, record.name, 60)
+
+      {
+        project: link_to(project_name, project_show_path(project_name)),
+        package: link_to(package_name, package_show_path(project_name, package_name)),
+        issues: safe_join(record.issues.map { |issue| link_to(issue.label, issue.url, title: issue.summary) }, ', '),
+        actions: link_to(project_monitor_path(record.project, pkgname: record.name)) do
+                   tag.i(class: %w[fas fa-heartbeat text-danger], title: 'Monitor')
+                 end
+      }
+    end
+  end
+end

--- a/src/api/app/views/webui/shared/_patchinfos_table.html.haml
+++ b/src/api/app/views/webui/shared/_patchinfos_table.html.haml
@@ -1,4 +1,5 @@
-%table.responsive.table.table-sm.table-bordered.table-hover.w-100#open-patchinfos-table{ title: 'Running Maintenance Updates' }
+%table.responsive.table.table-sm.table-bordered.table-hover.w-100#open-patchinfos-table{ title: 'Running Maintenance Updates',
+                                                                                         'data-source': source_url }
   %thead
     %tr
       %th Project
@@ -6,27 +7,18 @@
       %th Issues
       %th Actions
   %tbody
-    - involved_patchinfos.each do |patchinfo|
-      %tr
-        - shortened_prj, shortened_pkg = elide_two(patchinfo[:package][:project], patchinfo[:package][:name], 60)
-        %td= link_to(shortened_prj, project_show_path(patchinfo[:package][:project]))
-        %td= link_to(shortened_pkg, package_show_path(patchinfo[:package][:project], patchinfo[:package][:name]))
-        %td
-          - size = patchinfo[:issues].size
-          - patchinfo[:issues].each_with_index do |item, index|
-            = succeed "#{',' if index < size - 1}" do
-              = link_to item[:label], item[:url], title: item[:summary]
-        %td
-          = link_to(project_monitor_path(patchinfo[:package][:project], pkgname: patchinfo[:package][:name])) do
-            %i.fas.fa-heartbeat.text-danger{ title: 'Monitor' }
 
-= javascript_tag do
+= content_for :ready_function do
   :plain
-    $(function() {
-      $('#open-patchinfos-table').dataTable({
-        iDisplayLength: 10,
-        stateSave: true,
-        stateDuration: #{2.days}
-      });
+    $('#open-patchinfos-table').DataTable({
+      responsive: true,
+      processing: true,
+      serverSide: true,
+      ajax: $('#open-patchinfos-table').data('source'),
+      columns: [
+        { data: 'project' },
+        { data: 'package' },
+        { data: 'issues' },
+        { data: 'actions' }
+      ]
     });
-

--- a/src/api/app/views/webui/users/tasks/index.html.haml
+++ b/src/api/app/views/webui/users/tasks/index.html.haml
@@ -61,8 +61,8 @@
         = render(partial: 'webui/shared/requests_table', locals: { id: 'all_requests_table', source_url: user_requests_path(User.session!),
                  page_length: 10 })
 
-- involved_patchinfos = User.session!.involved_patchinfos
-- if involved_patchinfos.present?
+- number_of_involved_patchinfos = User.session!.involved_patchinfos.size
+- if number_of_involved_patchinfos.positive?
   .card.mt-3#patchinfos
     .bg-light
       %ul.nav.nav-tabs.pt-2.px-3.flex-nowrap.collapsible{ role: 'tablist' }
@@ -70,7 +70,7 @@
           %a.nav-link.text-nowrap.active{ href: '#patchinfos-in', title: "Requests that #{User.session!} has to merge" }
             Maintenance Requests
             %span.badge.badge-primary
-              = involved_patchinfos.size
+              = number_of_involved_patchinfos
     .card-body
       .tab-content#patchinfos-in
-        = render(partial: 'webui/shared/patchinfos_table', locals: { involved_patchinfos: involved_patchinfos })
+        = render(partial: 'webui/shared/patchinfos_table', locals: { source_url: my_patchinfos_path })

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -322,6 +322,8 @@ OBSApi::Application.routes.draw do
         end
       end
 
+      resources :patchinfos, only: [:index], controller: 'webui/users/patchinfos', as: :my_patchinfos
+
       post 'rss_tokens' => :create, controller: 'webui/users/rss_tokens', as: :my_rss_token
       post 'status_messages/:id' => :acknowledge, controller: 'webui/status_messages', as: :acknowledge_status_message
     end


### PR DESCRIPTION
Prevent N+1 queries for IssueTracker and User (it wasn't needed to load users, so this was dealt with by not fetching users anymore).

Fetch maintenance requests once the page is loaded.

Fixes #10959