### PR TITLE
Implement architectures and repositories filters for OBS workflows

### DIFF
--- a/src/api/app/models/token/errors.rb
+++ b/src/api/app/models/token/errors.rb
@@ -5,6 +5,14 @@ module Token::Errors
     setup 404
   end
 
+  class UnsupportedWorkflowFilters < APIError
+    setup 422
+  end
+
+  class UnsupportedWorkflowFilterTypes < APIError
+    setup 422
+  end
+
   class NonExistentWorkflowsFile < APIError
     setup 404
   end

--- a/src/api/app/models/workflow.rb
+++ b/src/api/app/models/workflow.rb
@@ -1,12 +1,26 @@
 class Workflow
   SUPPORTED_STEPS = { 'branch_package' => Workflow::Step::BranchPackageStep }.freeze
+  SUPPORTED_FILTERS = [:architectures, :repositories].freeze
+  # The order of the filter types determines their precedence
+  SUPPORTED_FILTER_TYPES = [:only, :ignore].freeze
 
   def initialize(workflow:, scm_extractor_payload:, token:)
-    @workflow = workflow
+    @workflow = workflow.with_indifferent_access
     @scm_extractor_payload = scm_extractor_payload
     @token = token
+
     raise Token::Errors::InvalidWorkflowStepDefinition, "Invalid workflow step definition: #{errors.to_sentence}" unless
       valid?
+
+    # Filters aren't mandatory in a workflow
+    return unless @workflow.key?(:filters)
+
+    raise Token::Errors::UnsupportedWorkflowFilters, "Unsupported filters: #{@unsupported_filters.keys.to_sentence}" if unsupported_filters?
+
+    return unless unsupported_filter_types?
+
+    raise Token::Errors::UnsupportedWorkflowFilterTypes,
+          "Filters #{@unsupported_filter_types.to_sentence} have unsupported keys. #{SUPPORTED_FILTER_TYPES.to_sentence} are the only supported keys."
   end
 
   def valid?
@@ -22,6 +36,26 @@ class Workflow
         .select { |new_step| acc << new_step }
       acc
     end
+  end
+
+  def filters
+    filters = {}
+
+    return filters if supported_filters.blank?
+
+    SUPPORTED_FILTERS.each do |filter|
+      SUPPORTED_FILTER_TYPES.each do |filter_type|
+        # The filter type might not be present... so in that case, we go to the next
+        next unless (filter_values = supported_filters.dig(filter, filter_type))
+
+        filters[filter] = { "#{filter_type}": filter_values }
+
+        # As soon as a supported filter type is present, we get out of the loop since the following filter types have a lower precedence
+        break
+      end
+    end
+
+    filters
   end
 
   def errors
@@ -54,5 +88,25 @@ class Workflow
     SUPPORTED_STEPS[step_name].new(step_instructions: step_instructions,
                                    scm_extractor_payload: @scm_extractor_payload,
                                    token: @token)
