### PR TITLE
Remove package id from event table

### DIFF
--- a/src/api/app/models/event/base.rb
+++ b/src/api/app/models/event/base.rb
@@ -346,12 +346,10 @@ end
 #  undone_jobs :integer          default(0)
 #  created_at  :datetime         indexed
 #  updated_at  :datetime
-#  package_id  :integer          indexed
 #
 # Indexes
 #
 #  index_events_on_created_at  (created_at)
 #  index_events_on_eventtype   (eventtype)
 #  index_events_on_mails_sent  (mails_sent)
-#  index_events_on_package_id  (package_id)
 #

--- a/src/api/app/models/event/base.rb
+++ b/src/api/app/models/event/base.rb
@@ -4,6 +4,7 @@ module Event
   class Base < ApplicationRecord
     self.inheritance_column = 'eventtype'
     self.table_name = 'events'
+    self.ignored_columns = ['package_id']
 
     after_create :create_project_log_entry_job, if: -> { (PROJECT_CLASSES | PACKAGE_CLASSES).include?(self.class.name) }
 

--- a/src/api/app/models/event/branch_command.rb
+++ b/src/api/app/models/event/branch_command.rb
@@ -21,12 +21,10 @@ end
 #  undone_jobs :integer          default(0)
 #  created_at  :datetime         indexed
 #  updated_at  :datetime
-#  package_id  :integer          indexed
 #
 # Indexes
 #
 #  index_events_on_created_at  (created_at)
 #  index_events_on_eventtype   (eventtype)
 #  index_events_on_mails_sent  (mails_sent)
-#  index_events_on_package_id  (package_id)
 #

--- a/src/api/app/models/event/build_fail.rb
+++ b/src/api/app/models/event/build_fail.rb
@@ -55,12 +55,10 @@ end
 #  undone_jobs :integer          default(0)
 #  created_at  :datetime         indexed
 #  updated_at  :datetime
-#  package_id  :integer          indexed
 #
 # Indexes
 #
 #  index_events_on_created_at  (created_at)
 #  index_events_on_eventtype   (eventtype)
 #  index_events_on_mails_sent  (mails_sent)
-#  index_events_on_package_id  (package_id)
 #

--- a/src/api/app/models/event/build_success.rb
+++ b/src/api/app/models/event/build_success.rb
@@ -20,12 +20,10 @@ end
 #  undone_jobs :integer          default(0)
 #  created_at  :datetime         indexed
 #  updated_at  :datetime
-#  package_id  :integer          indexed
 #
 # Indexes
 #
 #  index_events_on_created_at  (created_at)
 #  index_events_on_eventtype   (eventtype)
 #  index_events_on_mails_sent  (mails_sent)
-#  index_events_on_package_id  (package_id)
 #

--- a/src/api/app/models/event/build_unchanged.rb
+++ b/src/api/app/models/event/build_unchanged.rb
@@ -20,12 +20,10 @@ end
 #  undone_jobs :integer          default(0)
 #  created_at  :datetime         indexed
 #  updated_at  :datetime
-#  package_id  :integer          indexed
 #
 # Indexes
 #
 #  index_events_on_created_at  (created_at)
 #  index_events_on_eventtype   (eventtype)
 #  index_events_on_mails_sent  (mails_sent)
-#  index_events_on_package_id  (package_id)
 #

--- a/src/api/app/models/event/comment_for_package.rb
+++ b/src/api/app/models/event/comment_for_package.rb
@@ -23,12 +23,10 @@ end
 #  undone_jobs :integer          default(0)
 #  created_at  :datetime         indexed
 #  updated_at  :datetime
-#  package_id  :integer          indexed
 #
 # Indexes
 #
 #  index_events_on_created_at  (created_at)
 #  index_events_on_eventtype   (eventtype)
 #  index_events_on_mails_sent  (mails_sent)
-#  index_events_on_package_id  (package_id)
 #

--- a/src/api/app/models/event/comment_for_project.rb
+++ b/src/api/app/models/event/comment_for_project.rb
@@ -23,12 +23,10 @@ end
 #  undone_jobs :integer          default(0)
 #  created_at  :datetime         indexed
 #  updated_at  :datetime
-#  package_id  :integer          indexed
 #
 # Indexes
 #
 #  index_events_on_created_at  (created_at)
 #  index_events_on_eventtype   (eventtype)
 #  index_events_on_mails_sent  (mails_sent)
-#  index_events_on_package_id  (package_id)
 #

