### PR TITLE
[backend] forward and log X-Request-ID headers

### DIFF
--- a/src/backend/BSRPC.pm
+++ b/src/backend/BSRPC.pm
@@ -35,6 +35,7 @@ use strict;
 our $useragent = 'BSRPC 0.9.1';
 our $noproxy;
 our $logtimeout;
+our $autoheaders;
 
 my %hostlookupcache;
 my %cookiestore;	# our session store to keep iChain fast
@@ -89,6 +90,14 @@ sub useproxy {
     return 0 if ".$host" =~ /\Q$_\E$/s;
   }
   return 1;
+}
+
+sub addautoheaders {
+  my ($hdrs, $aheaders) = @_;
+  for (@{$aheaders || $autoheaders || []}) {
+    my $k = (split(':', $_, 2))[0];
+    push @$hdrs, $_ unless grep {/^\Q$k\E:/i} @$hdrs;
+  }
 }
 
 sub createreq {
@@ -277,6 +286,7 @@ sub rpc {
   }
   my $uri = createuri($param, @args);
   my $proxy = $param->{'proxy'};
+  addautoheaders(\@xhdrs);
   my ($proto, $host, $port, $req, $proxytunnel) = createreq($param, $uri, $proxy, \%cookiestore, @xhdrs);
   if ($proto eq 'https' || $proxytunnel) {
     die("https not supported\n") unless $tossl || $param->{'https'};

--- a/src/backend/BSWatcher.pm
+++ b/src/backend/BSWatcher.pm
@@ -1157,6 +1157,7 @@ sub rpc {
     my $auth = $param->{'authenticator'}->($param);
     push @xhdrs, "Authorization: $auth" if $auth;
   }
+  BSRPC::addautoheaders(\@xhdrs, $jev->{'autoheaders'} || []);
 
   my $proxy = $param->{'proxy'};
   my ($proto, $host, $port, $req, $proxytunnel) = BSRPC::createreq($param, $uri, $proxy, \%cookiestore, @xhdrs);

--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -2129,6 +2129,7 @@ sub notify_jobresult {
   $buildtype = $1 if $info->{'file'} =~ /\.(spec|dsc|kiwi|livebuild)$/;
   $buildtype ||= Build::recipe2buildtype($info->{'file'}) || 'unknown';
   $buildtype = $info->{'imagetype'} && ($info->{'imagetype'}->[0] || '') eq 'product' ? 'kiwi-product' : 'kiwi-image' if $buildtype eq 'kiwi';
+  $ninfo{'buildtype'} = $buildtype;
   print "job statistics: $job $prpa $jobstatus->{'result'} $ninfo{'readytime'}-$ninfo{'starttime'}-$ninfo{'endtime'} $jobstatus->{'workerid'} $buildtype\n";
   if ($jobstatus->{'result'} eq 'unchanged') {
     BSNotify::notify('BUILD_UNCHANGED', \%ninfo);


### PR DESCRIPTION
This allows us to track the origin of requests more easily.
The api was changed to set this header in commit
863e09b8d2e2e88ddd953e201ce84230b84ea44a.

_Replace this line with a description of your changes. Please follow the suggestions in the comment below._

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
