### PR TITLE
Use home project as namespace for branched package

### DIFF
--- a/src/api/app/models/workflow/step/branch_package_step.rb
+++ b/src/api/app/models/workflow/step/branch_package_step.rb
@@ -42,7 +42,8 @@ class Workflow
       end
 
       def target_project
-        source_project + ":PR-#{@scm_extractor_payload[:pr_number]}"
+        # TODO: should be token.user.login
+        "home:#{User.session!.login}:#{source_project}:PR-#{@scm_extractor_payload[:pr_number]}"
       end
 
       def remote_source?
@@ -62,7 +63,6 @@ class Workflow
 
       def branch
         check_source_access
-
         BranchPackage.new({ project: source_project, package: source_package,
                             target_project: target_project,
                             target_package: target_package }).branch

--- a/src/api/spec/cassettes/Token_Workflow/_call/when_the_webhook_and_configuration_is_correct/when_the_SCM_is_GitHub/behaves_like_successful_workflow_call/creates_a_new_Event_BuildFail_subscription.yml
+++ b/src/api/spec/cassettes/Token_Workflow/_call/when_the_webhook_and_configuration_is_correct/when_the_SCM_is_GitHub/behaves_like_successful_workflow_call/creates_a_new_Event_BuildFail_subscription.yml
@@ -2,12 +2,12 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/test-project/_meta?user=user_9
+    uri: http://backend:5352/source/home:Iggy/_meta?user=Iggy
     body:
       encoding: UTF-8
       string: |
-        <project name="test-project">
-          <title>An Evil Cradling</title>
+        <project name="home:Iggy">
+          <title/>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -30,25 +30,65 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '149'
+      - '130'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:Iggy">
+          <title></title>
+          <description></description>
+          <person userid="Iggy" role="maintainer"/>
+        </project>
+  recorded_at: Tue, 08 Jun 2021 14:19:19 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/test-project/_meta?user=user_1
     body:
       encoding: UTF-8
       string: |
         <project name="test-project">
-          <title>An Evil Cradling</title>
+          <title>Nine Coaches Waiting</title>
+          <description/>
+          <person userid="Iggy" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '153'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="test-project">
+          <title>Nine Coaches Waiting</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Tue, 25 May 2021 14:02:06 GMT
+  recorded_at: Tue, 08 Jun 2021 14:19:19 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/test-project/test-package/_meta?user=user_10
+    uri: http://backend:5352/source/test-project/test-package/_meta?user=user_2
     body:
       encoding: UTF-8
       string: |
         <package name="test-package" project="test-project">
-          <title>Postern of Fate</title>
-          <description>Sit modi est voluptas.</description>
+          <title>The Way Through the Woods</title>
+          <description>Laboriosam voluptatem voluptatem ut.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -69,15 +109,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '149'
+      - '173'
     body:
       encoding: UTF-8
       string: |
         <package name="test-package" project="test-project">
-          <title>Postern of Fate</title>
-          <description>Sit modi est voluptas.</description>
+          <title>The Way Through the Woods</title>
+          <description>Laboriosam voluptatem voluptatem ut.</description>
         </package>
-  recorded_at: Tue, 25 May 2021 14:02:06 GMT
+  recorded_at: Tue, 08 Jun 2021 14:19:19 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22test-package%22%20and%20linkinfo/@project=%22test-project%22%20and%20@project=%22test-project%22)
@@ -111,14 +151,14 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Tue, 25 May 2021 14:02:06 GMT
+  recorded_at: Tue, 08 Jun 2021 14:19:19 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/test-project:PR-4/_meta?user=Iggy
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/_meta?user=Iggy
     body:
       encoding: UTF-8
       string: |
-        <project name="test-project:PR-4">
+        <project name="home:Iggy:test-project:PR-4">
           <title>Branch project for package test-package</title>
           <description>This project was created for package test-package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
@@ -142,25 +182,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '255'
+      - '265'
     body:
       encoding: UTF-8
       string: |
-        <project name="test-project:PR-4">
+        <project name="home:Iggy:test-project:PR-4">
           <title>Branch project for package test-package</title>
           <description>This project was created for package test-package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Tue, 25 May 2021 14:02:06 GMT
+  recorded_at: Tue, 08 Jun 2021 14:19:19 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/test-project:PR-4/test-package/_meta?user=Iggy
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/test-package/_meta?user=Iggy
     body:
       encoding: UTF-8
       string: |
-        <package name="test-package" project="test-project:PR-4">
-          <title>Postern of Fate</title>
-          <description>Sit modi est voluptas.</description>
+        <package name="test-package" project="home:Iggy:test-project:PR-4">
+          <title>The Way Through the Woods</title>
+          <description>Laboriosam voluptatem voluptatem ut.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -181,18 +221,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '154'
+      - '188'
     body:
       encoding: UTF-8
       string: |
-        <package name="test-package" project="test-project:PR-4">
-          <title>Postern of Fate</title>
-          <description>Sit modi est voluptas.</description>
+        <package name="test-package" project="home:Iggy:test-project:PR-4">
+          <title>The Way Through the Woods</title>
+          <description>Laboriosam voluptatem voluptatem ut.</description>
         </package>
-  recorded_at: Tue, 25 May 2021 14:02:06 GMT
+  recorded_at: Tue, 08 Jun 2021 14:19:19 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/test-project:PR-4/test-package?cmd=branch&noservice=1&opackage=test-package&oproject=test-project&user=Iggy
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/test-package?cmd=branch&noservice=1&opackage=test-package&oproject=test-project&user=Iggy
     body:
       encoding: UTF-8
       string: ''
@@ -217,28 +257,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '206'
+      - '204'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="51" vrev="51">
+        <revision rev="5" vrev="5">
           <srcmd5>411c6fd260778a3381a135e5cc0c1797</srcmd5>
           <version>unknown</version>
-          <time>1621951326</time>
+          <time>1623161959</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Tue, 25 May 2021 14:02:06 GMT
+  recorded_at: Tue, 08 Jun 2021 14:19:19 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/test-project:PR-4/test-package/_meta?user=Iggy
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/test-package/_meta?user=Iggy
     body:
       encoding: UTF-8
       string: |
-        <package name="test-package" project="test-project:PR-4">
-          <title>Postern of Fate</title>
-          <description>Sit modi est voluptas.</description>
+        <package name="test-package" project="home:Iggy:test-project:PR-4">
+          <title>The Way Through the Woods</title>
+          <description>Laboriosam voluptatem voluptatem ut.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -259,18 +299,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '154'
+      - '188'
     body:
       encoding: UTF-8
       string: |
-        <package name="test-package" project="test-project:PR-4">
-          <title>Postern of Fate</title>
-          <description>Sit modi est voluptas.</description>
+        <package name="test-package" project="home:Iggy:test-project:PR-4">
+          <title>The Way Through the Woods</title>
+          <description>Laboriosam voluptatem voluptatem ut.</description>
         </package>
-  recorded_at: Tue, 25 May 2021 14:02:06 GMT
+  recorded_at: Tue, 08 Jun 2021 14:19:19 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/test-project:PR-4/test-package
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/test-package
     body:
       encoding: US-ASCII
       string: ''
@@ -293,18 +333,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '430'
+      - '428'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test-package" rev="51" vrev="51" srcmd5="411c6fd260778a3381a135e5cc0c1797">
+        <directory name="test-package" rev="5" vrev="5" srcmd5="411c6fd260778a3381a135e5cc0c1797">
           <linkinfo project="test-project" package="test-package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="6dee1c1851207b12d4c251e1946048c7" lsrcmd5="411c6fd260778a3381a135e5cc0c1797"/>
-          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1621949508"/>
+          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1623161473"/>
         </directory>
-  recorded_at: Tue, 25 May 2021 14:02:06 GMT
+  recorded_at: Tue, 08 Jun 2021 14:19:19 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/test-project:PR-4/test-package?view=info
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/test-package?view=info
     body:
       encoding: US-ASCII
       string: ''
@@ -327,18 +367,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '333'
+      - '331'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="test-package" rev="51" vrev="51" srcmd5="6dee1c1851207b12d4c251e1946048c7" lsrcmd5="411c6fd260778a3381a135e5cc0c1797" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
+        <sourceinfo package="test-package" rev="5" vrev="5" srcmd5="6dee1c1851207b12d4c251e1946048c7" lsrcmd5="411c6fd260778a3381a135e5cc0c1797" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="test-project" package="test-package"/>
         </sourceinfo>
-  recorded_at: Tue, 25 May 2021 14:02:07 GMT
+  recorded_at: Tue, 08 Jun 2021 14:19:20 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/test-project:PR-4/test-package
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/test-package
     body:
       encoding: US-ASCII
       string: ''
@@ -361,18 +401,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '430'
+      - '428'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test-package" rev="51" vrev="51" srcmd5="411c6fd260778a3381a135e5cc0c1797">
+        <directory name="test-package" rev="5" vrev="5" srcmd5="411c6fd260778a3381a135e5cc0c1797">
           <linkinfo project="test-project" package="test-package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="6dee1c1851207b12d4c251e1946048c7" lsrcmd5="411c6fd260778a3381a135e5cc0c1797"/>
-          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1621949508"/>
+          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1623161473"/>
         </directory>
-  recorded_at: Tue, 25 May 2021 14:02:07 GMT
+  recorded_at: Tue, 08 Jun 2021 14:19:20 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/test-project:PR-4/test-package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/test-package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
     body:
       encoding: UTF-8
       string: ''
@@ -397,21 +437,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '321'
+      - '340'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="2dc0c408631a71cdeacf50b170c3d049">
-          <old project="test-project:PR-4" package="test-package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="test-project:PR-4" package="test-package" rev="51" srcmd5="411c6fd260778a3381a135e5cc0c1797"/>
+        <sourcediff key="37765be80e53d48c57de6ccbf89b0e40">
+          <old project="home:Iggy:test-project:PR-4" package="test-package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="home:Iggy:test-project:PR-4" package="test-package" rev="5" srcmd5="411c6fd260778a3381a135e5cc0c1797"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Tue, 25 May 2021 14:02:07 GMT
+  recorded_at: Tue, 08 Jun 2021 14:19:20 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/test-project:PR-4/test-package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/test-package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
     body:
       encoding: UTF-8
       string: ''
@@ -436,23 +476,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '354'
+      - '364'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="c2c424aaf6189b5e9df6c7e3b3027755">
+        <sourcediff key="2ed48d1faed509c13a6d1bc9bd36407d">
           <old project="test-project" package="test-package" rev="d41d8cd98f00b204e9800998ecf8427e" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="test-project:PR-4" package="test-package" rev="6dee1c1851207b12d4c251e1946048c7" srcmd5="6dee1c1851207b12d4c251e1946048c7"/>
+          <new project="home:Iggy:test-project:PR-4" package="test-package" rev="6dee1c1851207b12d4c251e1946048c7" srcmd5="6dee1c1851207b12d4c251e1946048c7"/>
           <files/>
         </sourcediff>
-  recorded_at: Tue, 25 May 2021 14:02:07 GMT
+  recorded_at: Tue, 08 Jun 2021 14:19:20 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/test-project:PR-4/_meta?user=Iggy
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/_meta?user=Iggy
     body:
       encoding: UTF-8
       string: |
-        <project name="test-project:PR-4">
+        <project name="home:Iggy:test-project:PR-4">
           <title>Branch project for package test-package</title>
           <description>This project was created for package test-package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
@@ -479,11 +519,11 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '295'
+      - '305'
     body:
       encoding: UTF-8
       string: |
-        <project name="test-project:PR-4">
+        <project name="home:Iggy:test-project:PR-4">
           <title>Branch project for package test-package</title>
           <description>This project was created for package test-package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
@@ -491,10 +531,10 @@ http_interactions:
             <disable/>
           </publish>
         </project>
-  recorded_at: Tue, 25 May 2021 14:02:07 GMT
+  recorded_at: Tue, 08 Jun 2021 14:19:20 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/test-project:PR-4/test-package/_branch_request?user=Iggy
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/test-package/_branch_request?user=Iggy
     body:
       encoding: UTF-8
       string: '{"action":"opened","pull_request":{"head":{"repo":{"full_name":"username/test_repo"},"sha":null}}}'
@@ -517,28 +557,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '206'
+      - '204'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="52" vrev="52">
+        <revision rev="6" vrev="6">
           <srcmd5>e8d0ddbf3cd22e52520a074eb37b5259</srcmd5>
           <version>unknown</version>
-          <time>1621951327</time>
+          <time>1623161960</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Tue, 25 May 2021 14:02:07 GMT
+  recorded_at: Tue, 08 Jun 2021 14:19:20 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/test-project:PR-4/test-package/_meta?user=Iggy
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/test-package/_meta?user=Iggy
     body:
       encoding: UTF-8
       string: |
-        <package name="test-package" project="test-project:PR-4">
-          <title>Postern of Fate</title>
-          <description>Sit modi est voluptas.</description>
+        <package name="test-package" project="home:Iggy:test-project:PR-4">
+          <title>The Way Through the Woods</title>
+          <description>Laboriosam voluptatem voluptatem ut.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -559,18 +599,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '154'
+      - '188'
     body:
       encoding: UTF-8
       string: |
-        <package name="test-package" project="test-project:PR-4">
-          <title>Postern of Fate</title>
-          <description>Sit modi est voluptas.</description>
+        <package name="test-package" project="home:Iggy:test-project:PR-4">
+          <title>The Way Through the Woods</title>
+          <description>Laboriosam voluptatem voluptatem ut.</description>
         </package>
-  recorded_at: Tue, 25 May 2021 14:02:07 GMT
+  recorded_at: Tue, 08 Jun 2021 14:19:20 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/test-project:PR-4/test-package
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/test-package
     body:
       encoding: US-ASCII
       string: ''
@@ -593,19 +633,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '532'
+      - '530'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test-package" rev="52" vrev="52" srcmd5="e8d0ddbf3cd22e52520a074eb37b5259">
+        <directory name="test-package" rev="6" vrev="6" srcmd5="e8d0ddbf3cd22e52520a074eb37b5259">
           <linkinfo project="test-project" package="test-package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="2f8f66d64fd327463204b8b238fede8e" lsrcmd5="e8d0ddbf3cd22e52520a074eb37b5259"/>
-          <entry name="_branch_request" md5="dea1816075f5d14403700c04bfefc8f2" size="98" mtime="1621949508"/>
-          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1621949508"/>
+          <entry name="_branch_request" md5="dea1816075f5d14403700c04bfefc8f2" size="98" mtime="1623161833"/>
+          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1623161473"/>
         </directory>
-  recorded_at: Tue, 25 May 2021 14:02:07 GMT
+  recorded_at: Tue, 08 Jun 2021 14:19:20 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/test-project:PR-4/test-package?view=info
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/test-package?view=info
     body:
       encoding: US-ASCII
       string: ''
@@ -628,18 +668,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '333'
+      - '331'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="test-package" rev="52" vrev="52" srcmd5="2f8f66d64fd327463204b8b238fede8e" lsrcmd5="e8d0ddbf3cd22e52520a074eb37b5259" verifymd5="3f8defb2fc634d5ae5bc26d21016de91">
+        <sourceinfo package="test-package" rev="6" vrev="6" srcmd5="2f8f66d64fd327463204b8b238fede8e" lsrcmd5="e8d0ddbf3cd22e52520a074eb37b5259" verifymd5="3f8defb2fc634d5ae5bc26d21016de91">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="test-project" package="test-package"/>
         </sourceinfo>
-  recorded_at: Tue, 25 May 2021 14:02:07 GMT
+  recorded_at: Tue, 08 Jun 2021 14:19:20 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/test-project:PR-4/test-package
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/test-package
     body:
       encoding: US-ASCII
       string: ''
@@ -662,19 +702,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '532'
+      - '530'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test-package" rev="52" vrev="52" srcmd5="e8d0ddbf3cd22e52520a074eb37b5259">
+        <directory name="test-package" rev="6" vrev="6" srcmd5="e8d0ddbf3cd22e52520a074eb37b5259">
           <linkinfo project="test-project" package="test-package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="2f8f66d64fd327463204b8b238fede8e" lsrcmd5="e8d0ddbf3cd22e52520a074eb37b5259"/>
-          <entry name="_branch_request" md5="dea1816075f5d14403700c04bfefc8f2" size="98" mtime="1621949508"/>
-          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1621949508"/>
+          <entry name="_branch_request" md5="dea1816075f5d14403700c04bfefc8f2" size="98" mtime="1623161833"/>
+          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1623161473"/>
         </directory>
-  recorded_at: Tue, 25 May 2021 14:02:07 GMT
+  recorded_at: Tue, 08 Jun 2021 14:19:20 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/test-project:PR-4/test-package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/test-package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
     body:
       encoding: UTF-8
       string: ''
@@ -699,21 +739,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '321'
+      - '340'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="12e396c9ac9bc680ec49547d39aa04a9">
-          <old project="test-project:PR-4" package="test-package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="test-project:PR-4" package="test-package" rev="52" srcmd5="e8d0ddbf3cd22e52520a074eb37b5259"/>
+        <sourcediff key="55a09b86e63423dff62523b02da67850">
+          <old project="home:Iggy:test-project:PR-4" package="test-package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="home:Iggy:test-project:PR-4" package="test-package" rev="6" srcmd5="e8d0ddbf3cd22e52520a074eb37b5259"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Tue, 25 May 2021 14:02:07 GMT
+  recorded_at: Tue, 08 Jun 2021 14:19:20 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/test-project:PR-4/test-package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/test-package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
     body:
       encoding: UTF-8
       string: ''
@@ -734,7 +774,7 @@ http_interactions:
       Content-Type:
       - text/xml
       Content-Length:
-      - '377'
+      - '387'
       Cache-Control:
       - no-cache
       Connection:
@@ -742,12 +782,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="919122e20ded2ca17cf41391450b5ba6">
+        <sourcediff key="4215d181fa14622e6168914e9b5813db">
           <old project="test-project" package="test-package" rev="d41d8cd98f00b204e9800998ecf8427e" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="test-project:PR-4" package="test-package" rev="2f8f66d64fd327463204b8b238fede8e" srcmd5="2f8f66d64fd327463204b8b238fede8e"/>
+          <new project="home:Iggy:test-project:PR-4" package="test-package" rev="2f8f66d64fd327463204b8b238fede8e" srcmd5="2f8f66d64fd327463204b8b238fede8e"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Tue, 25 May 2021 14:02:07 GMT
+  recorded_at: Tue, 08 Jun 2021 14:19:20 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Token_Workflow/_call/when_the_webhook_and_configuration_is_correct/when_the_SCM_is_GitHub/behaves_like_successful_workflow_call/creates_a_new_Event_BuildSuccess_subscription.yml
+++ b/src/api/spec/cassettes/Token_Workflow/_call/when_the_webhook_and_configuration_is_correct/when_the_SCM_is_GitHub/behaves_like_successful_workflow_call/creates_a_new_Event_BuildSuccess_subscription.yml
@@ -2,12 +2,12 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/test-project/_meta?user=user_7
+    uri: http://backend:5352/source/home:Iggy/_meta?user=Iggy
     body:
       encoding: UTF-8
       string: |
-        <project name="test-project">
-          <title>The Last Temptation</title>
+        <project name="home:Iggy">
+          <title/>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -30,25 +30,65 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '152'
+      - '130'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:Iggy">
+          <title></title>
+          <description></description>
+          <person userid="Iggy" role="maintainer"/>
+        </project>
+  recorded_at: Tue, 08 Jun 2021 14:17:12 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/test-project/_meta?user=user_1
     body:
       encoding: UTF-8
       string: |
         <project name="test-project">
-          <title>The Last Temptation</title>
+          <title>Cover Her Face</title>
+          <description/>
+          <person userid="Iggy" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '147'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="test-project">
+          <title>Cover Her Face</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Tue, 25 May 2021 14:02:05 GMT
+  recorded_at: Tue, 08 Jun 2021 14:17:12 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/test-project/test-package/_meta?user=user_8
+    uri: http://backend:5352/source/test-project/test-package/_meta?user=user_2
     body:
       encoding: UTF-8
       string: |
         <package name="test-package" project="test-project">
-          <title>Arms and the Man</title>
-          <description>Blanditiis repudiandae quas commodi.</description>
+          <title>The Stars' Tennis Balls</title>
+          <description>Aspernatur occaecati qui illum.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -69,15 +109,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '164'
+      - '166'
     body:
       encoding: UTF-8
       string: |
         <package name="test-package" project="test-project">
-          <title>Arms and the Man</title>
-          <description>Blanditiis repudiandae quas commodi.</description>
+          <title>The Stars' Tennis Balls</title>
+          <description>Aspernatur occaecati qui illum.</description>
         </package>
-  recorded_at: Tue, 25 May 2021 14:02:05 GMT
+  recorded_at: Tue, 08 Jun 2021 14:17:12 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22test-package%22%20and%20linkinfo/@project=%22test-project%22%20and%20@project=%22test-project%22)
@@ -111,14 +151,14 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Tue, 25 May 2021 14:02:05 GMT
+  recorded_at: Tue, 08 Jun 2021 14:17:12 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/test-project:PR-4/_meta?user=Iggy
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/_meta?user=Iggy
     body:
       encoding: UTF-8
       string: |
-        <project name="test-project:PR-4">
+        <project name="home:Iggy:test-project:PR-4">
           <title>Branch project for package test-package</title>
           <description>This project was created for package test-package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
@@ -142,25 +182,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '255'
+      - '265'
     body:
       encoding: UTF-8
       string: |
-        <project name="test-project:PR-4">
+        <project name="home:Iggy:test-project:PR-4">
           <title>Branch project for package test-package</title>
           <description>This project was created for package test-package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Tue, 25 May 2021 14:02:06 GMT
+  recorded_at: Tue, 08 Jun 2021 14:17:12 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/test-project:PR-4/test-package/_meta?user=Iggy
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/test-package/_meta?user=Iggy
     body:
       encoding: UTF-8
       string: |
-        <package name="test-package" project="test-project:PR-4">
-          <title>Arms and the Man</title>
-          <description>Blanditiis repudiandae quas commodi.</description>
+        <package name="test-package" project="home:Iggy:test-project:PR-4">
+          <title>The Stars' Tennis Balls</title>
+          <description>Aspernatur occaecati qui illum.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -181,18 +221,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '169'
+      - '181'
     body:
       encoding: UTF-8
       string: |
-        <package name="test-package" project="test-project:PR-4">
-          <title>Arms and the Man</title>
-          <description>Blanditiis repudiandae quas commodi.</description>
+        <package name="test-package" project="home:Iggy:test-project:PR-4">
+          <title>The Stars' Tennis Balls</title>
+          <description>Aspernatur occaecati qui illum.</description>
         </package>
-  recorded_at: Tue, 25 May 2021 14:02:06 GMT
+  recorded_at: Tue, 08 Jun 2021 14:17:12 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/test-project:PR-4/test-package?cmd=branch&noservice=1&opackage=test-package&oproject=test-project&user=Iggy
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/test-package?cmd=branch&noservice=1&opackage=test-package&oproject=test-project&user=Iggy
     body:
       encoding: UTF-8
       string: ''
@@ -217,28 +257,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '206'
+      - '204'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="49" vrev="49">
+        <revision rev="1" vrev="1">
           <srcmd5>411c6fd260778a3381a135e5cc0c1797</srcmd5>
           <version>unknown</version>
-          <time>1621951326</time>
+          <time>1623161832</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Tue, 25 May 2021 14:02:06 GMT
+  recorded_at: Tue, 08 Jun 2021 14:17:12 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/test-project:PR-4/test-package/_meta?user=Iggy
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/test-package/_meta?user=Iggy
     body:
       encoding: UTF-8
       string: |
-        <package name="test-package" project="test-project:PR-4">
-          <title>Arms and the Man</title>
-          <description>Blanditiis repudiandae quas commodi.</description>
+        <package name="test-package" project="home:Iggy:test-project:PR-4">
+          <title>The Stars' Tennis Balls</title>
+          <description>Aspernatur occaecati qui illum.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -259,18 +299,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '169'
+      - '181'
     body:
       encoding: UTF-8
       string: |
-        <package name="test-package" project="test-project:PR-4">
-          <title>Arms and the Man</title>
-          <description>Blanditiis repudiandae quas commodi.</description>
+        <package name="test-package" project="home:Iggy:test-project:PR-4">
+          <title>The Stars' Tennis Balls</title>
+          <description>Aspernatur occaecati qui illum.</description>
         </package>