--- a/src/api/app/models/event/comment_for_request.rb
+++ b/src/api/app/models/event/comment_for_request.rb
@@ -32,12 +32,10 @@ end
 #  undone_jobs :integer          default(0)
 #  created_at  :datetime         indexed
 #  updated_at  :datetime
-#  package_id  :integer          indexed
 #
 # Indexes
 #
 #  index_events_on_created_at  (created_at)
 #  index_events_on_eventtype   (eventtype)
 #  index_events_on_mails_sent  (mails_sent)
-#  index_events_on_package_id  (package_id)
 #

--- a/src/api/app/models/event/commit.rb
+++ b/src/api/app/models/event/commit.rb
@@ -36,12 +36,10 @@ end
 #  undone_jobs :integer          default(0)
 #  created_at  :datetime         indexed
 #  updated_at  :datetime
-#  package_id  :integer          indexed
 #
 # Indexes
 #
 #  index_events_on_created_at  (created_at)
 #  index_events_on_eventtype   (eventtype)
 #  index_events_on_mails_sent  (mails_sent)
-#  index_events_on_package_id  (package_id)
 #

--- a/src/api/app/models/event/create_package.rb
+++ b/src/api/app/models/event/create_package.rb
@@ -31,12 +31,10 @@ end
 #  undone_jobs :integer          default(0)
 #  created_at  :datetime         indexed
 #  updated_at  :datetime
-#  package_id  :integer          indexed
 #
 # Indexes
 #
 #  index_events_on_created_at  (created_at)
 #  index_events_on_eventtype   (eventtype)
 #  index_events_on_mails_sent  (mails_sent)
-#  index_events_on_package_id  (package_id)
 #

--- a/src/api/app/models/event/create_project.rb
+++ b/src/api/app/models/event/create_project.rb
@@ -31,12 +31,10 @@ end
 #  undone_jobs :integer          default(0)
 #  created_at  :datetime         indexed
 #  updated_at  :datetime
-#  package_id  :integer          indexed
 #
 # Indexes
 #
 #  index_events_on_created_at  (created_at)
 #  index_events_on_eventtype   (eventtype)
 #  index_events_on_mails_sent  (mails_sent)
-#  index_events_on_package_id  (package_id)
 #

--- a/src/api/app/models/event/delete_package.rb
+++ b/src/api/app/models/event/delete_package.rb
@@ -32,12 +32,10 @@ end
 #  undone_jobs :integer          default(0)
 #  created_at  :datetime         indexed
 #  updated_at  :datetime
-#  package_id  :integer          indexed
 #
 # Indexes
 #
 #  index_events_on_created_at  (created_at)
 #  index_events_on_eventtype   (eventtype)
 #  index_events_on_mails_sent  (mails_sent)
-#  index_events_on_package_id  (package_id)
 #

--- a/src/api/app/models/event/delete_project.rb
+++ b/src/api/app/models/event/delete_project.rb
@@ -27,12 +27,10 @@ end
 #  undone_jobs :integer          default(0)
 #  created_at  :datetime         indexed
 #  updated_at  :datetime
-#  package_id  :integer          indexed
 #
 # Indexes
 #
 #  index_events_on_created_at  (created_at)
 #  index_events_on_eventtype   (eventtype)
 #  index_events_on_mails_sent  (mails_sent)
-#  index_events_on_package_id  (package_id)
 #

--- a/src/api/app/models/event/packtrack.rb
+++ b/src/api/app/models/event/packtrack.rb
@@ -20,12 +20,10 @@ end
 #  undone_jobs :integer          default(0)
 #  created_at  :datetime         indexed
 #  updated_at  :datetime
-#  package_id  :integer          indexed
 #
 # Indexes
 #
 #  index_events_on_created_at  (created_at)
 #  index_events_on_eventtype   (eventtype)
 #  index_events_on_mails_sent  (mails_sent)
-#  index_events_on_package_id  (package_id)
 #

--- a/src/api/app/models/event/repo_build_finished.rb
+++ b/src/api/app/models/event/repo_build_finished.rb
@@ -29,12 +29,10 @@ end
 #  undone_jobs :integer          default(0)
 #  created_at  :datetime         indexed
 #  updated_at  :datetime
-#  package_id  :integer          indexed
 #
 # Indexes
 #
 #  index_events_on_created_at  (created_at)
 #  index_events_on_eventtype   (eventtype)
 #  index_events_on_mails_sent  (mails_sent)
-#  index_events_on_package_id  (package_id)
 #

