### PR TITLE
Setup filters in .obs/workflows.yml

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -3,3 +3,12 @@ workflow:
     - branch_package:
         source_project: OBS:Server:Unstable
         source_package: obs-server
+  filters:
+    architectures:
+      only:
+        - x86_64
+    repositories:
+      only:
+        - SLE_12_SP5
+        - SLE_15_SP1
+        - SLE_15_SP2


### PR DESCRIPTION
To use the feature implemented in #11318.

The architectures and repositories are the same as the ones from the CI check `OBS Package Build`.

Once we merge this, following PRs will only report what we defined in the filters.