### PR TITLE
Create job to report build status to SCM via SCMStatusReporter

### DIFF
--- a/src/api/app/jobs/create_job.rb
+++ b/src/api/app/jobs/create_job.rb
@@ -9,8 +9,7 @@ class CreateJob < ApplicationJob
 
     # in test suite the undone_jobs are 0 as the delayed jobs are not delayed
     event.with_lock do
-      event.undone_jobs -= 1
-      event.save!
+      event.mark_job_done!
     end
   end
 

--- a/src/api/app/jobs/report_to_scm_job.rb
+++ b/src/api/app/jobs/report_to_scm_job.rb
@@ -1,0 +1,27 @@
+# We don't properly capitalize SCM in the class name since CreateJob is doing `CLASS_NAME.to_s.camelize.safe_constantize`
+class ReportToScmJob < CreateJob
+  ALLOWED_EVENTS = ['Event::BuildFail', 'Event::BuildSuccess'].freeze
+
+  queue_as :scm
+
+  def perform(event_id)
+    event = Event::Base.find(event_id)
+    return false unless event.undone_jobs.positive?
+
+    event_type = event.eventtype
+    return false unless ALLOWED_EVENTS.include?(event_type)
+
+    event_package = Package.find_by_project_and_name(event.payload['project'], event.payload['package'])
+    return false if event_package.blank?
+
+    EventSubscriptionsFinder.new
+                            .for_scm_channel_with_token(event_type: event_type, event_package: event_package)
+                            .each do |event_subscription|
+      SCMStatusReporter.new(event_subscription.payload,
+                            event_subscription.token.scm_token,
+                            event_subscription.eventtype).call
+    end
+
+    true
+  end
+end

--- a/src/api/app/models/event/base.rb
+++ b/src/api/app/models/event/base.rb
@@ -106,7 +106,7 @@ module Event
     end
 
     def initialize(attribs)
-      attributes = attribs.dup
+      attributes = attribs.dup.with_indifferent_access
       super()
       self.created_at = attribs[:time] if attributes[:time]
       attributes.delete :eventtype
@@ -168,6 +168,13 @@ module Event
         self.undone_jobs += 1
       end
       save if self.undone_jobs.positive?
+    end
+
+    def mark_job_done!
+      return unless undone_jobs.positive?
+
+      self.undone_jobs -= 1
+      save!
     end
 
     # to be overwritten in subclasses

--- a/src/api/app/models/event/build_fail.rb
+++ b/src/api/app/models/event/build_fail.rb
@@ -6,6 +6,8 @@ module Event
     self.description = 'Package has failed to build'
     receiver_roles :maintainer, :bugowner, :reader, :watcher
 
+    create_jobs :report_to_scm_job
+
     def subject
       "Build failure of #{payload['project']}/#{payload['package']} in #{payload['repository']}/#{payload['arch']}"
     end

--- a/src/api/app/models/event/build_success.rb
+++ b/src/api/app/models/event/build_success.rb
@@ -3,6 +3,8 @@ module Event
     self.message_bus_routing_key = 'package.build_success'
     self.description = 'Package has succeeded building'
 
+    create_jobs :report_to_scm_job
+
     def state
       'success'
     end

--- a/src/api/app/queries/event_subscriptions_finder.rb
+++ b/src/api/app/queries/event_subscriptions_finder.rb
@@ -1,0 +1,13 @@
+class EventSubscriptionsFinder
+  def initialize(relation = EventSubscription.all)
+    @relation = relation
+  end
+
+  def for_scm_channel_with_token(event_type:, event_package:)
+    @relation
+      .where(eventtype: event_type,
+             package: event_package,
+             channel: :scm)
+      .where.not(token_id: nil)
+  end
+end

--- a/src/api/app/services/scm_status_reporter.rb
+++ b/src/api/app/services/scm_status_reporter.rb
@@ -2,7 +2,7 @@ class SCMStatusReporter
   attr_accessor :payload, :scm_token, :state
 
   def initialize(payload, scm_token, event_type = nil)
