### PR TITLE
Remove distro hashing

### DIFF
--- a/src/api/app/controllers/distributions_controller.rb
+++ b/src/api/app/controllers/distributions_controller.rb
@@ -46,6 +46,8 @@ class DistributionsController < ApplicationController
   # PATCH/PUT /distributions/1234
   def update
     distribution = Distribution.find(params[:id])
+    # We don't allow updating remote distributions
+    distribution.readonly! if distribution.remote
 
     if distribution.update_from_xmlhash(@body_xml)
       render_ok
@@ -58,6 +60,8 @@ class DistributionsController < ApplicationController
   # DELETE /distributions/1234
   def destroy
     distribution = Distribution.find(params[:id])
+    # We don't allow deleting remote distributions
+    distribution.readonly! if distribution.remote
     distribution.destroy
 
     render_ok

--- a/src/api/app/controllers/distributions_controller.rb
+++ b/src/api/app/controllers/distributions_controller.rb
@@ -13,7 +13,7 @@ class DistributionsController < ApplicationController
 
   # GET /distributions
   def index
-    @distributions = Distribution.all_as_hash
+    @distributions = Distribution.local
 
     respond_to do |format|
       format.xml
@@ -23,7 +23,7 @@ class DistributionsController < ApplicationController
 
   # GET /distributions/1234
   def show
-    @distribution = Distribution.find(params[:id]).to_hash
+    @distribution = Distribution.find(params[:id])
 
     respond_to do |format|
       format.xml
@@ -69,7 +69,7 @@ class DistributionsController < ApplicationController
 
   # GET /distributions/include_remotes
   def include_remotes
-    @distributions = Distribution.all_including_remotes
+    @distributions = Distribution.all
 
     respond_to do |format|
       format.xml { render :index }
@@ -96,7 +96,7 @@ class DistributionsController < ApplicationController
       render_error message: 'No distributions found in body',
                    status: 400, errorcode: 'invalid_distributions'
     else
-      Distribution.where(remote: false).destroy_all
+      Distribution.local.destroy_all
       distributions.map(&:save!)
       render_ok
     end

--- a/src/api/app/controllers/public_controller.rb
+++ b/src/api/app/controllers/public_controller.rb
@@ -109,7 +109,7 @@ class PublicController < ApplicationController
 
   # GET /public/distributions
   def distributions
-    @distributions = Distribution.all_as_hash
+    @distributions = Distribution.local
 
     render 'distributions/index'
   end

--- a/src/api/app/controllers/webui/interconnects_controller.rb
+++ b/src/api/app/controllers/webui/interconnects_controller.rb
@@ -7,6 +7,8 @@ class Webui::InterconnectsController < Webui::WebuiController
     respond_to do |format|
       if @project.valid? && @project.store
         logger.debug "New remote project with url #{@project.remoteurl}"
+        # Schedule a distribution refresh
+        FetchRemoteDistributionsJob.perform_later
         message = "Project '#{@project}' was successfully created."
         format.html do
           flash[:success] = message

--- a/src/api/app/controllers/webui/repositories_controller.rb
+++ b/src/api/app/controllers/webui/repositories_controller.rb
@@ -29,12 +29,15 @@ class Webui::RepositoriesController < Webui::WebuiController
 
   # GET project/add_repository_from_default_list/:project
   def distributions
-    @distributions = Distribution.all_including_remotes.group_by { |e| e['vendor'] }
+    @distributions = Distribution.all.group_by(&:vendor)
     return if @distributions.present?
-    redirect_to(action: 'new', project: @project) && return unless User.admin_session?
 
-    redirect_to(new_interconnect_path,
-                alert: 'There are no distributions configured. Maybe you want to connect to one of the public OBS instances?')
+    if User.admin_session?
+      redirect_to(new_interconnect_path,
+                  alert: 'There are no distributions configured. Maybe you want to connect to one of the public OBS instances?')
+    else
+      redirect_to(action: 'new', project: @project)
+    end
   end
 
   # POST project/save_repository

--- a/src/api/app/jobs/fetch_remote_distributions_job.rb
+++ b/src/api/app/jobs/fetch_remote_distributions_job.rb
@@ -1,0 +1,36 @@
+class FetchRemoteDistributionsJob < ApplicationJob
+  def perform
+    Project.remote.each do |project|
+      distributions_xml = Project::RemoteURL.load(project, '/distributions.xml')
+
+      # don't let broken remote instances break us
+      if Xmlhash.parse(distributions_xml.to_s).blank?
+        Distribution.remote.for_project(project.name).destroy_all
+      else
+        Suse::Validator.validate('distributions', distributions_xml)
+        distributions_xmlhash = Xmlhash.parse(distributions_xml)
+        bulk_replace(project: project.name, distributions_xmlhash: distributions_xmlhash)
+      end
+    end
+  end
+
+  private
+
+  def bulk_replace(project: nil, distributions_xmlhash: Xmlhash.new)
+    errors = []
+    distributions = []
+
+    distributions_xmlhash.elements('distribution') do |distribution_xmlhash|
+      distribution = Distribution.new_from_xmlhash(distribution_xmlhash)
+      distribution.project = "#{project}:#{distribution.project}"
+      distribution.remote = true
+      distributions << distribution
+      errors << distributions.errors unless distribution.valid?
+    end
+
+    raise "#{errors.map(&:full_messages)}" if errors.any? || distributions.empty?
+
+    Distribution.remote.for_project(project).destroy_all
+    distributions.map(&:save!)
+  end
+end

