### PR TITLE
Update the SCM token of workflow tokens in the UI

### DIFF
--- a/src/api/app/controllers/webui/users/tokens_controller.rb
+++ b/src/api/app/controllers/webui/users/tokens_controller.rb
@@ -1,5 +1,5 @@
 class Webui::Users::TokensController < Webui::WebuiController
-  before_action :set_token, only: [:destroy]
+  before_action :set_token, only: [:edit, :update, :destroy]
   before_action :set_params, :set_package, only: [:create]
 
   after_action :verify_authorized, except: :index
@@ -12,6 +12,24 @@ class Webui::Users::TokensController < Webui::WebuiController
   def new
     @token = Token.new
     authorize [:webui, @token]
+  end
+
+  def edit
+    authorize [:webui, @token]
+  end
+
+  def update
+    authorize [:webui, @token]
+
+    new_scm_token = params.require(:token).permit(:scm_token)
+
+    if @token.update(new_scm_token)
+      flash[:success] = 'Token successfully updated'
+    else
+      flash[:error] = 'Failed to update Token'
+    end
+
+    redirect_to tokens_url
   end
 
   def create

--- a/src/api/app/policies/webui/token_policy.rb
+++ b/src/api/app/policies/webui/token_policy.rb
@@ -21,6 +21,14 @@ class Webui::TokenPolicy < ApplicationPolicy
     Flipper.enabled?(:trigger_workflow, user)
   end
 
+  def edit?
+    update?
+  end
+
+  def update?
+    record.user == user && record.type == 'Token::Workflow' && Flipper.enabled?(:trigger_workflow, user)
+  end
+
   def create?
     # TODO: when trigger_workflow is rolled out, remove the Flipper check
     record.user == user && record.type != 'Token::Rss' && Flipper.enabled?(:trigger_workflow, user)

--- a/src/api/app/views/webui/users/tokens/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui/users/tokens/_breadcrumb_items.html.haml
@@ -1,4 +1,17 @@
 %li.breadcrumb-item
   = link_to('Your Profile', user_path(User.session!))
-%li.breadcrumb-item.active{ 'aria-current' => 'page' }
-  Tokens
+
+- case action_name
+- when 'index'
+  %li.breadcrumb-item.active{ 'aria-current' => 'page' }
+    Tokens
+- when 'new'
+  %li.breadcrumb-item{ 'aria-current' => 'page' }
+    = link_to 'Tokens', tokens_path
+  %li.breadcrumb-item.active{ 'aria-current' => 'page' }
+    Create Token
+- when 'edit'
+  %li.breadcrumb-item{ 'aria-current' => 'page' }
+    = link_to 'Tokens', tokens_path
+  %li.breadcrumb-item.active{ 'aria-current' => 'page' }
+    Edit Token

--- a/src/api/app/views/webui/users/tokens/edit.html.haml
+++ b/src/api/app/views/webui/users/tokens/edit.html.haml
@@ -1,0 +1,25 @@
+.card
+  .card-body
+    %h3.mb-3 Edit Token
+
+    .row
+      .col-12.col-md-10.col-lg-8
+        -# "as: :token" to have a consistent name across all various token classes
+        = form_for(@token, as: :token, url: token_path, method: :put, local: true) do |f|
+          .form-row#edit-token
+            .col-12.col-md-10.col-lg-9
+              .form-group
+                = f.label(:id, 'Id:')
+                = @token.id
+              .form-group
+                = f.label(:type, 'Operation:')
+                = @token.class.token_name.capitalize
+              .form-group
+                = f.label(:scm_token) do
+                  SCM token:
+                  %abbr.text-danger{ title: 'required' } *
+                .input-group
+                  = f.password_field(:scm_token, size: 80, class: 'form-control', placeholder: 'Please enter your new SCM token', required: true)
+          .actions
+            = link_to('Cancel', tokens_path, title: 'Cancel', class: 'btn btn-outline-secondary px-4 mr-3 mt-3 mt-sm-0')
+            = f.submit('Update', class: 'btn btn-primary px-4 mt-3 mt-sm-0')

--- a/src/api/app/views/webui/users/tokens/index.html.haml
+++ b/src/api/app/views/webui/users/tokens/index.html.haml
@@ -22,8 +22,11 @@
                 %td= token.class.token_name.capitalize
                 %td.text-word-break-all= link_to("#{truncate(token.package.project.name, length: 80)}/#{truncate(token.package.name, length: 80)}",
                   package_show_path(project: token.package.project, package: token.package)) if token.package
-                %td.text-center
-                  = link_to '#', title: 'Delete Token', class: 'btn btn-sm btn-outline-danger',
+                %td
+                  - if policy([:webui, token]).edit?
+                    = link_to(edit_token_path(token), title: 'Edit Token') do
+                      %i.fas.fa-edit
+                  = link_to '#', title: 'Delete Token',
                     data: { toggle: 'modal', target: '#delete-token-modal', token_id: token.id, action: token_path(token) } do
                     %i.fas.fa-times-circle.text-danger
 

--- a/src/api/app/views/webui/users/tokens/new.html.haml
+++ b/src/api/app/views/webui/users/tokens/new.html.haml
@@ -42,9 +42,9 @@
           .form-row
             .col-12.col-md-10.col-lg-9
               .form-group.d-none#fieldset-token-scm-token
-                = f.label(:scm_token, 'Source Code Management Token')
-                %abbr.text-danger{ title: "required, when Operation is 'worflow'" } *
-                = f.text_field(:scm_token, size: 80, class: 'form-control', placeholder: 'Source Code Management Token')
+                = f.label(:scm_token, 'SCM Token')
+                %abbr.text-danger{ title: 'required' } *
+                = f.password_field(:scm_token, size: 80, class: 'form-control', placeholder: 'Please enter your SCM token')
 
           .actions
             = link_to('Cancel', tokens_path, title: 'Cancel', class: 'btn btn-outline-secondary px-4 mr-3 mt-3 mt-sm-0')

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -332,7 +332,7 @@ OBSApi::Application.routes.draw do
       post 'rss_tokens' => :create, controller: 'webui/users/rss_tokens', as: :my_rss_token
       post 'status_messages/:id' => :acknowledge, controller: 'webui/status_messages', as: :acknowledge_status_message
 
-      resources :tokens, only: [:index, :destroy, :new, :create], controller: 'webui/users/tokens'
+      resources :tokens, controller: 'webui/users/tokens'
     end
 
     get 'home', to: 'webui/webui#home', as: :home


### PR DESCRIPTION
As a first step, only the SCM token of workflow tokens can be updated. Updating other token types isn't possible right now, so the `Edit` icon isn't displayed for non-workflow tokens. Regenerating the string of a token is going to happen later.

Also made some changes to be consistent throughout the Create/Edit forms and with other forms like having breadcrumbs for the `Create Token` and `Edit Token` pages.