### PR TITLE
Fix exception class handling for release token model

### DIFF
--- a/src/api/app/controllers/trigger/errors.rb
+++ b/src/api/app/controllers/trigger/errors.rb
@@ -6,7 +6,4 @@ module Trigger::Errors
           403,
           'No valid token found'
   end
-
-  class NoPermissionForPackage < APIError
-  end
 end

--- a/src/api/app/models/token.rb
+++ b/src/api/app/models/token.rb
@@ -8,6 +8,8 @@ class Token < ApplicationRecord
 
   validates :user, presence: true
 
+  include Token::Errors
+
   def token_name
     self.class.token_name
   end

--- a/src/api/app/models/token/errors.rb
+++ b/src/api/app/models/token/errors.rb
@@ -1,0 +1,7 @@
+module Token::Errors
+  extend ActiveSupport::Concern
+
+  class NoReleaseTargetFound < APIError
+    setup 404
+  end
+end

--- a/src/api/app/models/token/release.rb
+++ b/src/api/app/models/token/release.rb
@@ -8,10 +8,7 @@ class Token::Release < Token
 
   def call(_options)
     manual_release_targets = package_from_association_or_params.project.release_targets.where(trigger: 'manual')
-    unless manual_release_targets.any?
-      raise NoPermissionForPackage.setup('not_found', 404,
-                                         "#{package_from_association_or_params.project} has no release targets that are triggered manually")
-    end
+    raise NoReleaseTargetFound, "#{package_from_association_or_params.project} has no release targets that are triggered manually" unless manual_release_targets.any?
 
     manual_release_targets.each do |release_target|
       release_package(package_from_association_or_params,


### PR DESCRIPTION
The location of the exception class definition
was wrong and therefore an uninitialized constant error
was thrown by the release token model.

The naming of the exception class did not quite fit
as well.