-  recorded_at: Tue, 25 May 2021 14:02:06 GMT
+  recorded_at: Tue, 08 Jun 2021 14:17:12 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/test-project:PR-4/test-package
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/test-package
     body:
       encoding: US-ASCII
       string: ''
@@ -293,18 +333,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '430'
+      - '428'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test-package" rev="49" vrev="49" srcmd5="411c6fd260778a3381a135e5cc0c1797">
+        <directory name="test-package" rev="1" vrev="1" srcmd5="411c6fd260778a3381a135e5cc0c1797">
           <linkinfo project="test-project" package="test-package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="6dee1c1851207b12d4c251e1946048c7" lsrcmd5="411c6fd260778a3381a135e5cc0c1797"/>
-          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1621949508"/>
+          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1623161473"/>
         </directory>
-  recorded_at: Tue, 25 May 2021 14:02:06 GMT
+  recorded_at: Tue, 08 Jun 2021 14:17:12 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/test-project:PR-4/test-package?view=info
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/test-package?view=info
     body:
       encoding: US-ASCII
       string: ''
@@ -327,18 +367,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '333'
+      - '331'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="test-package" rev="49" vrev="49" srcmd5="6dee1c1851207b12d4c251e1946048c7" lsrcmd5="411c6fd260778a3381a135e5cc0c1797" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
+        <sourceinfo package="test-package" rev="1" vrev="1" srcmd5="6dee1c1851207b12d4c251e1946048c7" lsrcmd5="411c6fd260778a3381a135e5cc0c1797" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="test-project" package="test-package"/>
         </sourceinfo>
-  recorded_at: Tue, 25 May 2021 14:02:06 GMT
+  recorded_at: Tue, 08 Jun 2021 14:17:12 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/test-project:PR-4/test-package
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/test-package
     body:
       encoding: US-ASCII
       string: ''
@@ -361,18 +401,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '430'
+      - '428'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test-package" rev="49" vrev="49" srcmd5="411c6fd260778a3381a135e5cc0c1797">
+        <directory name="test-package" rev="1" vrev="1" srcmd5="411c6fd260778a3381a135e5cc0c1797">
           <linkinfo project="test-project" package="test-package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="6dee1c1851207b12d4c251e1946048c7" lsrcmd5="411c6fd260778a3381a135e5cc0c1797"/>
-          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1621949508"/>
+          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1623161473"/>
         </directory>
-  recorded_at: Tue, 25 May 2021 14:02:06 GMT
+  recorded_at: Tue, 08 Jun 2021 14:17:12 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/test-project:PR-4/test-package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/test-package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
     body:
       encoding: UTF-8
       string: ''
@@ -397,21 +437,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '321'
+      - '340'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="5002e7e0b4548a71eb4b9ec8e7007220">
-          <old project="test-project:PR-4" package="test-package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="test-project:PR-4" package="test-package" rev="49" srcmd5="411c6fd260778a3381a135e5cc0c1797"/>
+        <sourcediff key="e45400e4c0a21f2eabcf47d5542cb6ca">
+          <old project="home:Iggy:test-project:PR-4" package="test-package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="home:Iggy:test-project:PR-4" package="test-package" rev="1" srcmd5="411c6fd260778a3381a135e5cc0c1797"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Tue, 25 May 2021 14:02:06 GMT
+  recorded_at: Tue, 08 Jun 2021 14:17:12 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/test-project:PR-4/test-package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/test-package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
     body:
       encoding: UTF-8
       string: ''
@@ -436,23 +476,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '354'
+      - '364'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="c2c424aaf6189b5e9df6c7e3b3027755">
+        <sourcediff key="2ed48d1faed509c13a6d1bc9bd36407d">
           <old project="test-project" package="test-package" rev="d41d8cd98f00b204e9800998ecf8427e" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="test-project:PR-4" package="test-package" rev="6dee1c1851207b12d4c251e1946048c7" srcmd5="6dee1c1851207b12d4c251e1946048c7"/>
+          <new project="home:Iggy:test-project:PR-4" package="test-package" rev="6dee1c1851207b12d4c251e1946048c7" srcmd5="6dee1c1851207b12d4c251e1946048c7"/>
           <files/>
         </sourcediff>
-  recorded_at: Tue, 25 May 2021 14:02:06 GMT
+  recorded_at: Tue, 08 Jun 2021 14:17:12 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/test-project:PR-4/_meta?user=Iggy
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/_meta?user=Iggy
     body:
       encoding: UTF-8
       string: |
-        <project name="test-project:PR-4">
+        <project name="home:Iggy:test-project:PR-4">
           <title>Branch project for package test-package</title>
           <description>This project was created for package test-package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
@@ -479,11 +519,11 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '295'
+      - '305'
     body:
       encoding: UTF-8
       string: |
-        <project name="test-project:PR-4">
+        <project name="home:Iggy:test-project:PR-4">
           <title>Branch project for package test-package</title>
           <description>This project was created for package test-package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
@@ -491,10 +531,10 @@ http_interactions:
             <disable/>
           </publish>
         </project>
-  recorded_at: Tue, 25 May 2021 14:02:06 GMT
+  recorded_at: Tue, 08 Jun 2021 14:17:12 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/test-project:PR-4/test-package/_branch_request?user=Iggy
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/test-package/_branch_request?user=Iggy
     body:
       encoding: UTF-8
       string: '{"action":"opened","pull_request":{"head":{"repo":{"full_name":"username/test_repo"},"sha":null}}}'
@@ -517,28 +557,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '206'
+      - '204'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="50" vrev="50">
+        <revision rev="2" vrev="2">
           <srcmd5>e8d0ddbf3cd22e52520a074eb37b5259</srcmd5>
           <version>unknown</version>
-          <time>1621951326</time>
+          <time>1623161833</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Tue, 25 May 2021 14:02:06 GMT
+  recorded_at: Tue, 08 Jun 2021 14:17:13 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/test-project:PR-4/test-package/_meta?user=Iggy
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/test-package/_meta?user=Iggy
     body:
       encoding: UTF-8
       string: |
-        <package name="test-package" project="test-project:PR-4">
-          <title>Arms and the Man</title>
-          <description>Blanditiis repudiandae quas commodi.</description>
+        <package name="test-package" project="home:Iggy:test-project:PR-4">
+          <title>The Stars' Tennis Balls</title>
+          <description>Aspernatur occaecati qui illum.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -559,18 +599,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '169'
+      - '181'
     body:
       encoding: UTF-8
       string: |
-        <package name="test-package" project="test-project:PR-4">
-          <title>Arms and the Man</title>
-          <description>Blanditiis repudiandae quas commodi.</description>
+        <package name="test-package" project="home:Iggy:test-project:PR-4">
+          <title>The Stars' Tennis Balls</title>
+          <description>Aspernatur occaecati qui illum.</description>
         </package>
-  recorded_at: Tue, 25 May 2021 14:02:06 GMT
+  recorded_at: Tue, 08 Jun 2021 14:17:13 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/test-project:PR-4/test-package
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/test-package
     body:
       encoding: US-ASCII
       string: ''
@@ -593,19 +633,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '532'
+      - '530'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test-package" rev="50" vrev="50" srcmd5="e8d0ddbf3cd22e52520a074eb37b5259">
+        <directory name="test-package" rev="2" vrev="2" srcmd5="e8d0ddbf3cd22e52520a074eb37b5259">
           <linkinfo project="test-project" package="test-package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="2f8f66d64fd327463204b8b238fede8e" lsrcmd5="e8d0ddbf3cd22e52520a074eb37b5259"/>
-          <entry name="_branch_request" md5="dea1816075f5d14403700c04bfefc8f2" size="98" mtime="1621949508"/>
-          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1621949508"/>
+          <entry name="_branch_request" md5="dea1816075f5d14403700c04bfefc8f2" size="98" mtime="1623161833"/>
+          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1623161473"/>
         </directory>
-  recorded_at: Tue, 25 May 2021 14:02:06 GMT
+  recorded_at: Tue, 08 Jun 2021 14:17:13 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/test-project:PR-4/test-package?view=info
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/test-package?view=info
     body:
       encoding: US-ASCII
       string: ''
@@ -628,18 +668,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '333'
+      - '331'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="test-package" rev="50" vrev="50" srcmd5="2f8f66d64fd327463204b8b238fede8e" lsrcmd5="e8d0ddbf3cd22e52520a074eb37b5259" verifymd5="3f8defb2fc634d5ae5bc26d21016de91">
+        <sourceinfo package="test-package" rev="2" vrev="2" srcmd5="2f8f66d64fd327463204b8b238fede8e" lsrcmd5="e8d0ddbf3cd22e52520a074eb37b5259" verifymd5="3f8defb2fc634d5ae5bc26d21016de91">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="test-project" package="test-package"/>
         </sourceinfo>
-  recorded_at: Tue, 25 May 2021 14:02:06 GMT
+  recorded_at: Tue, 08 Jun 2021 14:17:13 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/test-project:PR-4/test-package
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/test-package
     body:
       encoding: US-ASCII
       string: ''
@@ -662,19 +702,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '532'
+      - '530'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test-package" rev="50" vrev="50" srcmd5="e8d0ddbf3cd22e52520a074eb37b5259">
+        <directory name="test-package" rev="2" vrev="2" srcmd5="e8d0ddbf3cd22e52520a074eb37b5259">
           <linkinfo project="test-project" package="test-package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="2f8f66d64fd327463204b8b238fede8e" lsrcmd5="e8d0ddbf3cd22e52520a074eb37b5259"/>
-          <entry name="_branch_request" md5="dea1816075f5d14403700c04bfefc8f2" size="98" mtime="1621949508"/>
-          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1621949508"/>
+          <entry name="_branch_request" md5="dea1816075f5d14403700c04bfefc8f2" size="98" mtime="1623161833"/>
+          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1623161473"/>
         </directory>
-  recorded_at: Tue, 25 May 2021 14:02:06 GMT
+  recorded_at: Tue, 08 Jun 2021 14:17:13 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/test-project:PR-4/test-package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/test-package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
     body:
       encoding: UTF-8
       string: ''
@@ -699,21 +739,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '321'
+      - '340'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="44adcb945bb577f4c94834010058ae37">
-          <old project="test-project:PR-4" package="test-package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="test-project:PR-4" package="test-package" rev="50" srcmd5="e8d0ddbf3cd22e52520a074eb37b5259"/>
+        <sourcediff key="ff7681e5c3418238e43c1891b79a5280">
+          <old project="home:Iggy:test-project:PR-4" package="test-package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="home:Iggy:test-project:PR-4" package="test-package" rev="2" srcmd5="e8d0ddbf3cd22e52520a074eb37b5259"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Tue, 25 May 2021 14:02:06 GMT
+  recorded_at: Tue, 08 Jun 2021 14:17:13 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/test-project:PR-4/test-package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/test-package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
     body:
       encoding: UTF-8
       string: ''
@@ -733,21 +773,21 @@ http_interactions:
     headers:
       Content-Type:
       - text/xml
-      Content-Length:
-      - '377'
       Cache-Control:
       - no-cache
       Connection:
       - close
+      Content-Length:
+      - '387'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="919122e20ded2ca17cf41391450b5ba6">
+        <sourcediff key="4215d181fa14622e6168914e9b5813db">
           <old project="test-project" package="test-package" rev="d41d8cd98f00b204e9800998ecf8427e" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="test-project:PR-4" package="test-package" rev="2f8f66d64fd327463204b8b238fede8e" srcmd5="2f8f66d64fd327463204b8b238fede8e"/>
+          <new project="home:Iggy:test-project:PR-4" package="test-package" rev="2f8f66d64fd327463204b8b238fede8e" srcmd5="2f8f66d64fd327463204b8b238fede8e"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Tue, 25 May 2021 14:02:06 GMT
+  recorded_at: Tue, 08 Jun 2021 14:17:13 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Token_Workflow/_call/when_the_webhook_and_configuration_is_correct/when_the_SCM_is_GitHub/behaves_like_successful_workflow_call/creates_a_new_branched_project_with_PR_suffix.yml
+++ b/src/api/spec/cassettes/Token_Workflow/_call/when_the_webhook_and_configuration_is_correct/when_the_SCM_is_GitHub/behaves_like_successful_workflow_call/creates_a_new_branched_project_with_PR_suffix.yml
@@ -2,15 +2,94 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/test-project/_meta?user=user_11
+    uri: http://backend:5352/source/home:Iggy/_meta?user=Iggy
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:Iggy">
+          <title/>
+          <description/>
+          <person userid="Iggy" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '130'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:Iggy">
+          <title></title>
+          <description></description>
+          <person userid="Iggy" role="maintainer"/>
+        </project>
+  recorded_at: Tue, 08 Jun 2021 14:18:13 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/test-project/_meta?user=user_1
     body:
       encoding: UTF-8
       string: |
         <project name="test-project">
-          <title>The Soldier's Art</title>
+          <title>The Monkey's Raincoat</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '154'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="test-project">
+          <title>The Monkey's Raincoat</title>
+          <description></description>
+          <person userid="Iggy" role="maintainer"/>
+        </project>
+  recorded_at: Tue, 08 Jun 2021 14:18:14 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/test-project/test-package/_meta?user=user_2
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test-package" project="test-project">
+          <title>Eyeless in Gaza</title>
+          <description>Minima sequi quae quia.</description>
+        </package>
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -34,50 +113,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <project name="test-project">
-          <title>The Soldier's Art</title>
-          <description></description>
-          <person userid="Iggy" role="maintainer"/>
-        </project>
-  recorded_at: Tue, 25 May 2021 14:02:07 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/test-project/test-package/_meta?user=user_12
-    body:
-      encoding: UTF-8
-      string: |
         <package name="test-package" project="test-project">
-          <title>Ego Dominus Tuus</title>
-          <description>Placeat quidem id itaque.</description>
+          <title>Eyeless in Gaza</title>
+          <description>Minima sequi quae quia.</description>
         </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '153'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test-package" project="test-project">
-          <title>Ego Dominus Tuus</title>
-          <description>Placeat quidem id itaque.</description>
-        </package>
-  recorded_at: Tue, 25 May 2021 14:02:07 GMT
+  recorded_at: Tue, 08 Jun 2021 14:18:14 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22test-package%22%20and%20linkinfo/@project=%22test-project%22%20and%20@project=%22test-project%22)
@@ -111,14 +151,14 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Tue, 25 May 2021 14:02:07 GMT
+  recorded_at: Tue, 08 Jun 2021 14:18:14 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/test-project:PR-4/_meta?user=Iggy
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/_meta?user=Iggy
     body:
       encoding: UTF-8
       string: |
-        <project name="test-project:PR-4">
+        <project name="home:Iggy:test-project:PR-4">
           <title>Branch project for package test-package</title>
           <description>This project was created for package test-package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
@@ -142,25 +182,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '255'
+      - '265'
     body:
       encoding: UTF-8
       string: |
-        <project name="test-project:PR-4">
+        <project name="home:Iggy:test-project:PR-4">
           <title>Branch project for package test-package</title>
           <description>This project was created for package test-package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Tue, 25 May 2021 14:02:07 GMT
+  recorded_at: Tue, 08 Jun 2021 14:18:14 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/test-project:PR-4/test-package/_meta?user=Iggy
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/test-package/_meta?user=Iggy
     body:
       encoding: UTF-8
       string: |
-        <package name="test-package" project="test-project:PR-4">
-          <title>Ego Dominus Tuus</title>
-          <description>Placeat quidem id itaque.</description>
+        <package name="test-package" project="home:Iggy:test-project:PR-4">
+          <title>Eyeless in Gaza</title>
+          <description>Minima sequi quae quia.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -181,18 +221,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '158'
+      - '165'
     body:
       encoding: UTF-8
       string: |
-        <package name="test-package" project="test-project:PR-4">
-          <title>Ego Dominus Tuus</title>
-          <description>Placeat quidem id itaque.</description>
+        <package name="test-package" project="home:Iggy:test-project:PR-4">
+          <title>Eyeless in Gaza</title>
+          <description>Minima sequi quae quia.</description>
         </package>
-  recorded_at: Tue, 25 May 2021 14:02:07 GMT
+  recorded_at: Tue, 08 Jun 2021 14:18:14 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/test-project:PR-4/test-package?cmd=branch&noservice=1&opackage=test-package&oproject=test-project&user=Iggy
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/test-package?cmd=branch&noservice=1&opackage=test-package&oproject=test-project&user=Iggy
     body:
       encoding: UTF-8
       string: ''
@@ -217,28 +257,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '206'
+      - '204'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="53" vrev="53">
+        <revision rev="3" vrev="3">
           <srcmd5>411c6fd260778a3381a135e5cc0c1797</srcmd5>
           <version>unknown</version>
-          <time>1621951327</time>
+          <time>1623161894</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Tue, 25 May 2021 14:02:07 GMT
+  recorded_at: Tue, 08 Jun 2021 14:18:14 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/test-project:PR-4/test-package/_meta?user=Iggy
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/test-package/_meta?user=Iggy
     body:
       encoding: UTF-8
       string: |
-        <package name="test-package" project="test-project:PR-4">
-          <title>Ego Dominus Tuus</title>
-          <description>Placeat quidem id itaque.</description>
+        <package name="test-package" project="home:Iggy:test-project:PR-4">
+          <title>Eyeless in Gaza</title>
+          <description>Minima sequi quae quia.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -259,18 +299,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '158'
+      - '165'
     body:
       encoding: UTF-8
       string: |
-        <package name="test-package" project="test-project:PR-4">
-          <title>Ego Dominus Tuus</title>
-          <description>Placeat quidem id itaque.</description>
+        <package name="test-package" project="home:Iggy:test-project:PR-4">
+          <title>Eyeless in Gaza</title>
+          <description>Minima sequi quae quia.</description>
         </package>
-  recorded_at: Tue, 25 May 2021 14:02:07 GMT
+  recorded_at: Tue, 08 Jun 2021 14:18:14 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/test-project:PR-4/test-package
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/test-package
     body:
       encoding: US-ASCII
       string: ''
@@ -293,18 +333,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '430'
+      - '428'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test-package" rev="53" vrev="53" srcmd5="411c6fd260778a3381a135e5cc0c1797">
+        <directory name="test-package" rev="3" vrev="3" srcmd5="411c6fd260778a3381a135e5cc0c1797">
           <linkinfo project="test-project" package="test-package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="6dee1c1851207b12d4c251e1946048c7" lsrcmd5="411c6fd260778a3381a135e5cc0c1797"/>
-          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1621949508"/>
+          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1623161473"/>
         </directory>
-  recorded_at: Tue, 25 May 2021 14:02:07 GMT
+  recorded_at: Tue, 08 Jun 2021 14:18:14 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/test-project:PR-4/test-package?view=info
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/test-package?view=info
     body:
       encoding: US-ASCII
       string: ''
@@ -327,18 +367,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '333'
+      - '331'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="test-package" rev="53" vrev="53" srcmd5="6dee1c1851207b12d4c251e1946048c7" lsrcmd5="411c6fd260778a3381a135e5cc0c1797" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
+        <sourceinfo package="test-package" rev="3" vrev="3" srcmd5="6dee1c1851207b12d4c251e1946048c7" lsrcmd5="411c6fd260778a3381a135e5cc0c1797" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="test-project" package="test-package"/>
         </sourceinfo>
-  recorded_at: Tue, 25 May 2021 14:02:07 GMT
+  recorded_at: Tue, 08 Jun 2021 14:18:14 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/test-project:PR-4/test-package
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/test-package
     body:
       encoding: US-ASCII
       string: ''
@@ -361,18 +401,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '430'
+      - '428'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test-package" rev="53" vrev="53" srcmd5="411c6fd260778a3381a135e5cc0c1797">
+        <directory name="test-package" rev="3" vrev="3" srcmd5="411c6fd260778a3381a135e5cc0c1797">
           <linkinfo project="test-project" package="test-package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="6dee1c1851207b12d4c251e1946048c7" lsrcmd5="411c6fd260778a3381a135e5cc0c1797"/>
-          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1621949508"/>
+          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1623161473"/>
         </directory>
-  recorded_at: Tue, 25 May 2021 14:02:07 GMT
+  recorded_at: Tue, 08 Jun 2021 14:18:14 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/test-project:PR-4/test-package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/test-package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
     body:
       encoding: UTF-8
       string: ''
@@ -397,21 +437,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '321'
+      - '340'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="a8c55c3af8a40615d0b7c05b00eb7676">
-          <old project="test-project:PR-4" package="test-package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="test-project:PR-4" package="test-package" rev="53" srcmd5="411c6fd260778a3381a135e5cc0c1797"/>
+        <sourcediff key="e6ade4ca65fb40ad9d8208a937147d04">
+          <old project="home:Iggy:test-project:PR-4" package="test-package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="home:Iggy:test-project:PR-4" package="test-package" rev="3" srcmd5="411c6fd260778a3381a135e5cc0c1797"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Tue, 25 May 2021 14:02:07 GMT
+  recorded_at: Tue, 08 Jun 2021 14:18:14 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/test-project:PR-4/test-package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/test-package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
     body:
       encoding: UTF-8
       string: ''
@@ -436,23 +476,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '354'
+      - '364'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="c2c424aaf6189b5e9df6c7e3b3027755">
+        <sourcediff key="2ed48d1faed509c13a6d1bc9bd36407d">
           <old project="test-project" package="test-package" rev="d41d8cd98f00b204e9800998ecf8427e" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="test-project:PR-4" package="test-package" rev="6dee1c1851207b12d4c251e1946048c7" srcmd5="6dee1c1851207b12d4c251e1946048c7"/>
+          <new project="home:Iggy:test-project:PR-4" package="test-package" rev="6dee1c1851207b12d4c251e1946048c7" srcmd5="6dee1c1851207b12d4c251e1946048c7"/>
           <files/>
         </sourcediff>
-  recorded_at: Tue, 25 May 2021 14:02:07 GMT
+  recorded_at: Tue, 08 Jun 2021 14:18:14 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/test-project:PR-4/_meta?user=Iggy
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/_meta?user=Iggy
     body:
       encoding: UTF-8
       string: |
-        <project name="test-project:PR-4">
+        <project name="home:Iggy:test-project:PR-4">
           <title>Branch project for package test-package</title>
           <description>This project was created for package test-package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
@@ -479,11 +519,11 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '295'
+      - '305'
     body:
       encoding: UTF-8
       string: |
-        <project name="test-project:PR-4">
+        <project name="home:Iggy:test-project:PR-4">
           <title>Branch project for package test-package</title>
           <description>This project was created for package test-package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
@@ -491,10 +531,10 @@ http_interactions:
             <disable/>
           </publish>
         </project>
-  recorded_at: Tue, 25 May 2021 14:02:07 GMT
+  recorded_at: Tue, 08 Jun 2021 14:18:14 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/test-project:PR-4/test-package/_branch_request?user=Iggy
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/test-package/_branch_request?user=Iggy
     body:
       encoding: UTF-8
       string: '{"action":"opened","pull_request":{"head":{"repo":{"full_name":"username/test_repo"},"sha":null}}}'
@@ -517,28 +557,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '206'
+      - '204'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="54" vrev="54">
+        <revision rev="4" vrev="4">
           <srcmd5>e8d0ddbf3cd22e52520a074eb37b5259</srcmd5>
           <version>unknown</version>
-          <time>1621951327</time>
+          <time>1623161894</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Tue, 25 May 2021 14:02:07 GMT
+  recorded_at: Tue, 08 Jun 2021 14:18:14 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/test-project:PR-4/test-package/_meta?user=Iggy
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/test-package/_meta?user=Iggy
     body:
       encoding: UTF-8
       string: |
-        <package name="test-package" project="test-project:PR-4">
-          <title>Ego Dominus Tuus</title>
-          <description>Placeat quidem id itaque.</description>
+        <package name="test-package" project="home:Iggy:test-project:PR-4">
+          <title>Eyeless in Gaza</title>
+          <description>Minima sequi quae quia.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -559,18 +599,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '158'
+      - '165'
     body:
       encoding: UTF-8
       string: |
-        <package name="test-package" project="test-project:PR-4">
-          <title>Ego Dominus Tuus</title>
-          <description>Placeat quidem id itaque.</description>
+        <package name="test-package" project="home:Iggy:test-project:PR-4">
+          <title>Eyeless in Gaza</title>
+          <description>Minima sequi quae quia.</description>
         </package>
