### PR TITLE
Fix failing specs for Rails 6.1.x

### DIFF
--- a/src/api/app/mixins/flipper_feature.rb
+++ b/src/api/app/mixins/flipper_feature.rb
@@ -2,6 +2,6 @@ module FlipperFeature
   def feature_enabled?(feature)
     return if Flipper.enabled?(feature.to_sym, User.possibly_nobody)
 
-    render file: Rails.root.join('public/404'), status: :not_found, layout: false
+    render file: Rails.root.join('public/404.html'), status: :not_found, layout: false
   end
 end

--- a/src/api/app/models/cloud/ec2/configuration.rb
+++ b/src/api/app/models/cloud/ec2/configuration.rb
@@ -22,7 +22,7 @@ module Cloud
       has_secure_token :external_id
       belongs_to :user
 
-      validates :external_id, uniqueness: true
+      validates :external_id, uniqueness: { case_sensitive: true }
       validates :arn, uniqueness: { case_sensitive: true }, allow_nil: true
       # http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
       validates :arn, format: { with: %r{\Aarn:([\w/:* +=,.@\-_])+\z}, message: 'not a valid format', allow_blank: true }


### PR DESCRIPTION
See commit messages for details.

The failing specs were (I took the output from previous next_rails PRs):
```
  12) Webui::Users::NotificationsController with feature flag not enabled GET #index returns not_found status
      Failure/Error: render file: Rails.root.join('public/404'), status: :not_found, layout: false
      
      ArgumentError:
        `render file:` should be given the absolute path to a file. '/home/frontend/project/src/api/public/404' was given instead
      # ./app/mixins/flipper_feature.rb:5:in `feature_enabled?'
      # ./app/controllers/webui/users/notifications_controller.rb:55:in `check_feature_toggle'
      # ./spec/controllers/webui/users/notifications_controller_spec.rb:246:in `block (4 levels) in <top (required)>'
```

and 

```
  11) Cloud::Ec2::Configuration validations is expected to validate that :external_id is case-sensitively unique
      Failure/Error: it { is_expected.to validate_uniqueness_of(:external_id) }
      
        Expected Cloud::Ec2::Configuration to validate that :external_id is
        case-sensitively unique, but this could not be proved.
          After taking the given Cloud::Ec2::Configuration, whose :external_id
          is ‹"R6xMLDkUxFiwVcphNxNL7RpH"›, and saving it as the existing record,
          then making a new Cloud::Ec2::Configuration and setting its
          :external_id to a different value, ‹"r6XmldKuXfIWvCPHnXnl7rPh"›, the
          matcher expected the new Cloud::Ec2::Configuration to be valid, but it
          was invalid instead, producing these validation errors:
      
          * external_id: ["has already been taken"]
      # ./spec/models/cloud/ec2/configuration_spec.rb:6:in `block (3 levels) in <top (required)>'
```