### PR TITLE
Adjust error handling for non-existent workflows.yml

### DIFF
--- a/src/api/app/services/workflows/yaml_downloader.rb
+++ b/src/api/app/services/workflows/yaml_downloader.rb
@@ -16,7 +16,7 @@ module Workflows
     def download_yaml_file
       Down.download(download_url, max_size: MAX_FILE_SIZE)
     rescue Down::Error => e
-      raise Token::Errors::NonExistentWorkflowsFile, ".obs/workflows.yml could not be downloaded on the SCM branch #{@scm_payload[:target_branch]}: #{e.message}"
+      raise Token::Errors::NonExistentWorkflowsFile, ".obs/workflows.yml could not be downloaded from the SCM branch #{@scm_payload[:target_branch]}: #{e.message}"
     end
 
     def download_url
@@ -27,6 +27,8 @@ module Workflows
       when 'gitlab'
         "#{@scm_payload[:api_endpoint]}/#{@scm_payload[:path_with_namespace]}/-/raw/#{@scm_payload[:target_branch]}/.obs/workflows.yml"
       end
+    rescue Octokit::NotFound => e
+      raise Token::Errors::NonExistentWorkflowsFile, ".obs/workflows.yml could not be downloaded from the SCM branch #{@scm_payload[:target_branch]}: #{e.message}"
     end
   end
 end

--- a/src/api/spec/controllers/trigger_workflow_controller_spec.rb
+++ b/src/api/spec/controllers/trigger_workflow_controller_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe TriggerWorkflowController, type: :controller, beta: true do
       it { expect(response).to have_http_status(:not_found) }
 
       it "displays a user-friendly error message in the response's body" do
-        expect(response.body).to include('.obs/workflows.yml could not be downloaded on the SCM branch main: Beep Boop, something is wrong')
+        expect(response.body).to include('.obs/workflows.yml could not be downloaded from the SCM branch main: Beep Boop, something is wrong')
       end
     end
 

--- a/src/api/spec/models/token/workflow_spec.rb
+++ b/src/api/spec/models/token/workflow_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe Token::Workflow, vcr: true do
 
       it 'raises a user-friendly error message' do
         expect { subject }.to raise_error(Token::Errors::NonExistentWorkflowsFile,
-                                          '.obs/workflows.yml could not be downloaded on the SCM branch main: Beep Boop, something is wrong')
+                                          '.obs/workflows.yml could not be downloaded from the SCM branch main: Beep Boop, something is wrong')
       end
     end
 


### PR DESCRIPTION
When the file doesn't exist in the default branch of the SCM repository,
is Octokit which fails first. So we handle the exception at this point.

Co-authored-by: Rubhan Azeem <rubhan.azeem@suse.com>