-  recorded_at: Tue, 25 May 2021 14:02:08 GMT
+  recorded_at: Tue, 08 Jun 2021 14:18:14 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/test-project:PR-4/test-package
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/test-package
     body:
       encoding: US-ASCII
       string: ''
@@ -593,19 +633,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '532'
+      - '530'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test-package" rev="54" vrev="54" srcmd5="e8d0ddbf3cd22e52520a074eb37b5259">
+        <directory name="test-package" rev="4" vrev="4" srcmd5="e8d0ddbf3cd22e52520a074eb37b5259">
           <linkinfo project="test-project" package="test-package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="2f8f66d64fd327463204b8b238fede8e" lsrcmd5="e8d0ddbf3cd22e52520a074eb37b5259"/>
-          <entry name="_branch_request" md5="dea1816075f5d14403700c04bfefc8f2" size="98" mtime="1621949508"/>
-          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1621949508"/>
+          <entry name="_branch_request" md5="dea1816075f5d14403700c04bfefc8f2" size="98" mtime="1623161833"/>
+          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1623161473"/>
         </directory>
-  recorded_at: Tue, 25 May 2021 14:02:08 GMT
+  recorded_at: Tue, 08 Jun 2021 14:18:14 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/test-project:PR-4/test-package?view=info
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/test-package?view=info
     body:
       encoding: US-ASCII
       string: ''
@@ -628,18 +668,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '333'
+      - '331'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="test-package" rev="54" vrev="54" srcmd5="2f8f66d64fd327463204b8b238fede8e" lsrcmd5="e8d0ddbf3cd22e52520a074eb37b5259" verifymd5="3f8defb2fc634d5ae5bc26d21016de91">
+        <sourceinfo package="test-package" rev="4" vrev="4" srcmd5="2f8f66d64fd327463204b8b238fede8e" lsrcmd5="e8d0ddbf3cd22e52520a074eb37b5259" verifymd5="3f8defb2fc634d5ae5bc26d21016de91">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="test-project" package="test-package"/>
         </sourceinfo>
-  recorded_at: Tue, 25 May 2021 14:02:08 GMT
+  recorded_at: Tue, 08 Jun 2021 14:18:14 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/test-project:PR-4/test-package
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/test-package
     body:
       encoding: US-ASCII
       string: ''
@@ -662,19 +702,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '532'
+      - '530'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test-package" rev="54" vrev="54" srcmd5="e8d0ddbf3cd22e52520a074eb37b5259">
+        <directory name="test-package" rev="4" vrev="4" srcmd5="e8d0ddbf3cd22e52520a074eb37b5259">
           <linkinfo project="test-project" package="test-package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="2f8f66d64fd327463204b8b238fede8e" lsrcmd5="e8d0ddbf3cd22e52520a074eb37b5259"/>
-          <entry name="_branch_request" md5="dea1816075f5d14403700c04bfefc8f2" size="98" mtime="1621949508"/>
-          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1621949508"/>
+          <entry name="_branch_request" md5="dea1816075f5d14403700c04bfefc8f2" size="98" mtime="1623161833"/>
+          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1623161473"/>
         </directory>
-  recorded_at: Tue, 25 May 2021 14:02:08 GMT
+  recorded_at: Tue, 08 Jun 2021 14:18:14 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/test-project:PR-4/test-package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/test-package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
     body:
       encoding: UTF-8
       string: ''
@@ -699,21 +739,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '321'
+      - '340'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="aef537fe18cd55f25c1124837dfff183">
-          <old project="test-project:PR-4" package="test-package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="test-project:PR-4" package="test-package" rev="54" srcmd5="e8d0ddbf3cd22e52520a074eb37b5259"/>
+        <sourcediff key="d730396692fffab674195fd9617183d7">
+          <old project="home:Iggy:test-project:PR-4" package="test-package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="home:Iggy:test-project:PR-4" package="test-package" rev="4" srcmd5="e8d0ddbf3cd22e52520a074eb37b5259"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Tue, 25 May 2021 14:02:08 GMT
+  recorded_at: Tue, 08 Jun 2021 14:18:14 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/test-project:PR-4/test-package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-4/test-package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
     body:
       encoding: UTF-8
       string: ''
@@ -734,7 +774,7 @@ http_interactions:
       Content-Type:
       - text/xml
       Content-Length:
-      - '377'
+      - '387'
       Cache-Control:
       - no-cache
       Connection:
@@ -742,12 +782,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="919122e20ded2ca17cf41391450b5ba6">
+        <sourcediff key="4215d181fa14622e6168914e9b5813db">
           <old project="test-project" package="test-package" rev="d41d8cd98f00b204e9800998ecf8427e" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="test-project:PR-4" package="test-package" rev="2f8f66d64fd327463204b8b238fede8e" srcmd5="2f8f66d64fd327463204b8b238fede8e"/>
+          <new project="home:Iggy:test-project:PR-4" package="test-package" rev="2f8f66d64fd327463204b8b238fede8e" srcmd5="2f8f66d64fd327463204b8b238fede8e"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Tue, 25 May 2021 14:02:08 GMT
+  recorded_at: Tue, 08 Jun 2021 14:18:14 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Token_Workflow/_call/when_the_webhook_and_configuration_is_correct/when_the_SCM_is_GitLab/behaves_like_successful_workflow_call/creates_a_new_Event_BuildFail_subscription.yml
+++ b/src/api/spec/cassettes/Token_Workflow/_call/when_the_webhook_and_configuration_is_correct/when_the_SCM_is_GitLab/behaves_like_successful_workflow_call/creates_a_new_Event_BuildFail_subscription.yml
@@ -2,12 +2,12 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/test-project/_meta?user=user_3
+    uri: http://backend:5352/source/home:Iggy/_meta?user=Iggy
     body:
       encoding: UTF-8
       string: |
-        <project name="test-project">
-          <title>Alone on a Wide, Wide Sea</title>
+        <project name="home:Iggy">
+          <title/>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -30,25 +30,65 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '158'
+      - '130'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:Iggy">
+          <title></title>
+          <description></description>
+          <person userid="Iggy" role="maintainer"/>
+        </project>
+  recorded_at: Tue, 08 Jun 2021 14:16:11 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/test-project/_meta?user=user_1
     body:
       encoding: UTF-8
       string: |
         <project name="test-project">
-          <title>Alone on a Wide, Wide Sea</title>
+          <title>Ring of Bright Water</title>
+          <description/>
+          <person userid="Iggy" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '153'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="test-project">
+          <title>Ring of Bright Water</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Tue, 25 May 2021 14:02:04 GMT
+  recorded_at: Tue, 08 Jun 2021 14:16:11 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/test-project/test-package/_meta?user=user_4
+    uri: http://backend:5352/source/test-project/test-package/_meta?user=user_2
     body:
       encoding: UTF-8
       string: |
         <package name="test-package" project="test-project">
-          <title>Brandy of the Damned</title>
-          <description>Necessitatibus incidunt excepturi aut.</description>
+          <title>O Pioneers!</title>
+          <description>Optio voluptas fugit commodi.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -69,15 +109,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '170'
+      - '152'
     body:
       encoding: UTF-8
       string: |
         <package name="test-package" project="test-project">
-          <title>Brandy of the Damned</title>
-          <description>Necessitatibus incidunt excepturi aut.</description>
+          <title>O Pioneers!</title>
+          <description>Optio voluptas fugit commodi.</description>
         </package>
-  recorded_at: Tue, 25 May 2021 14:02:04 GMT
+  recorded_at: Tue, 08 Jun 2021 14:16:12 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22test-package%22%20and%20linkinfo/@project=%22test-project%22%20and%20@project=%22test-project%22)
@@ -111,14 +151,14 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Tue, 25 May 2021 14:02:04 GMT
+  recorded_at: Tue, 08 Jun 2021 14:16:12 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/test-project:PR-3/_meta?user=Iggy
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/_meta?user=Iggy
     body:
       encoding: UTF-8
       string: |
-        <project name="test-project:PR-3">
+        <project name="home:Iggy:test-project:PR-3">
           <title>Branch project for package test-package</title>
           <description>This project was created for package test-package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
@@ -142,25 +182,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '255'
+      - '265'
     body:
       encoding: UTF-8
       string: |
-        <project name="test-project:PR-3">
+        <project name="home:Iggy:test-project:PR-3">
           <title>Branch project for package test-package</title>
           <description>This project was created for package test-package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Tue, 25 May 2021 14:02:04 GMT
+  recorded_at: Tue, 08 Jun 2021 14:16:12 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/test-project:PR-3/test-package/_meta?user=Iggy
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/test-package/_meta?user=Iggy
     body:
       encoding: UTF-8
       string: |
-        <package name="test-package" project="test-project:PR-3">
-          <title>Brandy of the Damned</title>
-          <description>Necessitatibus incidunt excepturi aut.</description>
+        <package name="test-package" project="home:Iggy:test-project:PR-3">
+          <title>O Pioneers!</title>
+          <description>Optio voluptas fugit commodi.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -181,18 +221,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '175'
+      - '167'
     body:
       encoding: UTF-8
       string: |
-        <package name="test-package" project="test-project:PR-3">
-          <title>Brandy of the Damned</title>
-          <description>Necessitatibus incidunt excepturi aut.</description>
+        <package name="test-package" project="home:Iggy:test-project:PR-3">
+          <title>O Pioneers!</title>
+          <description>Optio voluptas fugit commodi.</description>
         </package>
-  recorded_at: Tue, 25 May 2021 14:02:04 GMT
+  recorded_at: Tue, 08 Jun 2021 14:16:12 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/test-project:PR-3/test-package?cmd=branch&noservice=1&opackage=test-package&oproject=test-project&user=Iggy
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/test-package?cmd=branch&noservice=1&opackage=test-package&oproject=test-project&user=Iggy
     body:
       encoding: UTF-8
       string: ''
@@ -217,28 +257,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '206'
+      - '204'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="15" vrev="15">
+        <revision rev="9" vrev="9">
           <srcmd5>411c6fd260778a3381a135e5cc0c1797</srcmd5>
           <version>unknown</version>
-          <time>1621951324</time>
+          <time>1623161772</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Tue, 25 May 2021 14:02:04 GMT
+  recorded_at: Tue, 08 Jun 2021 14:16:12 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/test-project:PR-3/test-package/_meta?user=Iggy
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/test-package/_meta?user=Iggy
     body:
       encoding: UTF-8
       string: |
-        <package name="test-package" project="test-project:PR-3">
-          <title>Brandy of the Damned</title>
-          <description>Necessitatibus incidunt excepturi aut.</description>
+        <package name="test-package" project="home:Iggy:test-project:PR-3">
+          <title>O Pioneers!</title>
+          <description>Optio voluptas fugit commodi.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -259,18 +299,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '175'
+      - '167'
     body:
       encoding: UTF-8
       string: |
-        <package name="test-package" project="test-project:PR-3">
-          <title>Brandy of the Damned</title>
-          <description>Necessitatibus incidunt excepturi aut.</description>
+        <package name="test-package" project="home:Iggy:test-project:PR-3">
+          <title>O Pioneers!</title>
+          <description>Optio voluptas fugit commodi.</description>
         </package>
-  recorded_at: Tue, 25 May 2021 14:02:04 GMT
+  recorded_at: Tue, 08 Jun 2021 14:16:12 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/test-project:PR-3/test-package
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/test-package
     body:
       encoding: US-ASCII
       string: ''
@@ -293,18 +333,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '430'
+      - '428'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test-package" rev="15" vrev="15" srcmd5="411c6fd260778a3381a135e5cc0c1797">
+        <directory name="test-package" rev="9" vrev="9" srcmd5="411c6fd260778a3381a135e5cc0c1797">
           <linkinfo project="test-project" package="test-package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="6dee1c1851207b12d4c251e1946048c7" lsrcmd5="411c6fd260778a3381a135e5cc0c1797"/>
-          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1621949508"/>
+          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1623161473"/>
         </directory>
-  recorded_at: Tue, 25 May 2021 14:02:04 GMT
+  recorded_at: Tue, 08 Jun 2021 14:16:12 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/test-project:PR-3/test-package?view=info
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/test-package?view=info
     body:
       encoding: US-ASCII
       string: ''
@@ -327,18 +367,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '333'
+      - '331'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="test-package" rev="15" vrev="15" srcmd5="6dee1c1851207b12d4c251e1946048c7" lsrcmd5="411c6fd260778a3381a135e5cc0c1797" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
+        <sourceinfo package="test-package" rev="9" vrev="9" srcmd5="6dee1c1851207b12d4c251e1946048c7" lsrcmd5="411c6fd260778a3381a135e5cc0c1797" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="test-project" package="test-package"/>
         </sourceinfo>
-  recorded_at: Tue, 25 May 2021 14:02:04 GMT
+  recorded_at: Tue, 08 Jun 2021 14:16:12 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/test-project:PR-3/test-package
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/test-package
     body:
       encoding: US-ASCII
       string: ''
@@ -361,18 +401,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '430'
+      - '428'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test-package" rev="15" vrev="15" srcmd5="411c6fd260778a3381a135e5cc0c1797">
+        <directory name="test-package" rev="9" vrev="9" srcmd5="411c6fd260778a3381a135e5cc0c1797">
           <linkinfo project="test-project" package="test-package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="6dee1c1851207b12d4c251e1946048c7" lsrcmd5="411c6fd260778a3381a135e5cc0c1797"/>
-          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1621949508"/>
+          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1623161473"/>
         </directory>
-  recorded_at: Tue, 25 May 2021 14:02:04 GMT
+  recorded_at: Tue, 08 Jun 2021 14:16:12 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/test-project:PR-3/test-package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/test-package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
     body:
       encoding: UTF-8
       string: ''
@@ -397,21 +437,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '321'
+      - '340'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="d07d55e05aeb0195b5e00c8659ce2f68">
-          <old project="test-project:PR-3" package="test-package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="test-project:PR-3" package="test-package" rev="15" srcmd5="411c6fd260778a3381a135e5cc0c1797"/>
+        <sourcediff key="75b465f221df411313de38bfcb8fb4d2">
+          <old project="home:Iggy:test-project:PR-3" package="test-package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="home:Iggy:test-project:PR-3" package="test-package" rev="9" srcmd5="411c6fd260778a3381a135e5cc0c1797"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Tue, 25 May 2021 14:02:04 GMT
+  recorded_at: Tue, 08 Jun 2021 14:16:12 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/test-project:PR-3/test-package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/test-package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
     body:
       encoding: UTF-8
       string: ''
@@ -436,23 +476,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '354'
+      - '364'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="1c11a6cbcfb43f172da6413cb984d226">
+        <sourcediff key="8a6af69cf41142c36694c3f05afc9881">
           <old project="test-project" package="test-package" rev="d41d8cd98f00b204e9800998ecf8427e" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="test-project:PR-3" package="test-package" rev="6dee1c1851207b12d4c251e1946048c7" srcmd5="6dee1c1851207b12d4c251e1946048c7"/>
+          <new project="home:Iggy:test-project:PR-3" package="test-package" rev="6dee1c1851207b12d4c251e1946048c7" srcmd5="6dee1c1851207b12d4c251e1946048c7"/>
           <files/>
         </sourcediff>
-  recorded_at: Tue, 25 May 2021 14:02:04 GMT
+  recorded_at: Tue, 08 Jun 2021 14:16:12 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/test-project:PR-3/_meta?user=Iggy
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/_meta?user=Iggy
     body:
       encoding: UTF-8
       string: |
-        <project name="test-project:PR-3">
+        <project name="home:Iggy:test-project:PR-3">
           <title>Branch project for package test-package</title>
           <description>This project was created for package test-package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
@@ -479,11 +519,11 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '295'
+      - '305'
     body:
       encoding: UTF-8
       string: |
-        <project name="test-project:PR-3">
+        <project name="home:Iggy:test-project:PR-3">
           <title>Branch project for package test-package</title>
           <description>This project was created for package test-package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
@@ -491,10 +531,10 @@ http_interactions:
             <disable/>
           </publish>
         </project>
-  recorded_at: Tue, 25 May 2021 14:02:04 GMT
+  recorded_at: Tue, 08 Jun 2021 14:16:12 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/test-project:PR-3/test-package/_branch_request?user=Iggy
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/test-package/_branch_request?user=Iggy
     body:
       encoding: UTF-8
       string: '{"object_kind":"merge_request","project":{"http_url":null},"object_attributes":{"source":{"default_branch":null}}}'
@@ -521,24 +561,24 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="16" vrev="16">
+        <revision rev="10" vrev="10">
           <srcmd5>f14c95a8699c85b68de530c9b8060d5c</srcmd5>
           <version>unknown</version>
-          <time>1621951324</time>
+          <time>1623161772</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Tue, 25 May 2021 14:02:04 GMT
+  recorded_at: Tue, 08 Jun 2021 14:16:12 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/test-project:PR-3/test-package/_meta?user=Iggy
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/test-package/_meta?user=Iggy
     body:
       encoding: UTF-8
       string: |
-        <package name="test-package" project="test-project:PR-3">
-          <title>Brandy of the Damned</title>
-          <description>Necessitatibus incidunt excepturi aut.</description>
+        <package name="test-package" project="home:Iggy:test-project:PR-3">
+          <title>O Pioneers!</title>
+          <description>Optio voluptas fugit commodi.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -559,18 +599,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '175'
+      - '167'
     body:
       encoding: UTF-8
       string: |
-        <package name="test-package" project="test-project:PR-3">
-          <title>Brandy of the Damned</title>
-          <description>Necessitatibus incidunt excepturi aut.</description>
+        <package name="test-package" project="home:Iggy:test-project:PR-3">
+          <title>O Pioneers!</title>
+          <description>Optio voluptas fugit commodi.</description>
         </package>
-  recorded_at: Tue, 25 May 2021 14:02:04 GMT
+  recorded_at: Tue, 08 Jun 2021 14:16:12 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/test-project:PR-3/test-package
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/test-package
     body:
       encoding: US-ASCII
       string: ''
@@ -597,15 +637,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="test-package" rev="16" vrev="16" srcmd5="f14c95a8699c85b68de530c9b8060d5c">
+        <directory name="test-package" rev="10" vrev="10" srcmd5="f14c95a8699c85b68de530c9b8060d5c">
           <linkinfo project="test-project" package="test-package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="d097703241cb290c7ed6122b049dcf31" lsrcmd5="f14c95a8699c85b68de530c9b8060d5c"/>
-          <entry name="_branch_request" md5="b8cf7070f6f77f83a014c4cd5d228748" size="114" mtime="1621950801"/>
-          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1621949508"/>
+          <entry name="_branch_request" md5="b8cf7070f6f77f83a014c4cd5d228748" size="114" mtime="1623161473"/>
+          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1623161473"/>
         </directory>
-  recorded_at: Tue, 25 May 2021 14:02:04 GMT
+  recorded_at: Tue, 08 Jun 2021 14:16:12 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/test-project:PR-3/test-package?view=info
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/test-package?view=info
     body:
       encoding: US-ASCII
       string: ''
@@ -632,14 +672,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="test-package" rev="16" vrev="16" srcmd5="d097703241cb290c7ed6122b049dcf31" lsrcmd5="f14c95a8699c85b68de530c9b8060d5c" verifymd5="b347991eda489ac2dbd914f4b56a5b0b">
+        <sourceinfo package="test-package" rev="10" vrev="10" srcmd5="d097703241cb290c7ed6122b049dcf31" lsrcmd5="f14c95a8699c85b68de530c9b8060d5c" verifymd5="b347991eda489ac2dbd914f4b56a5b0b">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="test-project" package="test-package"/>
         </sourceinfo>
-  recorded_at: Tue, 25 May 2021 14:02:04 GMT
+  recorded_at: Tue, 08 Jun 2021 14:16:12 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/test-project:PR-3/test-package
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/test-package
     body:
       encoding: US-ASCII
       string: ''
@@ -666,15 +706,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="test-package" rev="16" vrev="16" srcmd5="f14c95a8699c85b68de530c9b8060d5c">
+        <directory name="test-package" rev="10" vrev="10" srcmd5="f14c95a8699c85b68de530c9b8060d5c">
           <linkinfo project="test-project" package="test-package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="d097703241cb290c7ed6122b049dcf31" lsrcmd5="f14c95a8699c85b68de530c9b8060d5c"/>
-          <entry name="_branch_request" md5="b8cf7070f6f77f83a014c4cd5d228748" size="114" mtime="1621950801"/>
-          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1621949508"/>
+          <entry name="_branch_request" md5="b8cf7070f6f77f83a014c4cd5d228748" size="114" mtime="1623161473"/>
+          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1623161473"/>
         </directory>
-  recorded_at: Tue, 25 May 2021 14:02:04 GMT
+  recorded_at: Tue, 08 Jun 2021 14:16:12 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/test-project:PR-3/test-package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/test-package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
     body:
       encoding: UTF-8
       string: ''
@@ -699,21 +739,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '321'
+      - '341'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="9690697f7268c258a6ffa149f07203de">
-          <old project="test-project:PR-3" package="test-package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="test-project:PR-3" package="test-package" rev="16" srcmd5="f14c95a8699c85b68de530c9b8060d5c"/>
+        <sourcediff key="839689c7537f9af5caa4b6a6ac4eb970">
+          <old project="home:Iggy:test-project:PR-3" package="test-package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="home:Iggy:test-project:PR-3" package="test-package" rev="10" srcmd5="f14c95a8699c85b68de530c9b8060d5c"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Tue, 25 May 2021 14:02:04 GMT
+  recorded_at: Tue, 08 Jun 2021 14:16:12 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/test-project:PR-3/test-package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/test-package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
     body:
       encoding: UTF-8
       string: ''
@@ -734,7 +774,7 @@ http_interactions:
       Content-Type:
       - text/xml
       Content-Length:
-      - '377'
+      - '387'
       Cache-Control:
       - no-cache
       Connection:
@@ -742,12 +782,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="295f3f98538a69e9f0529a5acc7bda35">
+        <sourcediff key="6c814dd4cc028b08eb6bc579a32b8f1c">
           <old project="test-project" package="test-package" rev="d41d8cd98f00b204e9800998ecf8427e" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="test-project:PR-3" package="test-package" rev="d097703241cb290c7ed6122b049dcf31" srcmd5="d097703241cb290c7ed6122b049dcf31"/>
+          <new project="home:Iggy:test-project:PR-3" package="test-package" rev="d097703241cb290c7ed6122b049dcf31" srcmd5="d097703241cb290c7ed6122b049dcf31"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Tue, 25 May 2021 14:02:04 GMT
+  recorded_at: Tue, 08 Jun 2021 14:16:12 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Token_Workflow/_call/when_the_webhook_and_configuration_is_correct/when_the_SCM_is_GitLab/behaves_like_successful_workflow_call/creates_a_new_Event_BuildSuccess_subscription.yml
+++ b/src/api/spec/cassettes/Token_Workflow/_call/when_the_webhook_and_configuration_is_correct/when_the_SCM_is_GitLab/behaves_like_successful_workflow_call/creates_a_new_Event_BuildSuccess_subscription.yml
@@ -2,12 +2,12 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/test-project/_meta?user=user_1
+    uri: http://backend:5352/source/home:Iggy/_meta?user=Iggy
     body:
       encoding: UTF-8
       string: |
-        <project name="test-project">
-          <title>The Skull Beneath the Skin</title>
+        <project name="home:Iggy">
+          <title/>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -30,16 +30,56 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '159'
+      - '130'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:Iggy">
+          <title></title>
+          <description></description>
+          <person userid="Iggy" role="maintainer"/>
+        </project>
+  recorded_at: Tue, 08 Jun 2021 14:12:59 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/test-project/_meta?user=user_1
     body:
       encoding: UTF-8
       string: |
         <project name="test-project">
-          <title>The Skull Beneath the Skin</title>
+          <title>The Monkey's Raincoat</title>
+          <description/>
+          <person userid="Iggy" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '154'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="test-project">
+          <title>The Monkey's Raincoat</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Tue, 25 May 2021 14:02:03 GMT
+  recorded_at: Tue, 08 Jun 2021 14:12:59 GMT
 - request:
     method: put
     uri: http://backend:5352/source/test-project/test-package/_meta?user=user_2
