### PR TITLE
Disable CodeClimate checks which have RuboCop equivalents

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,4 +1,25 @@
 version: "2"
+# We disable checks which have equivalents in RuboCop to avoid reporting twice the same things
+# Documentation: https://docs.codeclimate.com/docs/maintainability#section-checks
+checks:
+  # Same as cop Metrics/ParameterLists from RuboCop
+  argument-count:
+    enabled: false
+  # Same as cops Metrics/ClassLength and Metrics/ModuleLength from RuboCop
+  file-lines:
+    enabled: false
+  # Same as cop Metrics/PerceivedComplexity from RuboCop
+  method-complexity:
+    enabled: false
+  # Same as cop Metrics/MethodLength from RuboCop
+  method-length:
+    enabled: false
+  # Same as cop Metrics/BlockNesting from RuboCop
+  nested-control-flow:
+    enabled: false
+  # Same as cop Metrics/CyclomaticComplexity from RuboCop
+  return-statements:
+    enabled: false
 exclude_patterns:
   - "dist/"
   - "src/api/test/"


### PR DESCRIPTION
This is to avoid reporting twice the same thing due to having two standards for various code quality metrics. RuboCop is the standard whenever CodeClimate and RuboCop have the same checks/cops.

The CodeClimate checks are described here https://docs.codeclimate.com/docs/maintainability#section-checks

I compared them to the cops provided by RuboCop to see which ones are overlapping. This is how I came up with a list of CodeClimate checks to disable.