### PR TITLE
[backend] proxy the missingdodresources request through the src server

### DIFF
--- a/src/backend/BSSched/DoD.pm
+++ b/src/backend/BSSched/DoD.pm
@@ -432,9 +432,8 @@ sub signalmissing {
     my $proj = $remoteprojs->{$projid};
     return unless $proj;
     return unless $proj->{'partition'};		# not supported yet
-    my $server = $proj->{'partition'} ? $proj->{'remoteurl'} : $BSConfig::srcserver;
     my $param = {
-      'uri' => "$server/build/$prp/$arch",
+      'uri' => "$BSConfig::srcserver/build/$prp/$arch/_repository",
       'request' => 'POST',
       'receiver' => \&BSHTTP::null_receiver,
       'async' => {
@@ -443,7 +442,7 @@ sub signalmissing {
         '_prp' => $prp,
       },
     };
-    my @args = 'view=missingdodresources';
+    my @args = 'cmd=missingdodresources';
     push @args, map {"resource=$_"} @$dodresources;
     push @args, "partition=$BSConfig::partition" if $BSConfig::partition;
     eval { $ctx->xrpc("missingdodresources/$prp", $param, undef, @args) };

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -5436,6 +5436,21 @@ sub postrepo {
   return ($res, $BSXML::collection);
 }
 
+sub missingdodresources {
+  my ($cgi, $projid, $repoid, $arch) = @_;
+  checkprojrepoarch($projid, $repoid, $arch);
+  my $reposerver = $BSConfig::partitioning ? BSSrcServer::Partition::projid2reposerver($projid) : $BSConfig::reposerver;
+  my $param = {
+    'uri' => "$reposerver/build/$projid/$repoid/$arch/_repository",
+    'request' => 'POST',
+    'ignorestatus' => 1,
+    'receiver' => \&BSServer::reply_receiver,
+  };
+  my @args = BSRPC::args($cgi, 'resource', 'partition');
+  BSWatcher::rpc($param, undef, 'cmd=missingdodresources', @args);
+  return undef;
+}
+
 ####################################################################
 
 sub service {
@@ -7218,6 +7233,7 @@ my $dispatches = [
   '/build/$project/$repository/$arch package* view:?' => \&getpackagelist_build,
   '!- /build/$project/$repository/$arch/_builddepinfo package* view:?' => \&getbuilddepinfo,
   '/build/$project/$repository/$arch/_jobhistory package* code:* limit:num? endtime_start:num? endtime_end:num?' => \&getjobhistory,
+  'POST:/build/$project/$repository/$arch/_repository cmd=missingdodresources resource:* partition:?' => \&missingdodresources,
   'POST:/build/$project/$repository/$arch/_repository match:' =>  \&postrepo,
   'POST:/build/$project/$repository/$arch/$package cmd=copy oproject:project? opackage:package? orepository:repository? setupdateinfoid:? resign:bool? setrelease:? multibuild:bool?' => \&copybuild,
   'POST:/build/$project/$repository/$arch/$package' => \&uploadbuild,


### PR DESCRIPTION
This is the only POST request from the scheduler to a repo server.
It currently gets rejected due to our access configuration, so
use the src server as proxy.

_Replace this line with a description of your changes. Please follow the suggestions in the comment below._

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