+  end
+
+  def unsupported_filters?
+    @unsupported_filters ||= @workflow[:filters].select { |key, _value| SUPPORTED_FILTERS.exclude?(key.to_sym) }
+
+    @unsupported_filters.present?
+  end
+
+  def unsupported_filter_types?
+    @unsupported_filter_types = []
+
+    @workflow[:filters].each do |filter, value|
+      @unsupported_filter_types << filter unless value.keys.all? { |filter_type| SUPPORTED_FILTER_TYPES.include?(filter_type.to_sym) }
+    end
+
+    @unsupported_filter_types.present?
+  end
+
+  def supported_filters
+    @supported_filters ||= @workflow[:filters]&.select { |key, _value| SUPPORTED_FILTERS.include?(key.to_sym) }
   end
 end

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_a_new_PR_event/behaves_like_successful_new_PR_or_MR_event/only_reports_for_repositories_and_architectures_matching_the_filters.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_a_new_PR_event/behaves_like_successful_new_PR_or_MR_event/only_reports_for_repositories_and_architectures_matching_the_filters.yml
@@ -1,0 +1,485 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '27'
+    body:
+      encoding: UTF-8
+      string: |
+        <collection>
+        </collection>
+  recorded_at: Tue, 06 Jul 2021 16:21:47 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package?cmd=branch&noservice=1&opackage=bar_package&oproject=foo_project&user=Iggy
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '208'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="579" vrev="579">
+          <srcmd5>7acaf13f1bdf1ca7680784c23eb55d8e</srcmd5>
+          <version>unknown</version>
+          <time>1625588507</time>
+          <user>Iggy</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Tue, 06 Jul 2021 16:21:47 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '725'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="579" vrev="579" srcmd5="7acaf13f1bdf1ca7680784c23eb55d8e">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="7263783416e23e49b16b62bb59ff3e8f" baserev="7263783416e23e49b16b62bb59ff3e8f" xsrcmd5="e1d2aca6fbb24b41227663f10f37a4b0" lsrcmd5="7acaf13f1bdf1ca7680784c23eb55d8e"/>
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1625580181"/>
+          <entry name="_config" md5="08e13667e7139883b76b185c52b60c38" size="54" mtime="1625587867"/>
+          <entry name="_link" md5="b951315b3dc868ef27413d8203a4f0a8" size="119" mtime="1625588507"/>
+          <entry name="somefile.txt" md5="6fa4622f87ac91a108a5e2ab1b8fc45a" size="63" mtime="1625587867"/>
+        </directory>
+  recorded_at: Tue, 06 Jul 2021 16:21:47 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package?view=info
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '333'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourceinfo package="bar_package" rev="579" vrev="1233" srcmd5="e1d2aca6fbb24b41227663f10f37a4b0" lsrcmd5="7acaf13f1bdf1ca7680784c23eb55d8e" verifymd5="7263783416e23e49b16b62bb59ff3e8f">
+          <error>bad build configuration, no build type defined or detected</error>
+          <linked project="foo_project" package="bar_package"/>
+        </sourceinfo>
+  recorded_at: Tue, 06 Jul 2021 16:21:47 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '725'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="579" vrev="579" srcmd5="7acaf13f1bdf1ca7680784c23eb55d8e">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="7263783416e23e49b16b62bb59ff3e8f" baserev="7263783416e23e49b16b62bb59ff3e8f" xsrcmd5="e1d2aca6fbb24b41227663f10f37a4b0" lsrcmd5="7acaf13f1bdf1ca7680784c23eb55d8e"/>
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1625580181"/>
+          <entry name="_config" md5="08e13667e7139883b76b185c52b60c38" size="54" mtime="1625587867"/>
+          <entry name="_link" md5="b951315b3dc868ef27413d8203a4f0a8" size="119" mtime="1625588507"/>
+          <entry name="somefile.txt" md5="6fa4622f87ac91a108a5e2ab1b8fc45a" size="63" mtime="1625587867"/>
+        </directory>
+  recorded_at: Tue, 06 Jul 2021 16:21:47 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '338'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="dcff39a9029315b45342a13650ef8fad">
+          <old project="home:Iggy:foo_project:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="home:Iggy:foo_project:PR-1" package="bar_package" rev="579" srcmd5="7acaf13f1bdf1ca7680784c23eb55d8e"/>
+          <files/>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Tue, 06 Jul 2021 16:21:47 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '360'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="3ff5bf78f10fa84d47f1aa1eb06cbd6b">
+          <old project="foo_project" package="bar_package" rev="7263783416e23e49b16b62bb59ff3e8f" srcmd5="7263783416e23e49b16b62bb59ff3e8f"/>
+          <new project="home:Iggy:foo_project:PR-1" package="bar_package" rev="e1d2aca6fbb24b41227663f10f37a4b0" srcmd5="e1d2aca6fbb24b41227663f10f37a4b0"/>
+          <files/>
+        </sourcediff>
+  recorded_at: Tue, 06 Jul 2021 16:21:47 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package/_branch_request?user=Iggy
+    body:
+      encoding: UTF-8
+      string: '{"action":"opened","pull_request":{"head":{"repo":{"full_name":"reponame"},"sha":"123"}}}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '208'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="580" vrev="580">
+          <srcmd5>2ab8b738d4e32f2fbd16ec2586b77e6a</srcmd5>
+          <version>unknown</version>
+          <time>1625588507</time>
+          <user>Iggy</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Tue, 06 Jul 2021 16:21:47 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '724'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="580" vrev="580" srcmd5="2ab8b738d4e32f2fbd16ec2586b77e6a">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="7263783416e23e49b16b62bb59ff3e8f" baserev="7263783416e23e49b16b62bb59ff3e8f" xsrcmd5="f3509c16cf7cbfcbb0faf6bf5d8142fe" lsrcmd5="2ab8b738d4e32f2fbd16ec2586b77e6a"/>
+          <entry name="_branch_request" md5="4becc0c108a703b38c26920c45965516" size="89" mtime="1625580187"/>
+          <entry name="_config" md5="08e13667e7139883b76b185c52b60c38" size="54" mtime="1625587867"/>
+          <entry name="_link" md5="b951315b3dc868ef27413d8203a4f0a8" size="119" mtime="1625588507"/>
+          <entry name="somefile.txt" md5="6fa4622f87ac91a108a5e2ab1b8fc45a" size="63" mtime="1625587867"/>
+        </directory>
+  recorded_at: Tue, 06 Jul 2021 16:21:47 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package?view=info
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '333'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourceinfo package="bar_package" rev="580" vrev="1234" srcmd5="f3509c16cf7cbfcbb0faf6bf5d8142fe" lsrcmd5="2ab8b738d4e32f2fbd16ec2586b77e6a" verifymd5="b5bdb92b1d32c64d2ec493c218518853">
+          <error>bad build configuration, no build type defined or detected</error>
+          <linked project="foo_project" package="bar_package"/>
+        </sourceinfo>
+  recorded_at: Tue, 06 Jul 2021 16:21:47 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '724'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="580" vrev="580" srcmd5="2ab8b738d4e32f2fbd16ec2586b77e6a">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="7263783416e23e49b16b62bb59ff3e8f" baserev="7263783416e23e49b16b62bb59ff3e8f" xsrcmd5="f3509c16cf7cbfcbb0faf6bf5d8142fe" lsrcmd5="2ab8b738d4e32f2fbd16ec2586b77e6a"/>
+          <entry name="_branch_request" md5="4becc0c108a703b38c26920c45965516" size="89" mtime="1625580187"/>
+          <entry name="_config" md5="08e13667e7139883b76b185c52b60c38" size="54" mtime="1625587867"/>
+          <entry name="_link" md5="b951315b3dc868ef27413d8203a4f0a8" size="119" mtime="1625588507"/>
+          <entry name="somefile.txt" md5="6fa4622f87ac91a108a5e2ab1b8fc45a" size="63" mtime="1625587867"/>
+        </directory>
+  recorded_at: Tue, 06 Jul 2021 16:21:47 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '338'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="b4c55e03d5b52e679b89140a1df955da">
+          <old project="home:Iggy:foo_project:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="home:Iggy:foo_project:PR-1" package="bar_package" rev="580" srcmd5="2ab8b738d4e32f2fbd16ec2586b77e6a"/>
+          <files/>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Tue, 06 Jul 2021 16:21:47 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '383'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="de5d80b3e7003bffb2bb2e27c2c1bf1e">
+          <old project="foo_project" package="bar_package" rev="7263783416e23e49b16b62bb59ff3e8f" srcmd5="7263783416e23e49b16b62bb59ff3e8f"/>
+          <new project="home:Iggy:foo_project:PR-1" package="bar_package" rev="f3509c16cf7cbfcbb0faf6bf5d8142fe" srcmd5="f3509c16cf7cbfcbb0faf6bf5d8142fe"/>
+          <files/>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Tue, 06 Jul 2021 16:21:47 GMT
+recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/for_a_new_MR_event/behaves_like_successful_new_PR_or_MR_event/only_reports_for_repositories_and_architectures_matching_the_filters.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/for_a_new_MR_event/behaves_like_successful_new_PR_or_MR_event/only_reports_for_repositories_and_architectures_matching_the_filters.yml
@@ -1,0 +1,901 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/home:Iggy/_meta?user=Iggy
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:Iggy">
+          <title/>
+          <description/>
+          <person userid="Iggy" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '130'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:Iggy">
+          <title></title>
+          <description></description>
+          <person userid="Iggy" role="maintainer"/>
+        </project>
+  recorded_at: Tue, 06 Jul 2021 16:10:43 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/foo_project/_meta?user=user_23
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="foo_project">
+          <title>The Green Bay Tree</title>
+          <description/>
+          <person userid="Iggy" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '150'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="foo_project">
+          <title>The Green Bay Tree</title>
+          <description></description>
+          <person userid="Iggy" role="maintainer"/>
+        </project>
+  recorded_at: Tue, 06 Jul 2021 16:10:43 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_24
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="bar_package" project="foo_project">
+          <title>Taming a Sea Horse</title>
+          <description>Assumenda consequuntur quia recusandae.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '167'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="bar_package" project="foo_project">
+          <title>Taming a Sea Horse</title>
+          <description>Assumenda consequuntur quia recusandae.</description>
+        </package>
+  recorded_at: Tue, 06 Jul 2021 16:10:43 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/foo_project/bar_package/_config
+    body:
+      encoding: UTF-8
+      string: Et aut iste. Iure et sit. Nobis aperiam eligendi.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '211'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="603" vrev="603">
+          <srcmd5>bbdc4d0e953bdbe6d414910c390180db</srcmd5>
+          <version>unknown</version>
+          <time>1625587843</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Tue, 06 Jul 2021 16:10:43 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Dolor eveniet fuga. Ad asperiores culpa. Qui corporis ut.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '211'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="604" vrev="604">
+          <srcmd5>e804fc0f23fe63551b8f4357515e8c7f</srcmd5>
+          <version>unknown</version>
+          <time>1625587843</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Tue, 06 Jul 2021 16:10:43 GMT
+- request:
+    method: post
+    uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '27'
+    body:
+      encoding: UTF-8
+      string: |
+        <collection>
+        </collection>
+  recorded_at: Tue, 06 Jul 2021 16:10:43 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/_meta?user=Iggy
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:Iggy:foo_project:PR-1">
+          <title>Branch project for package bar_package</title>
+          <description>This project was created for package bar_package via attribute OBS:Maintained</description>
+          <person userid="Iggy" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '262'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:Iggy:foo_project:PR-1">
+          <title>Branch project for package bar_package</title>
+          <description>This project was created for package bar_package via attribute OBS:Maintained</description>
+          <person userid="Iggy" role="maintainer"/>
+        </project>
+  recorded_at: Tue, 06 Jul 2021 16:10:43 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package/_meta?user=Iggy
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="bar_package" project="home:Iggy:foo_project:PR-1">
+          <title>Taming a Sea Horse</title>
+          <description>Assumenda consequuntur quia recusandae.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '182'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="bar_package" project="home:Iggy:foo_project:PR-1">
+          <title>Taming a Sea Horse</title>
+          <description>Assumenda consequuntur quia recusandae.</description>
+        </package>
+  recorded_at: Tue, 06 Jul 2021 16:10:43 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package?cmd=branch&noservice=1&opackage=bar_package&oproject=foo_project&user=Iggy
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '208'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="531" vrev="531">
+          <srcmd5>76d2aa263d8898329de10b3c1b1582c1</srcmd5>
+          <version>unknown</version>
+          <time>1625587843</time>
+          <user>Iggy</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Tue, 06 Jul 2021 16:10:43 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package/_meta?user=Iggy
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="bar_package" project="home:Iggy:foo_project:PR-1">
+          <title>Taming a Sea Horse</title>
+          <description>Assumenda consequuntur quia recusandae.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '182'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="bar_package" project="home:Iggy:foo_project:PR-1">
+          <title>Taming a Sea Horse</title>
+          <description>Assumenda consequuntur quia recusandae.</description>
+        </package>
+  recorded_at: Tue, 06 Jul 2021 16:10:43 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '725'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="531" vrev="531" srcmd5="76d2aa263d8898329de10b3c1b1582c1">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="e804fc0f23fe63551b8f4357515e8c7f" baserev="e804fc0f23fe63551b8f4357515e8c7f" xsrcmd5="2a354d288fa2c602900e4267cc55ecd8" lsrcmd5="76d2aa263d8898329de10b3c1b1582c1"/>
+          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1625580166"/>
+          <entry name="_config" md5="62dc35b08d569af627d085e10f75ef86" size="49" mtime="1625587843"/>
+          <entry name="_link" md5="c19ed1bc21f0ba7814f29792f5d58f48" size="119" mtime="1625587843"/>
+          <entry name="somefile.txt" md5="ed321db255ada8ce027a33cc600e43cb" size="57" mtime="1625587843"/>
+        </directory>
+  recorded_at: Tue, 06 Jul 2021 16:10:43 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package?view=info
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '333'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourceinfo package="bar_package" rev="531" vrev="1135" srcmd5="2a354d288fa2c602900e4267cc55ecd8" lsrcmd5="76d2aa263d8898329de10b3c1b1582c1" verifymd5="e804fc0f23fe63551b8f4357515e8c7f">
+          <error>bad build configuration, no build type defined or detected</error>
+          <linked project="foo_project" package="bar_package"/>
+        </sourceinfo>
+  recorded_at: Tue, 06 Jul 2021 16:10:43 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '725'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="531" vrev="531" srcmd5="76d2aa263d8898329de10b3c1b1582c1">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="e804fc0f23fe63551b8f4357515e8c7f" baserev="e804fc0f23fe63551b8f4357515e8c7f" xsrcmd5="2a354d288fa2c602900e4267cc55ecd8" lsrcmd5="76d2aa263d8898329de10b3c1b1582c1"/>
+          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1625580166"/>
+          <entry name="_config" md5="62dc35b08d569af627d085e10f75ef86" size="49" mtime="1625587843"/>
+          <entry name="_link" md5="c19ed1bc21f0ba7814f29792f5d58f48" size="119" mtime="1625587843"/>
+          <entry name="somefile.txt" md5="ed321db255ada8ce027a33cc600e43cb" size="57" mtime="1625587843"/>
+        </directory>
+  recorded_at: Tue, 06 Jul 2021 16:10:43 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '338'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="01f7efa96f24053df5940dd7c5e4dfb4">
+          <old project="home:Iggy:foo_project:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="home:Iggy:foo_project:PR-1" package="bar_package" rev="531" srcmd5="76d2aa263d8898329de10b3c1b1582c1"/>
+          <files/>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Tue, 06 Jul 2021 16:10:43 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '360'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="2a15bfe9a1fd924d635558a9073b57ef">
+          <old project="foo_project" package="bar_package" rev="e804fc0f23fe63551b8f4357515e8c7f" srcmd5="e804fc0f23fe63551b8f4357515e8c7f"/>
+          <new project="home:Iggy:foo_project:PR-1" package="bar_package" rev="2a354d288fa2c602900e4267cc55ecd8" srcmd5="2a354d288fa2c602900e4267cc55ecd8"/>
+          <files/>
+        </sourcediff>
+  recorded_at: Tue, 06 Jul 2021 16:10:43 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/_meta?user=Iggy
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:Iggy:foo_project:PR-1">
+          <title>Branch project for package bar_package</title>
+          <description>This project was created for package bar_package via attribute OBS:Maintained</description>
+          <person userid="Iggy" role="maintainer"/>
+          <publish>
+            <disable/>
+          </publish>
+          <repository name="openSUSE_Tumbleweed">
+            <path project="foo_project" repository="openSUSE_Tumbleweed"/>
+            <arch>x86_64</arch>
+          </repository>
+          <repository name="Unicorn_123">
+            <path project="foo_project" repository="Unicorn_123"/>
+            <arch>x86_64</arch>
+            <arch>i586</arch>
+            <arch>ppc</arch>
+            <arch>aarch64</arch>
+          </repository>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '652'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:Iggy:foo_project:PR-1">
+          <title>Branch project for package bar_package</title>
+          <description>This project was created for package bar_package via attribute OBS:Maintained</description>
+          <person userid="Iggy" role="maintainer"/>
+          <publish>
+            <disable/>
+          </publish>
+          <repository name="openSUSE_Tumbleweed">
+            <path project="foo_project" repository="openSUSE_Tumbleweed"/>
+            <arch>x86_64</arch>
+          </repository>
+          <repository name="Unicorn_123">
+            <path project="foo_project" repository="Unicorn_123"/>
+            <arch>x86_64</arch>
+            <arch>i586</arch>
+            <arch>ppc</arch>
+            <arch>aarch64</arch>
+          </repository>
+        </project>
+  recorded_at: Tue, 06 Jul 2021 16:10:43 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package/_branch_request?user=Iggy
+    body:
+      encoding: UTF-8
+      string: '{"object_kind":null,"project":{"http_url":null},"object_attributes":{"source":{"default_branch":"123"}}}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '208'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="532" vrev="532">
+          <srcmd5>ca228d71546a8024949a4725849c9ba2</srcmd5>
+          <version>unknown</version>
+          <time>1625587844</time>
+          <user>Iggy</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Tue, 06 Jul 2021 16:10:44 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package/_meta?user=Iggy
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="bar_package" project="home:Iggy:foo_project:PR-1">
+          <title>Taming a Sea Horse</title>
+          <description>Assumenda consequuntur quia recusandae.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '182'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="bar_package" project="home:Iggy:foo_project:PR-1">
+          <title>Taming a Sea Horse</title>
+          <description>Assumenda consequuntur quia recusandae.</description>
+        </package>
+  recorded_at: Tue, 06 Jul 2021 16:10:44 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '725'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="532" vrev="532" srcmd5="ca228d71546a8024949a4725849c9ba2">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="e804fc0f23fe63551b8f4357515e8c7f" baserev="e804fc0f23fe63551b8f4357515e8c7f" xsrcmd5="f7e04315a5d60ec1c5beedb663b6c0ab" lsrcmd5="ca228d71546a8024949a4725849c9ba2"/>
+          <entry name="_branch_request" md5="3604bb2fa00e7261df781f340c5e9ac1" size="104" mtime="1625580172"/>
+          <entry name="_config" md5="62dc35b08d569af627d085e10f75ef86" size="49" mtime="1625587843"/>
+          <entry name="_link" md5="c19ed1bc21f0ba7814f29792f5d58f48" size="119" mtime="1625587843"/>
+          <entry name="somefile.txt" md5="ed321db255ada8ce027a33cc600e43cb" size="57" mtime="1625587843"/>
+        </directory>
+  recorded_at: Tue, 06 Jul 2021 16:10:44 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package?view=info
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '333'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourceinfo package="bar_package" rev="532" vrev="1136" srcmd5="f7e04315a5d60ec1c5beedb663b6c0ab" lsrcmd5="ca228d71546a8024949a4725849c9ba2" verifymd5="685caa65c30934df0ec9a79e8c54dabe">
+          <error>bad build configuration, no build type defined or detected</error>
+          <linked project="foo_project" package="bar_package"/>
+        </sourceinfo>
+  recorded_at: Tue, 06 Jul 2021 16:10:44 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '725'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="532" vrev="532" srcmd5="ca228d71546a8024949a4725849c9ba2">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="e804fc0f23fe63551b8f4357515e8c7f" baserev="e804fc0f23fe63551b8f4357515e8c7f" xsrcmd5="f7e04315a5d60ec1c5beedb663b6c0ab" lsrcmd5="ca228d71546a8024949a4725849c9ba2"/>
+          <entry name="_branch_request" md5="3604bb2fa00e7261df781f340c5e9ac1" size="104" mtime="1625580172"/>
+          <entry name="_config" md5="62dc35b08d569af627d085e10f75ef86" size="49" mtime="1625587843"/>
+          <entry name="_link" md5="c19ed1bc21f0ba7814f29792f5d58f48" size="119" mtime="1625587843"/>
+          <entry name="somefile.txt" md5="ed321db255ada8ce027a33cc600e43cb" size="57" mtime="1625587843"/>
+        </directory>
+  recorded_at: Tue, 06 Jul 2021 16:10:44 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '338'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="67a1687fa7747492cf729b4f061b8527">
+          <old project="home:Iggy:foo_project:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="home:Iggy:foo_project:PR-1" package="bar_package" rev="532" srcmd5="ca228d71546a8024949a4725849c9ba2"/>
+          <files/>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Tue, 06 Jul 2021 16:10:44 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/home:Iggy:foo_project:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '383'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="361560cc0c3f050c01c40acaecf5f51c">
+          <old project="foo_project" package="bar_package" rev="e804fc0f23fe63551b8f4357515e8c7f" srcmd5="e804fc0f23fe63551b8f4357515e8c7f"/>
+          <new project="home:Iggy:foo_project:PR-1" package="bar_package" rev="f7e04315a5d60ec1c5beedb663b6c0ab" srcmd5="f7e04315a5d60ec1c5beedb663b6c0ab"/>
+          <files/>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Tue, 06 Jul 2021 16:10:44 GMT
+recorded_with: VCR 6.0.0

