### PR TITLE
Stop sending "building jobs" measurements

### DIFF
--- a/src/api/app/jobs/worker_measurements_job.rb
+++ b/src/api/app/jobs/worker_measurements_job.rb
@@ -37,13 +37,6 @@ class WorkerMeasurementsJob < ApplicationJob
       RabbitmqBus.send_to_bus('metrics', "jobs,arch=#{architecture_name},state=waiting count=#{waiting}")
       RabbitmqBus.send_to_bus('metrics', "jobs,arch=#{architecture_name},state=blocked count=#{blocked}")
     end
-
-    @workerstatus.search('//building').each do |job|
-      hostarch = job.attributes['hostarch'].value
-      arch = job.attributes['arch'].value
-      progression = Time.now.to_i - job.attributes['starttime'].value.to_i
-      RabbitmqBus.send_to_bus('metrics', "jobs,hostarch=#{hostarch},arch=#{arch},state=building progression=#{progression},count=1")
-    end
   end
 
   def send_scheduler_metrics


### PR DESCRIPTION
Sending "building jobs" rise up two problems:
1) sending them before scheduler measurements, Grafana didn't get data about scheduler measurements,
2) sending them after scheduler measurements, Grafana didn't get all the data regarding "building jobs" measurements

In both cases, graphics shown in Grafana about "building jobs" and schedulers are currently not accurate.

Therefore, stop sending "building jobs" measurements till the root cause of the problem is figured out. Tests should be done in a test environment, not in production.

Overrides #11378.

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
