### PR TITLE
Pass X-Request-ID with each request to the backend

### DIFF
--- a/src/api/app/controllers/application_controller.rb
+++ b/src/api/app/controllers/application_controller.rb
@@ -12,6 +12,7 @@ class ApplicationController < ActionController::Base
   include FlipperFeature
 
   include RescueHandler
+  include SetCurrentRequestDetails
 
   # session :disabled => true
 

--- a/src/api/app/controllers/concerns/set_current_request_details.rb
+++ b/src/api/app/controllers/concerns/set_current_request_details.rb
@@ -1,0 +1,9 @@
+module SetCurrentRequestDetails
+  extend ActiveSupport::Concern
+
+  included do
+    before_action do
+      Current.request_id = request.uuid
+    end
+  end
+end

--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -11,6 +11,7 @@ class Webui::WebuiController < ActionController::Base
   include Pundit
   include FlipperFeature
   include Webui::RescueHandler
+  include SetCurrentRequestDetails
   protect_from_forgery
 
   before_action :set_influxdb_data

--- a/src/api/app/lib/backend/connection_helper.rb
+++ b/src/api/app/lib/backend/connection_helper.rb
@@ -47,25 +47,30 @@ module Backend
     # Performs a http get request to the configured OBS Backend server.
     # @return [String]
     def http_get(endpoint, options = {})
-      Backend::Connection.get(calculate_url(endpoint, options), options[:headers] || {}).body.force_encoding('UTF-8')
+      Backend::Connection.get(calculate_url(endpoint, options), calculate_headers(options)).body.force_encoding('UTF-8')
     end
 
     # Performs a http post request to the configured OBS Backend server.
     # @return [String]
     def http_post(endpoint, options = {})
-      Backend::Connection.post(calculate_url(endpoint, options), options[:data], options[:headers] || {}).body.force_encoding('UTF-8')
+      Backend::Connection.post(calculate_url(endpoint, options), options[:data], calculate_headers(options)).body.force_encoding('UTF-8')
     end
 
     # Performs a http put request to the configured OBS Backend server.
     # @return [String]
     def http_put(endpoint, options = {})
-      Backend::Connection.put(calculate_url(endpoint, options), options[:data], options[:headers] || {}).body.force_encoding('UTF-8')
+      Backend::Connection.put(calculate_url(endpoint, options), options[:data], calculate_headers(options)).body.force_encoding('UTF-8')
     end
 
     # Performs a http delete request to the configured OBS Backend server.
     # @return [String]
     def http_delete(endpoint, options = {})
-      Backend::Connection.delete(calculate_url(endpoint, options), options[:headers] || {}).body.force_encoding('UTF-8')
+      Backend::Connection.delete(calculate_url(endpoint, options), calculate_headers(options)).body.force_encoding('UTF-8')
+    end
+
+    def calculate_headers(options)
+      input_headers = options.fetch(:headers, {})
+      { 'x-request-id': Current.request_id }.merge(input_headers)
     end
 
     def calculate_url(endpoint, options)

--- a/src/api/app/models/current.rb
+++ b/src/api/app/models/current.rb
@@ -1,0 +1,3 @@
+class Current < ActiveSupport::CurrentAttributes
+  attribute :request_id
+end


### PR DESCRIPTION
Pass X-Request-ID with each request to the backend
    
Once we also log this in the backend log, this will
make it easier to find all requests that were triggered
by a certain user request.


patch from @darix 