### PR TITLE
[backend] worker buildenv builds: do not pass the binary names as pac…

### DIFF
--- a/src/backend/BSSched/BuildJob/Package.pm
+++ b/src/backend/BSSched/BuildJob/Package.pm
@@ -195,7 +195,7 @@ sub check {
     return ('scheduled', [ { 'explain' => 'retrying bad build' }, $hdeps ]);
   } else {
     my $rebuildmethod = $repo->{'rebuild'} || 'transitive';
-    if ($rebuildmethod eq 'local' || $pdata->{'hasbuildenv'}) {
+    if ($rebuildmethod eq 'local' || $pdata->{'hasbuildenv'} || $info->{'hasbuildenv'}) {
       # rebuild on src changes only
       goto relsynccheck;
     }

--- a/src/backend/BSSched/Checker.pm
+++ b/src/backend/BSSched/Checker.pm
@@ -746,7 +746,7 @@ sub expandandsort {
     }
     $pkg2src{$packid} = $info->{'name'};
 
-    if ($pdata->{'hasbuildenv'}) {
+    if ($pdata->{'hasbuildenv'} || $info->{'hasbuildenv'}) {
       $pdeps{$packid} = [];
       next;
     }

--- a/src/backend/BSXML.pm
+++ b/src/backend/BSXML.pm
@@ -194,6 +194,7 @@ our $packinfo = [
 	    'nodbgpkgs',	# kiwi
 	    'nosrcpkgs',	# kiwi
 	    'nativebuild',	# cross build: native
+	    'hasbuildenv',
 	 [[ 'path' =>
 		'project',
 		'repository',

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -1695,6 +1695,7 @@ sub getprojpack {
 	      $rinfo->{'error'} = "don't know how to build $file";
 	      next;
 	    }
+	    $rinfo->{'hasbuildenv'} = 1 if $files->{'_buildenv'} || $files->{"_buildenv.$repoid.$arch"};
 	    if (($type eq 'kiwi' || $buildtype eq 'kiwi') && $BSConfig::kiwiprojects && !$cgi->{'ignoredisable'}) {
 	      my %kiwiprojects = map {$_ => 1} @$BSConfig::kiwiprojects;
 	      if (!$kiwiprojects{$projid}) {

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -2163,12 +2163,12 @@ sub getbinaries_buildenv {
         $pbvl = BSRPC::rpc({
           'uri' => "$server/getpackagebinaryversionlist",
           'timeout' => $gettimeout,
-        }, $BSXML::packagebinaryversionlist, "project=$projid", "repository=$repoid", "arch=$arch", map {"package=$_"} @needed_names);
+        }, $BSXML::packagebinaryversionlist, "project=$projid", "repository=$repoid", "arch=$arch");
       } else {
         $pbvl = BSRPC::rpc({
           'uri' => "$server/build/$projid/$repoid/$arch",
           'timeout' => $gettimeout,
-        }, $BSXML::packagebinaryversionlist, "view=binaryversions", map {"package=$_"} @needed_names);
+        }, $BSXML::packagebinaryversionlist, "view=binaryversions");
       }
     };
     undef $pbvl if $@;

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -2148,7 +2148,7 @@ sub getbinaries_buildenv {
 
   my @bdeps = grep {$_->{'name'} && $_->{'hdrmd5'}} @{$buildinfo->{'bdep'} || []};
   die("binaries without hdrmd5 in buildenv\n") unless @bdeps == @{$buildinfo->{'bdep'} || []};
-  my %needed = map {+"$_->{'name'}.$_->{'hdrmd5'}" => []} @bdeps;;
+  my %needed = map {+"$_->{'name'}.$_->{'hdrmd5'}" => []} @bdeps;
   my %needed_names = map {$_->{'name'} => 1} @bdeps;
   my @needed_names = sort(keys %needed_names);
 
@@ -2230,6 +2230,7 @@ sub getbinaries_buildenv {
 
   my @cacheold;
   my @cachenew;
+  my %used;
 
   # check the cache
   if ($cachedir) {
@@ -2249,6 +2250,8 @@ sub getbinaries_buildenv {
 	    delete $needed{$needed};
 	    last;
           }
+	  die unless $bv->{'name'} =~ /(.*)\.rpm$/;
+	  $used{$needed} = { 'name' => $1, 'project' => $projid, 'repository' => $repoid, 'hdrmd5' => $id };
 	} else {
 	  unlink("$dir/$bv->{'name'}");
 	}
@@ -2309,12 +2312,22 @@ sub getbinaries_buildenv {
         unlink("$dir/$bv->{'name'}");
 	next;
       }
+      die unless $bv->{'name'} =~ /(.*)\.rpm$/;
+      $used{$needed} = { 'name' => $1, 'project' => $projid, 'repository' => $repoid, 'hdrmd5' => $id };
       my $cacheid =  Digest::MD5::md5_hex("$projid/$repoid/$arch/$bv->{'hdrmd5'}");
       push @cachenew, [$cacheid, $s[7], "$dir/$bv->{'name'}"];
       delete $needed{$needed};
       last;
     }
     die("download of $needed failed\n") if $needed{$needed};
+  }
+  my $outbdep = ($buildinfo->{'outbuildinfo'} || {})->{'bdep'};
+  if ($outbdep) {
+    for (@bdeps) {
+      my $obdep = $used{"$_->{'name'}.$_->{'hdrmd5'}"};
+      die("did not use package $_?\n") unless $obdep;
+      push @$outbdep, $obdep;
+    }
   }
 
   manage_cache($cachesize, \@cacheold, \@cachenew) if $cachedir;


### PR DESCRIPTION
…kage filter

This will not do, especially for maintenance incidents where the package
names have an incident suffix.

_Replace this line with a description of your changes. Please follow the suggestions in the comment below._

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
