### PR TITLE
Download and parse workflows from SCM

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -83,6 +83,8 @@ gem 'strong_migrations'
 # for some rails console fancy
 gem 'pry-rails'
 gem 'awesome_print'
+# flexible and safe downloading of remote files
+gem 'down'
 
 group :development, :production do
   # to have the delayed job daemon

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -144,6 +144,8 @@ GEM
       delayed_job (>= 3.0, < 5)
     diff-lcs (1.4.4)
     docile (1.3.5)
+    down (5.2.1)
+      addressable (~> 2.5)
     erubi (1.10.0)
     erubis (2.7.0)
     execjs (2.7.0)
@@ -474,6 +476,7 @@ DEPENDENCIES
   database_cleaner-active_record
   deep_cloneable
   delayed_job_active_record
+  down
   factory_bot_rails
   faker
   flipper

--- a/src/api/app/models/workflow.rb
+++ b/src/api/app/models/workflow.rb
@@ -1,0 +1,28 @@
+class Workflow
+  include ActiveModel::Model
+
+  SUPPORTED_EVENTS = %w[pull_request].freeze
+  SUPPORTED_STEPS = { 'branch_package' => Workflow::Step::BranchPackageStep }.freeze
+
+  validates :event, inclusion: { in: SUPPORTED_EVENTS, allow_nil: false }
+
+  def initialize(workflow:, pr_number:)
+    @workflow = workflow
+    @pr_number = pr_number
+  end
+
+  def event
+    @workflow['filters']['event']
+  end
+
+  def steps
+    steps = []
+
+    @workflow['steps'].each do |step|
+      step.each do |step_name, step_instructions|
+        steps << SUPPORTED_STEPS[step_name].new(step_instructions: step_instructions, pr_number: @pr_number)
+      end
+    end
+    steps
+  end
+end

--- a/src/api/app/models/workflow/step/branch_package_step.rb
+++ b/src/api/app/models/workflow/step/branch_package_step.rb
@@ -1,0 +1,67 @@
+class Workflow
+  module Step
+    class BranchPackageStep
+      include ActiveModel::Model
+
+      attr_reader :errors
+
+      validates :source_project, :source_package, presence: true
+
+      def initialize(step_instructions:, pr_number:)
+        @step_instructions = step_instructions
+        @pr_number = pr_number
+        @errors = []
+      end
+
+      def call
+        branch
+      end
+
+      private
+
+      def source_project
+        @step_instructions['source_project']
+      end
+
+      def source_package
+        @step_instructions['source_package']
+      end
+
+      def destination_package
+        return @step_instructions['destination_package'] if @step_instructions['destination_package'].present?
+
+        source_package
+      end
+
+      def destination_project
+        source_project + ":PR-#{@pr_number}"
+      end
+
+      def branch
+        unless Project.find_remote_project(source_project)
+          options = { use_source: false, follow_project_links: true, follow_multibuild: true }
+
+          src_package = Package.get_by_project_and_name(source_project, source_package, options)
+
+          raise Pundit::NotAuthorizedError unless PackagePolicy.new(User.session, src_package).create_branch?
+        end
+
+        branch_params = { project: source_project, package: source_package,
+                          target_project: destination_project, target_package: destination_package }
+        BranchPackage.new(branch_params).branch
+
+        Event::BranchCommand.create(project: source_project, package: source_package,
+                                    targetproject: destination_project,
+                                    targetpackage: destination_package,
+                                    user: User.session.login)
+        Package.find_by_project_and_name(destination_project, destination_package)
+      rescue BranchPackage::DoubleBranchPackageError
+        @errors << 'You have already branched this package'
+      rescue CreateProjectNoPermission
+        @errors << 'Sorry, you are not authorized to create this Project.'
+      rescue ArgumentError, Package::UnknownObjectError, Project::UnknownObjectError, APIError, ActiveRecord::RecordInvalid => e
+        @errors << "Failed to branch: #{e.message}"
+      end
+    end
+  end
+end

--- a/src/api/app/services/workflows/yaml_download_service.rb
+++ b/src/api/app/services/workflows/yaml_download_service.rb
@@ -1,0 +1,24 @@
+module Workflows
+  class YAMLDownloadService
+    MAX_FILE_SIZE = 1024 * 1024 # 1MB
+
+    attr_reader :errors
+
+    def initialize(url:)
+      @url = url
+      @errors = []
+    end
+
+    def call
+      download_yaml_file
+    end
+
+    private
+
+    def download_yaml_file
+      Down.download(@url, max_size: MAX_FILE_SIZE)
+    rescue Down::Error => e
+      @errors << e.message
+    end
+  end
+end

--- a/src/api/app/services/workflows/yaml_to_workflows_service.rb
+++ b/src/api/app/services/workflows/yaml_to_workflows_service.rb
@@ -1,0 +1,24 @@
+module Workflows
+  class YAMLToWorkflowsService
+    def initialize(yaml_file:, pr_number:)
+      @yaml_file = yaml_file
+      @pr_number = pr_number
+    end
+
+    def call
+      create_workflows
+    end
+
+    private
+
+    def create_workflows
+      parsed_workflows_yaml = YAML.safe_load(File.read(@yaml_file))
+      workflows = []
+
+      parsed_workflows_yaml.each do |_workflow_name, workflow|
+        workflows << Workflow.new(workflow: workflow, pr_number: @pr_number)
+      end
+      workflows
+    end
+  end
+end

--- a/src/api/config/initializers/zeitwerk.rb
+++ b/src/api/config/initializers/zeitwerk.rb
@@ -9,6 +9,8 @@ Rails.autoloaders.each do |autoloader|
     'opensuse_upstream_version_finder' => 'OpenSUSEUpstreamVersionFinder',
     'remote_url' => 'RemoteURL',
     'rss_channel' => 'RSSChannel',
-    'url_generator' => 'URLGenerator'
+    'url_generator' => 'URLGenerator',
+    'yaml_download_service' => 'YAMLDownloadService',
+    'yaml_to_workflows_service' => 'YAMLToWorkflowsService'
   )
 end


### PR DESCRIPTION
This PR introduces a basic solution to download the workflow yaml file from the SCM service (GitHub/GitLab) and to create workflows from it. Each workflow and the containing steps are separate objects that encapsulate the attributes and logic to execute it. By using models for it, we can make use of the built in validation capabilities. 

The code introduced here will be called from the `Token::Workflow#call` introduced in https://github.com/openSUSE/open-build-service/pull/11056
Inside the call we would do something like that:

```
yaml_file = Workflows::YAMLDownloadService.new(url: 'https://raw.githubusercontent.com/krauselukas/test_github_deployments/main/.obs/workflow.yaml').call

workflows = Workflows::YAMLToWorkflowsService.new(yaml_file: yaml_file, pr_number: "1234").call

step = workflows.first.steps.first

step.call if step.valid?
```

**TODO:**
  * Write specs
  