### PR TITLE
Document worker capabilities endpoint with OpenAPI

### DIFF
--- a/src/api/public/apidocs-new/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs-new/OBS-v2.10.50.yaml
@@ -104,6 +104,8 @@ paths:
 
   /worker/status:
     $ref: 'paths/worker_status.yaml'
+  /worker/{architecture_name}:{worker_id}:
+    $ref: 'paths/worker_architecture_name_worker_id.yaml'
 
 components:
   securitySchemes:

--- a/src/api/public/apidocs-new/components/schemas/worker_capabilities.yaml
+++ b/src/api/public/apidocs-new/components/schemas/worker_capabilities.yaml
@@ -1,0 +1,41 @@
+type: object
+properties:
+  hostarch:
+    type: string
+    xml:
+      attribute: true
+  registerserver:
+    type: string
+    xml:
+      attribute: true
+  workerid:
+    type: string
+    xml:
+      attribute: true
+  hostlabel:
+    type: string
+  sandbox:
+    type: string
+  linux:
+    type: object
+    properties:
+      version:
+        type: string
+      flavor:
+        type: string
+  hardware:
+    type: object
+    properties:
+      cpu:
+        type: object
+        properties:
+          flag:
+            type: array
+            items:
+              type: string
+      processors:
+        type: string
+      jobs:
+        type: string
+xml:
+  name: worker

--- a/src/api/public/apidocs-new/paths/worker_architecture_name_worker_id.yaml
+++ b/src/api/public/apidocs-new/paths/worker_architecture_name_worker_id.yaml
@@ -1,0 +1,60 @@
+get:
+  summary: Lists capabilites of a worker.
+  description: |
+    Lists capabilites of a worker.
+
+    This can be useful when checking for constraints.
+
+    This operation is the same as `GET /worker/capability/{architecture_name}:{worker_id}`.
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/architecture_name.yaml'
+    - in: path
+      name: worker_id
+      schema:
+        type: string
+      required: true
+      description: Worker id.
+      example: '1a1f67b948b6:1'
+  responses:
+    '200':
+      description: OK
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/worker_capabilities.yaml'
+          example:
+            hostarch: 'x86_64'
+            registerserver: 'http://backend:5252'
+            workerid: '1a1f67b948b6:1'
+            hostlabel: 'OBS_WORKER_SECURITY_LEVEL_'
+            sandbox: 'chroot'
+            linux:
+              version: '5.11.6-1'
+              flavor: 'default'
+            hardware:
+              cpu:
+                flag:
+                  - 'fpu'
+                  - 'vme'
+                  - 'de'
+                  - 'pse'
+                  - 'tsc'
+                  - 'msr'
+              processors: '8'
+              jobs: '1'
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '404':
+      description: Not Found.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          example:
+            code: '404'
+            summary: 'remote error: unknown worker (http://backend:5252/worker/x86_64:1a1f67b948bf:1)'
+            details: '404 remote error: unknown worker (http://backend:5252/worker/x86_64:1a1f67b948bf:1)'
+  tags:
+    - Workers


### PR DESCRIPTION
Document `GET /worker/{architecture_name}:{worker_id}` endpoint with the OpenAPI definition.

This operation is the same as `GET /worker/capability/{architecture_name}:{worker_id}`.

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
