### PR TITLE
Use the SCM's branch instead of the default one

### DIFF
--- a/src/api/app/models/token/workflow.rb
+++ b/src/api/app/models/token/workflow.rb
@@ -9,7 +9,6 @@ class Token::Workflow < Token
 
     scm_extractor_payload = extractor.call # returns { scm: 'github', repo_url: 'http://...' }
     yaml_file = Workflows::YAMLDownloader.new(scm_extractor_payload).call
-    # BUT THIS DOESN'T
     # workflows = Workflows::YAMLToWorkflowsService.new(yaml_file: yaml_file, pr_number: scm_extractor_payload[:pr_number]).call
     # step = workflows.first.steps.first
     # step.call if step.valid?

--- a/src/api/app/services/trigger_controller_service/scm_extractor.rb
+++ b/src/api/app/services/trigger_controller_service/scm_extractor.rb
@@ -25,7 +25,6 @@ module TriggerControllerService
           commit_sha: @payload['pull_request']['head']['sha'],
           pr_number: @payload['number'],
           branch: @payload['pull_request']['head']['ref'],
-          default_branch: @payload['repository']['default_branch'],
           action: @payload['action'], # TODO: Names may differ, maybe we need to find our own naming (defer to service?)
           repository_owner: @payload['pull_request']['head']['repo']['owner']['login'],
           repository_name: @payload['pull_request']['head']['repo']['name']
@@ -37,7 +36,6 @@ module TriggerControllerService
           commit_sha: @payload['object_attributes']['last_commit']['id'],
           pr_number: @payload['object_attributes']['iid'],
           branch: @payload['object_attributes']['source_branch'],
-          default_branch: @payload['project']['default_branch'],
           action: @payload['object_attributes']['action'], # TODO: Names may differ, maybe we need to find our own naming (defer to service?)
           project_id: @payload['project']['id'],
           path_with_namespace: @payload['project']['path_with_namespace']

--- a/src/api/app/services/workflows/yaml_downloader.rb
+++ b/src/api/app/services/workflows/yaml_downloader.rb
@@ -24,9 +24,9 @@ module Workflows
     def download_url
       case @scm_payload[:scm]
       when 'github'
-        "https://raw.githubusercontent.com/#{@scm_payload[:repository_owner]}/#{@scm_payload[:repository_name]}/#{@scm_payload[:default_branch]}/.obs/workflows.yml"
+        "https://raw.githubusercontent.com/#{@scm_payload[:repository_owner]}/#{@scm_payload[:repository_name]}/#{@scm_payload[:branch]}/.obs/workflows.yml"
       when 'gitlab'
-        "https://gitlab.com/#{@scm_payload[:path_with_namespace]}/-/raw/#{@scm_payload[:default_branch]}/.obs/workflows.yml"
+        "https://gitlab.com/#{@scm_payload[:path_with_namespace]}/-/raw/#{@scm_payload[:branch]}/.obs/workflows.yml"
       end
     end
   end


### PR DESCRIPTION
We use the SCM's branch instead of the repository's default one