### PR TITLE
Move from Leap 15.1 to Leap 15.3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,17 @@
 version: "2.1"
 services:
   db:
-    image: registry.opensuse.org/obs/server/unstable/container/leap151/containers/openbuildservice/mariadb
+    image: registry.opensuse.org/obs/server/unstable/container/leap153/containers/openbuildservice/mariadb
     ports:
       - "3306:3306"
     command: /usr/lib/mysql/mysql-systemd-helper start
   cache:
-    image: registry.opensuse.org/obs/server/unstable/container/leap151/containers/openbuildservice/memcached
+    image: registry.opensuse.org/obs/server/unstable/container/leap153/containers/openbuildservice/memcached
     ports:
       - "11211:11211"
     command: /usr/sbin/memcached -u memcached
   backend:
-    image: registry.opensuse.org/obs/server/unstable/container/leap151/containers/openbuildservice/backend
+    image: registry.opensuse.org/obs/server/unstable/container/leap153/containers/openbuildservice/backend
     volumes:
       - .:/obs
       - ./dist/aws_credentials:/etc/obs/cloudupload/.aws/config
@@ -19,7 +19,7 @@ services:
       - ./dist/clouduploader.rb:/usr/bin/clouduploader
     command: /obs/contrib/start_development_backend -d /obs
   worker:
-    image: registry.opensuse.org/obs/server/unstable/container/leap151/containers/openbuildservice/backend
+    image: registry.opensuse.org/obs/server/unstable/container/leap153/containers/openbuildservice/backend
     volumes:
       - .:/obs
     privileged: true

--- a/src/api/docker-files/Dockerfile
+++ b/src/api/docker-files/Dockerfile
@@ -3,7 +3,7 @@
 # contained rails app generating files in the git checkout with
 # some strange user...
 
-FROM registry.opensuse.org/obs/server/unstable/container/leap151/containers/openbuildservice/frontend-base
+FROM registry.opensuse.org/obs/server/unstable/container/leap153/containers/openbuildservice/frontend-base
 ARG CONTAINER_USERID
 
 # for lint task

--- a/src/api/docker-files/Dockerfile.minitest
+++ b/src/api/docker-files/Dockerfile.minitest
@@ -2,7 +2,7 @@
 # sure different users can run it without the contained rails app generating
 # files in the git checkout with some strange user...
 
-FROM registry.opensuse.org/obs/server/unstable/container/leap151/containers/openbuildservice/frontend-backend
+FROM registry.opensuse.org/obs/server/unstable/container/leap153/containers/openbuildservice/frontend-backend
 
 # Configure our user
 ARG CONTAINER_USERID


### PR DESCRIPTION
Move our development environment from Leap 15.1 to Leap 15.3

To test it:

checkout the branch and run `docker-compose down && rake docker:build && docker-compose up`


-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
