### PR TITLE
[backend] implement first part of modulemd data creation

### DIFF
--- a/src/backend/BSSched/BuildJob.pm
+++ b/src/backend/BSSched/BuildJob.pm
@@ -915,6 +915,14 @@ sub create_jobdata {
   $debuginfo = BSUtil::enabled($repoid, $proj->{'debuginfo'}, $debuginfo, $myarch);
   $debuginfo = BSUtil::enabled($repoid, $pdata->{'debuginfo'}, $debuginfo, $myarch);
   $binfo->{'debuginfo'} = 1 if $debuginfo;
+  if ($ctx->{'modularity_label'}) {
+    $binfo->{'modularity_package'} = $ctx->{'modularity_package'};
+    $binfo->{'modularity_srcmd5'} = $ctx->{'modularity_srcmd5'};
+    $binfo->{'modularity_meta'} = $ctx->{'modularity_meta'};
+    $binfo->{'modularity_platform'} = $ctx->{'modularity_platform'};
+    $binfo->{'modularity_label'} = $ctx->{'modularity_label'};
+    $binfo->{'modularity_macros'} = BSSched::Modulemd::calc_macros($bconf, $ctx->{'modularity_label'}, $binfo->{'bcnt'} || 1, $ctx->{'modularity_extramacros'});
+  }
   return $binfo;
 }
 

--- a/src/backend/BSSched/BuildJob/Package.pm
+++ b/src/backend/BSSched/BuildJob/Package.pm
@@ -211,6 +211,7 @@ sub check {
     my $dep2pkg = $ctx->{'dep2pkg'};
     my $dep2pkg_host = $ctx->{'dep2pkg_host'};
     $check .= $ctx->{'genmetaalgo'} if $ctx->{'genmetaalgo'};
+    $check .= $ctx->{'modularity_meta'} if $ctx->{'modularity_meta'};
     $check .= $rebuildmethod;
     $check .= $pool->pkg2pkgid($dep2pkg->{$_}) for sort @$edeps;
     $check .= $pool_host->pkg2pkgid($dep2pkg_host->{$_}) for sort @{$hdeps || []};
@@ -277,6 +278,7 @@ sub check {
 	push @new_meta, ($pool_host->pkg2pkgid($dep2pkg_host->{$bin})."  $hostarch:$bin");
       }
     }