@@ -47,8 +87,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test-package" project="test-project">
-          <title>Postern of Fate</title>
-          <description>Facilis recusandae harum fugiat.</description>
+          <title>Precious Bane</title>
+          <description>Alias blanditiis ab minus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -69,15 +109,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '159'
+      - '151'
     body:
       encoding: UTF-8
       string: |
         <package name="test-package" project="test-project">
-          <title>Postern of Fate</title>
-          <description>Facilis recusandae harum fugiat.</description>
+          <title>Precious Bane</title>
+          <description>Alias blanditiis ab minus.</description>
         </package>
-  recorded_at: Tue, 25 May 2021 14:02:03 GMT
+  recorded_at: Tue, 08 Jun 2021 14:12:59 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22test-package%22%20and%20linkinfo/@project=%22test-project%22%20and%20@project=%22test-project%22)
@@ -111,14 +151,14 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Tue, 25 May 2021 14:02:03 GMT
+  recorded_at: Tue, 08 Jun 2021 14:12:59 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/test-project:PR-3/_meta?user=Iggy
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/_meta?user=Iggy
     body:
       encoding: UTF-8
       string: |
-        <project name="test-project:PR-3">
+        <project name="home:Iggy:test-project:PR-3">
           <title>Branch project for package test-package</title>
           <description>This project was created for package test-package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
@@ -142,25 +182,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '255'
+      - '265'
     body:
       encoding: UTF-8
       string: |
-        <project name="test-project:PR-3">
+        <project name="home:Iggy:test-project:PR-3">
           <title>Branch project for package test-package</title>
           <description>This project was created for package test-package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Tue, 25 May 2021 14:02:03 GMT
+  recorded_at: Tue, 08 Jun 2021 14:12:59 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/test-project:PR-3/test-package/_meta?user=Iggy
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/test-package/_meta?user=Iggy
     body:
       encoding: UTF-8
       string: |
-        <package name="test-package" project="test-project:PR-3">
-          <title>Postern of Fate</title>
-          <description>Facilis recusandae harum fugiat.</description>
+        <package name="test-package" project="home:Iggy:test-project:PR-3">
+          <title>Precious Bane</title>
+          <description>Alias blanditiis ab minus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -181,18 +221,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '164'
+      - '166'
     body:
       encoding: UTF-8
       string: |
-        <package name="test-package" project="test-project:PR-3">
-          <title>Postern of Fate</title>
-          <description>Facilis recusandae harum fugiat.</description>
+        <package name="test-package" project="home:Iggy:test-project:PR-3">
+          <title>Precious Bane</title>
+          <description>Alias blanditiis ab minus.</description>
         </package>
-  recorded_at: Tue, 25 May 2021 14:02:03 GMT
+  recorded_at: Tue, 08 Jun 2021 14:12:59 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/test-project:PR-3/test-package?cmd=branch&noservice=1&opackage=test-package&oproject=test-project&user=Iggy
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/test-package?cmd=branch&noservice=1&opackage=test-package&oproject=test-project&user=Iggy
     body:
       encoding: UTF-8
       string: ''
@@ -217,28 +257,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '206'
+      - '204'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="13" vrev="13">
+        <revision rev="5" vrev="5">
           <srcmd5>411c6fd260778a3381a135e5cc0c1797</srcmd5>
           <version>unknown</version>
-          <time>1621951323</time>
+          <time>1623161579</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Tue, 25 May 2021 14:02:03 GMT
+  recorded_at: Tue, 08 Jun 2021 14:12:59 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/test-project:PR-3/test-package/_meta?user=Iggy
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/test-package/_meta?user=Iggy
     body:
       encoding: UTF-8
       string: |
-        <package name="test-package" project="test-project:PR-3">
-          <title>Postern of Fate</title>
-          <description>Facilis recusandae harum fugiat.</description>
+        <package name="test-package" project="home:Iggy:test-project:PR-3">
+          <title>Precious Bane</title>
+          <description>Alias blanditiis ab minus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -259,18 +299,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '164'
+      - '166'
     body:
       encoding: UTF-8
       string: |
-        <package name="test-package" project="test-project:PR-3">
-          <title>Postern of Fate</title>
-          <description>Facilis recusandae harum fugiat.</description>
+        <package name="test-package" project="home:Iggy:test-project:PR-3">
+          <title>Precious Bane</title>
+          <description>Alias blanditiis ab minus.</description>
         </package>
-  recorded_at: Tue, 25 May 2021 14:02:03 GMT
+  recorded_at: Tue, 08 Jun 2021 14:12:59 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/test-project:PR-3/test-package
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/test-package
     body:
       encoding: US-ASCII
       string: ''
@@ -293,18 +333,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '430'
+      - '428'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test-package" rev="13" vrev="13" srcmd5="411c6fd260778a3381a135e5cc0c1797">
+        <directory name="test-package" rev="5" vrev="5" srcmd5="411c6fd260778a3381a135e5cc0c1797">
           <linkinfo project="test-project" package="test-package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="6dee1c1851207b12d4c251e1946048c7" lsrcmd5="411c6fd260778a3381a135e5cc0c1797"/>
-          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1621949508"/>
+          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1623161473"/>
         </directory>
-  recorded_at: Tue, 25 May 2021 14:02:03 GMT
+  recorded_at: Tue, 08 Jun 2021 14:12:59 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/test-project:PR-3/test-package?view=info
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/test-package?view=info
     body:
       encoding: US-ASCII
       string: ''
@@ -327,18 +367,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '333'
+      - '331'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="test-package" rev="13" vrev="13" srcmd5="6dee1c1851207b12d4c251e1946048c7" lsrcmd5="411c6fd260778a3381a135e5cc0c1797" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
+        <sourceinfo package="test-package" rev="5" vrev="5" srcmd5="6dee1c1851207b12d4c251e1946048c7" lsrcmd5="411c6fd260778a3381a135e5cc0c1797" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="test-project" package="test-package"/>
         </sourceinfo>
-  recorded_at: Tue, 25 May 2021 14:02:03 GMT
+  recorded_at: Tue, 08 Jun 2021 14:12:59 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/test-project:PR-3/test-package
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/test-package
     body:
       encoding: US-ASCII
       string: ''
@@ -361,18 +401,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '430'
+      - '428'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test-package" rev="13" vrev="13" srcmd5="411c6fd260778a3381a135e5cc0c1797">
+        <directory name="test-package" rev="5" vrev="5" srcmd5="411c6fd260778a3381a135e5cc0c1797">
           <linkinfo project="test-project" package="test-package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="6dee1c1851207b12d4c251e1946048c7" lsrcmd5="411c6fd260778a3381a135e5cc0c1797"/>
-          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1621949508"/>
+          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1623161473"/>
         </directory>
-  recorded_at: Tue, 25 May 2021 14:02:03 GMT
+  recorded_at: Tue, 08 Jun 2021 14:12:59 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/test-project:PR-3/test-package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/test-package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
     body:
       encoding: UTF-8
       string: ''
@@ -397,21 +437,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '321'
+      - '340'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="3282c896f54a7df7c533ee0d7b2a83a6">
-          <old project="test-project:PR-3" package="test-package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="test-project:PR-3" package="test-package" rev="13" srcmd5="411c6fd260778a3381a135e5cc0c1797"/>
+        <sourcediff key="28aa6c7f009b7cd9f55419470a595827">
+          <old project="home:Iggy:test-project:PR-3" package="test-package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="home:Iggy:test-project:PR-3" package="test-package" rev="5" srcmd5="411c6fd260778a3381a135e5cc0c1797"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Tue, 25 May 2021 14:02:03 GMT
+  recorded_at: Tue, 08 Jun 2021 14:12:59 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/test-project:PR-3/test-package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/test-package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
     body:
       encoding: UTF-8
       string: ''
@@ -436,23 +476,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '354'
+      - '364'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="1c11a6cbcfb43f172da6413cb984d226">
+        <sourcediff key="8a6af69cf41142c36694c3f05afc9881">
           <old project="test-project" package="test-package" rev="d41d8cd98f00b204e9800998ecf8427e" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="test-project:PR-3" package="test-package" rev="6dee1c1851207b12d4c251e1946048c7" srcmd5="6dee1c1851207b12d4c251e1946048c7"/>
+          <new project="home:Iggy:test-project:PR-3" package="test-package" rev="6dee1c1851207b12d4c251e1946048c7" srcmd5="6dee1c1851207b12d4c251e1946048c7"/>
           <files/>
         </sourcediff>
-  recorded_at: Tue, 25 May 2021 14:02:03 GMT
+  recorded_at: Tue, 08 Jun 2021 14:12:59 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/test-project:PR-3/_meta?user=Iggy
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/_meta?user=Iggy
     body:
       encoding: UTF-8
       string: |
-        <project name="test-project:PR-3">
+        <project name="home:Iggy:test-project:PR-3">
           <title>Branch project for package test-package</title>
           <description>This project was created for package test-package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
@@ -479,11 +519,11 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '295'
+      - '305'
     body:
       encoding: UTF-8
       string: |
-        <project name="test-project:PR-3">
+        <project name="home:Iggy:test-project:PR-3">
           <title>Branch project for package test-package</title>
           <description>This project was created for package test-package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
@@ -491,10 +531,10 @@ http_interactions:
             <disable/>
           </publish>
         </project>
-  recorded_at: Tue, 25 May 2021 14:02:03 GMT
+  recorded_at: Tue, 08 Jun 2021 14:13:00 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/test-project:PR-3/test-package/_branch_request?user=Iggy
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/test-package/_branch_request?user=Iggy
     body:
       encoding: UTF-8
       string: '{"object_kind":"merge_request","project":{"http_url":null},"object_attributes":{"source":{"default_branch":null}}}'
@@ -517,28 +557,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '206'
+      - '204'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="14" vrev="14">
+        <revision rev="6" vrev="6">
           <srcmd5>f14c95a8699c85b68de530c9b8060d5c</srcmd5>
           <version>unknown</version>
-          <time>1621951323</time>
+          <time>1623161580</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Tue, 25 May 2021 14:02:03 GMT
+  recorded_at: Tue, 08 Jun 2021 14:13:00 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/test-project:PR-3/test-package/_meta?user=Iggy
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/test-package/_meta?user=Iggy
     body:
       encoding: UTF-8
       string: |
-        <package name="test-package" project="test-project:PR-3">
-          <title>Postern of Fate</title>
-          <description>Facilis recusandae harum fugiat.</description>
+        <package name="test-package" project="home:Iggy:test-project:PR-3">
+          <title>Precious Bane</title>
+          <description>Alias blanditiis ab minus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -559,18 +599,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '164'
+      - '166'
     body:
       encoding: UTF-8
       string: |
-        <package name="test-package" project="test-project:PR-3">
-          <title>Postern of Fate</title>
-          <description>Facilis recusandae harum fugiat.</description>
+        <package name="test-package" project="home:Iggy:test-project:PR-3">
+          <title>Precious Bane</title>
+          <description>Alias blanditiis ab minus.</description>
         </package>
-  recorded_at: Tue, 25 May 2021 14:02:03 GMT
+  recorded_at: Tue, 08 Jun 2021 14:13:00 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/test-project:PR-3/test-package
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/test-package
     body:
       encoding: US-ASCII
       string: ''
@@ -593,19 +633,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '533'
+      - '531'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test-package" rev="14" vrev="14" srcmd5="f14c95a8699c85b68de530c9b8060d5c">
+        <directory name="test-package" rev="6" vrev="6" srcmd5="f14c95a8699c85b68de530c9b8060d5c">
           <linkinfo project="test-project" package="test-package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="d097703241cb290c7ed6122b049dcf31" lsrcmd5="f14c95a8699c85b68de530c9b8060d5c"/>
-          <entry name="_branch_request" md5="b8cf7070f6f77f83a014c4cd5d228748" size="114" mtime="1621950801"/>
-          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1621949508"/>
+          <entry name="_branch_request" md5="b8cf7070f6f77f83a014c4cd5d228748" size="114" mtime="1623161473"/>
+          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1623161473"/>
         </directory>
-  recorded_at: Tue, 25 May 2021 14:02:03 GMT
+  recorded_at: Tue, 08 Jun 2021 14:13:00 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/test-project:PR-3/test-package?view=info
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/test-package?view=info
     body:
       encoding: US-ASCII
       string: ''
@@ -628,18 +668,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '333'
+      - '331'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="test-package" rev="14" vrev="14" srcmd5="d097703241cb290c7ed6122b049dcf31" lsrcmd5="f14c95a8699c85b68de530c9b8060d5c" verifymd5="b347991eda489ac2dbd914f4b56a5b0b">
+        <sourceinfo package="test-package" rev="6" vrev="6" srcmd5="d097703241cb290c7ed6122b049dcf31" lsrcmd5="f14c95a8699c85b68de530c9b8060d5c" verifymd5="b347991eda489ac2dbd914f4b56a5b0b">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="test-project" package="test-package"/>
         </sourceinfo>
-  recorded_at: Tue, 25 May 2021 14:02:03 GMT
+  recorded_at: Tue, 08 Jun 2021 14:13:00 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/test-project:PR-3/test-package
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/test-package
     body:
       encoding: US-ASCII
       string: ''
@@ -662,19 +702,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '533'
+      - '531'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test-package" rev="14" vrev="14" srcmd5="f14c95a8699c85b68de530c9b8060d5c">
+        <directory name="test-package" rev="6" vrev="6" srcmd5="f14c95a8699c85b68de530c9b8060d5c">
           <linkinfo project="test-project" package="test-package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="d097703241cb290c7ed6122b049dcf31" lsrcmd5="f14c95a8699c85b68de530c9b8060d5c"/>
-          <entry name="_branch_request" md5="b8cf7070f6f77f83a014c4cd5d228748" size="114" mtime="1621950801"/>
-          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1621949508"/>
+          <entry name="_branch_request" md5="b8cf7070f6f77f83a014c4cd5d228748" size="114" mtime="1623161473"/>
+          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1623161473"/>
         </directory>
-  recorded_at: Tue, 25 May 2021 14:02:03 GMT
+  recorded_at: Tue, 08 Jun 2021 14:13:00 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/test-project:PR-3/test-package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/test-package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
     body:
       encoding: UTF-8
       string: ''
@@ -699,21 +739,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '321'
+      - '340'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="49a6aac7a0b46400fbfbe991e45c2ef3">
-          <old project="test-project:PR-3" package="test-package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="test-project:PR-3" package="test-package" rev="14" srcmd5="f14c95a8699c85b68de530c9b8060d5c"/>
+        <sourcediff key="74fbddc32b1b6e32c68acd1ccf0d3d0a">
+          <old project="home:Iggy:test-project:PR-3" package="test-package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="home:Iggy:test-project:PR-3" package="test-package" rev="6" srcmd5="f14c95a8699c85b68de530c9b8060d5c"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Tue, 25 May 2021 14:02:03 GMT
+  recorded_at: Tue, 08 Jun 2021 14:13:00 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/test-project:PR-3/test-package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/test-package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
     body:
       encoding: UTF-8
       string: ''
@@ -734,7 +774,7 @@ http_interactions:
       Content-Type:
       - text/xml
       Content-Length:
-      - '377'
+      - '387'
       Cache-Control:
       - no-cache
       Connection:
@@ -742,12 +782,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="295f3f98538a69e9f0529a5acc7bda35">
+        <sourcediff key="6c814dd4cc028b08eb6bc579a32b8f1c">
           <old project="test-project" package="test-package" rev="d41d8cd98f00b204e9800998ecf8427e" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="test-project:PR-3" package="test-package" rev="d097703241cb290c7ed6122b049dcf31" srcmd5="d097703241cb290c7ed6122b049dcf31"/>
+          <new project="home:Iggy:test-project:PR-3" package="test-package" rev="d097703241cb290c7ed6122b049dcf31" srcmd5="d097703241cb290c7ed6122b049dcf31"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Tue, 25 May 2021 14:02:04 GMT
+  recorded_at: Tue, 08 Jun 2021 14:13:00 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Token_Workflow/_call/when_the_webhook_and_configuration_is_correct/when_the_SCM_is_GitLab/behaves_like_successful_workflow_call/creates_a_new_branched_project_with_PR_suffix.yml
+++ b/src/api/spec/cassettes/Token_Workflow/_call/when_the_webhook_and_configuration_is_correct/when_the_SCM_is_GitLab/behaves_like_successful_workflow_call/creates_a_new_branched_project_with_PR_suffix.yml
@@ -2,12 +2,12 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/test-project/_meta?user=user_5
+    uri: http://backend:5352/source/home:Iggy/_meta?user=Iggy
     body:
       encoding: UTF-8
       string: |
-        <project name="test-project">
-          <title>Ah, Wilderness!</title>
+        <project name="home:Iggy">
+          <title/>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -30,25 +30,65 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '148'
+      - '130'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:Iggy">
+          <title></title>
+          <description></description>
+          <person userid="Iggy" role="maintainer"/>
+        </project>
+  recorded_at: Tue, 08 Jun 2021 14:14:31 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/test-project/_meta?user=user_1
     body:
       encoding: UTF-8
       string: |
         <project name="test-project">
-          <title>Ah, Wilderness!</title>
+          <title>Ego Dominus Tuus</title>
+          <description/>
+          <person userid="Iggy" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '149'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="test-project">
+          <title>Ego Dominus Tuus</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Tue, 25 May 2021 14:02:05 GMT
+  recorded_at: Tue, 08 Jun 2021 14:14:31 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/test-project/test-package/_meta?user=user_6
+    uri: http://backend:5352/source/test-project/test-package/_meta?user=user_2
     body:
       encoding: UTF-8
       string: |
         <package name="test-package" project="test-project">
-          <title>The Doors of Perception</title>
-          <description>Accusamus totam distinctio delectus.</description>
+          <title>Ah, Wilderness!</title>
+          <description>Nihil officia laboriosam autem.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -69,15 +109,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '158'
     body:
       encoding: UTF-8
       string: |
         <package name="test-package" project="test-project">
-          <title>The Doors of Perception</title>
-          <description>Accusamus totam distinctio delectus.</description>
+          <title>Ah, Wilderness!</title>
+          <description>Nihil officia laboriosam autem.</description>
         </package>
-  recorded_at: Tue, 25 May 2021 14:02:05 GMT
+  recorded_at: Tue, 08 Jun 2021 14:14:31 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22test-package%22%20and%20linkinfo/@project=%22test-project%22%20and%20@project=%22test-project%22)
@@ -111,14 +151,14 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Tue, 25 May 2021 14:02:05 GMT
+  recorded_at: Tue, 08 Jun 2021 14:14:31 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/test-project:PR-3/_meta?user=Iggy
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/_meta?user=Iggy
     body:
       encoding: UTF-8
       string: |
-        <project name="test-project:PR-3">
+        <project name="home:Iggy:test-project:PR-3">
           <title>Branch project for package test-package</title>
           <description>This project was created for package test-package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
@@ -142,25 +182,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '255'
+      - '265'
     body:
       encoding: UTF-8
       string: |
-        <project name="test-project:PR-3">
+        <project name="home:Iggy:test-project:PR-3">
           <title>Branch project for package test-package</title>
           <description>This project was created for package test-package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Tue, 25 May 2021 14:02:05 GMT
+  recorded_at: Tue, 08 Jun 2021 14:14:31 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/test-project:PR-3/test-package/_meta?user=Iggy
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/test-package/_meta?user=Iggy
     body:
       encoding: UTF-8
       string: |
-        <package name="test-package" project="test-project:PR-3">
-          <title>The Doors of Perception</title>
-          <description>Accusamus totam distinctio delectus.</description>
+        <package name="test-package" project="home:Iggy:test-project:PR-3">
+          <title>Ah, Wilderness!</title>
+          <description>Nihil officia laboriosam autem.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -181,18 +221,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '176'
+      - '173'
     body:
       encoding: UTF-8
       string: |
-        <package name="test-package" project="test-project:PR-3">
-          <title>The Doors of Perception</title>
-          <description>Accusamus totam distinctio delectus.</description>
+        <package name="test-package" project="home:Iggy:test-project:PR-3">
+          <title>Ah, Wilderness!</title>
+          <description>Nihil officia laboriosam autem.</description>
         </package>
-  recorded_at: Tue, 25 May 2021 14:02:05 GMT
+  recorded_at: Tue, 08 Jun 2021 14:14:32 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/test-project:PR-3/test-package?cmd=branch&noservice=1&opackage=test-package&oproject=test-project&user=Iggy
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/test-package?cmd=branch&noservice=1&opackage=test-package&oproject=test-project&user=Iggy
     body:
       encoding: UTF-8
       string: ''
@@ -217,28 +257,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '206'
+      - '204'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="17" vrev="17">
+        <revision rev="7" vrev="7">
           <srcmd5>411c6fd260778a3381a135e5cc0c1797</srcmd5>
           <version>unknown</version>
-          <time>1621951325</time>
+          <time>1623161672</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Tue, 25 May 2021 14:02:05 GMT
+  recorded_at: Tue, 08 Jun 2021 14:14:32 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/test-project:PR-3/test-package/_meta?user=Iggy
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/test-package/_meta?user=Iggy
     body:
       encoding: UTF-8
       string: |
-        <package name="test-package" project="test-project:PR-3">
-          <title>The Doors of Perception</title>
-          <description>Accusamus totam distinctio delectus.</description>
+        <package name="test-package" project="home:Iggy:test-project:PR-3">
+          <title>Ah, Wilderness!</title>
+          <description>Nihil officia laboriosam autem.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -259,18 +299,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '176'
+      - '173'
     body:
       encoding: UTF-8
       string: |
-        <package name="test-package" project="test-project:PR-3">
-          <title>The Doors of Perception</title>
-          <description>Accusamus totam distinctio delectus.</description>
+        <package name="test-package" project="home:Iggy:test-project:PR-3">
+          <title>Ah, Wilderness!</title>
+          <description>Nihil officia laboriosam autem.</description>
         </package>
-  recorded_at: Tue, 25 May 2021 14:02:05 GMT
+  recorded_at: Tue, 08 Jun 2021 14:14:32 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/test-project:PR-3/test-package
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/test-package
     body:
       encoding: US-ASCII
       string: ''
@@ -293,18 +333,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '430'
+      - '428'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test-package" rev="17" vrev="17" srcmd5="411c6fd260778a3381a135e5cc0c1797">
+        <directory name="test-package" rev="7" vrev="7" srcmd5="411c6fd260778a3381a135e5cc0c1797">
           <linkinfo project="test-project" package="test-package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="6dee1c1851207b12d4c251e1946048c7" lsrcmd5="411c6fd260778a3381a135e5cc0c1797"/>
-          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1621949508"/>
+          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1623161473"/>
         </directory>
-  recorded_at: Tue, 25 May 2021 14:02:05 GMT
+  recorded_at: Tue, 08 Jun 2021 14:14:32 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/test-project:PR-3/test-package?view=info
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/test-package?view=info
     body:
       encoding: US-ASCII
       string: ''
@@ -327,18 +367,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '333'
+      - '331'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="test-package" rev="17" vrev="17" srcmd5="6dee1c1851207b12d4c251e1946048c7" lsrcmd5="411c6fd260778a3381a135e5cc0c1797" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
+        <sourceinfo package="test-package" rev="7" vrev="7" srcmd5="6dee1c1851207b12d4c251e1946048c7" lsrcmd5="411c6fd260778a3381a135e5cc0c1797" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="test-project" package="test-package"/>
         </sourceinfo>
-  recorded_at: Tue, 25 May 2021 14:02:05 GMT
+  recorded_at: Tue, 08 Jun 2021 14:14:32 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/test-project:PR-3/test-package
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/test-package
     body:
       encoding: US-ASCII
       string: ''
@@ -361,18 +401,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '430'
+      - '428'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test-package" rev="17" vrev="17" srcmd5="411c6fd260778a3381a135e5cc0c1797">
+        <directory name="test-package" rev="7" vrev="7" srcmd5="411c6fd260778a3381a135e5cc0c1797">
           <linkinfo project="test-project" package="test-package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="6dee1c1851207b12d4c251e1946048c7" lsrcmd5="411c6fd260778a3381a135e5cc0c1797"/>
-          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1621949508"/>
+          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1623161473"/>
         </directory>
-  recorded_at: Tue, 25 May 2021 14:02:05 GMT
+  recorded_at: Tue, 08 Jun 2021 14:14:32 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/test-project:PR-3/test-package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/test-package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
     body:
       encoding: UTF-8
       string: ''
