### PR TITLE
Require rack version we have in the bundle

### DIFF
--- a/dist/obs-bundled-gems.spec
+++ b/dist/obs-bundled-gems.spec
@@ -52,7 +52,7 @@ This package bundles all the gems required by the Open Build Service
 to make it easier to deploy the obs-server package.
 
 %define rake_version 12.3.3
-%define rack_version 2.1.4
+%define rack_version 2.2.3
 
 %package -n obs-api-deps
 Summary:        Holding dependencies required to run the OBS frontend


### PR DESCRIPTION
After merge we need to link to [devel:languages:ruby:extensions/rubygem-rack](https://build.opensuse.org/package/show/devel:languages:ruby:extensions/rubygem-rack) in 2.10:Staging.