### PR TITLE
Report build results of multibuild flavors to SCM

### DIFF
--- a/src/api/app/jobs/report_to_scm_job.rb
+++ b/src/api/app/jobs/report_to_scm_job.rb
@@ -11,7 +11,7 @@ class ReportToScmJob < CreateJob
     event_type = event.eventtype
     return false unless ALLOWED_EVENTS.include?(event_type)
 
-    event_package = Package.find_by_project_and_name(event.payload['project'], event.payload['package'])
+    event_package = Package.find_by_project_and_name(event.payload['project'], Package.striping_multibuild_suffix(event.payload['package']))
     return false if event_package.blank?
 
     EventSubscriptionsFinder.new

--- a/src/api/app/models/token/workflow.rb
+++ b/src/api/app/models/token/workflow.rb
@@ -32,6 +32,7 @@ class Token::Workflow < Token
     Project.get_by_name(step.target_project).repositories.each do |repository|
       # TODO: Fix n+1 queries
       repository.architectures.each do |architecture|
+        # We cannot report multibuild flavors here... so they will be missing from the initial report
         SCMStatusReporter.new({ project: step.target_project, package: step.target_package, repository: repository.name, arch: architecture.name },
                               scm_extractor_payload, scm_token).call
       end


### PR DESCRIPTION
We don't know the multibuild flavors before doing the initial report, so they will only be reported back to the SCM once the builds are done.