### PR TITLE
Index in_beta and in_rollout fields in users table

### DIFF
--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -831,15 +831,6 @@ RSpec/VerifiedDoubles:
     - 'spec/support/shared_contexts/setup_ldap_mock.rb'
     - 'spec/support/shared_examples/a_ldap_connection.rb'
 
-# Offense count: 2
-# Cop supports --auto-correct.
-# Configuration parameters: Include.
-# Include: db/migrate/*.rb
-Rails/AddColumnIndex:
-  Exclude:
-    - 'db/migrate/20180814112739_add_in_beta_to_user.rb'
-    - 'db/migrate/20190704072437_add_column_in_rollout_to_users.rb'
-
 # Offense count: 1
 # Cop supports --auto-correct.
 Rails/ApplicationController:

--- a/src/api/app/models/unregistered_user.rb
+++ b/src/api/app/models/unregistered_user.rb
@@ -77,8 +77,8 @@ end
 #  deprecated_password_salt      :string(255)
 #  email                         :string(200)      default(""), not null
 #  ignore_auth_services          :boolean          default(FALSE)
-#  in_beta                       :boolean          default(FALSE)
-#  in_rollout                    :boolean          default(TRUE)
+#  in_beta                       :boolean          default(FALSE), indexed
+#  in_rollout                    :boolean          default(TRUE), indexed
 #  last_logged_in_at             :datetime
 #  login                         :text(65535)      indexed
 #  login_failure_count           :integer          default(0), not null
@@ -91,6 +91,8 @@ end
 #
 # Indexes
 #
-#  users_login_index     (login) UNIQUE
-#  users_password_index  (deprecated_password)
+#  index_users_on_in_beta     (in_beta)
+#  index_users_on_in_rollout  (in_rollout)
+#  users_login_index          (login) UNIQUE
+#  users_password_index       (deprecated_password)
 #

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -934,8 +934,8 @@ end
 #  deprecated_password_salt      :string(255)
 #  email                         :string(200)      default(""), not null
 #  ignore_auth_services          :boolean          default(FALSE)
-#  in_beta                       :boolean          default(FALSE)
-#  in_rollout                    :boolean          default(TRUE)
+#  in_beta                       :boolean          default(FALSE), indexed
+#  in_rollout                    :boolean          default(TRUE), indexed
 #  last_logged_in_at             :datetime
 #  login                         :text(65535)      indexed
 #  login_failure_count           :integer          default(0), not null
@@ -948,6 +948,8 @@ end
 #
 # Indexes
 #
-#  users_login_index     (login) UNIQUE
-#  users_password_index  (deprecated_password)
+#  index_users_on_in_beta     (in_beta)
+#  index_users_on_in_rollout  (in_rollout)
+#  users_login_index          (login) UNIQUE
+#  users_password_index       (deprecated_password)
 #

--- a/src/api/db/migrate/20180814112739_add_in_beta_to_user.rb
+++ b/src/api/db/migrate/20180814112739_add_in_beta_to_user.rb
@@ -1,5 +1,5 @@
 class AddInBetaToUser < ActiveRecord::Migration[5.2]
   def change
-    add_column :users, :in_beta, :boolean, default: false, index: true
+    add_column :users, :in_beta, :boolean, default: false
   end
 end

--- a/src/api/db/migrate/20190704072437_add_column_in_rollout_to_users.rb
+++ b/src/api/db/migrate/20190704072437_add_column_in_rollout_to_users.rb
@@ -1,5 +1,5 @@
 class AddColumnInRolloutToUsers < ActiveRecord::Migration[5.2]
   def change
-    add_column :users, :in_rollout, :boolean, default: true, index: true
+    add_column :users, :in_rollout, :boolean, default: true
   end
 end

--- a/src/api/db/migrate/20210623134455_add_missing_indices_to_users.rb
+++ b/src/api/db/migrate/20210623134455_add_missing_indices_to_users.rb
@@ -1,0 +1,6 @@
+class AddMissingIndicesToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_index(:users, :in_beta)
+    add_index(:users, :in_rollout)
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_25_145710) do
+ActiveRecord::Schema.define(version: 2021_06_23_134455) do
 
   create_table "architectures", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false, collation: "utf8_general_ci"
@@ -1057,6 +1057,8 @@ ActiveRecord::Schema.define(version: 2021_05_25_145710) do
     t.boolean "in_rollout", default: true
     t.string "biography", default: ""
     t.index ["deprecated_password"], name: "users_password_index"
+    t.index ["in_beta"], name: "index_users_on_in_beta"
+    t.index ["in_rollout"], name: "index_users_on_in_rollout"
     t.index ["login"], name: "users_login_index", unique: true, length: 255
   end
 


### PR DESCRIPTION
These fields were not indexed before.

Fix Rails/AddColumnIndex RuboCop offenses.

Follow-up to #11270.

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
