### PR TITLE
[backend] support DoD container registries

### DIFF
--- a/src/backend/BSRepServer/DoD.pm
+++ b/src/backend/BSRepServer/DoD.pm
@@ -16,10 +16,17 @@
 #
 package BSRepServer::DoD;
 
+use Digest::SHA ();
+
 use BSWatcher ':https';
 use BSVerify;
 use BSHandoff;
+use BSContar;
 use BSStdServer;
+use BSUtil;
+
+use BSRepServer::Containertar;
+use BSRepServer::Containerinfo;
 
 use Build;
 
@@ -51,14 +58,131 @@ sub is_wanted_dodbinary {
   return 1;
 }
 
+sub is_wanted_dodcontainer {
+  my ($pool, $p, $path, $doverify) = @_;
+  my $q = BSUtil::retrieve("$path.obsbinlnk", 1);
+  return 0 unless $q;
+  my $data = $pool->pkg2data($p);
+  return 0 if $data->{'name'} ne $q->{'name'} || $data->{'version'} ne $q->{'version'};
+  BSVerify::verify_nevraquery($q) if $doverify;		# just in case
+  return 1;
+}
+
+sub blob_matches_digest {
+  my ($tmp, $digest) = @_;
+  my $ctx;
+  $ctx = Digest::SHA->new($1) if $digest =~ /^sha(256|512):/;
+  return 0 unless $ctx;
+  my $fd;
+  return 0 unless open ($fd, '<', $tmp);
+  $ctx->addfile($fd);
+  close($fd);
+  return (split(':', $digest, 2))[1] eq $ctx->hexdigest() ? 1 : 0;
+}
+
+sub fetchdodcontainer {
+  my ($gdst, $pool, $repo, $p, $handoff) = @_;
+  my $container = $pool->pkg2name($p);
+  $container =~ s/^container://;
+
+  my $pkgname = $container;
+  $pkgname =~ s/\//_/g;
+  $pkgname = "_$pkgname" if $pkgname =~ /^_/;
+  BSVerify::verify_filename($pkgname);
+  BSVerify::verify_simple($pkgname);
+  my $dir = "$gdst/:full";
+
+  if (-e "$dir/$pkgname.obsbinlnk" && -e "$dir/$pkgname.containerinfo") {
+    # package exists, why are we called? verify that it matches our expectations
+    return "$dir/$pkgname.tar" if is_wanted_dodcontainer($pool, $p, "$dir/$pkgname");
+  }
+  # we really need to download, handoff to ajax if not already done
+  BSHandoff::handoff(@$handoff) if $handoff && !$BSStdServer::isajax;
+
+  # download all missing blobs
+  my $path = $pool->pkg2path($p);
+  die("bad DoD container path: $path\n") unless $path =~ /^(.*)\?(.*?)$/;
+  my $regrepo = $1;
+  my @blobs = split(',', $2);
+  for my $blob (@blobs) {
+    next if -e "$dir/_blob.$blob";
+    my $tmp = "$dir/._blob.$blob.$$";
+    my $url = $repo->dodurl();
+    $url .= '/' unless $url =~ /\/$/;
+    $url .= "v2/$regrepo/blobs/$blob";
+    print "fetching: $url\n";
+    my $param = {'uri' => $url, 'filename' => $tmp, 'receiver' => \&BSHTTP::file_receiver, 'proxy' => $proxy};
+    $param->{'maxredirects'} = $maxredirects if defined $maxredirects;
+    my $r;
+    eval { $r = BSWatcher::rpc($param); };
+    if ($@) {
+      $@ =~ s/(\d* *)/$1$url: /;
+      die($@);
+    }
+    return unless defined $r;
+    if (!blob_matches_digest($tmp, $blob)) {
+      unlink($tmp);
+      die("$url: blob does not match digest\n");
+    }
+    rename($tmp, "$dir/_blob.$blob") || die("rename $tmp $dir/_blob.$blob: $!\n");
+  }
+
+  # delete old cruft
+  unlink("$dir/$pkgname.containerinfo");
+  unlink("$dir/$pkgname.obsbinlnk");
+
+  # write containerinfo file
+  my $data = $pool->pkg2data($p);
+  # hack: get tags from provides
+  my @tags;
+  for (@{$data->{'provides' || []}}) {
+    push @tags, $_ unless / = /;
+  }
+  push @tags, $data->{'name'} unless @tags;
+  my $mtime = time();
+  my @layers = @blobs;
+  shift @layers;
+  my $manifest = {
+    'Config' => $blobs[0],
+    'RepoTags' => \@tags,
+    'Layers' => \@layers,
+  };
+  my $manifest_ent = BSContar::create_manifest_entry($manifest, $mtime);
+  my $containerinfo = {
+    'tar_manifest' => $manifest_ent->{'data'},
+    'tar_size' => 1,	# make construct_container_tar() happy
+    'tar_mtime' => $mtime,
+    'tar_blobids' => \@blobs,
+    'name' => $container,
+    'version' => $data->{'version'},
+    'tags' => \@tags,
+    'file' => "$pkgname.tar",
+  };
+  $containerinfo->{'release'} = $data->{'release'} if defined $data->{'release'};
+  my ($tar) = BSRepServer::Containertar::construct_container_tar($dir, $containerinfo);
+  ($containerinfo->{'tar_md5sum'}, $containerinfo->{'tar_sha256sum'}, $containerinfo->{'tar_size'}) = BSContar::checksum_tar($tar);
+  BSRepServer::Containerinfo::writecontainerinfo("$dir/.$pkgname.containerinfo", "$dir/$pkgname.containerinfo", $containerinfo);
+
+  # write obsbinlnk file (do this last!)
+  my $lnk = BSRepServer::Containerinfo::containerinfo2nevra($containerinfo);
+  $lnk->{'source'} = $lnk->{'name'};
+  BSVerify::verify_nevraquery($lnk);
+  $lnk->{'hdrmd5'} = $containerinfo->{'tar_md5sum'};
+  $lnk->{'path'} = "$pkgname.tar";
+  BSUtil::store("$dir/.$pkgname.obsbinlnk", "$dir/$pkgname.obsbinlnk", $lnk);
+
+  return "$dir/$pkgname.tar";
+}
+
 sub fetchdodbinary {
   my ($gdst, $pool, $repo, $p, $handoff) = @_;
 
   die($repo->name()." is no dod repo\n") unless $repo->dodurl();
+  my $pkgname = $pool->pkg2name($p);
+  return fetchdodcontainer($gdst, $pool, $repo, $p, $handoff) if $pkgname =~ /^container:/;
   my $path = $pool->pkg2path($p);
   die("$path has an unsupported suffix\n") unless $path =~ /\.($binsufsre)$/;
   my $suf = $1;
-  my $pkgname = $pool->pkg2name($p);
   if (defined(&BSSolv::pool::pkg2inmodule) && $pool->pkg2inmodule($p)) {
     $pkgname .= '-' . $pool->pkg2evr($p) . '.' . $pool->pkg2arch($p);
   }

--- a/src/backend/BSRepServer/DoD.pm
+++ b/src/backend/BSRepServer/DoD.pm
@@ -21,13 +21,8 @@ use Digest::SHA ();
 use BSWatcher ':https';
 use BSVerify;
 use BSHandoff;
-use BSContar;
 use BSStdServer;
 use BSUtil;
-use BSBearer;
-
-use BSRepServer::Containertar;
-use BSRepServer::Containerinfo;
 
 use Build;
 
@@ -69,34 +64,11 @@ sub is_wanted_dodcontainer {
   return 1;
 }
 
-sub blob_matches_digest {
-  my ($tmp, $digest) = @_;
-  my $ctx;
-  $ctx = Digest::SHA->new($1) if $digest =~ /^sha(256|512):/;
-  return 0 unless $ctx;
-  my $fd;
-  return 0 unless open ($fd, '<', $tmp);
-  $ctx->addfile($fd);
-  close($fd);
-  return (split(':', $digest, 2))[1] eq $ctx->hexdigest() ? 1 : 0;
-}
-
-my %registry_authenticators;
-
-sub doauthrpc {
-  my ($param, $xmlargs, @args) = @_;
-  $param = { %$param, 'resulthook' => sub { $xmlargs->($_[0]) } };
-  return BSWatcher::rpc($param, $xmlargs, @args);
-}
-
 sub fetchdodcontainer {
   my ($gdst, $pool, $repo, $p, $handoff) = @_;
-  my $container = $pool->pkg2name($p);
-  $container =~ s/^container://;
 
-  my $pkgname = $container;
-  $pkgname =~ s/\//_/g;
-  $pkgname = "_$pkgname" if $pkgname =~ /^_/;
+  my $pkgname = $pool->pkg2name($p);
+  $pkgname =~ s/^container://;
   BSVerify::verify_filename($pkgname);
   BSVerify::verify_simple($pkgname);
   my $dir = "$gdst/:full";
@@ -113,76 +85,11 @@ sub fetchdodcontainer {
   die("bad DoD container path: $path\n") unless $path =~ /^(.*)\?(.*?)$/;
   my $regrepo = $1;
   my @blobs = split(',', $2);
-  for my $blob (@blobs) {
-    next if -e "$dir/_blob.$blob";
-    my $tmp = "$dir/._blob.$blob.$$";
-    my $url = $repo->dodurl();
-    $url .= '/' unless $url =~ /\/$/;
-    my $authenticator = $registry_authenticators{"$url$regrepo"};
-    $authenticator = $registry_authenticators{"$url$regrepo"} = BSBearer::generate_authenticator(undef, 'verbose' => 1, 'rpccall' => \&doauthrpc) unless $authenticator;
-    $url .= "v2/$regrepo/blobs/$blob";
-    print "fetching: $url\n";
-    my $param = {'uri' => $url, 'filename' => $tmp, 'receiver' => \&BSHTTP::file_receiver, 'proxy' => $proxy};
-    $param->{'authenticator'} = $authenticator;
-    $param->{'maxredirects'} = $maxredirects if defined $maxredirects;
-    my $r;
-    eval { $r = BSWatcher::rpc($param); };
-    if ($@) {
-      $@ =~ s/(\d* *)/$1$url: /;
-      die($@);
-    }
-    return unless defined $r;
-    if (!blob_matches_digest($tmp, $blob)) {
-      unlink($tmp);
-      die("$url: blob does not match digest\n");
-    }
-    rename($tmp, "$dir/_blob.$blob") || die("rename $tmp $dir/_blob.$blob: $!\n");
-  }
+  return undef unless BSRepServer::Registry::download_blobs($dir, $repo->dodurl(), $regrepo, \@blobs, $proxy, $maxredirects);
 
-  # delete old cruft
-  unlink("$dir/$pkgname.containerinfo");
-  unlink("$dir/$pkgname.obsbinlnk");
-
-  # write containerinfo file
+  # write containerinfo and obsbinlnk files
   my $data = $pool->pkg2data($p);
-  # hack: get tags from provides
-  my @tags;
-  for (@{$data->{'provides' || []}}) {
-    push @tags, $_ unless / = /;
-  }
-  push @tags, $data->{'name'} unless @tags;
-  my $mtime = time();
-  my @layers = @blobs;
-  shift @layers;
-  my $manifest = {
-    'Config' => $blobs[0],
-    'RepoTags' => \@tags,
-    'Layers' => \@layers,
-  };
-  my $manifest_ent = BSContar::create_manifest_entry($manifest, $mtime);
-  my $containerinfo = {
-    'tar_manifest' => $manifest_ent->{'data'},
-    'tar_size' => 1,	# make construct_container_tar() happy
-    'tar_mtime' => $mtime,
-    'tar_blobids' => \@blobs,
-    'name' => $container,
-    'version' => $data->{'version'},
-    'tags' => \@tags,
-    'file' => "$pkgname.tar",
-  };
-  $containerinfo->{'release'} = $data->{'release'} if defined $data->{'release'};
-  my ($tar) = BSRepServer::Containertar::construct_container_tar($dir, $containerinfo);
-  ($containerinfo->{'tar_md5sum'}, $containerinfo->{'tar_sha256sum'}, $containerinfo->{'tar_size'}) = BSContar::checksum_tar($tar);
-  BSRepServer::Containerinfo::writecontainerinfo("$dir/.$pkgname.containerinfo", "$dir/$pkgname.containerinfo", $containerinfo);
-
-  # write obsbinlnk file (do this last!)
-  my $lnk = BSRepServer::Containerinfo::containerinfo2nevra($containerinfo);
-  $lnk->{'source'} = $lnk->{'name'};
-  BSVerify::verify_nevraquery($lnk);
-  $lnk->{'hdrmd5'} = $containerinfo->{'tar_md5sum'};
-  $lnk->{'path'} = "$pkgname.tar";
-  BSUtil::store("$dir/.$pkgname.obsbinlnk", "$dir/$pkgname.obsbinlnk", $lnk);
-
+  BSRepServer::Registry::construct_containerinfo($dir, $pkgname, $data, \@blobs);
   return "$dir/$pkgname.tar";
 }
 

--- a/src/backend/BSRepServer/Registry.pm
+++ b/src/backend/BSRepServer/Registry.pm
@@ -18,14 +18,25 @@
 package BSRepServer::Registry;
 
 use JSON::XS ();
+use Digest::SHA ();
 
+use BSConfiguration;
+use BSWatcher ':https';
 use BSTUF;
 use BSUtil;
-use BSConfiguration;
+use BSVerify;
+use BSBearer;
+use BSContar;
+
+use BSRepServer::Containertar;
+use BSRepServer::Containerinfo;
+
 
 use strict;
 
 my $uploaddir = "$BSConfig::bsdir/upload";
+
+my %registry_authenticators;
 
 sub select_manifest {
   my ($mani, $goarch, $goos, $govariant) = @_;
@@ -62,6 +73,104 @@ sub extend_timestamp {
   }
   close($fd);
   return $tuf;
+}
+
+sub blob_matches_digest {
+  my ($tmp, $digest) = @_;
+  my $ctx;
+  $ctx = Digest::SHA->new($1) if $digest =~ /^sha(256|512):/;
+  return 0 unless $ctx;
+  my $fd;
+  return 0 unless open ($fd, '<', $tmp);
+  $ctx->addfile($fd);
+  close($fd);
+  return (split(':', $digest, 2))[1] eq $ctx->hexdigest() ? 1 : 0;
+}
+
+sub doauthrpc {
+  my ($param, $xmlargs, @args) = @_;
+  $param = { %$param, 'resulthook' => sub { $xmlargs->($_[0]) } };
+  return BSWatcher::rpc($param, $xmlargs, @args);
+}
+
+sub download_blobs {
+  my ($dir, $url, $regrepo, $blobs, $proxy, $maxredirects) = @_;
+
+  $url .= '/' unless $url =~ /\/$/;
+  for my $blob (@$blobs) {
+    next if -e "$dir/_blob.$blob";
+    my $tmp = "$dir/._blob.$blob.$$";
+    my $authenticator = $registry_authenticators{"$url$regrepo"};
+    $authenticator = $registry_authenticators{"$url$regrepo"} = BSBearer::generate_authenticator(undef, 'verbose' => 1, 'rpccall' => \&doauthrpc) unless $authenticator;
+    my $bloburl = "${url}v2/$regrepo/blobs/$blob";
+    # print "fetching: $bloburl\n";
+    my $param = {'uri' => $bloburl, 'filename' => $tmp, 'receiver' => \&BSHTTP::file_receiver, 'proxy' => $proxy};
+    $param->{'authenticator'} = $authenticator;
+    $param->{'maxredirects'} = $maxredirects if defined $maxredirects;
+    my $r;
+    eval { $r = BSWatcher::rpc($param); };
+    if ($@) {
+      unlink($tmp);
+      $@ =~ s/(\d* *)/$1$bloburl: /;
+      die($@);
+    }
+    return unless defined $r;
+    if (!blob_matches_digest($tmp, $blob)) {
+      unlink($tmp);
+      die("$bloburl: blob does not match digest\n");
+    }
+    rename($tmp, "$dir/_blob.$blob") || die("rename $tmp $dir/_blob.$blob: $!\n");
+  }
+  return 1;
+}
+
+sub construct_containerinfo {
+  my ($dir, $pkgname, $data, $blobs) = @_;
+
+  BSVerify::verify_filename($pkgname);
+  BSVerify::verify_simple($pkgname);
+
+  # delete old cruft
+  unlink("$dir/$pkgname.containerinfo");
+  unlink("$dir/$pkgname.obsbinlnk");
+
+  # hack: get tags from provides
+  my @tags;
+  for (@{$data->{'provides' || []}}) {
+    push @tags, $_ unless / = /;
+  }
+  push @tags, $data->{'name'} unless @tags;
+  my $mtime = time();
+  my @layers = @$blobs;
+  shift @layers;
+  my $manifest = {
+    'Config' => $blobs->[0],
+    'RepoTags' => \@tags,
+    'Layers' => \@layers,
+  };
+  my $manifest_ent = BSContar::create_manifest_entry($manifest, $mtime);
+  my $containerinfo = {
+    'tar_manifest' => $manifest_ent->{'data'},
+    'tar_size' => 1,	# make construct_container_tar() happy
+    'tar_mtime' => $mtime,
+    'tar_blobids' => $blobs,
+    'name' => $pkgname,
+    'version' => $data->{'version'},
+    'tags' => \@tags,
+    'file' => "$pkgname.tar",
+  };
+  $containerinfo->{'release'} = $data->{'release'} if defined $data->{'release'};
+  my ($tar) = BSRepServer::Containertar::construct_container_tar($dir, $containerinfo);
+  ($containerinfo->{'tar_md5sum'}, $containerinfo->{'tar_sha256sum'}, $containerinfo->{'tar_size'}) = BSContar::checksum_tar($tar);
+  BSRepServer::Containerinfo::writecontainerinfo("$dir/.$pkgname.containerinfo", "$dir/$pkgname.containerinfo", $containerinfo);
+
+  # write obsbinlnk file (do this last!)
+  my $lnk = BSRepServer::Containerinfo::containerinfo2nevra($containerinfo);
+  $lnk->{'source'} = $lnk->{'name'};
+  BSVerify::verify_nevraquery($lnk);
+  $lnk->{'hdrmd5'} = $containerinfo->{'tar_md5sum'};
+  $lnk->{'path'} = "$pkgname.tar";
+  BSUtil::store("$dir/.$pkgname.obsbinlnk", "$dir/$pkgname.obsbinlnk", $lnk);
 }
 
 1;

--- a/src/backend/BSSched/BuildJob/Docker.pm
+++ b/src/backend/BSSched/BuildJob/Docker.pm
@@ -312,6 +312,8 @@ sub check {
   if ($state eq 'scheduled') {
     my $dods = BSSched::DoD::dodcheck($ctx, $pool, $myarch, @edeps);
     return ('blocked', $dods) if $dods;
+    $dods = BSSched::DoD::dodcheck($ctx, $ctx->{'pool'}, $myarch, map {$_->{'name'}} @cbdep);
+    return ('blocked', $dods) if $dods;
   }
   return ($state, $data);
 }

--- a/src/backend/BSSched/BuildJob/KiwiImage.pm
+++ b/src/backend/BSSched/BuildJob/KiwiImage.pm
@@ -271,6 +271,8 @@ sub check {
   if ($state eq 'scheduled') {
     my $dods = BSSched::DoD::dodcheck($ctx, $pool, $myarch, @edeps);
     return ('blocked', $dods) if $dods;
+    $dods = BSSched::DoD::dodcheck($ctx, $ctx->{'pool'}, $myarch, $cbdep->{'name'}) if $cbdep;
+    return ('blocked', $dods) if $dods;
   }
   return ($state, $data);
 }

--- a/src/backend/BSSched/BuildRepo.pm
+++ b/src/backend/BSSched/BuildRepo.pm
@@ -957,7 +957,7 @@ sub addrepo_scan {
   my $doddata;
   if ($BSConfig::enable_download_on_demand) {
     $doddata = BSSched::DoD::get_doddata($gctx, $prp, $arch);
-    ($dirty, $r) = BSSched::DoD::put_doddata_in_cache($pool, $prp, $r, $doddata, $dir);
+    ($dirty, $r) = BSSched::DoD::put_doddata_in_cache($gctx, $doddata, $pool, $prp, $r, $dir);
   }
 
   my @bins;
@@ -994,7 +994,7 @@ sub addrepo_scan {
   return undef unless $r;
   # write solv file (unless alien arch)
   if ($dirty && $arch eq $gctx->{'arch'}) {
-    @bins = BSSched::DoD::clean_obsolete_dodpackages($pool, $r, $dir, @bins) if $doddata;
+    @bins = BSSched::DoD::clean_obsolete_dodpackages($gctx, $doddata, $pool, $prp, $r, $dir, @bins) if $doddata;
     writesolv("$dir.solv.new", "$dir.solv", $r);
   }
   $repocache->setcache($prp, $arch) if $repocache;

--- a/src/backend/BSSched/DoD.pm
+++ b/src/backend/BSSched/DoD.pm
@@ -23,6 +23,7 @@ use Digest::MD5 ();
 
 use BSUtil;
 use BSSched::RPC;
+use BSSched::Blobstore;
 use BSXML;
 use BSHTTP;
 
@@ -82,7 +83,7 @@ sub readparsed {
 =cut
 
 sub put_doddata_in_cache {
-  my ($pool, $prp, $cache, $doddata, $dir) = @_;
+  my ($gctx, $doddata, $pool, $prp, $cache, $dir) = @_;
   if (!$doddata) {
     return (0, $cache) if !$cache || !$cache->dodurl();
     $cache->updatedoddata() if defined &BSSolv::repo::updatedoddata;
@@ -119,7 +120,7 @@ sub put_doddata_in_cache {
 =cut
 
 sub clean_obsolete_dodpackages {
-  my ($pool, $cache, $dir, @bins) = @_;
+  my ($gctx, $doddata, $pool, $prp, $cache, $dir, @bins) = @_;
 
   return @bins unless defined &BSSolv::repo::pkgpaths;
   my %paths = $cache->pkgpaths();
@@ -166,6 +167,16 @@ sub clean_obsolete_dodpackages {
     unlink("$dir/$path");
   }
   $cache->updatefrombins($dir, @nbins) if $nbinsdirty;
+
+  if ($clean_blobs && defined(&BSSolv::repo::getdodblobs)) {
+    my %blobs = map {$_ => 1} $cache->getdodblobs();
+    for my $blob (sort(grep {/^_blob\.(.*)$/ && !$blobs{$1}} ls($dir))) {
+      print "      - :full/$blob [DoD cleanup]\n";
+      unlink("$dir/$blob");
+      BSSched::Blobstore::blobstore_chk($gctx, $blob);
+    }
+  }
+
   return @nbins;
 }
 
@@ -177,6 +188,7 @@ sub clean_obsolete_dodpackages {
 
 sub dodcheck {
   my ($ctx, $pool, $arch, @pkgs) = @_;
+  return unless @pkgs;
   $ctx = $ctx->{'realctx'} if $ctx->{'realctx'};	# we need the real one to add entries
   my %names;
   if (defined &BSSolv::repo::dodcookie) {
@@ -382,6 +394,90 @@ sub init_doddata {
     $changed = 1;
   }
   BSUtil::touch("$dodsdir/.changed") if $changed && -d $dodsdir;
+}
+
+
+=head2 signalmissing_resume- TODO: add summary
+
+ TODO: add description
+
+=cut
+
+sub signalmissing_resume {
+  my ($ctx, $handle, $error) = @_;
+  my ($projid, $repoid) = split('/', $handle->{'_prp'}, 2);
+  my $gctx = $ctx->{'gctx'};
+  if ($error) {
+    if (BSSched::RPC::is_transient_error($error)) {
+      $gctx->{'retryevents'}->addretryevent({'type' => 'repository', 'project' => $projid, 'repository' => $repoid, 'arch' => $gctx->{'arch'}});
+    }
+    return;
+  }
+}
+
+=head2 signalmissing - inform the dodup tool about missing dod resources
+
+=cut
+
+sub signalmissing {
+  my ($ctx, $prp, $arch, $dodresources) = @_;
+  return unless @{$dodresources || []};
+  my $gctx = $ctx->{'gctx'};
+  my $projpacks = $gctx->{'projpacks'};
+  my ($projid, $repoid) = split('/', $prp, 2);
+
+  if (!$projpacks->{$projid}) {
+    # dod from different partition, use repo server
+    my $remoteprojs = $gctx->{'remoteprojs'};
+    my $proj = $remoteprojs->{$projid};
+    return unless $proj;
+    return unless $proj->{'partition'};		# not supported yet
+    my $server = $proj->{'partition'} ? $proj->{'remoteurl'} : $BSConfig::srcserver;
+    my $param = {
+      'uri' => "$server/build/$prp/$arch",
+      'request' => 'POST',
+      'receiver' => \&BSHTTP::null_receiver,
+      'async' => {
+        '_resume' => \&signalmissing_resume,
+        '_changetype' => 'low',
+        '_prp' => $prp,
+      },
+    };
+    my @args = 'view=missingdodresources';
+    push @args, map {"resource=$_"} @$dodresources;
+    push @args, "partition=$BSConfig::partition" if $BSConfig::partition;
+    eval { $ctx->xrpc("missingdodresources/$prp", $param, undef, @args) };
+    if ($@) {
+      warn($@);
+      $gctx->{'retryevents'}->addretryevent({'type' => 'repository', 'project' => $projid, 'repository' => $repoid, 'arch' => $arch });
+    }
+    return;
+  }
+
+  # local dod, directly modify
+  my $id = "$gctx->{'arch'}";
+  $id = "$BSConfig::partition/$id" if $BSConfig::partition;
+  my $dir = "$gctx->{'reporoot'}/$prp/$arch/:full";
+  mkdir_p($dir);
+  my @dr = sort(BSUtil::unify(@$dodresources));
+  my $needed = BSUtil::retrieve("$dir/doddata.needed", 1);
+  return $needed if $needed && BSUtil::identical($needed->{$id} || [], \@dr);
+  my $fd;
+  if (!BSUtil::lockopen($fd, '>>', "$dir/doddata.needed", 1)) {
+    warn("$dir/doddata.needed: $!\n");
+    return;
+  }
+  $needed = {};
+  $needed = BSUtil::retrieve("$dir/doddata.needed", 1) || {} if -s "$dir/doddata.needed";
+  if (!@dr) {
+    delete $needed->{$id};
+    delete $needed->{''}->{$id} if $needed->{''};
+  } else {
+    $needed->{$id} = \@dr;
+    $needed->{''}->{$id} = time();
+  }
+  BSUtil::store("$dir/.doddata.needed", "$dir/doddata.needed", $needed);
+  close($fd);
 }
 
 1;

--- a/src/backend/bs_dodup
+++ b/src/backend/bs_dodup
@@ -15,12 +15,15 @@ use Encode;
 use Fcntl qw(:DEFAULT :flock);
 use XML::Structured ':bytes';
 use Getopt::Long ();
+use JSON::XS;
 
 use BSConfiguration;
 use BSRPC ':https';
 use BSHTTP;
 use BSXML;
 use BSUtil;
+use BSContar;
+use BSBearer;
 use File::Temp ();
 
 use Build::Repo;
@@ -364,12 +367,230 @@ sub dod_mdk {
   return ($newcookie, $url);
 }
 
+sub getdodresources {
+  my ($doddata) = @_;
+  my $projid = $doddata->{'project'};
+  my $repoid = $doddata->{'repository'};
+  my $arch = $doddata->{'arch'};
+  my $repodir = "$reporoot/$projid/$repoid/$arch/:full";
+  my $needed = BSUtil::retrieve("$repodir/doddata.needed", 1);
+  return () unless ref($needed) eq 'HASH';
+  my %dodresources;
+  for (values(%$needed)) {
+    next unless ref($_) eq 'ARRAY';
+    $dodresources{$_} = 1 for @$_;
+  }
+  return sort keys %dodresources;
+}
+
+my %registry_authenticators;
+my $registry_timeout = 60;
+
+sub registry_select_manifest {
+  my ($manifests, $arch) = @_;
+  my $goarch;
+  my $govariant;
+  if ($arch =~ /^i[3456]86$/) {
+    $goarch = '386';
+  } elsif ($arch eq 'x86_64') {
+    $goarch = 'amd64';
+  } elsif ($arch eq 'aarch64') {
+    $goarch = 'arm64';
+    $govariant= 'v8';
+  } elsif ($arch =~ /^arm(v\d+)/) {
+    $goarch = 'arm';
+    $govariant= $1;
+  } else {
+    $goarch = $arch;
+  }
+  for my $m (@{$manifests || []}) {
+    next unless $m->{'digest'};
+    my $platform = $m->{'platform'};
+    if ($platform) {
+      next if $goarch && $platform->{'architecture'} && $platform->{'architecture'} ne $goarch;
+      next if $govariant && $platform->{'variant'} && $platform->{'variant'} ne $govariant;
+    }
+    return $m;
+  }
+  return undef;
+}
+
+sub registry_valid_digest {
+  my ($what, $digest) = @_;
+  die("$what: missing digest\n") unless $digest;
+  return $digest if $digest =~ /^sha512:[a-fA-F0-9]{128}$/s;
+  return $digest if $digest =~ /^sha256:[a-fA-F0-9]{64}$/s;
+  die("$what: unknown digest '$digest'\n");
+}
+
+sub registry_fetch_manifest {
+  my ($url, $arch, $repo, $tag, $olddigest, $oldfatdigest, $fatdigest) = @_;
+
+  my $authenticator = $registry_authenticators{"$url/$repo"};
+  $authenticator = $registry_authenticators{"$url/$repo"} = BSBearer::generate_authenticator(undef, 'verbose' => 1) unless $authenticator;
+
+  my $accept_hdr = "Accept: $BSContar::mt_docker_manifest, $BSContar::mt_docker_manifestlist, $BSContar::mt_oci_manifest, $BSContar::mt_oci_index";
+  my $replyheaders;
+  my $param = {
+    'uri' => "$url/v2/$repo/manifests/$tag",
+    'headers' => [ $accept_hdr ],
+    'authenticator' => $authenticator,
+    'replyheaders' => \$replyheaders,
+    'timeout' => $registry_timeout,
+    'maxredirects' => 5,
+  };
+
+  # try a HEAD request first if we already have a digest
+  if ($olddigest || ($oldfatdigest && !$fatdigest)) {
+    $param->{'request'} = 'HEAD';
+    eval { BSRPC::rpc($param) };
+    return (undef, undef, $fatdigest) if $@ && $@ =~ /^404/;
+    die($@) if $@;
+    my $ct = $replyheaders->{'content-type'};
+    die("$repo/$tag: no content-type\n") unless $ct;
+    my $digest = $replyheaders->{'docker-content-digest'};
+    die("$repo/$tag: no docker-content-digest\n") unless $digest;
+    if ($ct eq $BSContar::mt_docker_manifestlist || $ct eq $BSContar::mt_oci_index) {
+      die("$repo/$tag: fat manifest points to another fat manifest\n") if $fatdigest;
+      return (undef, $olddigest, $oldfatdigest) if $olddigest && $oldfatdigest && $digest eq $oldfatdigest;
+    } else {
+      die("$repo/$tag: unknown content-type '$ct'\n") unless $ct eq $BSContar::mt_docker_manifest || $ct eq $BSContar::mt_oci_manifest;
+      return (undef, $digest, $fatdigest) if $olddigest && $olddigest eq $digest;
+    }
+    delete $param->{'request'};
+    undef $replyheaders;
+  }
+
+  my $mani_json;
+  eval { $mani_json = BSRPC::rpc($param) };
+  return (undef, undef, $fatdigest) if $@ && $@ =~ /^404/;
+  die($@) if $@;
+  my $ct = $replyheaders->{'content-type'};
+  die("$repo/$tag: no content-type\n") unless $ct;
+  my $digest = $replyheaders->{'docker-content-digest'};
+  die("$repo/$tag: no docker-content-digest\n") unless $digest;
+  registry_valid_digest("$repo/$tag docker-content-digest", $digest);
+  if ($ct eq $BSContar::mt_docker_manifestlist || $ct eq $BSContar::mt_oci_index) {
+    die("$repo/$tag: fat manifest points to another fat manifest\n") if $fatdigest;
+    $fatdigest = $digest;
+    my $mani = JSON::XS::decode_json($mani_json);
+    my $manifest = registry_select_manifest($mani->{'manifests'}, $arch);
+    return (undef, undef, $fatdigest) unless $manifest;
+    $digest = registry_valid_digest("$repo/$tag", $manifest->{'digest'});
+    return (undef, $digest, $fatdigest) if $olddigest && $olddigest eq $digest;
+    return registry_fetch_manifest($url, $arch, $repo, $digest, $olddigest, $oldfatdigest, $fatdigest);
+  }
+  die("$repo/$tag: unknown content-type '$ct'\n") unless $ct eq $BSContar::mt_docker_manifest || $ct eq $BSContar::mt_oci_manifest;
+  my $mani = JSON::XS::decode_json($mani_json);
+  my $config = $mani->{'config'};
+  die("$repo/$tag: missing config\n") unless $config;
+  my @blobs;
+  push @blobs, registry_valid_digest("$repo/$tag config", $config->{'digest'});
+  for my $l (@{$mani->{'layers'} || []}) {
+    push @blobs, registry_valid_digest("$repo/$tag layer", $l->{'digest'});
+  }
+  return (\@blobs, $digest, $fatdigest);
+}
+
+# This needs to be in sync with BSRepServer::DoD!
+sub mangle_container_name {
+  my ($name) = @_;
+  $name =~ s/^container://;
+  $name =~ s/\//_/g;
+  $name = "_$name" if $name =~ /^_/;
+  return $name;
+}
+
+sub dod_registry {
+  my ($doddata, $cookie, $file) = @_;
+  my $arch = $doddata->{'arch'};
+  my @dodresources = getdodresources($doddata);
+  my $url = $doddata->{'url'};
+  $url =~ s/\/+$//;
+  my $cache = {};
+
+  $cookie ||= '0';
+  my $repodir = $file;
+  $repodir =~ s/\/[^\/]+$//;	# hack
+
+  my $oldcache = BSUtil::retrieve("$repodir/doddata", 1) || {};
+  my %olddodresources = map {$_ => 1} @{$oldcache->{'/dodresources'} || []};
+  my $oldfatmissing = ($oldcache->{'/fatmissing'} || [])->[0] || {};
+
+  my @newdodresources;
+  my %newfatmissing;
+
+  my ($changed, $unchanged, $missing, $broken) = (0, 0, 0, 0);
+
+  for my $resource (@dodresources) {
+    next unless $resource =~ /^container:(.*):([^\/:]+)$/s;
+    my ($repo, $tag) = ($1, $2);
+    my $oldentry;
+    $oldentry = $oldcache->{$resource} if $olddodresources{$resource};
+    my ($olddigest, $oldfatdigest);
+    ($olddigest, $oldfatdigest) = ($oldentry->{'version'}, $oldentry->{'fatdigest'}) if $oldentry;
+    $oldfatdigest = $oldfatmissing->{$resource} if !$oldentry;
+    my ($blobs, $digest, $fatdigest);
+    eval { ($blobs, $digest, $fatdigest) = registry_fetch_manifest($url, $arch, $repo, $tag, $olddigest, $oldfatdigest) };
+    if ($@) {
+      # resource is broken, reuse old entry if we have it
+      warn($@);
+      $broken++;
+      next unless $olddodresources{$resource};
+      push @newdodresources, $resource;
+      $cache->{$resource} = $oldentry if $oldentry;
+      $newfatmissing{$resource} = $oldfatdigest if !$oldentry && $oldfatdigest;
+      next;
+    }
+    push @newdodresources, $resource;
+    if (!$digest) {
+      # resource does not exist
+      $missing++;
+      $newfatmissing{$resource} = $fatdigest if $fatdigest;
+      next;
+    }
+    if (!$blobs) {
+      # resource is unchanged, use blobs from old entry
+      die unless $oldentry && $oldentry->{'path'} =~ /\?([^\?\/]+)$/s;
+      $blobs = [ split(',', $1) ];
+      $unchanged++;
+    } else {
+      $changed++;
+    }
+    my $version = $digest;
+    $version =~ s/.*://;
+    my $mangled_name = mangle_container_name($resource);
+    my @provides;
+    push @provides, "container:$mangled_name = $version-0";
+    push @provides, $resource unless $resource eq "container:$mangled_name";
+    my $pkg = {
+      'name' => "container:$mangled_name",
+      'version' => $version,
+      'release' => 0,
+      'provides' => \@provides,
+      'arch' => 'noarch',
+      'path' => "$repo?".join(',', @$blobs),
+      'digest' => $digest,
+    };
+    $pkg->{'fatdigest'} = $fatdigest if $fatdigest;
+    $cache->{$resource} = $pkg;
+  }
+  $cache->{'/dodresources'} = \@newdodresources;
+  $cache->{'/fatmissing'} = [ \%newfatmissing ] if %newfatmissing;
+  $cache->{'/url'} = $url;
+  print "  unchanged $unchanged, changed $changed, missing $missing, broken $broken\n";
+  return undef if BSUtil::identical($cache, $oldcache);
+  BSUtil::store($file, undef, $cache);
+  return $cookie + 1, $url
+}
+
 my %handler = (
   'arch'      => \&dod_arch,
   'deb'       => \&dod_deb,
   'susetags'  => \&dod_susetags,
   'rpmmd'     => \&dod_rpmmd,
   'mdk'       => \&dod_mdk,
+  'registry'  => \&dod_registry,
 );
 
 sub cmppkg {
@@ -414,6 +635,7 @@ sub addpkg {
 
 sub parsemetadata {
   my ($doddata, $file, $baseurl, $moduleinfo) = @_;
+  return if $doddata->{'repotype'} eq 'registry';
   my $cache = {};
   my $archfilter;
   if ($doddata->{'archfilter'}) {
@@ -586,7 +808,17 @@ sub daemon {
     my %nextcheck;
     for my $prpa (keys %doddatas) {
       my $doddata = $doddatas{$prpa};
-      $nextcheck{$prpa} = $doddata->{'lastcheck'} + ($doddata->{'haderror'} ? $checkinterval_error : $checkinterval_ok);
+      if ($doddata->{'haderror'}) {
+	$nextcheck{$prpa} = $doddata->{'lastcheck'} + $checkinterval_error;
+	next;
+      }
+      my $repodir = "$reporoot/$prpa/:full";
+      my @s = stat("$repodir/doddata.needed");
+      if (@s && $s[9] > $doddata->{'lastcheck'}) {
+        $nextcheck{$prpa} = $doddata->{'lastcheck'};
+      } else {
+        $nextcheck{$prpa} = $doddata->{'lastcheck'} + $checkinterval_ok;
+      }
     }
     # check em
     for my $prpa (sort {$nextcheck{$a} <=> $nextcheck{$b} || $a cmp $b} keys %doddatas) {

--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -1485,6 +1485,15 @@ sub getbinary {
   return undef;
 }
 
+sub missingdodresources {
+  my ($cgi, $projid, $repoid, $arch) = @_;
+  die("not a DoD repo '$projid/$repoid/$arch'\n") unless -s "$reporoot/$projid/$repoid/$arch/:full/doddata";
+  my $id = $arch;
+  $id = "$cgi->{'partition'}/$id" if $cgi->{'partition'};
+  BSRepServer::DoD::setmissingdodresources("$reporoot/$projid/$repoid/$arch", $id, $cgi->{'resource'});
+  return $BSStdServer::return_ok;
+}
+
 sub isolder {
   my ($old, $new) = @_;
   return 0 if $old !~ /\.rpm$/;
@@ -4343,6 +4352,7 @@ my $dispatches = [
   '!- HEAD:' => undef,
 
   'POST:/build/$project cmd=move oproject:project' => \&moveproject,
+  'POST:/build/$project/$repository/$arch/_repository cmd=missingdodresources resource:* partition:?' => \&missingdodresources,
   'POST:/build/$project/$repository/$arch/_repository match:' => \&postrepo,
   '/build/$project/$repository/$arch package* view:?' => \&getpackagelist_build,
   '/build/$project/$repository/$arch/_builddepinfo package* view:?' => \&getbuilddepinfo,

--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -209,14 +209,19 @@ sub getbinaryversions {
       return unless defined $path;
       # TODO: move it out of the loop otherwise the same files might be queried multiple times
       my @s = stat($path);
-      $sizek = ($s[7] + 1023) >> 10;
-      $hdrmd5 = Build::queryhdrmd5($path);
+      if (!@s && $bin =~ /^container:/ && $path =~ /\.tar$/) {
+        $hdrmd5 = undef;
+      } else {
+        $sizek = ($s[7] + 1023) >> 10;
+        $hdrmd5 = Build::queryhdrmd5($path);
+      }
       $needscan = 1;
     }
     if ($bin =~ /^container:/ && $path =~ /(\.tar(?:\..+)?)$/) {
       my $n = "$bin$1";
       my @s = stat($path);
       @s = BSRepServer::Containertar::stat_container($path) if $1 eq '.tar' && !@s;
+      $hdrmd5 = $s[20] if $s[20] && !defined($hdrmd5);
       push @res, {'name' => $n, 'hdrmd5' => $hdrmd5, 'sizek' => (($s[7] + 1023) >> 10)} if @s;
       next;
     }
@@ -1397,6 +1402,7 @@ sub getbinary_repository {
   return if $BSStdServer::isajax && !defined $serial;
   my $view = $cgi->{'view'} || '';
   my $path = "$reporoot/$projid/$repoid/$arch/:full/$bin";
+  my $path_fd;
   my $needscan;
   if (! -f $path) {
     # return by name
@@ -1423,11 +1429,18 @@ sub getbinary_repository {
     }
     undef $repo;
     undef $pool;
-    if ($path =~ /\.tar$/ && ! -f $path && !$BSStdServer::isajax) {
-      return getbinary_info($cgi, $projid, $repoid, $arch, $path, $path) if $view eq 'fileinfo' || $view eq 'fileinfo_ext';
-      return undef if BSRepServer::Containertar::reply_container($path);
+    if (! -f $path) {
+      die("404 $bin: $!\n") unless $bin =~ /^container:/ && $path =~ /\.tar$/;;
+      if ($view ne 'fileinfo' && $view ne 'fileinfo_ext') {
+	if (!$BSStdServer::isajax) {
+	  # use reply_container to directly send the blobs instead of constructing the complete tar
+	  forwardevent($cgi, 'scanrepo', $projid, undef, $repoid, $arch) if $needscan;
+          BSRepServer::Containertar::reply_container($path);
+	  return undef;
+	}
+        $path_fd = BSRepServer::Containertar::open_container($path);
+      }
     }
-    die("404 $bin: $!\n") unless -f $path;
   }
   BSWatcher::serialize_end($serial) if defined $serial;
   forwardevent($cgi, 'scanrepo', $projid, undef, $repoid, $arch) if $needscan;
@@ -1436,7 +1449,7 @@ sub getbinary_repository {
   my $type = 'application/octet-stream';
   $type = 'application/x-rpm' if $path=~ /\.rpm$/;
   $type = 'application/x-debian-package' if $path=~ /\.deb$/;
-  BSWatcher::reply_file($path, "Content-Type: $type");
+  BSWatcher::reply_file($path_fd || $path, "Content-Type: $type");
   return undef;
 }
 


### PR DESCRIPTION
Those DoD resources are different to repositories because there is no way to request the complete state from the server.
 Thus we collect the needed DoD resources in the scheduler and put them into a "doddata.needed" file. The bs_dodup server then uses this information to request data for each resource.