--- a/src/api/app/models/event/repo_build_started.rb
+++ b/src/api/app/models/event/repo_build_started.rb
@@ -29,12 +29,10 @@ end
 #  undone_jobs :integer          default(0)
 #  created_at  :datetime         indexed
 #  updated_at  :datetime
-#  package_id  :integer          indexed
 #
 # Indexes
 #
 #  index_events_on_created_at  (created_at)
 #  index_events_on_eventtype   (eventtype)
 #  index_events_on_mails_sent  (mails_sent)
-#  index_events_on_package_id  (package_id)
 #

--- a/src/api/app/models/event/repo_publish_state.rb
+++ b/src/api/app/models/event/repo_publish_state.rb
@@ -17,12 +17,10 @@ end
 #  undone_jobs :integer          default(0)
 #  created_at  :datetime         indexed
 #  updated_at  :datetime
-#  package_id  :integer          indexed
 #
 # Indexes
 #
 #  index_events_on_created_at  (created_at)
 #  index_events_on_eventtype   (eventtype)
 #  index_events_on_mails_sent  (mails_sent)
-#  index_events_on_package_id  (package_id)
 #

--- a/src/api/app/models/event/repo_published.rb
+++ b/src/api/app/models/event/repo_published.rb
@@ -28,12 +28,10 @@ end
 #  undone_jobs :integer          default(0)
 #  created_at  :datetime         indexed
 #  updated_at  :datetime
-#  package_id  :integer          indexed
 #
 # Indexes
 #
 #  index_events_on_created_at  (created_at)
 #  index_events_on_eventtype   (eventtype)
 #  index_events_on_mails_sent  (mails_sent)
-#  index_events_on_package_id  (package_id)
 #

--- a/src/api/app/models/event/request_change.rb
+++ b/src/api/app/models/event/request_change.rb
@@ -16,12 +16,10 @@ end
 #  undone_jobs :integer          default(0)
 #  created_at  :datetime         indexed
 #  updated_at  :datetime
-#  package_id  :integer          indexed
 #
 # Indexes
 #
 #  index_events_on_created_at  (created_at)
 #  index_events_on_eventtype   (eventtype)
 #  index_events_on_mails_sent  (mails_sent)
-#  index_events_on_package_id  (package_id)
 #

--- a/src/api/app/models/event/request_create.rb
+++ b/src/api/app/models/event/request_create.rb
@@ -43,12 +43,10 @@ end
 #  undone_jobs :integer          default(0)
 #  created_at  :datetime         indexed
 #  updated_at  :datetime
-#  package_id  :integer          indexed
 #
 # Indexes
 #
 #  index_events_on_created_at  (created_at)
 #  index_events_on_eventtype   (eventtype)
 #  index_events_on_mails_sent  (mails_sent)
-#  index_events_on_package_id  (package_id)
 #

--- a/src/api/app/models/event/request_delete.rb
+++ b/src/api/app/models/event/request_delete.rb
@@ -16,12 +16,10 @@ end
 #  undone_jobs :integer          default(0)
 #  created_at  :datetime         indexed
 #  updated_at  :datetime
-#  package_id  :integer          indexed
 #
 # Indexes
 #
 #  index_events_on_created_at  (created_at)
 #  index_events_on_eventtype   (eventtype)
 #  index_events_on_mails_sent  (mails_sent)
-#  index_events_on_package_id  (package_id)
 #

--- a/src/api/app/models/event/request_reviews_done.rb
+++ b/src/api/app/models/event/request_reviews_done.rb
@@ -20,12 +20,10 @@ end
 #  undone_jobs :integer          default(0)
 #  created_at  :datetime         indexed
 #  updated_at  :datetime
-#  package_id  :integer          indexed
 #
 # Indexes
 #
 #  index_events_on_created_at  (created_at)
 #  index_events_on_eventtype   (eventtype)
 #  index_events_on_mails_sent  (mails_sent)
-#  index_events_on_package_id  (package_id)
 #

--- a/src/api/app/models/event/request_statechange.rb
+++ b/src/api/app/models/event/request_statechange.rb
@@ -38,12 +38,10 @@ end
 #  undone_jobs :integer          default(0)
 #  created_at  :datetime         indexed
 #  updated_at  :datetime
-#  package_id  :integer          indexed
 #
 # Indexes
 #
 #  index_events_on_created_at  (created_at)
 #  index_events_on_eventtype   (eventtype)
 #  index_events_on_mails_sent  (mails_sent)
-#  index_events_on_package_id  (package_id)
 #

