### PR TITLE
Report back build state to the correct scm repository

### DIFF
--- a/src/api/app/models/workflow/step/branch_package_step.rb
+++ b/src/api/app/models/workflow/step/branch_package_step.rb
@@ -108,7 +108,7 @@ class Workflow
           action: @scm_extractor_payload[:action],
           pull_request: {
             head: {
-              repo: { full_name: @scm_extractor_payload[:repository_full_name] },
+              repo: { full_name: @scm_extractor_payload[:source_repository_full_name] },
               sha: @scm_extractor_payload[:commit_sha]
             }
           }

--- a/src/api/app/services/scm_status_reporter.rb
+++ b/src/api/app/services/scm_status_reporter.rb
@@ -12,7 +12,7 @@ class SCMStatusReporter
     if github?
       github_client = Octokit::Client.new(access_token: @scm_token)
       # https://docs.github.com/en/rest/reference/repos#create-a-commit-status
-      github_client.create_status("#{@payload[:repository_full_name]}",
+      github_client.create_status("#{@payload[:target_repository_full_name]}",
                                   @payload[:commit_sha],
                                   @state,
                                   { context: 'OBS Workflow' })

--- a/src/api/app/services/trigger_controller_service/scm_extractor.rb
+++ b/src/api/app/services/trigger_controller_service/scm_extractor.rb
@@ -44,7 +44,8 @@ module TriggerControllerService
         source_branch: @payload.dig('pull_request', 'head', 'ref'),
         target_branch: @payload.dig('pull_request', 'base', 'ref'),
         action: @payload['action'], # TODO: Names may differ, maybe we need to find our own naming (defer to service?)
-        repository_full_name: @payload.dig('pull_request', 'head', 'repo', 'full_name'),
+        source_repository_full_name: @payload.dig('pull_request', 'head', 'repo', 'full_name'),
+        target_repository_full_name: @payload.dig('pull_request', 'base', 'repo', 'full_name'),
         event: @event
       }.with_indifferent_access
     end

--- a/src/api/app/services/trigger_controller_service/scm_extractor.rb
+++ b/src/api/app/services/trigger_controller_service/scm_extractor.rb
@@ -38,7 +38,6 @@ module TriggerControllerService
     def github_extractor_payload
       {
         scm: 'github',
-        repo_url: @payload.dig('pull_request', 'head', 'repo', 'html_url'),
         commit_sha: @payload.dig('pull_request', 'head', 'sha'),
         pr_number: @payload['number'],
         source_branch: @payload.dig('pull_request', 'head', 'ref'),

--- a/src/api/app/services/workflows/yaml_downloader.rb
+++ b/src/api/app/services/workflows/yaml_downloader.rb
@@ -24,7 +24,7 @@ module Workflows
     def download_url
       case @scm_payload[:scm]
       when 'github'
-        "https://raw.githubusercontent.com/#{@scm_payload[:repository_full_name]}/#{@scm_payload[:target_branch]}/.obs/workflows.yml"
+        "https://raw.githubusercontent.com/#{@scm_payload[:target_repository_full_name]}/#{@scm_payload[:target_branch]}/.obs/workflows.yml"
       when 'gitlab'
         "https://gitlab.com/#{@scm_payload[:path_with_namespace]}/-/raw/#{@scm_payload[:target_branch]}/.obs/workflows.yml"
       end

--- a/src/api/spec/services/trigger_controller_service/scm_extractor_spec.rb
+++ b/src/api/spec/services/trigger_controller_service/scm_extractor_spec.rb
@@ -57,13 +57,16 @@ RSpec.describe TriggerControllerService::ScmExtractor do
           pull_request: {
             head: {
               repo: {
-                full_name: 'danidoni/test_repo',
+                full_name: 'iggy/source_repo',
                 html_url: 'https://github.com/openSUSE/open-build-service'
               },
               ref: 'add-changes',
               sha: '9e0ea1fd99c9000cbb8b8c9d28763d0ddace0b65'
             },
             base: {
+              repo: {
+                full_name: 'iggy/target_repo',
+              },
               ref: 'main'
             }
           },
@@ -79,7 +82,8 @@ RSpec.describe TriggerControllerService::ScmExtractor do
           source_branch: 'add-changes',
           target_branch: 'main',
           action: 'opened',
-          repository_full_name: 'danidoni/test_repo',
+          source_repository_full_name: 'iggy/source_repo',
+          target_repository_full_name: 'iggy/target_repo',
           event: 'pull_request'
         }
       end

--- a/src/api/spec/services/trigger_controller_service/scm_extractor_spec.rb
+++ b/src/api/spec/services/trigger_controller_service/scm_extractor_spec.rb
@@ -57,15 +57,14 @@ RSpec.describe TriggerControllerService::ScmExtractor do
           pull_request: {
             head: {
               repo: {
-                full_name: 'iggy/source_repo',
-                html_url: 'https://github.com/openSUSE/open-build-service'
+                full_name: 'iggy/source_repo'
               },
               ref: 'add-changes',
               sha: '9e0ea1fd99c9000cbb8b8c9d28763d0ddace0b65'
             },
             base: {
               repo: {
-                full_name: 'iggy/target_repo',
+                full_name: 'iggy/target_repo'
               },
               ref: 'main'
             }
@@ -76,7 +75,6 @@ RSpec.describe TriggerControllerService::ScmExtractor do
       let(:expected_hash) do
         {
           scm: 'github',
-          repo_url: 'https://github.com/openSUSE/open-build-service',
           commit_sha: '9e0ea1fd99c9000cbb8b8c9d28763d0ddace0b65',
           pr_number: 4,
           source_branch: 'add-changes',

--- a/src/api/spec/services/workflows/yaml_downloader_spec.rb
+++ b/src/api/spec/services/workflows/yaml_downloader_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Workflows::YAMLDownloader, type: :service do
     end
 
     context 'github' do
-      let(:payload) { { scm: 'github', target_branch: 'master', repository_full_name: 'openSUSE/obs-server' } }
-      let(:url) { "https://raw.githubusercontent.com/#{payload[:repository_full_name]}/#{payload[:target_branch]}/.obs/workflows.yml" }
+      let(:payload) { { scm: 'github', target_branch: 'master', target_repository_full_name: 'openSUSE/obs-server' } }
+      let(:url) { "https://raw.githubusercontent.com/#{payload[:target_repository_full_name]}/#{payload[:target_branch]}/.obs/workflows.yml" }
 
       it { expect(Down).to have_received(:download).with(url, max_size: max_size) }
     end


### PR DESCRIPTION
We were using the head (source) repository instead of
the base (target) repository to report back the
build state of a workflow. This is wrong since the
state is reported using the scm token of the target
repo owner/maintainer, which leads to permission
problems (since it doesn't associate the reported
state to the PR, but directly to the commit on the
source repository).

We also changed the download url, we should only
take the "workflow.yml" file from the target
repository.

Co-authored-by: Saray Cabrera Padrón <scabrerapadron@suse.de>
