### PR TITLE
[backend] use correct arch for dodcheck in the cross build case

### DIFF
--- a/src/backend/BSRepServer/DoD.pm
+++ b/src/backend/BSRepServer/DoD.pm
@@ -1,0 +1,105 @@
+# Copyright (c) 2015 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program (see the file COPYING); if not, write to the
+# Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+#
+package BSRepServer::DoD;
+
+use BSWatcher ':https';
+use BSVerify;
+use BSHandoff;
+use BSStdServer;
+
+use Build;
+
+use strict;
+use warnings;
+
+my $proxy;
+$proxy = $BSConfig::proxy if defined($BSConfig::proxy);
+
+my $maxredirects = 3;
+
+my @binsufs = qw{rpm deb pkg.tar.gz pkg.tar.xz pkg.tar.zst};
+my $binsufsre = join('|', map {"\Q$_\E"} @binsufs);
+
+sub is_wanted_dodbinary {
+  my ($pool, $p, $path, $doverify) = @_;
+  my $q;
+  eval { $q = Build::query($path, 'evra' => 1) };
+  return 0 unless $q;
+  my $data = $pool->pkg2data($p);
+  $data->{'release'} = '__undef__' unless defined $data->{'release'};
+  $q->{'release'} = '__undef__' unless defined $q->{'release'};
+  return 0 if $data->{'name'} ne $q->{'name'} ||
+	      ($data->{'arch'} || '') ne ($q->{'arch'} || '') ||
+	      ($data->{'epoch'} || 0) != ($q->{'epoch'} || 0) ||
+	      $data->{'version'} ne $q->{'version'} ||
+	      $data->{'release'} ne $q->{'release'};
+  BSVerify::verify_nevraquery($q) if $doverify;		# just in case
+  return 1;
+}
+
+sub fetchdodbinary {
+  my ($gdst, $pool, $repo, $p, $handoff) = @_;
+
+  die($repo->name()." is no dod repo\n") unless $repo->dodurl();
+  my $path = $pool->pkg2path($p);
+  die("$path has an unsupported suffix\n") unless $path =~ /\.($binsufsre)$/;
+  my $suf = $1;
+  my $pkgname = $pool->pkg2name($p);
+  if (defined(&BSSolv::pool::pkg2inmodule) && $pool->pkg2inmodule($p)) {
+    $pkgname .= '-' . $pool->pkg2evr($p) . '.' . $pool->pkg2arch($p);
+  }
+  $pkgname .= ".$suf";
+  BSVerify::verify_filename($pkgname);
+  BSVerify::verify_simple($pkgname);
+  my $localname = "$gdst/:full/$pkgname";
+  if (-e $localname) {
+    # package exists, why are we called? verify that it matches our expectations
+    return $localname if is_wanted_dodbinary($pool, $p, $localname);
+  }
+  # we really need to download, handoff to ajax if not already done
+  BSHandoff::handoff(@$handoff) if $handoff && !$BSStdServer::isajax;
+  my $url = $repo->dodurl();
+  $url .= '/' unless $url =~ /\/$/;
+  $url .= $pool->pkg2path($p);
+  my $tmp = "$gdst/:full/.dod.$$.$pkgname";
+  #print "fetching: $url\n";
+  my $param = {'uri' => $url, 'filename' => $tmp, 'receiver' => \&BSHTTP::file_receiver, 'proxy' => $proxy};
+  $param->{'maxredirects'} = $maxredirects if defined $maxredirects;
+  my $r;
+  eval { $r = BSWatcher::rpc($param); };
+  if ($@) {
+    $@ =~ s/(\d* *)/$1$url: /;
+    die($@);
+  }
+  return unless defined $r;
+  my $checksum;
+  $checksum = $pool->pkg2checksum($p) if defined &BSSolv::pool::pkg2checksum;
+  eval {
+    # verify the checksum if we know it
+    die("checksum error for $tmp, expected $checksum\n") if $checksum && !$pool->verifypkgchecksum($p, $tmp);
+    # also make sure that the evra matches what we want
+    die("downloaded package is not the one we want\n") unless is_wanted_dodbinary($pool, $p, $tmp, 1);
+  };
+  if ($@) {
+    unlink($tmp);
+    die($@);
+  }
+  rename($tmp, $localname) || die("rename $tmp $localname: $!\n");
+  return $localname;
+}
+
+1;

