### PR TITLE
SCM integration - Support for private instances (Github and Gitlab)

### DIFF
--- a/src/api/app/models/token/workflow.rb
+++ b/src/api/app/models/token/workflow.rb
@@ -10,7 +10,7 @@ class Token::Workflow < Token
     return unless extractor.allowed_event_and_action?
 
     scm_extractor_payload = extractor.call
-    yaml_file = Workflows::YAMLDownloader.new(scm_extractor_payload).call
+    yaml_file = Workflows::YAMLDownloader.new(scm_extractor_payload, token: self).call
     workflows = Workflows::YAMLToWorkflowsService.new(yaml_file: yaml_file, scm_extractor_payload: scm_extractor_payload, token: self).call
 
     workflows.each do |workflow|

--- a/src/api/app/services/scm_status_reporter.rb
+++ b/src/api/app/services/scm_status_reporter.rb
@@ -11,14 +11,14 @@ class SCMStatusReporter
 
   def call
     if github?
-      github_client = Octokit::Client.new(access_token: @scm_token)
+      github_client = Octokit::Client.new(access_token: @scm_token, api_endpoint: @event_subscription_payload[:api_endpoint])
       # https://docs.github.com/en/rest/reference/repos#create-a-commit-status
       github_client.create_status(@event_subscription_payload[:target_repository_full_name],
                                   @event_subscription_payload[:commit_sha],
                                   @state,
                                   status_options)
     else
-      gitlab_client = Gitlab.client(endpoint: 'https://gitlab.com/api/v4',
+      gitlab_client = Gitlab.client(endpoint: "#{@event_subscription_payload[:api_endpoint]}/api/v4",
                                     private_token: @scm_token)
       # https://docs.gitlab.com/ce/api/commits.html#post-the-build-status-to-a-commit
       gitlab_client.update_commit_status(@event_subscription_payload[:project_id],

--- a/src/api/app/services/trigger_controller_service/scm_extractor.rb
+++ b/src/api/app/services/trigger_controller_service/scm_extractor.rb
@@ -38,6 +38,12 @@ module TriggerControllerService
     end
 
     def github_extractor_payload
+      host = URI.parse(@payload.dig('sender', 'url')).host
+      api_endpoint = if host.start_with?('api.github.com')
+                       "https://#{host}"
+                     else
+                       "https://#{host}/api/v3/"
+                     end
       {
         scm: 'github',
         commit_sha: @payload.dig('pull_request', 'head', 'sha'),
@@ -47,7 +53,8 @@ module TriggerControllerService
         action: @payload['action'], # TODO: Names may differ, maybe we need to find our own naming (defer to service?)
         source_repository_full_name: @payload.dig('pull_request', 'head', 'repo', 'full_name'),
         target_repository_full_name: @payload.dig('pull_request', 'base', 'repo', 'full_name'),
-        event: @event
+        event: @event,
+        api_endpoint: api_endpoint
       }.with_indifferent_access
     end
 
@@ -66,8 +73,7 @@ module TriggerControllerService
         project_id: @payload.dig('project', 'id'),
         path_with_namespace: @payload.dig('project', 'path_with_namespace'),
         event: @event,
-        scheme: uri.scheme,
-        host: uri.host
+        api_endpoint: "#{uri.scheme}://#{uri.host}"
       }.with_indifferent_access
     end
   end

--- a/src/api/app/services/trigger_controller_service/scm_extractor.rb
+++ b/src/api/app/services/trigger_controller_service/scm_extractor.rb
@@ -52,10 +52,12 @@ module TriggerControllerService
     end
 
     def gitlab_extractor_payload
+      http_url = @payload.dig('project', 'http_url')
+      uri = URI.parse(http_url)
       {
         scm: 'gitlab',
         object_kind: @payload['object_kind'],
-        http_url: @payload.dig('project', 'http_url'),
+        http_url: http_url,
         commit_sha: @payload.dig('object_attributes', 'last_commit', 'id'),
         pr_number: @payload.dig('object_attributes', 'iid'),
         source_branch: @payload.dig('object_attributes', 'source_branch'),
@@ -63,7 +65,9 @@ module TriggerControllerService
         action: @payload.dig('object_attributes', 'action'), # TODO: Names may differ, maybe we need to find our own naming (defer to service?)
         project_id: @payload.dig('project', 'id'),
         path_with_namespace: @payload.dig('project', 'path_with_namespace'),
-        event: @event
+        event: @event,
+        scheme: uri.scheme,
+        host: uri.host
       }.with_indifferent_access
     end
   end

--- a/src/api/app/services/workflows/yaml_downloader.rb
+++ b/src/api/app/services/workflows/yaml_downloader.rb
@@ -23,7 +23,7 @@ module Workflows
       when 'github'
         "https://raw.githubusercontent.com/#{@scm_payload[:target_repository_full_name]}/#{@scm_payload[:target_branch]}/.obs/workflows.yml"
       when 'gitlab'
-        "https://gitlab.com/#{@scm_payload[:path_with_namespace]}/-/raw/#{@scm_payload[:target_branch]}/.obs/workflows.yml"
+        "#{@scm_payload[:scheme]}://#{@scm_payload[:host]}/#{@scm_payload[:path_with_namespace]}/-/raw/#{@scm_payload[:target_branch]}/.obs/workflows.yml"
       end
     end
   end

--- a/src/api/app/services/workflows/yaml_downloader.rb
+++ b/src/api/app/services/workflows/yaml_downloader.rb
@@ -2,8 +2,9 @@ module Workflows
   class YAMLDownloader
     MAX_FILE_SIZE = 1024 * 1024 # 1MB
 
-    def initialize(scm_payload)
+    def initialize(scm_payload, token:)
       @scm_payload = scm_payload
+      @token = token
     end
 
     def call
@@ -21,9 +22,10 @@ module Workflows
     def download_url
       case @scm_payload[:scm]
       when 'github'
-        "https://raw.githubusercontent.com/#{@scm_payload[:target_repository_full_name]}/#{@scm_payload[:target_branch]}/.obs/workflows.yml"
+        client = Octokit::Client.new(access_token: @token.scm_token, api_endpoint: @scm_payload[:api_endpoint])
+        client.content("#{@scm_payload[:target_repository_full_name]}", path: '/.obs/workflows.yml')[:download_url]
       when 'gitlab'
-        "#{@scm_payload[:scheme]}://#{@scm_payload[:host]}/#{@scm_payload[:path_with_namespace]}/-/raw/#{@scm_payload[:target_branch]}/.obs/workflows.yml"
+        "#{@scm_payload[:api_endpoint]}/#{@scm_payload[:path_with_namespace]}/-/raw/#{@scm_payload[:target_branch]}/.obs/workflows.yml"
       end
     end
   end

--- a/src/api/spec/controllers/trigger_workflow_controller_spec.rb
+++ b/src/api/spec/controllers/trigger_workflow_controller_spec.rb
@@ -14,10 +14,16 @@ RSpec.describe TriggerWorkflowController, type: :controller, beta: true do
           }
         },
         base: {
-          ref: 'main'
+          ref: 'main',
+          repo: {
+            full_name: 'rubhanazeem/hello_world'
+          }
         }
       },
