### PR TITLE
Recreate the foreign key after recreating the index

### DIFF
--- a/src/api/db/migrate/20210505160725_add_kind_to_path_element_uniq_indexes.rb
+++ b/src/api/db/migrate/20210505160725_add_kind_to_path_element_uniq_indexes.rb
@@ -1,17 +1,15 @@
 class AddKindToPathElementUniqIndexes < ActiveRecord::Migration[6.0]
   def up
-    safety_assured { execute 'SET FOREIGN_KEY_CHECKS=0;' }
+    remove_foreign_key :path_elements, name: 'path_elements_ibfk_1'
     remove_index :path_elements, name: 'parent_repository_index'
     add_index :path_elements, ['parent_id', 'repository_id', 'kind'], name: 'parent_repository_index', unique: true
-  ensure
-    safety_assured { execute 'SET FOREIGN_KEY_CHECKS=1;' }
+    add_foreign_key 'path_elements', 'repositories', column: 'parent_id', name: 'path_elements_ibfk_1'
   end
 
   def down
-    safety_assured { execute 'SET FOREIGN_KEY_CHECKS=0;' }
+    remove_foreign_key :path_elements, name: 'path_elements_ibfk_1'
     remove_index :path_elements, name: 'parent_repository_index'
     add_index :path_elements, ['parent_id', 'repository_id'], name: 'parent_repository_index', unique: true
-  ensure
-    safety_assured { execute 'SET FOREIGN_KEY_CHECKS=1;' }
+    add_foreign_key 'path_elements', 'repositories', column: 'parent_id', name: 'path_elements_ibfk_1'
   end
 end


### PR DESCRIPTION
We ran into some mariadb problem when not doing this.

```
SHOW ENGINE INNODB STATUS;
...
------------------------
LATEST FOREIGN KEY ERROR
------------------------
...
DELETE FROM `repositories` WHERE `repositories`.`id` = 3229851
Foreign key constraint fails for table `obs_production`.`repositories`:
...
CONSTRAINT `path_elements_ibfk_1` FOREIGN KEY (`parent_id`) REFERENCES `repositories` (`id`)
...
But the referencing table `obs_production`.`path_elements`
or its .ibd file or the required index does not currently exist!
```
