### PR TITLE
Execute the workflow's steps

### DIFF
--- a/src/api/app/models/workflow.rb
+++ b/src/api/app/models/workflow.rb
@@ -6,9 +6,9 @@ class Workflow
 
   validates :event, inclusion: { in: SUPPORTED_EVENTS, allow_nil: false }
 
-  def initialize(workflow:, pr_number:)
+  def initialize(workflow:, scm_extractor_payload:)
     @workflow = workflow
-    @pr_number = pr_number
+    @scm_extractor_payload = scm_extractor_payload
   end
 
   def event
@@ -20,7 +20,10 @@ class Workflow
 
     @workflow['steps'].each do |step|
       step.each do |step_name, step_instructions|
-        steps << SUPPORTED_STEPS[step_name].new(step_instructions: step_instructions, pr_number: @pr_number)
+        next if SUPPORTED_STEPS[step_name].blank?
+
+        new_step = SUPPORTED_STEPS[step_name].new(step_instructions: step_instructions, scm_extractor_payload: @scm_extractor_payload)
+        steps << new_step if new_step.allowed_event_and_action?
       end
     end
     steps

--- a/src/api/app/services/workflows/yaml_to_workflows_service.rb
+++ b/src/api/app/services/workflows/yaml_to_workflows_service.rb
@@ -1,8 +1,8 @@
 module Workflows
   class YAMLToWorkflowsService
-    def initialize(yaml_file:, pr_number:)
+    def initialize(yaml_file:, scm_extractor_payload:)
       @yaml_file = yaml_file
-      @pr_number = pr_number
+      @scm_extractor_payload = scm_extractor_payload
     end
 
     def call
@@ -16,7 +16,7 @@ module Workflows
       workflows = []
 
       parsed_workflows_yaml.each do |_workflow_name, workflow|
-        workflows << Workflow.new(workflow: workflow, pr_number: @pr_number)
+        workflows << Workflow.new(workflow: workflow, scm_extractor_payload: @scm_extractor_payload)
       end
       workflows
     end


### PR DESCRIPTION
After downloading the workflow's configuration file we execute the
workflow's steps against the configured project and package.

Then, validate the steps inside the Step model.

Depending on each kind of step, we know which kind of event and actions
we expect from the webhooks and what actions we want to perform or
ignore (i.e. branch a packae in OBS, just rebuild the package, etc.)

That's why we moved the checks about webhook events and actions to the
Step class.
