### PR TITLE
Do not rely on named scope chain for BsRequest::FindFor::Query

### DIFF
--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -58,9 +58,8 @@ class BsRequest < ApplicationRecord
   scope :by_package_reviews, ->(package_ids) { where(reviews: { package: package_ids }) }
   scope :by_group_reviews, ->(group_ids) { where(reviews: { group: group_ids }) }
 
-  scope :for_user, ->(params) { BsRequest::FindFor::User.new(params).all }
-  scope :for_group, ->(params) { BsRequest::FindFor::Group.new(params).all }
-  scope :for_project, ->(params) { BsRequest::FindFor::Project.new(params).all }
+  # FIXME: Get rid of this find_for scope since Rails 6.1, named scope chain does no longer leak scope to class-level querying methods
+  #        For details, see https://guides.rubyonrails.org/6_1_release_notes.html#active-record-notable-changes
   scope :find_for, ->(params) { BsRequest::FindFor::Query.new(params).all }
   scope :obsolete, -> { where(state: OBSOLETE_STATES) }
   scope :with_target_project, lambda { |target_project|

--- a/src/api/app/models/bs_request/find_for/query.rb
+++ b/src/api/app/models/bs_request/find_for/query.rb
@@ -5,9 +5,9 @@ class BsRequest
         @relation = @relation.with_types(types) if types.present?
         @relation = @relation.in_states(states) if states.present?
         @relation = @relation.from_source_project(source_project_name) if source_project_name.present?
-        @relation = @relation.for_project(@parameters) if project_name.present?
-        @relation = @relation.for_user(@parameters) if user_login.present?
-        @relation = @relation.for_group(@parameters) if group_title.present?
+        @relation = BsRequest::FindFor::Project.new(@parameters, @relation).all if project_name.present?
+        @relation = BsRequest::FindFor::User.new(@parameters, @relation).all if user_login.present?
+        @relation = BsRequest::FindFor::Group.new(@parameters, @relation).all if group_title.present?
         @relation = @relation.in_ids(ids) if ids.present?
         @relation = @relation.do_search(search) if search.present?
         @relation


### PR DESCRIPTION
Since Rails 6.1, named scope chains will no longer leak the scope to class level querying methods.  As a result of this, the
"BsRequest::FindFor::Query#all" starts to perform some of its queries again on the unscoped relation instead of keeping them chained. This resulted in unexpected/wrong results.

See https://guides.rubyonrails.org/6_1_release_notes.html#active-record-notable-changes
Related to #9748

Co-authored-by: Lukas Krause <lkrause@suse.de>