### PR TITLE
[backend] rework constraints handling in the dispatcher

### DIFF
--- a/src/backend/BSDispatcher/Constraints.pm
+++ b/src/backend/BSDispatcher/Constraints.pm
@@ -214,7 +214,7 @@ sub overwriteconstraints {
 
 # constructs a data object from a list and a XML::Structured dtd
 sub list2struct {
-  my ($dtd, $list, $job) = @_;
+  my ($dtd, $list) = @_;
   my $top = {};
   for my $l (@{$list || []}) {
     my @l = @$l;
@@ -290,7 +290,7 @@ sub list2struct {
         }
       }
     };
-    warn("list2struct: $job: @$l: $@") if $@;
+    die("@$l: $@") if $@;
   }
   return $top;
 }

--- a/src/backend/bs_dispatch
+++ b/src/backend/bs_dispatch
@@ -122,9 +122,9 @@ if ($options->{'testconstraints'}) {
     }
     if ($constraintsprj_file) {
       my @lines = map { [ split(' ', $_) ] } split("\n", readstr($constraintsprj_file));
-      my $prjconfconstraint = BSDispatcher::Constraints::list2struct($BSXML::constraints, \@lines);
-      if ($prjconfconstraint) {
-        $constraints = $constraints ? BSDispatcher::Constraints::mergeconstraints($prjconfconstraint, $constraints) : $prjconfconstraint;
+      my $prjconfconstraints = BSDispatcher::Constraints::list2struct($BSXML::constraints, \@lines);
+      if ($prjconfconstraints) {
+        $constraints = $constraints ? BSDispatcher::Constraints::mergeconstraints($prjconfconstraints, $constraints) : $prjconfconstraints;
       }
     }
     die("No parseable workerinfo\n") unless keys %$workerinfo;
@@ -216,6 +216,8 @@ my $badhostchanged = 1;
 my %newestsrcchange;
 my %infocache;
 my %constraintscache;
+my %prjconfconstraintscache;
+my $prjconfconstraintscache_lastdrop;
 
 my %lastbuild;	# last time a job was build in that prpa
 
@@ -416,10 +418,34 @@ sub getconstraints {
   };
   if ($@) {
     warn($@);
-    return [ time() + 600 ];	# better luck next time
+    chomp $@;
+    return [ $@, time() + 600 ];	# better luck next time
   }
-  return undef unless $constraintsxml;
-  return BSUtil::fromxml($constraintsxml, $BSXML::constraints, 1);
+  my $constraints;
+  eval {
+    $constraints = BSUtil::fromxml($constraintsxml, $BSXML::constraints);
+    die("huh?\n") unless ref($constraints) eq 'HASH';
+  };
+  if ($@) {
+    chomp $@;
+    return [ "bad constraints: $@" ];
+  }
+  return $constraints;
+}
+
+sub getprjconfconstraints {
+  my ($info) = @_;
+  my @l = map { [ split(' ', $_) ] } @{$info->{'prjconfconstraint'}};
+  my $constraints;
+  eval {
+    $constraints = BSDispatcher::Constraints::list2struct($BSXML::constraints, \@l);
+    die("huh?\n") unless ref($constraints) eq 'HASH';
+  };
+  if ($@) {
+    chomp $@;
+    return [ "bad prjconfconstraints: $@" ];
+  }
+  return $constraints;
 }
 
 # normalizes an xml size element to mega bytes
@@ -911,6 +937,12 @@ while (1) {
       }
     }
   }
+
+  # drop prjconfconstraints cache from time to time
+  if (($prjconfconstraintscache_lastdrop || 0) + 1800 < $now) {
+    %prjconfconstraintscache = ();
+    $prjconfconstraintscache_lastdrop = $now;
+  }
   
   my %workerload;
   my %numidle;
@@ -1258,26 +1290,31 @@ while (1) {
       my $lastoracleidle;
       my $constraints;
       if ($info->{'constraintsmd5'}) {
-	my $constraintsmd5 = $ic->{$job}->{'constraintsmd5'};
-	if (!exists($constraintscache{$constraintsmd5})) {
-	  $constraintscache{$constraintsmd5} = getconstraints($info, $constraintsmd5);
-	}
+	my $constraintsmd5 = $info->{'constraintsmd5'};
 	$constraints = $constraintscache{$constraintsmd5};
-	if (!ref($constraints)) {
-	  BSUtil::printlog("job has bad constraints file: $job");
-	  next;
-	}
+	$constraintscache{$constraintsmd5} = $constraints = getconstraints($info, $constraintsmd5) unless $constraints;
 	if (ref($constraints) eq 'ARRAY') {
-	  delete($constraintscache{$constraintsmd5}) if $constraints->[0] < $now;
+	  if ($constraints->[1]) {
+	    delete($constraintscache{$constraintsmd5}) if $constraints->[1] < $now;
+	    next;
+	  }
+	  warn("$arch/$job: $constraints->[0]\n");
+	  failjob($info, $arch, $job, $constraints->[0]);
 	  next;
 	}
-        $constraints = BSDispatcher::Constraints::overwriteconstraints($info, $constraints) if $constraints->{'overwrite'};
+	$constraints = BSDispatcher::Constraints::overwriteconstraints($info, $constraints) if $constraints->{'overwrite'};
       }
       if ($info->{'prjconfconstraint'}) {
-	my @l = map { [ split(' ', $_) ] } @{$info->{'prjconfconstraint'}};
-	my $prjconfconstraint = BSDispatcher::Constraints::list2struct($BSXML::constraints, \@l, "$arch/$job");
-	if ($prjconfconstraint) {
-	  $constraints = $constraints ? BSDispatcher::Constraints::mergeconstraints($prjconfconstraint, $constraints) : $prjconfconstraint;
+	my $cachekey = join("\n", @{$info->{'prjconfconstraint'}});
+	my $prjconfconstraints = $prjconfconstraintscache{$cachekey};
+	$prjconfconstraintscache{$cachekey} = $prjconfconstraints = getprjconfconstraints($info) unless $prjconfconstraints;
+	if (ref($prjconfconstraints) eq 'ARRAY') {
+	  warn("$arch/$job: $prjconfconstraints->[0]\n");
+	  failjob($info, $arch, $job, $prjconfconstraints->[0]);
+	  next;
+	}
+	if (%{$prjconfconstraints || {}}) {
+	  $constraints = $constraints ? BSDispatcher::Constraints::mergeconstraints($prjconfconstraints, $constraints) : $prjconfconstraints;
 	}
       }
       undef $constraints if $constraints && !%$constraints;


### PR DESCRIPTION
We now fail jobs if we cannot parse the package or
project constraints. Before, a job with a bad package
constraints simply was never dispatched. Bad project
constraints were ignored.

This commit also implements a cache for parsed project
constraints.

_Replace this line with a description of your changes. Please follow the suggestions in the comment below._

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
