### PR TITLE
Published binary, status and ymp endpoints

### DIFF
--- a/src/api/public/apidocs-new/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs-new/OBS-v2.10.50.yaml
@@ -106,6 +106,8 @@ paths:
     $ref: 'paths/published_project_name_repository_name_architecture_name.yaml'
   /published/{project_name}/{repository_name}/{architecture_name}/{binary_filename}:
     $ref: 'paths/published_project_name_repository_name_architecture_name_binary_filename.yaml'
+  /published/{project_name}/{repository_name}/{architecture_name}/{binary_filename}?view=ymp:
+    $ref: 'paths/published_project_name_repository_name_architecture_name_binary_filename_view_ymp.yaml'
 
   /request:
     $ref: 'paths/request.yaml'

--- a/src/api/public/apidocs-new/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs-new/OBS-v2.10.50.yaml
@@ -100,8 +100,11 @@ paths:
     $ref: 'paths/published_project_name.yaml'
   /published/{project_name}/{repository_name}:
     $ref: 'paths/published_project_name_repository_name.yaml'
+  /published/{project_name}/{repository_name}?view=status:
+    $ref: 'paths/published_project_name_repository_name_view_status.yaml'
   /published/{project_name}/{repository_name}/{architecture_name}:
     $ref: 'paths/published_project_name_repository_name_architecture_name.yaml'
+
 
   /request:
     $ref: 'paths/request.yaml'

--- a/src/api/public/apidocs-new/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs-new/OBS-v2.10.50.yaml
@@ -104,7 +104,8 @@ paths:
     $ref: 'paths/published_project_name_repository_name_view_status.yaml'
   /published/{project_name}/{repository_name}/{architecture_name}:
     $ref: 'paths/published_project_name_repository_name_architecture_name.yaml'
-
+  /published/{project_name}/{repository_name}/{architecture_name}/{binary_filename}:
+    $ref: 'paths/published_project_name_repository_name_architecture_name_binary_filename.yaml'
 
   /request:
     $ref: 'paths/request.yaml'

--- a/src/api/public/apidocs-new/components/parameters/binary_filename.yaml
+++ b/src/api/public/apidocs-new/components/parameters/binary_filename.yaml
@@ -1,0 +1,7 @@
+in: path
+name: binary_filename
+schema:
+  type: string
+required: true
+description: Binary filename
+example: ctris-0.42.1-8.1.x86_64.rpm

--- a/src/api/public/apidocs-new/components/responses/download_binary_forbidden.yaml
+++ b/src/api/public/apidocs-new/components/responses/download_binary_forbidden.yaml
@@ -1,0 +1,11 @@
+description: |
+  Forbidden.
+
+  XML Schema used for body validation: [status.xsd](../schema/status.xsd)
+content:
+  application/xml; charset=utf-8:
+    schema:
+      $ref: '../schemas/api_response.yaml'
+    example:
+      code: download_binary_no_permission
+      summary: No permission for binaries from project home:Admin

--- a/src/api/public/apidocs-new/components/schemas/api_response.yaml
+++ b/src/api/public/apidocs-new/components/schemas/api_response.yaml
@@ -6,6 +6,8 @@ properties:
       attribute: true
   summary:
     type: string
+  details:
+    type: string
   data:
     # FIXME: 'name' attribute missing due to https://github.com/OAI/OpenAPI-Specification/issues/630
     type: array

--- a/src/api/public/apidocs-new/components/schemas/ymp_pattern.yaml
+++ b/src/api/public/apidocs-new/components/schemas/ymp_pattern.yaml
@@ -1,0 +1,53 @@
+type: object
+properties:
+  group:
+    type: object
+    properties:
+      repositories:
+        type: object
+        properties:
+          repository:
+            type: array
+            items:
+              type: object
+              properties:
+                recommended:
+                  type: string
+                  xml:
+                    attribute: true
+                name:
+                  type: string
+                summary:
+                  type: string
+                description:
+                  type: string
+                url:
+                  type: string
+      software:
+        type: object
+        properties:
+          item:
+            type: object
+            properties:
+              name:
+                type: string
+              summary:
+                type: string
+              description:
+                type: string
+      distversion:
+        type: string
+        xml:
+          attribute: true
+  xmlns:os:
+    type: string
+    xml:
+      attribute: true
+      example: "http://opensuse.org/Standards/One_Click_Install"
+  xmlns:
+    type: string
+    xml:
+      attribute: true
+      example: "http://opensuse.org/Standards/One_Click_Install"
+xml:
+  name: metapackage

