### PR TITLE
[api] fix remote and multibuild cases in trigger handling

### DIFF
--- a/src/api/app/controllers/trigger_controller.rb
+++ b/src/api/app/controllers/trigger_controller.rb
@@ -40,6 +40,7 @@ class TriggerController < ApplicationController
     if @token.package
       @token.project_from_association_or_params = @token.package.project
       @token.package_from_association_or_params = @token.package
+      @token.package_name = @token.package.name
     elsif params[:project] && params[:package]
       # If params[:project] is a Project that has a project link, then Package.get_by_project_and_name
       # might get a Package from another Project if the @token.package_find_options allows following
@@ -48,8 +49,8 @@ class TriggerController < ApplicationController
       @token.package_from_association_or_params = Package.get_by_project_and_name(params[:project],
                                                                                   params[:package],
                                                                                   @token.package_find_options)
+      # we need to store the package name for remote and for multibuild case
+      @token.package_name = params[:package]
     end
-    # This can happen due to the Package.get_by_project_and_name method
-    raise ActiveRecord::RecordNotFound if @token.package_from_association_or_params.nil?
   end
 end

--- a/src/api/app/models/token.rb
+++ b/src/api/app/models/token.rb
@@ -2,7 +2,7 @@ class Token < ApplicationRecord
   belongs_to :user
   belongs_to :package, inverse_of: :tokens
 
-  attr_accessor :package_from_association_or_params, :project_from_association_or_params
+  attr_accessor :package_from_association_or_params, :project_from_association_or_params, :package_name
 
   has_secure_token :string
 

--- a/src/api/app/models/token/rebuild.rb
+++ b/src/api/app/models/token/rebuild.rb
@@ -6,7 +6,7 @@ class Token::Rebuild < Token
   def call(options)
     # FIXME: Use the Package#rebuild? instead of calling the Backend directly
     Backend::Api::Sources::Package.rebuild(project_from_association_or_params.name,
-                                           package_from_association_or_params.name,
+                                           package_name,
                                            options)
   end
 

--- a/src/api/app/models/token/service.rb
+++ b/src/api/app/models/token/service.rb
@@ -4,6 +4,8 @@ class Token::Service < Token
   end
 
   def call(_options)
+    # we can not work on remote sources
+    raise ActiveRecord::RecordNotFound if package_from_association_or_params.nil?
     Backend::Api::Sources::Package.trigger_services(package_from_association_or_params.project.name,
                                                     package_from_association_or_params.name,
                                                     user.login)

--- a/src/api/app/policies/token/rebuild_policy.rb
+++ b/src/api/app/policies/token/rebuild_policy.rb
@@ -7,7 +7,7 @@ class Token
     def create?
       return false unless record.user.is_active?
 
-      if record.package_from_association_or_params.project == record.project_from_association_or_params
+      if record.package_from_association_or_params.try(:project) == record.project_from_association_or_params
         PackagePolicy.new(record.user, record.package_from_association_or_params).update?
       else
         # We authorize a package that comes via a project link


### PR DESCRIPTION
Not yet tested, but better crashing then corrupting builds

rebuild/release used wrong package in multibuild case and crashed
in remote case before.

_Replace this line with a description of your changes. Please follow the suggestions in the comment below._

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
