### PR TITLE
Add systemd service for scm delayed job queue

### DIFF
--- a/dist/Makefile
+++ b/dist/Makefile
@@ -5,7 +5,7 @@ LOGROTATE_CONFIGS     := obs-api obs-server obs-source_service
 OBS_BIN_SCRIPTS       := obs_productconvert
 OBS_SBIN_SCRIPTS      := obs_admin obs_serverstatus obsscheduler obsworker obsstoragesetup
 SYSTEMD_TARGET_FILES  := obs-api-support
-SYSTEMD_SERVICE_FILES := obs-clockwork obs-delayedjob-queue-project_log_rotate obs-delayedjob-queue-consistency_check obs-delayedjob-queue-default obs-delayedjob-queue-releasetracking obs-delayedjob-queue-issuetracking obs-delayedjob-queue-mailers obs-delayedjob-queue-staging obs-sphinx obsdeltastore obsdispatcher obsdodup obswarden obssrcserver obsrepserver obspublisher obssigner obsservice obsservicedispatch obssourcepublish obsgetbinariesproxy obsclouduploadserver obsclouduploadworker obsscheduler obsworker obsstoragesetup obsapisetup obsnotifyforward obsredis
+SYSTEMD_SERVICE_FILES := obs-clockwork obs-delayedjob-queue-project_log_rotate obs-delayedjob-queue-consistency_check obs-delayedjob-queue-default obs-delayedjob-queue-releasetracking obs-delayedjob-queue-issuetracking obs-delayedjob-queue-mailers obs-delayedjob-queue-staging obs-delayedjob-queue-scm obs-sphinx obsdeltastore obsdispatcher obsdodup obswarden obssrcserver obsrepserver obspublisher obssigner obsservice obsservicedispatch obssourcepublish obsgetbinariesproxy obsclouduploadserver obsclouduploadworker obsscheduler obsworker obsstoragesetup obsapisetup obsnotifyforward obsredis
 SYSTEMD_SERVICE_FILES_WITHOUT_LINK := obs-delayedjob-queue-quick@
 
 UNITDIR=/usr/lib/systemd/system/

--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -129,7 +129,7 @@ fi										\
 }
 %endif
 
-%global obs_api_support_scripts obs-api-support.target obs-clockwork.service obs-delayedjob-queue-consistency_check.service obs-delayedjob-queue-default.service obs-delayedjob-queue-issuetracking.service obs-delayedjob-queue-mailers.service obs-delayedjob-queue-project_log_rotate.service obs-delayedjob-queue-releasetracking.service obs-delayedjob-queue-staging.service obs-sphinx.service
+%global obs_api_support_scripts obs-api-support.target obs-clockwork.service obs-delayedjob-queue-consistency_check.service obs-delayedjob-queue-default.service obs-delayedjob-queue-issuetracking.service obs-delayedjob-queue-mailers.service obs-delayedjob-queue-project_log_rotate.service obs-delayedjob-queue-releasetracking.service obs-delayedjob-queue-staging.service obs-delayedjob-queue-scm.service obs-sphinx.service
 
 Name:           obs-server
 Summary:        The Open Build Service -- Server Component
@@ -946,6 +946,7 @@ usermod -a -G docker obsservicerun
 %{_unitdir}/obs-delayedjob-queue-quick@.service
 %{_unitdir}/obs-delayedjob-queue-releasetracking.service
 %{_unitdir}/obs-delayedjob-queue-staging.service
+%{_unitdir}/obs-delayedjob-queue-scm.service
 %{_unitdir}/obs-sphinx.service
 %if 0%{?suse_version}
 %{_sbindir}/rcobs-api-support
@@ -957,6 +958,7 @@ usermod -a -G docker obsservicerun
 %{_sbindir}/rcobs-delayedjob-queue-project_log_rotate
 %{_sbindir}/rcobs-delayedjob-queue-releasetracking
 %{_sbindir}/rcobs-delayedjob-queue-staging
+%{_sbindir}/rcobs-delayedjob-queue-scm
 %{_sbindir}/rcobs-sphinx
 %{_sbindir}/rcobsapisetup
 %endif

--- a/dist/systemd/obs-api-support.target
+++ b/dist/systemd/obs-api-support.target
@@ -1,6 +1,6 @@
 [Unit]
 Description = Open Build Service API Support Daemons
-Wants = obs-clockwork.service obs-delayedjob-queue-consistency_check.service obs-delayedjob-queue-default.service obs-delayedjob-queue-issuetracking.service obs-delayedjob-queue-mailers.service obs-delayedjob-queue-project_log_rotate.service obs-delayedjob-queue-quick@0.service obs-delayedjob-queue-quick@1.service obs-delayedjob-queue-quick@2.service obs-delayedjob-queue-releasetracking.service obs-delayedjob-queue-staging.service obs-sphinx.service
+Wants = obs-clockwork.service obs-delayedjob-queue-consistency_check.service obs-delayedjob-queue-default.service obs-delayedjob-queue-issuetracking.service obs-delayedjob-queue-mailers.service obs-delayedjob-queue-project_log_rotate.service obs-delayedjob-queue-quick@0.service obs-delayedjob-queue-quick@1.service obs-delayedjob-queue-quick@2.service obs-delayedjob-queue-releasetracking.service obs-delayedjob-queue-staging.service obs-delayedjob-queue-scm.service obs-sphinx.service
 After = network.target
 AllowIsolate = yes
 

--- a/dist/systemd/obs-delayedjob-queue-scm.service
+++ b/dist/systemd/obs-delayedjob-queue-scm.service
@@ -1,0 +1,16 @@
+[Unit]
+Description = Open Build Service DelayedJob Queue: scm
+BindsTo = obs-api-support.target
+
+[Service]
+Environment = "RAILS_ENV=production"
+User = @@APACHE_USER@@
+Group = @@APACHE_GROUP@@
+WorkingDirectory = @@OBS_API_PREFIX@@
+ExecStart = @@OBS_BUNDLE_BIN@@ exec script/delayed_job.api.rb --queue=scm start -i 1070
+ExecStop  = @@OBS_BUNDLE_BIN@@ exec script/delayed_job.api.rb --queue=scm stop -i 1070
+Type = forking
+PIDFile = @@OBS_API_PREFIX@@/tmp/pids/delayed_job.1070.pid
+
+[Install]
+WantedBy = obs-api-support.target


### PR DESCRIPTION
The `ReportToScmJob` (responsible for reporting back the resulting
build states of a Workflow to GitHub/GitLab) queues the jobs
in a dedicated delayedjob queue.

Co-authored-by: Dany Marcoux <dmarcoux@suse.com>
Co-authored-by: Victor Pereira <vpereira@suse.com>

(Taken from #11060 in order to merge changes which can already go on master.)