+    unshift @new_meta, $ctx->{'modularity_meta'} if $ctx->{'modularity_meta'};
     @new_meta = BSSolv::gen_meta($ctx->{'subpacks'}->{$info->{'name'}} || [], @new_meta);
     unshift @new_meta, ($pdata->{'verifymd5'} || $pdata->{'srcmd5'})."  $packid";
     if (Digest::MD5::md5_hex(join("\n", @new_meta)) eq substr($mylastcheck, 32, 32)) {

--- a/src/backend/BSSched/Modulemd.pm
+++ b/src/backend/BSSched/Modulemd.pm
@@ -1,0 +1,151 @@
+# Copyright (c) 2021 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program (see the file COPYING); if not, write to the
+# Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+#
+
+package BSSched::Modulemd;
+
+use strict;
+use warnings;
+
+use JSON::XS ();
+use Digest::SHA ();
+
+sub json_sha1 {
+  my ($d) = @_; 
+  my $json = JSON::XS->new->utf8->canonical->space_after->encode($d);
+  return Digest::SHA::sha1_hex($json);
+}
+
+sub calc_modularitylabel {
+  my ($bconf, $name, $stream, $timestamp, $deps) = @_;
+  my $pfdata = $bconf->{'buildflags:modulemdplatform'};
+  return undef unless $pfdata;
+  my ($versionprefix, $distprefix) = split(':', $pfdata, 2);
+  return undef unless defined $distprefix;
+  my %buildrequires;
+  for (@{$bconf->{'modules'} || []}) {
+    return undef unless /^(.+)-([^-]+)$/s;
+    $buildrequires{$1} = $2;
+  }
+  my $buildctx = json_sha1(\%buildrequires);
+  my %requires;
+  for my $dep (@{$deps || []}) {
+    my ($n, @v) = split(':', $dep);
+    my %v = map {$_ => 1} @v;
+    $requires{$n} = [ sort keys %v ];
+  }
+  my $depctx = json_sha1(\%requires);
+  my $mdctx = substr(Digest::SHA::sha1_hex("$buildctx:$depctx"), 0, 8);
+  my @gm = gmtime($timestamp);
+  my $mdversion = $versionprefix.sprintf("%04d%02d%02d%02d%02d%02d", $gm[5] + 1900, $gm[4] + 1, @gm[3,2,1,0]);
+  return "$name:$stream:$mdversion:$mdctx";
+}
+
+sub select_dependency {
+  my ($bconf, $modulemd) = @_;
+  my $pfdata = $bconf->{'buildflags:modulemdplatform'};
+  return undef unless $pfdata;
+  my ($versionprefix, $distprefix, @distprovides) = split(':', $pfdata);
+  my %distprovides = map {$_ => 1} @distprovides;
+  for (@distprovides) {
+    $distprovides{"$1-*"} = 1 if /^(.*)-/;
+  }
+  return {} unless $modulemd->{'dependencies'};
+  for my $dependency (@{$modulemd->{'dependencies'}}) {
+    my $good = 1;
+    for my $br (@{$dependency->{'buildrequires'} || []}) {
+      my ($n, @v) = split(':', $br);
+      if ($n =~ s/^-//) {
+        $good = 0 if grep {$distprovides{"$n-$_"}}  @v;
+      } else {
+        $good = 0 if $distprovides{"$n-*"} && !grep {$distprovides{"$n-$_"}} @v;
+      }
+      last unless $good;
+    }
+    return $dependency if $good;
+  }
+  return undef;
+}
+
+sub extend_modules {
+  my ($bconf, $buildrequires) = @_;
+  my $pfdata = $bconf->{'buildflags:modulemdplatform'};
+  return [ "buildflags:modulemdplatform is not set" ] unless $pfdata;
+  my ($versionprefix, $distprefix, @distprovides) = split(':', $pfdata);
+  my %distprovides = map {$_ => 1} @distprovides;
+  my @needed;
+  my @have = @{$bconf->{'modules'} || []};
+  push @have, @distprovides;
+  my %have = map {$_ => 1} @have;
+  my @errors;
+  for (@have) {
+    $have{"$1-*"} = $_ if /^(.*)-/;
+  }
+  my @ambiguous;
+  for my $br (@{$buildrequires || []}) {
+    my ($n, @v) = split(':', $br);
+    next if $n =~ /^-/;
+    if ($have{"$n-*"}) {
+      next if !@v || grep {$have{"$n-$_"}} @v;
+      push @errors, "modulemd requires ".join(" | ", map {"$n-$_"} @v)." instead of ".$have{"$n-*"};
+      next;
+    }
+    next if @v && grep {$have{"$n-$_"}} @v;
+    if (@v == 1) {
+      push @needed, "$n-$v[0]";
+      next;
+    }
+    if (!@v) {
+      push @errors, "modulemd requires any stream version of $n";
+    } else {
+      push @errors, "modulemd requires ".join(" | ", map {"$n-$_"} @v);
+    }
+  }
+  return \@errors if @errors;
+  if (@needed) {
+    my %modules = map {$_ => 1} @{$bconf->{'modules'} || []}, @needed;
+    $bconf->{'modules'} = [ sort keys %modules ];
+  }
+  return undef;
+}
+
+sub calc_dist {
+  my ($bconf, $ml, $bcnt) = @_;
+  my $pfdata = $bconf->{'buildflags:modulemdplatform'};
+  return undef unless $pfdata;
+  my ($versionprefix, $distprefix) = split(':', $pfdata);
+  return undef unless $distprefix;
+  my $ml_x = $ml;
+  $ml_x =~ s/:/./g;
+  return "$distprefix+$bcnt+".substr(Digest::SHA::sha1_hex($ml_x), 0, 8);
+}
+
+sub calc_macros {
+  my ($bconf, $ml, $bcnt, $extramacros) = @_;
+  my @ml = split(':', $ml, 4);
+  my $dist = calc_dist($bconf, $ml, $bcnt);
+  my $macros = '';
+  $macros .= "%dist $dist\n" if defined $dist;
+  $macros .= "%modularitylabel $ml\n";
+  $macros .= "%_module_name $ml[0]\n";
+  $macros .= "%_module_stream $ml[1]\n";
+  $macros .= "%_module_version $ml[2]\n";
+  $macros .= "%_module_context $ml[3]\n";
+  $macros .= "$extramacros\n" if $extramacros;
+  return $macros;
+}
+
+1;

--- a/src/backend/BSSrcServer/Modulemd.pm
+++ b/src/backend/BSSrcServer/Modulemd.pm
@@ -1,0 +1,185 @@
+# Copyright (c) 2021 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program (see the file COPYING); if not, write to the
+# Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+#
+
+package BSSrcServer::Modulemd;
+
+use strict;
+use warnings;
+
+eval { require YAML::XS; $YAML::XS::LoadBlessed = 0; };
+*YAML::XS::Load = sub {die("YAML::XS is not available\n")} unless defined &YAML::XS::Load;
+
+sub assert_str {
+  my ($str, $el) = @_;
+  die("missing $el\n") unless defined $str;
+  die("$el is not a string\n") if ref($str);
+  return $str;
+}
+
+sub parse_deps {
+  my ($d, $el) = @_;
+  return [] unless defined $d;
+  die("$el dependencies must be hash\n") unless ref($d) eq 'HASH';
+  my %deps;
+  for my $n (sort keys %$d) {
+    my $v = $d->{$n};
+    $v = [ $v ] if ref($v) eq '';
+    die("$el dependency stream must be array\n") unless ref($v) eq 'ARRAY';
+    my @v = @$v;
+    if (!@v) {
+      $deps{$n} = 1;
+    } elsif ($v[0] =~ /^-/) {
+      die("$el: mixed dependencies\n") if grep {!s/^-//} @v;
+      $deps{"-$n:".join(':', @v)} = 1;
+    } else {
+      $deps{"$n:".join(':', @v)} = 1 for @v;
+    }
+  }
+  return [ sort keys %deps ];
+}
+
+sub read_modulemd {
+  my ($yaml) = @_;
+  my $d = YAML::XS::Load($yaml);
+  die("bad modulemd data\n") unless $d && ref($d) eq 'HASH';
+  die("missing data element\n") unless ref($d->{'data'}) eq 'HASH';
+  return $d;
+}
+
+sub parse_modulemd {
+  my ($yaml) = @_;
+  my $d = read_modulemd($yaml);
+  $d = $d->{'data'};
+  my $r = {};
+  $r->{'name'} = assert_str($d->{'name'}, 'name');
+  $r->{'stream'} = assert_str($d->{'stream'}, 'stream');
+  $d->{'dependencies'} = [ $d->{'dependencies'} ] if ref($d->{'dependencies'}) eq 'HASH';
+  for my $dd (@{$d->{'dependencies'} || []}) {
+    die("dependency block must be hash\n") unless ref($dd) eq 'HASH';
+    my $rd = {};
+    $rd->{'buildrequires'} = parse_deps($dd->{'buildrequires'}) if $dd->{'buildrequires'};
+    $rd->{'requires'} = parse_deps($dd->{'requires'}) if $dd->{'requires'};
+    push @{$r->{'dependency'}}, $rd if %$rd;
+  }
+  my $buildopts = $d->{'buildopts'};
+  if ($buildopts && ref($buildopts) eq 'HASH') {
+    if ($buildopts->{'rpms'} && ref($buildopts->{'rpms'}) eq 'HASH') {
+      my $macros = $buildopts->{'rpms'}->{'macros'};
+      if ($macros && ref($macros) eq '') {
+        $macros =~ s/\n?\z/\n/s;
+        $r->{'macros'} = $macros;
+      }
+    }
+  }
+  return $r;
+}
+
+sub tostream {
+  my ($md, $modules, $modularitylabel, $modularityplatform) = @_;
+  die("no md version\n") unless $md->{'version'};
+  if ($md->{'version'} == 1) {
+    $md->{'version'} = 2;
+    if ($md->{'data'} && ref($md->{'data'}->{'dependencies'}) eq 'HASH') {
+      $md->{'data'}->{'dependencies'} = [ $md->{'data'}->{'dependencies'} ];
+    }
+  }
+  if ($md->{'version'} != 2) {
+    die("unsupported md version\n");
+  }
+  $md = $md->{'data'};
+  return unless $md->{'dependencies'};
+  my ($versionprefix, $distprefix, @distprovides) = split(':', $modularityplatform);
+  my %distprovides = map {$_ => 1} @distprovides;
+  for (@distprovides) {
+    $distprovides{"$1-*"} = $_ if /^(.*)-/;
+  }
+use Data::Dumper;
+print Dumper(\%distprovides);
+  my $newdeps;
+  for my $dd (@{$md->{'dependencies'} || []}) {
+    die("dependency block must be hash\n") unless ref($dd) eq 'HASH';
+    my $buildrequires = parse_deps($dd->{'buildrequires'});
+    my $requires = parse_deps($dd->{'requires'});
+    my $good = 1;
+    for my $br (@$buildrequires) {
+print "check $br\n";
+      my ($n, @v) = split(':', $br);
+      if ($n =~ s/^-//) {
+	$good = 0 if grep {$distprovides{"$n-$_"}} @v; 
+      } else {
+	$good = 0 if $distprovides{"$n-*"} && !grep {$distprovides{"$n-$_"}} @v; 
+      }
+      last unless $good;
+    }
+    next unless $good;
+    my @newbuildrequires;
+    my %brmap;
+    for my $br (@$buildrequires) {
+      my ($n, @v) = split(':', $br);
+      my $newbr;
+      if ($n =~ s/^-//) {
+	$newbr = $distprovides{"$n-*"};
+	die("module $n is not available\n") unless $newbr;
+      } else {
+        if (@v) {
+	  @v = map {"$n-$_"} grep {$distprovides{"$n-$_"}} @v;
+	} else {
+	  @v = [ $distprovides{"$n-*"} ];
+	}
+        $newbr = $v[0];
+	die("module $n is not available\n") unless $newbr;
+      }
+      $newbr =~ s/^\Q$n\E-/$n:/;
+print "BRMAP $br -> $newbr\n";
+      $brmap{$br} = $newbr;
+      $br = $newbr;
+    }
+    for my $r (@$requires) {
+print "REQ $r\n";
+      $r = $brmap{$r} if defined $brmap{$r};
+    }
+    $newdeps = {};
+    $newdeps->{'buildrequires'} = $buildrequires if @$buildrequires;
+    $newdeps->{'requires'} = $requires if @$requires;
+  }
+  die("could not select dependency block\n") unless $newdeps;
+  $md->{'dependencies'} = [ $newdeps ];
+  my @l = split(':', $modularitylabel);
+  $md->{'name'} = $l[0];
+  $md->{'stream'} = $l[1];
+  $md->{'version'} = $l[2];
+  $md->{'context'} = $l[3];
+  $md->{'xmd'} = {};
+}
+
+sub slurp {
+  my ($fn) = @_;
+  my $f;
+  if (!open($f, '<', $fn)) {
+    die("$fn: $!\n");
+  }
+  my $d = '';
+  1 while sysread($f, $d, 8192, length($d));
+  close $f;
+  return $d;
+}
+
+#use Data::Dumper;
+#my $y = slurp($ARGV[0]);
+#print Dumper(parse_modulemd($y));
+
+1;

--- a/src/backend/BSXML.pm
+++ b/src/backend/BSXML.pm
@@ -301,6 +301,19 @@ our $channel = [
      ]],
 ];
 
