### PR TITLE
Fix broken checkboxes for architectures

### DIFF
--- a/src/api/app/views/webui/architectures/index.html.haml
+++ b/src/api/app/views/webui/architectures/index.html.haml
@@ -18,6 +18,7 @@
       - @architectures.each do |arch|
         .custom-control.custom-checkbox.custom-control-inline
           = check_box_tag('available', true, arch.available, class: 'custom-control-input', id: "arch-#{arch}",
+            onchange: "this.setAttribute('data-params', this.name + '=' + this.checked)",
             data: { remote: true, url: architecture_path(arch), method: :patch })
           %label.custom-control-label.pr-2{ for: "arch-#{arch}" }
             = arch.name


### PR DESCRIPTION
Without this change, it isn't possible to enable a single architecture since the `available` param was never sent.

**Edit:**

To reproduce the bug log in as Admin, go to _Configuration > Architectures_, try to add a new architecture (check), refresh the page, and then you'll see it appears unchecked again.

With this fix, the added architecture keeps checked.