### PR TITLE
Avoid leaking Workflows::YAMLDownloader errors outside the class

### DIFF
--- a/src/api/app/models/token/workflow.rb
+++ b/src/api/app/models/token/workflow.rb
@@ -10,13 +10,7 @@ class Token::Workflow < Token
     return unless extractor.allowed_event_and_action?
 
     scm_extractor_payload = extractor.call
-    yaml_downloader = Workflows::YAMLDownloader.new(scm_extractor_payload)
-    yaml_file = yaml_downloader.call
-    if yaml_file.blank?
-      raise Token::Errors::NonExistentWorkflowsFile,
-            ".obs/workflows.yml could not be downloaded on the SCM branch #{scm_extractor_payload[:target_branch]}: #{yaml_downloader.errors.join('\n')}"
-    end
-
+    yaml_file = Workflows::YAMLDownloader.new(scm_extractor_payload).call
     workflows = Workflows::YAMLToWorkflowsService.new(yaml_file: yaml_file, scm_extractor_payload: scm_extractor_payload, token: self).call
 
     workflows.each do |workflow|

--- a/src/api/app/services/workflows/yaml_downloader.rb
+++ b/src/api/app/services/workflows/yaml_downloader.rb
@@ -2,11 +2,8 @@ module Workflows
   class YAMLDownloader
     MAX_FILE_SIZE = 1024 * 1024 # 1MB
 
-    attr_reader :errors
-
     def initialize(scm_payload)
       @scm_payload = scm_payload
-      @errors = []
     end
 
     def call
@@ -18,8 +15,7 @@ module Workflows
     def download_yaml_file
       Down.download(download_url, max_size: MAX_FILE_SIZE)
     rescue Down::Error => e
-      @errors << e.message
-      nil
+      raise Token::Errors::NonExistentWorkflowsFile, ".obs/workflows.yml could not be downloaded on the SCM branch #{@scm_payload[:target_branch]}: #{e.message}"
     end
 
     def download_url


### PR DESCRIPTION
It's better to handle everything in the class itself. Other classes relying on this class can rescue if needed.

Following up on #11331