### PR TITLE
Revert "Retrieve the workflows conf file from target branch"

### DIFF
--- a/src/api/app/services/workflows/yaml_downloader.rb
+++ b/src/api/app/services/workflows/yaml_downloader.rb
@@ -24,9 +24,9 @@ module Workflows
     def download_url
       case @scm_payload[:scm]
       when 'github'
-        "https://raw.githubusercontent.com/#{@scm_payload[:repository_full_name]}/#{@scm_payload[:target_branch]}/.obs/workflows.yml"
+        "https://raw.githubusercontent.com/#{@scm_payload[:repository_full_name]}/#{@scm_payload[:repository_name]}/#{@scm_payload[:default_branch]}/.obs/workflows.yml"
       when 'gitlab'
-        "https://gitlab.com/#{@scm_payload[:path_with_namespace]}/-/raw/#{@scm_payload[:target_branch]}/.obs/workflows.yml"
+        "https://gitlab.com/#{@scm_payload[:path_with_namespace]}/-/raw/#{@scm_payload[:default_branch]}/.obs/workflows.yml"
       end
     end
   end


### PR DESCRIPTION
Given we're not gonna implement the branch filters now, this PR reverts back #11083 to prevent anyone from using any other workflow configuration file but the one present in the reference branch (main, in our case).