-      number: 4
+      number: 4,
+      sender: {
+        url: 'https://api.github.com'
+      }
     }
   end
 
@@ -25,11 +31,14 @@ RSpec.describe TriggerWorkflowController, type: :controller, beta: true do
 
   describe 'POST :create' do
     context 'workflows.yml do not exist' do
+      let(:octokit_client) { instance_double(Octokit::Client) }
       let(:token_extractor_instance) { instance_double(::TriggerControllerService::TokenExtractor) }
 
       before do
         allow(::TriggerControllerService::TokenExtractor).to receive(:new).and_return(token_extractor_instance)
         allow(token_extractor_instance).to receive(:call).and_return(token)
+        allow(Octokit::Client).to receive(:new).and_return(octokit_client)
+        allow(octokit_client).to receive(:content).and_return({ download_url: 'https://google.com' })
         allow(Down).to receive(:download).and_raise(Down::Error, 'Beep Boop, something is wrong')
         request.headers['HTTP_X_GITHUB_EVENT'] = 'pull_request'
         post :create, params: { format: :json }, body: github_payload.to_json

--- a/src/api/spec/models/token/workflow_spec.rb
+++ b/src/api/spec/models/token/workflow_spec.rb
@@ -16,7 +16,10 @@ RSpec.describe Token::Workflow, vcr: true do
           ref: 'main'
         }
       },
-      number: 4
+      number: 4,
+      sender: {
+        url: 'https://api.github.com'
+      }
     }
   end
 
@@ -28,6 +31,9 @@ RSpec.describe Token::Workflow, vcr: true do
         source_branch: 'source',
         target_branch: 'master',
         action: 'open'
+      },
+      project: {
+        http_url: 'https://gitlab.com/eduardoj2/test.git'
       },
       action: 'opened'
     }
@@ -120,6 +126,7 @@ RSpec.describe Token::Workflow, vcr: true do
     end
 
     context 'when the workflows.yml do not exist on the reference branch' do
+      let(:octokit_client) { instance_double(Octokit::Client) }
       let(:scm) { 'github' }
       let(:event) { 'pull_request' }
       let(:payload) { github_payload }
@@ -127,6 +134,8 @@ RSpec.describe Token::Workflow, vcr: true do
       let!(:package) { create(:package, name: 'test-package', project: project) }
 
       before do
