### PR TITLE
Simplify how webui routes are defined for groups

### DIFF
--- a/src/api/app/controllers/webui/groups/bs_requests_controller.rb
+++ b/src/api/app/controllers/webui/groups/bs_requests_controller.rb
@@ -13,7 +13,7 @@ module Webui
       private
 
       def set_group
-        @user_or_group = Group.find_by_title!(params[:title])
+        @user_or_group = Group.find_by_title!(params[:group_title])
       end
 
       def request_method

--- a/src/api/app/controllers/webui/groups/users_controller.rb
+++ b/src/api/app/controllers/webui/groups/users_controller.rb
@@ -11,7 +11,7 @@ module Webui
         user = User.find_by(login: params[:user_login])
         if user.nil?
           flash[:error] = "User '#{params[:user_login]}' not found"
-          redirect_to group_show_path(@group)
+          redirect_to group_path(@group)
           return
         end
 
@@ -22,7 +22,7 @@ module Webui
           flash[:error] = "Couldn't add user '#{user}' to group '#{@group}': #{group_user.errors.full_messages.to_sentence}"
         end
 
-        redirect_to group_show_path(@group)
+        redirect_to group_path(@group)
       end
 
       def destroy
@@ -34,7 +34,7 @@ module Webui
           flash[:error] = "Couldn't remove user '#{@user}' from group '#{@group}'"
         end
 
-        redirect_to group_show_path(@group)
+        redirect_to group_path(@group)
       end
 
       def update

--- a/src/api/app/helpers/webui/group_helper.rb
+++ b/src/api/app/helpers/webui/group_helper.rb
@@ -1,6 +1,6 @@
 module Webui::GroupHelper
   def group_with_icon(group_title)
     group = Group.find_by(title: group_title)
-    image_tag_for(group, size: 20) + ' ' + link_to(group_title, group_show_path(group))
+    image_tag_for(group, size: 20) + ' ' + link_to(group_title, group_path(group))
   end
 end

--- a/src/api/app/helpers/webui/user_or_groups_roles_helper.rb
+++ b/src/api/app/helpers/webui/user_or_groups_roles_helper.rb
@@ -11,8 +11,8 @@ module Webui::UserOrGroupsRolesHelper
     end
   end
 
-  def user_or_group_show_path(object)
-    object.is_a?(User) ? user_path(object) : group_show_path(object)
+  def user_or_group_path(object)
+    object.is_a?(User) ? user_path(object) : group_path(object)
   end
 
   def user_or_groups_roles_delete_path(project, type, object, package)

--- a/src/api/app/views/webui/groups/index.html.haml
+++ b/src/api/app/views/webui/groups/index.html.haml
@@ -14,12 +14,12 @@
         - @groups.each do |group|
           %tr
             %td
-              = link_to(group, group_show_path(title: group))
+              = link_to(group, group_path(title: group))
             %td
               = safe_join(group.users.map { |user| link_to(truncate(user.login, length: 20), user_path(user), title: user.login) }, ', ')
 
     .pt-4
-      = link_to(group_new_path, title: 'Create Group') do
+      = link_to(new_group_path, title: 'Create Group') do
         %i.fas.fa-plus-circle.text-primary
         Create Group
 

--- a/src/api/app/views/webui/groups/new.html.haml
+++ b/src/api/app/views/webui/groups/new.html.haml
@@ -4,7 +4,7 @@
   .card-body
     %h3= @pagetitle
     .col-lg-6.pl-0
-      = form_for(Group.new, url: group_create_path, method: :post) do |form|
+      = form_for(Group.new, url: groups_path, method: :post) do |form|
         .form-group
           = form.label(:title)
           %abbr.text-danger{ title: 'required' } *

--- a/src/api/app/views/webui/search/_results_owner.html.haml
+++ b/src/api/app/views/webui/search/_results_owner.html.haml
@@ -22,7 +22,7 @@
                 .card.m-1.p-2.search-result
                   .row.no-gutters
                     .col-auto