@@ -397,21 +437,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '321'
+      - '340'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="b34dd7858e1d784725f99a6535b1d7cc">
-          <old project="test-project:PR-3" package="test-package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="test-project:PR-3" package="test-package" rev="17" srcmd5="411c6fd260778a3381a135e5cc0c1797"/>
+        <sourcediff key="2742d59274898216cf30bac2550d3bb7">
+          <old project="home:Iggy:test-project:PR-3" package="test-package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="home:Iggy:test-project:PR-3" package="test-package" rev="7" srcmd5="411c6fd260778a3381a135e5cc0c1797"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Tue, 25 May 2021 14:02:05 GMT
+  recorded_at: Tue, 08 Jun 2021 14:14:32 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/test-project:PR-3/test-package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/test-package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
     body:
       encoding: UTF-8
       string: ''
@@ -436,23 +476,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '354'
+      - '364'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="1c11a6cbcfb43f172da6413cb984d226">
+        <sourcediff key="8a6af69cf41142c36694c3f05afc9881">
           <old project="test-project" package="test-package" rev="d41d8cd98f00b204e9800998ecf8427e" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="test-project:PR-3" package="test-package" rev="6dee1c1851207b12d4c251e1946048c7" srcmd5="6dee1c1851207b12d4c251e1946048c7"/>
+          <new project="home:Iggy:test-project:PR-3" package="test-package" rev="6dee1c1851207b12d4c251e1946048c7" srcmd5="6dee1c1851207b12d4c251e1946048c7"/>
           <files/>
         </sourcediff>
-  recorded_at: Tue, 25 May 2021 14:02:05 GMT
+  recorded_at: Tue, 08 Jun 2021 14:14:32 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/test-project:PR-3/_meta?user=Iggy
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/_meta?user=Iggy
     body:
       encoding: UTF-8
       string: |
-        <project name="test-project:PR-3">
+        <project name="home:Iggy:test-project:PR-3">
           <title>Branch project for package test-package</title>
           <description>This project was created for package test-package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
@@ -479,11 +519,11 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '295'
+      - '305'
     body:
       encoding: UTF-8
       string: |
-        <project name="test-project:PR-3">
+        <project name="home:Iggy:test-project:PR-3">
           <title>Branch project for package test-package</title>
           <description>This project was created for package test-package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
@@ -491,10 +531,10 @@ http_interactions:
             <disable/>
           </publish>
         </project>
-  recorded_at: Tue, 25 May 2021 14:02:05 GMT
+  recorded_at: Tue, 08 Jun 2021 14:14:32 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/test-project:PR-3/test-package/_branch_request?user=Iggy
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/test-package/_branch_request?user=Iggy
     body:
       encoding: UTF-8
       string: '{"object_kind":"merge_request","project":{"http_url":null},"object_attributes":{"source":{"default_branch":null}}}'
@@ -517,28 +557,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '206'
+      - '204'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="18" vrev="18">
+        <revision rev="8" vrev="8">
           <srcmd5>f14c95a8699c85b68de530c9b8060d5c</srcmd5>
           <version>unknown</version>
-          <time>1621951325</time>
+          <time>1623161672</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Tue, 25 May 2021 14:02:05 GMT
+  recorded_at: Tue, 08 Jun 2021 14:14:32 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/test-project:PR-3/test-package/_meta?user=Iggy
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/test-package/_meta?user=Iggy
     body:
       encoding: UTF-8
       string: |
-        <package name="test-package" project="test-project:PR-3">
-          <title>The Doors of Perception</title>
-          <description>Accusamus totam distinctio delectus.</description>
+        <package name="test-package" project="home:Iggy:test-project:PR-3">
+          <title>Ah, Wilderness!</title>
+          <description>Nihil officia laboriosam autem.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -559,18 +599,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '176'
+      - '173'
     body:
       encoding: UTF-8
       string: |
-        <package name="test-package" project="test-project:PR-3">
-          <title>The Doors of Perception</title>
-          <description>Accusamus totam distinctio delectus.</description>
+        <package name="test-package" project="home:Iggy:test-project:PR-3">
+          <title>Ah, Wilderness!</title>
+          <description>Nihil officia laboriosam autem.</description>
         </package>
-  recorded_at: Tue, 25 May 2021 14:02:05 GMT
+  recorded_at: Tue, 08 Jun 2021 14:14:32 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/test-project:PR-3/test-package
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/test-package
     body:
       encoding: US-ASCII
       string: ''
@@ -593,19 +633,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '533'
+      - '531'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test-package" rev="18" vrev="18" srcmd5="f14c95a8699c85b68de530c9b8060d5c">
+        <directory name="test-package" rev="8" vrev="8" srcmd5="f14c95a8699c85b68de530c9b8060d5c">
           <linkinfo project="test-project" package="test-package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="d097703241cb290c7ed6122b049dcf31" lsrcmd5="f14c95a8699c85b68de530c9b8060d5c"/>
-          <entry name="_branch_request" md5="b8cf7070f6f77f83a014c4cd5d228748" size="114" mtime="1621950801"/>
-          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1621949508"/>
+          <entry name="_branch_request" md5="b8cf7070f6f77f83a014c4cd5d228748" size="114" mtime="1623161473"/>
+          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1623161473"/>
         </directory>
-  recorded_at: Tue, 25 May 2021 14:02:05 GMT
+  recorded_at: Tue, 08 Jun 2021 14:14:32 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/test-project:PR-3/test-package?view=info
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/test-package?view=info
     body:
       encoding: US-ASCII
       string: ''
@@ -628,18 +668,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '333'
+      - '331'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="test-package" rev="18" vrev="18" srcmd5="d097703241cb290c7ed6122b049dcf31" lsrcmd5="f14c95a8699c85b68de530c9b8060d5c" verifymd5="b347991eda489ac2dbd914f4b56a5b0b">
+        <sourceinfo package="test-package" rev="8" vrev="8" srcmd5="d097703241cb290c7ed6122b049dcf31" lsrcmd5="f14c95a8699c85b68de530c9b8060d5c" verifymd5="b347991eda489ac2dbd914f4b56a5b0b">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="test-project" package="test-package"/>
         </sourceinfo>
-  recorded_at: Tue, 25 May 2021 14:02:05 GMT
+  recorded_at: Tue, 08 Jun 2021 14:14:32 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/test-project:PR-3/test-package
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/test-package
     body:
       encoding: US-ASCII
       string: ''
@@ -662,19 +702,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '533'
+      - '531'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test-package" rev="18" vrev="18" srcmd5="f14c95a8699c85b68de530c9b8060d5c">
+        <directory name="test-package" rev="8" vrev="8" srcmd5="f14c95a8699c85b68de530c9b8060d5c">
           <linkinfo project="test-project" package="test-package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="d097703241cb290c7ed6122b049dcf31" lsrcmd5="f14c95a8699c85b68de530c9b8060d5c"/>
-          <entry name="_branch_request" md5="b8cf7070f6f77f83a014c4cd5d228748" size="114" mtime="1621950801"/>
-          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1621949508"/>
+          <entry name="_branch_request" md5="b8cf7070f6f77f83a014c4cd5d228748" size="114" mtime="1623161473"/>
+          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1623161473"/>
         </directory>
-  recorded_at: Tue, 25 May 2021 14:02:05 GMT
+  recorded_at: Tue, 08 Jun 2021 14:14:32 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/test-project:PR-3/test-package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/test-package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
     body:
       encoding: UTF-8
       string: ''
@@ -699,21 +739,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '321'
+      - '340'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="00329204ce6dcf9e9fb6f4fe4f8c95da">
-          <old project="test-project:PR-3" package="test-package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="test-project:PR-3" package="test-package" rev="18" srcmd5="f14c95a8699c85b68de530c9b8060d5c"/>
+        <sourcediff key="eb85455704320c931b9172bb6e534315">
+          <old project="home:Iggy:test-project:PR-3" package="test-package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="home:Iggy:test-project:PR-3" package="test-package" rev="8" srcmd5="f14c95a8699c85b68de530c9b8060d5c"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Tue, 25 May 2021 14:02:05 GMT
+  recorded_at: Tue, 08 Jun 2021 14:14:32 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/test-project:PR-3/test-package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
+    uri: http://backend:5352/source/home:Iggy:test-project:PR-3/test-package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
     body:
       encoding: UTF-8
       string: ''
@@ -734,7 +774,7 @@ http_interactions:
       Content-Type:
       - text/xml
       Content-Length:
-      - '377'
+      - '387'
       Cache-Control:
       - no-cache
       Connection:
@@ -742,12 +782,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="295f3f98538a69e9f0529a5acc7bda35">
+        <sourcediff key="6c814dd4cc028b08eb6bc579a32b8f1c">
           <old project="test-project" package="test-package" rev="d41d8cd98f00b204e9800998ecf8427e" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="test-project:PR-3" package="test-package" rev="d097703241cb290c7ed6122b049dcf31" srcmd5="d097703241cb290c7ed6122b049dcf31"/>
+          <new project="home:Iggy:test-project:PR-3" package="test-package" rev="d097703241cb290c7ed6122b049dcf31" srcmd5="d097703241cb290c7ed6122b049dcf31"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Tue, 25 May 2021 14:02:05 GMT
+  recorded_at: Tue, 08 Jun 2021 14:14:32 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_we_feed_an_extractor_payload_for_github/and_the_payload_is_valid/1_2_1_1_1.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_we_feed_an_extractor_payload_for_github/and_the_payload_is_valid/1_2_1_1_1.yml
@@ -1,161 +1,6 @@
 ---
 http_interactions:
 - request:
-    method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_15
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="foo_project">
-          <title>In Death Ground</title>
-          <description/>
-          <person userid="Iggy" role="maintainer"/>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '147'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="foo_project">
-          <title>In Death Ground</title>
-          <description></description>
-          <person userid="Iggy" role="maintainer"/>
-        </project>
-  recorded_at: Wed, 26 May 2021 14:52:13 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_16
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="bar_package" project="foo_project">
-          <title>Behold the Man</title>
-          <description>Accusamus est cum consequatur.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '154'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="bar_package" project="foo_project">
-          <title>Behold the Man</title>
-          <description>Accusamus est cum consequatur.</description>
-        </package>
-  recorded_at: Wed, 26 May 2021 14:52:13 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_config
-    body:
-      encoding: UTF-8
-      string: Eos numquam enim. Eos aut vel. Facilis quaerat iste.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '209'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="33" vrev="33">
-          <srcmd5>361263e68ae28ea2ef61d10201c7aced</srcmd5>
-          <version>unknown</version>
-          <time>1622040733</time>
-          <user>unknown</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-  recorded_at: Wed, 26 May 2021 14:52:13 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
-    body:
-      encoding: UTF-8
-      string: Ratione eaque adipisci. Voluptatibus cupiditate natus. Rerum perspiciatis
-        ratione.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '209'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="34" vrev="34">
-          <srcmd5>9d25baf0e65f7f40de897431f0a9e50c</srcmd5>
-          <version>unknown</version>
-          <time>1622040733</time>
-          <user>unknown</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-  recorded_at: Wed, 26 May 2021 14:52:13 GMT
-- request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
     body:
@@ -188,88 +33,10 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Wed, 26 May 2021 14:52:13 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/foo_project:PR-1/_meta?user=Iggy
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="foo_project:PR-1">
-          <title>Branch project for package bar_package</title>
-          <description>This project was created for package bar_package via attribute OBS:Maintained</description>
-          <person userid="Iggy" role="maintainer"/>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '252'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="foo_project:PR-1">
-          <title>Branch project for package bar_package</title>
-          <description>This project was created for package bar_package via attribute OBS:Maintained</description>
-          <person userid="Iggy" role="maintainer"/>
-        </project>
-  recorded_at: Wed, 26 May 2021 14:52:14 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/foo_project:PR-1/bar_package/_meta?user=Iggy
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="bar_package" project="foo_project:PR-1">
-          <title>Behold the Man</title>
-          <description>Accusamus est cum consequatur.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '159'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="bar_package" project="foo_project:PR-1">
-          <title>Behold the Man</title>
-          <description>Accusamus est cum consequatur.</description>
-        </package>
-  recorded_at: Wed, 26 May 2021 14:52:14 GMT
+  recorded_at: Tue, 08 Jun 2021 11:05:05 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/foo_project:PR-1/bar_package?cmd=branch&noservice=1&opackage=bar_package&oproject=foo_project&user=Iggy
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package?cmd=branch&noservice=1&opackage=bar_package&oproject=foo_project&user=Iggy
     body:
       encoding: UTF-8
       string: ''
@@ -294,60 +61,22 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '206'
+      - '204'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="11" vrev="11">
-          <srcmd5>76c41d5b5dc87fe323d8dcb38b22aed6</srcmd5>
+        <revision rev="9" vrev="9">
+          <srcmd5>6ff6d9747eff4ea294397bcf5f8d298c</srcmd5>
           <version>unknown</version>
-          <time>1622040734</time>
+          <time>1623150305</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Wed, 26 May 2021 14:52:14 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/foo_project:PR-1/bar_package/_meta?user=Iggy
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="bar_package" project="foo_project:PR-1">
-          <title>Behold the Man</title>
-          <description>Accusamus est cum consequatur.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '159'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="bar_package" project="foo_project:PR-1">
-          <title>Behold the Man</title>
-          <description>Accusamus est cum consequatur.</description>
-        </package>
-  recorded_at: Wed, 26 May 2021 14:52:14 GMT
+  recorded_at: Tue, 08 Jun 2021 11:05:05 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/foo_project:PR-1/bar_package
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package
     body:
       encoding: US-ASCII
       string: ''
@@ -370,20 +99,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '620'
+      - '618'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="11" vrev="11" srcmd5="76c41d5b5dc87fe323d8dcb38b22aed6">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="9d25baf0e65f7f40de897431f0a9e50c" baserev="9d25baf0e65f7f40de897431f0a9e50c" xsrcmd5="1f49e63befb4141c9ea2068ce87431e6" lsrcmd5="76c41d5b5dc87fe323d8dcb38b22aed6"/>
-          <entry name="_config" md5="dbb8a1896ca7eb76503349f80efcebd6" size="52" mtime="1622040733"/>
-          <entry name="_link" md5="45c4e8aeefd436f30fcd22096428d9e4" size="119" mtime="1622040734"/>
-          <entry name="somefile.txt" md5="3ccafea33f2204f3da2094884f675c7a" size="82" mtime="1622040733"/>
+        <directory name="bar_package" rev="9" vrev="9" srcmd5="6ff6d9747eff4ea294397bcf5f8d298c">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="161b4b6e68e1881be864809af287aa13" baserev="161b4b6e68e1881be864809af287aa13" xsrcmd5="2eb831cd9f7011516ac495296c8a3dec" lsrcmd5="6ff6d9747eff4ea294397bcf5f8d298c"/>
+          <entry name="_config" md5="6bff983f9804f565d81bdce9c4927da1" size="63" mtime="1623150195"/>
+          <entry name="_link" md5="4416255f3687e473985fe3fb94d5e306" size="119" mtime="1623150224"/>
+          <entry name="somefile.txt" md5="0587c6aa712d0693b19e9e11ac7b05d0" size="69" mtime="1623150195"/>
         </directory>
-  recorded_at: Wed, 26 May 2021 14:52:14 GMT
+  recorded_at: Tue, 08 Jun 2021 11:05:05 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/foo_project:PR-1/bar_package?view=info
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package?view=info
     body:
       encoding: US-ASCII
       string: ''
@@ -406,18 +135,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '330'
+      - '329'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="11" vrev="45" srcmd5="1f49e63befb4141c9ea2068ce87431e6" lsrcmd5="76c41d5b5dc87fe323d8dcb38b22aed6" verifymd5="9d25baf0e65f7f40de897431f0a9e50c">
+        <sourceinfo package="bar_package" rev="9" vrev="25" srcmd5="2eb831cd9f7011516ac495296c8a3dec" lsrcmd5="6ff6d9747eff4ea294397bcf5f8d298c" verifymd5="161b4b6e68e1881be864809af287aa13">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Wed, 26 May 2021 14:52:14 GMT
+  recorded_at: Tue, 08 Jun 2021 11:05:05 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/foo_project:PR-1/bar_package
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package
     body:
       encoding: US-ASCII
       string: ''
@@ -440,20 +169,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '620'
+      - '618'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="11" vrev="11" srcmd5="76c41d5b5dc87fe323d8dcb38b22aed6">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="9d25baf0e65f7f40de897431f0a9e50c" baserev="9d25baf0e65f7f40de897431f0a9e50c" xsrcmd5="1f49e63befb4141c9ea2068ce87431e6" lsrcmd5="76c41d5b5dc87fe323d8dcb38b22aed6"/>
-          <entry name="_config" md5="dbb8a1896ca7eb76503349f80efcebd6" size="52" mtime="1622040733"/>
-          <entry name="_link" md5="45c4e8aeefd436f30fcd22096428d9e4" size="119" mtime="1622040734"/>
-          <entry name="somefile.txt" md5="3ccafea33f2204f3da2094884f675c7a" size="82" mtime="1622040733"/>
+        <directory name="bar_package" rev="9" vrev="9" srcmd5="6ff6d9747eff4ea294397bcf5f8d298c">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="161b4b6e68e1881be864809af287aa13" baserev="161b4b6e68e1881be864809af287aa13" xsrcmd5="2eb831cd9f7011516ac495296c8a3dec" lsrcmd5="6ff6d9747eff4ea294397bcf5f8d298c"/>
+          <entry name="_config" md5="6bff983f9804f565d81bdce9c4927da1" size="63" mtime="1623150195"/>
+          <entry name="_link" md5="4416255f3687e473985fe3fb94d5e306" size="119" mtime="1623150224"/>
+          <entry name="somefile.txt" md5="0587c6aa712d0693b19e9e11ac7b05d0" size="69" mtime="1623150195"/>
         </directory>
-  recorded_at: Wed, 26 May 2021 14:52:14 GMT
+  recorded_at: Tue, 08 Jun 2021 11:05:05 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/foo_project:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
     body:
       encoding: UTF-8
       string: ''
@@ -478,21 +207,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '317'
+      - '336'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="fcbda9336fec17bea490874d1faa21dc">
-          <old project="foo_project:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="foo_project:PR-1" package="bar_package" rev="11" srcmd5="76c41d5b5dc87fe323d8dcb38b22aed6"/>
+        <sourcediff key="1f3deacaed1b7f2b59c5261547a6bc3c">
+          <old project="home:Iggy:foo_project:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="home:Iggy:foo_project:PR-1" package="bar_package" rev="9" srcmd5="6ff6d9747eff4ea294397bcf5f8d298c"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Wed, 26 May 2021 14:52:14 GMT
+  recorded_at: Tue, 08 Jun 2021 11:05:05 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/foo_project:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
     body:
       encoding: UTF-8
       string: ''
@@ -517,65 +246,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '350'
+      - '360'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="fd9ebe793bc93955ccc8f130d6a4447b">
-          <old project="foo_project" package="bar_package" rev="9d25baf0e65f7f40de897431f0a9e50c" srcmd5="9d25baf0e65f7f40de897431f0a9e50c"/>
-          <new project="foo_project:PR-1" package="bar_package" rev="1f49e63befb4141c9ea2068ce87431e6" srcmd5="1f49e63befb4141c9ea2068ce87431e6"/>
+        <sourcediff key="b117dd8d44ba32f1a083f291f3bf53a3">
+          <old project="foo_project" package="bar_package" rev="161b4b6e68e1881be864809af287aa13" srcmd5="161b4b6e68e1881be864809af287aa13"/>
+          <new project="home:Iggy:foo_project:PR-1" package="bar_package" rev="2eb831cd9f7011516ac495296c8a3dec" srcmd5="2eb831cd9f7011516ac495296c8a3dec"/>
           <files/>
         </sourcediff>
-  recorded_at: Wed, 26 May 2021 14:52:14 GMT
+  recorded_at: Tue, 08 Jun 2021 11:05:05 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project:PR-1/_meta?user=Iggy
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="foo_project:PR-1">
-          <title>Branch project for package bar_package</title>
-          <description>This project was created for package bar_package via attribute OBS:Maintained</description>
-          <person userid="Iggy" role="maintainer"/>
-          <publish>
-            <disable/>
-          </publish>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '292'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="foo_project:PR-1">
-          <title>Branch project for package bar_package</title>
-          <description>This project was created for package bar_package via attribute OBS:Maintained</description>
-          <person userid="Iggy" role="maintainer"/>
-          <publish>
-            <disable/>
-          </publish>
-        </project>
-  recorded_at: Wed, 26 May 2021 14:52:14 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/foo_project:PR-1/bar_package/_branch_request?user=Iggy
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package/_branch_request?user=Iggy
     body:
       encoding: UTF-8
       string: '{"action":"opened","pull_request":{"head":{"repo":{"full_name":null},"sha":null}}}'
@@ -602,56 +285,18 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="12" vrev="12">
-          <srcmd5>383f8b8f14d4f785b8f5ed0de419efcf</srcmd5>
+        <revision rev="10" vrev="10">
+          <srcmd5>03b18129ccb8eb63cb7f4e86a78365f0</srcmd5>
           <version>unknown</version>
-          <time>1622040734</time>
+          <time>1623150305</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Wed, 26 May 2021 14:52:15 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/foo_project:PR-1/bar_package/_meta?user=Iggy
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="bar_package" project="foo_project:PR-1">
-          <title>Behold the Man</title>
-          <description>Accusamus est cum consequatur.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '159'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="bar_package" project="foo_project:PR-1">
-          <title>Behold the Man</title>
-          <description>Accusamus est cum consequatur.</description>
-        </package>
-  recorded_at: Wed, 26 May 2021 14:52:15 GMT
+  recorded_at: Tue, 08 Jun 2021 11:05:05 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/foo_project:PR-1/bar_package
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package
     body:
       encoding: US-ASCII
       string: ''
@@ -678,17 +323,17 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="12" vrev="12" srcmd5="383f8b8f14d4f785b8f5ed0de419efcf">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="9d25baf0e65f7f40de897431f0a9e50c" baserev="9d25baf0e65f7f40de897431f0a9e50c" xsrcmd5="f6357e73f9d0527e05cc2e62bb5f4523" lsrcmd5="383f8b8f14d4f785b8f5ed0de419efcf"/>
-          <entry name="_branch_request" md5="5d8aefeee8f093120d1d26f3aeebbdfb" size="82" mtime="1622034474"/>
-          <entry name="_config" md5="dbb8a1896ca7eb76503349f80efcebd6" size="52" mtime="1622040733"/>
-          <entry name="_link" md5="45c4e8aeefd436f30fcd22096428d9e4" size="119" mtime="1622040734"/>
-          <entry name="somefile.txt" md5="3ccafea33f2204f3da2094884f675c7a" size="82" mtime="1622040733"/>
+        <directory name="bar_package" rev="10" vrev="10" srcmd5="03b18129ccb8eb63cb7f4e86a78365f0">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="161b4b6e68e1881be864809af287aa13" baserev="161b4b6e68e1881be864809af287aa13" xsrcmd5="a152bade3fc16b5fce200b21604bd614" lsrcmd5="03b18129ccb8eb63cb7f4e86a78365f0"/>
+          <entry name="_branch_request" md5="5d8aefeee8f093120d1d26f3aeebbdfb" size="82" mtime="1623150191"/>
+          <entry name="_config" md5="6bff983f9804f565d81bdce9c4927da1" size="63" mtime="1623150195"/>
+          <entry name="_link" md5="4416255f3687e473985fe3fb94d5e306" size="119" mtime="1623150224"/>
+          <entry name="somefile.txt" md5="0587c6aa712d0693b19e9e11ac7b05d0" size="69" mtime="1623150195"/>
         </directory>
-  recorded_at: Wed, 26 May 2021 14:52:15 GMT
+  recorded_at: Tue, 08 Jun 2021 11:05:05 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/foo_project:PR-1/bar_package?view=info
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package?view=info
     body:
       encoding: US-ASCII
       string: ''
@@ -715,14 +360,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="12" vrev="46" srcmd5="f6357e73f9d0527e05cc2e62bb5f4523" lsrcmd5="383f8b8f14d4f785b8f5ed0de419efcf" verifymd5="65d6aed68a4bd14aedf50aa7a40805f7">
+        <sourceinfo package="bar_package" rev="10" vrev="26" srcmd5="a152bade3fc16b5fce200b21604bd614" lsrcmd5="03b18129ccb8eb63cb7f4e86a78365f0" verifymd5="85c54e367fa29451ce52bc4368c6545e">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Wed, 26 May 2021 14:52:15 GMT
+  recorded_at: Tue, 08 Jun 2021 11:05:05 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/foo_project:PR-1/bar_package
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package
     body:
       encoding: US-ASCII
       string: ''
