### PR TITLE
Do no expand the upload rev

### DIFF
--- a/src/backend/BSSrcServer/Link.pm
+++ b/src/backend/BSSrcServer/Link.pm
@@ -535,6 +535,7 @@ sub applylink {
 sub handlelinks {
   my ($rev, $files, $li) = @_;
 
+  return "bad srcmd5: $rev->{'srcmd5'}" unless $rev->{'srcmd5'} =~ /^[0-9a-f]{32}$/;
   my @linkinfo;
   my %seen;
   my $projid = $rev->{'project'};


### PR DESCRIPTION
When trying to expand the upload rev, a bogus tree files is written
(if the upload rev contains a _link file). For instance, a tree file
can look like this:

c157a79031e1c40f85931829bc5fc552  foo
f9079d5de256dd593c7eabdb29699e53  /LINK
upload  /LOCAL

Since the upload rev has no "real" srcmd5, the format of the tree
file is corrupted. Such a corrupted tree file can be used to generate
a <directory/> xml that has an <entry/> whose "name" attribute is the
empty string and whose "md5" attribute contains 32 "garbage" bytes
(that is, an illegal md5). For instance,

marcus@linux:~> curl http://localhost:5352/source/home:mallory/lnk2?expand=1
<directory name="lnk2" rev="4fc0e0e48934e51692aeec749600d854" vrev="10" srcmd5="4fc0e0e48934e51692aeec749600d854">
  <linkinfo project="home:mallory" package="lnk2" rev="2568453a6f3542d64649fdd50186cb28" srcmd5="2568453a6f3542d64649fdd50186cb28" lsrcmd5="6497434b763387d4daba84e582636df7"/>
  <entry name="" md5="upload  /LOCAL                  " error="No such file or directory"/>
  <entry name="foo" md5="c157a79031e1c40f85931829bc5fc552" size="4" mtime="1624438950"/>
</directory>
marcus@linux:~>

Such a <directory/> may confuse "broken" clients (since the error
attribute is present, clients have the chance to refuse such a
<directory/>).

(Note: in the curl call we do not expand the upload rev; the upload
rev is only expanded once to generate the broken tree file; the
broken tree file is then used to generate the broken <entry/> from
above)

In order to avoid this, simply do not expand the upload rev. Note
that if a link's rev or a passed in linkrev points to the upload rev,
the expansion fails because the revision returned by $getrev->(...)
is "strange" (see the code in handlelinks). Hence, it is sufficient
to check at the beginning of handlelinks if the passed revision is
the upload rev.

_Replace this line with a description of your changes. Please follow the suggestions in the comment below._

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
