### PR TITLE
Fix the style and the collapse of Mentioned Issues

### DIFF
--- a/src/api/app/assets/stylesheets/webui/collapsible-text.scss
+++ b/src/api/app/assets/stylesheets/webui/collapsible-text.scss
@@ -44,3 +44,8 @@
   @include collapsible($maxHeight: 2.75em, $maxWidth: 'none');
   .obs-collapsible-textbox {  @extend .pr-0; }
 }
+
+#issue-summary {
+  @include collapsible($maxHeight: 1.5em);
+  .obs-collapsible-textbox {  @extend .pr-0; }
+}

--- a/src/api/app/helpers/webui/webui_helper.rb
+++ b/src/api/app/helpers/webui/webui_helper.rb
@@ -273,21 +273,6 @@ module Webui::WebuiHelper
     safe_join(string.scan(/.{1,#{length}}/), '<wbr>'.html_safe)
   end
 
-  def toggle_sliced_text(text, slice_length = 50, id = "toggle_sliced_text_#{Time.now.to_f.to_s.delete('.')}")
-    return text if text.to_s.length < slice_length
-
-    javascript_toggle_code = "$(\"[data-toggle-id='".html_safe + id + "']\").toggle();".html_safe
-    short = tag.span('data-toggle-id' => id) do
-      tag.span(text.slice(0, slice_length) + ' ') +
-        link_to('[+]', 'javascript:void(0)', onclick: javascript_toggle_code)
-    end
-    long = tag.span('data-toggle-id' => id, :style => 'display: none;') do
-      tag.span(text + ' ') +
-        link_to('[-]', 'javascript:void(0)', onclick: javascript_toggle_code)
-    end
-    short + long
-  end
-
   # paths param will accept one or more paths to match to make this tab active.
   # Only the first one will be used as link though if more than one is present.
   def tab_link(label, paths, active = false, html_class = 'nav-link text-nowrap')

--- a/src/api/app/views/webui/request/_issues_table.html.haml
+++ b/src/api/app/views/webui/request/_issues_table.html.haml
@@ -1,23 +1,17 @@
-%p
-  %b
-    Mentioned Issues (#{issues.length})
-%table
-  %tbody
-    - issues.each do |long_name, issue|
-      - if issue[:owner] && issue[:state]
-        %tr
-          %td
-            = link_to(long_name, issue[:url], target: '_blank', rel: 'noopener')
-          %td.nowrap
-            - if issue[:owner]
-              = user_with_realname_and_icon issue[:owner], short: true
-          %td
-            = issue[:state]&.capitalize
-      - else
-        %tr.even
-          %td{ colspan: '3' }
-            = link_to(long_name, issue[:url], target: '_blank', rel: 'noopener')
-      - if issue[:summary]
-        %tr.odd
-          %td{ colspan: '3' }
-            = toggle_sliced_text(issue[:summary])
+.card.mt-3
+  .card-body
+    %h5 Mentioned Issues (#{issues.length})
+    .list-group.list-group-flush
+      - issues.each do |long_name, issue|
+        .list-group-item
+          - if issue[:owner] && issue[:state]
+            .row
+              = link_to(long_name, issue[:url], target: '_blank', rel: 'noopener')
+              %span.ml-3= issue[:state]&.capitalize
+              %span.ml-3= user_with_realname_and_icon issue[:owner], short: true
+          - else
+            .row
+              = link_to(long_name, issue[:url], target: '_blank', rel: 'noopener')
+          - if issue[:summary]
+            .row.mt-2#issue-summary
+              = render partial: 'webui/shared/collapsible_text', locals: { text: issue[:summary] }

--- a/src/api/spec/helpers/webui/webui_helper_spec.rb
+++ b/src/api/spec/helpers/webui/webui_helper_spec.rb
@@ -199,24 +199,6 @@ RSpec.describe Webui::WebuiHelper do
     end
   end
 
-  describe '#toggle_sliced_text' do
-    let(:short_text) { 'short_text' }
-    let(:big_text) { 'big_text_' * 100 }
-    let(:sliced_text) { big_text.slice(0, 50) }
-
-    context 'with nil as text' do
-      it { expect(toggle_sliced_text(nil)).to be_nil }
-    end
-
-    context 'with a short text' do
-      it { expect(toggle_sliced_text(short_text)).to eq(short_text) }
-    end
-
-    context 'with a big text' do
-      it { expect(toggle_sliced_text(big_text)).to match(/(.+)#{sliced_text}(.+)\[\+\](.+)#{big_text}(.+)\[-\](.+)/) }
-    end
-  end
-
   describe '#pick_max_problems' do
     let(:max_shown) { 5 }
 


### PR DESCRIPTION
In the _Mentioned Issues_ section, collapsing the summary of the issue was broken. It was implemented by `Webui::WebuiHelper#toggle_sliced_text`. The helper has been removed and the text is now collapsed in the same way as any other text in the application, with "Show more/less" link.

Improve the style of the section too.

Fixes #10829.

**Before:**

![Screenshot_2021-05-13 Request 26 (new)(1)](https://user-images.githubusercontent.com/2581944/118110850-36024a80-b3e3-11eb-9a86-b617ff5f25f0.png)


**After:**

![Screenshot_2021-05-13 Request 26 (new)](https://user-images.githubusercontent.com/2581944/118110873-3bf82b80-b3e3-11eb-8bbb-c0997a87cc52.png)
