### PR TITLE
Refactor Token::Workflow model and add exception

### DIFF
--- a/src/api/app/models/token/workflow.rb
+++ b/src/api/app/models/token/workflow.rb
@@ -7,16 +7,31 @@ class Token::Workflow < Token
     extractor = TriggerControllerService::ScmExtractor.new(options[:scm], options[:event], options[:payload])
     return unless extractor.allowed_event_and_action?
 
-    scm_extractor_payload = extractor.call # returns { scm: 'github', repo_url: 'http://...' }
+    scm_extractor_payload = extractor.call
     yaml_file = Workflows::YAMLDownloader.new(scm_extractor_payload).call
     workflows = Workflows::YAMLToWorkflowsService.new(yaml_file: yaml_file, scm_extractor_payload: scm_extractor_payload).call
-    step = workflows.first.steps.first
-    package_from_step = if step && step.valid?
-                          step.call
-                        else
-                          raise 'Invalid workflow step definition'
-                        end
 
+    workflows.each do |workflow|
+      workflow.steps.each do |step|
+        run_step_and_report(step, scm_extractor_payload, scm_token)
+      end
+    end
+  end
+
+  private
+
+  def run_step_and_report(step, scm_extractor_payload, scm_token)
+    raise 'Invalid workflow step definition' unless step.valid?
+
+    package_from_step = step.call
+
+    raise "We couldn't branch your package" unless package_from_step
+
+    set_subscription(package_from_step, scm_extractor_payload)
+    SCMStatusReporter.new(scm_extractor_payload, scm_token).call
+  end
+
+  def set_subscription(package_from_step, scm_extractor_payload)
     ['Event::BuildFail', 'Event::BuildSuccess'].each do |build_event|
       # TODO: Deal with old EventSubscription (this can happen when someone pushes a new commit to a PR/branch, then we only want to report to the latest commit)
       EventSubscription.create!(eventtype: build_event,
@@ -28,8 +43,6 @@ class Token::Workflow < Token
                                 package: package_from_step,
                                 payload: scm_extractor_payload)
     end
-
-    SCMStatusReporter.new(scm_extractor_payload, scm_token).call
   end
 end
 

--- a/src/api/spec/support/files/invalid_steps_workflows.yml
+++ b/src/api/spec/support/files/invalid_steps_workflows.yml
@@ -1,5 +1,5 @@
 workflow123:
   steps:
-    - invalid_step:
-        source_project: "test-project"
-        source_package: "test-package"
+    - branch_package:
+        source_project:
+        source_package:


### PR DESCRIPTION
Right now we have only one workflow and one or zero steps in it. But in the near future will need to loop over many of them.
Starting looping already will save us to check if the step exists. It usually happens when the incoming event is one that we don't want to handle. So, in this case, we just ignore it and do nothing.

From now on, an exception is raised when OBS isn't able to branch the package for any reason.