--- a/src/api/public/apidocs-new/paths/published_project_name.yaml
+++ b/src/api/public/apidocs-new/paths/published_project_name.yaml
@@ -21,6 +21,8 @@ get:
               - name: 'openSUSE_15.2'
     '401':
       $ref: '../components/responses/unauthorized.yaml'
+    '403':
+      $ref: '../components/responses/download_binary_forbidden.yaml'
     '404':
       description: Not Found.
       content:

--- a/src/api/public/apidocs-new/paths/published_project_name_repository_name.yaml
+++ b/src/api/public/apidocs-new/paths/published_project_name_repository_name.yaml
@@ -23,6 +23,8 @@ get:
               - name: 'x86_64'
     '401':
       $ref: '../components/responses/unauthorized.yaml'
+    '403':
+      $ref: '../components/responses/download_binary_forbidden.yaml'
     '404':
       description: Not Found.
       content:

--- a/src/api/public/apidocs-new/paths/published_project_name_repository_name_architecture_name.yaml
+++ b/src/api/public/apidocs-new/paths/published_project_name_repository_name_architecture_name.yaml
@@ -22,6 +22,8 @@ get:
               - name: 'obs-api-testsuite-rspec-2.11~alpha.20200618T200341.d42d8310aa-lp152.10515.1.x86_64.rpm'
     '401':
       $ref: '../components/responses/unauthorized.yaml'
+    '403':
+      $ref: '../components/responses/download_binary_forbidden.yaml'
     '404':
       description: Not Found.
       content:

