### PR TITLE
Remove 'Workflows' and project from status_options

### DIFF
--- a/src/api/app/services/scm_status_reporter.rb
+++ b/src/api/app/services/scm_status_reporter.rb
@@ -35,7 +35,7 @@ class SCMStatusReporter
   end
 
   def status_options
-    { context: "OBS Workflow: #{@event_payload[:project]}/#{@event_payload[:package]} - #{@event_payload[:repository]}/#{@event_payload[:arch]}",
+    { context: "OBS: #{@event_payload[:package]} - #{@event_payload[:repository]}/#{@event_payload[:arch]}",
       target_url: Rails.application.routes.url_helpers.package_show_url(@event_payload[:project], @event_payload[:package], host: Configuration.obs_url) }
   end
 


### PR DESCRIPTION
This information is superfluous, so it can be removed.