### PR TITLE
Set page titles for create/edit token pages

### DIFF
--- a/src/api/app/views/webui/users/tokens/edit.html.haml
+++ b/src/api/app/views/webui/users/tokens/edit.html.haml
@@ -1,6 +1,8 @@
+- @pagetitle = 'Edit Token'
+
 .card
   .card-body
-    %h3.mb-3 Edit Token
+    %h3.mb-3= @pagetitle
 
     .row
       .col-12.col-md-10.col-lg-8

--- a/src/api/app/views/webui/users/tokens/new.html.haml
+++ b/src/api/app/views/webui/users/tokens/new.html.haml
@@ -1,8 +1,9 @@
+- @pagetitle = 'Create Token'
 - type_options = Token::OPERATIONS.map { |a| "Token::#{a}".constantize.token_name }
 
 .card
   .card-body
-    %h3.mb-3 Create Token
+    %h3.mb-3= @pagetitle
 
     .row
       .col-12.col-md-10.col-lg-8


### PR DESCRIPTION
We forgot to do this in PRs which introduced those pages.

Without this change, those two pages have the default title, which is `Open Build Service` on our production instance.