### PR TITLE
[dist] remove Wants= from most of our systemd service files

### DIFF
--- a/dist/systemd/obs-clockwork.service
+++ b/dist/systemd/obs-clockwork.service
@@ -2,7 +2,6 @@
 Description = Open Build Service Clockwork Daemon
 BindsTo = obs-api-support.target
 After = mariadb.service obsapisetup.service
-Wants = mariadb.service obsapisetup.service
 
 [Service]
 Environment = "RAILS_ENV=production"

--- a/dist/systemd/obs-delayedjob-queue-consistency_check.service
+++ b/dist/systemd/obs-delayedjob-queue-consistency_check.service
@@ -2,7 +2,6 @@
 Description = Open Build Service DelayedJob Queue: consistency_check
 BindsTo = obs-api-support.target
 After = mariadb.service obsapisetup.service
-Wants = mariadb.service obsapisetup.service
 
 [Service]
 Environment = "RAILS_ENV=production"

--- a/dist/systemd/obs-delayedjob-queue-default.service
+++ b/dist/systemd/obs-delayedjob-queue-default.service
@@ -2,7 +2,6 @@
 Description = Open Build Service DelayedJob Queue: default
 BindsTo = obs-api-support.target
 After = mariadb.service obsapisetup.service
-Wants = mariadb.service obsapisetup.service
 
 [Service]
 Environment = "RAILS_ENV=production"

--- a/dist/systemd/obs-delayedjob-queue-issuetracking.service
+++ b/dist/systemd/obs-delayedjob-queue-issuetracking.service
@@ -2,7 +2,6 @@
 Description = Open Build Service DelayedJob Queue: issuetracking
 BindsTo = obs-api-support.target
 After = mariadb.service obsapisetup.service
-Wants = mariadb.service obsapisetup.service
 
 [Service]
 Environment = "RAILS_ENV=production"

--- a/dist/systemd/obs-delayedjob-queue-mailers.service
+++ b/dist/systemd/obs-delayedjob-queue-mailers.service
@@ -2,7 +2,6 @@
 Description = Open Build Service DelayedJob Queue: mailers
 BindsTo = obs-api-support.target
 After = mariadb.service obsapisetup.service
-Wants = mariadb.service obsapisetup.service
 
 [Service]
 Environment = "RAILS_ENV=production"

--- a/dist/systemd/obs-delayedjob-queue-project_log_rotate.service
+++ b/dist/systemd/obs-delayedjob-queue-project_log_rotate.service
@@ -2,7 +2,6 @@
 Description = Open Build Service DelayedJob Queue: project_log_rotate
 BindsTo = obs-api-support.target
 After = mariadb.service obsapisetup.service
-Wants = mariadb.service obsapisetup.service
 
 [Service]
 Environment = "RAILS_ENV=production"

--- a/dist/systemd/obs-delayedjob-queue-quick@.service
+++ b/dist/systemd/obs-delayedjob-queue-quick@.service
@@ -2,7 +2,6 @@
 Description = Open Build Service DelayedJob Queue Instance: quick
 BindsTo = obs-api-support.target
 After = mariadb.service obsapisetup.service
-Wants = mariadb.service obsapisetup.service
 
 [Service]
 Environment = "RAILS_ENV=production"

--- a/dist/systemd/obs-delayedjob-queue-releasetracking.service
+++ b/dist/systemd/obs-delayedjob-queue-releasetracking.service
@@ -2,7 +2,6 @@
 Description = Open Build Service DelayedJob Queue: releasetracking
 BindsTo = obs-api-support.target
 After = mariadb.service obsapisetup.service
-Wants = mariadb.service obsapisetup.service
 
 [Service]
 Environment = "RAILS_ENV=production"

--- a/dist/systemd/obs-delayedjob-queue-scm.service
+++ b/dist/systemd/obs-delayedjob-queue-scm.service
@@ -2,7 +2,6 @@
 Description = Open Build Service DelayedJob Queue: scm
 BindsTo = obs-api-support.target
 After = mariadb.service obsapisetup.service
-Wants = mariadb.service obsapisetup.service
 
 [Service]
 Environment = "RAILS_ENV=production"

--- a/dist/systemd/obs-delayedjob-queue-staging.service
+++ b/dist/systemd/obs-delayedjob-queue-staging.service
@@ -2,7 +2,6 @@
 Description = Open Build Service DelayedJob Queue: staging
 BindsTo = obs-api-support.target
 After = mariadb.service obsapisetup.service
-Wants = mariadb.service obsapisetup.service
 
 [Service]
 Environment = "RAILS_ENV=production"

--- a/dist/systemd/obs-sphinx.service
+++ b/dist/systemd/obs-sphinx.service
@@ -3,7 +3,6 @@ Description = Open Build Service Sphinx Search Daemon
 BindsTo = obs-api-support.target
 Conflicts = searchd.service
 After = mariadb.service obsapisetup.service
-Wants = mariadb.service obsapisetup.service
 
 [Service]
 Environment = "RAILS_ENV=production"

--- a/dist/systemd/obsscheduler.service
+++ b/dist/systemd/obsscheduler.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=OBS job scheduler
 Requires=obsrepserver.service
-Wants=obsapisetup.service
 After=network.target obssrcserver.service obsrepserver.service obsapisetup.service
 
 [Service]


### PR DESCRIPTION
"Wants=" will start the configured service, if disabled or not. This is
not we want with our obscheduler or OBS API services.

In a distributed setup like build.opensuse.org it is not common that the
database runs on the same host like the API, therefor starting mariadb
or running obsapisetup is not recommended.
