### PR TITLE
 Do case insensitive comparison on string parameter

### DIFF
--- a/src/api/app/controllers/person_controller.rb
+++ b/src/api/app/controllers/person_controller.rb
@@ -118,7 +118,7 @@ class PersonController < ApplicationController
       # only admin is allowed to change these, ignore for others
       user.state = xml.value('state')
       update_globalroles(user, xml)
-      user.update(ignore_auth_services: xml.value('ignore_auth_services').to_s == 'true')
+      user.update(ignore_auth_services: xml.value('ignore_auth_services').to_s.casecmp?('true'))
 
       if xml['owner']
         user.state = :subaccount

--- a/src/api/app/controllers/webui/architectures_controller.rb
+++ b/src/api/app/controllers/webui/architectures_controller.rb
@@ -9,7 +9,7 @@ class Webui::ArchitecturesController < Webui::WebuiController
   def update
     architecture = Architecture.find(params[:id])
 
-    if architecture.update(available: params[:available] == 'true')
+    if architecture.update(available: params[:available].to_s.casecmp?('true'))
       flash.now[:success] = "Updated architecture '#{architecture.name}'"
       ::Configuration.write_to_backend
       status = :ok

--- a/src/api/app/controllers/webui/groups/users_controller.rb
+++ b/src/api/app/controllers/webui/groups/users_controller.rb
@@ -42,7 +42,7 @@ module Webui
 
         # In the UI we have multiple "maintainer" checkboxes. They need to have different ids and names
         # to avoid conflicting html ids.
-        if params['maintainer'] == 'true'
+        if params['maintainer'].to_s.casecmp?('true')
           # FIXME: This should be an attribute of GroupsUser
           group_maintainer = GroupMaintainer.create(user: @user, group: @group)
           if group_maintainer.valid?

--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -538,7 +538,7 @@ class Webui::PackageController < Webui::WebuiController
 
   def buildresult
     if @project.repositories.any?
-      show_all = params[:show_all] == 'true'
+      show_all = params[:show_all].to_s.casecmp?('true')
       @index = params[:index]
       @buildresults = @package.buildresult(@project, show_all)
       render partial: 'buildstatus', locals: { buildresults: @buildresults,

--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -387,7 +387,7 @@ class Webui::ProjectController < Webui::WebuiController
   private
 
   def show_all?
-    (params[:all].to_s == 'true')
+    params[:all].to_s.casecmp?('true')
   end
 
   def project_for_datatable


### PR DESCRIPTION

Do case insensitive string comparison as suggested by rubocop.

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
