### PR TITLE
Add a remote boolean for Distribution

### DIFF
--- a/src/api/app/models/distribution.rb
+++ b/src/api/app/models/distribution.rb
@@ -76,6 +76,7 @@ end
 #  link       :string(255)
 #  name       :string(255)      not null
 #  project    :string(255)      not null
+#  remote     :boolean          default(FALSE)
 #  reponame   :string(255)      not null
 #  repository :string(255)      not null
 #  vendor     :string(255)      not null

--- a/src/api/db/data/20210520160000_set_default_for_distro_remote.rb
+++ b/src/api/db/data/20210520160000_set_default_for_distro_remote.rb
@@ -1,0 +1,14 @@
+class SetDefaultForDistroRemote < ActiveRecord::Migration[6.0]
+  def up
+    Distribution.unscoped.in_batches do |relation|
+      # rubocop:disable Rails/SkipsModelValidations
+      relation.update_all(remote: false)
+      # rubocop:enable Rails/SkipsModelValidations
+      sleep(0.01)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/src/api/db/data_schema.rb
+++ b/src/api/db/data_schema.rb
@@ -1,2 +1,2 @@
 # encoding: UTF-8
-DataMigrate::Data.define(version: 20210505160000)
+DataMigrate::Data.define(version: 20210520160000)

--- a/src/api/db/migrate/20210520150000_add_remote_to_distribution.rb
+++ b/src/api/db/migrate/20210520150000_add_remote_to_distribution.rb
@@ -1,0 +1,10 @@
+class AddRemoteToDistribution < ActiveRecord::Migration[6.0]
+  def up
+    add_column :distributions, :remote, :boolean
+    change_column_default :distributions, :remote, false
+  end
+
+  def down
+    remove_column :distributions, :remote
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_11_201658) do
+ActiveRecord::Schema.define(version: 2021_05_20_150000) do
 
   create_table "architectures", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false, collation: "utf8_general_ci"
@@ -381,6 +381,7 @@ ActiveRecord::Schema.define(version: 2021_05_11_201658) do
     t.string "reponame", null: false, collation: "utf8_unicode_ci"
     t.string "repository", null: false, collation: "utf8_unicode_ci"
     t.string "link", collation: "utf8_unicode_ci"
+    t.boolean "remote", default: false
   end
 
   create_table "download_repositories", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|


### PR DESCRIPTION
In preparation to move remote Distributions from memcache to a database cache so we can use ActiveRecord for them.

We should not merge this together with the rest of the refactoring (coming later).