### PR TITLE
Raise APIError subclass if SCM Token is unauthorized

### DIFF
--- a/src/api/app/models/token/errors.rb
+++ b/src/api/app/models/token/errors.rb
@@ -8,4 +8,8 @@ module Token::Errors
   class NonExistentWorkflowsFile < APIError
     setup 404
   end
+
+  class SCMTokenInvalid < APIError
+    setup 401
+  end
 end

--- a/src/api/app/models/token/workflow.rb
+++ b/src/api/app/models/token/workflow.rb
@@ -22,6 +22,8 @@ class Token::Workflow < Token
     workflows.each do |workflow|
       workflow.steps.each do |step|
         run_step_and_report(step, scm_extractor_payload, scm_token)
+      rescue Octokit::Unauthorized, Gitlab::Error::Unauthorized => e
+        raise Token::Errors::SCMTokenInvalid, e.message
       end
     end
   end


### PR DESCRIPTION
Improve the error handling and user feedback in case the SCM token of the user is invalid