### PR TITLE
Create the Configuration singleton in the database cleaner if necessary

### DIFF
--- a/src/api/spec/support/database_cleaner.rb
+++ b/src/api/spec/support/database_cleaner.rb
@@ -38,7 +38,7 @@ RSpec.configure do |config|
     create(:obs_attrib_type, name: 'UpdateProject')
     create(:obs_attrib_type, name: 'VeryImportantProject')
     create(:obs_attrib_type, name: 'DelegateRequestTarget')
-    Configuration.update(allow_user_to_create_home_project: false)
+    Configuration.first_or_create(name: 'private', title: 'Open Build Service').update(allow_user_to_create_home_project: false)
   end
 
   config.after do


### PR DESCRIPTION
Create the `Configuration` in the database if it doesn't exist

a `rake db:seed` still necessary before running any spec