### PR TITLE
Stop validating parameters in TriggerController

### DIFF
--- a/src/api/app/controllers/trigger_controller.rb
+++ b/src/api/app/controllers/trigger_controller.rb
@@ -5,6 +5,8 @@ class TriggerController < ApplicationController
   skip_before_action :extract_user
   # Authentication happens with tokens, so no login is required
   skip_before_action :require_login
+  # GitLab/Github send data as parameters which are not strings
+  skip_before_action :validate_params
   after_action :verify_authorized
 
   before_action :validate_gitlab_event

--- a/src/api/app/services/trigger_controller_service/token_extractor.rb
+++ b/src/api/app/services/trigger_controller_service/token_extractor.rb
@@ -7,7 +7,7 @@ module TriggerControllerService
     end
 
     def call
-      if @token_id
+      if @token_id && signature
         extract_token_from_request_signature
       else
         extract_auth_token_from_headers

--- a/src/api/spec/services/trigger_controller_service/token_extractor_spec.rb
+++ b/src/api/spec/services/trigger_controller_service/token_extractor_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe ::TriggerControllerService::TokenExtractor do
     end
 
     context 'with the ID of a nonexistent token in the params' do
-      let(:request) { OpenStruct.new(params: { id: -1 }, body: StringIO.new(request_body)) }
+      let(:request) { OpenStruct.new(params: { id: -1 }, body: StringIO.new(request_body), env: {}) }
 
       it 'returns nil' do
         expect(subject).to be_nil


### PR DESCRIPTION
All SCMs send data in there that is parsed to hashes for instance.

We removed this in the last refactoring...