@@ -749,17 +394,17 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="12" vrev="12" srcmd5="383f8b8f14d4f785b8f5ed0de419efcf">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="9d25baf0e65f7f40de897431f0a9e50c" baserev="9d25baf0e65f7f40de897431f0a9e50c" xsrcmd5="f6357e73f9d0527e05cc2e62bb5f4523" lsrcmd5="383f8b8f14d4f785b8f5ed0de419efcf"/>
-          <entry name="_branch_request" md5="5d8aefeee8f093120d1d26f3aeebbdfb" size="82" mtime="1622034474"/>
-          <entry name="_config" md5="dbb8a1896ca7eb76503349f80efcebd6" size="52" mtime="1622040733"/>
-          <entry name="_link" md5="45c4e8aeefd436f30fcd22096428d9e4" size="119" mtime="1622040734"/>
-          <entry name="somefile.txt" md5="3ccafea33f2204f3da2094884f675c7a" size="82" mtime="1622040733"/>
+        <directory name="bar_package" rev="10" vrev="10" srcmd5="03b18129ccb8eb63cb7f4e86a78365f0">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="161b4b6e68e1881be864809af287aa13" baserev="161b4b6e68e1881be864809af287aa13" xsrcmd5="a152bade3fc16b5fce200b21604bd614" lsrcmd5="03b18129ccb8eb63cb7f4e86a78365f0"/>
+          <entry name="_branch_request" md5="5d8aefeee8f093120d1d26f3aeebbdfb" size="82" mtime="1623150191"/>
+          <entry name="_config" md5="6bff983f9804f565d81bdce9c4927da1" size="63" mtime="1623150195"/>
+          <entry name="_link" md5="4416255f3687e473985fe3fb94d5e306" size="119" mtime="1623150224"/>
+          <entry name="somefile.txt" md5="0587c6aa712d0693b19e9e11ac7b05d0" size="69" mtime="1623150195"/>
         </directory>
-  recorded_at: Wed, 26 May 2021 14:52:15 GMT
+  recorded_at: Tue, 08 Jun 2021 11:05:06 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/foo_project:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
     body:
       encoding: UTF-8
       string: ''
@@ -784,21 +429,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '317'
+      - '337'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="c1d92ee92c43085294c4aeb5de000519">
-          <old project="foo_project:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="foo_project:PR-1" package="bar_package" rev="12" srcmd5="383f8b8f14d4f785b8f5ed0de419efcf"/>
+        <sourcediff key="ed3555121d9b08840e6c7899062e2608">
+          <old project="home:Iggy:foo_project:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="home:Iggy:foo_project:PR-1" package="bar_package" rev="10" srcmd5="03b18129ccb8eb63cb7f4e86a78365f0"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Wed, 26 May 2021 14:52:15 GMT
+  recorded_at: Tue, 08 Jun 2021 11:05:06 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/foo_project:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
     body:
       encoding: UTF-8
       string: ''
@@ -818,21 +463,21 @@ http_interactions:
     headers:
       Content-Type:
       - text/xml
+      Content-Length:
+      - '383'
       Cache-Control:
       - no-cache
       Connection:
       - close
-      Content-Length:
-      - '373'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="e478ecdad68bc4cacc07a85482e0266d">
-          <old project="foo_project" package="bar_package" rev="9d25baf0e65f7f40de897431f0a9e50c" srcmd5="9d25baf0e65f7f40de897431f0a9e50c"/>
-          <new project="foo_project:PR-1" package="bar_package" rev="f6357e73f9d0527e05cc2e62bb5f4523" srcmd5="f6357e73f9d0527e05cc2e62bb5f4523"/>
+        <sourcediff key="d6fec56dcd0dab4dc9ed6e135a3974be">
+          <old project="foo_project" package="bar_package" rev="161b4b6e68e1881be864809af287aa13" srcmd5="161b4b6e68e1881be864809af287aa13"/>
+          <new project="home:Iggy:foo_project:PR-1" package="bar_package" rev="a152bade3fc16b5fce200b21604bd614" srcmd5="a152bade3fc16b5fce200b21604bd614"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Wed, 26 May 2021 14:52:15 GMT
+  recorded_at: Tue, 08 Jun 2021 11:05:06 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_we_feed_an_extractor_payload_for_github/and_the_payload_is_valid/1_2_1_1_2.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_we_feed_an_extractor_payload_for_github/and_the_payload_is_valid/1_2_1_1_2.yml
@@ -2,12 +2,12 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_13
+    uri: http://backend:5352/source/home:Iggy/_meta?user=Iggy
     body:
       encoding: UTF-8
       string: |
-        <project name="foo_project">
-          <title>This Lime Tree Bower</title>
+        <project name="home:Iggy">
+          <title/>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -30,25 +30,65 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '152'
+      - '130'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:Iggy">
+          <title></title>
+          <description></description>
+          <person userid="Iggy" role="maintainer"/>
+        </project>
+  recorded_at: Tue, 08 Jun 2021 11:06:38 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/foo_project/_meta?user=user_1
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>This Lime Tree Bower</title>
+          <title>A Catskill Eagle</title>
+          <description/>
+          <person userid="Iggy" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '148'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="foo_project">
+          <title>A Catskill Eagle</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Wed, 26 May 2021 14:52:12 GMT
+  recorded_at: Tue, 08 Jun 2021 11:06:38 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_14
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_2
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Behold the Man</title>
-          <description>Reprehenderit ipsum eum quia.</description>
+          <title>The Heart Is Deceitful Above All Things</title>
+          <description>Non rem consectetur et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -69,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '153'
+      - '172'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Behold the Man</title>
-          <description>Reprehenderit ipsum eum quia.</description>
+          <title>The Heart Is Deceitful Above All Things</title>
+          <description>Non rem consectetur et.</description>
         </package>
-  recorded_at: Wed, 26 May 2021 14:52:12 GMT
+  recorded_at: Tue, 08 Jun 2021 11:06:38 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Velit molestiae corporis. Ut vitae harum. Laborum est quos.
+      string: Libero in error. Odit odio iure. Sint sed repellendus.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -107,21 +147,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="31" vrev="31">
-          <srcmd5>b2c2db133f933b16a9823ad4701e88ae</srcmd5>
+        <revision rev="17" vrev="17">
+          <srcmd5>25bb090afd7a6b7fbd124edf8a6ee954</srcmd5>
           <version>unknown</version>
-          <time>1622040732</time>
+          <time>1623150398</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Wed, 26 May 2021 14:52:12 GMT
+  recorded_at: Tue, 08 Jun 2021 11:06:38 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Nulla labore dolorem. Quos dolor veniam. Nam aut ipsum.
+      string: Nihil cupiditate eos. Suscipit quis quaerat. Atque nemo aut.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -145,15 +185,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="32" vrev="32">
-          <srcmd5>80baf2d20717e3c0831f4502aa7b0dd2</srcmd5>
+        <revision rev="18" vrev="18">
+          <srcmd5>9c3df90a62ca0fa13d4520847db52308</srcmd5>
           <version>unknown</version>
-          <time>1622040732</time>
+          <time>1623150398</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Wed, 26 May 2021 14:52:12 GMT
+  recorded_at: Tue, 08 Jun 2021 11:06:38 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -187,14 +227,14 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Wed, 26 May 2021 14:52:12 GMT
+  recorded_at: Tue, 08 Jun 2021 11:06:38 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project:PR-1/_meta?user=Iggy
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/_meta?user=Iggy
     body:
       encoding: UTF-8
       string: |
-        <project name="foo_project:PR-1">
+        <project name="home:Iggy:foo_project:PR-1">
           <title>Branch project for package bar_package</title>
           <description>This project was created for package bar_package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
@@ -218,25 +258,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '252'
+      - '262'
     body:
       encoding: UTF-8
       string: |
-        <project name="foo_project:PR-1">
+        <project name="home:Iggy:foo_project:PR-1">
           <title>Branch project for package bar_package</title>
           <description>This project was created for package bar_package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Wed, 26 May 2021 14:52:12 GMT
+  recorded_at: Tue, 08 Jun 2021 11:06:38 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project:PR-1/bar_package/_meta?user=Iggy
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package/_meta?user=Iggy
     body:
       encoding: UTF-8
       string: |
-        <package name="bar_package" project="foo_project:PR-1">
-          <title>Behold the Man</title>
-          <description>Reprehenderit ipsum eum quia.</description>
+        <package name="bar_package" project="home:Iggy:foo_project:PR-1">
+          <title>The Heart Is Deceitful Above All Things</title>
+          <description>Non rem consectetur et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -257,328 +297,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '158'
+      - '187'
     body:
       encoding: UTF-8
       string: |
-        <package name="bar_package" project="foo_project:PR-1">
-          <title>Behold the Man</title>
-          <description>Reprehenderit ipsum eum quia.</description>
+        <package name="bar_package" project="home:Iggy:foo_project:PR-1">
+          <title>The Heart Is Deceitful Above All Things</title>
+          <description>Non rem consectetur et.</description>
         </package>
-  recorded_at: Wed, 26 May 2021 14:52:13 GMT
+  recorded_at: Tue, 08 Jun 2021 11:06:38 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/foo_project:PR-1/bar_package?cmd=branch&noservice=1&opackage=bar_package&oproject=foo_project&user=Iggy
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package?cmd=branch&noservice=1&opackage=bar_package&oproject=foo_project&user=Iggy
     body:
       encoding: UTF-8
       string: ''
     headers:
       Content-Type:
       - application/octet-stream
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '204'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="9" vrev="9">
-          <srcmd5>f7e389e0b2eed159c90641ed7544c414</srcmd5>
-          <version>unknown</version>
-          <time>1622040733</time>
-          <user>Iggy</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-  recorded_at: Wed, 26 May 2021 14:52:13 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/foo_project:PR-1/bar_package/_meta?user=Iggy
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="bar_package" project="foo_project:PR-1">
-          <title>Behold the Man</title>
-          <description>Reprehenderit ipsum eum quia.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '158'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="bar_package" project="foo_project:PR-1">
-          <title>Behold the Man</title>
-          <description>Reprehenderit ipsum eum quia.</description>
-        </package>
-  recorded_at: Wed, 26 May 2021 14:52:13 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/foo_project:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '618'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="9" vrev="9" srcmd5="f7e389e0b2eed159c90641ed7544c414">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="80baf2d20717e3c0831f4502aa7b0dd2" baserev="80baf2d20717e3c0831f4502aa7b0dd2" xsrcmd5="a205ee56ea990df3d37cfdf08643fca5" lsrcmd5="f7e389e0b2eed159c90641ed7544c414"/>
-          <entry name="_config" md5="a915f4f1510278df45d3644738a671ac" size="59" mtime="1622040732"/>
-          <entry name="_link" md5="5023bae2ef5326060032541d34984d91" size="119" mtime="1622040733"/>
-          <entry name="somefile.txt" md5="8d607e7436333cc0db65c735e2fe4ac3" size="55" mtime="1622040732"/>
-        </directory>
-  recorded_at: Wed, 26 May 2021 14:52:13 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/foo_project:PR-1/bar_package?view=info
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '329'
-    body:
-      encoding: UTF-8
-      string: |
-        <sourceinfo package="bar_package" rev="9" vrev="41" srcmd5="a205ee56ea990df3d37cfdf08643fca5" lsrcmd5="f7e389e0b2eed159c90641ed7544c414" verifymd5="80baf2d20717e3c0831f4502aa7b0dd2">
-          <error>bad build configuration, no build type defined or detected</error>
-          <linked project="foo_project" package="bar_package"/>
-        </sourceinfo>
-  recorded_at: Wed, 26 May 2021 14:52:13 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/foo_project:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '618'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="9" vrev="9" srcmd5="f7e389e0b2eed159c90641ed7544c414">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="80baf2d20717e3c0831f4502aa7b0dd2" baserev="80baf2d20717e3c0831f4502aa7b0dd2" xsrcmd5="a205ee56ea990df3d37cfdf08643fca5" lsrcmd5="f7e389e0b2eed159c90641ed7544c414"/>
-          <entry name="_config" md5="a915f4f1510278df45d3644738a671ac" size="59" mtime="1622040732"/>
-          <entry name="_link" md5="5023bae2ef5326060032541d34984d91" size="119" mtime="1622040733"/>
-          <entry name="somefile.txt" md5="8d607e7436333cc0db65c735e2fe4ac3" size="55" mtime="1622040732"/>
-        </directory>
-  recorded_at: Wed, 26 May 2021 14:52:13 GMT
-- request:
-    method: post
-    uri: http://backend:5352/source/foo_project:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      Content-Type:
-      - application/octet-stream
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '316'
-    body:
-      encoding: UTF-8
-      string: |
-        <sourcediff key="967bfe906bf9187149ccad01dc77afd8">
-          <old project="foo_project:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="foo_project:PR-1" package="bar_package" rev="9" srcmd5="f7e389e0b2eed159c90641ed7544c414"/>
-          <files/>
-          <issues>
-          </issues>
-        </sourcediff>
-  recorded_at: Wed, 26 May 2021 14:52:13 GMT
-- request:
-    method: post
-    uri: http://backend:5352/source/foo_project:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      Content-Type:
-      - application/octet-stream
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '350'
-    body:
-      encoding: UTF-8
-      string: |
-        <sourcediff key="b761d9270be1c9c6454a3a3d720f74ca">
-          <old project="foo_project" package="bar_package" rev="80baf2d20717e3c0831f4502aa7b0dd2" srcmd5="80baf2d20717e3c0831f4502aa7b0dd2"/>
-          <new project="foo_project:PR-1" package="bar_package" rev="a205ee56ea990df3d37cfdf08643fca5" srcmd5="a205ee56ea990df3d37cfdf08643fca5"/>
-          <files/>
-        </sourcediff>
-  recorded_at: Wed, 26 May 2021 14:52:13 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/foo_project:PR-1/_meta?user=Iggy
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="foo_project:PR-1">
-          <title>Branch project for package bar_package</title>
-          <description>This project was created for package bar_package via attribute OBS:Maintained</description>
-          <person userid="Iggy" role="maintainer"/>
-          <publish>
-            <disable/>
-          </publish>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '292'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="foo_project:PR-1">
-          <title>Branch project for package bar_package</title>
-          <description>This project was created for package bar_package via attribute OBS:Maintained</description>
-          <person userid="Iggy" role="maintainer"/>
-          <publish>
-            <disable/>
-          </publish>
-        </project>
-  recorded_at: Wed, 26 May 2021 14:52:13 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/foo_project:PR-1/bar_package/_branch_request?user=Iggy
-    body:
-      encoding: UTF-8
-      string: '{"action":"opened","pull_request":{"head":{"repo":{"full_name":null},"sha":null}}}'
-    headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -601,24 +337,24 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="10" vrev="10">
-          <srcmd5>7803d8a1653a393981489b45be4f9f01</srcmd5>
+        <revision rev="11" vrev="11">
+          <srcmd5>696d936075286c0d3ec2c62281f78d37</srcmd5>
           <version>unknown</version>
-          <time>1622040733</time>
+          <time>1623150398</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Wed, 26 May 2021 14:52:13 GMT
+  recorded_at: Tue, 08 Jun 2021 11:06:38 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project:PR-1/bar_package/_meta?user=Iggy
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package/_meta?user=Iggy
     body:
       encoding: UTF-8
       string: |
-        <package name="bar_package" project="foo_project:PR-1">
-          <title>Behold the Man</title>
-          <description>Reprehenderit ipsum eum quia.</description>
+        <package name="bar_package" project="home:Iggy:foo_project:PR-1">
+          <title>The Heart Is Deceitful Above All Things</title>
+          <description>Non rem consectetur et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -639,18 +375,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '158'
+      - '187'
     body:
       encoding: UTF-8
       string: |
-        <package name="bar_package" project="foo_project:PR-1">
-          <title>Behold the Man</title>
-          <description>Reprehenderit ipsum eum quia.</description>
+        <package name="bar_package" project="home:Iggy:foo_project:PR-1">
+          <title>The Heart Is Deceitful Above All Things</title>
+          <description>Non rem consectetur et.</description>
         </package>
-  recorded_at: Wed, 26 May 2021 14:52:13 GMT
+  recorded_at: Tue, 08 Jun 2021 11:06:38 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/foo_project:PR-1/bar_package
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package
     body:
       encoding: US-ASCII
       string: ''
@@ -673,21 +409,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '722'
+      - '620'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="10" vrev="10" srcmd5="7803d8a1653a393981489b45be4f9f01">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="80baf2d20717e3c0831f4502aa7b0dd2" baserev="80baf2d20717e3c0831f4502aa7b0dd2" xsrcmd5="5fb2a0cd59cbb163fcffe56667dbbd14" lsrcmd5="7803d8a1653a393981489b45be4f9f01"/>
-          <entry name="_branch_request" md5="5d8aefeee8f093120d1d26f3aeebbdfb" size="82" mtime="1622034474"/>
-          <entry name="_config" md5="a915f4f1510278df45d3644738a671ac" size="59" mtime="1622040732"/>
-          <entry name="_link" md5="5023bae2ef5326060032541d34984d91" size="119" mtime="1622040733"/>
-          <entry name="somefile.txt" md5="8d607e7436333cc0db65c735e2fe4ac3" size="55" mtime="1622040732"/>
+        <directory name="bar_package" rev="11" vrev="11" srcmd5="696d936075286c0d3ec2c62281f78d37">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="9c3df90a62ca0fa13d4520847db52308" baserev="9c3df90a62ca0fa13d4520847db52308" xsrcmd5="3296bf7dcbcbd38834dd135e2ef550cb" lsrcmd5="696d936075286c0d3ec2c62281f78d37"/>
+          <entry name="_config" md5="01e7288c06accac2a7d1655fa9f52ad8" size="54" mtime="1623150398"/>
+          <entry name="_link" md5="7e63df45c1e20b840e5b2457152bb1c0" size="119" mtime="1623150398"/>
+          <entry name="somefile.txt" md5="8f53346cae4251c4fec68894c90d0ca2" size="60" mtime="1623150398"/>
         </directory>
-  recorded_at: Wed, 26 May 2021 14:52:13 GMT
+  recorded_at: Tue, 08 Jun 2021 11:06:38 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/foo_project:PR-1/bar_package?view=info
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package?view=info
     body:
       encoding: US-ASCII
       string: ''
@@ -714,14 +449,248 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="10" vrev="42" srcmd5="5fb2a0cd59cbb163fcffe56667dbbd14" lsrcmd5="7803d8a1653a393981489b45be4f9f01" verifymd5="a0b398b8c2635b84c3ce3c5c899a95a2">
+        <sourceinfo package="bar_package" rev="11" vrev="29" srcmd5="3296bf7dcbcbd38834dd135e2ef550cb" lsrcmd5="696d936075286c0d3ec2c62281f78d37" verifymd5="9c3df90a62ca0fa13d4520847db52308">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Wed, 26 May 2021 14:52:13 GMT
+  recorded_at: Tue, 08 Jun 2021 11:06:38 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/foo_project:PR-1/bar_package
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '620'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="11" vrev="11" srcmd5="696d936075286c0d3ec2c62281f78d37">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="9c3df90a62ca0fa13d4520847db52308" baserev="9c3df90a62ca0fa13d4520847db52308" xsrcmd5="3296bf7dcbcbd38834dd135e2ef550cb" lsrcmd5="696d936075286c0d3ec2c62281f78d37"/>
+          <entry name="_config" md5="01e7288c06accac2a7d1655fa9f52ad8" size="54" mtime="1623150398"/>
+          <entry name="_link" md5="7e63df45c1e20b840e5b2457152bb1c0" size="119" mtime="1623150398"/>
+          <entry name="somefile.txt" md5="8f53346cae4251c4fec68894c90d0ca2" size="60" mtime="1623150398"/>
+        </directory>
+  recorded_at: Tue, 08 Jun 2021 11:06:38 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '337'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="704bfbfe866179050cae7ce45028dc60">
+          <old project="home:Iggy:foo_project:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="home:Iggy:foo_project:PR-1" package="bar_package" rev="11" srcmd5="696d936075286c0d3ec2c62281f78d37"/>
+          <files/>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Tue, 08 Jun 2021 11:06:38 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '360'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="7347b0678e8d4ff77102ef92405618ad">
+          <old project="foo_project" package="bar_package" rev="9c3df90a62ca0fa13d4520847db52308" srcmd5="9c3df90a62ca0fa13d4520847db52308"/>
+          <new project="home:Iggy:foo_project:PR-1" package="bar_package" rev="3296bf7dcbcbd38834dd135e2ef550cb" srcmd5="3296bf7dcbcbd38834dd135e2ef550cb"/>
+          <files/>
+        </sourcediff>
+  recorded_at: Tue, 08 Jun 2021 11:06:38 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/_meta?user=Iggy
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:Iggy:foo_project:PR-1">
+          <title>Branch project for package bar_package</title>
+          <description>This project was created for package bar_package via attribute OBS:Maintained</description>
+          <person userid="Iggy" role="maintainer"/>
+          <publish>
+            <disable/>
+          </publish>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '302'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:Iggy:foo_project:PR-1">
+          <title>Branch project for package bar_package</title>
+          <description>This project was created for package bar_package via attribute OBS:Maintained</description>
+          <person userid="Iggy" role="maintainer"/>
+          <publish>
+            <disable/>
+          </publish>
+        </project>
+  recorded_at: Tue, 08 Jun 2021 11:06:38 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package/_branch_request?user=Iggy
+    body:
+      encoding: UTF-8
+      string: '{"action":"opened","pull_request":{"head":{"repo":{"full_name":null},"sha":null}}}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '206'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="12" vrev="12">
+          <srcmd5>8216b6befe3c6f1c5028942c6ab88495</srcmd5>
+          <version>unknown</version>
+          <time>1623150398</time>
+          <user>Iggy</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Tue, 08 Jun 2021 11:06:38 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package/_meta?user=Iggy
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="bar_package" project="home:Iggy:foo_project:PR-1">
+          <title>The Heart Is Deceitful Above All Things</title>
+          <description>Non rem consectetur et.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '187'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="bar_package" project="home:Iggy:foo_project:PR-1">
+          <title>The Heart Is Deceitful Above All Things</title>
+          <description>Non rem consectetur et.</description>
+        </package>
+  recorded_at: Tue, 08 Jun 2021 11:06:38 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package
     body:
       encoding: US-ASCII
       string: ''
@@ -748,95 +717,166 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="10" vrev="10" srcmd5="7803d8a1653a393981489b45be4f9f01">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="80baf2d20717e3c0831f4502aa7b0dd2" baserev="80baf2d20717e3c0831f4502aa7b0dd2" xsrcmd5="5fb2a0cd59cbb163fcffe56667dbbd14" lsrcmd5="7803d8a1653a393981489b45be4f9f01"/>
-          <entry name="_branch_request" md5="5d8aefeee8f093120d1d26f3aeebbdfb" size="82" mtime="1622034474"/>
-          <entry name="_config" md5="a915f4f1510278df45d3644738a671ac" size="59" mtime="1622040732"/>
-          <entry name="_link" md5="5023bae2ef5326060032541d34984d91" size="119" mtime="1622040733"/>
-          <entry name="somefile.txt" md5="8d607e7436333cc0db65c735e2fe4ac3" size="55" mtime="1622040732"/>
+        <directory name="bar_package" rev="12" vrev="12" srcmd5="8216b6befe3c6f1c5028942c6ab88495">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="9c3df90a62ca0fa13d4520847db52308" baserev="9c3df90a62ca0fa13d4520847db52308" xsrcmd5="47cee82bd1b6092cabfd49692f267b43" lsrcmd5="8216b6befe3c6f1c5028942c6ab88495"/>
+          <entry name="_branch_request" md5="5d8aefeee8f093120d1d26f3aeebbdfb" size="82" mtime="1623150191"/>
+          <entry name="_config" md5="01e7288c06accac2a7d1655fa9f52ad8" size="54" mtime="1623150398"/>
+          <entry name="_link" md5="7e63df45c1e20b840e5b2457152bb1c0" size="119" mtime="1623150398"/>
+          <entry name="somefile.txt" md5="8f53346cae4251c4fec68894c90d0ca2" size="60" mtime="1623150398"/>
         </directory>
