### PR TITLE
Undo uneeded changes and adapt Nokogiri template handler

### DIFF
--- a/src/api/config/initializers/airbrake.rb
+++ b/src/api/config/initializers/airbrake.rb
@@ -51,11 +51,7 @@ Airbrake.configure do |c|
   # Airbrake. By default, all "password" attributes will have their contents
   # replaced.
   # https://github.com/airbrake/airbrake-ruby#blocklist_keys
-  if RailsVersion.is_6_1?
-    c.blocklist_keys = [/password/i, /authorization/i]
-  else
-    c.blacklist_keys = [/password/i, /authorization/i]
-  end
+  c.blacklist_keys = [/password/i, /authorization/i]
 
   # Alternatively, you can integrate with Rails' filter_parameters.
   # Read more: https://goo.gl/gqQ1xS

--- a/src/api/config/initializers/nokogiri_builder.rb
+++ b/src/api/config/initializers/nokogiri_builder.rb
@@ -7,9 +7,9 @@ module ActionView
       class_attribute :default_format
       self.default_format = Mime[:xml]
 
-      def call(template)
+      def call(_template, source)
         'xml = ::Nokogiri::XML::Builder.new { |xml|' +
-          template.source +
+          source +
           "}.to_xml(:indent => 2, :encoding => 'UTF-8',
             :save_with => Nokogiri::XML::Node::SaveOptions::NO_DECLARATION | Nokogiri::XML::Node::SaveOptions::FORMAT).gsub('&#13;', '\r')"
       end


### PR DESCRIPTION
Getting closer to updating Rails version to 6.1.x. It's expected than the CI check `next_rails` is failing. Those failures will be fixed in other PRs.

See commit messages for details on the changes.