--- a/src/api/spec/models/workflow/step/branch_package_step_spec.rb
+++ b/src/api/spec/models/workflow/step/branch_package_step_spec.rb
@@ -63,6 +63,11 @@ RSpec.describe Workflow::Step::BranchPackageStep, vcr: true do
   end
 
   RSpec.shared_context 'successful new PR or MR event' do
+    before do
+      create(:repository, name: 'Unicorn_123', project: package.project, architectures: ['x86_64', 'i586', 'ppc', 'aarch64'])
+      create(:repository, name: 'openSUSE_Tumbleweed', project: package.project, architectures: ['x86_64'])
+    end
+
     let(:step_instructions) do
       {
         source_project: package.project.name,
@@ -70,12 +75,38 @@ RSpec.describe Workflow::Step::BranchPackageStep, vcr: true do
       }
     end
 
+    let(:workflow_filters) do
+      { architectures: { only: ['x86_64', 'i586'] }, repositories: { ignore: ['openSUSE_Tumbleweed'] } }
+    end
+
+    let(:target_project_name) { "home:#{user.login}:#{project.name}:PR-1" }
+
     it { expect { subject.call }.to(change(Package, :count).by(1)) }
     it { expect(subject.call.project.name).to eq("home:#{user.login}:#{project.name}:PR-1") }
     it { expect { subject.call.source_file('_branch_request') }.not_to raise_error }
     it { expect(subject.call.source_file('_branch_request')).to include('123') }
     it { expect { subject.call }.to(change(EventSubscription.where(eventtype: 'Event::BuildFail'), :count).by(1)) }
     it { expect { subject.call }.to(change(EventSubscription.where(eventtype: 'Event::BuildSuccess'), :count).by(1)) }
