### PR TITLE
Add data migration to handle old event_subscriptions

### DIFF
--- a/src/api/db/data/20210707102506_add_api_endpoints_to_payload.rb
+++ b/src/api/db/data/20210707102506_add_api_endpoints_to_payload.rb
@@ -1,0 +1,21 @@
+class AddApiEndpointsToPayload < ActiveRecord::Migration[6.1]
+  def up
+    EventSubscription.where(channel: 'scm').each do |event_sub|
+      next if event_sub.payload['api_endpoint'].present?
+
+      if event_sub.payload['scm'] == 'github'
+        event_sub.payload['api_endpoint'] = 'https://api.github.com'
+      else
+        http_url = event_sub.payload['http_url']
+        uri = URI.parse(http_url)
+        api_endpoint = "#{uri.scheme}://#{uri.host}"
+        event_sub.payload['api_endpoint'] = api_endpoint
+      end
+      event_sub.save!
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/src/api/db/data_schema.rb
+++ b/src/api/db/data_schema.rb
@@ -1,2 +1,2 @@
 # encoding: UTF-8
-DataMigrate::Data.define(version: 20210520160000)
+DataMigrate::Data.define(version: 20210707102506)


### PR DESCRIPTION
We need to migrate SCM event_subscriptions according to the new payload structure.

Co-authored-by: @saraycp 


Fixes #11346 