### PR TITLE
Sanitize simple_format

### DIFF
--- a/src/api/app/views/layouts/webui/_flash.html.haml
+++ b/src/api/app/views/layouts/webui/_flash.html.haml
@@ -19,7 +19,7 @@
           = link_to('more info', 'javascript:void(0)', class: 'btn-more alert-link')
           .more_info.d-none
             .more-info-content
-              = simple_format(@more_info)
+              = sanitize(simple_format(@more_info), tags: %w[br p])
         -# haml-lint:enable InstanceVariables
         %button.close{ type: 'button', 'data-dismiss': 'alert', 'aria-label': 'Close' }
           %span{ 'aria-hidden': 'true' }

--- a/src/api/app/views/webui/patchinfo/show.html.haml
+++ b/src/api/app/views/webui/patchinfo/show.html.haml
@@ -30,7 +30,7 @@
       .card.mb-3
         %h5.card-header Message
         .card-body
-          = simple_format @patchinfo.message
+          = sanitize(simple_format(@patchinfo.message), tags: %w[br p])
 
   .col-md-6
     .card.mb-3

--- a/src/api/app/views/webui/request/_review_tab.html.haml
+++ b/src/api/app/views/webui/request/_review_tab.html.haml
@@ -5,7 +5,7 @@
       = user_with_realname_and_icon(User.find_by(login: review.creator))
       requested:
     .ml-4
-      %p= simple_format(review.reason || 'No reason given')
+      %p= sanitize(simple_format(review.reason || 'No reason given'), tags: %w[br p])
   %p
     = text_area_tag('comment', '', rows: 4, class: 'w-100 form-control', placeholder: 'Please comment on your decision')
   %p

--- a/src/api/app/views/webui/shared/_collapsible_text.html.haml
+++ b/src/api/app/views/webui/shared/_collapsible_text.html.haml
@@ -2,4 +2,4 @@
 - if text.present?
   .obs-collapsible-textbox
     .obs-collapsible-text
-      = simple_format(text)
+      = sanitize(simple_format(text), tags: %w[br p])


### PR DESCRIPTION
simple_format marks output as html safe. All of this data includes user input.
Through XML parsing we even store HTML in the database.

```ruby
Xmlhash.parse('<project name="hans"><description>&lt;h2&gt;Hello World&lt;/h2&gt;</description></project>')
=> {"name"=>"hans", "description"=>"<h2>Hello World</h2>"}
```

So better sanitize the simple_format output.


