### PR TITLE
Do not run the workflow steps if some are unsupported

### DIFF
--- a/src/api/app/models/token/errors.rb
+++ b/src/api/app/models/token/errors.rb
@@ -16,4 +16,8 @@ module Token::Errors
   class WorkflowsYamlNotParsable < APIError
     setup 400
   end
+
+  class InvalidWorkflowStepDefinition < APIError
+    setup 403
+  end
 end

--- a/src/api/spec/models/token/workflow_spec.rb
+++ b/src/api/spec/models/token/workflow_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe Token::Workflow, vcr: true do
       end
 
       it 'raises an "Invalid workflow step definition" error' do
-        expect { subject }.to raise_error('Invalid workflow step definition')
+        expect { subject }.to raise_error('Invalid workflow step definition: ')
       end
     end
 

--- a/src/api/spec/models/workflow_spec.rb
+++ b/src/api/spec/models/workflow_spec.rb
@@ -10,20 +10,34 @@ RSpec.describe Workflow, type: :model do
     described_class.new(workflow: yaml, scm_extractor_payload: github_extractor_payload, token: create(:workflow_token))
   end
 
-  describe 'steps' do
-    context 'with supported step' do
+  describe '#steps' do
+    context 'with a supported step' do
       it 'initializes the supported step objects' do
         expect(subject.steps.first).to be_a(Workflow::Step::BranchPackageStep)
       end
     end
 
-    context 'with unsupported step' do
+    context 'with several supported steps' do
       let(:yaml) do
-        { 'steps' => [{ 'unsupported_step' => { 'source_project' => 'test-project', 'source_package' => 'test-package' } }] }
+        { 'steps' => [{ 'branch_package' => { source_project: 'project',
+                                              source_package: 'package' } },
+                      { 'branch_package' => { source_project: 'project',
+                                              source_package: 'package' } }] }
       end
 
-      it 'returns an empty array' do
-        expect(subject.steps).to be_empty
+      it 'returns an array with two items' do
+        expect(subject.steps.count).to be 2
+      end
+    end
+
+    context 'with one unsupported step' do
+      let(:yaml) do
+        { 'steps' => [{ 'unsupported_step' => {} },
+                      { 'branch_package' => {} }] }
+      end
+
+      it 'returns an array with no items' do
+        expect { subject }.to raise_error("Invalid workflow step definition: 'unsupported_step' is not a supported step")
       end
     end
 
@@ -34,6 +48,61 @@ RSpec.describe Workflow, type: :model do
 
       it 'returns an empty array' do
         expect(subject.steps).to be_empty
+      end
+    end
+  end
+
+  describe '#valid' do
+    context 'with a supported step' do
+      it { expect(subject).to be_valid }
+    end
+
+    context 'with several supported steps' do
+      let(:yaml) do
+        { 'steps' => [{ 'branch_package' => { source_project: 'project',
+                                              source_package: 'package' } },
+                      { 'branch_package' => { source_project: 'project',
+                                              source_package: 'package' } }] }
+      end
+
+      it { expect(subject).to be_valid }
+    end
+
+    context 'with several unsupported steps' do
+      let(:yaml) do
+        { 'steps' => [{ 'unsupported_step' => {} },
+                      { 'branch_package' => {} }] }
+      end
+
+      it { expect { subject }.to raise_error("Invalid workflow step definition: 'unsupported_step' is not a supported step") }
+    end
+  end
+
+  describe '#errors' do
+    context 'with a supported step' do
+      it { expect(subject.errors).to be_empty }
+    end
+
+    context 'with several supported steps' do
+      let(:yaml) do
+        { 'steps' => [{ 'branch_package' => { source_project: 'project',
+                                              source_package: 'package' } },
+                      { 'branch_package' => { source_project: 'project',
+                                              source_package: 'package' } }] }
+      end
+
+      it { expect(subject.errors).to be_empty }
+    end
+
+    context 'with several unsupported steps' do
+      let(:yaml) do
+        { 'steps' => [{ 'unsupported_step' => {} },
+                      { 'unsupported_step' => {} },
+                      { 'branch_package' => {} }] }
+      end
+
+      it 'has several errors' do
+        expect { subject }.to raise_error("Invalid workflow step definition: 'unsupported_step' is not a supported step and 'unsupported_step' is not a supported step")
       end
     end
   end


### PR DESCRIPTION
This change aborts the whole step running when there is an unsupported step.

This is how it will respond if there are unsupported specs:

![image](https://user-images.githubusercontent.com/2650/124494542-43223100-ddb7-11eb-86db-deb7daabfb0a.png)
