### PR TITLE
Hardcode 'opened' on _branch_request file

### DIFF
--- a/src/api/app/models/workflow/step/branch_package_step.rb
+++ b/src/api/app/models/workflow/step/branch_package_step.rb
@@ -122,7 +122,10 @@ class Workflow
 
       def branch_request_content_github
         {
-          action: @scm_extractor_payload[:action],
+          # TODO: change to @scm_extractor_payload[:action]
+          # when check_for_branch_request method in obs-service-tar_scm accepts other actions than 'opened'
+          # https://github.com/openSUSE/obs-service-tar_scm/blob/2319f50e741e058ad599a6890ac5c710112d5e48/TarSCM/tasks.py#L145
+          action: 'opened',
           pull_request: {
             head: {
               repo: { full_name: @scm_extractor_payload[:source_repository_full_name] },


### PR DESCRIPTION
GitHub actions like `synchronize` are not handled by `check_for_branch_request` method in [obs-service-tar_scm](https://github.com/openSUSE/obs-service-tar_scm/blob/2319f50e741e058ad599a6890ac5c710112d5e48/TarSCM/tasks.py#L145). Only `opened` action.

For now, we are going to make the `_branch_request` file contain `'opened'` action to ensure the source files are updated correctly in the OBS package.

There is nothing to change on the GitLab part in this regard, as  `check_for_branch_request` checks ` 'object_kind'` which is always `'merge_request'`, it doesn't change on different actions (there is a `object_attributes > action` key in GiLab's payload  for that)