### PR TITLE
Disable Rails/BulkChangeTable

### DIFF
--- a/src/api/.rubocop.yml
+++ b/src/api/.rubocop.yml
@@ -278,26 +278,10 @@ Rails/Output:
 Rails/UniqueValidationWithoutIndex:
   Enabled: false
 
-# We decided not to modify old migrations
+# This encourages change_table that isn't inspectable by strong_migrations
+# and threfor less safe
 Rails/BulkChangeTable:
-  Exclude:
-    - 'db/migrate/20140210114542_remove_project_and_package_from_subscription.rb'
-    - 'db/migrate/20140624101042_add_package_tracking.rb'
-    - 'db/migrate/20140717101042_add_updateinfo_tracking.rb'
-    - 'db/migrate/20140718112346_flexible_updateinfoid.rb'
-    - 'db/migrate/20140721112346_delayed_job_indexes.rb'
-    - 'db/migrate/20140729101042_updateinfo_tracking_second_attempt.rb'
-    - 'db/migrate/20140801071042_product_version_tracking.rb'
-    - 'db/migrate/20170516140442_add_several_fields_to_kiwi_repositories.rb'
-    - 'db/migrate/20170607110443_add_and_remove_some_index_in_bs_request_actions.rb'
-    - 'db/migrate/20170630121602_add_index_bs_requests_action.rb'
-    - 'db/migrate/20170619111734_alter_notifications_to_use_polymorphic.rb'
-    - 'db/migrate/20170905081525_add_has_secure_password_support.rb'
-    - 'db/migrate/20170911142301_change_kiwi_package_groups_columns_from_big_int_to_int.rb'
-    - 'db/migrate/20170912140257_change_kiwi_packages_columns_from_big_int_to_int.rb'
-    - 'db/migrate/20171107125828_rename_kiwi_preference_types_to_kiwi_preferences.rb'
-    - 'db/migrate/20180516074538_explicitly_set_charset.rb'
-    - 'db/migrate/20210505160725_add_kind_to_path_element_uniq_indexes.rb'
+  Enable: false
 
 ##################### RSpec ##################################
 

--- a/src/api/.rubocop.yml
+++ b/src/api/.rubocop.yml
@@ -279,7 +279,7 @@ Rails/UniqueValidationWithoutIndex:
   Enabled: false
 
 # This encourages change_table that isn't inspectable by strong_migrations
-# and threfor less safe
+# and therefore, less safe
 Rails/BulkChangeTable:
   Enable: false
 


### PR DESCRIPTION
This encourages change_table that isn't inspectable by strong_migrations
and threfore less safe. I rather have one too many SQL command executed than
one too many unsafe migration.

