### PR TITLE
Add uniqueness validation for token string

### DIFF
--- a/src/api/app/models/token.rb
+++ b/src/api/app/models/token.rb
@@ -7,6 +7,7 @@ class Token < ApplicationRecord
   has_secure_token :string
 
   validates :user, presence: true
+  validates :string, uniqueness: { case_sensitive: false }
 
   include Token::Errors
 


### PR DESCRIPTION
On the database level we already ensure the uniqueness
of the token string through an uniq index. In order to
properly test this in the model specs and to have better
exception handling, the validation should also be present
in the token model.