### PR TITLE
Add support for token.scm_token in POST /person/<login>/token

### DIFF
--- a/docs/api/api/api.txt
+++ b/docs/api/api/api.txt
@@ -168,6 +168,7 @@ POST /person/<userid>/token
   project: together with package, used to create a token for a specific package
   package: together with project, used to create a token for a specific package
   operation: runservice(default), rebuild, release
+  scm_token: SCM token used in OBS workflows to report back the workflow status, when the operation is workflow
 
 XmlResult: status
 

--- a/src/api/app/controllers/person/token_controller.rb
+++ b/src/api/app/controllers/person/token_controller.rb
@@ -16,7 +16,7 @@ module Person
 
       pkg = (Package.get_by_project_and_name(params[:project], params[:package]) if params[:project] || params[:package])
 
-      @token = Token.token_type(params[:operation]).create(user: @user, package: pkg)
+      @token = Token.token_type(params[:operation]).create(user: @user, package: pkg, scm_token: params[:scm_token])
     end
 
     # DELETE /person/<login>/token/<id>

--- a/src/api/public/apidocs-new/paths/person_login_token.yaml
+++ b/src/api/public/apidocs-new/paths/person_login_token.yaml
@@ -82,6 +82,15 @@ post:
 
         When operation is not specified, 'runservice' is the default value.
       example: runservice
+    - in: query
+      name: scm_token
+      schema:
+        type: string
+      description: |
+        SCM token used in OBS workflows to report back the workflow status, when the operation is workflow.
+
+        It's normally possible to generate SCM tokens directly on the SCM's website like GitHub or GitLab.
+      example: ghp_fake_token_123
   responses:
     '200':
       description: |

--- a/src/api/spec/controllers/person/token_controller_spec.rb
+++ b/src/api/spec/controllers/person/token_controller_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Person::TokenController, vcr: false do
 
       before do
         login user
-        post :create, params: { login: user.login, package: package, project: package.project, operation: 'runservice' }, format: :xml
+        post :create, params: { login: user.login, package: package, project: package.project, operation: 'runservice', scm_token: '123456789' }, format: :xml
       end
 
       it { expect(response).to have_http_status(:success) }


### PR DESCRIPTION
The commit was cherry-picked from #11060 in order to merge changes which can already go on `master`.