### PR TITLE
Add real_time_tidy to ThinkingSphinx dev configuration

### DIFF
--- a/src/api/config/thinking_sphinx.yml.example
+++ b/src/api/config/thinking_sphinx.yml.example
@@ -3,6 +3,7 @@ development:
   bin_path: /usr/bin
   mem_limit: 512M
   charset_table: "0..9, a..z, A..Z->a..z, U+410..U+42F->U+430..U+44F, U+430..U+44F"
+  real_time_tidy: true
 test:
   mysql41: 9313
   bin_path: /usr/bin


### PR DESCRIPTION
This will clean up real-time orphan records after reindexing. As the first step, to ensure this is not causing any error, we are going to enable it only in development environment.
