### PR TITLE
[backend] support local build for cross builds

### DIFF
--- a/src/backend/BSRepServer/BuildInfo.pm
+++ b/src/backend/BSRepServer/BuildInfo.pm
@@ -96,8 +96,16 @@ sub buildinfo {
   my $debugoutput = '';
   $ctx->{'expanddebug'} = \$debugoutput if $opts{'debug'};
 
-  my @prpsearchpath = BSRepServer::ProjPacks::expandsearchpath($ctx->{'gctx'}, $projid, $repo);
+  # set prpsearchpath
+  my $pathelement;
+  $pathelement = 'hostsystem' if $repo->{'crosshostarch'} && $repo->{'crosshostarch'} eq $arch;
+  my @prpsearchpath = BSRepServer::ProjPacks::expandsearchpath($ctx->{'gctx'}, $projid, $repo, $pathelement);
   $ctx->{'prpsearchpath'} = \@prpsearchpath;
+  if ($repo->{'crosshostarch'} && $repo->{'crosshostarch'} ne $arch) {
+    $pathelement = 'hostsystem' if $repo->{'crosshostarch'} && $repo->{'crosshostarch'} eq $arch;
+    my @prpsearchpath_host = BSRepServer::ProjPacks::expandsearchpath($ctx->{'gctx'}, $projid, $repo, 'hostsystem');
+    $ctx->{'prpsearchpath_host'} = \@prpsearchpath_host;
+  }
 
   # setup config
   $ctx->setup();

--- a/src/backend/BSRepServer/ProjPacks.pm
+++ b/src/backend/BSRepServer/ProjPacks.pm
@@ -94,14 +94,15 @@ sub update_projpacks {
 }
 
 sub expandsearchpath {
-  my ($gctx, $projid, $repo) = @_;
+  my ($gctx, $projid, $repo, $pathelement) = @_;
 
   my $myarch = $gctx->{'arch'};
   my $projpacks = $gctx->{'projpacks'};
   my $remoteprojs = $gctx->{'remoteprojs'};
+  $pathelement ||= 'path';
   my %done;
   my @ret;
-  my @path = @{$repo->{'path'} || []}; 
+  my @path = @{$repo->{$pathelement} || $repo->{'path'} || []}; 
   # our own repository is not included in the path,
   # so put it infront of everything
   unshift @path, {'project' => $projid, 'repository' => $repo->{'name'}};
@@ -117,7 +118,7 @@ sub expandsearchpath {
       next unless $proj;
       $done{"/$prp"} = 1;       # mark expanded
       my @repo = grep {$_->{'name'} eq $rid} @{$proj->{'repository'} || []}; 
-      push @path, @{$repo[0]->{'path'}} if @repo && $repo[0]->{'path'};
+      push @path, @{$repo[0]->{$pathelement} || $repo[0]->{'path'} || []} if @repo;
     }    
   }
   return @ret;

--- a/src/backend/BSRepServer/Remote.pm
+++ b/src/backend/BSRepServer/Remote.pm
@@ -44,7 +44,7 @@ sub addrepo_remote {
   return undef unless $remoteproj;
   my @modules;
   @modules = $pool->getmodules() if defined &BSSolv::pool::getmodules;
-  print "fetching remote repository state for $prp\n";
+  print "fetching remote repository state for $prp/$arch\n";
   my $param = {
     'uri' => "$remoteproj->{'remoteurl'}/build/$remoteproj->{'remoteproject'}/$repoid/$arch/_repository",
     'timeout' => 200,

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -1149,13 +1149,19 @@ sub getprojpack {
       # add all projects from the expanded path
       my $er = $expandedrepos{"$projid/$cgi->{'repository'}->[0]"};
       die($er) unless ref($er);
+      my $c;
       eval {
-	concatconfigs($projid, $cgi->{'repository'}->[0], $remotemap, @$er);
+	$c = concatconfigs($projid, $cgi->{'repository'}->[0], $remotemap, @$er);
       };
       for my $prp (@$er) {
         my ($p) = split('/', $prp, 2);
         next if $remotemap && $remotemap->{$p};
 	push @projids, $p unless $p eq $projid || grep {$_ eq $p} @projids;
+      }
+      my $repo = (grep {$_->{'name'} eq $cgi->{'repository'}->[0]} @{$jinfo->{'repository'} || []})[0];
+      if ($repo && $repo->{'hostsystem'}) {
+        my $conf = Build::read_config($arch, [ split("\n", $c) ]);
+        $repo->{'crosshostarch'} = $conf->{'hostarch'} || $arch;
       }
     }
 


### PR DESCRIPTION
Co-authored-by: Michael Schröder <mls@suse.de>

_Replace this line with a description of your changes. Please follow the suggestions in the comment below._

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
