### PR TITLE
[api] fix hostsystem repository handling

### DIFF
--- a/docs/api/api/obs.rng
+++ b/docs/api/api/obs.rng
@@ -307,6 +307,16 @@
             </element>
         </zeroOrMore>
         <zeroOrMore>
+          <element name="hostsystem">
+            <attribute name="repository">
+              <data type="string" />
+            </attribute>
+            <attribute name="project">
+              <data type="string" />
+            </attribute>
+          </element>
+        </zeroOrMore>
+        <zeroOrMore>
             <element name="path">
               <attribute name="repository">
                 <data type="string" />
@@ -316,16 +326,6 @@
               </attribute>
             </element>
         </zeroOrMore>
-        <optional>
-          <element name="hostsystem">
-            <attribute name="repository">
-              <data type="string" />
-            </attribute>
-            <attribute name="project">
-              <data type="string" />
-            </attribute>
-          </element>
-        </optional>
         <zeroOrMore>
           <element name="arch">
             <ref name="build-arch" />

--- a/src/api/.rubocop.yml
+++ b/src/api/.rubocop.yml
@@ -297,6 +297,7 @@ Rails/BulkChangeTable:
     - 'db/migrate/20170912140257_change_kiwi_packages_columns_from_big_int_to_int.rb'
     - 'db/migrate/20171107125828_rename_kiwi_preference_types_to_kiwi_preferences.rb'
     - 'db/migrate/20180516074538_explicitly_set_charset.rb'
+    - 'db/migrate/20210505160725_add_kind_to_path_element_uniq_indexes.rb'
 
 ##################### RSpec ##################################
 

--- a/src/api/.rubocop.yml
+++ b/src/api/.rubocop.yml
@@ -42,6 +42,7 @@ Style/MethodCallWithArgsParentheses:
   Exclude:
     - 'app/views/**/*'
     - 'db/migrate/**/*'
+    - 'db/data/**/*'
     - 'Gemfile*'
   # the cop doesn't come with a well defined list of good methods, so this
   # list is the list of offending functions when introducing. Removing functions

--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -1011,6 +1011,7 @@ Rails/SkipsModelValidations:
   Exclude:
     - 'db/migrate/20170621100321_add_channel_to_event_subscriptions.rb'
     - 'db/migrate/20170630144825_convert_tokens_to_service_tokens.rb'
+    - 'db/data/20210505155012_backfill_add_kind_to_path_element.rb'
 
 # Offense count: 82
 # Cop supports --auto-correct.

--- a/src/api/app/models/path_element.rb
+++ b/src/api/app/models/path_element.rb
@@ -15,14 +15,14 @@ end
 # Table name: path_elements
 #
 #  id            :integer          not null, primary key
-#  kind          :string(10)       default("standard")
+#  kind          :string(10)       default("standard"), indexed => [parent_id, repository_id]
 #  position      :integer          not null
-#  parent_id     :integer          not null, indexed => [repository_id]
-#  repository_id :integer          not null, indexed => [parent_id], indexed
+#  parent_id     :integer          not null, indexed => [repository_id, kind]
+#  repository_id :integer          not null, indexed => [parent_id, kind], indexed
 #
 # Indexes
 #
-#  parent_repository_index  (parent_id,repository_id) UNIQUE
+#  parent_repository_index  (parent_id,repository_id,kind) UNIQUE
 #  repository_id            (repository_id)
 #
 # Foreign Keys

--- a/src/api/app/models/path_element.rb
+++ b/src/api/app/models/path_element.rb
@@ -7,7 +7,7 @@ class PathElement < ApplicationRecord
   belongs_to :link, class_name: 'Repository', foreign_key: 'repository_id', inverse_of: :links
 
   validates :link, :repository, presence: true
-  validates :repository, uniqueness: { scope: :link }
+  validates :repository, uniqueness: { scope: [:link, :kind] }
 end
 
 # == Schema Information
@@ -15,6 +15,7 @@ end
 # Table name: path_elements
 #
 #  id            :integer          not null, primary key
+#  kind          :string(10)       default("standard")
 #  position      :integer          not null
 #  parent_id     :integer          not null, indexed => [repository_id]
 #  repository_id :integer          not null, indexed => [parent_id], indexed

--- a/src/api/db/data/20210505155012_backfill_add_kind_to_path_element.rb
+++ b/src/api/db/data/20210505155012_backfill_add_kind_to_path_element.rb
@@ -1,0 +1,12 @@
+class BackfillAddKindToPathElement < ActiveRecord::Migration[6.0]
+  def up
+    PathElement.unscoped.in_batches do |relation|
+      relation.update_all kind: 'standard'
+      sleep(0.01)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/src/api/db/migrate/20210505155931_add_kind_to_path_element.rb
+++ b/src/api/db/migrate/20210505155931_add_kind_to_path_element.rb
@@ -1,0 +1,6 @@
+class AddKindToPathElement < ActiveRecord::Migration[6.0]
+  def change
+    add_column :path_elements, :kind, "ENUM('standard','hostsystem')"
+    change_column_default :path_elements, :kind, from: nil, to: 'standard'
+  end
+end