+
+    # rubocop:disable RSpec/MultipleExpectations, RSpec/ExampleLength, RSpec/MessageSpies
+    # RSpec/MultipleExpectations, RSpec/ExampleLength - We want to test those expectations together since they depend on each other to be true
+    # RSpec/MesssageSpies - The method `and_call_original` isn't available on `have_received`, so we need to use `receive`
+    it 'only reports for repositories and architectures matching the filters' do
+      expect(SCMStatusReporter).to receive(:new).with({ project: target_project_name, package: package.name, repository: 'Unicorn_123', arch: 'i586' },
+                                                      scm_extractor_payload, token.scm_token).and_call_original
+      expect(SCMStatusReporter).to receive(:new).with({ project: target_project_name, package: package.name, repository: 'Unicorn_123', arch: 'x86_64' },
+                                                      scm_extractor_payload, token.scm_token).and_call_original
+
+      expect(SCMStatusReporter).not_to receive(:new).with({ project: target_project_name, package: package.name, repository: 'Unicorn_123', arch: 'ppc' },
+                                                          scm_extractor_payload, token.scm_token)
+      expect(SCMStatusReporter).not_to receive(:new).with({ project: target_project_name, package: package.name, repository: 'Unicorn_123', arch: 'aarch64' },
+                                                          scm_extractor_payload, token.scm_token)
+      expect(SCMStatusReporter).not_to receive(:new).with({ project: target_project_name, package: package.name, repository: 'openSUSE_Tumbleweed', arch: 'x86_64' },
+                                                          scm_extractor_payload, token.scm_token)
+
+      subject.call({ workflow_filters: workflow_filters })
+    end
+    # rubocop:enable RSpec/MultipleExpectations, RSpec/ExampleLength, RSpec/MessageSpies
   end
 
   RSpec.shared_context 'successful update event when the branch_package already exists' do
