### PR TITLE
Limit the webhook actions we accept

### DIFF
--- a/src/api/app/services/trigger_controller_service/scm_extractor.rb
+++ b/src/api/app/services/trigger_controller_service/scm_extractor.rb
@@ -1,8 +1,8 @@
 module TriggerControllerService
   # NOTE: this class is coupled to GitHub pull requests events and GitLab merge requests events.
   class ScmExtractor
-    ALLOWED_GITHUB_ACTIONS = ['opened', 'synchronize', 'closed'].freeze
-    ALLOWED_GITLAB_ACTIONS = ['open', 'update', 'close', 'reopen', 'merge'].freeze
+    ALLOWED_GITHUB_ACTIONS = ['opened'].freeze
+    ALLOWED_GITLAB_ACTIONS = ['open'].freeze
 
     def initialize(scm, event, payload)
       # TODO: What should we do when the user sends a wwwurlencoded payload? Raise an exception?


### PR DESCRIPTION
Right now, we should only accept open/opened actions for  `pull_request` or `Merge Request Hook` events. The rest of the actions should be ignored for now.

We avoid raising exceptions when checking if the `step` is present and is valid.

Fixes #11207