-                      = link_to(user_or_group_show_path(record)) do
+                      = link_to(user_or_group_path(record)) do
                         = image_tag_for(record, size: 60, custom_class: 'align-self-center shadow-lg border border-secondary rounded border-2')
                     .col
                       .card-body.p-0.pl-2

--- a/src/api/app/views/webui/shared/user_or_groups_roles/_list.html.haml
+++ b/src/api/app/views/webui/shared/user_or_groups_roles/_list.html.haml
@@ -6,7 +6,7 @@
   %tr
     %td.align-middle
       = image_tag_for(record, size: 20)
-      = link_to(display_name(record), user_or_group_show_path(record))
+      = link_to(display_name(record), user_or_group_path(record))
     - roles.each do |role|
       %td.align-middle
         .custom-control.custom-checkbox

--- a/src/api/app/views/webui/staging/workflows/_infos.html.haml
+++ b/src/api/app/views/webui/staging/workflows/_infos.html.haml
@@ -5,12 +5,12 @@
       %dt Managers:
       %dd
         %ul.pl-2.list-unstyled
-          %li= link_to managers.title, group_show_path(managers)
+          %li= link_to managers.title, group_path(managers)
 
       %dt Empty projects:
       %dd= render 'empty_projects_list', projects: empty_projects, staging_workflow: staging_workflow
 
-      %dt= link_to('Backlog:', group_show_path(staging_workflow.managers_group, anchor: 'reviews-in'))
+      %dt= link_to('Backlog:', group_path(staging_workflow.managers_group, anchor: 'reviews-in'))
       %dd= render 'requests_list', requests: unassigned_requests, more_requests: more_unassigned_requests
 
       %dt= link_to('Ready:', project_requests_path(staging_workflow.project, state: :new))

--- a/src/api/app/views/webui/user/_info.html.haml
+++ b/src/api/app/views/webui/user/_info.html.haml
@@ -23,7 +23,7 @@
         %ul
           - groups.each do |group|
             %li
-              = link_to(group_show_path(group)) do
+              = link_to(group_path(group)) do
                 #{group.title}
                 %span.badge.badge-primary.align-baseline
                   #{group.tasks} #{'task'.pluralize(group.tasks)}

--- a/src/api/app/views/webui/user/user_profile_redesign/_info.html.haml
+++ b/src/api/app/views/webui/user/user_profile_redesign/_info.html.haml
@@ -18,7 +18,7 @@
       %ul.list-group.list-group-flush
         - groups.each do |group|
           %li.list-group-item.d-flex.justify-content-between.align-items-center.p-2
-            = link_to(group.title, group_show_path(group))
+            = link_to(group.title, group_path(group))
             %span.badge.badge-primary
               #{group.tasks} #{'task'.pluralize(group.tasks)}
 

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -346,20 +346,13 @@ OBSApi::Application.routes.draw do
 
     resource :session, only: [:new, :create, :destroy], controller: 'webui/session'
 
-    controller 'webui/groups/bs_requests' do
-      get 'groups/(:title)/requests' => :index, constraints: { title: %r{[^/]*} }, as: 'group_requests'
-    end
+    resources :groups, only: [:index, :show, :new, :create], param: :title, constraints: cons, controller: 'webui/groups' do
+      resources :user, only: [:create, :destroy, :update], param: :user_login, constraints: cons, controller: 'webui/groups/users'
+      resources :requests, only: [:index], controller: 'webui/groups/bs_requests'
 
-    controller 'webui/groups' do
-      get 'groups' => :index
-      get 'group/show/:title' => :show, constraints: { title: %r{[^/]*} }, as: 'group_show'
-      get 'group/new' => :new
-      post 'group/create' => :create
-      get 'group/autocomplete' => :autocomplete, as: 'autocomplete_groups'
-    end
-
-    resources :groups, only: [], param: :title, constraints: cons do
-      resources :user, only: [:create, :destroy, :update], constraints: cons, param: :user_login, controller: 'webui/groups/users'
+      collection do
+        get :autocomplete
+      end
     end
 
     resources :comments, constraints: cons, only: [:create, :destroy, :update], controller: 'webui/comments' do

