### PR TITLE
Create/Update event subscriptions in Workflow::Step::BranchPackageStep

### DIFF
--- a/src/api/app/models/token/workflow.rb
+++ b/src/api/app/models/token/workflow.rb
@@ -9,7 +9,7 @@ class Token::Workflow < Token
 
     scm_extractor_payload = extractor.call
     yaml_file = Workflows::YAMLDownloader.new(scm_extractor_payload).call
-    workflows = Workflows::YAMLToWorkflowsService.new(yaml_file: yaml_file, scm_extractor_payload: scm_extractor_payload).call
+    workflows = Workflows::YAMLToWorkflowsService.new(yaml_file: yaml_file, scm_extractor_payload: scm_extractor_payload, token: self).call
 
     workflows.each do |workflow|
       workflow.steps.each do |step|

--- a/src/api/app/models/workflow.rb
+++ b/src/api/app/models/workflow.rb
@@ -1,9 +1,10 @@
 class Workflow
   SUPPORTED_STEPS = { 'branch_package' => Workflow::Step::BranchPackageStep }.freeze
 
-  def initialize(workflow:, scm_extractor_payload:)
+  def initialize(workflow:, scm_extractor_payload:, token:)
     @workflow = workflow
     @scm_extractor_payload = scm_extractor_payload
+    @token = token
   end
 
   def steps
@@ -14,7 +15,7 @@ class Workflow
       step.each do |step_name, step_instructions|
         next if SUPPORTED_STEPS[step_name].blank?
 
-        new_step = SUPPORTED_STEPS[step_name].new(step_instructions: step_instructions, scm_extractor_payload: @scm_extractor_payload)
+        new_step = SUPPORTED_STEPS[step_name].new(step_instructions: step_instructions, scm_extractor_payload: @scm_extractor_payload, token: @token)
         steps << new_step if new_step.allowed_event_and_action?
       end
     end

--- a/src/api/app/models/workflow/step/branch_package_step.rb
+++ b/src/api/app/models/workflow/step/branch_package_step.rb
@@ -59,7 +59,7 @@ class Workflow
         options = { use_source: false, follow_project_links: true, follow_multibuild: true }
         src_package = Package.get_by_project_and_name(source_project, source_package, options)
 
-        raise Pundit::NotAuthorizedError unless PackagePolicy.new(User.session, src_package).create_branch?
+        raise Pundit::NotAuthorizedError unless PackagePolicy.new(@token.user, src_package).create_branch?
       end
 
       def branch
@@ -72,7 +72,7 @@ class Workflow
         Event::BranchCommand.create(project: source_project, package: source_package,
                                     targetproject: target_project,
                                     targetpackage: target_package,
-                                    user: User.session.login)
+                                    user: @token.user.login)
 
         Package.find_by_project_and_name(target_project, target_package)
       rescue BranchPackage::DoubleBranchPackageError, CreateProjectNoPermission,
@@ -127,7 +127,7 @@ class Workflow
         ['Event::BuildFail', 'Event::BuildSuccess'].each do |build_event|
           subscription = EventSubscription.first_or_create!(eventtype: build_event,
                                                             receiver_role: 'reader', # We pass a valid value, but we don't need this.
-                                                            user: User.session.login,
+                                                            user: @token.user,
                                                             channel: 'scm',
                                                             enabled: true,
                                                             token: @token,

--- a/src/api/app/models/workflow/step/branch_package_step.rb
+++ b/src/api/app/models/workflow/step/branch_package_step.rb
@@ -1,3 +1,5 @@
+# rubocop:disable Metrics/ClassLength
+# This class will be refactored to use a ActiveModel::Validator
 class Workflow
   module Step
     class BranchPackageStep
@@ -138,3 +140,4 @@ class Workflow
     end
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/src/api/app/services/workflows/yaml_to_workflows_service.rb
+++ b/src/api/app/services/workflows/yaml_to_workflows_service.rb
@@ -1,8 +1,9 @@
 module Workflows
   class YAMLToWorkflowsService
-    def initialize(yaml_file:, scm_extractor_payload:)
+    def initialize(yaml_file:, scm_extractor_payload:, token:)
       @yaml_file = yaml_file
       @scm_extractor_payload = scm_extractor_payload
+      @token = token
     end
 
     def call
@@ -16,7 +17,7 @@ module Workflows
       workflows = []
 
       parsed_workflows_yaml.each do |_workflow_name, workflow|
-        workflows << Workflow.new(workflow: workflow, scm_extractor_payload: @scm_extractor_payload)
+        workflows << Workflow.new(workflow: workflow, scm_extractor_payload: @scm_extractor_payload, token: @token)
       end
       workflows
     end

--- a/src/api/spec/models/workflow/step/branch_package_step_spec.rb
+++ b/src/api/spec/models/workflow/step/branch_package_step_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe Workflow::Step::BranchPackageStep, vcr: true do
 
   subject do
     described_class.new(step_instructions: step_instructions,
-                        scm_extractor_payload: scm_extractor_payload)
+                        scm_extractor_payload: scm_extractor_payload,
+                        token: create(:workflow_token))
   end
 
   describe '#allowed_event_and_action?' do

--- a/src/api/spec/models/workflow_spec.rb
+++ b/src/api/spec/models/workflow_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Workflow, type: :model do
   end
 
   subject do
-    described_class.new(workflow: yaml, scm_extractor_payload: github_extractor_payload)
+    described_class.new(workflow: yaml, scm_extractor_payload: github_extractor_payload, token: create(:workflow_token))
   end
 
   describe 'steps' do

--- a/src/api/spec/services/workflows/yaml_to_workflows_service_spec.rb
+++ b/src/api/spec/services/workflows/yaml_to_workflows_service_spec.rb
@@ -3,18 +3,19 @@ require 'rails_helper'
 RSpec.describe Workflows::YAMLToWorkflowsService, type: :service do
   include_context 'a scm payload hash'
   let(:workflows_yml_file) { File.expand_path(Rails.root.join('spec/support/files/workflows.yml')) }
+  let(:token) { create(:workflow_token) }
 
   describe '#call' do
     context 'with webhook payload from gitlab' do
       it 'initializes a workflow object' do
-        service = Workflows::YAMLToWorkflowsService.new(yaml_file: workflows_yml_file, scm_extractor_payload: gitlab_extractor_payload)
+        service = Workflows::YAMLToWorkflowsService.new(yaml_file: workflows_yml_file, scm_extractor_payload: gitlab_extractor_payload, token: token)
         expect(service.call.first).to be_a(Workflow)
       end
     end
 
     context 'with webhook payload from github' do
       it 'initializes a workflow object' do
-        service = Workflows::YAMLToWorkflowsService.new(yaml_file: workflows_yml_file, scm_extractor_payload: github_extractor_payload)
+        service = Workflows::YAMLToWorkflowsService.new(yaml_file: workflows_yml_file, scm_extractor_payload: github_extractor_payload, token: token)
         expect(service.call.first).to be_a(Workflow)
       end
     end


### PR DESCRIPTION
It belongs in this class since we only want to report back to SCMs whenever we branch a package. A workflow without this step won't report to the SCM. At least, not for now.