### PR TITLE
Introduce tokens in web UI

### DIFF
--- a/src/api/app/assets/javascripts/webui/autocomplete.js
+++ b/src/api/app/assets/javascripts/webui/autocomplete.js
@@ -59,13 +59,22 @@ $(document).ready(function() {
 
   $('#linked_project, #review_project, #token_project_name').on('autocompletechange', function() {
     var projectName = $(this).val(),
-        source = $('#linked_package, #review_package, #token_package_name').autocomplete('option', 'source');
+        packageInput = $('#linked_package, #review_package, #token_package_name');
 
-    if (!projectName) return;
+    if (!packageInput.is(':visible')) return;
+
+    if (!projectName) {
+      packageInput.val('').attr('disabled', true);
+      return;
+    }
+
+    if (packageInput.attr('disabled')) { packageInput.removeAttr('disabled').focus(); }
+
+    var source = packageInput.autocomplete('option', 'source');
 
     // Ensure old parameters got removed
     source = source.replace(/\?.+/, '') + '?project=' + projectName;
     // Update the source target of the package autocomplete
-    $('#linked_package, #review_package, #token_package_name').autocomplete('option', { source: source });
+    packageInput.autocomplete('option', { source: source });
   });
 });

--- a/src/api/app/assets/javascripts/webui/autocomplete.js
+++ b/src/api/app/assets/javascripts/webui/autocomplete.js
@@ -57,15 +57,15 @@ $(document).ready(function() {
     });
   });
 
-  $('#linked_project, #review_project').on('autocompletechange', function() {
+  $('#linked_project, #review_project, #token_project_name').on('autocompletechange', function() {
     var projectName = $(this).val(),
-        source = $('#linked_package, #review_package').autocomplete('option', 'source');
+        source = $('#linked_package, #review_package, #token_package_name').autocomplete('option', 'source');
 
     if (!projectName) return;
 
     // Ensure old parameters got removed
     source = source.replace(/\?.+/, '') + '?project=' + projectName;
     // Update the source target of the package autocomplete
-    $('#linked_package, #review_package').autocomplete('option', { source: source });
+    $('#linked_package, #review_package, #token_package_name').autocomplete('option', { source: source });
   });
 });

--- a/src/api/app/assets/javascripts/webui/autocomplete.js
+++ b/src/api/app/assets/javascripts/webui/autocomplete.js
@@ -57,9 +57,9 @@ $(document).ready(function() {
     });
   });
 