-  recorded_at: Wed, 26 May 2021 14:52:13 GMT
-- request:
-    method: post
-    uri: http://backend:5352/source/foo_project:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      Content-Type:
-      - application/octet-stream
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '317'
-    body:
-      encoding: UTF-8
-      string: |
-        <sourcediff key="9b6538ae9b959bba6deb675ac55d8665">
-          <old project="foo_project:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="foo_project:PR-1" package="bar_package" rev="10" srcmd5="7803d8a1653a393981489b45be4f9f01"/>
-          <files/>
-          <issues>
-          </issues>
-        </sourcediff>
-  recorded_at: Wed, 26 May 2021 14:52:13 GMT
-- request:
-    method: post
-    uri: http://backend:5352/source/foo_project:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      Content-Type:
-      - application/octet-stream
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '373'
-    body:
-      encoding: UTF-8
-      string: |
-        <sourcediff key="a64bf9eec0217b58cd6933dd916ef5f6">
-          <old project="foo_project" package="bar_package" rev="80baf2d20717e3c0831f4502aa7b0dd2" srcmd5="80baf2d20717e3c0831f4502aa7b0dd2"/>
-          <new project="foo_project:PR-1" package="bar_package" rev="5fb2a0cd59cbb163fcffe56667dbbd14" srcmd5="5fb2a0cd59cbb163fcffe56667dbbd14"/>
-          <files/>
-          <issues>
-          </issues>
-        </sourcediff>
-  recorded_at: Wed, 26 May 2021 14:52:13 GMT
+  recorded_at: Tue, 08 Jun 2021 11:06:39 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/foo_project:PR-1/bar_package/_branch_request
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package?view=info
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '330'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourceinfo package="bar_package" rev="12" vrev="30" srcmd5="47cee82bd1b6092cabfd49692f267b43" lsrcmd5="8216b6befe3c6f1c5028942c6ab88495" verifymd5="c719d2084a5aec7fb5e07b85d39b4a49">
+          <error>bad build configuration, no build type defined or detected</error>
+          <linked project="foo_project" package="bar_package"/>
+        </sourceinfo>
+  recorded_at: Tue, 08 Jun 2021 11:06:39 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '722'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="12" vrev="12" srcmd5="8216b6befe3c6f1c5028942c6ab88495">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="9c3df90a62ca0fa13d4520847db52308" baserev="9c3df90a62ca0fa13d4520847db52308" xsrcmd5="47cee82bd1b6092cabfd49692f267b43" lsrcmd5="8216b6befe3c6f1c5028942c6ab88495"/>
+          <entry name="_branch_request" md5="5d8aefeee8f093120d1d26f3aeebbdfb" size="82" mtime="1623150191"/>
+          <entry name="_config" md5="01e7288c06accac2a7d1655fa9f52ad8" size="54" mtime="1623150398"/>
+          <entry name="_link" md5="7e63df45c1e20b840e5b2457152bb1c0" size="119" mtime="1623150398"/>
+          <entry name="somefile.txt" md5="8f53346cae4251c4fec68894c90d0ca2" size="60" mtime="1623150398"/>
+        </directory>
+  recorded_at: Tue, 08 Jun 2021 11:06:39 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '337'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="c56dbaf2fd8a6da5ddf3d368cf0e7990">
+          <old project="home:Iggy:foo_project:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="home:Iggy:foo_project:PR-1" package="bar_package" rev="12" srcmd5="8216b6befe3c6f1c5028942c6ab88495"/>
+          <files/>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Tue, 08 Jun 2021 11:06:39 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '383'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="efd61555bb5f27568cde237a47be5f31">
+          <old project="foo_project" package="bar_package" rev="9c3df90a62ca0fa13d4520847db52308" srcmd5="9c3df90a62ca0fa13d4520847db52308"/>
+          <new project="home:Iggy:foo_project:PR-1" package="bar_package" rev="47cee82bd1b6092cabfd49692f267b43" srcmd5="47cee82bd1b6092cabfd49692f267b43"/>
+          <files/>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Tue, 08 Jun 2021 11:06:39 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package/_branch_request
     body:
       encoding: US-ASCII
       string: ''
@@ -863,5 +903,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"action":"opened","pull_request":{"head":{"repo":{"full_name":null},"sha":null}}}'
-  recorded_at: Wed, 26 May 2021 14:52:13 GMT
+  recorded_at: Tue, 08 Jun 2021 11:06:39 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_we_feed_an_extractor_payload_for_gitlab/and_the_payload_is_valid/1_2_2_1_1.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_we_feed_an_extractor_payload_for_gitlab/and_the_payload_is_valid/1_2_2_1_1.yml
@@ -1,160 +1,6 @@
 ---
 http_interactions:
 - request:
-    method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_1
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="foo_project">
-          <title>The Proper Study</title>
-          <description/>
-          <person userid="Iggy" role="maintainer"/>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '148'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="foo_project">
-          <title>The Proper Study</title>
-          <description></description>
-          <person userid="Iggy" role="maintainer"/>
-        </project>
-  recorded_at: Wed, 26 May 2021 14:52:08 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_2
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="bar_package" project="foo_project">
-          <title>A Monstrous Regiment of Women</title>
-          <description>Earum optio ipsam praesentium.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '169'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="bar_package" project="foo_project">
-          <title>A Monstrous Regiment of Women</title>
-          <description>Earum optio ipsam praesentium.</description>
-        </package>
-  recorded_at: Wed, 26 May 2021 14:52:08 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_config
-    body:
-      encoding: UTF-8
-      string: Iure dolor fugit. Consequatur esse sed. Laborum suscipit et.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '209'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="19" vrev="19">
-          <srcmd5>90af607edd4b5698b07e3afe5f579621</srcmd5>
-          <version>unknown</version>
-          <time>1622040728</time>
-          <user>unknown</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-  recorded_at: Wed, 26 May 2021 14:52:08 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
-    body:
-      encoding: UTF-8
-      string: Est aut qui. Suscipit dolorum dolor. Qui ea est.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '209'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="20" vrev="20">
-          <srcmd5>81ca42b61afd99d7090217a92420925c</srcmd5>
-          <version>unknown</version>
-          <time>1622040728</time>
-          <user>unknown</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-  recorded_at: Wed, 26 May 2021 14:52:08 GMT
-- request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
     body:
@@ -187,88 +33,10 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Wed, 26 May 2021 14:52:08 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/foo_project:PR-3/_meta?user=Iggy
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="foo_project:PR-3">
-          <title>Branch project for package bar_package</title>
-          <description>This project was created for package bar_package via attribute OBS:Maintained</description>
-          <person userid="Iggy" role="maintainer"/>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '252'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="foo_project:PR-3">
-          <title>Branch project for package bar_package</title>
-          <description>This project was created for package bar_package via attribute OBS:Maintained</description>
-          <person userid="Iggy" role="maintainer"/>
-        </project>
-  recorded_at: Wed, 26 May 2021 14:52:08 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/foo_project:PR-3/bar_package/_meta?user=Iggy
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="bar_package" project="foo_project:PR-3">
-          <title>A Monstrous Regiment of Women</title>
-          <description>Earum optio ipsam praesentium.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '174'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="bar_package" project="foo_project:PR-3">
-          <title>A Monstrous Regiment of Women</title>
-          <description>Earum optio ipsam praesentium.</description>
-        </package>
-  recorded_at: Wed, 26 May 2021 14:52:08 GMT
+  recorded_at: Tue, 08 Jun 2021 11:05:06 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/foo_project:PR-3/bar_package?cmd=branch&noservice=1&opackage=bar_package&oproject=foo_project&user=Iggy
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-3/bar_package?cmd=branch&noservice=1&opackage=bar_package&oproject=foo_project&user=Iggy
     body:
       encoding: UTF-8
       string: ''
@@ -297,56 +65,18 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="3" vrev="3">
-          <srcmd5>38a746ee53cad399a3c4483d72651787</srcmd5>
+        <revision rev="9" vrev="9">
+          <srcmd5>6ff6d9747eff4ea294397bcf5f8d298c</srcmd5>
           <version>unknown</version>
-          <time>1622040728</time>
+          <time>1623150306</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Wed, 26 May 2021 14:52:08 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/foo_project:PR-3/bar_package/_meta?user=Iggy
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="bar_package" project="foo_project:PR-3">
-          <title>A Monstrous Regiment of Women</title>
-          <description>Earum optio ipsam praesentium.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '174'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="bar_package" project="foo_project:PR-3">
-          <title>A Monstrous Regiment of Women</title>
-          <description>Earum optio ipsam praesentium.</description>
-        </package>
-  recorded_at: Wed, 26 May 2021 14:52:08 GMT
+  recorded_at: Tue, 08 Jun 2021 11:05:06 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/foo_project:PR-3/bar_package
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-3/bar_package
     body:
       encoding: US-ASCII
       string: ''
@@ -373,16 +103,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="3" vrev="3" srcmd5="38a746ee53cad399a3c4483d72651787">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="81ca42b61afd99d7090217a92420925c" baserev="81ca42b61afd99d7090217a92420925c" xsrcmd5="7a0408593eb148d75d5e2ef72989159f" lsrcmd5="38a746ee53cad399a3c4483d72651787"/>
-          <entry name="_config" md5="2007e2e010f70934c8b12368120c2dbb" size="60" mtime="1622040728"/>
-          <entry name="_link" md5="3f097454e3c2bcfa9e8ad6d53bf04d25" size="119" mtime="1622040728"/>
-          <entry name="somefile.txt" md5="52a23d5a39748acb93957afbe508352c" size="48" mtime="1622040728"/>
+        <directory name="bar_package" rev="9" vrev="9" srcmd5="6ff6d9747eff4ea294397bcf5f8d298c">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="161b4b6e68e1881be864809af287aa13" baserev="161b4b6e68e1881be864809af287aa13" xsrcmd5="2eb831cd9f7011516ac495296c8a3dec" lsrcmd5="6ff6d9747eff4ea294397bcf5f8d298c"/>
+          <entry name="_config" md5="6bff983f9804f565d81bdce9c4927da1" size="63" mtime="1623150195"/>
+          <entry name="_link" md5="4416255f3687e473985fe3fb94d5e306" size="119" mtime="1623150224"/>
+          <entry name="somefile.txt" md5="0587c6aa712d0693b19e9e11ac7b05d0" size="69" mtime="1623150195"/>
         </directory>
-  recorded_at: Wed, 26 May 2021 14:52:08 GMT
+  recorded_at: Tue, 08 Jun 2021 11:05:06 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/foo_project:PR-3/bar_package?view=info
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-3/bar_package?view=info
     body:
       encoding: US-ASCII
       string: ''
@@ -409,14 +139,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="3" vrev="23" srcmd5="7a0408593eb148d75d5e2ef72989159f" lsrcmd5="38a746ee53cad399a3c4483d72651787" verifymd5="81ca42b61afd99d7090217a92420925c">
+        <sourceinfo package="bar_package" rev="9" vrev="25" srcmd5="2eb831cd9f7011516ac495296c8a3dec" lsrcmd5="6ff6d9747eff4ea294397bcf5f8d298c" verifymd5="161b4b6e68e1881be864809af287aa13">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Wed, 26 May 2021 14:52:08 GMT
+  recorded_at: Tue, 08 Jun 2021 11:05:06 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/foo_project:PR-3/bar_package
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-3/bar_package
     body:
       encoding: US-ASCII
       string: ''
@@ -443,16 +173,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="3" vrev="3" srcmd5="38a746ee53cad399a3c4483d72651787">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="81ca42b61afd99d7090217a92420925c" baserev="81ca42b61afd99d7090217a92420925c" xsrcmd5="7a0408593eb148d75d5e2ef72989159f" lsrcmd5="38a746ee53cad399a3c4483d72651787"/>
-          <entry name="_config" md5="2007e2e010f70934c8b12368120c2dbb" size="60" mtime="1622040728"/>
-          <entry name="_link" md5="3f097454e3c2bcfa9e8ad6d53bf04d25" size="119" mtime="1622040728"/>
-          <entry name="somefile.txt" md5="52a23d5a39748acb93957afbe508352c" size="48" mtime="1622040728"/>
+        <directory name="bar_package" rev="9" vrev="9" srcmd5="6ff6d9747eff4ea294397bcf5f8d298c">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="161b4b6e68e1881be864809af287aa13" baserev="161b4b6e68e1881be864809af287aa13" xsrcmd5="2eb831cd9f7011516ac495296c8a3dec" lsrcmd5="6ff6d9747eff4ea294397bcf5f8d298c"/>
+          <entry name="_config" md5="6bff983f9804f565d81bdce9c4927da1" size="63" mtime="1623150195"/>
+          <entry name="_link" md5="4416255f3687e473985fe3fb94d5e306" size="119" mtime="1623150224"/>
+          <entry name="somefile.txt" md5="0587c6aa712d0693b19e9e11ac7b05d0" size="69" mtime="1623150195"/>
         </directory>
-  recorded_at: Wed, 26 May 2021 14:52:08 GMT
+  recorded_at: Tue, 08 Jun 2021 11:05:06 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/foo_project:PR-3/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-3/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
     body:
       encoding: UTF-8
       string: ''
@@ -477,21 +207,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '316'
+      - '336'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="ae8cecf3652d1e5df5d428dfa3819f32">
-          <old project="foo_project:PR-3" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="foo_project:PR-3" package="bar_package" rev="3" srcmd5="38a746ee53cad399a3c4483d72651787"/>
+        <sourcediff key="fbd2de2ee49d0898594a11ff1d4763a3">
+          <old project="home:Iggy:foo_project:PR-3" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="home:Iggy:foo_project:PR-3" package="bar_package" rev="9" srcmd5="6ff6d9747eff4ea294397bcf5f8d298c"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Wed, 26 May 2021 14:52:08 GMT
+  recorded_at: Tue, 08 Jun 2021 11:05:06 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/foo_project:PR-3/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-3/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
     body:
       encoding: UTF-8
       string: ''
@@ -516,65 +246,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '350'
+      - '360'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="2576fae98796977c87346311a039f21b">
-          <old project="foo_project" package="bar_package" rev="81ca42b61afd99d7090217a92420925c" srcmd5="81ca42b61afd99d7090217a92420925c"/>
-          <new project="foo_project:PR-3" package="bar_package" rev="7a0408593eb148d75d5e2ef72989159f" srcmd5="7a0408593eb148d75d5e2ef72989159f"/>
+        <sourcediff key="5b8efa9672caf9e1b1d8858d5c69c33f">
+          <old project="foo_project" package="bar_package" rev="161b4b6e68e1881be864809af287aa13" srcmd5="161b4b6e68e1881be864809af287aa13"/>
+          <new project="home:Iggy:foo_project:PR-3" package="bar_package" rev="2eb831cd9f7011516ac495296c8a3dec" srcmd5="2eb831cd9f7011516ac495296c8a3dec"/>
           <files/>
         </sourcediff>
-  recorded_at: Wed, 26 May 2021 14:52:08 GMT
+  recorded_at: Tue, 08 Jun 2021 11:05:06 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project:PR-3/_meta?user=Iggy
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="foo_project:PR-3">
-          <title>Branch project for package bar_package</title>
-          <description>This project was created for package bar_package via attribute OBS:Maintained</description>
-          <person userid="Iggy" role="maintainer"/>
-          <publish>
-            <disable/>
-          </publish>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '292'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="foo_project:PR-3">
-          <title>Branch project for package bar_package</title>
-          <description>This project was created for package bar_package via attribute OBS:Maintained</description>
-          <person userid="Iggy" role="maintainer"/>
-          <publish>
-            <disable/>
-          </publish>
-        </project>
-  recorded_at: Wed, 26 May 2021 14:52:08 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/foo_project:PR-3/bar_package/_branch_request?user=Iggy
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-3/bar_package/_branch_request?user=Iggy
     body:
       encoding: UTF-8
       string: '{"object_kind":null,"project":{"http_url":null},"object_attributes":{"source":{"default_branch":null}}}'
@@ -597,60 +281,22 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '204'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="4" vrev="4">
-          <srcmd5>16d63eeffe1d05294403f80ba73b60b3</srcmd5>
+        <revision rev="10" vrev="10">
+          <srcmd5>d98cabf00f4ff2ecef4e8a2f95d8e735</srcmd5>
           <version>unknown</version>
-          <time>1622040728</time>
+          <time>1623150306</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Wed, 26 May 2021 14:52:08 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/foo_project:PR-3/bar_package/_meta?user=Iggy
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="bar_package" project="foo_project:PR-3">
-          <title>A Monstrous Regiment of Women</title>
-          <description>Earum optio ipsam praesentium.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '174'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="bar_package" project="foo_project:PR-3">
-          <title>A Monstrous Regiment of Women</title>
-          <description>Earum optio ipsam praesentium.</description>
-        </package>
-  recorded_at: Wed, 26 May 2021 14:52:08 GMT
+  recorded_at: Tue, 08 Jun 2021 11:05:06 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/foo_project:PR-3/bar_package
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-3/bar_package
     body:
       encoding: US-ASCII
       string: ''
@@ -673,21 +319,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '721'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="4" vrev="4" srcmd5="16d63eeffe1d05294403f80ba73b60b3">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="81ca42b61afd99d7090217a92420925c" baserev="81ca42b61afd99d7090217a92420925c" xsrcmd5="6cac2e626db23852f8b902881f0ec2f7" lsrcmd5="16d63eeffe1d05294403f80ba73b60b3"/>
-          <entry name="_branch_request" md5="143356c99b20845f131d56e993f196b1" size="103" mtime="1622034475"/>
-          <entry name="_config" md5="2007e2e010f70934c8b12368120c2dbb" size="60" mtime="1622040728"/>
-          <entry name="_link" md5="3f097454e3c2bcfa9e8ad6d53bf04d25" size="119" mtime="1622040728"/>
-          <entry name="somefile.txt" md5="52a23d5a39748acb93957afbe508352c" size="48" mtime="1622040728"/>
+        <directory name="bar_package" rev="10" vrev="10" srcmd5="d98cabf00f4ff2ecef4e8a2f95d8e735">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="161b4b6e68e1881be864809af287aa13" baserev="161b4b6e68e1881be864809af287aa13" xsrcmd5="a0493c68a1ed2c772224e942f9a17a20" lsrcmd5="d98cabf00f4ff2ecef4e8a2f95d8e735"/>
+          <entry name="_branch_request" md5="143356c99b20845f131d56e993f196b1" size="103" mtime="1623150193"/>
+          <entry name="_config" md5="6bff983f9804f565d81bdce9c4927da1" size="63" mtime="1623150195"/>
+          <entry name="_link" md5="4416255f3687e473985fe3fb94d5e306" size="119" mtime="1623150224"/>
+          <entry name="somefile.txt" md5="0587c6aa712d0693b19e9e11ac7b05d0" size="69" mtime="1623150195"/>
         </directory>
-  recorded_at: Wed, 26 May 2021 14:52:09 GMT
+  recorded_at: Tue, 08 Jun 2021 11:05:06 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/foo_project:PR-3/bar_package?view=info
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-3/bar_package?view=info
     body:
       encoding: US-ASCII
       string: ''
@@ -710,18 +356,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '329'
+      - '330'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="4" vrev="24" srcmd5="6cac2e626db23852f8b902881f0ec2f7" lsrcmd5="16d63eeffe1d05294403f80ba73b60b3" verifymd5="f540027e4e5faa3b7a623c7cb54a55a1">
+        <sourceinfo package="bar_package" rev="10" vrev="26" srcmd5="a0493c68a1ed2c772224e942f9a17a20" lsrcmd5="d98cabf00f4ff2ecef4e8a2f95d8e735" verifymd5="b7c82b197df352db4f3c1ab6858623ad">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Wed, 26 May 2021 14:52:09 GMT
+  recorded_at: Tue, 08 Jun 2021 11:05:06 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/foo_project:PR-3/bar_package
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-3/bar_package
     body:
       encoding: US-ASCII
       string: ''
@@ -744,21 +390,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '721'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="4" vrev="4" srcmd5="16d63eeffe1d05294403f80ba73b60b3">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="81ca42b61afd99d7090217a92420925c" baserev="81ca42b61afd99d7090217a92420925c" xsrcmd5="6cac2e626db23852f8b902881f0ec2f7" lsrcmd5="16d63eeffe1d05294403f80ba73b60b3"/>
-          <entry name="_branch_request" md5="143356c99b20845f131d56e993f196b1" size="103" mtime="1622034475"/>
-          <entry name="_config" md5="2007e2e010f70934c8b12368120c2dbb" size="60" mtime="1622040728"/>
-          <entry name="_link" md5="3f097454e3c2bcfa9e8ad6d53bf04d25" size="119" mtime="1622040728"/>
-          <entry name="somefile.txt" md5="52a23d5a39748acb93957afbe508352c" size="48" mtime="1622040728"/>
+        <directory name="bar_package" rev="10" vrev="10" srcmd5="d98cabf00f4ff2ecef4e8a2f95d8e735">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="161b4b6e68e1881be864809af287aa13" baserev="161b4b6e68e1881be864809af287aa13" xsrcmd5="a0493c68a1ed2c772224e942f9a17a20" lsrcmd5="d98cabf00f4ff2ecef4e8a2f95d8e735"/>
+          <entry name="_branch_request" md5="143356c99b20845f131d56e993f196b1" size="103" mtime="1623150193"/>
+          <entry name="_config" md5="6bff983f9804f565d81bdce9c4927da1" size="63" mtime="1623150195"/>
+          <entry name="_link" md5="4416255f3687e473985fe3fb94d5e306" size="119" mtime="1623150224"/>
+          <entry name="somefile.txt" md5="0587c6aa712d0693b19e9e11ac7b05d0" size="69" mtime="1623150195"/>
         </directory>
-  recorded_at: Wed, 26 May 2021 14:52:09 GMT
+  recorded_at: Tue, 08 Jun 2021 11:05:06 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/foo_project:PR-3/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-3/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
     body:
       encoding: UTF-8
       string: ''
@@ -783,21 +429,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '316'
+      - '337'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="3c89af41dbb589d75d727fc8fd0c5560">
-          <old project="foo_project:PR-3" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="foo_project:PR-3" package="bar_package" rev="4" srcmd5="16d63eeffe1d05294403f80ba73b60b3"/>
+        <sourcediff key="182f100308a4db96d92b95611e9b3cc0">
+          <old project="home:Iggy:foo_project:PR-3" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="home:Iggy:foo_project:PR-3" package="bar_package" rev="10" srcmd5="d98cabf00f4ff2ecef4e8a2f95d8e735"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Wed, 26 May 2021 14:52:09 GMT
+  recorded_at: Tue, 08 Jun 2021 11:05:06 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/foo_project:PR-3/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-3/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
     body:
       encoding: UTF-8
       string: ''
@@ -817,21 +463,21 @@ http_interactions:
     headers:
       Content-Type:
       - text/xml
+      Content-Length:
+      - '383'
       Cache-Control:
       - no-cache
       Connection:
       - close
-      Content-Length:
-      - '373'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="0c998767a741a9c31e126fa7959ea518">
-          <old project="foo_project" package="bar_package" rev="81ca42b61afd99d7090217a92420925c" srcmd5="81ca42b61afd99d7090217a92420925c"/>
-          <new project="foo_project:PR-3" package="bar_package" rev="6cac2e626db23852f8b902881f0ec2f7" srcmd5="6cac2e626db23852f8b902881f0ec2f7"/>
+        <sourcediff key="9e1b4f587f12a9c77954d5b2a09da9e8">
+          <old project="foo_project" package="bar_package" rev="161b4b6e68e1881be864809af287aa13" srcmd5="161b4b6e68e1881be864809af287aa13"/>
+          <new project="home:Iggy:foo_project:PR-3" package="bar_package" rev="a0493c68a1ed2c772224e942f9a17a20" srcmd5="a0493c68a1ed2c772224e942f9a17a20"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Wed, 26 May 2021 14:52:09 GMT
+  recorded_at: Tue, 08 Jun 2021 11:05:06 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_we_feed_an_extractor_payload_for_gitlab/and_the_payload_is_valid/1_2_2_1_2.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_we_feed_an_extractor_payload_for_gitlab/and_the_payload_is_valid/1_2_2_1_2.yml
@@ -2,12 +2,12 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_3
+    uri: http://backend:5352/source/home:Iggy/_meta?user=Iggy
     body:
       encoding: UTF-8
       string: |
