### PR TITLE
RFC: Support the retrieval of the sha256sums in bs_srcserver getfilelist

### DIFF
--- a/src/backend/BSRevision.pm
+++ b/src/backend/BSRevision.pm
@@ -538,6 +538,12 @@ sub revcpiofile {
   return BSSrcrep::cpiofile($rev->{'project'}, $rev->{'package'}, $filename, $md5, $forcehandle);
 }
 
+sub revdigest {
+  my ($rev, $filename, $md5, $alg) = @_;
+  die("unsupported algorithm: $alg\n") unless $alg eq 'sha256';
+  return "$alg:" . BSSrcrep::filesha256($rev->{'project'}, $rev->{'package'}, $filename, $md5);
+}
+
 sub lsrev {
   my ($rev, $linkinfo) = @_;
   die("nothing known\n") unless $rev;

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -3323,10 +3323,7 @@ sub sourcecommitfilelist {
     } else {
       die("duplicate file: $entry->{'name'}\n") if exists $files->{$entry->{'name'}};
       if ($entry->{'hash'}) {
-        my $fd = gensym;
-        BSRevision::revopen($orev, $entry->{'name'}, $entry->{'md5'}, $fd);
-        my $sha256 = Digest::SHA->new(256);
-        my $hash_to_check = "sha256:" . $sha256->addfile($fd)->hexdigest;
+        my $hash_to_check = BSRevision::revdigest($orev, $entry->{'name'}, $entry->{'md5'}, 'sha256');
         if ($hash_to_check ne $entry->{'hash'}) {
           die("SHA mismatch for same md5sum in $packid for file $entry->{'name'} with sum $entry->{'md5'}\n");
         }

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -2860,7 +2860,9 @@ sub getfilelist {
   for my $filename (sort keys %$files) {
     my @s = BSRevision::revstat($rev, $filename, $files->{$filename});
     if (@s) {
-      push @res, {'name' => $filename, 'md5' => $files->{$filename}, 'size' => $s[7], 'mtime' => $s[9]};
+      my $entry = {'name' => $filename, 'md5' => $files->{$filename}, 'size' => $s[7], 'mtime' => $s[9]};
+      $entry->{'hash'} = BSRevision::revdigest($rev, $filename, $files->{$filename}, $cgi->{'digestalg'}) if $cgi->{'digestalg'};
+      push @res, $entry;
     } else {
       push @res, {'name' => $filename, 'md5' => $files->{$filename}, 'error' => "$!"};
     }
@@ -7418,7 +7420,7 @@ my $dispatches = [
 
   '/source/$project/$package view=getmultibuild' => \&getmultibuildpackages,
   '/source/$project/$package view=info rev? linkrev? parse:bool? nofilename:bool? repository? arch? withchangesmd5:bool? noexpand:bool? withmetamd5:bool?' => \&getpackagesourceinfo,
-  '/source/$project/$package rev? linkrev? emptylink:bool? deleted:bool? expand:bool? view:? extension:? lastworking:bool? withlinked:bool? meta:bool? product:?' => \&getfilelist,
+  '/source/$project/$package rev? linkrev? emptylink:bool? deleted:bool? expand:bool? view:? extension:? lastworking:bool? withlinked:bool? meta:bool? product:? digestalg:?' => \&getfilelist,
   '/source/$project/$package/_history rev? meta:bool? deleted:bool? limit:num?' => \&getpackagehistory,
   '/source/$project/$package/_meta rev? expand:bool? meta:bool? deleted:bool? view:? interconnect:?' => \&getpackage,
   'PUT:/source/$project/$package/_meta user:? comment:? requestid:num?' => \&putpackage,


### PR DESCRIPTION
```
    This way it is possible to implement "osc copypac --to-apiurl <foo> ..."
    in a more "secure" way without any additional overhead (that is,
    without the need to download all source files and manual digest
    computation). osc's current implementation is somewhat "insecure"
    because it solely relies on md5.

This is just an idea... feel free to reject:)
```