--- a/src/api/app/models/distribution.rb
+++ b/src/api/app/models/distribution.rb
@@ -4,6 +4,10 @@ class Distribution < ApplicationRecord
   has_and_belongs_to_many :icons, -> { distinct }, class_name: 'DistributionIcon'
   has_and_belongs_to_many :architectures, -> { distinct }, class_name: 'Architecture'
 
+  scope :local, -> { where(remote: false) }
+  scope :remote, -> { where(remote: true) }
+  scope :for_project, ->(project_name) { where('project like ?', project_name + ':%') }
+
   def self.new_from_xmlhash(xmlhash)
     return new unless xmlhash.is_a?(Xmlhash::XMLHash)
 

--- a/src/api/app/views/distributions/_distribution.xml.builder
+++ b/src/api/app/views/distributions/_distribution.xml.builder
@@ -1,16 +1,16 @@
-builder.distribution(vendor: distribution['vendor'], version: distribution['version'], id: distribution['id']) do
-  builder.name(distribution['name'])
-  builder.project(distribution['project'])
-  builder.reponame(distribution['reponame'])
-  builder.repository(distribution['repository'])
-  builder.link(distribution['link'])
-  distribution['icons'].each do |i|
-    attr = { url: i['url'] }
-    attr[:width] = i['width'] if i['width'].present?
-    attr[:height] = i['height'] if i['height'].present?
+builder.distribution(vendor: distribution.vendor, version: distribution.version, id: distribution.id) do
+  builder.name(distribution.name)
+  builder.project(distribution.project)
+  builder.reponame(distribution.reponame)
+  builder.repository(distribution.repository)
+  builder.link(distribution.link)
+  distribution.icons.each do |icon|
+    attr = { url: icon.url }
+    attr[:width] = icon.width if icon.width.present?
+    attr[:height] = icon.height if icon.height.present?
     builder.icon(attr)
   end
-  distribution['architectures'].each do |architecture|
-    builder.architecture(architecture.to_s)
+  distribution.architectures.each do |architecture|
+    builder.architecture(architecture.name)
   end
 end

--- a/src/api/app/views/webui/repositories/distributions.html.haml
+++ b/src/api/app/views/webui/repositories/distributions.html.haml
@@ -13,26 +13,26 @@
       .form-group.pl-3
         -# rubocop:disable Style/CombinableLoops
         - list.each do |distribution|
-          - selected = @project.has_distribution(distribution['project'], distribution['repository'])
+          - selected = @project.has_distribution(distribution.project, distribution.repository)
           .custom-control.custom-checkbox.custom-control-inline
-            = check_box_tag 'distributions[]', distribution['reponame'], selected,
-                                               id: "repo_#{replace_jquery_meta_characters(distribution['reponame'])}",
+            = check_box_tag 'distributions[]', distribution.reponame, selected,
+                                               id: "repo_#{replace_jquery_meta_characters(distribution.reponame)}",
                                                class: 'repocheckbox custom-control-input'
-            = label_tag :distribution_name, for: "repo_#{replace_jquery_meta_characters(distribution['reponame'])}", class: 'custom-control-label' do
-              = distribution['name']
+            = label_tag :distribution_name, for: "repo_#{replace_jquery_meta_characters(distribution.reponame)}", class: 'custom-control-label' do
+              = distribution.name
         - list.each do |distribution|
           = form_tag({ action: :create, project: @project }, remote: true, class: 'd-none',
-                                                             id: "repo_#{replace_jquery_meta_characters(distribution['reponame'])}_create") do
-            = hidden_field_tag 'repository', distribution['reponame']
-            = hidden_field_tag 'target_project', distribution['project']
-            = hidden_field_tag 'target_repo', distribution['repository']
-            - distribution['architectures'].each do |arch|
+                                                             id: "repo_#{replace_jquery_meta_characters(distribution.reponame)}_create") do
+            = hidden_field_tag 'repository', distribution.reponame
+            = hidden_field_tag 'target_project', distribution.project
+            = hidden_field_tag 'target_repo', distribution.repository
+            - distribution.architectures.each do |arch|
               = hidden_field_tag 'architectures[]', arch
 
           = form_tag({ action: :destroy }, remote: true, class: 'd-none',
-                                           id: "repo_#{replace_jquery_meta_characters(distribution['reponame'])}_destroy") do
+                                           id: "repo_#{replace_jquery_meta_characters(distribution.reponame)}_destroy") do
             = hidden_field_tag 'project', @project.name