--- a/src/backend/BSSched/BuildJob.pm
+++ b/src/backend/BSSched/BuildJob.pm
@@ -1089,11 +1089,12 @@ sub create {
   # do DoD checking
   if (!$ctx->{'isreposerver'}) {
     my $dods;
+    my $arch = $bconf->{'hostarch'} && $ctx->{'conf_host'} ? $bconf->{'hostarch'} : $myarch;
     if ($kiwimode) {
       # image packages are already checked (they come from a different pool anyway)
-      $dods = BSSched::DoD::dodcheck($ctx, $pool, $myarch, @pdeps, @vmdeps, @sysdeps);
+      $dods = BSSched::DoD::dodcheck($ctx, $pool, $arch, @pdeps, @vmdeps, @sysdeps);
     } else {
-      $dods = BSSched::DoD::dodcheck($ctx, $pool, $myarch, @pdeps, @vmdeps, @bdeps, @sysdeps);
+      $dods = BSSched::DoD::dodcheck($ctx, $pool, $arch, @pdeps, @vmdeps, @bdeps, @sysdeps);
     }
     if ($dods) {
       print "        blocked: $dods\n" if $ctx->{'verbose'};

--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -79,6 +79,7 @@ use BSRepServer::Containertar;
 use BSRepServer::Remote;
 use BSRepServer::Registry;
 use BSRepServer::YMP;
+use BSRepServer::DoD;
 use BSDispatcher::Constraints;
 use BSCando;
 
@@ -125,75 +126,6 @@ sub jobname {
   $job =~ s/\//::/g;
   $job = ':'.Digest::MD5::md5_hex($prp).'::'.(length($packid) > 160 ? ':'.Digest::MD5::md5_hex($packid) : $packid) if length($job) > 200;
   return $job;
-}
-
-sub is_wanted_dodbinary {
-  my ($pool, $p, $path, $doverify) = @_;
-  my $q;
-  eval { $q = Build::query($path, 'evra' => 1) };
-  return 0 unless $q;
-  my $data = $pool->pkg2data($p);
-  $data->{'release'} = '__undef__' unless defined $data->{'release'};
-  $q->{'release'} = '__undef__' unless defined $q->{'release'};
-  return 0 if $data->{'name'} ne $q->{'name'} ||
-	      ($data->{'arch'} || '') ne ($q->{'arch'} || '') ||
-	      ($data->{'epoch'} || 0) != ($q->{'epoch'} || 0) ||
-	      $data->{'version'} ne $q->{'version'} ||
-	      $data->{'release'} ne $q->{'release'};
-  BSVerify::verify_nevraquery($q) if $doverify;		# just in case
-  return 1;
-}
-
-sub fetchdodbinary {
-  my ($pool, $repo, $p, $arch, $maxredirects, $handoff) = @_;
-
-  my $reponame = $repo->name();
-  die("$reponame is no dod repo\n") unless $repo->dodurl();
-  my $path = $pool->pkg2path($p);
-  die("$path has an unsupported suffix\n") unless $path =~ /\.($binsufsre)$/;
-  my $suf = $1;
-  my $pkgname = $pool->pkg2name($p);
-  if (defined(&BSSolv::pool::pkg2inmodule) && $pool->pkg2inmodule($p)) {
-    $pkgname .= '-' . $pool->pkg2evr($p) . '.' . $pool->pkg2arch($p);
-  }
-  $pkgname .= ".$suf";
-  BSVerify::verify_filename($pkgname);
-  BSVerify::verify_simple($pkgname);
-  my $localname = "$reporoot/$reponame/$arch/:full/$pkgname";
-  if (-e $localname) {
-    # package exists, why are we called? verify that it matches our expectations
-    return $localname if is_wanted_dodbinary($pool, $p, $localname);
-  }
-  # we really need to download, handoff to ajax if not already done
-  BSHandoff::handoff(@$handoff) if $handoff && !$BSStdServer::isajax;
-  my $url = $repo->dodurl();
-  $url .= '/' unless $url =~ /\/$/;
-  $url .= $pool->pkg2path($p);
-  my $tmp = "$reporoot/$reponame/$arch/:full/.dod.$$.$pkgname";
-  #print "fetching: $url\n";
-  my $param = {'uri' => $url, 'filename' => $tmp, 'receiver' => \&BSHTTP::file_receiver, 'proxy' => $proxy};
-  $param->{'maxredirects'} = $maxredirects if defined $maxredirects;
-  my $r;
-  eval { $r = BSWatcher::rpc($param); };
-  if ($@) {
-    $@ =~ s/(\d* *)/$1$url: /;
-    die($@);
-  }
-  return unless defined $r;
-  my $checksum;
-  $checksum = $pool->pkg2checksum($p) if defined &BSSolv::pool::pkg2checksum;
-  eval {
-    # verify the checksum if we know it
-    die("checksum error for $tmp, expected $checksum\n") if $checksum && !$pool->verifypkgchecksum($p, $tmp);
-    # also make sure that the evra matches what we want
-    die("downloaded package is not the one we want\n") unless is_wanted_dodbinary($pool, $p, $tmp, 1);
-  };
-  if ($@) {
-    unlink($tmp);
-    die($@);
-  }
-  rename($tmp, $localname) || die("rename $tmp $localname: $!\n");
-  return $localname;
 }
 
 sub readpackstatus {
@@ -273,7 +205,7 @@ sub getbinaryversions {
       } else {
 	@handoff = ("/build/$projid/$repoid/$arch/_repository", undef, 'view=binaryversions', BSRPC::args($cgi, 'binary', 'module'));
       }
-      $path = fetchdodbinary($pool, $repo, $p, $arch, 3, \@handoff);
+      $path = BSRepServer::DoD::fetchdodbinary("$reporoot/$prp/$arch", $pool, $repo, $p, \@handoff);
       return unless defined $path;
       # TODO: move it out of the loop otherwise the same files might be queried multiple times
       my @s = stat($path);
@@ -474,7 +406,7 @@ sub getbinaries {
     my $path = "$reporoot/".$pool->pkg2fullpath($p, $arch);
     if ($dodurl && $pool->pkg2pkgid($p) eq 'd0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0') {
       my @handoff = ('/getbinaries', undef, "project=$projid", "repository=$repoid", "arch=$arch", BSRPC::args($cgi, 'binaries', 'module'));
-      $path = fetchdodbinary($pool, $repo, $p, $arch, 3, \@handoff);
+      $path = BSRepServer::DoD::fetchdodbinary("$reporoot/$prp/$arch", $pool, $repo, $p, \@handoff);
       return unless defined $path;
       $needscan = 1;
     }
@@ -878,7 +810,7 @@ sub getbinarylist_repository {
       my $path = "$reporoot/".$pool->pkg2fullpath($p, $arch);
       if ($dodurl && $pool->pkg2pkgid($p) eq 'd0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0') {
 	my @handoff = ("/build/$projid/$repoid/$arch/_repository", undef, BSRPC::args($cgi, 'view', 'binary', 'module'));
-        $path = fetchdodbinary($pool, $repo, $p, $arch, 3, \@handoff);
+        $path = BSRepServer::DoD::fetchdodbinary("$reporoot/$prp/$arch", $pool, $repo, $p, \@handoff);
         return unless defined $path;
         $needscan = 1;
       }
@@ -966,7 +898,7 @@ sub getbinarylist_repository {
         $r->{'size'} = '';
 	if ($dodurl && $cgi->{'binary'}) {
 	  # this is used in the interconnect, so we need to fetch the dod binary
-	  $path = fetchdodbinary($pool, $repo, $p, $arch, 3, \@handoff);
+	  $path = BSRepServer::DoD::fetchdodbinary("$reporoot/$prp/arch", $pool, $repo, $p, \@handoff);
 	  return unless defined $path;
           my @s = stat($path);
           ($r->{'mtime'}, $r->{'size'}) = ($s[9], $s[7]) if @s;
@@ -1468,9 +1400,10 @@ sub getbinary_repository {
   my $needscan;
   if (! -f $path) {
     # return by name
+    my $prp = "$projid/$repoid";
     my $pool = BSSolv::pool->new();
     $pool->setmodules($cgi->{'module'} || []) if defined &BSSolv::pool::setmodules;
-    my $repo = BSRepServer::addrepo_scan($pool, "$projid/$repoid", $arch);
+    my $repo = BSRepServer::addrepo_scan($pool, $prp, $arch);
     my $dodurl = $repo->dodurl();
     my %rnames = $repo ? $repo->pkgnames() : ();
     my $p = $rnames{$bin};
@@ -1483,8 +1416,8 @@ sub getbinary_repository {
     die("404 no such binary '$bin'\n") unless $p;
     $path = "$reporoot/".$pool->pkg2fullpath($p, $arch);
     if ($dodurl && $pool->pkg2pkgid($p) eq 'd0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0') {
-      my @handoff = ("/build/$projid/$repoid/$arch/_repository/$bin", undef, BSRPC::args($cgi, 'view', 'module'));
-      $path = fetchdodbinary($pool, $repo, $p, $arch, 3, \@handoff);
+      my @handoff = ("/build/$prp/$arch/_repository/$bin", undef, BSRPC::args($cgi, 'view', 'module'));
+      $path = BSRepServer::DoD::fetchdodbinary("$reporoot/$prp/$arch", $pool, $repo, $p, \@handoff);
       return unless defined $path;
       $needscan = 1;
     }


### PR DESCRIPTION
_Replace this line with a description of your changes. Please follow the suggestions in the comment below._

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
