### PR TITLE
[backend] BSDispatcher::list2struct: add to arrays in leaf elements

### DIFF
--- a/src/backend/BSDispatcher/Constraints.pm
+++ b/src/backend/BSDispatcher/Constraints.pm
@@ -223,13 +223,15 @@ sub list2struct {
       my @loc = split(':', shift @l);
       my @how = @$dtd;
       my $out = $top;
+      my $outref;
       while (@loc) {
         my $am = shift @how;
         my $e = shift @loc;
-        my $addit;
-        my $delit;
+        my ($addit, $delit, $modit);
         $addit = 1 if $e =~ s/\+$//;
         $delit = 1 if !$addit && $e =~ s/=$//;
+	$modit = 1 if !$addit && !$delit && $e =~ s/!$//;
+	$modit = 1 if !$addit && !$delit && @loc;	# default non-leaf elements
         my %known = map {ref($_) ? (!@$_ ? () : (ref($_->[0]) ? $_->[0]->[0] : $_->[0] => $_)) : ($_=> $_)} @how;
         my $ke = $known{$e};
         die("unknown element: $e\n") unless $ke;
@@ -241,25 +243,28 @@ sub list2struct {
         if (!ref($ke) || (@$ke == 1 && !ref($ke->[0]))) {
           die("element '$e' has subelements\n") if @loc;
           die("element '$e' contains attributes\n") if @l && $l[0] =~ /=/;
-          delete $out->{$e} unless $addit;
           if (!ref($ke)) {
+            delete $out->{$e} unless $addit;
             die("element '$e' must be singleton\n") if exists $out->{$e};
             $out->{$e} = join(' ', @l);
           } else {
+            delete $out->{$e} if $modit;
             push @{$out->{$e}}, @l;
           }
           @how = ();
         } else {
           my $nout = {};
           if (@$ke == 1) {
-            $nout = pop @{$out->{$e}} if exists $out->{$e} && !$addit;
+            $nout = pop @{$out->{$e}} if exists $out->{$e} && $modit;
             push @{$out->{$e}}, $nout;
             @how = @{$ke->[0]};
+	    $outref = $out->{$e};
           } else {
             $nout = delete $out->{$e} if exists $out->{$e} && !$addit;
             die("element '$e' must be singleton\n") if exists $out->{$e};
             $out->{$e} = $nout;
             @how = @$ke;
+	    $outref = undef;
           }
           $out = $nout;
         }
@@ -285,8 +290,10 @@ sub list2struct {
           shift @l;
         }
         if (@l) {
-          die("element '$am' contains content\n") unless $known{'_content'};
-          $out->{'_content'} = join(' ', @l);
+	  die("element '$am' contains content\n") unless $known{'_content'};
+	  @l = ( join(' ', @l) ) unless $outref;
+	  $out->{'_content'} = shift @l;
+	  push @$outref, BSUtil::clone({ %$out, '_content' => $_ }) for @l;
         }
       }
     };

--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -2684,7 +2684,7 @@ sub forwardevent {
   $arch = 'publish' if $type eq 'publish';
   if ($type eq 'suspendproject' || $type eq 'resumeproject') {
     # those events stack - we must not overwrite them. randomize somewhat.
-    $evname = "type:::$$-".Digest::MD5::md5_hex("$$/$evname".time());
+    $evname = "${type}:::$$-".Digest::MD5::md5_hex("$$/$evname".time());
   }
   if ($arch) {
     mkdir_p("$eventdir/$arch");


### PR DESCRIPTION
The old code modified the old entry instead. Thus, a prjconstraint
of
    hardware:cpu:flag exclude=true EL0
    hardware:cpu:flag cpuid
resulted in the EL0 exclude being ignored. We now default to
"add" mode for leaf elements. You can force the old "overwrite last
entry" mode by adding a '!' character, like:
    hardware:cpu:flag! cpuid

_Replace this line with a description of your changes. Please follow the suggestions in the comment below._

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