-        <project name="foo_project">
-          <title>A Farewell to Arms</title>
+        <project name="home:Iggy">
+          <title/>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -30,25 +30,65 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '150'
+      - '130'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:Iggy">
+          <title></title>
+          <description></description>
+          <person userid="Iggy" role="maintainer"/>
+        </project>
+  recorded_at: Tue, 08 Jun 2021 11:08:30 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/foo_project/_meta?user=user_1
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>A Farewell to Arms</title>
+          <title>Paths of Glory</title>
+          <description/>
+          <person userid="Iggy" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '146'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="foo_project">
+          <title>Paths of Glory</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Wed, 26 May 2021 14:52:09 GMT
+  recorded_at: Tue, 08 Jun 2021 11:08:30 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_4
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_2
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>From Here to Eternity</title>
-          <description>Ut voluptatem error dicta.</description>
+          <title>Waiting for the Barbarians</title>
+          <description>Doloribus consectetur vel rerum.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -69,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '157'
+      - '168'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>From Here to Eternity</title>
-          <description>Ut voluptatem error dicta.</description>
+          <title>Waiting for the Barbarians</title>
+          <description>Doloribus consectetur vel rerum.</description>
         </package>
-  recorded_at: Wed, 26 May 2021 14:52:09 GMT
+  recorded_at: Tue, 08 Jun 2021 11:08:30 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Sint inventore at. Hic eum assumenda. Incidunt vel quis.
+      string: Corporis architecto veniam. Quas omnis corrupti. Recusandae et error.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -107,21 +147,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="21" vrev="21">
-          <srcmd5>a2d501f7ad932e97a67a24042f4708bb</srcmd5>
+        <revision rev="19" vrev="19">
+          <srcmd5>0a153c2bede6ef7b9be8e0d351a0fd06</srcmd5>
           <version>unknown</version>
-          <time>1622040729</time>
+          <time>1623150510</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Wed, 26 May 2021 14:52:09 GMT
+  recorded_at: Tue, 08 Jun 2021 11:08:30 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Quis ad ut. Id quidem magnam. Et veniam commodi.
+      string: Maiores aut minus. Blanditiis ea pariatur. Dolores distinctio voluptas.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -145,15 +185,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="22" vrev="22">
-          <srcmd5>b5092fe38335226905e10d575d6aceb6</srcmd5>
+        <revision rev="20" vrev="20">
+          <srcmd5>ab5fce380bec1979e3cc527a027667d9</srcmd5>
           <version>unknown</version>
-          <time>1622040729</time>
+          <time>1623150510</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Wed, 26 May 2021 14:52:09 GMT
+  recorded_at: Tue, 08 Jun 2021 11:08:30 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -187,14 +227,14 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Wed, 26 May 2021 14:52:09 GMT
+  recorded_at: Tue, 08 Jun 2021 11:08:30 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project:PR-3/_meta?user=Iggy
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-3/_meta?user=Iggy
     body:
       encoding: UTF-8
       string: |
-        <project name="foo_project:PR-3">
+        <project name="home:Iggy:foo_project:PR-3">
           <title>Branch project for package bar_package</title>
           <description>This project was created for package bar_package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
@@ -218,25 +258,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '252'
+      - '262'
     body:
       encoding: UTF-8
       string: |
-        <project name="foo_project:PR-3">
+        <project name="home:Iggy:foo_project:PR-3">
           <title>Branch project for package bar_package</title>
           <description>This project was created for package bar_package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Wed, 26 May 2021 14:52:09 GMT
+  recorded_at: Tue, 08 Jun 2021 11:08:30 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project:PR-3/bar_package/_meta?user=Iggy
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-3/bar_package/_meta?user=Iggy
     body:
       encoding: UTF-8
       string: |
-        <package name="bar_package" project="foo_project:PR-3">
-          <title>From Here to Eternity</title>
-          <description>Ut voluptatem error dicta.</description>
+        <package name="bar_package" project="home:Iggy:foo_project:PR-3">
+          <title>Waiting for the Barbarians</title>
+          <description>Doloribus consectetur vel rerum.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -257,18 +297,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '162'
+      - '183'
     body:
       encoding: UTF-8
       string: |
-        <package name="bar_package" project="foo_project:PR-3">
-          <title>From Here to Eternity</title>
-          <description>Ut voluptatem error dicta.</description>
+        <package name="bar_package" project="home:Iggy:foo_project:PR-3">
+          <title>Waiting for the Barbarians</title>
+          <description>Doloribus consectetur vel rerum.</description>
         </package>
-  recorded_at: Wed, 26 May 2021 14:52:09 GMT
+  recorded_at: Tue, 08 Jun 2021 11:08:30 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/foo_project:PR-3/bar_package?cmd=branch&noservice=1&opackage=bar_package&oproject=foo_project&user=Iggy
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-3/bar_package?cmd=branch&noservice=1&opackage=bar_package&oproject=foo_project&user=Iggy
     body:
       encoding: UTF-8
       string: ''
@@ -293,28 +333,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '204'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="5" vrev="5">
-          <srcmd5>2ec9172da8b62a42bae9d1b416a93bb2</srcmd5>
+        <revision rev="11" vrev="11">
+          <srcmd5>efb915bd72763f95a215561aa19950fb</srcmd5>
           <version>unknown</version>
-          <time>1622040729</time>
+          <time>1623150510</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Wed, 26 May 2021 14:52:09 GMT
+  recorded_at: Tue, 08 Jun 2021 11:08:30 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project:PR-3/bar_package/_meta?user=Iggy
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-3/bar_package/_meta?user=Iggy
     body:
       encoding: UTF-8
       string: |
-        <package name="bar_package" project="foo_project:PR-3">
-          <title>From Here to Eternity</title>
-          <description>Ut voluptatem error dicta.</description>
+        <package name="bar_package" project="home:Iggy:foo_project:PR-3">
+          <title>Waiting for the Barbarians</title>
+          <description>Doloribus consectetur vel rerum.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -335,18 +375,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '162'
+      - '183'
     body:
       encoding: UTF-8
       string: |
-        <package name="bar_package" project="foo_project:PR-3">
-          <title>From Here to Eternity</title>
-          <description>Ut voluptatem error dicta.</description>
+        <package name="bar_package" project="home:Iggy:foo_project:PR-3">
+          <title>Waiting for the Barbarians</title>
+          <description>Doloribus consectetur vel rerum.</description>
         </package>
-  recorded_at: Wed, 26 May 2021 14:52:09 GMT
+  recorded_at: Tue, 08 Jun 2021 11:08:30 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/foo_project:PR-3/bar_package
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-3/bar_package
     body:
       encoding: US-ASCII
       string: ''
@@ -369,20 +409,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '618'
+      - '620'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="5" vrev="5" srcmd5="2ec9172da8b62a42bae9d1b416a93bb2">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="b5092fe38335226905e10d575d6aceb6" baserev="b5092fe38335226905e10d575d6aceb6" xsrcmd5="21a9e7ad321e11a935a785b13824af5c" lsrcmd5="2ec9172da8b62a42bae9d1b416a93bb2"/>
-          <entry name="_config" md5="4ddca0f4e33d89bf65ca311d0990bb84" size="56" mtime="1622040729"/>
-          <entry name="_link" md5="3618e4fee10b2e8a273b95d73ab75954" size="119" mtime="1622040729"/>
-          <entry name="somefile.txt" md5="3e5c50babd66987eeffedff384a1bad2" size="48" mtime="1622040729"/>
+        <directory name="bar_package" rev="11" vrev="11" srcmd5="efb915bd72763f95a215561aa19950fb">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="ab5fce380bec1979e3cc527a027667d9" baserev="ab5fce380bec1979e3cc527a027667d9" xsrcmd5="2f9888cd2a9470e2911ffcfaf51ce8e4" lsrcmd5="efb915bd72763f95a215561aa19950fb"/>
+          <entry name="_config" md5="26d64d0fe1c8399ab303591a38652e23" size="69" mtime="1623150510"/>
+          <entry name="_link" md5="eb30112d18011bb5b5159cf68944462a" size="119" mtime="1623150510"/>
+          <entry name="somefile.txt" md5="cdcaf34e5d682a8d9a6dd8c3ac10ba79" size="71" mtime="1623150510"/>
         </directory>
-  recorded_at: Wed, 26 May 2021 14:52:09 GMT
+  recorded_at: Tue, 08 Jun 2021 11:08:30 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/foo_project:PR-3/bar_package?view=info
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-3/bar_package?view=info
     body:
       encoding: US-ASCII
       string: ''
@@ -405,18 +445,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '329'
+      - '330'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="5" vrev="27" srcmd5="21a9e7ad321e11a935a785b13824af5c" lsrcmd5="2ec9172da8b62a42bae9d1b416a93bb2" verifymd5="b5092fe38335226905e10d575d6aceb6">
+        <sourceinfo package="bar_package" rev="11" vrev="31" srcmd5="2f9888cd2a9470e2911ffcfaf51ce8e4" lsrcmd5="efb915bd72763f95a215561aa19950fb" verifymd5="ab5fce380bec1979e3cc527a027667d9">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Wed, 26 May 2021 14:52:09 GMT
+  recorded_at: Tue, 08 Jun 2021 11:08:30 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/foo_project:PR-3/bar_package
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-3/bar_package
     body:
       encoding: US-ASCII
       string: ''
@@ -439,20 +479,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '618'
+      - '620'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="5" vrev="5" srcmd5="2ec9172da8b62a42bae9d1b416a93bb2">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="b5092fe38335226905e10d575d6aceb6" baserev="b5092fe38335226905e10d575d6aceb6" xsrcmd5="21a9e7ad321e11a935a785b13824af5c" lsrcmd5="2ec9172da8b62a42bae9d1b416a93bb2"/>
-          <entry name="_config" md5="4ddca0f4e33d89bf65ca311d0990bb84" size="56" mtime="1622040729"/>
-          <entry name="_link" md5="3618e4fee10b2e8a273b95d73ab75954" size="119" mtime="1622040729"/>
-          <entry name="somefile.txt" md5="3e5c50babd66987eeffedff384a1bad2" size="48" mtime="1622040729"/>
+        <directory name="bar_package" rev="11" vrev="11" srcmd5="efb915bd72763f95a215561aa19950fb">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="ab5fce380bec1979e3cc527a027667d9" baserev="ab5fce380bec1979e3cc527a027667d9" xsrcmd5="2f9888cd2a9470e2911ffcfaf51ce8e4" lsrcmd5="efb915bd72763f95a215561aa19950fb"/>
+          <entry name="_config" md5="26d64d0fe1c8399ab303591a38652e23" size="69" mtime="1623150510"/>
+          <entry name="_link" md5="eb30112d18011bb5b5159cf68944462a" size="119" mtime="1623150510"/>
+          <entry name="somefile.txt" md5="cdcaf34e5d682a8d9a6dd8c3ac10ba79" size="71" mtime="1623150510"/>
         </directory>
-  recorded_at: Wed, 26 May 2021 14:52:09 GMT
+  recorded_at: Tue, 08 Jun 2021 11:08:30 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/foo_project:PR-3/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-3/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
     body:
       encoding: UTF-8
       string: ''
@@ -477,21 +517,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '316'
+      - '337'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="d8b90eb32ff093868be5b660b61b43de">
-          <old project="foo_project:PR-3" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="foo_project:PR-3" package="bar_package" rev="5" srcmd5="2ec9172da8b62a42bae9d1b416a93bb2"/>
+        <sourcediff key="ac41b156239c72a108ee8a3af24ae3c8">
+          <old project="home:Iggy:foo_project:PR-3" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="home:Iggy:foo_project:PR-3" package="bar_package" rev="11" srcmd5="efb915bd72763f95a215561aa19950fb"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Wed, 26 May 2021 14:52:09 GMT
+  recorded_at: Tue, 08 Jun 2021 11:08:30 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/foo_project:PR-3/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-3/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
     body:
       encoding: UTF-8
       string: ''
@@ -516,23 +556,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '350'
+      - '360'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="a39ffab297eb7ec6fd9ee356ee22d419">
-          <old project="foo_project" package="bar_package" rev="b5092fe38335226905e10d575d6aceb6" srcmd5="b5092fe38335226905e10d575d6aceb6"/>
-          <new project="foo_project:PR-3" package="bar_package" rev="21a9e7ad321e11a935a785b13824af5c" srcmd5="21a9e7ad321e11a935a785b13824af5c"/>
+        <sourcediff key="96954258adc6b845d662e1aa1bca333d">
+          <old project="foo_project" package="bar_package" rev="ab5fce380bec1979e3cc527a027667d9" srcmd5="ab5fce380bec1979e3cc527a027667d9"/>
+          <new project="home:Iggy:foo_project:PR-3" package="bar_package" rev="2f9888cd2a9470e2911ffcfaf51ce8e4" srcmd5="2f9888cd2a9470e2911ffcfaf51ce8e4"/>
           <files/>
         </sourcediff>
-  recorded_at: Wed, 26 May 2021 14:52:09 GMT
+  recorded_at: Tue, 08 Jun 2021 11:08:30 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project:PR-3/_meta?user=Iggy
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-3/_meta?user=Iggy
     body:
       encoding: UTF-8
       string: |
-        <project name="foo_project:PR-3">
+        <project name="home:Iggy:foo_project:PR-3">
           <title>Branch project for package bar_package</title>
           <description>This project was created for package bar_package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
@@ -559,11 +599,11 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '292'
+      - '302'
     body:
       encoding: UTF-8
       string: |
-        <project name="foo_project:PR-3">
+        <project name="home:Iggy:foo_project:PR-3">
           <title>Branch project for package bar_package</title>
           <description>This project was created for package bar_package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
@@ -571,10 +611,10 @@ http_interactions:
             <disable/>
           </publish>
         </project>
-  recorded_at: Wed, 26 May 2021 14:52:10 GMT
+  recorded_at: Tue, 08 Jun 2021 11:08:30 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project:PR-3/bar_package/_branch_request?user=Iggy
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-3/bar_package/_branch_request?user=Iggy
     body:
       encoding: UTF-8
       string: '{"object_kind":null,"project":{"http_url":null},"object_attributes":{"source":{"default_branch":null}}}'
@@ -597,28 +637,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '204'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="6" vrev="6">
-          <srcmd5>e07b5fd94863ea26ce05c0b124bcae74</srcmd5>
+        <revision rev="12" vrev="12">
+          <srcmd5>67a0517f75eff575d1655f2cd82e1ffc</srcmd5>
           <version>unknown</version>
-          <time>1622040730</time>
+          <time>1623150511</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Wed, 26 May 2021 14:52:10 GMT
+  recorded_at: Tue, 08 Jun 2021 11:08:31 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project:PR-3/bar_package/_meta?user=Iggy
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-3/bar_package/_meta?user=Iggy
     body:
       encoding: UTF-8
       string: |
-        <package name="bar_package" project="foo_project:PR-3">
-          <title>From Here to Eternity</title>
-          <description>Ut voluptatem error dicta.</description>
+        <package name="bar_package" project="home:Iggy:foo_project:PR-3">
+          <title>Waiting for the Barbarians</title>
+          <description>Doloribus consectetur vel rerum.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -639,18 +679,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '162'
+      - '183'
     body:
       encoding: UTF-8
       string: |
-        <package name="bar_package" project="foo_project:PR-3">
-          <title>From Here to Eternity</title>
-          <description>Ut voluptatem error dicta.</description>
+        <package name="bar_package" project="home:Iggy:foo_project:PR-3">
+          <title>Waiting for the Barbarians</title>
+          <description>Doloribus consectetur vel rerum.</description>
         </package>
-  recorded_at: Wed, 26 May 2021 14:52:10 GMT
+  recorded_at: Tue, 08 Jun 2021 11:08:31 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/foo_project:PR-3/bar_package
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-3/bar_package
     body:
       encoding: US-ASCII
       string: ''
@@ -673,21 +713,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '721'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="6" vrev="6" srcmd5="e07b5fd94863ea26ce05c0b124bcae74">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="b5092fe38335226905e10d575d6aceb6" baserev="b5092fe38335226905e10d575d6aceb6" xsrcmd5="e6dcd7e3299281b74b28b80741ed9a99" lsrcmd5="e07b5fd94863ea26ce05c0b124bcae74"/>
-          <entry name="_branch_request" md5="143356c99b20845f131d56e993f196b1" size="103" mtime="1622034475"/>
-          <entry name="_config" md5="4ddca0f4e33d89bf65ca311d0990bb84" size="56" mtime="1622040729"/>
-          <entry name="_link" md5="3618e4fee10b2e8a273b95d73ab75954" size="119" mtime="1622040729"/>
-          <entry name="somefile.txt" md5="3e5c50babd66987eeffedff384a1bad2" size="48" mtime="1622040729"/>
+        <directory name="bar_package" rev="12" vrev="12" srcmd5="67a0517f75eff575d1655f2cd82e1ffc">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="ab5fce380bec1979e3cc527a027667d9" baserev="ab5fce380bec1979e3cc527a027667d9" xsrcmd5="e84d152be69b1bc38c76205f83aca357" lsrcmd5="67a0517f75eff575d1655f2cd82e1ffc"/>
+          <entry name="_branch_request" md5="143356c99b20845f131d56e993f196b1" size="103" mtime="1623150193"/>
+          <entry name="_config" md5="26d64d0fe1c8399ab303591a38652e23" size="69" mtime="1623150510"/>
+          <entry name="_link" md5="eb30112d18011bb5b5159cf68944462a" size="119" mtime="1623150510"/>
+          <entry name="somefile.txt" md5="cdcaf34e5d682a8d9a6dd8c3ac10ba79" size="71" mtime="1623150510"/>
         </directory>
-  recorded_at: Wed, 26 May 2021 14:52:10 GMT
+  recorded_at: Tue, 08 Jun 2021 11:08:31 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/foo_project:PR-3/bar_package?view=info
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-3/bar_package?view=info
     body:
       encoding: US-ASCII
       string: ''
@@ -710,18 +750,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '329'
+      - '330'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="6" vrev="28" srcmd5="e6dcd7e3299281b74b28b80741ed9a99" lsrcmd5="e07b5fd94863ea26ce05c0b124bcae74" verifymd5="d82123d275c879e0784a54eb271ee42f">
+        <sourceinfo package="bar_package" rev="12" vrev="32" srcmd5="e84d152be69b1bc38c76205f83aca357" lsrcmd5="67a0517f75eff575d1655f2cd82e1ffc" verifymd5="b94efce3be2a686c92486ab01b80c4ef">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Wed, 26 May 2021 14:52:10 GMT
+  recorded_at: Tue, 08 Jun 2021 11:08:31 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/foo_project:PR-3/bar_package
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-3/bar_package
     body:
       encoding: US-ASCII
       string: ''
@@ -744,21 +784,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '721'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="6" vrev="6" srcmd5="e07b5fd94863ea26ce05c0b124bcae74">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="b5092fe38335226905e10d575d6aceb6" baserev="b5092fe38335226905e10d575d6aceb6" xsrcmd5="e6dcd7e3299281b74b28b80741ed9a99" lsrcmd5="e07b5fd94863ea26ce05c0b124bcae74"/>
-          <entry name="_branch_request" md5="143356c99b20845f131d56e993f196b1" size="103" mtime="1622034475"/>
-          <entry name="_config" md5="4ddca0f4e33d89bf65ca311d0990bb84" size="56" mtime="1622040729"/>
-          <entry name="_link" md5="3618e4fee10b2e8a273b95d73ab75954" size="119" mtime="1622040729"/>
-          <entry name="somefile.txt" md5="3e5c50babd66987eeffedff384a1bad2" size="48" mtime="1622040729"/>
+        <directory name="bar_package" rev="12" vrev="12" srcmd5="67a0517f75eff575d1655f2cd82e1ffc">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="ab5fce380bec1979e3cc527a027667d9" baserev="ab5fce380bec1979e3cc527a027667d9" xsrcmd5="e84d152be69b1bc38c76205f83aca357" lsrcmd5="67a0517f75eff575d1655f2cd82e1ffc"/>
+          <entry name="_branch_request" md5="143356c99b20845f131d56e993f196b1" size="103" mtime="1623150193"/>
+          <entry name="_config" md5="26d64d0fe1c8399ab303591a38652e23" size="69" mtime="1623150510"/>
+          <entry name="_link" md5="eb30112d18011bb5b5159cf68944462a" size="119" mtime="1623150510"/>
+          <entry name="somefile.txt" md5="cdcaf34e5d682a8d9a6dd8c3ac10ba79" size="71" mtime="1623150510"/>
         </directory>
-  recorded_at: Wed, 26 May 2021 14:52:10 GMT
+  recorded_at: Tue, 08 Jun 2021 11:08:31 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/foo_project:PR-3/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-3/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
     body:
       encoding: UTF-8
       string: ''
@@ -783,21 +823,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '316'
+      - '337'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="a0d72042ee79fe895171985ff6fbb3d5">
-          <old project="foo_project:PR-3" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="foo_project:PR-3" package="bar_package" rev="6" srcmd5="e07b5fd94863ea26ce05c0b124bcae74"/>
+        <sourcediff key="1f389afdb156a19f2243f3b95c31980e">
+          <old project="home:Iggy:foo_project:PR-3" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="home:Iggy:foo_project:PR-3" package="bar_package" rev="12" srcmd5="67a0517f75eff575d1655f2cd82e1ffc"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Wed, 26 May 2021 14:52:10 GMT
+  recorded_at: Tue, 08 Jun 2021 11:08:31 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/foo_project:PR-3/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-3/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
     body:
       encoding: UTF-8
       string: ''
@@ -822,21 +862,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '373'
+      - '383'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="13529b112b17b33086a1aad4f3dae7ef">
-          <old project="foo_project" package="bar_package" rev="b5092fe38335226905e10d575d6aceb6" srcmd5="b5092fe38335226905e10d575d6aceb6"/>
-          <new project="foo_project:PR-3" package="bar_package" rev="e6dcd7e3299281b74b28b80741ed9a99" srcmd5="e6dcd7e3299281b74b28b80741ed9a99"/>
+        <sourcediff key="3a2e222a0525aecf039282fec93228fd">
+          <old project="foo_project" package="bar_package" rev="ab5fce380bec1979e3cc527a027667d9" srcmd5="ab5fce380bec1979e3cc527a027667d9"/>
+          <new project="home:Iggy:foo_project:PR-3" package="bar_package" rev="e84d152be69b1bc38c76205f83aca357" srcmd5="e84d152be69b1bc38c76205f83aca357"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Wed, 26 May 2021 14:52:10 GMT
+  recorded_at: Tue, 08 Jun 2021 11:08:31 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/foo_project:PR-3/bar_package/_branch_request
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-3/bar_package/_branch_request
     body:
       encoding: US-ASCII
       string: ''
@@ -863,5 +903,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"object_kind":null,"project":{"http_url":null},"object_attributes":{"source":{"default_branch":null}}}'
-  recorded_at: Wed, 26 May 2021 14:52:10 GMT
+  recorded_at: Tue, 08 Jun 2021 11:08:31 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/models/token/workflow_spec.rb
+++ b/src/api/spec/models/token/workflow_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Token::Workflow, vcr: true do
-  let(:token_user) { create(:confirmed_user, login: 'Iggy') }
+  let(:token_user) { create(:confirmed_user, :with_home, login: 'Iggy') }
   let(:workflow_token) { create(:workflow_token, user: token_user) }
   let(:github_payload) do
     {

--- a/src/api/spec/models/workflow/step/branch_package_step_spec.rb
+++ b/src/api/spec/models/workflow/step/branch_package_step_spec.rb
@@ -1,7 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe Workflow::Step::BranchPackageStep, vcr: true do
-  let(:user) { create(:confirmed_user, login: 'Iggy') }
+  let!(:user) { create(:confirmed_user, :with_home, login: 'Iggy') }
+
+  before do
+    allow(User).to receive(:session!).and_return(user)
+  end
 
   subject do
     described_class.new(step_instructions: step_instructions,


### PR DESCRIPTION
As requested, namespace `target_project` under `home:$USER` 

At least for testing, to create the home project was necessary.

To test, I'm setting the `User.session!` to `user`, however this information should come from `token.user`

 
TODO:
- [x] check dependency on home project
- [ ] pass `token.user` to the `BranchPackageStep.call` method
https://trello.com/c/F014licj/1688-place-the-branched-package-under-home
