### PR TITLE
Return true in release token model

### DIFF
--- a/src/api/app/models/token/release.rb
+++ b/src/api/app/models/token/release.rb
@@ -21,6 +21,7 @@ class Token::Release < Token
                         manual: true,
                         comment: 'Releasing via trigger event' })
     end
+    true
   end
 
   def package_find_options


### PR DESCRIPTION
Currently the call method in the Token::Release model
returns the ReleaseTarget objects. Since we don't do
anything with the returned objects we can simply return
a boolean value instead.
