### PR TITLE
Hide scm channel from subscription configuration page

### DIFF
--- a/src/api/app/models/event_subscription.rb
+++ b/src/api/app/models/event_subscription.rb
@@ -21,6 +21,9 @@ class EventSubscription < ApplicationRecord
     scm: 4
   }
 
+  # Channels used by the event system, but not meant to be enabled by hand
+  INTERNAL_ONLY_CHANNELS = ['scm'].freeze
+
   serialize :payload, JSON
 
   belongs_to :user, inverse_of: :event_subscriptions
@@ -77,8 +80,8 @@ class EventSubscription < ApplicationRecord
       subscription_receiver_role: receiver_role }
   end
 
-  def self.without_channel_disabled
-    channels.keys.reject { |channel| channel == 'disabled' }
+  def self.without_disabled_or_internal_channels
+    channels.keys.reject { |channel| channel == 'disabled' || channel.in?(INTERNAL_ONLY_CHANNELS) }
   end
 end
 

--- a/src/api/app/models/event_subscription/for_role_form.rb
+++ b/src/api/app/models/event_subscription/for_role_form.rb
@@ -10,7 +10,7 @@ class EventSubscription
     end
 
     def call
-      @channels = EventSubscription.without_channel_disabled.map do |channel|
+      @channels = EventSubscription.without_disabled_or_internal_channels.map do |channel|
         channel_for_event_class_and_role(@event, name, channel)
       end
 

--- a/src/api/spec/models/event_subscription/for_role_form_spec.rb
+++ b/src/api/spec/models/event_subscription/for_role_form_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe EventSubscription::ForRoleForm do
     let(:subscription) { channel.subscription }
 
     RSpec.shared_examples 'a channel with subscription' do |channel_name|
-      it { expect(subject.channels.map(&:name)).to match_array(EventSubscription.channels.keys[1..-1]) }
+      it { expect(subject.channels.map(&:name)).to match_array(EventSubscription.without_disabled_or_internal_channels) }
       it { expect(channel.name).to eq(channel_name) }
       it { expect(subscription.eventtype).to eq(event_class.to_s) }
       it { expect(subscription.receiver_role).to eq(role) }


### PR DESCRIPTION
The scm channel in the event system is not meant to be
set by hand, its only used internally to report the state of a
workflow (at least for now). Therefore we should not allow
to set it by hand (since it doesnt bring any value).

![2021-05-21_19-29](https://user-images.githubusercontent.com/22001671/119176131-00a4cf00-ba6b-11eb-93a6-b77d5676003d.png)