-  $('#linked_project, #review_project, #token_project_name').on('autocompletechange', function() {
+  $('#linked_project, #review_project, #project_name').on('autocompletechange', function() {
     var projectName = $(this).val(),
-        packageInput = $('#linked_package, #review_package, #token_package_name');
+        packageInput = $('#linked_package, #review_package, #package_name');
 
     if (!packageInput.is(':visible')) return;
 

--- a/src/api/app/assets/javascripts/webui/request.js
+++ b/src/api/app/assets/javascripts/webui/request.js
@@ -105,6 +105,9 @@ function requestAddAutocomplete(autocompleteElement) { // jshint ignore:line
     var selected = $(autocompleteElement+' option:selected').attr('value');
     $('.' + selected).removeClass('d-none');
     $('.hideable input:visible').removeAttr('disabled');
+    if ($('#review_package').is(':visible') && !$('#review_project').val()) {
+      $('#review_package').attr('disabled', true);
+    }
   });
 }
 

--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -41,7 +41,7 @@ class Webui::ProjectController < Webui::WebuiController
   end
 
   def autocomplete_projects
-    render json: Project.autocomplete(params[:term]).not_maintenance_incident.pluck(:name)
+    render json: Project.autocomplete(params[:term], params[:local]).not_maintenance_incident.pluck(:name)
   end
 
   def autocomplete_incidents

--- a/src/api/app/controllers/webui/users/rss_tokens_controller.rb
+++ b/src/api/app/controllers/webui/users/rss_tokens_controller.rb
@@ -7,7 +7,7 @@ module Webui
       after_action :verify_authorized
 
       def create
-        token = authorize(Token::Rss.find_or_initialize_by(user: User.session))
+        token = authorize(::Token::Rss.find_or_initialize_by(user: User.session))
         if token.persisted?
           flash[:success] = 'Successfully re-generated your RSS feed url'
           token.regenerate_string

--- a/src/api/app/controllers/webui/users/tokens_controller.rb
+++ b/src/api/app/controllers/webui/users/tokens_controller.rb
@@ -5,7 +5,7 @@ class Webui::Users::TokensController < Webui::WebuiController
   after_action :verify_policy_scoped, only: :index
 
   def index
-    @tokens = policy_scope([:webui, Token])
+    @tokens = policy_scope([:webui, Token]).page(params[:page])
   end
 
   def destroy

--- a/src/api/app/controllers/webui/users/tokens_controller.rb
+++ b/src/api/app/controllers/webui/users/tokens_controller.rb
@@ -1,0 +1,26 @@
+class Webui::Users::TokensController < Webui::WebuiController
+  before_action :set_token, only: [:destroy]
+
+  after_action :verify_authorized, except: :index
+  after_action :verify_policy_scoped, only: :index
+
+  def index
+    @tokens = policy_scope([:webui, Token])
+  end
+
+  def destroy
+    authorize [:webui, @token]
+    @token.destroy
+    flash[:success] = 'Token was successfully deleted.'
+    redirect_to tokens_url
+  end
+
+  private
+
+  def set_token
+    @token = Token.find(params[:id])
+  rescue ActiveRecord::RecordNotFound => e
+    flash[:error] = e.message
+    redirect_to tokens_url
+  end
+end

--- a/src/api/app/controllers/webui/users/tokens_controller.rb
+++ b/src/api/app/controllers/webui/users/tokens_controller.rb
@@ -15,7 +15,7 @@ class Webui::Users::TokensController < Webui::WebuiController
   end
 
   def create
-    @token = Token.token_type(@params[:operation]).new(@params.merge(user: User.session, package: @package))
+    @token = Token.token_type(@params[:type]).new(@params.except(:type).merge(user: User.session, package: @package))
 
     authorize [:webui, @token]
 
@@ -49,31 +49,32 @@ class Webui::Users::TokensController < Webui::WebuiController
   end
 
   def set_params
-    @params = params.require(:token).except(:string_readonly).permit(:operation, :project_name, :package_name, :scm_token).tap do |token_parameters|
-      token_parameters.require(:operation)
+    @params = params.except(:project_name, :package_name).require(:token).except(:string_readonly).permit(:type, :scm_token).tap do |token_parameters|
+      token_parameters.require(:type)
     end
+    @extra_params = params.slice(:project_name, :package_name).permit!
   end
 
   def set_package
-    return if @params[:project_name].blank? && @params[:package_name].blank?
+    return if @extra_params[:project_name].blank? && @extra_params[:package_name].blank?
 
     # Prevent setting a package for a workflow token
-    return if @params[:operation] == 'workflow'
+    return if @params[:type] == 'workflow'
 
     # Check if only project_name or only package_name are present
-    if @params[:project_name].present? ^ @params[:package_name].present?
+    if @extra_params[:project_name].present? ^ @extra_params[:package_name].present?
       flash.now[:error] = 'When providing an optional package, both Project name and Package name must be provided.'
       render partial: 'create' and return
     end
 
     # If both project_name and package_name are present, check if this is an existing package
     begin
-      @package = Package.get_by_project_and_name(@params[:project_name], @params[:package_name])
+      @package = Package.get_by_project_and_name(@extra_params[:project_name], @extra_params[:package_name])
     rescue Project::UnknownObjectError
-      flash.now[:error] = "When providing an optional package, the package must exist. Project '#{@params[:project_name]}' does not exist."
+      flash.now[:error] = "When providing an optional package, the package must exist. Project '#{@extra_params[:project_name]}' does not exist."
       render partial: 'create'
     rescue Package::UnknownObjectError
-      flash.now[:error] = "When providing an optional package, the package must exist. Package '#{@params[:project_name]}/#{@params[:package_name]}' does not exist."
+      flash.now[:error] = "When providing an optional package, the package must exist. Package '#{@extra_params[:project_name]}/#{@extra_params[:package_name]}' does not exist."
       render partial: 'create'
     end
   end

--- a/src/api/app/controllers/webui/users/tokens_controller.rb
+++ b/src/api/app/controllers/webui/users/tokens_controller.rb
@@ -1,6 +1,6 @@
 class Webui::Users::TokensController < Webui::WebuiController
   before_action :set_token, only: [:destroy]
-  before_action :set_params, :set_package, :set_scm_token, only: [:create]
+  before_action :set_params, :set_package, only: [:create]
 
   after_action :verify_authorized, except: :index
   after_action :verify_policy_scoped, only: :index
@@ -15,18 +15,19 @@ class Webui::Users::TokensController < Webui::WebuiController
   end
 
   def create
-    @token = Token.token_type(@params[:operation]).new(@params.merge(user: User.session))
+    @token = Token.token_type(@params[:operation]).new(@params.merge(user: User.session, package: @package))
 
     authorize [:webui, @token]
 
-    @token.save
-
     respond_to do |format|
       format.js do
-        render partial: 'create', locals: {
-          string: @token.string,
-          flash: { success: "Token successfully created! Make sure you save it - you won't be able to access it again." }
-        }
+        if @token.save
+          flash.now[:success] = "Token successfully created! Make sure you save it - you won't be able to access it again."
+          render partial: 'create', locals: { string: @token.string }
+        else
+          flash.now[:error] = "Failed to create token: #{@token.errors.full_messages.to_sentence}."
+          render partial: 'create'
+        end
       end
     end
   end
@@ -48,21 +49,32 @@ class Webui::Users::TokensController < Webui::WebuiController
   end
 
   def set_params
-    @params = params.require(:token).except(:string_readonly).permit(:operation, :scm_token).tap do |token_parameters|
+    @params = params.require(:token).except(:string_readonly).permit(:operation, :project_name, :package_name, :scm_token).tap do |token_parameters|
       token_parameters.require(:operation)
     end
-    @package_params = params.slice(:project_name, :package_name).permit!
   end
 
   def set_package
-    return unless @package_params[:project_name].present? && @package_params[:package_name].present?
+    return if @params[:project_name].blank? && @params[:package_name].blank?
 
-    @package = Package.get_by_project_and_name(@package_params[:project_name], @package_params[:package_name])
-  end
+    # Prevent setting a package for a workflow token
+    return if @params[:operation] == 'workflow'
 
-  def set_scm_token
-    return unless @params[:operation] == 'workflow'
+    # Check if only project_name or only package_name are present
+    if @params[:project_name].present? ^ @params[:package_name].present?
+      flash.now[:error] = 'When providing an optional package, both Project name and Package name must be provided.'
+      render partial: 'create' and return
+    end
 
-    @scm_token = @params[:scm_token]
+    # If both project_name and package_name are present, check if this is an existing package
+    begin
+      @package = Package.get_by_project_and_name(@params[:project_name], @params[:package_name])
+    rescue Project::UnknownObjectError
+      flash.now[:error] = "When providing an optional package, the package must exist. Project '#{@params[:project_name]}' does not exist."
+      render partial: 'create'
+    rescue Package::UnknownObjectError
+      flash.now[:error] = "When providing an optional package, the package must exist. Package '#{@params[:project_name]}/#{@params[:package_name]}' does not exist."
+      render partial: 'create'
+    end
   end
 end

--- a/src/api/app/controllers/webui/users/tokens_controller.rb
+++ b/src/api/app/controllers/webui/users/tokens_controller.rb
@@ -1,11 +1,34 @@
 class Webui::Users::TokensController < Webui::WebuiController
   before_action :set_token, only: [:destroy]
+  before_action :set_params, :set_package, :set_scm_token, only: [:create]
 
   after_action :verify_authorized, except: :index
   after_action :verify_policy_scoped, only: :index
 
   def index
     @tokens = policy_scope([:webui, Token]).page(params[:page])
+  end
+
+  def new
+    @token = Token.new
+    authorize [:webui, @token]
+  end
+
+  def create
+    @token = Token.token_type(@params[:operation]).new(@params.merge(user: User.session))
+
+    authorize [:webui, @token]
+
+    @token.save
+
+    respond_to do |format|
+      format.js do
+        render partial: 'create', locals: {
+          string: @token.string,
+          flash: { success: "Token successfully created! Make sure you save it - you won't be able to access it again." }
+        }
+      end
+    end
   end
 
   def destroy
@@ -22,5 +45,21 @@ class Webui::Users::TokensController < Webui::WebuiController
   rescue ActiveRecord::RecordNotFound => e
     flash[:error] = e.message
     redirect_to tokens_url
+  end
+
+  def set_params
+    @params = params.require(:token).except(:string_readonly).permit(:operation, :project_name, :package_name, :scm_token).tap do |token_parameters|
+      token_parameters.require(:operation)
+    end
+  end
+
+  def set_package
+    @package = Package.get_by_project_and_name(@params[:project_name], @params[:package_name]) if @params[:project_name].present? && @params[:package_name].present?
+  end
+
+  def set_scm_token
+    return unless @params[:operation] == 'workflow'
+
+    @scm_token = @params[:scm_token]
   end
 end

--- a/src/api/app/controllers/webui/users/tokens_controller.rb
+++ b/src/api/app/controllers/webui/users/tokens_controller.rb
@@ -48,13 +48,16 @@ class Webui::Users::TokensController < Webui::WebuiController
   end
 
   def set_params
-    @params = params.require(:token).except(:string_readonly).permit(:operation, :project_name, :package_name, :scm_token).tap do |token_parameters|
+    @params = params.require(:token).except(:string_readonly).permit(:operation, :scm_token).tap do |token_parameters|
       token_parameters.require(:operation)
     end
+    @package_params = params.slice(:project_name, :package_name).permit!
   end
 
   def set_package
-    @package = Package.get_by_project_and_name(@params[:project_name], @params[:package_name]) if @params[:project_name].present? && @params[:package_name].present?
+    return unless @package_params[:project_name].present? && @package_params[:package_name].present?
+
+    @package = Package.get_by_project_and_name(@package_params[:project_name], @package_params[:package_name])
   end
 
   def set_scm_token

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -101,9 +101,9 @@ class Project < ApplicationRecord
   }
 
   scope :remote, -> { where('NOT ISNULL(projects.remoteurl)') }
-  scope :local, -> { where.not('NOT ISNULL(projects.remoteurl)') }
+  scope :local, -> { where('ISNULL(projects.remoteurl)') }
 
-  scope :autocomplete, ->(search) { AutocompleteFinder::Project.new(Project.default_scoped, search).call }
+  scope :autocomplete, ->(search, local = false) { AutocompleteFinder::Project.new(local ? Project.local : Project.default_scoped, search).call }
   scope :for_user, ->(user_id) { joins(:relationships).where(relationships: { user_id: user_id, role_id: Role.hashed['maintainer'] }) }
   scope :related_to_user, ->(user_id) { joins(:relationships).where(relationships: { user_id: user_id }) }
   scope :for_group, ->(group_id) { joins(:relationships).where(relationships: { group_id: group_id, role_id: Role.hashed['maintainer'] }) }

--- a/src/api/app/models/token.rb
+++ b/src/api/app/models/token.rb
@@ -9,6 +9,7 @@ class Token < ApplicationRecord
 
   validates :user, presence: true
   validates :string, uniqueness: { case_sensitive: false }
+  validates :scm_token, absence: true, if: -> { type != 'Token::Workflow' }
 
   include Token::Errors
 

--- a/src/api/app/models/token.rb
+++ b/src/api/app/models/token.rb
@@ -3,7 +3,7 @@ class Token < ApplicationRecord
   has_many :event_subscriptions, dependent: :destroy
   belongs_to :package, inverse_of: :tokens
 
-  attr_accessor :object_to_authorize, :operation, :project_name, :package_name
+  attr_accessor :object_to_authorize
 
   has_secure_token :string
 

--- a/src/api/app/models/token.rb
+++ b/src/api/app/models/token.rb
@@ -3,7 +3,7 @@ class Token < ApplicationRecord
   has_many :event_subscriptions, dependent: :destroy
   belongs_to :package, inverse_of: :tokens
 
-  attr_accessor :object_to_authorize
+  attr_accessor :object_to_authorize, :operation, :project_name, :package_name
 
   has_secure_token :string
 
@@ -11,6 +11,8 @@ class Token < ApplicationRecord
   validates :string, uniqueness: { case_sensitive: false }
 
   include Token::Errors
+
+  OPERATIONS = ['Rebuild', 'Release', 'Service', 'Workflow'].freeze
 
   def token_name
     self.class.token_name

--- a/src/api/app/policies/webui/token/rebuild_policy.rb
+++ b/src/api/app/policies/webui/token/rebuild_policy.rb
@@ -1,0 +1,1 @@
+class Webui::Token::RebuildPolicy < Webui::TokenPolicy; end

--- a/src/api/app/policies/webui/token/release_policy.rb
+++ b/src/api/app/policies/webui/token/release_policy.rb
@@ -1,0 +1,1 @@
+class Webui::Token::ReleasePolicy < Webui::TokenPolicy; end

--- a/src/api/app/policies/webui/token/rss_policy.rb
+++ b/src/api/app/policies/webui/token/rss_policy.rb
@@ -1,0 +1,1 @@
+class Webui::Token::RssPolicy < Webui::TokenPolicy; end

--- a/src/api/app/policies/webui/token/service_policy.rb
+++ b/src/api/app/policies/webui/token/service_policy.rb
@@ -1,0 +1,1 @@
+class Webui::Token::ServicePolicy < Webui::TokenPolicy; end

--- a/src/api/app/policies/webui/token/workflow_policy.rb
+++ b/src/api/app/policies/webui/token/workflow_policy.rb
@@ -1,0 +1,1 @@
+class Webui::Token::WorkflowPolicy < Webui::TokenPolicy; end

--- a/src/api/app/policies/webui/token_policy.rb
+++ b/src/api/app/policies/webui/token_policy.rb
@@ -15,8 +15,18 @@ class Webui::TokenPolicy < ApplicationPolicy
     end
   end
 
-  def destroy?
+  def new?
+    # TODO: when trigger_workflow is rolled out, uncomment the next line and remove the Flipper check
+    # true
+    Flipper.enabled?(:trigger_workflow, user)
+  end
+
+  def create?
     # TODO: when trigger_workflow is rolled out, remove the Flipper check
     record.user == user && record.type != 'Token::Rss' && Flipper.enabled?(:trigger_workflow, user)
+  end
+
+  def destroy?
+    create?
   end
 end

--- a/src/api/app/policies/webui/token_policy.rb
+++ b/src/api/app/policies/webui/token_policy.rb
@@ -1,0 +1,22 @@
+class Webui::TokenPolicy < ApplicationPolicy
+  def initialize(user, record, opts = {})
+    super(user, record, opts.merge(ensure_logged_in: true))
+  end
+
+  class Scope < Scope
+    def initialize(user, scope)
+      raise Pundit::NotAuthorizedError, reason: ApplicationPolicy::ANONYMOUS_USER if user.nil? || user.is_nobody?
+
+      super(user, scope)
+    end
+
+    def resolve
+      scope.where(user: user).where.not(type: 'Token::Rss').includes(package: :project)
+    end
+  end
+
+  def destroy?
+    # TODO: when trigger_workflow is rolled out, remove the Flipper check
+    record.user == user && record.type != 'Token::Rss' && Flipper.enabled?(:trigger_workflow, user)
+  end
+end

--- a/src/api/app/views/webui/packages/branches/into.html.haml
+++ b/src/api/app/views/webui/packages/branches/into.html.haml
@@ -25,7 +25,7 @@
             = form_tag(packages_branches_path) do
               = render partial: 'webui/shared/autocomplete', locals: { html_id: 'linked_project', label: 'Original project name',
                                                                        data: { source: autocomplete_projects_path } }
-              = render partial: 'webui/shared/autocomplete', locals: { html_id: 'linked_package', label: 'Original package name',
+              = render partial: 'webui/shared/autocomplete', locals: { html_id: 'linked_package', label: 'Original package name', disabled: true,
                                                                        data: { source: autocomplete_packages_path } }
               = hidden_field_tag 'target_project', @project
               = render partial: 'webui/shared/package_branch_form', locals: { show_project_field: false, target_project: @project,

--- a/src/api/app/views/webui/user/_index_actions.html.haml
+++ b/src/api/app/views/webui/user/_index_actions.html.haml
@@ -4,3 +4,5 @@
   - if configuration.passwords_changable?(user)
     = render partial: 'webui/user/index_actions/change_password'
   = render partial: 'webui/user/index_actions/change_notifications'
+  - if feature_enabled?('trigger_workflow')
+    = render partial: 'webui/user/index_actions/manage_tokens'

--- a/src/api/app/views/webui/user/index_actions/_manage_tokens.haml
+++ b/src/api/app/views/webui/user/index_actions/_manage_tokens.haml
@@ -1,0 +1,4 @@
+%li.nav-item
+  = link_to(tokens_path, class: 'nav-link', title: 'Manage Your Tokens') do
+    %i.fas.fa-lg.mr-2.fa-key
+    %span.nav-item-name Manage Your Tokens

--- a/src/api/app/views/webui/users/notifications/_notifications_list.html.haml
+++ b/src/api/app/views/webui/users/notifications/_notifications_list.html.haml
@@ -17,7 +17,7 @@
     .card
       .card-body
         .text-center
-          %span.ml-3= page_entries_info notifications, entry_name: 'notification'
+          %span.ml-3= page_entries_info notifications, entry_name: ''
           = link_to_all unless notifications.total_pages == 1 && params['show_all'].nil?
         .list-group.list-group-flush.mt-3
           - notifications.each do |n|

--- a/src/api/app/views/webui/users/tokens/_actions.html.haml
+++ b/src/api/app/views/webui/users/tokens/_actions.html.haml
@@ -1,0 +1,1 @@
+= link_to('Back to List of Tokens', tokens_path, title: 'Back to List of Tokens', class: 'btn btn-outline-secondary px-4 mt-3 mt-sm-0')

--- a/src/api/app/views/webui/users/tokens/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui/users/tokens/_breadcrumb_items.html.haml
@@ -1,0 +1,4 @@
+%li.breadcrumb-item
+  = link_to('Your Profile', user_path(User.session!))
+%li.breadcrumb-item.active{ 'aria-current' => 'page' }
+  Tokens

--- a/src/api/app/views/webui/users/tokens/_create.js.erb
+++ b/src/api/app/views/webui/users/tokens/_create.js.erb
@@ -1,0 +1,5 @@
+$('#flash').html("<%= escape_javascript(render(layout: false, partial: 'layouts/webui/flash', object: flash)) %>");
+$('#created-token').removeClass('d-none');
+$('#token_string_readonly').val("<%= escape_javascript(string) %>");
+$('.form-row :input').not('#token_string_readonly').prop('disabled', true);
+$('.actions').html("<%= escape_javascript(render partial: 'actions') %>");

--- a/src/api/app/views/webui/users/tokens/_create.js.erb
+++ b/src/api/app/views/webui/users/tokens/_create.js.erb
@@ -1,5 +1,7 @@
 $('#flash').html("<%= escape_javascript(render(layout: false, partial: 'layouts/webui/flash', object: flash)) %>");
-$('#created-token').removeClass('d-none');
-$('#token_string_readonly').val("<%= escape_javascript(string) %>");
-$('.form-row :input').not('#token_string_readonly').prop('disabled', true);
-$('.actions').html("<%= escape_javascript(render partial: 'actions') %>");
+<% if flash[:error].blank? %>
+  $('#created-token').removeClass('d-none');
+  $('#token_string_readonly').val("<%= escape_javascript(string) %>");
+  $('.form-row :input').not('#token_string_readonly').prop('disabled', true);
+  $('.actions').html("<%= escape_javascript(render partial: 'actions') %>");
+<% end %>

--- a/src/api/app/views/webui/users/tokens/index.html.haml
+++ b/src/api/app/views/webui/users/tokens/index.html.haml
@@ -4,6 +4,8 @@
   .card-body
     %h3= @pagetitle
 
+    .text-center= page_entries_info(@tokens)
+
     - if @tokens.count.positive?
       .table-responsive
         %table.table.table-sm.table-striped.table-bordered
@@ -29,6 +31,8 @@
       = link_to new_token_path do
         %i.fas.fa-plus-circle.text-primary
         Create Token
+
+= paginate @tokens, views_prefix: 'webui'
 
 .modal.fade#delete-token-modal{ tabindex: -1, role: 'dialog', aria: { labelledby: 'delete-token-modal-label', hidden: true } }
   .modal-dialog.modal-dialog-centered{ role: 'document' }

--- a/src/api/app/views/webui/users/tokens/index.html.haml
+++ b/src/api/app/views/webui/users/tokens/index.html.haml
@@ -1,0 +1,55 @@
+- @pagetitle = 'Tokens'
+
+.card
+  .card-body
+    %h3= @pagetitle
+
+    - if @tokens.count.positive?
+      .table-responsive
+        %table.table.table-sm.table-striped.table-bordered
+          %thead
+            %tr
+              %th Id
+              %th Operation
+              %th Package
+              %th
+          %tbody
+            - @tokens.each do |token|
+              %tr
+                %td= token.id
+                %td= token.class.token_name.capitalize
+                %td= link_to("#{truncate(token.package.project.name, length: 80)}/#{truncate(token.package.name, length: 80)}",
+                  package_show_path(project: token.package.project, package: token.package)) if token.package
+                %td.text-center
+                  = link_to '#', title: 'Delete Token', class: 'text-nowrap',
+                    data: { toggle: 'modal', target: '#delete-token-modal', token_id: token.id, action: token_path(token) } do
+                    %i.fas.fa-times-circle.text-danger
+
+    .pt-4
+      = link_to new_token_path do
+        %i.fas.fa-plus-circle.text-primary
+        Create Token
+
+.modal.fade#delete-token-modal{ tabindex: -1, role: 'dialog', aria: { labelledby: 'delete-token-modal-label', hidden: true } }
+  .modal-dialog.modal-dialog-centered{ role: 'document' }
+    .modal-content
+      .modal-header
+        %h5.modal-title#delete-token-modal-label Do you really want to delete this token?
+      .modal-body
+        %p
+          Please confirm that you want to delete the token with id
+          = surround "'" do
+            %span#token-id
+        = form_tag nil, method: :delete do
+          .modal-footer
+            %a.btn.btn-sm.btn-outline-secondary.px-4{ data: { dismiss: 'modal' } }
+              Cancel
+            %input.btn.btn-sm.btn-danger.px-4{ type: 'submit', name: 'commit', value: 'Delete', data: { disable: { with: 'Delete' } } }
+
+- content_for :ready_function do
+  :plain
+    $('#delete-token-modal').on('show.bs.modal', function (event) {
+      var link = $(event.relatedTarget);
+      $(this).find('#token-id').text(link.data('token-id'));
+      $(this).find('form').attr('action', link.data('action'));
+    })

--- a/src/api/app/views/webui/users/tokens/index.html.haml
+++ b/src/api/app/views/webui/users/tokens/index.html.haml
@@ -20,7 +20,7 @@
               %tr
                 %td= token.id
                 %td= token.class.token_name.capitalize
-                %td= link_to("#{truncate(token.package.project.name, length: 80)}/#{truncate(token.package.name, length: 80)}",
+                %td.text-word-break-all= link_to("#{truncate(token.package.project.name, length: 80)}/#{truncate(token.package.name, length: 80)}",
                   package_show_path(project: token.package.project, package: token.package)) if token.package
                 %td.text-center
                   = link_to '#', title: 'Delete Token', class: 'text-nowrap',

--- a/src/api/app/views/webui/users/tokens/index.html.haml
+++ b/src/api/app/views/webui/users/tokens/index.html.haml
@@ -23,7 +23,7 @@
                 %td.text-word-break-all= link_to("#{truncate(token.package.project.name, length: 80)}/#{truncate(token.package.name, length: 80)}",
                   package_show_path(project: token.package.project, package: token.package)) if token.package
                 %td.text-center
-                  = link_to '#', title: 'Delete Token', class: 'text-nowrap',
+                  = link_to '#', title: 'Delete Token', class: 'btn btn-sm btn-outline-danger',
                     data: { toggle: 'modal', target: '#delete-token-modal', token_id: token.id, action: token_path(token) } do
                     %i.fas.fa-times-circle.text-danger
 

--- a/src/api/app/views/webui/users/tokens/new.html.haml
+++ b/src/api/app/views/webui/users/tokens/new.html.haml
@@ -28,16 +28,15 @@
                     = radio.radio_button(class: 'custom-control-input')
                     = radio.label(class: 'custom-control-label')
 
-          .form-row
+          .form-row#package-project-form
             .col-sm
               = render partial: 'webui/shared/autocomplete', locals: { html_id: 'token[project_name]', label: 'Project name', required: false,
                                                                        data: { source: autocomplete_projects_path(local: true) } }
             .col-sm
               = render partial: 'webui/shared/autocomplete', locals: { html_id: 'token[package_name]', label: 'Package name', required: false,
                                                                        data: { source: autocomplete_packages_path } }
-          .row.mb-3
-            .col
-              .text-muted
+            .col-12
+              .form-group.form-text.text-muted
                 Optional: provide project and package names, to limit the token to a specific package.
 
           .form-row
@@ -66,10 +65,12 @@
     $('input[type=radio]').on('change', function() {
       if (this.value == 'workflow') {
         $('#fieldset-token-scm-token').removeClass('d-none');
+        $('#package-project-form').addClass('d-none');
         $('#token_scm_token').attr('required', true);
       }
       else if (!$('#fieldset-token-scm-token').attr('disabled')) {
         $('#fieldset-token-scm-token').addClass('d-none');
+        $('#package-project-form').removeClass('d-none');
         $('#token_scm_token').attr('required', false);
       }
     });

--- a/src/api/app/views/webui/users/tokens/new.html.haml
+++ b/src/api/app/views/webui/users/tokens/new.html.haml
@@ -34,7 +34,7 @@
                                                                        data: { source: autocomplete_projects_path(local: true) } }
             .col-sm
               = render partial: 'webui/shared/autocomplete', locals: { html_id: 'token[package_name]', label: 'Package name', required: false,
-                                                                       data: { source: autocomplete_packages_path } }
+                                                                       data: { source: autocomplete_packages_path }, disabled: true }
             .col-12
               .form-group.form-text.text-muted
                 Optional: provide project and package names, to limit the token to a specific package.

--- a/src/api/app/views/webui/users/tokens/new.html.haml
+++ b/src/api/app/views/webui/users/tokens/new.html.haml
@@ -30,13 +30,11 @@
 
           .form-row
             .col-sm
-              .form-group
-                = f.label(:project_name)
-                = f.text_field(:project_name, size: 80, class: 'form-control', placeholder: 'Project Name')
+              = render partial: 'webui/shared/autocomplete', locals: { html_id: 'token[project_name]', label: 'Project name', required: false,
+                                                                       data: { source: autocomplete_projects_path(local: true) } }
             .col-sm
-              .form-group
-                = f.label(:package_name)
-                = f.text_field(:package_name, size: 80, class: 'form-control', placeholder: 'Package name')
+              = render partial: 'webui/shared/autocomplete', locals: { html_id: 'token[package_name]', label: 'Package name', required: false,
+                                                                       data: { source: autocomplete_packages_path } }
           .row.mb-3
             .col
               .text-muted

--- a/src/api/app/views/webui/users/tokens/new.html.haml
+++ b/src/api/app/views/webui/users/tokens/new.html.haml
@@ -11,7 +11,11 @@
             .col-12.col-md-10.col-lg-9
               %fieldset.form-group
                 = f.label(:string_readonly, 'Your new OBS Personal Access Token Secret', class: 'col-form-label col-form-label-lg')
-                = f.text_field(:string_readonly, class: 'form-control', readonly: true)
+                .input-group
+                  = f.text_field(:string_readonly, class: 'form-control', readonly: true)
+                  .input-group-append#copy-to-clipboard
+                    %span.input-group-text
+                      %i.fas.fa-clipboard
               %hr
 
           .form-row
@@ -48,3 +52,36 @@
           .actions
             = link_to('Cancel', tokens_path, title: 'Cancel', class: 'btn btn-outline-secondary px-4 mr-3 mt-3 mt-sm-0')
             = f.submit('Create', class: 'btn btn-primary px-4 mt-3 mt-sm-0')
+
+:javascript
+  function copyToClipboard(elementId) {
+    document.getElementById(elementId).select();
+    document.execCommand('copy');
+  }
+
+- content_for :ready_function do
+  :plain
+    // Default operation value: 'runservice'
+    $('#token_operation_runservice').attr('checked', true);
+
+    // Shows/Hide SCM Token input field
+    $('input[type=radio]').on('change', function() {
+      if (this.value == 'workflow') {
+        $('#fieldset-token-scm-token').removeClass('d-none');
+        $('#token_scm_token').attr('required', true);
+      }
+      else if (!$('#fieldset-token-scm-token').attr('disabled')) {
+        $('#fieldset-token-scm-token').addClass('d-none');
+        $('#token_scm_token').attr('required', false);
+      }
+    });
+
+    // Definition of the tooltip and click event handler for the "Copy to clipboard" icon
+    $('#copy-to-clipboard').tooltip({ title: 'Copy to clipboard' }).on('click', function () {
+      copyToClipboard('token_string_readonly');
+
+      // Shows "Copied!" tooltip. Later on shows the previous message 'Copy to clipboard' as tooltip.
+      $(this).tooltip('dispose').tooltip({ title: 'Copied!' }).tooltip('show').on('hidden.bs.tooltip', function () {
+        $(this).tooltip('dispose').tooltip({ title: 'Copy to clipboard' });
+      });
+    });

--- a/src/api/app/views/webui/users/tokens/new.html.haml
+++ b/src/api/app/views/webui/users/tokens/new.html.haml
@@ -1,0 +1,50 @@
+- operation_options = Token::OPERATIONS.map { |a| "Token::#{a}".constantize.token_name }
+
+.card
+  .card-body
+    %h3.mb-3 Create Token
+
+    .row
+      .col-12.col-md-10.col-lg-8
+        = form_with(model: @token, method: :post, local: false) do |f|
+          .form-row.d-none#created-token
+            .col-12.col-md-10.col-lg-9
+              %fieldset.form-group
+                = f.label(:string_readonly, 'Your new OBS Personal Access Token Secret', class: 'col-form-label col-form-label-lg')
+                = f.text_field(:string_readonly, class: 'form-control', readonly: true)
+              %hr
+
+          .form-row
+            .col
+              .form-group
+                = f.label(:operation, class: 'col-form-label col-form-label-lg mr-2')
+                .w-100.d-sm-none
+                = f.collection_radio_buttons(:operation, operation_options, :to_s, :to_s, class: 'custom-control-input', required: true) do |radio|
+                  .custom-control.custom-radio.custom-control-inline
+                    = radio.radio_button(class: 'custom-control-input')
+                    = radio.label(class: 'custom-control-label')
+
+          .form-row
+            .col-sm
+              .form-group
+                = f.label(:project_name)
+                = f.text_field(:project_name, size: 80, class: 'form-control', placeholder: 'Project Name')
+            .col-sm
+              .form-group
+                = f.label(:package_name)
+                = f.text_field(:package_name, size: 80, class: 'form-control', placeholder: 'Package name')
+          .row.mb-3
+            .col
+              .text-muted
+                Optional: provide project and package names, to limit the token to a specific package.
+
+          .form-row
+            .col-12.col-md-10.col-lg-9
+              .form-group.d-none#fieldset-token-scm-token
+                = f.label(:scm_token, 'Source Code Management Token')
+                %abbr.text-danger{ title: "required, when Operation is 'worflow'" } *
+                = f.text_field(:scm_token, size: 80, class: 'form-control', placeholder: 'Source Code Management Token')
+
+          .actions
+            = link_to('Cancel', tokens_path, title: 'Cancel', class: 'btn btn-outline-secondary px-4 mr-3 mt-3 mt-sm-0')
+            = f.submit('Create', class: 'btn btn-primary px-4 mt-3 mt-sm-0')

--- a/src/api/app/views/webui/users/tokens/new.html.haml
+++ b/src/api/app/views/webui/users/tokens/new.html.haml
@@ -1,4 +1,4 @@
-- operation_options = Token::OPERATIONS.map { |a| "Token::#{a}".constantize.token_name }
+- type_options = Token::OPERATIONS.map { |a| "Token::#{a}".constantize.token_name }
 
 .card
   .card-body
@@ -21,19 +21,19 @@
           .form-row
             .col
               .form-group
-                = f.label(:operation, class: 'col-form-label col-form-label-lg mr-2')
+                = f.label(:type, class: 'col-form-label col-form-label-lg mr-2')
                 .w-100.d-sm-none
-                = f.collection_radio_buttons(:operation, operation_options, :to_s, :to_s, class: 'custom-control-input', required: true) do |radio|
+                = f.collection_radio_buttons(:type, type_options, :to_s, :to_s, class: 'custom-control-input', required: true) do |radio|
                   .custom-control.custom-radio.custom-control-inline
                     = radio.radio_button(class: 'custom-control-input')
                     = radio.label(class: 'custom-control-label')
 
           .form-row#package-project-form
             .col-sm
-              = render partial: 'webui/shared/autocomplete', locals: { html_id: 'token[project_name]', label: 'Project name', required: false,
+              = render partial: 'webui/shared/autocomplete', locals: { html_id: 'project_name', label: 'Project name', required: false,
                                                                        data: { source: autocomplete_projects_path(local: true) } }
             .col-sm
-              = render partial: 'webui/shared/autocomplete', locals: { html_id: 'token[package_name]', label: 'Package name', required: false,
+              = render partial: 'webui/shared/autocomplete', locals: { html_id: 'package_name', label: 'Package name', required: false,
                                                                        data: { source: autocomplete_packages_path }, disabled: true }
             .col-12
               .form-group.form-text.text-muted
@@ -58,8 +58,8 @@
 
 - content_for :ready_function do
   :plain
-    // Default operation value: 'runservice'
-    $('#token_operation_runservice').attr('checked', true);
+    // Default type value: 'runservice'
+    $('#token_type_runservice').attr('checked', true);
 
     // Shows/Hide SCM Token input field
     $('input[type=radio]').on('change', function() {

--- a/src/api/config/locales/kaminari.en.yml
+++ b/src/api/config/locales/kaminari.en.yml
@@ -12,7 +12,7 @@ en:
       one_page:
         display_entries:
           zero: "No %{entry_name} found"
-          one: "Displaying <b>1</b>"
-          other: "Displaying <b>all %{count}</b>"
+          one: "Displaying <b>1</b> %{entry_name}"
+          other: "Displaying <b>all %{count} %{entry_name}</b>"
       more_pages:
-        display_entries: "Displaying <b>%{first}&nbsp;-&nbsp;%{last}</b> of <b>%{total}</b>"
+        display_entries: "Displaying %{entry_name} <b>%{first}&nbsp;-&nbsp;%{last}</b> of <b>%{total}</b>"

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -332,7 +332,7 @@ OBSApi::Application.routes.draw do
       post 'rss_tokens' => :create, controller: 'webui/users/rss_tokens', as: :my_rss_token
       post 'status_messages/:id' => :acknowledge, controller: 'webui/status_messages', as: :acknowledge_status_message
 
-      resources :tokens, only: [:index, :destroy], controller: 'webui/users/tokens'
+      resources :tokens, only: [:index, :destroy, :new, :create], controller: 'webui/users/tokens'
     end
 
     get 'home', to: 'webui/webui#home', as: :home

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -331,6 +331,8 @@ OBSApi::Application.routes.draw do
 
       post 'rss_tokens' => :create, controller: 'webui/users/rss_tokens', as: :my_rss_token
       post 'status_messages/:id' => :acknowledge, controller: 'webui/status_messages', as: :acknowledge_status_message
+
+      resources :tokens, only: [:index, :destroy], controller: 'webui/users/tokens'
     end
 
     get 'home', to: 'webui/webui#home', as: :home

--- a/src/api/spec/controllers/webui/users/tokens_controller_spec.rb
+++ b/src/api/spec/controllers/webui/users/tokens_controller_spec.rb
@@ -1,0 +1,123 @@
+require 'rails_helper'
+
+RSpec.describe Webui::Users::TokensController, type: :controller do
+  RSpec.shared_examples 'check for flashing an error' do
+    it "doesn't flash a success" do
+      expect(subject.request.flash[:success]).to be_nil
+    end
+
+    it 'flashes an error' do
+      expect(subject.request.flash[:error]).not_to be_nil
+    end
+  end
+
+  RSpec.shared_examples 'check for flashing a success' do
+    it 'flashes a success' do
+      expect(subject.request.flash[:success]).not_to be_nil
+    end
+
+    it "doesn't flash an error" do
+      expect(subject.request.flash[:error]).to be_nil
+    end
+  end
+
+  let(:user) { create(:confirmed_user, login: 'foo') }
+  let(:other_user) { create(:confirmed_user, login: 'bar') }
+
+  before do
+    Flipper[:trigger_workflow].enable
+    login user
+  end
+
+  describe 'GET #index' do
+    before do
+      create(:service_token, user: user)
+      create(:workflow_token, user: user)
+      create(:rss_token, user: user)
+      create(:release_token, user: other_user)
+
+      get :index
+    end
+
+    it { expect(assigns(:tokens).count).to eq(2) }
+  end
+
+  describe 'POST #create' do
+    let(:project) { create(:project) }
+    let(:package) { create(:package, project: project) }
+
+    subject { post :create, xhr: true, params: form_parameters }
+
+    context 'operation is runservice, no project and no package parameters' do
+      let(:form_parameters) { { token: { operation: 'runservice' } } }
+
+      include_examples 'check for flashing a success'
+    end
+
+    context 'operation is release, with project parameter, without package parameter' do
+      let(:form_parameters) { { token: { operation: 'release', project_name: project.name } } }
+
+      include_examples 'check for flashing an error'
+
+      it { expect { subject }.not_to change(Token, :count) }
+    end
+
+    context 'operation is rebuild, with project and package parameter' do
+      let(:form_parameters) { { token: { operation: 'rebuild', project_name: project.name, package_name: package.name } } }
+
+      include_examples 'check for flashing a success'
+
+      it { expect { subject }.to change(Token, :count).from(0).to(1) }
+    end
+
+    context 'operation is workflow' do
+      context 'with SCM' do
+        let(:form_parameters) { { token: { operation: 'workflow', scm_token: 'test_SCM_token_string' } } }
+
+        include_examples 'check for flashing a success'
+
+        it { expect { subject }.to change(Token, :count).from(0).to(1) }
+      end
+
+      context 'without SCM' do
+        let(:form_parameters) { { token: { operation: 'workflow' } } }
+
+        include_examples 'check for flashing an error'
+
+        it { expect { subject }.not_to change(Token, :count) }
+      end
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    let!(:token) { create(:service_token, user: user) }
+    let(:delete_parameters) { { id: token.id } }
+
+    subject { delete :destroy, params: delete_parameters }
+
+    context 'existent token' do
+      include_examples 'check for flashing a success'
+
+      it { is_expected.to redirect_to(tokens_path) }
+      it { expect { subject }.to change(Token, :count).from(1).to(0) }
+    end
+
+    context 'non-existent token' do
+      let(:delete_parameters) { { id: token.id + 1 } }
+
+      include_examples 'check for flashing an error'
+
+      it { is_expected.to redirect_to(tokens_path) }
+      it { expect { subject }.not_to change(Token, :count) }
+    end
+
+    context 'token of other user' do
+      let(:token) { create(:service_token, user: other_user) }
+
+      include_examples 'check for flashing an error'
+
+      it { is_expected.to redirect_to(root_path) }
+      it { expect { subject }.not_to change(Token, :count) }
+    end
+  end
+end

--- a/src/api/spec/controllers/webui/users/tokens_controller_spec.rb
+++ b/src/api/spec/controllers/webui/users/tokens_controller_spec.rb
@@ -48,31 +48,31 @@ RSpec.describe Webui::Users::TokensController, type: :controller do
 
     subject { post :create, xhr: true, params: form_parameters }
 
-    context 'operation is runservice, no project and no package parameters' do
-      let(:form_parameters) { { token: { operation: 'runservice' } } }
+    context 'type is runservice, no project and no package parameters' do
+      let(:form_parameters) { { token: { type: 'runservice' } } }
 
       include_examples 'check for flashing a success'
     end
 
-    context 'operation is release, with project parameter, without package parameter' do
-      let(:form_parameters) { { token: { operation: 'release', project_name: project.name } } }
+    context 'type is release, with project parameter, without package parameter' do
+      let(:form_parameters) { { token: { type: 'release' }, project_name: project.name } }
 
       include_examples 'check for flashing an error'
 
       it { expect { subject }.not_to change(Token, :count) }
     end
 
-    context 'operation is rebuild, with project and package parameter' do
-      let(:form_parameters) { { token: { operation: 'rebuild', project_name: project.name, package_name: package.name } } }
+    context 'type is rebuild, with project and package parameter' do
+      let(:form_parameters) { { token: { type: 'rebuild' }, project_name: project.name, package_name: package.name } }
 
       include_examples 'check for flashing a success'
 
       it { expect { subject }.to change(Token, :count).from(0).to(1) }
     end
 
-    context 'operation is workflow' do
+    context 'type is workflow' do
       context 'with SCM' do
-        let(:form_parameters) { { token: { operation: 'workflow', scm_token: 'test_SCM_token_string' } } }
+        let(:form_parameters) { { token: { type: 'workflow', scm_token: 'test_SCM_token_string' } } }
 
         include_examples 'check for flashing a success'
 
@@ -80,7 +80,7 @@ RSpec.describe Webui::Users::TokensController, type: :controller do
       end
 
       context 'without SCM' do
-        let(:form_parameters) { { token: { operation: 'workflow' } } }
+        let(:form_parameters) { { token: { type: 'workflow' } } }
 
         include_examples 'check for flashing an error'
 

--- a/src/api/spec/features/webui/projects_spec.rb
+++ b/src/api/spec/features/webui/projects_spec.rb
@@ -116,6 +116,8 @@ RSpec.describe 'Projects', type: :feature, js: true do
 
     it 'an existing package' do
       fill_in('linked_project', with: other_user.home_project_name)
+      # Remove focus from autocomplete. Needed to remove the `disabled` attribute from `linked_package`.
+      find('#target_package').click
       fill_in('linked_package', with: package_of_another_project.name)
       # This needs global write through
       click_button('Branch')
@@ -126,6 +128,8 @@ RSpec.describe 'Projects', type: :feature, js: true do
 
     it 'an existing package, but chose a different target package name' do
       fill_in('linked_project', with: other_user.home_project_name)
+      # Remove focus from autocomplete. Needed to remove the `disabled` attribute from `linked_package`.
+      find('#target_package').click
       fill_in('linked_package', with: package_of_another_project.name)
       fill_in('Branch package name', with: 'some_different_name')
       # This needs global write through
@@ -139,6 +143,8 @@ RSpec.describe 'Projects', type: :feature, js: true do
       create(:package_with_file, name: package_of_another_project.name, project: user.home_project)
 
       fill_in('linked_project', with: other_user.home_project_name)
+      # Remove focus from autocomplete. Needed to remove the `disabled` attribute from `linked_package`.
+      find('#target_package').click
       fill_in('linked_package', with: package_of_another_project.name)
       # This needs global write through
       click_button('Branch')

--- a/src/api/spec/features/webui/requests_spec.rb
+++ b/src/api/spec/features/webui/requests_spec.rb
@@ -262,6 +262,8 @@ RSpec.describe 'Bootstrap_Requests', type: :feature, js: true, vcr: true do
         desktop? ? click_link('Add a Review') : click_menu_link('Actions', 'Add a Review')
         find(:id, 'review_type').select('Package')
         fill_in 'review_project', with: submitter.home_project
+        # Remove focus from autocomplete. Needed to remove the `disabled` attribute from `review_package`.
+        find('#review_comment').click
         fill_in 'review_package', with: package.name
         click_button('Accept')
         expect(page).to have_text("Open review for #{submitter.home_project} / #{package.name}")


### PR DESCRIPTION
Manage user tokens from the web user interface.

This new option can  be accessed from "User Profile", "Manage Your Tokens".

This option will be shown only if the ~`user_profile_redesign`~ `trigger_workflow` feature flag is enabled.

This pull request only implements listing and deleting tokens.

Policies for using tokens from the web-ui were created under `app/policies/webui/tokens/`, to not colide with the existing token policies, under `app/policies/token/`.

-----------------
Switching to Draft. Things to be done before switching to "Ready for review":
* [x] Add pagination.
* [x] Add "Create token".
* [x] Don't show the token string field in the list of tokens.
-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature