### PR TITLE
Fix Minitest tests related to trigger_controller

### DIFF
--- a/src/api/app/controllers/trigger_controller.rb
+++ b/src/api/app/controllers/trigger_controller.rb
@@ -15,7 +15,7 @@ class TriggerController < ApplicationController
   def create
     authorize @token
     @token.user.run_as do
-      @token.call(params.slice(:repository, :arch))
+      @token.call(params.slice(:repository, :arch).permit!)
       render_ok
     end
   end

--- a/src/api/test/functional/source_services_test.rb
+++ b/src/api/test/functional/source_services_test.rb
@@ -597,12 +597,12 @@ class SourceServicesTest < ActionDispatch::IntegrationTest
     post '/trigger/runservice', headers: { 'Authorization' => "Token #{token}" }
     # success, but no source service configured :)
     assert_response 403
-    assert_xml_tag tag: 'status', attributes: { code: 'no_permission_for_inactive' }
+    assert_xml_tag tag: 'status', attributes: { code: 'create_token/service_not_authorized' }
     # with global token
     post '/trigger/runservice?project=home:tom&package=service', headers: { 'Authorization' => "Token #{alltoken}" }
     # success, but no source service configured :)
     assert_response 403
-    assert_xml_tag tag: 'status', attributes: { code: 'no_permission_for_inactive' }
+    assert_xml_tag tag: 'status', attributes: { code: 'create_token/service_not_authorized' }
 
     # reset and drop stuff as tom
     tom.state = 'confirmed'


### PR DESCRIPTION
Fixes:
1. Instead of raising the error NoPermissionForActive when authorization isn't passing, we're doing it with Pundit now. This explains why the tests had to be changed.

2. `ActionController::UnfilteredParameters: unable to convert unpermitted parameters to hash` was happening since we didn't run permit on the params.