### PR TITLE
Changes from Rails' update task

### DIFF
--- a/src/api/.rubocop.yml
+++ b/src/api/.rubocop.yml
@@ -206,6 +206,12 @@ Style/HashTransformValues:
 Style/SafeNavigation:
   Enabled: false
 
+Style/StringLiterals:
+  Exclude:
+    # Configuration files are often generated and especially when updating Rails, it's leading to conflicts when running the Rails update task
+    # due to changes from single to double quotes... we have better things to do!
+    - 'config/**/*'
+
 ##################### Metrics ##################################
 
 # Disabled due Rspec.describe and routes.draw can't be split

--- a/src/api/.rubocop.yml
+++ b/src/api/.rubocop.yml
@@ -21,6 +21,8 @@ AllCops:
     - 'db/migrate/20161128115942_init_schema.rb'
     # this file will be deleted as soon as app/jobs/consistency_check_job.rb is validated
     - 'app/jobs/old/consistency_check_job.rb'
+    # Binaries are generated, so we don't lint them
+    - 'bin/**/*'
   SuggestExtensions:
     # We don't want extra cops for minitest since we want to migrate those tests to RSpec
     rubocop-minitest: false

--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -191,6 +191,8 @@ group :development do
   gem 'annotate'
   # toolkit to upgrade your Rails application
   gem 'next_rails'
+  # listen to file modifications and notify Rails (or any subscriber) about the changes
+  gem 'listen'
 end
 
 # Gems used only for assets and not required in production environments by default.

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -241,6 +241,9 @@ GEM
     kaminari-core (1.2.1)
     launchy (2.5.0)
       addressable (~> 2.7)
+    listen (3.5.1)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
     lograge (0.11.2)
       actionpack (>= 4)
       activesupport (>= 4)
@@ -338,6 +341,9 @@ GEM
     rainbow (3.0.0)
     rake (13.0.3)
     rantly (2.0.0)
+    rb-fsevent (0.11.0)
+    rb-inotify (0.10.1)
+      ffi (~> 1.0)
     rbtree (0.4.4)
     rbtree3 (0.6.0)
     rdoc (6.3.1)
@@ -532,6 +538,7 @@ DEPENDENCIES
   jquery-ui-rails (~> 4.2.1)
   kaminari
   launchy
+  listen
   lograge
   minitest
   minitest-ci

--- a/src/api/Gemfile.next.lock
+++ b/src/api/Gemfile.next.lock
@@ -245,6 +245,9 @@ GEM
     kaminari-core (1.2.1)
     launchy (2.5.0)
       addressable (~> 2.7)
+    listen (3.5.1)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
     lograge (0.11.2)
       actionpack (>= 4)
       activesupport (>= 4)
@@ -342,6 +345,9 @@ GEM
     rainbow (3.0.0)
     rake (13.0.3)
     rantly (2.0.0)
+    rb-fsevent (0.11.0)
+    rb-inotify (0.10.1)
+      ffi (~> 1.0)
     rbtree (0.4.4)
     rbtree3 (0.6.0)
     rdoc (6.3.1)
@@ -535,6 +541,7 @@ DEPENDENCIES
   jquery-ui-rails (~> 4.2.1)
   kaminari
   launchy
+  listen
   lograge
   minitest
   minitest-ci

--- a/src/api/app/lib/routes_helper/webui_matcher.rb
+++ b/src/api/app/lib/routes_helper/webui_matcher.rb
@@ -1,3 +1,5 @@
+require 'api_error'
+
 module RoutesHelper
   class WebuiMatcher
     class InvalidRequestFormat < APIError

--- a/src/api/bin/rails
+++ b/src/api/bin/rails
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby.ruby2.5
+#!/usr/bin/env ruby.ruby2.5
 APP_PATH = File.expand_path('../config/application', __dir__)
-require_relative '../config/boot'
-require 'rails/commands'
+require_relative "../config/boot"
+require "rails/commands"

--- a/src/api/bin/rake
+++ b/src/api/bin/rake
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby.ruby2.5
-require_relative '../config/boot'
-require 'rake'
+#!/usr/bin/env ruby.ruby2.5
+require_relative "../config/boot"
+require "rake"
 Rake.application.run

--- a/src/api/bin/setup
+++ b/src/api/bin/setup
@@ -1,0 +1,33 @@
+#!/usr/bin/env ruby.ruby2.5
+require "fileutils"
+
+# path to your application root.
+APP_ROOT = File.expand_path('..', __dir__)
+
+def system!(*args)
+  system(*args) || abort("\n== Command #{args} failed ==")
+end
+
+FileUtils.chdir APP_ROOT do
+  # This script is a way to set up or update your development environment automatically.
+  # This script is idempotent, so that you can run it at any time and get an expectable outcome.
+  # Add necessary setup steps to this file.
+
+  puts '== Installing dependencies =='
+  system! 'gem install bundler --conservative'
+  system('bundle check') || system!('bundle install')
+
+  # puts "\n== Copying sample files =="
+  # unless File.exist?('config/database.yml')
+  #   FileUtils.cp 'config/database.yml.sample', 'config/database.yml'
+  # end
+
+  puts "\n== Preparing database =="
+  system! 'bin/rails db:prepare'
+
+  puts "\n== Removing old logs and tempfiles =="
+  system! 'bin/rails log:clear tmp:clear'
+
+  puts "\n== Restarting application server =="
+  system! 'bin/rails restart'
+end

--- a/src/api/config.ru
+++ b/src/api/config.ru
@@ -1,6 +1,6 @@
 # This file is used by Rack-based servers to start the application.
 
-require ::File.expand_path('config/environment', __dir__)
+require_relative 'config/environment'
 map Rails.application.config.relative_url_root || '/' do
   run OBSApi::Application
 end

--- a/src/api/config/environments/development.rb
+++ b/src/api/config/environments/development.rb
@@ -52,7 +52,7 @@ OBSApi::Application.configure do
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
-  # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   # Bullet configuration
   config.after_initialize do

--- a/src/api/config/locales/en.yml
+++ b/src/api/config/locales/en.yml
@@ -16,8 +16,18 @@
 #
 # This would use the information in config/locales/es.yml.
 #
+# The following keys must be escaped otherwise they will not be retrieved by
+# the default I18n backend:
+#
+# true, false, on, off, yes, no
+#
+# Instead, surround them with single quotes.
+#
+# en:
+#   'true': 'foo'
+#
 # To learn more, please read the Rails Internationalization guide
-# available at http://guides.rubyonrails.org/i18n.html.
+# available at https://guides.rubyonrails.org/i18n.html.
 
 en:
   time:


### PR DESCRIPTION
Getting closer to updating Rails version to 6.1.x. It's expected that the CI check `next_rails` is still failing. Those failures will be fixed in other PRs.

See commit messages for details on the changes.

The changes work both in Rails 6.0.x and Rails 6.1.x.