### PR TITLE
Move error classes from Token to BranchPackage errors module

### DIFF
--- a/src/api/app/models/branch_package/errors.rb
+++ b/src/api/app/models/branch_package/errors.rb
@@ -3,6 +3,18 @@ module BranchPackage::Errors
 
   class InvalidFilelistError < APIError; end
 
+  class CanNotBranchPackage < APIError
+    setup 422
+  end
+
+  class CanNotBranchPackageNoPermission < APIError
+    setup 403
+  end
+
+  class CanNotBranchPackageNotFound < APIError
+    setup 404
+  end
+
   class DoubleBranchPackageError < APIError
     attr_reader :project, :package
 

--- a/src/api/app/models/token/errors.rb
+++ b/src/api/app/models/token/errors.rb
@@ -28,16 +28,4 @@ module Token::Errors
   class InvalidWorkflowStepDefinition < APIError
     setup 403
   end
-
-  class CanNotBranchPackage < APIError
-    setup 422
-  end
-
-  class CanNotBranchPackageNoPermission < APIError
-    setup 403
-  end
-
-  class CanNotBranchPackageNotFound < APIError
-    setup 404
-  end
 end

--- a/src/api/app/models/workflow/step/branch_package_step.rb
+++ b/src/api/app/models/workflow/step/branch_package_step.rb
@@ -83,7 +83,7 @@ class Workflow
         begin
           src_package = Package.get_by_project_and_name(source_project_name, source_package_name, options)
         rescue Package::UnknownObjectError
-          raise Token::Errors::CanNotBranchPackageNotFound, "Package #{source_project_name}/#{source_package_name} not found, it could not be branched."
+          raise BranchPackage::Errors::CanNotBranchPackageNotFound, "Package #{source_project_name}/#{source_package_name} not found, it could not be branched."
         end
 
         Pundit.authorize(@token.user, src_package, :create_branch?)
@@ -97,9 +97,10 @@ class Workflow
                               target_project: target_project_name,
                               target_package: target_package_name }).branch
         rescue BranchPackage::InvalidArgument, InvalidProjectNameError, ArgumentError => e
-          raise Token::Errors::CanNotBranchPackage, "Package #{source_project_name}/#{source_package_name} could not be branched: #{e.message}"
+          raise BranchPackage::Errors::CanNotBranchPackage, "Package #{source_project_name}/#{source_package_name} could not be branched: #{e.message}"
         rescue Project::WritePermissionError, CreateProjectNoPermission => e
-          raise Token::Errors::CanNotBranchPackageNoPermission, "Package #{source_project_name}/#{source_package_name} could not be branched due to missing permissions: #{e.message}"
+          raise BranchPackage::Errors::CanNotBranchPackageNoPermission,
+                "Package #{source_project_name}/#{source_package_name} could not be branched due to missing permissions: #{e.message}"
         end
 
         Event::BranchCommand.create(project: source_project_name, package: source_package_name,

--- a/src/api/spec/models/workflow/step/branch_package_step_spec.rb
+++ b/src/api/spec/models/workflow/step/branch_package_step_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Workflow::Step::BranchPackageStep, vcr: true do
       }
     end
 
-    it { expect { subject.call }.to raise_error(Token::Errors::CanNotBranchPackageNotFound) }
+    it { expect { subject.call }.to raise_error(BranchPackage::Errors::CanNotBranchPackageNotFound) }
   end
 
   RSpec.shared_context 'failed when project name is invalid' do
@@ -42,7 +42,7 @@ RSpec.describe Workflow::Step::BranchPackageStep, vcr: true do
       }
     end
 
-    it { expect { subject.call }.to raise_error(Token::Errors::CanNotBranchPackage) }
+    it { expect { subject.call }.to raise_error(BranchPackage::Errors::CanNotBranchPackage) }
   end
 
   RSpec.shared_context 'failed without branch permissions' do
@@ -59,7 +59,7 @@ RSpec.describe Workflow::Step::BranchPackageStep, vcr: true do
       }
     end
 
-    it { expect { subject.call }.to raise_error(Token::Errors::CanNotBranchPackageNoPermission) }
+    it { expect { subject.call }.to raise_error(BranchPackage::Errors::CanNotBranchPackageNoPermission) }
   end
 
   RSpec.shared_context 'successful new PR or MR event' do


### PR DESCRIPTION
The errors classes are related with branching and have nothing to do with `Token` therefore lets move it to `BranchPackage/errors.rb`