### PR TITLE
Remove duplication of what pass_to_backend does

### DIFF
--- a/src/api/app/controllers/application_controller.rb
+++ b/src/api/app/controllers/application_controller.rb
@@ -156,10 +156,10 @@ class ApplicationController < ActionController::Base
     path + query_string
   end
 
-  def pass_to_backend(path = nil)
+  def pass_to_backend(path = nil, force_get: false)
     path ||= get_request_path
 
-    if request.get? || request.head?
+    if request.get? || request.head? || force_get
       volley_backend_path(path) unless forward_from_backend(path)
       return
     end

--- a/src/api/app/controllers/public_controller.rb
+++ b/src/api/app/controllers/public_controller.rb
@@ -104,7 +104,7 @@ class PublicController < ApplicationController
     path = "/source/#{CGI.escape(params[:project])}/#{CGI.escape(params[:package])}/#{CGI.escape(file)}"
 
     path += build_query_from_hash(params, [:rev, :limit])
-    volley_backend_path(path) unless forward_from_backend(path)
+    pass_to_backend(path)
   end
 
   # GET /public/distributions

--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -395,8 +395,8 @@ class SourceController < ApplicationController
   def lastevents
     path = get_request_path
 
-    # map to a GET, so we can X-forward it
-    volley_backend_path(path) unless forward_from_backend(path)
+    # force to a GET, so we can X-forward it
+    pass_to_backend(path, force_get: true)
   end
 
   # POST /source?cmd=createmaintenanceincident

--- a/src/api/app/controllers/source_project_config_controller.rb
+++ b/src/api/app/controllers/source_project_config_controller.rb
@@ -7,15 +7,7 @@ class SourceProjectConfigController < SourceController
 
     sliced_params = slice_and_permit(params, [:rev])
 
-    return if forward_from_backend(config.full_path(sliced_params))
-
-    content = config.content(sliced_params)
-
-    unless content
-      render_404(config.errors.full_messages.to_sentence)
-      return
-    end
-    send_config(content, config.response[:type])
+    pass_to_backend(config.full_path(sliced_params))
   end
 
   # PUT /source/:project/_config


### PR DESCRIPTION
Handing proxying to the webserver or sending the file is
exactly what pass_to_backend does. No need to re-do this in
controller code.

Preparation for #10990 

