### PR TITLE
Remove package_id from ignored_columns in event base model

### DIFF
--- a/src/api/app/models/event/base.rb
+++ b/src/api/app/models/event/base.rb
@@ -4,7 +4,6 @@ module Event
   class Base < ApplicationRecord
     self.inheritance_column = 'eventtype'
     self.table_name = 'events'
-    self.ignored_columns = ['package_id']
 
     after_create :create_project_log_entry_job, if: -> { (PROJECT_CLASSES | PACKAGE_CLASSES).include?(self.class.name) }
 


### PR DESCRIPTION
Ignoring the package_id columns was only needed prior
to a db migration which removed the corresponding column.
After the migration is successfully applied this line can
be removed again.