@@ -216,6 +247,12 @@ RSpec.describe Workflow::Step::BranchPackageStep, vcr: true do
 
       context 'for a new PR event' do
         let(:action) { 'opened' }
+        let(:octokit_client) { instance_double(Octokit::Client) }
+
+        before do
+          allow(Octokit::Client).to receive(:new).and_return(octokit_client)
+          allow(octokit_client).to receive(:create_status).and_return(true)
+        end
 
         it_behaves_like 'successful new PR or MR event'
         it_behaves_like 'failed when source_package does not exist'
@@ -283,6 +320,12 @@ RSpec.describe Workflow::Step::BranchPackageStep, vcr: true do
 
       context 'for a new MR event' do
         let(:action) { 'open' }
+        let(:gitlab_client) { instance_double(Gitlab::Client) }
+
+        before do
+          allow(Gitlab).to receive(:client).and_return(gitlab_client)
+          allow(gitlab_client).to receive(:update_commit_status).and_return(true)
+        end
 
         it_behaves_like 'successful new PR or MR event'
         it_behaves_like 'failed when source_package does not exist'


### PR DESCRIPTION
We are going to report back the build results to the SCM according to the architectures and repositories defined in the filters of OBS workflows.

While we're happy with the code as it is now, there are still some potential improvements like validating values provided to the filters. As noted in comments, we could also use a query object for some methods. We could gather all errors together before raising if any error is present. All of this is nice to have, but not a blocker to delivering this feature. We're going to tackle as much as possible in the remaining days of the deliverable.