### PR TITLE
Document checkconstraints command for workers with OpenAPI

### DIFF
--- a/src/api/public/apidocs-new/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs-new/OBS-v2.10.50.yaml
@@ -124,6 +124,8 @@ paths:
     $ref: 'paths/worker_status.yaml'
   /worker/{architecture_name}:{worker_id}:
     $ref: 'paths/worker_architecture_name_worker_id.yaml'
+  /worker?cmd=checkconstraints:
+    $ref: 'paths/worker_cmd_checkconstraints.yaml'
 
 components:
   securitySchemes:

--- a/src/api/public/apidocs-new/components/schemas/constraints.yaml
+++ b/src/api/public/apidocs-new/components/schemas/constraints.yaml
@@ -1,0 +1,48 @@
+type: object
+properties:
+  hostlabel:
+    type: string
+  sandbox:
+    type: string
+    example: chroot
+  linux:
+    type: object
+    properties:
+      version:
+        type: object
+        properties:
+          min:
+            type: string
+          max:
+            type: string
+      flavor:
+        type: string
+  hardware:
+    type: object
+    properties:
+      cpu:
+        type: object
+        properties:
+          flag:
+            type: array
+            items:
+              type: string
+      processors:
+        type: string
+      disk:
+        type: object
+        properties:
+          size:
+            type: string
+      memory:
+        type: object
+        properties:
+          size:
+            type: string
+      physicalmemory:
+        type: object
+        properties:
+          size:
+            type: string
+xml:
+  name: constraints

--- a/src/api/public/apidocs-new/paths/worker_cmd_checkconstraints.yaml
+++ b/src/api/public/apidocs-new/paths/worker_cmd_checkconstraints.yaml
@@ -1,0 +1,114 @@
+post:
+  summary: Lists workers which match a constraints filter.
+  description: |
+    Given a project, package, repository and architecture, list workers which can build with that restrictions, and also match a constraints filter.
+
+    This endpoint doesn't create or modify any data.
+
+    More information about constraints can be found in the
+    [user guide](https://openbuildservice.org/help/manuals/obs-user-guide/cha.obs.build_job_constraints.html).
+
+    This operation is the same as `POST /worker/command/run?cmd=checkconstraints`.
+  security:
+    - basic_authentication: []
+  parameters:
+    - in: query
+      name: project
+      schema:
+        type: string
+      required: true
+      example: home:user1
+      description: Project name.
+    - in: query
+      name: repository
+      schema:
+        type: string
+      required: true
+      description: Repository name.
+      example: openSUSE_Tumbleweed
+    - in: query
+      name: arch
+      schema:
+        type: string
+      required: true
+      description: Architecture name.
+      example: x86_64
+    - in: query
+      name: package
+      schema:
+        type: string
+      required: true
+      description: Package name.
+      example: test_package
+  requestBody:
+    description: Constraints XML filter
+    required: true
+    content:
+      application/xml; charset=utf-8:
+        schema:
+          $ref: '../components/schemas/constraints.yaml'
+        examples:
+          cpu_flags:
+            summary: Cpu flags
+            value:
+              hardware:
+                cpu:
+                  flag:
+                    - mmx
+                    - sse2
+          processors:
+            summary: Number of processors
+            value:
+              hardware:
+                processors: 2
+          mix:
+            summary: Linux version and linux flavor
+            value:
+              linux:
+                version:
+                  min: 3.0
+                  max: 4.0
+                flavor: default
+  responses:
+    '200':
+      description: OK
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/directory.yaml'
+          examples:
+            two_workers:
+              summary: Two Workers Satisfy the Constraints
+              value:
+                entry:
+                  - name: 'x86_64:1a1f67b948b6:1'
+                  - name: 'x86_64:1a1f67b948b6:2'
+            no_workers:
+              summary: No Workers Satisfy the Constraints
+              value:
+    '400':
+      description: Bad Request.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          example:
+            code: 'missing_parameter'
+            summary: Required Parameter arch missing
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '404':
+      description: Not Found.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          example:
+            code: 'not_found'
+            summary: |
+              &lt;status code="404"&gt;
+              &lt;summary&gt;repository 'home:Admin/openSUSE_Tumbleweed' has no architecture 'x86_64d'&lt;/summary&gt;
+              &lt;details&gt;404 repository 'home:Admin/openSUSE_Tumbleweed' has no architecture 'x86_64d'&lt;/details&gt;
+              &lt;/status&gt;
+  tags:
+    - Workers


### PR DESCRIPTION
Document `POST /worker?cmd=checkconstraints` endpoint with OpenAPI.

This operation is the same as `POST /worker/command/run?cmd=checkconstraints`.

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