+our $modulemd = [
+    'modulemd' =>
+	'name',
+	'stream',
+	'timestamp',
+	[],
+	'macros',
+     [[ 'dependency' =>
+	    [ 'buildrequires' ],
+	    [ 'requires' ],
+     ]],
+];
+
 our $projpack = [
     'projpack' =>
     'repoid',
@@ -338,6 +351,7 @@ our $projpack = [
 		$aggregatelist,
 		$patchinfo,
 		'channelmd5',
+		$modulemd,
 		@flags,
 		'bcntsynctag',
 		'hasbuildenv',
@@ -613,6 +627,13 @@ our $buildinfo = [
 	'masterdispatched',	# dispatched through a master dispatcher
 	'nounchanged',	# do not check for "unchanged" builds
       [ 'module' ],	# list of modules to use
+
+        'modularity_package',
+        'modularity_srcmd5',
+        'modularity_macros',
+        'modularity_label',
+        'modularity_platform',
+        'modularity_meta',
 
       [ 'preinstallimage' =>
 	    'project',

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -79,6 +79,7 @@ use BSSrcServer::Registry;
 use BSSrcServer::Signkey;
 use BSSrcServer::Notify;
 use BSSrcServer::LinkinfoDB;
+use BSSrcServer::Modulemd;
 
 require BSSrcServer::SQLite if $BSConfig::published_db_sqlite || $BSConfig::source_db_sqlite;
 
@@ -1585,6 +1586,23 @@ sub getprojpack {
 	    }
 	    $pinfo->{'info'} = \@dinfo if @dinfo;
 	  }
+	} elsif ($files->{'_modulemd.yaml'}) {
+	  my $d;
+	  eval {
+	    my @s = BSRevision::revstat($rev, '_modulemd.yaml', $files->{'_modulemd.yaml'});
+	    die("_modulemd.yaml: maximum size exceeded\n") if $s[7] > 1024*1204;
+	    my $yaml = BSRevision::revreadstr($rev, '_modulemd.yaml', $files->{'_modulemd.yaml'});
+	    $d = BSSrcServer::Modulemd::parse_modulemd($yaml);
+	    $d->{'timestamp'} = $pinfo->{'revtime'} || $s[9];
+	  };
+	  if ($@) {
+	    my $err = $@;
+	    chomp $err;
+	    $pinfo->{'error'} = "_modulemd.yaml: $err";
+	    next;
+	  }
+	  $pinfo->{'modulemd'} = $d;
+	  next;
         } elsif ($cgi->{'withdeps'}) {
 	  my @dinfo;
 
@@ -5860,6 +5878,19 @@ sub getobsgendiffdata {
   return undef;
 }
 
+sub getmodulemd {
+  my ($cgi, $projid, $packid, $srcmd5) = @_;
+  my $rev = {'project' => $projid, 'package' => $packid, 'srcmd5' => $srcmd5};
+  my $files = BSRevision::lsrev($rev);
+  die("no modulemd data in $projid/$packid\n") unless $files->{'_modulemd.yaml'};
+  my @s = BSRevision::revstat($rev, '_modulemd.yaml', $files->{'_modulemd.yaml'});
+  die("_modulemd.yaml: maximum size exceeded\n") if $s[7] > 1024*1204;
+  my $yaml = BSRevision::revreadstr($rev, '_modulemd.yaml', $files->{'_modulemd.yaml'});
+  my $d = BSSrcServer::Modulemd::read_modulemd($yaml);
+  BSSrcServer::Modulemd::tostream($d, $cgi->{'modules'} || [], $cgi->{'modularitylabel'}, $cgi->{'modularityplatform'});
+  return ($d, \&BSUtil::tostorable, 'Content-Type: application/octet-stream');
+}
+
 ####################################################################
 
 # this is shared for AJAX requests
@@ -7190,6 +7221,7 @@ my $dispatches = [
   '/getbinaries $project $repository $arch binaries: nometa:bool? workerid? now:num? module*' => \&worker_getbinaries,
   '/getbinaryversions $project $repository $arch binaries: nometa:bool? workerid? now:num? module*' => \&worker_getbinaryversions,
   '/getobsgendiffdata $project $repository $arch jobid? workerid?' => \&getobsgendiffdata,
+  '/getmodulemd $project $package $srcmd5:md5 module* modularityplatform: modularitylabel:' => \&getmodulemd,
 
   # publisher/signer calls
   '/getsignkey $project withpubkey:bool? autoextend:bool? withalgo:bool?' => \&getsignkey,

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -1117,6 +1117,22 @@ sub getobsgendiffdata {
   return $res;
 }
 
+sub getmodulemddata {
+  my ($buildinfo, $dir) = @_;
+  my $server = $buildinfo->{'srcserver'} || $srcserver;
+  my @args;
+  push @args, map {"module=$_"} @{$buildinfo->{'module'}};
+  push @args, "modularityplatform=$buildinfo->{'modularity_platform'}";
+  push @args, "modularitylabel=$buildinfo->{'modularity_label'}";
+  my $md = BSRPC::rpc({
+    'uri' => "$server/getmodulemd",
+    'filename' => "$dir/_modulemd.in",
+    'timeout' => $gettimeout,
+  }, \&BSUtil::fromstorable, "project=$buildinfo->{'project'}", "package=$buildinfo->{'modularity_package'}", "srcmd5=$buildinfo->{'modularity_srcmd5'}", @args);
+  $md->{'data'}->{'arch'} = $buildinfo->{'arch'};
+  BSUtil::store("$dir/_modulemd.pst", undef, $md);
+}
+
 sub getsslcert {
   my ($buildinfo, $dir, $signtype) = @_;
   my $server = $buildinfo->{'srcserver'} || $srcserver;
@@ -2677,6 +2693,7 @@ sub getbinaries {
       }
     }
   }
+  push @meta, $buildinfo->{'modularity_meta'} if $buildinfo->{'modularity_meta'};
   BSBuild::setgenmetaalgo($buildinfo->{'genmetaalgo'}) if $buildinfo->{'genmetaalgo'};
   @meta = BSBuild::gen_meta($buildinfo->{'subpack'} || [], @meta);
   return @meta;
@@ -3272,6 +3289,7 @@ sub dobuild {
     $config = $buildinfo->{'config'};
   } else {
     $config = BSRPC::rpc("$server/getconfig", undef, "project=$projid", "repository=$repoid", @configpath);
+    $config = Build::combine_configs($config, "Macros:\n$buildinfo->{'modularity_macros'}") if $buildinfo->{'modularity_macros'};
   }
   $buildinfo->{'outbuildinfo'}->{'config'} = $config;
   writestr("$buildroot/.build.config", undef, $config);
@@ -3286,9 +3304,13 @@ sub dobuild {
     }
   }
 
+  if ($buildinfo->{'modularity_meta'}) {
+    getmodulemddata($buildinfo, $srcdir, $bconf);
+  }
+
   if ($oldpkgdir && !$kiwimode && $buildinfo->{'file'} ne 'preinstallimage') {
-      getoldpackages($buildinfo, $oldpkgdir, $useccache);
-      getlinkedccache($buildinfo, $oldpkgdir) if $useccache && ! -f "$oldpkgdir/_ccache.tar";
+    getoldpackages($buildinfo, $oldpkgdir, $useccache);
+    getlinkedccache($buildinfo, $oldpkgdir) if $useccache && ! -f "$oldpkgdir/_ccache.tar";
   }
 
   $stats->{'times'}->{'download'}->{'time'}->{'unit'} = "s";


### PR DESCRIPTION
This consists of the parsing of the modulemd data, the setup
of the modules and macros, and the generation of a _modulemd.pst
file at build time.

_Replace this line with a description of your changes. Please follow the suggestions in the comment below._

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