-            = hidden_field_tag 'target', distribution['reponame']
+            = hidden_field_tag 'target', distribution.reponame
         -# rubocop:enable Style/CombinableLoops
     %h6
       = image_tag('distributions/kiwi.svg')

--- a/src/api/config/clock.rb
+++ b/src/api/config/clock.rb
@@ -48,6 +48,10 @@ module Clockwork
     BsRequest.delayed_auto_accept
   end
 
+  every(1.hour, 'refresh remote distros') do
+    FetchRemoteDistributionsJob.perform_later
+  end
+
   every(1.day, 'optimize history', thread: true, at: '05:00') do
     ActiveRecord::Base.connection_pool.with_connection do |sql|
       sql.execute('optimize table status_histories;')

--- a/src/api/spec/cassettes/Interconnects/creating_custom_interconnect.yml
+++ b/src/api/spec/cassettes/Interconnects/creating_custom_interconnect.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://backend:5352/build/custom_packman/_result?code=unresolvable&view=status
+    uri: https://pmbs-api.links2linux.de/public/distributions.xml
     body:
       encoding: US-ASCII
       string: ''
@@ -18,6 +18,69 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      Date:
+      - Tue, 08 Jun 2021 14:16:32 GMT
+      Server:
+      - Apache/2.4.43 (Linux/SUSE)
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      - public
+      Vary:
+      - Accept-Encoding
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Opensuse-Runtimes:
+      - '{"view":0.38410117849707603,"db":0.5667409859597683,"backend":0}'
+      X-Request-Id:
+      - 63499eb8-f823-4759-be08-06cd8572bdd4
+      X-Opensuse-Apiversion:
+      - 2.10.10
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Runtime:
+      - '0.004311'
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Phusion Passenger 6.0.7
+      Etag:
+      - W/"3b4f25197b32d45e6f04f017f956bb09"
+      Status:
+      - 200 OK
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/xml; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: "<distributions/>\n"
+  recorded_at: Tue, 08 Jun 2021 14:16:32 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/custom_packman/_result?code=unresolvable&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 9e2fcb9a-ce1d-4a47-9b15-22f446dc2eb5
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'custom_packman' does not exist
+    headers:
       Content-Type:
       - text/xml
       Cache-Control:
@@ -25,14 +88,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '56'
+      - '156'
     body:
       encoding: UTF-8
-      string: '<resultlist state="00000000000000000000000000000000" />
-
-'
-    http_version: 
-  recorded_at: Wed, 06 Mar 2019 13:14:48 GMT
+      string: |
+        <status code="404">
+          <summary>project 'custom_packman' does not exist</summary>
+          <details>404 project 'custom_packman' does not exist</details>
+        </status>
+  recorded_at: Tue, 08 Jun 2021 14:16:32 GMT
 - request:
     method: get
     uri: http://backend:5352/build/custom_packman/_result?view=summary
@@ -40,6 +104,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - e9777282-cef6-4c4f-aa4a-9a553e0c33c0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -48,8 +114,8 @@ http_interactions:
       - Ruby
   response:
     status:
-      code: 200
-      message: OK
+      code: 404
+      message: project 'custom_packman' does not exist
     headers:
       Content-Type:
       - text/xml
@@ -58,12 +124,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '56'
+      - '156'
     body:
       encoding: UTF-8
