### PR TITLE
Fix testing for 210

### DIFF
--- a/dist/t/0060-check_required_services.ts
+++ b/dist/t/0060-check_required_services.ts
@@ -34,8 +34,13 @@ my $version = `rpm -q --queryformat %{Version} obs-server`;
 my @enabled_daemons = @active_daemons;
 
 if ($version !~ /^2\.[89]\./) {
-  push @active_daemons, 'obs-clockwork.service', 'obs-delayedjob-queue-consistency_check.service', 'obs-delayedjob-queue-default.service', 'obs-delayedjob-queue-issuetracking.service', 'obs-delayedjob-queue-mailers.service', 'obs-delayedjob-queue-project_log_rotate.service', 'obs-delayedjob-queue-quick@0.service', 'obs-delayedjob-queue-quick@1.service', 'obs-delayedjob-queue-quick@2.service', 'obs-delayedjob-queue-releasetracking.service', 'obs-delayedjob-queue-staging.service', 'obs-delayedjob-queue-scm.service', 'obs-sphinx.service';
-  $tests = $tests + 13;
+  push @active_daemons, 'obs-clockwork.service', 'obs-delayedjob-queue-consistency_check.service', 'obs-delayedjob-queue-default.service', 'obs-delayedjob-queue-issuetracking.service', 'obs-delayedjob-queue-mailers.service', 'obs-delayedjob-queue-project_log_rotate.service', 'obs-delayedjob-queue-quick@0.service', 'obs-delayedjob-queue-quick@1.service', 'obs-delayedjob-queue-quick@2.service', 'obs-delayedjob-queue-releasetracking.service', 'obs-delayedjob-queue-staging.service', 'obs-sphinx.service';
+  $tests += 12;
+  my @out=`systemctl show --property=LoadError obs-delayedjob-queue-scm.service`;
+  if ($out[0] !~ /^LoadError=org.freedesktop.systemd1.NoSuchUnit/) {
+    push @active_daemons, 'obs-delayedjob-queue-scm.service';
+    $tests += 1;
+  }
 }
 
 plan tests => $tests;

--- a/dist/t/0060-check_required_services.ts
+++ b/dist/t/0060-check_required_services.ts
@@ -62,7 +62,6 @@ while ($max_wait > 0) {
 	foreach my $srv (@active_daemons) {
 		my @state=`systemctl is-active $srv 2>/dev/null`;
 		chomp($state[0]);
-		print "$srv $state[0]\n";
 		if ( $state[0] eq 'active') {
 			$srv_state{$srv} = $state[0];
 		} elsif ( $state[0] eq 'failed') {


### PR DESCRIPTION
* only add obs-delayedjob-queue-scm to the list to check if unit exists (missing in 2.10 and older)
* log service state to logfile to get the noise out of the test results