### PR TITLE
Avoid sorting Actions DataTable's column

### DIFF
--- a/src/api/app/views/webui/projects/maintained_projects/index.html.haml
+++ b/src/api/app/views/webui/projects/maintained_projects/index.html.haml
@@ -35,6 +35,6 @@
       ajax: $('#maintained-projects-datatable').data('source'),
       columns: [
         { data: 'name' },
-        { data: 'actions' }
+        { data: 'actions', orderable: false, searchable: false }
       ]
     });

--- a/src/api/app/views/webui/shared/_patchinfos_table.html.haml
+++ b/src/api/app/views/webui/shared/_patchinfos_table.html.haml
@@ -19,6 +19,6 @@
         { data: 'project' },
         { data: 'package' },
         { data: 'issues' },
-        { data: 'actions' }
+        { data: 'actions', orderable: false, searchable: false }
       ]
     });


### PR DESCRIPTION
The Actions column contains icons that are links to perform some action. It makes no sense to sort by that column. From now on, the DataTable's column is configured to not be "orderable".

Actions column without ordering:

![Screenshot_2021-05-18 Open Build Service(2)](https://user-images.githubusercontent.com/2581944/118689039-e965a780-b806-11eb-953a-baf3568a9aa4.png)

as we do in other tables too:

![Screenshot_2021-05-18 Open Build Service(1)](https://user-images.githubusercontent.com/2581944/118688799-ab688380-b806-11eb-9419-448c349d92eb.png)

Fixes #10608