### PR TITLE
Add real_time_tidy to ThinkingSphinx

### DIFF
--- a/src/api/config/thinking_sphinx.yml.example
+++ b/src/api/config/thinking_sphinx.yml.example
@@ -17,3 +17,4 @@ production:
   bin_path: /usr/bin
   mem_limit: 512M
   charset_table: "0..9, a..z, A..Z->a..z, U+410..U+42F->U+430..U+44F, U+430..U+44F"
+  real_time_tidy: true


### PR DESCRIPTION
This will clean up real-time orphan records after reindexing.
This time will be enabled for the production environment.
