### PR TITLE
Fix TokenExtractor and write specs

### DIFF
--- a/src/api/spec/controllers/trigger_controller_spec.rb
+++ b/src/api/spec/controllers/trigger_controller_spec.rb
@@ -208,8 +208,8 @@ RSpec.describe TriggerController, vcr: true do
       it_behaves_like 'it verifies the signature'
     end
 
-    context 'with HTTP_X_HUB_SIGNATURE http header' do
-      let(:signature_header_name) { 'HTTP_X_HUB_SIGNATURE' }
+    context 'with HTTP_X_HUB_SIGNATURE_256 http header' do
+      let(:signature_header_name) { 'HTTP_X_HUB_SIGNATURE_256' }
 
       it_behaves_like 'it verifies the signature'
     end

--- a/src/api/spec/factories/tokens.rb
+++ b/src/api/spec/factories/tokens.rb
@@ -1,14 +1,15 @@
 FactoryBot.define do
   factory :token do
     string { Faker::Lorem.characters(number: 32) }
+    user
+    package
+
+    trait :with_package_from_association_or_param do
+      package_from_association_or_params { package }
+    end
 
     factory :service_token, class: 'Token::Service' do
       type { 'Token::Service' }
-      user
-      package
-      trait :with_package_from_association_or_param do
-        package_from_association_or_params { package }
-      end
     end
 
     factory :rss_token, class: 'Token::Rss' do
@@ -17,20 +18,10 @@ FactoryBot.define do
 
     factory :rebuild_token, class: 'Token::Rebuild' do
       type { 'Token::Rebuild' }
-      user
-      package
-      trait :with_package_from_association_or_param do
-        package_from_association_or_params { package }
-      end
     end
 
     factory :release_token, class: 'Token::Release' do
       type { 'Token::Release' }
-      user
-      package
-      trait :with_package_from_association_or_param do
-        package_from_association_or_params { package }
-      end
     end
   end
 end

--- a/src/api/spec/services/trigger_controller_service/token_extractor_spec.rb
+++ b/src/api/spec/services/trigger_controller_service/token_extractor_spec.rb
@@ -1,29 +1,94 @@
 require 'rails_helper'
-require 'ostruct'
+require 'ostruct' # for OpenStruct
+require 'stringio' # for StringIO
 
 RSpec.describe ::TriggerControllerService::TokenExtractor do
-  let(:request) { OpenStruct.new(env: { 'HTTP_X_GITLAB_EVENT' => 'Push Hook', 'HTTP_X_GITLAB_TOKEN' => 'XY123456' }) }
-  let(:token_extractor) { described_class.new(request) }
+  describe '#call' do
+    subject { described_class.new(request).call }
 
-  describe '.new' do
-    it { expect { token_extractor }.not_to raise_error }
-  end
+    let(:token) { create(:service_token) }
+    let(:request_body) { 'Lorem Ipsum' }
 
-  describe '#extract_auth_token' do
-    it { expect(token_extractor.extract_auth_token).to eq('Token XY123456') }
+    context 'without a token ID in the params and a token in HTTP headers' do
+      let(:request) { OpenStruct.new(params: {}, body: StringIO.new(request_body), env: {}) }
 
-    context 'with HTTP_AUTHORIZATION' do
-      let(:request) { OpenStruct.new(env: { 'HTTP_AUTHORIZATION' => 'FOO1234' }) }
-
-      it { expect(token_extractor.extract_auth_token).to eq('FOO1234') }
-    end
-  end
-
-  describe '#valid?' do
-    before do
-      token_extractor.extract_auth_token
+      it 'returns nil' do
+        expect(subject).to be_nil
+      end
     end
 
-    it { expect(token_extractor).to be_valid }
+    context 'with the ID of a nonexistent token in the params' do
+      let(:request) { OpenStruct.new(params: { id: -1 }, body: StringIO.new(request_body)) }
+
+      it 'returns nil' do
+        expect(subject).to be_nil
+      end
+    end
+
+    context 'with the ID of a token in the params and a valid signature in the HTTP headers' do
+      let(:request) { OpenStruct.new(params: { id: token.id }, body: StringIO.new(request_body), env: {}) }
+
+      it 'returns nil' do
+        expect(subject).to be_nil
+      end
+    end
+
+    ['HTTP_X_OBS_SIGNATURE', 'HTTP_X_HUB_SIGNATURE_256', 'HTTP_X-Pagure-Signature-256'].each do |http_header|
+      context "with the ID of a token in the params and the HTTP header #{http_header} containing a signature of the request body" do
+        let(:signature) { OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha256'), token.string, request_body) }
+        let(:request) do
+          OpenStruct.new(params: { id: token.id }, body: StringIO.new(request_body),
+                         env: { http_header => "sha256=#{signature}" })
+        end
+
+        it 'returns the token' do
+          expect(subject).to eq(token)
+        end
+      end
+    end
+
+    context 'with a wrong token in the HTTP header HTTP_X_GITLAB_TOKEN' do
+      let(:request) do
+        OpenStruct.new(params: {}, body: StringIO.new(request_body),
+                       env: { 'HTTP_X_GITLAB_TOKEN' => 'Québec' })
+      end
+
+      it 'returns nil' do
+        expect(subject).to be_nil
+      end
+    end
+
+    context 'with a token in the HTTP header HTTP_X_GITLAB_TOKEN' do
+      let(:request) do
+        OpenStruct.new(params: {}, body: StringIO.new(request_body),
+                       env: { 'HTTP_X_GITLAB_TOKEN' => token.string })
+      end
+
+      it 'returns the token' do
+        expect(subject).to eq(token)
+      end
+    end
+
+    context 'with an incorrectly formatted HTTP header HTTP_AUTHORIZATION' do
+      let(:request) do
+        OpenStruct.new(params: {}, body: StringIO.new(request_body),
+                       env: { 'HTTP_AUTHORIZATION' => token.string })
+      end
+
+      it 'raises ActiveRecord::RecordNotFound' do
+        expect { subject }.to raise_error(ActiveRecord::RecordNotFound, "Couldn't find Token")
+      end
+    end
+
+    context 'with a token in the HTTP header HTTP_AUTHORIZATION' do
+      let(:request) do
+        OpenStruct.new(params: {}, body: StringIO.new(request_body),
+                       env: { 'HTTP_AUTHORIZATION' => "Basic #{token.string}" })
+      end
+
+      it 'returns the token' do
+        expect(subject).to eq(token)
+      end
+    end
   end
 end


### PR DESCRIPTION
Some specs are still failing, but they are related to the trigger controller and Token models.