-    @payload = payload
+    @payload = payload.with_indifferent_access
     @scm_token = scm_token
 
     @state = event_type.nil? ? 'pending' : scm_final_state(event_type)

--- a/src/api/spec/jobs/report_to_scm_job_spec.rb
+++ b/src/api/spec/jobs/report_to_scm_job_spec.rb
@@ -1,0 +1,102 @@
+require 'rails_helper'
+
+RSpec.describe ReportToScmJob, vcr: false do
+  let(:user) { create(:confirmed_user, login: 'foolano') }
+  let(:token) { Token::Workflow.create(user: user, scm_token: 'fake_token') }
+  let(:project) { create(:project, name: 'project_1', maintainer: user) }
+  let(:package) { create(:package, name: 'package_1', project: project) }
+  let(:repository) { create(:repository, name: 'repository_1', project: project) }
+  let(:event) { Event::BuildSuccess.create({ project: project.name, package: package.name, repository: repository.name, reason: 'foo' }) }
+  let(:event_subscription) do
+    EventSubscription.create(token: token,
+                             user: user,
+                             package: package,
+                             receiver_role: 'reader',
+                             payload: { scm: 'github' },
+                             eventtype: 'Event::BuildSuccess',
+                             channel: :scm)
+  end
+
+  shared_examples 'not reporting to the SCM' do
+    it 'job return value is false' do
+      expect(subject).to be_falsey
+    end
+
+    it 'does not call the scm reporter' do
+      expect_any_instance_of(SCMStatusReporter).not_to receive(:call) # rubocop:disable RSpec/AnyInstance
+      subject
+    end
+  end
+
+  describe '#perform' do
+    subject { described_class.perform_now(event.id) }
+
+    context 'happy path' do
+      before do
+        event
+        event_subscription
+      end
+
+      it 'job return value is true' do
+        allow_any_instance_of(Octokit::Client).to receive(:create_status) # rubocop:disable RSpec/AnyInstance
+        expect(subject).to be_truthy
+      end
+
+      it 'does call the scm reporter' do
+        allow_any_instance_of(Octokit::Client).to receive(:create_status) # rubocop:disable RSpec/AnyInstance
+        expect_any_instance_of(SCMStatusReporter).to receive(:call).once # rubocop:disable RSpec/AnyInstance
+        subject
+      end
+    end
+
+    context 'when using a non-allowed event' do
+      let(:event) do
+        Event::Commit.create(project: project.name, package: package.name)
+      end
+
+      before do
+        event
+        event_subscription
+      end
+
+      it_behaves_like 'not reporting to the SCM'
+    end
+
+    context 'when the event is for some other project than the subscribed one' do
+      let(:event) { Event::BuildSuccess.create(project: 'some:other:project', package: package.name, repository: repository.name, reason: 'foo') }
+
+      before do
+        event
+        event_subscription
+      end
+
+      it_behaves_like 'not reporting to the SCM'
+    end
+
+    context 'when the event is for some other package than the subscribed one' do
+      let(:event) { Event::BuildSuccess.create(project: project.name, package: 'some_other_package', repository: repository.name, reason: 'foo') }
+
+      before do
+        event
+        event_subscription
+      end
+
+      it_behaves_like 'not reporting to the SCM'
+    end
+
+    context 'when the reporting raises an error' do
+      let(:event) { Event::BuildSuccess.create(project: project.name, package: package.name, repository: repository.name, reason: 'foo') }
+
+      before do
+        allow_any_instance_of(Octokit::Client).to receive(:create_status).and_raise(StandardError, '42') # rubocop:disable RSpec/AnyInstance
+        event
+        event_subscription
+      end
+
+      it 'does not call the scm reporter' do
+        expect_any_instance_of(SCMStatusReporter).to receive(:call).once # rubocop:disable RSpec/AnyInstance
+        subject
+      end
+    end
+  end
+end


### PR DESCRIPTION
Extracted from #11060

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