--- a/src/api/db/migrate/20210505160725_add_kind_to_path_element_uniq_indexes.rb
+++ b/src/api/db/migrate/20210505160725_add_kind_to_path_element_uniq_indexes.rb
@@ -1,0 +1,17 @@
+class AddKindToPathElementUniqIndexes < ActiveRecord::Migration[6.0]
+  def up
+    safety_assured { execute 'SET FOREIGN_KEY_CHECKS=0;' }
+    remove_index :path_elements, name: 'parent_repository_index'
+    add_index :path_elements, ['parent_id', 'repository_id', 'kind'], name: 'parent_repository_index', unique: true
+  ensure
+    safety_assured { execute 'SET FOREIGN_KEY_CHECKS=1;' }
+  end
+
+  def down
+    safety_assured { execute 'SET FOREIGN_KEY_CHECKS=0;' }
+    remove_index :path_elements, name: 'parent_repository_index'
+    add_index :path_elements, ['parent_id', 'repository_id'], name: 'parent_repository_index', unique: true
+  ensure
+    safety_assured { execute 'SET FOREIGN_KEY_CHECKS=1;' }
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_05_113812) do
+ActiveRecord::Schema.define(version: 2021_05_05_155931) do
 
   create_table "architectures", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false, collation: "utf8_general_ci"
@@ -721,6 +721,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_113812) do
     t.integer "parent_id", null: false
     t.integer "repository_id", null: false
     t.integer "position", null: false
+    t.column "kind", "enum('standard','hostsystem')", default: "standard"
     t.index ["parent_id", "repository_id"], name: "parent_repository_index", unique: true
     t.index ["repository_id"], name: "repository_id"
   end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_05_155931) do
+ActiveRecord::Schema.define(version: 2021_05_05_160725) do
 
   create_table "architectures", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false, collation: "utf8_general_ci"
@@ -722,7 +722,7 @@ ActiveRecord::Schema.define(version: 2021_05_05_155931) do
     t.integer "repository_id", null: false
     t.integer "position", null: false
     t.column "kind", "enum('standard','hostsystem')", default: "standard"
-    t.index ["parent_id", "repository_id"], name: "parent_repository_index", unique: true
+    t.index ["parent_id", "repository_id", "kind"], name: "parent_repository_index", unique: true
     t.index ["repository_id"], name: "repository_id"
   end
 

--- a/src/api/spec/models/project/update_from_xml_command_spec.rb
+++ b/src/api/spec/models/project/update_from_xml_command_spec.rb
@@ -98,55 +98,6 @@ RSpec.describe Project::UpdateFromXmlCommand do
       end
     end
 
-    describe 'hostsystem' do
-      let!(:target_project) { create(:project, name: 'target_project') }
-      let!(:target_repository) { create(:repository, name: 'target_repo', project: target_project) }
-
-      before do
-        repository_1.hostsystem = target_repository
-        repository_1.save!
-
-        @xml_hash = Xmlhash.parse(
-          <<-EOF
-            <project name="#{project.name}">
-              <repository name="repo_1" />
-              <repository name="repo_2">
-                <hostsystem repository="#{target_repository.name}" project="#{target_project.name}" />
-              </repository>
-            </project>
-          EOF
-        )
-      end
-
-      it 'updates the hostsystem of a repository' do
-        Project::UpdateFromXmlCommand.new(project).send(:update_repositories, @xml_hash, false)
-        expect(repository_1.reload.hostsystem).to be(nil)
-        expect(repository_2.reload.hostsystem).to eq(target_repository)
-      end
-
-      it 'raises an error if hostsystem refers itself' do
-        xml_hash = Xmlhash.parse(
-          <<-EOF
-            <project name="#{project.name}">
-              <repository name="repo_2">
-                <hostsystem repository="repo_2" project="#{project.name}" />
-              </repository>
-            </project>
-          EOF
-        )
-        expect { Project::UpdateFromXmlCommand.new(project).send(:update_repositories, xml_hash, false) }.to raise_error(
-          Project::SaveError, 'Using same repository as hostsystem element is not allowed'
-        )
-      end
-
-      it 'raises an error if target repository does not exist' do
-        target_repository.destroy
-        expect { Project::UpdateFromXmlCommand.new(project).send(:update_repositories, @xml_hash, false) }.to raise_error(
-          Project::SaveError, "Unknown target repository 'target_project/target_repo'"
-        )
-      end
-    end
-
     describe 'repository architecture' do
       it 'creates architectures for the repository' do
         xml_hash = Xmlhash.parse(


### PR DESCRIPTION
backend supports multiple entries. They are just a different kind of
path elements. So handling them via a flag in path elements instead
of heaving a single fixed entry per repository (actually per project
due to bug in former implementation).

_Replace this line with a description of your changes. Please follow the suggestions in the comment below._

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
