### PR TITLE
Remove version constraints for gems

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -82,7 +82,7 @@ group :development, :production do
   # to document ruby code
   gem 'rdoc'
   # to not rely on cron+rake
-  gem 'clockwork', '>= 0.7'
+  gem 'clockwork'
   # as interface to LDAP
   gem 'ruby-ldap', require: false
   # to have better logs

--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -16,7 +16,7 @@ gem 'airbrake-ruby'
 # as JSON library - the default json conflicts with activerecord (by means of vice-versa monkey patching)
 gem 'yajl-ruby', require: 'yajl/json_gem'
 # to search the database
-gem 'thinking-sphinx', '> 3.1'
+gem 'thinking-sphinx'
 # to paginate search results
 gem 'kaminari'
 # for abstract HTML

--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -23,8 +23,6 @@ gem 'kaminari'
 gem 'haml'
 # streamline HAML's integration in Rails
 gem 'haml-rails'
-# to avoid tilt downgrade
-gem 'tilt', '>= 1.4.1'
 # to use markdown in the comment system
 gem 'redcarpet'
 # for nested attribute forms

--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -121,7 +121,7 @@ group :test do
   # for mocking and stubbing
   gem 'mocha', require: false
   # for testing common Rails functionality with simple one-liners
-  gem 'shoulda-matchers', '~> 4.0'
+  gem 'shoulda-matchers'
   # assigns has been extracted to a gem
   gem 'rails-controller-testing'
   # To generate random data

--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -178,7 +178,7 @@ end
 # Gems used only for assets and not required in production environments by default.
 group :assets do
   # for minifying JavaScript
-  gem 'uglifier', '>= 1.2.2'
+  gem 'uglifier'
   # to use sass in the asset pipeline
   gem 'sassc-rails'
   # assets for jQuery DataTables

--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -1,6 +1,7 @@
 # Edit this Gemfile to bundle your application's dependencies.
 source 'https://rubygems.org'
 
+# We have a version constraint to tackle Rails updates whenever we have time
 gem 'rails', '~> 6.0'
 
 # as our database

--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -119,7 +119,7 @@ group :test do
   # to fake backend replies
   gem 'webmock'
   # for mocking and stubbing
-  gem 'mocha', '> 0.13.0', require: false
+  gem 'mocha', require: false
   # for testing common Rails functionality with simple one-liners
   gem 'shoulda-matchers', '~> 4.0'
   # assigns has been extracted to a gem

--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -143,7 +143,7 @@ group :development, :test do
   # for mocking the backend
   gem 'vcr'
   # as alternative to the standard IRB shell
-  gem 'pry', '>= 0.9.12'
+  gem 'pry'
   # add step-by-step debugging and stack navigation capabilities to pry
   gem 'pry-byebug'
   # for style checks

--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -1,5 +1,4 @@
 # Edit this Gemfile to bundle your application's dependencies.
-# This preamble is the current preamble for Rails 3 apps; edit as needed.
 source 'https://rubygems.org'
 
 gem 'rails', '~> 6.0'

--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -117,7 +117,7 @@ group :test do
   # to freeze time
   gem 'timecop'
   # to fake backend replies
-  gem 'webmock', '>= 2.3.0'
+  gem 'webmock'
   # for mocking and stubbing
   gem 'mocha', '> 0.13.0', require: false
   # for testing common Rails functionality with simple one-liners

--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -61,7 +61,7 @@ gem 'builder'
 # to write the rails metrics directly into InfluxDB.
 gem 'influxdb-rails'
 # for copying objects with their relations
-gem 'deep_cloneable', '~> 3.1.0'
+gem 'deep_cloneable'
 # Server-side datatables
 gem 'ajax-datatables-rails'
 # Add syntax highlight in ruby

--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -30,7 +30,7 @@ gem 'cocoon'
 # for activerecord lists. Used for AttribValues
 gem 'acts_as_list'
 # to parse a XML string into a ruby hash
-gem 'xmlhash', '>=1.3.6'
+gem 'xmlhash'
 # as authorization system
 gem 'pundit'
 # for password hashing

--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -9,7 +9,7 @@ gem 'mysql2'
 # for XML handling
 gem 'nokogiri'
 # for delayed tasks
-gem 'delayed_job_active_record', '>= 4.0.0'
+gem 'delayed_job_active_record'
 # to fill errbit
 gem 'airbrake'
 gem 'airbrake-ruby'

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -469,7 +469,7 @@ DEPENDENCIES
   data_migrate
   database_cleaner-active_record
   deep_cloneable (~> 3.1.0)
-  delayed_job_active_record (>= 4.0.0)
+  delayed_job_active_record
   factory_bot_rails
   faker
   flipper

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -494,7 +494,7 @@ DEPENDENCIES
   mocha
   mysql2
   nokogiri
-  pry (>= 0.9.12)
+  pry
   pry-byebug
   pry-rails
   puma

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -521,7 +521,7 @@ DEPENDENCIES
   test-unit
   thinking-sphinx
   timecop
-  uglifier (>= 1.2.2)
+  uglifier
   vcr
   voight_kampff
   webmock

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -519,7 +519,7 @@ DEPENDENCIES
   single_test
   strong_migrations
   test-unit
-  thinking-sphinx (> 3.1)
+  thinking-sphinx
   timecop
   uglifier (>= 1.2.2)
   vcr

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -524,7 +524,7 @@ DEPENDENCIES
   uglifier (>= 1.2.2)
   vcr
   voight_kampff
-  webmock (>= 2.3.0)
+  webmock
   xmlhash
   xmlrpc
   yajl-ruby

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -514,7 +514,7 @@ DEPENDENCIES
   ruby-ldap
   sassc-rails
   selenium-webdriver
-  shoulda-matchers (~> 4.0)
+  shoulda-matchers
   simplecov
   single_test
   strong_migrations

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -520,7 +520,6 @@ DEPENDENCIES
   strong_migrations
   test-unit
   thinking-sphinx (> 3.1)
-  tilt (>= 1.4.1)
   timecop
   uglifier (>= 1.2.2)
   vcr

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -525,7 +525,7 @@ DEPENDENCIES
   vcr
   voight_kampff
   webmock (>= 2.3.0)
-  xmlhash (>= 1.3.6)
+  xmlhash
   xmlrpc
   yajl-ruby
 

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -468,7 +468,7 @@ DEPENDENCIES
   dalli
   data_migrate
   database_cleaner-active_record
-  deep_cloneable (~> 3.1.0)
+  deep_cloneable
   delayed_job_active_record
   factory_bot_rails
   faker

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -459,7 +459,7 @@ DEPENDENCIES
   bunny-mock
   capybara
   capybara_minitest_spec
-  clockwork (>= 0.7)
+  clockwork
   cocoon
   codecov
   coderay

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -491,7 +491,7 @@ DEPENDENCIES
   minitest-ci
   minitest-fail-fast
   minitest-reporters
-  mocha (> 0.13.0)
+  mocha
   mysql2
   nokogiri
   pry (>= 0.9.12)


### PR DESCRIPTION
See commit descriptions for details about each gem.

The only gem (beside rails) with a version constraint is jquery-ui-rails. I would like to get rid of the gem if possible, but if I manage to do this, I'll do it in another PR. Updating the gem also involves changes to the code.