--- a/src/api/app/models/event/review_changed.rb
+++ b/src/api/app/models/event/review_changed.rb
@@ -30,12 +30,10 @@ end
 #  undone_jobs :integer          default(0)
 #  created_at  :datetime         indexed
 #  updated_at  :datetime
-#  package_id  :integer          indexed
 #
 # Indexes
 #
 #  index_events_on_created_at  (created_at)
 #  index_events_on_eventtype   (eventtype)
 #  index_events_on_mails_sent  (mails_sent)
-#  index_events_on_package_id  (package_id)
 #

--- a/src/api/app/models/event/review_wanted.rb
+++ b/src/api/app/models/event/review_wanted.rb
@@ -40,12 +40,10 @@ end
 #  undone_jobs :integer          default(0)
 #  created_at  :datetime         indexed
 #  updated_at  :datetime
-#  package_id  :integer          indexed
 #
 # Indexes
 #
 #  index_events_on_created_at  (created_at)
 #  index_events_on_eventtype   (eventtype)
 #  index_events_on_mails_sent  (mails_sent)
-#  index_events_on_package_id  (package_id)
 #

--- a/src/api/app/models/event/service_fail.rb
+++ b/src/api/app/models/event/service_fail.rb
@@ -35,12 +35,10 @@ end
 #  undone_jobs :integer          default(0)
 #  created_at  :datetime         indexed
 #  updated_at  :datetime
-#  package_id  :integer          indexed
 #
 # Indexes
 #
 #  index_events_on_created_at  (created_at)
 #  index_events_on_eventtype   (eventtype)
 #  index_events_on_mails_sent  (mails_sent)
-#  index_events_on_package_id  (package_id)
 #

--- a/src/api/app/models/event/service_success.rb
+++ b/src/api/app/models/event/service_success.rb
@@ -29,12 +29,10 @@ end
 #  undone_jobs :integer          default(0)
 #  created_at  :datetime         indexed
 #  updated_at  :datetime
-#  package_id  :integer          indexed
 #
 # Indexes
 #
 #  index_events_on_created_at  (created_at)
 #  index_events_on_eventtype   (eventtype)
 #  index_events_on_mails_sent  (mails_sent)
-#  index_events_on_package_id  (package_id)
 #

--- a/src/api/app/models/event/status_check_for_build.rb
+++ b/src/api/app/models/event/status_check_for_build.rb
@@ -17,12 +17,10 @@ end
 #  undone_jobs :integer          default(0)
 #  created_at  :datetime         indexed
 #  updated_at  :datetime
-#  package_id  :integer          indexed
 #
 # Indexes
 #
 #  index_events_on_created_at  (created_at)
 #  index_events_on_eventtype   (eventtype)
 #  index_events_on_mails_sent  (mails_sent)
-#  index_events_on_package_id  (package_id)
 #

--- a/src/api/app/models/event/status_check_for_published.rb
+++ b/src/api/app/models/event/status_check_for_published.rb
@@ -17,12 +17,10 @@ end
 #  undone_jobs :integer          default(0)
 #  created_at  :datetime         indexed
 #  updated_at  :datetime
-#  package_id  :integer          indexed
 #
 # Indexes
 #
 #  index_events_on_created_at  (created_at)
 #  index_events_on_eventtype   (eventtype)
 #  index_events_on_mails_sent  (mails_sent)
-#  index_events_on_package_id  (package_id)
 #

--- a/src/api/app/models/event/status_check_for_request.rb
+++ b/src/api/app/models/event/status_check_for_request.rb
@@ -16,12 +16,10 @@ end
 #  undone_jobs :integer          default(0)
 #  created_at  :datetime         indexed
 #  updated_at  :datetime
-#  package_id  :integer          indexed
 #
 # Indexes
 #
 #  index_events_on_created_at  (created_at)
 #  index_events_on_eventtype   (eventtype)
 #  index_events_on_mails_sent  (mails_sent)
-#  index_events_on_package_id  (package_id)
 #

--- a/src/api/app/models/event/undelete_package.rb
+++ b/src/api/app/models/event/undelete_package.rb
@@ -23,12 +23,10 @@ end
 #  undone_jobs :integer          default(0)
 #  created_at  :datetime         indexed
 #  updated_at  :datetime
-#  package_id  :integer          indexed
 #
 # Indexes
 #
 #  index_events_on_created_at  (created_at)
 #  index_events_on_eventtype   (eventtype)
 #  index_events_on_mails_sent  (mails_sent)
-#  index_events_on_package_id  (package_id)
 #