--- a/src/api/spec/controllers/webui/groups/bs_requests_controller_spec.rb
+++ b/src/api/spec/controllers/webui/groups/bs_requests_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Webui::Groups::BsRequestsController do
     let(:group) { create(:group) }
     let!(:relationship_project_group) { create(:relationship_project_group, group: group, project: target_project) }
     let!(:relationship_project_group2) { create(:relationship_project_group, group: group, project: target_project2) }
-    let(:base_params) { { title: group.title, format: :json, dataTableId: 'requests_in_table' } }
+    let(:base_params) { { group_title: group.title, format: :json, dataTableId: 'requests_in_table' } }
     let(:context_params) { {} }
     let(:params) { base_params.merge(context_params) }
 

--- a/src/api/spec/controllers/webui/groups/users_controller_spec.rb
+++ b/src/api/spec/controllers/webui/groups/users_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Webui::Groups::UsersController do
       end
 
       it 'adds the user to the group' do
-        expect(response).to redirect_to(group_show_path(title: group.title))
+        expect(response).to redirect_to(group_path(title: group.title))
         expect(flash[:success]).to eq("Added user '#{user}' to group '#{group}'")
         expect(group.users.where(groups_users: { user_id: user })).to exist
       end
@@ -76,7 +76,7 @@ RSpec.describe Webui::Groups::UsersController do
       end
 
       it 'removes the user from the group' do
-        expect(response).to redirect_to(group_show_path(title: group.title))
+        expect(response).to redirect_to(group_path(title: group.title))
         expect(flash[:success]).to eq("Removed user '#{user}' from group '#{group}'")
         expect(group.users.where(groups_users: { user_id: user })).not_to exist
       end

--- a/src/api/spec/features/webui/groups_spec.rb
+++ b/src/api/spec/features/webui/groups_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Groups', type: :feature, js: true do
   end
 
   def group_in_datatable(page, group)
-    expect(page).to have_link(group.title, href: group_show_path(group))
+    expect(page).to have_link(group.title, href: group_path(group))
     group.users.each { |user| expect(page).to have_link(user.login, href: user_path(user)) }
   end
 
@@ -26,7 +26,7 @@ RSpec.describe 'Groups', type: :feature, js: true do
   end
 
   it 'visit group show page' do
-    visit group_show_path(group_1)
+    visit group_path(group_1)
 
     # TODO: Remove this line if the dropdown is changed to a scrollable tab
     find('.nav-link.dropdown-toggle').click if mobile?
@@ -55,7 +55,7 @@ RSpec.describe 'Groups', type: :feature, js: true do
   end
 
   it 'remove a member from a group' do
-    visit group_show_path(group_1)
+    visit group_path(group_1)
 
     within(find('div.group-user', text: admin.login)) do
       click_link('Remove member from group')
@@ -67,7 +67,7 @@ RSpec.describe 'Groups', type: :feature, js: true do
   end
 
   it 'give maintainer rights to a group member' do
-    visit group_show_path(group_1)
+    visit group_path(group_1)
 
     within(find('div.group-user', text: admin.login)) do
       check('Maintainer')
@@ -77,7 +77,7 @@ RSpec.describe 'Groups', type: :feature, js: true do
   end
 
   it 'add a group member' do
-    visit group_show_path(group_2)
+    visit group_path(group_2)
 
     click_link('Add Member')
 


### PR DESCRIPTION
They are now all defined with resources and grouped together. Some route helpers slightly changed and were replaced with the following GNU sed commands:
```shell
  sed -i -e 's/group_show_path/group_path/g' src/api/**/*{.rb,.haml}
  sed -i -e 's/group_new_path/new_group_path/g' src/api/**/*{.rb,.haml}
  sed -i -e 's/group_create_path/groups_path/g' src/api/**/*{.rb,.haml}
```

I didn't find any `_url` version of the route helpers for those routes, so nothing had to change for this. 