+        allow(Octokit::Client).to receive(:new).and_return(octokit_client)
+        allow(octokit_client).to receive(:content).and_return({ download_url: 'https://google.com' })
         allow(Down).to receive(:download).and_raise(Down::Error, 'Beep Boop, something is wrong')
       end
 

--- a/src/api/spec/services/trigger_controller_service/scm_extractor_spec.rb
+++ b/src/api/spec/services/trigger_controller_service/scm_extractor_spec.rb
@@ -69,7 +69,15 @@ RSpec.describe TriggerControllerService::ScmExtractor do
               ref: 'main'
             }
           },
-          number: 4
+          project: {
+            http_url: 'https://gitlab.com/eduardoj2/test.git',
+            id: 26_212_710,
+            path_with_namespace: 'eduardoj2/test'
+          },
+          number: 4,
+          sender: {
+            url: 'https://api.github.com'
+          }
         }
       end
       let(:expected_hash) do
@@ -82,7 +90,8 @@ RSpec.describe TriggerControllerService::ScmExtractor do
           action: 'opened',
           source_repository_full_name: 'iggy/source_repo',
           target_repository_full_name: 'iggy/target_repo',
-          event: 'pull_request'
+          event: 'pull_request',
+          api_endpoint: 'https://api.github.com'
         }
       end
 
@@ -150,13 +159,15 @@ RSpec.describe TriggerControllerService::ScmExtractor do
       let(:event) { 'merge_request' }
       let(:payload) do
         {
+          project: {
+            http_url: 'https://gitlab.com/eduardoj2/test.git'
+          }
         }
       end
       let(:expected_hash) do
         {
           scm: 'gitlab',
           object_kind: nil,
-          http_url: nil,
           commit_sha: nil,
           pr_number: nil,
           source_branch: nil,
@@ -164,7 +175,9 @@ RSpec.describe TriggerControllerService::ScmExtractor do
           action: nil,
           project_id: nil,
           path_with_namespace: nil,
-          event: 'merge_request'
+          event: 'merge_request',
+          api_endpoint: 'https://gitlab.com',
+          http_url: 'https://gitlab.com/eduardoj2/test.git'
         }
       end
 

--- a/src/api/spec/services/workflows/yaml_downloader_spec.rb
+++ b/src/api/spec/services/workflows/yaml_downloader_spec.rb
@@ -1,24 +1,48 @@
 require 'rails_helper'
 
 RSpec.describe Workflows::YAMLDownloader, type: :service do
-  let(:yaml_downloader) { described_class.new(payload) }
+  let(:yaml_downloader) { described_class.new(payload, token: build(:workflow_token)) }
   let(:max_size) { Workflows::YAMLDownloader::MAX_FILE_SIZE }
+  let(:github_payload) do
+    {
+      scm: 'github',
+      commit_sha: '5d175d7f4c58d06907bba188fe9a4c8b6bd723da',
+      pr_number: 1,
+      source_branch: 'test-pr',
+      target_branch: 'master',
+      action: 'synchronize',
+      source_repository_full_name: 'rubhanazeem/hello_world',
+      target_repository_full_name: 'rubhanazeem/hello_world',
+      event: 'pull_request',
+      api_endpoint: 'https://api.github.com'
+    }
+  end
 
   describe '#call' do
     before do
       allow(Down).to receive(:download)
-      yaml_downloader.call
     end
 
     context 'github' do
-      let(:payload) { { scm: 'github', target_branch: 'master', target_repository_full_name: 'openSUSE/obs-server' } }
+      before do
+        allow(Octokit::Client).to receive(:new).and_return(octokit_client)
+        allow(octokit_client).to receive(:content).and_return({ download_url: url })
+        yaml_downloader.call
+      end
+
+      let(:payload) { github_payload }
+      let(:octokit_client) { instance_double(Octokit::Client) }
       let(:url) { "https://raw.githubusercontent.com/#{payload[:target_repository_full_name]}/#{payload[:target_branch]}/.obs/workflows.yml" }
 
       it { expect(Down).to have_received(:download).with(url, max_size: max_size) }
     end
 
     context 'gitlab' do
-      let(:payload) { { scm: 'gitlab', target_branch: 'master', path_with_namespace: 'openSUSE/obs-server' } }
+      before do
+        yaml_downloader.call
+      end
+
+      let(:payload) { { scm: 'gitlab', target_branch: 'master', path_with_namespace: 'openSUSE/obs-server', api_endpoint: 'https://gitlab.com' } }
       let(:url) { "https://gitlab.com/#{payload[:path_with_namespace]}/-/raw/#{payload[:target_branch]}/.obs/workflows.yml" }
 
       it { expect(Down).to have_received(:download).with(url, max_size: max_size) }


### PR DESCRIPTION
Remove hardcoded URLs and pass the hostname in the payload to generate URLs.

Fixes #11198 