--- a/src/api/public/apidocs-new/paths/published_project_name_repository_name_architecture_name_binary_filename.yaml
+++ b/src/api/public/apidocs-new/paths/published_project_name_repository_name_architecture_name_binary_filename.yaml
@@ -1,0 +1,48 @@
+get:
+  summary: Return the binary file itself.
+  description: >
+    Allow to download the binary file that was published and stored under the directory
+    given by project/repository/architecture/.
+
+    Can response with Media Types like application/x-rpm, text/xml, etc.
+
+    NOTE: Use this only if you absolutely have to, as it doesn't use the redirector.
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/project_name.yaml'
+    - $ref: '../components/parameters/repository_name.yaml'
+    - $ref: '../components/parameters/architecture_name.yaml'
+    - $ref: '../components/parameters/binary_filename.yaml'
+  responses:
+    '200':
+      description: OK
+      content:
+        application/*: # Media Types like application/x-rpm, application/octet-stream
+          schema:
+            type: string
+            format: binary
+        text/xml:
+          schema:
+            type: string
+            format: binary
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '404':
+      description: Not Found.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          examples:
+            NotFound:
+              value:
+                code: not_found
+                summary: "Couldn't find Project"
+            NoSuchFile:
+              value:
+                code: 404
+                summary: no such file
+                details: 404 no such file
+  tags:
+    - Published Binaries

--- a/src/api/public/apidocs-new/paths/published_project_name_repository_name_architecture_name_binary_filename.yaml
+++ b/src/api/public/apidocs-new/paths/published_project_name_repository_name_architecture_name_binary_filename.yaml
@@ -28,6 +28,8 @@ get:
             format: binary
     '401':
       $ref: '../components/responses/unauthorized.yaml'
+    '403':
+      $ref: '../components/responses/download_binary_forbidden.yaml'
     '404':
       description: Not Found.
       content:

--- a/src/api/public/apidocs-new/paths/published_project_name_repository_name_architecture_name_binary_filename_view_ymp.yaml
+++ b/src/api/public/apidocs-new/paths/published_project_name_repository_name_architecture_name_binary_filename_view_ymp.yaml
@@ -1,0 +1,56 @@
+get:
+  summary: Generate a ymp pattern that includes the needed repositories to install the given binary.
+  description: >
+    Generate a ymp pattern, which contains the list of packages needed for intalling certain software without having to
+    create dependencies between them.
+
+    Read more about patterns [in this tutorial](https://en.opensuse.org/openSUSE:Build_Service_Tutorial#Create_Patterns).
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/project_name.yaml'
+    - $ref: '../components/parameters/repository_name.yaml'
+    - $ref: '../components/parameters/architecture_name.yaml'
+    - $ref: '../components/parameters/binary_filename.yaml'
+  responses:
+    '200':
+      description: OK.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/ymp_pattern.yaml'
+          example:
+            group:
+              repositories:
+                repository:
+                  - recommended: true
+                    name: OBS:Server:Unstable
+                    summary: Developer versions of the Open Build Service Server
+                    description: These are the developer versions of the tools for the Open Build Service project
+                    url: https://download.opensuse.org/repositories/OBS:/Server:/Unstable/openSUSE_15.2
+                  - recommended: false
+                    name: openSUSE:Leap:15.2
+                    summary: openSUSE Leap 15.2
+                    description: openSUSE Leap borrows packages from SLE for the base system
+                    url: http://download.opensuse.org/distribution/leap/15.2/repo/oss
+              software:
+                item:
+                  name: virt-v2v-debuginfo
+                  summary: Debug information for package virt-v2v
+                  description: This package provides debug information for package virt-v2v
+              distversion: openSUSEsLeap 15.2
+            xmlns:os: "http://opensuse.org/Standards/One_Click_Install"
+            xmlns: "http://opensuse.org/Standards/One_Click_Install"
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '404':
+      description: Not Found.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          example:
+            code: not_found
+            summary: "Couldn't find Project"
+  tags:
+    - Published Binaries

--- a/src/api/public/apidocs-new/paths/published_project_name_repository_name_architecture_name_binary_filename_view_ymp.yaml
+++ b/src/api/public/apidocs-new/paths/published_project_name_repository_name_architecture_name_binary_filename_view_ymp.yaml
@@ -43,6 +43,8 @@ get:
             xmlns: "http://opensuse.org/Standards/One_Click_Install"
     '401':
       $ref: '../components/responses/unauthorized.yaml'
+    '403':
+      $ref: '../components/responses/download_binary_forbidden.yaml'
     '404':
       description: Not Found.
       content:

--- a/src/api/public/apidocs-new/paths/published_project_name_repository_name_view_status.yaml
+++ b/src/api/public/apidocs-new/paths/published_project_name_repository_name_view_status.yaml
@@ -1,0 +1,58 @@
+get:
+  summary: Present information about the last publication of the pair project and repository.
+  description: >
+    Get information about the build process (build id, start time, etc.) for the pair project and repository.
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/project_name.yaml'
+    - $ref: '../components/parameters/repository_name.yaml'
+    - in: query
+      name: view
+      schema:
+        type: string
+        enum:
+          - status
+      description: Set this parameter to status in order to get details about the last publication.
+      example: status
+  responses:
+    '200':
+      description: OK. The request has succeeded.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: succeeded
+                xml:
+                  attribute: true
+              starttime:
+                type: integer
+                example: 1617574611
+              endtime:
+                type: integer
+                example: 1617574611
+              buildid:
+                type: integer
+                example: 1569496563
+            xml:
+              name: status
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '404':
+      description: Not Found.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          examples:
+            project:
+              code: not_found
+              summary: "Couldn't find Project"
+            unknown:
+              value:
+                code: unknown
+  tags:
+    - Published Binaries

--- a/src/api/public/apidocs-new/paths/published_project_name_repository_name_view_status.yaml
+++ b/src/api/public/apidocs-new/paths/published_project_name_repository_name_view_status.yaml
@@ -41,6 +41,8 @@ get:
               name: status
     '401':
       $ref: '../components/responses/unauthorized.yaml'
+    '403':
+      $ref: '../components/responses/download_binary_forbidden.yaml'
     '404':
       description: Not Found.
       content:


### PR DESCRIPTION
Document the rest of the `published/*` endpoints to:

- get the status of the building process
- download the binary
- generate a ymp pattern

Add a missing 403 error response that can happen on every `published/*` endpoint when the binary download is blocked.

 

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
