### PR TITLE
[backend] Add buildhook feature

### DIFF
--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -3479,6 +3479,15 @@ sub getworkercode {
   return getcode($cgi, 'worker');
 }
 
+sub getbuildhook {
+  my ($cgi) = @_;
+  if ($BSConfig::buildhookpath) {
+    return getcode($cgi, $BSConfig::buildhookpath);
+  }else{
+    return undef
+  }
+}
+
 sub postrepo {
   my ($cgi, $projid, $repoid, $arch) = @_;
 
@@ -4366,6 +4375,7 @@ my $dispatches = [
   '!worker /worker $arch $port $state: workerid? working:bool? memory:num? disk:num? buildarch:arch* tellnojob:bool?' => \&workerstate,
   '!worker /getbuildcode' => \&getbuildcode,
   '!worker /getworkercode' => \&getworkercode,
+  '!worker /getbuildhook' => \&getbuildhook,
   '!worker POST:/putjob $arch $job $jobid $code:? now:num? kiwitree:bool? workerid?' => \&putjob,
   '!worker POST:/workerdispatched $arch $job $jobid hostarch:arch port workerid?' => \&workerdispatched,
   '!worker /getbinaries $project $repository $arch binaries: nometa:bool? metaonly:bool? workerid? now:num? module*' => \&getbinaries,

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -978,6 +978,8 @@ sub getcode {
     symlink('.', "$ndir/Time") || die("symlink: $!\n");
     # we just change every file to be on the safe side
     chmod(0755, "$ndir/$_->{'name'}") for @$res;
+  } elsif ($dir eq 'hook') {
+    chmod(0755, "$ndir/$_->{'name'}") for @$res;
   }
 
   # ok, commit
@@ -3098,6 +3100,26 @@ sub normalize_container {
 
 $Build::Kiwi::urlmapper = sub {return '_obsrepositories'}  unless $Build::Kiwi::urlmapper;
 
+sub buildhook {
+  my ($mode, $projid, $packid, $repoid, $arch) = @_;
+
+  my $hook = {};
+
+  if ($mode eq 'before'){
+    $hook = $BSConfig::beforebuildhook;
+  } elsif ($mode eq 'after'){
+    $hook = $BSConfig::afterbuildhook;
+  }
+
+  for my $key (sort {$b cmp $a} keys %{$hook}) {
+    if ("$projid/$packid" =~ /^$key$/) {
+      my $cmd = "hook/".$hook->{$key};
+      print "calling $mode build hook: '$cmd'\n";
+      qsystem($cmd, $buildroot, $projid, $packid, $repoid, $arch, $mode) && die("$cmd failed: $!\n");
+    }
+  }
+}
+
 sub dobuild {
   my ($buildinfo) = @_;
 
@@ -3454,14 +3476,19 @@ sub dobuild {
       push @args, '--kiwi-parameter', "--set-container-derived-from=$containerurl";
     }
   }
+
+  buildhook('before', $projid, $packid, $repoid, $arch) if $BSConfig::beforebuildhook;
+
   qsystem(@args);
+  my $ret = $?;
+
+  buildhook('after', $projid, $packid, $repoid, $arch) if $BSConfig::afterbuildhook;
 
   print "\n";
   print BSUtil::isotime(time()).": finished '$packid' for project '$projid' repository '$repoid' arch '$arch'";
   print " using helper $helper" if $helper;
   print "\n";
 
-  my $ret = $?;
   if ($ret == 512) { # system exit code 2 maps to 2 * 256
     if (($buildinfo->{'reason'} || '') eq "rebuild counter sync") {
       $ret = 0;
@@ -3785,6 +3812,12 @@ sub startbuild {
     my $peer = "$req->{'peer'}:$cgi->{'port'}";
     $workercode = getcode('worker', "http://$peer/getworkercode");
     die("could not update worker code\n") unless $workercode;
+    if (($BSConfig::beforebuildhook && %{ $BSConfig::beforebuildhook })||
+        ($BSConfig::afterbuildhook &&  %{ $BSConfig::afterbuildhook })){
+      print "fetching buildhook\n";
+      my $buildhook = getcode('hook', "http://$peer/getbuildhook");
+      warn("could not update build hook\n") unless $buildhook;
+    }
     $state->{'state'} = 'rebooting';
     print "activating new worker code $workercode\n";
     commitstate($state);


### PR DESCRIPTION
This PR should close #11027 

For test in local environment:
1. Create path buildhook:
   ```
   mkdir buildhook
   ```
2. Create simple buildhook script `test.sh`:
   ```bash
   #!/bin/bash
   
   BUILDROOT=$1
   PROJID=$2
   PACKID=$3
   REPOID=$4
   ARCH=$5
   MODE=$6
   
   exec > >(tee -a "$BUILDROOT/.build.log") 2>&1
   
   if [ "$MODE" = "before" ]; then
     echo "Before hook executing" > $BUILDROOT/.hook.log
   else
     echo "Before hook result:"
     echo "-------------------"
     cat $BUILDROOT/.hook.log
     echo "-------------------"
     echo "After hook executing"
   fi
   ```
3. Copy file `src/backend/BSConfig.pm.template` to `src/backend/BSConfig.pm` and add next lines:
   ```
   our $buildhookpath = "/obs/buildhook";
   our $beforebuildhook = {".*" => "test.sh"};
   our $afterbuildhook = {".*" => "test.sh"};
   ```
4. Start OBS
   ```
   docker-compose up
   ```
5. Add package and build it
6. See build log

** After **
![Screenshot from 2021-05-23 16-07-33](https://user-images.githubusercontent.com/74910851/119261743-674bf900-bbe1-11eb-96e2-084ac857d08d.png)