--- a/src/api/app/models/event/undelete_project.rb
+++ b/src/api/app/models/event/undelete_project.rb
@@ -17,12 +17,10 @@ end
 #  undone_jobs :integer          default(0)
 #  created_at  :datetime         indexed
 #  updated_at  :datetime
-#  package_id  :integer          indexed
 #
 # Indexes
 #
 #  index_events_on_created_at  (created_at)
 #  index_events_on_eventtype   (eventtype)
 #  index_events_on_mails_sent  (mails_sent)
-#  index_events_on_package_id  (package_id)
 #

--- a/src/api/app/models/event/update_package.rb
+++ b/src/api/app/models/event/update_package.rb
@@ -17,12 +17,10 @@ end
 #  undone_jobs :integer          default(0)
 #  created_at  :datetime         indexed
 #  updated_at  :datetime
-#  package_id  :integer          indexed
 #
 # Indexes
 #
 #  index_events_on_created_at  (created_at)
 #  index_events_on_eventtype   (eventtype)
 #  index_events_on_mails_sent  (mails_sent)
-#  index_events_on_package_id  (package_id)
 #

--- a/src/api/app/models/event/update_project.rb
+++ b/src/api/app/models/event/update_project.rb
@@ -17,12 +17,10 @@ end
 #  undone_jobs :integer          default(0)
 #  created_at  :datetime         indexed
 #  updated_at  :datetime
-#  package_id  :integer          indexed
 #
 # Indexes
 #
 #  index_events_on_created_at  (created_at)
 #  index_events_on_eventtype   (eventtype)
 #  index_events_on_mails_sent  (mails_sent)
-#  index_events_on_package_id  (package_id)
 #

--- a/src/api/app/models/event/update_project_config.rb
+++ b/src/api/app/models/event/update_project_config.rb
@@ -17,12 +17,10 @@ end
 #  undone_jobs :integer          default(0)
 #  created_at  :datetime         indexed
 #  updated_at  :datetime
-#  package_id  :integer          indexed
 #
 # Indexes
 #
 #  index_events_on_created_at  (created_at)
 #  index_events_on_eventtype   (eventtype)
 #  index_events_on_mails_sent  (mails_sent)
-#  index_events_on_package_id  (package_id)
 #

--- a/src/api/app/models/event/upload.rb
+++ b/src/api/app/models/event/upload.rb
@@ -17,12 +17,10 @@ end
 #  undone_jobs :integer          default(0)
 #  created_at  :datetime         indexed
 #  updated_at  :datetime
-#  package_id  :integer          indexed
 #
 # Indexes
 #
 #  index_events_on_created_at  (created_at)
 #  index_events_on_eventtype   (eventtype)
 #  index_events_on_mails_sent  (mails_sent)
-#  index_events_on_package_id  (package_id)
 #

--- a/src/api/app/models/event/version_change.rb
+++ b/src/api/app/models/event/version_change.rb
@@ -23,12 +23,10 @@ end
 #  undone_jobs :integer          default(0)
 #  created_at  :datetime         indexed
 #  updated_at  :datetime
-#  package_id  :integer          indexed
 #
 # Indexes
 #
 #  index_events_on_created_at  (created_at)
 #  index_events_on_eventtype   (eventtype)
 #  index_events_on_mails_sent  (mails_sent)
-#  index_events_on_package_id  (package_id)
 #

--- a/src/api/db/migrate/20210525145710_remove_package_from_event.rb
+++ b/src/api/db/migrate/20210525145710_remove_package_from_event.rb
@@ -1,0 +1,5 @@
+class RemovePackageFromEvent < ActiveRecord::Migration[6.0]
+  def change
+    safety_assured { remove_column :events, :package_id, :integer }
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_20_150000) do
+ActiveRecord::Schema.define(version: 2021_05_25_145710) do
 
   create_table "architectures", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false, collation: "utf8_general_ci"
@@ -421,11 +421,9 @@ ActiveRecord::Schema.define(version: 2021_05_20_150000) do
     t.datetime "updated_at", precision: 6
     t.integer "undone_jobs", default: 0
     t.boolean "mails_sent", default: false
-    t.integer "package_id"
     t.index ["created_at"], name: "index_events_on_created_at"
     t.index ["eventtype"], name: "index_events_on_eventtype"
     t.index ["mails_sent"], name: "index_events_on_mails_sent"
-    t.index ["package_id"], name: "index_events_on_package_id"
   end
 
   create_table "flags", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|


### PR DESCRIPTION
After changing the from the attempt of building an association
between an event and a package, to fetching the package
using the passed payload in the `ReportToScmJob`
in #11124
the package_id is not longer needed.