### PR TITLE
Only create a CSS grid on code inside diffs

### DIFF
--- a/src/api/app/assets/stylesheets/webui/coderay.scss
+++ b/src/api/app/assets/stylesheets/webui/coderay.scss
@@ -2,11 +2,11 @@
   background: $card-bg;
   color: $body-color;
 }
-.CodeRay pre {
-  margin: 0;
+.details-with-coderay .CodeRay pre {
   display: grid;
   grid-template-columns: min-content [col-separator] auto;
 }
+.CodeRay pre { margin: 0; }
 span.CodeRay { white-space: pre }
 
 .CodeRay .line-numbers {


### PR DESCRIPTION
Creating a CSS grid on code inside comments breaks the rendering of the content. This PR prevents creating a CSS grid for code inside comments.

Fixes #11154.

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature
