### PR TITLE
Validate presence of scm_token for Token::Workflow

### DIFF
--- a/src/api/app/models/token/workflow.rb
+++ b/src/api/app/models/token/workflow.rb
@@ -1,4 +1,6 @@
 class Token::Workflow < Token
+  validates :scm_token, presence: true
+
   def self.token_name
     'workflow'
   end


### PR DESCRIPTION
We always need an SCM token for a Token::Workflow record, so we should check that it's present. We don't want to valid its format or anything else for now.