### PR TITLE
Add removal of statistics#{download_counter,newest_stats} to release notes

### DIFF
--- a/ReleaseNotes-2.11
+++ b/ReleaseNotes-2.11
@@ -75,3 +75,5 @@ Breaking API changes:
  * The API endpoint '/announcements' is deprecated and will be removed in the
    next version. Announcements can be created through Status Messages by using
    'announcement' severity. Check the API documentation about Status Messages.
+ * The API endpoints '/statistics/download_counter' and '/statistics/newest_stats'
+   have been removed. They have been non-functional and unused for a long time.


### PR DESCRIPTION
Following up on #11422 and #11423. Just in case someone wonders.