### PR TITLE
Reset package update form on cancel.

### DIFF
--- a/src/api/app/views/webui/package/_basic_info.html.haml
+++ b/src/api/app/views/webui/package/_basic_info.html.haml
@@ -26,5 +26,4 @@
   $('#cancel-in-place-editing').on('click', function () {
     $('.in-place-editing .basic-info').toggleClass('d-none');
     $('.in-place-editing .editing-form').toggleClass('d-none');
-    return false;
   });

--- a/src/api/app/views/webui/package/_edit.html.haml
+++ b/src/api/app/views/webui/package/_edit.html.haml
@@ -13,5 +13,5 @@
     = form.label(:description, 'Description:')
     = form.text_area(:description, rows: 8, class: 'form-control')
   .form-group.text-right
-    = button_tag('Cancel', id: 'cancel-in-place-editing', class: 'cancel btn btn-outline-danger px-4')
+    = button_tag('Cancel', type: 'reset', class: 'cancel btn btn-outline-danger px-4', id: 'cancel-in-place-editing')
     = submit_tag('Update', class: 'btn btn-primary px-4')


### PR DESCRIPTION
If you try to edit the package description/title/URL and press the cancel button. When you try to edit again, the updated text stays there unless you reload the page. 

Fixes #11055 


