### PR TITLE
changed github link obs-testpackage.*_service from M0ses to openSUSE

### DIFF
--- a/dist/t/osc/fixtures/obs-testpackage-2.8._service
+++ b/dist/t/osc/fixtures/obs-testpackage-2.8._service
@@ -1,7 +1,7 @@
 <services>
   <service name="tar_scm">
     <param name="versionformat">%ad</param>
-    <param name="url">git://github.com/M0ses/obs-testpackage.git</param>
+    <param name="url">git://github.com/openSUSE/obs-testpackage.git</param>
     <param name="scm">git</param>
     <param name="extract">dist/obs-testpackage.spec</param>
   </service>

--- a/dist/t/osc/fixtures/obs-testpackage._service
+++ b/dist/t/osc/fixtures/obs-testpackage._service
@@ -1,7 +1,7 @@
 <services>
   <service name="obs_scm">
     <param name="version">0.0.1</param>
-    <param name="url">git://github.com/M0ses/obs-testpackage.git</param>
+    <param name="url">git://github.com/openSUSE/obs-testpackage.git</param>
     <param name="scm">git</param>
     <param name="extract">dist/obs-testpackage.spec</param>
   </service>


### PR DESCRIPTION
The OBS test suite should not rely on my private github repos. Therefore I
transferred the obs-testpackage repo to the openSUSE project.

This patch changes the url parameter in the tests `_service` files from

https://github.com/M0ses/obs-testpackage

to

https://github.com/openSUSE/obs-testpackage

to reflect this change an fix our test-suite
