### PR TITLE
[api][backend] allow to disable export of issue trackers

### DIFF
--- a/docs/api/api/obs.rng
+++ b/docs/api/api/obs.rng
@@ -364,6 +364,11 @@
           </element>
         </optional>
         <optional>
+          <element name="publish-issues">
+            <text/>
+          </element>
+        </optional>
+        <optional>
           <element name="issues-updated">
             <text/>
           </element>

--- a/src/api/db/migrate/20210707134455_publish_issues.rb
+++ b/src/api/db/migrate/20210707134455_publish_issues.rb
@@ -1,0 +1,5 @@
+class PublishIssues < ActiveRecord::Migration[6.0]
+  def change
+    add_column :issue_trackers, :publish_issues, :boolean, default: true
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_13_223300) do
+ActiveRecord::Schema.define(version: 2022_04_13_223301) do
 
   create_table "architectures", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false, collation: "utf8_general_ci"
@@ -547,6 +547,7 @@ ActiveRecord::Schema.define(version: 2022_04_13_223300) do
     t.text "label", null: false, collation: "utf8_general_ci"
     t.datetime "issues_updated", null: false
     t.boolean "enable_fetch", default: false
+    t.boolean "publish_issues", default: true
   end
 
   create_table "issues", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|

--- a/src/backend/BSSched/BuildJob/Patchinfo.pm
+++ b/src/backend/BSSched/BuildJob/Patchinfo.pm
@@ -691,6 +691,7 @@ sub build {
     for my $b (@{$patchinfo->{'issue'} || []}) {
       my $it = (grep {$_->{'name'} eq $b->{'tracker'}} @{$issue_trackers->{'issue-tracker'} || []})[0];
       if ($it && $b->{'id'}) {
+        next if $b->{'publish-issues'} eq 'false';
         my $trackerid = $b->{'id'};
         my $referenceid = $b->{'id'};
         if ($b->{'tracker'} eq 'cve') {

--- a/src/backend/BSXML.pm
+++ b/src/backend/BSXML.pm
@@ -1707,6 +1707,7 @@ our $issue_trackers = [
 	    'description',
 	    'kind',
             'label',
+            'publish-issues',
             'enable-fetch',
 	    'regex',
 	    'user',


### PR DESCRIPTION
allow to define issue trackers which should not get exported into
external meta data like updateinfo.xml

OBS-141

_Replace this line with a description of your changes. Please follow the suggestions in the comment below._

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
