### PR TITLE
Support for handling ARM 32bit userland only hardware

### DIFF
--- a/docs/api/api/constraints.rng
+++ b/docs/api/api/constraints.rng
@@ -91,6 +91,14 @@
               <element name="cpu">
                 <oneOrMore> 
                   <element name="flag">
+                    <optional>
+                      <attribute name="exclude">
+                        <choice>
+                          <value>false</value>
+                          <value>true</value>
+                        </choice>
+                      </attribute>
+                    </optional>
                     <text />
                   </element>
                 </oneOrMore> 

--- a/docs/api/api/constraints.xml
+++ b/docs/api/api/constraints.xml
@@ -13,6 +13,7 @@
     <cpu>
       <flag>fpu</flag>
       <flag>mmx</flag>
+      <flag exclude="true">nol0kernel</flag>
     </cpu>
     <processors>2</processors>
     <disk>

--- a/src/backend/BSXML.pm
+++ b/src/backend/BSXML.pm
@@ -1773,7 +1773,11 @@ our @constraint = (
       ],
       [ 'hardware' =>
 	  [ 'cpu' =>
-	      [ 'flag' ],
+	     [[ 'flag'=>
+	       'exclude',   # true or false. default is false.
+	       [],
+	       '_content' # the cpu flag from /proc/cpuinfo
+             ]],
 	  ],
 	    'processors',
 	    'jobs',

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -762,6 +762,7 @@ my $hw = {'cpu' => {}, 'processors' => 0};
 if (open(FILE, "<", "/proc/cpuinfo")) {
   my $cpu_implementer;
   my $cpu_variant;
+  my $cpu_part;
 
   while(<FILE>) {
     chomp;
@@ -779,6 +780,8 @@ if (open(FILE, "<", "/proc/cpuinfo")) {
       $cpu_implementer = $1;
     } elsif (/^CPU variant\s*:\s(.*)$/) {
       $cpu_variant = $1;
+    } elsif (/^CPU part\s*:\s(.*)$/) {
+      $cpu_part = $1;
     } elsif (/^cpu\s*:\sPOWER9/) {
       # PowerPC kernel provides no flags, but we need to be able
       # to distinguish between power7 and 8 at least
@@ -796,6 +799,7 @@ if (open(FILE, "<", "/proc/cpuinfo")) {
   # Check for aarch64/aarch32 compatibility
   if ($hostarch eq 'aarch64' && $cpu_implementer) {
     my $supports_aarch32;
+    my $require_aarch64_kernel;
 
     if ($cpu_implementer eq "0x50") {
       # Applied Micro / Ampere Computing
@@ -810,11 +814,21 @@ if (open(FILE, "<", "/proc/cpuinfo")) {
         $supports_aarch32 = 1;
       }
     } elsif ($cpu_implementer eq "0x41") {
-      # ARM Inc. - all variants support aarch32 compat for now
-      $supports_aarch32 = 1;
+      # ARM Inc.
+      if ($cpu_part eq '0xd0c' || $cpu_part eq '0xd0e') {
+        # Neoverse N1 || Cortex A76AE
+        # 32bit user land is supported, but only on a 64bit kernel
+        $require_aarch64_kernel = 1;
+        $supports_aarch32 = 1;
+      } elsif ($cpu_part lt '0xd0c') {
+        # old hardware had full support of 32bit
+        $supports_aarch32 = 1;
+      }
+      # otherwise we assume 64bit only for all future hardware
     }
 
     $hw->{'nativeonly'} = undef unless $supports_aarch32;
+    push @{$hw->{'cpu'}->{'flag'}}, 'EL0' if $require_aarch64_kernel;
   }
 }
 $hw->{'jobs'} = $jobs if $jobs;

--- a/src/backend/testdata/constraint/kernel
+++ b/src/backend/testdata/constraint/kernel
@@ -15,6 +15,9 @@
     </conditions>
     <hardware>
       <processors>1</processors>
+      <cpu>
+        <flag exclude="true">EL0</flag>
+      </cpu>
       <disk>
         <size unit="G">6</size>
       </disk>

--- a/src/backend/testdata/test_dispatcher
+++ b/src/backend/testdata/test_dispatcher
@@ -51,6 +51,7 @@ td simple05 false "kernel-default" armv7l small kernel
 td simple06 false "kernel-default" aarch64 small kernel
 td simple07 true "kernel-default" aarch64 medium kernel
 td simple08 true "kernel-default" aarch64 large kernel
+td simple09 false "kernel-default" armv7l large kernel # requires native kernel support (EL0)
 
 # simple source constraints like used by suse kernel
 td sandbox31 false "kernel-obs-qa" i586 medium kernel

--- a/src/backend/testdata/workerinfo/large
+++ b/src/backend/testdata/workerinfo/large
@@ -13,6 +13,7 @@
   <hardware>
     <cpu>
       <flag>mmx</flag>
+      <flag>EL0</flag>
     </cpu>
     <nativeonly/>
     <processors>32</processors>


### PR DESCRIPTION
New hardware supports 32bit user land, but no 32bit kernels anymore. We need to be able to destinguish build jobs without breaking remote interconnect. 

A OBS version compare expresion for prjconf will be provided by mls to complete this.

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
