### PR TITLE
Create the data_migrations table unless it exists

### DIFF
--- a/src/api/db/migrate/20210511201658_add_data_migrations_table.rb
+++ b/src/api/db/migrate/20210511201658_add_data_migrations_table.rb
@@ -1,0 +1,9 @@
+class AddDataMigrationsTable < ActiveRecord::Migration[6.0]
+  def change
+    # rubocop:disable Rails/CreateTableWithTimestamps
+    create_table :data_migrations, primary_key: 'version', id: false, if_not_exists: true do |t|
+      t.string :version
+    end
+    # rubocop:enable Rails/CreateTableWithTimestamps
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_05_160725) do
+ActiveRecord::Schema.define(version: 2021_05_11_201658) do
 
   create_table "architectures", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false, collation: "utf8_general_ci"
@@ -344,6 +344,9 @@ ActiveRecord::Schema.define(version: 2021_05_05_160725) do
     t.string "api_url", collation: "utf8_bin"
     t.string "unlisted_projects_filter", default: "^home:.+", collation: "utf8_bin"
     t.string "unlisted_projects_filter_description", default: "home projects", collation: "utf8_bin"
+  end
+
+  create_table "data_migrations", primary_key: "version", id: :string, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
   end
 
   create_table "delayed_jobs", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|


### PR DESCRIPTION
This table is usually created once you run some data_migrate rake task. Let's be more explicit about this.