-      string: '<resultlist state="00000000000000000000000000000000" />
-
-'
-    http_version: 
-  recorded_at: Wed, 06 Mar 2019 13:14:50 GMT
-recorded_with: VCR 4.0.0
+      string: |
+        <status code="404">
+          <summary>project 'custom_packman' does not exist</summary>
+          <details>404 project 'custom_packman' does not exist</details>
+        </status>
+  recorded_at: Tue, 08 Jun 2021 14:16:32 GMT
+recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Interconnects/creating_openSUSE_org_interconnect.yml
+++ b/src/api/spec/cassettes/Interconnects/creating_openSUSE_org_interconnect.yml
@@ -1,0 +1,725 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.opensuse.org/public/distributions.xml
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 08 Jun 2021 14:08:10 GMT
+      Server:
+      - Apache/2.4.33 (Linux/SUSE)
+      Strict-Transport-Security:
+      - max-age=31536000
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Vary:
+      - Accept-Encoding
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Opensuse-Runtimes:
+      - '{"view":22.576807998120785,"db":11.108079925179482,"backend":0}'
+      X-Request-Id:
+      - 35dbc7e6-7816-43fb-aaf3-16d7ae2d19da
+      X-Opensuse-Apiversion:
+      - 2.11~alpha.20210608T091701.79aaf33c2f
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Runtime:
+      - '0.076792'
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Phusion Passenger 6.0.7
+      Etag:
+      - W/"b14ae4eb3a91cfffc7d4fd0bf614e280"
+      Status:
+      - 200 OK
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <distributions>
+          <distribution vendor="openEuler" version="20.03" id="18648">
+            <name>openEuler 20.03</name>
+            <project>openEuler:20.03</project>
+            <reponame>openEuler_20.03</reponame>
+            <repository>standard</repository>
+            <link>http://www.openeuler.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/openeuler.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/openeuler.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+            <architecture>aarch64</architecture>
+          </distribution>
+          <distribution vendor="openEuler" version="21.03" id="18651">
+            <name>openEuler 21.03</name>
+            <project>openEuler:21.03</project>
+            <reponame>openEuler_21.03</reponame>
+            <repository>standard</repository>
+            <link>http://www.openeuler.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/openeuler.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/openeuler.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+            <architecture>aarch64</architecture>
+          </distribution>
+          <distribution vendor="openSUSE" version="Tumbleweed" id="18654">
+            <name>openSUSE Tumbleweed</name>
+            <project>openSUSE:Factory</project>
+            <reponame>openSUSE_Tumbleweed</reponame>
+            <repository>snapshot</repository>
+            <link>http://www.opensuse.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="16" height="16"/>
+            <architecture>i586</architecture>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="openSUSE" version="15.3" id="18657">
+            <name>openSUSE Leap 15.3</name>
+            <project>openSUSE:Leap:15.3</project>
+            <reponame>openSUSE_Leap_15.3</reponame>
+            <repository>standard</repository>
+            <link>http://www.opensuse.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="openSUSE" version="15.2" id="18660">
+            <name>openSUSE Leap 15.2</name>
+            <project>openSUSE:Leap:15.2</project>
+            <reponame>openSUSE_Leap_15.2</reponame>
+            <repository>standard</repository>
+            <link>http://www.opensuse.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="openSUSE" version="15.2 ARM" id="18663">
+            <name>openSUSE Leap 15.2 ARM</name>
+            <project>openSUSE:Leap:15.2:ARM</project>
+            <reponame>openSUSE_Leap_15.2_ARM</reponame>
+            <repository>ports</repository>
+            <link>http://www.opensuse.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="16" height="16"/>
+            <architecture>aarch64</architecture>
+            <architecture>armv7l</architecture>
+          </distribution>
+          <distribution vendor="openSUSE" version="15.2 PowerPC" id="18666">
+            <name>openSUSE Leap 15.2 PowerPC</name>
+            <project>openSUSE:Leap:15.2:PowerPC</project>
+            <reponame>openSUSE_Leap_15.2_PowerPC</reponame>
+            <repository>ports</repository>
+            <link>http://www.opensuse.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="16" height="16"/>
+            <architecture>ppc64le</architecture>
+          </distribution>
+          <distribution vendor="openSUSE" version="FactoryRISCV" id="18669">
+            <name>openSUSE Factory RISCV</name>
+            <project>openSUSE:Factory:RISCV</project>
+            <reponame>openSUSE_Factory_RISCV</reponame>
+            <repository>standard</repository>
+            <link>http://www.opensuse.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="16" height="16"/>
+            <architecture>riscv64</architecture>
+          </distribution>
+          <distribution vendor="openSUSE" version="FactoryARM" id="18672">
+            <name>openSUSE Factory ARM</name>
+            <project>openSUSE:Factory:ARM</project>
+            <reponame>openSUSE_Factory_ARM</reponame>
+            <repository>standard</repository>
+            <link>http://www.opensuse.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="16" height="16"/>
+            <architecture>armv7l</architecture>
+            <architecture>aarch64</architecture>
+          </distribution>
+          <distribution vendor="openSUSE" version="FactoryPPC" id="18675">
+            <name>openSUSE Factory PowerPC</name>
+            <project>openSUSE:Factory:PowerPC</project>
+            <reponame>openSUSE_Factory_PowerPC</reponame>
+            <repository>standard</repository>
+            <link>http://www.opensuse.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="16" height="16"/>
+            <architecture>ppc64</architecture>
+            <architecture>ppc64le</architecture>
+          </distribution>
+          <distribution vendor="openSUSE" version="FactoryzSystems" id="18678">
+            <name>openSUSE Factory zSystems</name>
+            <project>openSUSE:Factory:zSystems</project>
+            <reponame>openSUSE_Factory_zSystems</reponame>
+            <repository>standard</repository>
+            <link>http://www.opensuse.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="16" height="16"/>
+            <architecture>s390x</architecture>
+          </distribution>
+          <distribution vendor="openSUSE" version="SLE_15_SP3_Backports" id="18681">
+            <name>openSUSE Backports for SLE 15 SP3</name>
+            <project>openSUSE:Backports:SLE-15-SP3</project>
+            <reponame>SLE_15_SP3_Backports</reponame>
+            <repository>standard</repository>
+            <link>http://www.opensuse.org/</link>
+          </distribution>
+          <distribution vendor="openSUSE" version="SLE_15_SP2_Backports" id="18684">
+            <name>openSUSE Backports for SLE 15 SP2</name>
+            <project>openSUSE:Backports:SLE-15-SP2</project>
+            <reponame>SLE_15_SP2_Backports</reponame>
+            <repository>standard</repository>
+            <link>http://www.opensuse.org/</link>
+          </distribution>
+          <distribution vendor="openSUSE" version="SLE_15_SP1_Backports" id="18687">
+            <name>openSUSE Backports for SLE 15 SP1</name>
+            <project>openSUSE:Backports:SLE-15-SP1</project>
+            <reponame>SLE_15_SP1_Backports</reponame>
+            <repository>standard</repository>
+            <link>http://www.opensuse.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="openSUSE" version="SLE_15_Backports" id="18690">
+            <name>openSUSE Backports for SLE 15</name>
+            <project>openSUSE:Backports:SLE-15</project>
+            <reponame>SLE_15_Backports</reponame>
+            <repository>standard</repository>
+            <link>http://www.opensuse.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="openSUSE" version="SLE_12_SP5" id="18693">
+            <name>openSUSE Backports for SLE 12 SP5</name>
+            <project>openSUSE:Backports:SLE-12-SP5</project>
+            <reponame>SLE_12_SP5_Backports</reponame>
+            <repository>standard</repository>
+            <link>http://www.opensuse.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="openSUSE" version="SLE_12_SP4" id="18696">
+            <name>openSUSE Backports for SLE 12 SP4</name>
+            <project>openSUSE:Backports:SLE-12-SP4</project>
+            <reponame>SLE_12_SP4_Backports</reponame>
+            <repository>standard</repository>
+            <link>http://www.opensuse.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="openSUSE" version="SLE_12_SP3" id="18699">
+            <name>openSUSE Backports for SLE 12 SP3</name>
+            <project>openSUSE:Backports:SLE-12-SP3</project>
+            <reponame>SLE_12_SP3_Backports</reponame>
+            <repository>standard</repository>
+            <link>http://www.opensuse.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="openSUSE" version="SLE_12_SP2" id="18702">
+            <name>openSUSE Backports for SLE 12 SP2</name>
+            <project>openSUSE:Backports:SLE-12-SP2</project>
+            <reponame>SLE_12_SP2_Backports</reponame>
+            <repository>standard</repository>
+            <link>http://www.opensuse.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="openSUSE" version="SLE_12_SP1" id="18705">
+            <name>openSUSE Backports for SLE 12 SP1</name>
+            <project>openSUSE:Backports:SLE-12-SP1</project>
+            <reponame>SLE_12_SP1_Backports</reponame>
+            <repository>standard</repository>
+            <link>http://www.opensuse.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="openSUSE" version="SLE_12" id="18708">
+            <name>openSUSE Backports for SLE 12 SP0</name>
+            <project>openSUSE:Backports:SLE-12</project>
+            <reponame>SLE_12_Backports</reponame>
+            <repository>standard</repository>
+            <link>http://www.opensuse.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="SUSE Linux Enterprise" version="SLE-15-SP3" id="18711">
+            <name>SUSE SLE-15-SP3</name>
+            <project>SUSE:SLE-15-SP3:GA</project>
+            <reponame>SLE_15_SP3</reponame>
+            <repository>standard</repository>
+            <link>http://www.suse.com/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/suse.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/suse.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="SUSE Linux Enterprise" version="SLE-15-SP2" id="18714">
+            <name>SUSE SLE-15-SP2</name>
+            <project>SUSE:SLE-15-SP2:GA</project>
+            <reponame>SLE_15_SP2</reponame>
+            <repository>standard</repository>
+            <link>http://www.suse.com/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/suse.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/suse.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="SUSE Linux Enterprise" version="SLE-15-SP1" id="18717">
+            <name>SUSE SLE-15-SP1</name>
+            <project>SUSE:SLE-15-SP1:GA</project>
+            <reponame>SLE_15_SP1</reponame>
+            <repository>standard</repository>
+            <link>http://www.suse.com/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/suse.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/suse.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="SUSE Linux Enterprise" version="SLE-12-SP5" id="18720">
+            <name>SUSE SLE-12-SP5</name>
+            <project>SUSE:SLE-12-SP5:GA</project>
+            <reponame>SLE_12_SP5</reponame>
+            <repository>standard</repository>
+            <link>http://www.suse.com/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/suse.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/suse.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="SUSE Linux Enterprise" version="SLE-11-SP4" id="18723">
+            <name>SUSE SLE-11 SP 4</name>
+            <project>SUSE:SLE-11:SP4</project>
+            <reponame>SLE_11_SP4</reponame>
+            <repository>standard</repository>
+            <link>http://www.suse.com/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/suse.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/suse.png" width="16" height="16"/>
+            <architecture>i586</architecture>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Arch" version="1.0" id="18726">
+            <name>Arch Extra</name>
+            <project>Arch:Extra</project>
+            <reponame>Arch</reponame>
+            <repository>standard</repository>
+            <link>http://www.archlinux.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/arch.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/arch.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Arch" version="1.0" id="18729">
+            <name>Arch Community</name>
+            <project>Arch:Community</project>
+            <reponame>Arch</reponame>
+            <repository>standard</repository>
+            <link>http://www.archlinux.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/arch.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/arch.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Raspbian" version="10" id="18732">
+            <name>Raspbian 10</name>
+            <project>Raspbian:10</project>
+            <reponame>Raspbian_10</reponame>
+            <repository>standard</repository>
+            <link>http://www.raspbian.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/raspbian.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/raspbian.png" width="16" height="16"/>
+            <architecture>armv7l</architecture>
+          </distribution>
+          <distribution vendor="Raspbian" version="9.0" id="18735">
+            <name>Raspbian 9.0</name>
+            <project>Raspbian:9.0</project>
+            <reponame>Raspbian_9.0</reponame>
+            <repository>standard</repository>
+            <link>http://www.raspbian.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/raspbian.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/raspbian.png" width="16" height="16"/>
+            <architecture>armv7l</architecture>
+          </distribution>
+          <distribution vendor="Debian" version="Unstable" id="18738">
+            <name>Debian Unstable</name>
+            <project>Debian:Next</project>
+            <reponame>Debian_Unstable</reponame>
+            <repository>standard</repository>
+            <link>http://www.debian.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/debian.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/debian.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Debian" version="Testing" id="18741">
+            <name>Debian Testing</name>
+            <project>Debian:Testing</project>
+            <reponame>Debian_Testing</reponame>
+            <repository>update</repository>
+            <link>http://www.debian.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/debian.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/debian.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Debian" version="10" id="18744">
+            <name>Debian 10</name>
+            <project>Debian:10</project>
+            <reponame>Debian_10</reponame>
+            <repository>standard</repository>
+            <link>http://www.debian.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/debian.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/debian.png" width="16" height="16"/>
+            <architecture>i586</architecture>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Debian" version="9.0" id="18747">
+            <name>Debian 9.0</name>
+            <project>Debian:9.0</project>
+            <reponame>Debian_9.0</reponame>
+            <repository>standard</repository>
+            <link>http://www.debian.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/debian.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/debian.png" width="16" height="16"/>
+            <architecture>i586</architecture>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Fedora" version="Rawhide" id="18750">
+            <name>Fedora Rawhide (unstable)</name>
+            <project>Fedora:Rawhide</project>
+            <reponame>Fedora_Rawhide</reponame>
+            <repository>standard</repository>
+            <link>http://fedoraproject.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/fedora.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/fedora.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Fedora" version="34" id="18753">
+            <name>Fedora 34</name>
+            <project>Fedora:34</project>
+            <reponame>Fedora_34</reponame>
+            <repository>standard</repository>
+            <link>http://fedoraproject.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/fedora.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/fedora.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+            <architecture>armv7l</architecture>
+            <architecture>aarch64</architecture>
+            <architecture>ppc64le</architecture>
+          </distribution>
+          <distribution vendor="Fedora" version="33" id="18756">
+            <name>Fedora 33</name>
+            <project>Fedora:33</project>
+            <reponame>Fedora_33</reponame>
+            <repository>standard</repository>
+            <link>http://fedoraproject.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/fedora.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/fedora.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+            <architecture>armv7l</architecture>
+            <architecture>aarch64</architecture>
+            <architecture>ppc64le</architecture>
+          </distribution>
+          <distribution vendor="Fedora" version="32" id="18759">
+            <name>Fedora 32</name>
+            <project>Fedora:32</project>
+            <reponame>Fedora_32</reponame>
+            <repository>standard</repository>
+            <link>http://fedoraproject.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/fedora.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/fedora.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+            <architecture>armv7l</architecture>
+            <architecture>aarch64</architecture>
+            <architecture>ppc64le</architecture>
+          </distribution>
+          <distribution vendor="Fedora" version="31" id="18762">
+            <name>Fedora 31</name>
+            <project>Fedora:31</project>
+            <reponame>Fedora_31</reponame>
+            <repository>standard</repository>
+            <link>http://fedoraproject.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/fedora.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/fedora.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+            <architecture>armv7l</architecture>
+            <architecture>aarch64</architecture>
+            <architecture>ppc64le</architecture>
+          </distribution>
+          <distribution vendor="ScientificLinux" version="SL-7" id="18765">
+            <name>ScientificLinux 7</name>
+            <project>ScientificLinux:7</project>
+            <reponame>ScientificLinux_7</reponame>
+            <repository>standard</repository>
+            <link>http://www.ScientificLinux.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/scientificlinux.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/scientificlinux.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="ScientificLinux" version="SL-6" id="18768">
+            <name>ScientificLinux 6</name>
+            <project>ScientificLinux:6</project>
+            <reponame>ScientificLinux_6</reponame>
+            <repository>standard</repository>
+            <link>http://www.ScientificLinux.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/scientificlinux.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/scientificlinux.png" width="16" height="16"/>
+            <architecture>i586</architecture>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="RedHat" version="RHEL-7" id="18771">
+            <name>RedHat RHEL-7</name>
+            <project>RedHat:RHEL-7</project>
+            <reponame>RHEL_7</reponame>
+            <repository>standard</repository>
+            <link>http://www.redhat.com/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/redhat.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/redhat.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+            <architecture>ppc64</architecture>
+          </distribution>
+          <distribution vendor="RedHat" version="RHEL-6" id="18774">
+            <name>RedHat RHEL-6</name>
+            <project>RedHat:RHEL-6</project>
+            <reponame>RHEL_6</reponame>
+            <repository>standard</repository>
+            <link>http://www.redhat.com/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/redhat.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/redhat.png" width="16" height="16"/>
+            <architecture>i586</architecture>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="RedHat" version="RHEL-5" id="18777">
+            <name>RedHat RHEL-5</name>
+            <project>RedHat:RHEL-5</project>
+            <reponame>RHEL_5</reponame>
+            <repository>standard</repository>
+            <link>http://www.redhat.com/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/redhat.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/redhat.png" width="16" height="16"/>
+            <architecture>i586</architecture>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="CentOS" version="CentOS-8-Stream" id="18780">
+            <name>CentOS CentOS-8-Stream</name>
+            <project>CentOS:CentOS-8:Stream</project>
+            <reponame>CentOS_8_Stream</reponame>
+            <repository>standard</repository>
+            <link>http://www.centos.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/centos.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/centos.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="CentOS" version="CentOS-8" id="18783">
+            <name>CentOS CentOS-8</name>
+            <project>CentOS:CentOS-8</project>
+            <reponame>CentOS_8</reponame>
+            <repository>standard</repository>
+            <link>http://www.centos.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/centos.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/centos.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="CentOS" version="CentOS-7" id="18786">
+            <name>CentOS CentOS-7</name>
+            <project>CentOS:CentOS-7</project>
+            <reponame>CentOS_7</reponame>
+            <repository>standard</repository>
+            <link>http://www.centos.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/centos.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/centos.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Ubuntu" version="21.04" id="18789">
+            <name>Ubuntu 21.04</name>
+            <project>Ubuntu:21.04</project>
+            <reponame>xUbuntu_21.04</reponame>
+            <repository>universe</repository>
+            <link>http://www.ubuntu.com/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/ubuntu.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/ubuntu.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Ubuntu" version="20.10" id="18792">
+            <name>Ubuntu 20.10</name>
+            <project>Ubuntu:20.10</project>
+            <reponame>xUbuntu_20.10</reponame>
+            <repository>universe</repository>
+            <link>http://www.ubuntu.com/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/ubuntu.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/ubuntu.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Ubuntu" version="20.04" id="18795">
+            <name>Ubuntu 20.04</name>
+            <project>Ubuntu:20.04</project>
+            <reponame>xUbuntu_20.04</reponame>
+            <repository>universe</repository>
+            <link>http://www.ubuntu.com/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/ubuntu.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/ubuntu.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Ubuntu" version="18.04" id="18798">
+            <name>Ubuntu 18.04</name>
+            <project>Ubuntu:18.04</project>
+            <reponame>xUbuntu_18.04</reponame>
+            <repository>universe</repository>
+            <link>http://www.ubuntu.com/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/ubuntu.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/ubuntu.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Ubuntu" version="16.04" id="18801">
+            <name>Ubuntu 16.04</name>
+            <project>Ubuntu:16.04</project>
+            <reponame>xUbuntu_16.04</reponame>
+            <repository>universe</repository>
+            <link>http://www.ubuntu.com/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/ubuntu.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/ubuntu.png" width="16" height="16"/>
+            <architecture>i586</architecture>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Ubuntu" version="14.04" id="18804">
+            <name>Ubuntu 14.04</name>
+            <project>Ubuntu:14.04</project>
+            <reponame>xUbuntu_14.04</reponame>
+            <repository>standard</repository>
+            <link>http://www.ubuntu.com/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/ubuntu.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/ubuntu.png" width="16" height="16"/>
+            <architecture>i586</architecture>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Univention" version="4.4" id="18807">
+            <name>Univention UCS 4.4</name>
+            <project>Univention:4.4</project>
+            <reponame>Univention_4.4</reponame>
+            <repository>standard</repository>
+            <link>http://www.univention.com/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/univention.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/univention.png" width="16" height="16"/>
+            <architecture>i586</architecture>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Univention" version="4.3" id="18810">
+            <name>Univention UCS 4.3</name>
+            <project>Univention:4.3</project>
+            <reponame>Univention_4.3</reponame>
+            <repository>standard</repository>
+            <link>http://www.univention.com/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/univention.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/univention.png" width="16" height="16"/>
+            <architecture>i586</architecture>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Univention" version="4.2" id="18813">
+            <name>Univention UCS 4.2</name>
+            <project>Univention:4.2</project>
+            <reponame>Univention_4.2</reponame>
+            <repository>standard</repository>
+            <link>http://www.univention.com/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/univention.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/univention.png" width="16" height="16"/>
+            <architecture>i586</architecture>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Univention" version="4.1" id="18816">
+            <name>Univention UCS 4.1</name>
+            <project>Univention:4.1</project>
+            <reponame>Univention_4.1</reponame>
+            <repository>standard</repository>
+            <link>http://www.univention.com/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/univention.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/univention.png" width="16" height="16"/>
+            <architecture>i586</architecture>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Univention" version="4.0" id="18819">
+            <name>Univention UCS 4.0</name>
+            <project>Univention:4.0</project>
+            <reponame>Univention_4.0</reponame>
+            <repository>standard</repository>
+            <link>http://www.univention.com/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/univention.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/univention.png" width="16" height="16"/>
+            <architecture>i586</architecture>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Mageia" version="Cauldron" id="18822">
+            <name>Mageia Cauldron (unstable)</name>
+            <project>Mageia:Cauldron</project>
+            <reponame>Mageia_Cauldron</reponame>
+            <repository>standard</repository>
+            <link>http://www.mageia.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/mageia.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/mageia.png" width="16" height="16"/>
+            <architecture>i586</architecture>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Mageia" version="8" id="18825">
+            <name>Mageia 8</name>
+            <project>Mageia:8</project>
+            <reponame>Mageia_8</reponame>
+            <repository>standard</repository>
+            <link>http://www.mageia.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/mageia.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/mageia.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="Univention" version="3.2" id="18828">
+            <name>Univention UCS 3.2</name>
+            <project>Univention:3.2</project>
+            <reponame>Univention_3.2</reponame>
+            <repository>standard</repository>
+            <link>http://www.univention.com/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/univention.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/univention.png" width="16" height="16"/>
+            <architecture>i586</architecture>
+            <architecture>x86_64</architecture>
+          </distribution>
+          <distribution vendor="IBM" version="3.1" id="18831">
+            <name>IBM PowerKVM 3.1</name>
+            <project>IBM:PowerKVM:3.1</project>
+            <reponame>PowerKVM_3.1</reponame>
+            <repository>standard</repository>
+            <link>http://www-03.ibm.com/systems/power/software/linux/powerkvm/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/powerkvm.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/powerkvm.png" width="16" height="16"/>
+            <architecture>ppc64le</architecture>
+          </distribution>
+          <distribution vendor="Many" version="42.3" id="18834">
+            <name>AppImage</name>
+            <project>OBS:AppImage</project>
+            <reponame>AppImage</reponame>
+            <repository>AppImage</repository>
+            <link>http://www.appimage.org/</link>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="8" height="8"/>
+            <icon url="https://static.opensuse.org/distributions/logos/opensuse.png" width="16" height="16"/>
+            <architecture>x86_64</architecture>
+          </distribution>
+        </distributions>
+  recorded_at: Tue, 08 Jun 2021 14:08:10 GMT
+recorded_with: VCR 6.0.0

--- a/src/api/spec/controllers/public_controller_spec.rb
+++ b/src/api/spec/controllers/public_controller_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe PublicController, vcr: true do
     end
 
     it { expect(response).to have_http_status(:success) }
-    it { expect(assigns(:distributions)).to eq(Distribution.all_as_hash) }
+    it { expect(assigns(:distributions)).to eq(Distribution.local) }
   end
 
   describe 'GET #show_request' do


### PR DESCRIPTION
We render/display `Distribution`s from a hash because the `Distribution`s from the interconnect are from an XML.
This PR changes `Distribution`s to be fully based on records. Including the in-memory cache for `Distribution`s from remote.