### PR TITLE
Create SetPagetitleInView linter for haml-lint and enable it

### DIFF
--- a/src/api/.haml-lint.yml
+++ b/src/api/.haml-lint.yml
@@ -1,6 +1,16 @@
+require:
+  - './lib/haml-lint/custom_linters/set_pagetitle_in_view.rb'
+
 linters:
   LineLength:
     max: 150
+
+  # This custom linter will report an offense if @pagetitle is not set in a Haml view. Partials aren't processed by this linter.
+  SetPagetitleInView:
+    enabled: true
+    exclude:
+      # @pagetitle is set in the controller
+      - 'app/views/webui/users/new.html.haml'
 
   # Apply lint in all partials, but exclude 'breadcrumb_items' partials
   InstanceVariables:

--- a/src/api/app/views/webui/apidocs/index.html.haml
+++ b/src/api/app/views/webui/apidocs/index.html.haml
@@ -1,3 +1,5 @@
+- @pagetitle = 'API Documentation'
+
 .card
   .card-body
     -# rubocop:disable Rails/OutputSafety

--- a/src/api/app/views/webui/cloud/azure/configurations/show.html.haml
+++ b/src/api/app/views/webui/cloud/azure/configurations/show.html.haml
@@ -1,7 +1,8 @@
+- @pagetitle = 'Microsoft Azure Configuration'
+
 .card.mb-3
   .card-body
-    %h3.mb-3
-      Microsoft Azure Configuration
+    %h3.mb-3= @pagetitle
 
     %p
       You need to provide an application id and an application key in order to allow OBS to upload images to your Azure account.

--- a/src/api/app/views/webui/cloud/configurations/index.html.haml
+++ b/src/api/app/views/webui/cloud/configurations/index.html.haml
@@ -1,7 +1,8 @@
+- @pagetitle = 'Cloud Upload Configuration'
+
 .card.mb-3
   .card-body
-    %h3.mb-3
-      Cloud Upload Configuration
+    %h3.mb-3= @pagetitle
     %p
       You need to configure the cloud service providers you want to upload to.
     %ul

--- a/src/api/app/views/webui/cloud/ec2/configurations/show.html.haml
+++ b/src/api/app/views/webui/cloud/ec2/configurations/show.html.haml
@@ -1,7 +1,8 @@
+- @pagetitle = 'Amazon EC2 Configuration'
+
 .card.mb-3
   .card-body
-    %h3.mb-3
-      Amazon EC2 Configuration
+    %h3.mb-3= @pagetitle
     %p
       Amazon EC2 allows you to easily run instances of your appliance on Amazon's webservers.
 

--- a/src/api/app/views/webui/cloud/upload_jobs/index.html.haml
+++ b/src/api/app/views/webui/cloud/upload_jobs/index.html.haml
@@ -1,3 +1,5 @@
+- @pagetitle = 'Cloud Upload'
+
 - content_for :actions do
   %li.nav-item
     = link_to(cloud_configuration_index_path, title: 'Cloud Configuration', class: 'nav-link') do
@@ -6,7 +8,7 @@
 
 .card
   .card-body
-    %h3 Cloud Upload
+    %h3= @pagetitle
 
     %p
       %table.responsive.table.table-sm.table-bordered.table-hover#upload-jobs

--- a/src/api/app/views/webui/kiwi/images/edit.html.haml
+++ b/src/api/app/views/webui/kiwi/images/edit.html.haml
@@ -1,5 +1,7 @@
-- @layouttype = 'custom'
-- @package = @image.package
+:ruby
+  @layouttype = 'custom'
+  @package = @image.package
+  @pagetitle = 'Edit Kiwi Image'
 
 = form_for @image, html: { id: 'kiwi-image-update-form' } do |f|
   .row

--- a/src/api/app/views/webui/kiwi/images/show.html.haml
+++ b/src/api/app/views/webui/kiwi/images/show.html.haml
@@ -2,6 +2,7 @@
   @layouttype = 'custom'
   @project = @image.package.try(:project)
   @package = @image.package
+  @pagetitle = 'Kiwi Image'
 
 .row
   .col-12

--- a/src/api/app/views/webui/package/binaries.html.haml
+++ b/src/api/app/views/webui/package/binaries.html.haml
@@ -1,7 +1,9 @@
+- @pagetitle = "State of #{@repository} for #{@project} / #{@package_name}"
+
 .card
   = render partial: 'tabs', locals: { package: @package, project: @project }
   .card-body
-    %h3 State of #{@repository} for #{@project} / #{@package_name}
+    %h3= @pagetitle
     %ul.list-inline
       - if @configuration['download_url']
         = render partial: 'webui/shared/download_repository_link',

--- a/src/api/app/views/webui/staging/excluded_requests/index.html.haml
+++ b/src/api/app/views/webui/staging/excluded_requests/index.html.haml
@@ -1,9 +1,10 @@
+- @pagetitle = 'Excluded Requests'
 - request_exclusion_policy = Staging::RequestExclusionPolicy.new(User.possibly_nobody, @staging_workflow).create?
 .row
   .col-xl-12
     .card.mb-3
       .card-body
-        %h3 Excluded Requests
+        %h3= @pagetitle
         -# haml-lint:disable MultilinePipe
         %table.responsive.table.table-sm.table-bordered.table-hover.w-100#excluded-requests-datatable{ |
         data: excluded_requests_remote_url(@staging_workflow.project) } |

--- a/src/api/app/views/webui/timeout.html.haml
+++ b/src/api/app/views/webui/timeout.html.haml
@@ -1,4 +1,6 @@
-%h1 Timeout occurred
+- @pagetitle = 'Timeout occurred'
+
+%h1= @pagetitle
 %p
   We're sorry but the system is currently not able to handle your request
   in a reasonable time. Please try again later.

--- a/src/api/app/views/webui/users/notifications/index.html.haml
+++ b/src/api/app/views/webui/users/notifications/index.html.haml
@@ -1,3 +1,5 @@
+- @pagetitle = 'Notifications'
+
 = render partial: 'index_actions'
 
 .row

--- a/src/api/lib/haml-lint/custom_linters/set_pagetitle_in_view.rb
+++ b/src/api/lib/haml-lint/custom_linters/set_pagetitle_in_view.rb
@@ -1,0 +1,35 @@
+# This custom linter for haml-lint will report an offense if @pagetitle is not set in a Haml view. Partials aren't ignored by this linter.
+module HamlLint
+  class Linter::SetPagetitleInView < Linter
+    include LinterRegistry
+
+    # Report an offense if the instance variable @pagetitle is not set in a Haml view. Partials aren't ignored by this linter.
+    #
+    # @param [HamlLint::Tree::RootNode] the root of a syntax tree
+    def visit_root(root_node)
+      # Do not proceed if the view isn't under the directory 'app/views/webui/' and doesn't end with the extension '.html.haml'
+      return unless root_node.file.match?(%r{^app/views/webui/.*\.html\.haml$})
+
+      # Do not proceed if the view is a partial (only partials start with an underscore)
+      return if File.basename(root_node.file).start_with?('_')
+
+      # Do not proceed if the view defines the instance variable @pagetitle, then this rule is respected. Yay!
+      return if instance_variable_pagetitle_is_defined?(document)
+
+      record_lint(root_node, 'Set the instance variable @pagetitle to have a page title when the view is rendered.')
+    end
+
+    private
+
+    # @param [HamlLint::Document] a parsed Haml document and its associated metadata
+    def instance_variable_pagetitle_is_defined?(document)
+      parsed_ruby = HamlLint::RubyParser.new.parse(HamlLint::RubyExtractor.new.extract(document).source)
+
+      parsed_ruby.each_descendant.find do |descendant_node|
+        # Details on Abstract Syntax Tree from Parser gem: https://github.com/whitequark/parser/blob/11c7644365fe554217bb4670a4cbc905ab8504cd/doc/AST_FORMAT.md#to-instance-variable
+        # Are we assigning an instance variable? Is it called @pagetitle?
+        descendant_node.ivasgn_type? && descendant_node.children.first == :@pagetitle
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

We need to set the instance variable `@pagetitle` in views to have a page title when the view is rendered. This custom haml-lint linter is there to remind us if we forget. A PR like #11449 wouldn't need to be created since it would be caught by this custom linter.

`@pagetitle` is used in the [webui layout](https://github.com/openSUSE/open-build-service/blob/032494fd268578c4dfe6f7b77a7b0bd71bef61fe/src/api/app/views/layouts/webui/webui.html.haml#L10).

## Benchmarks

I ran some simple benchmarks on my computer in our Docker development environment by executing `time haml-lint` with the custom linter enabled and disabled.

When the custom linter `SetPagetitleInView` is:
- enabled: 29.2 seconds to 30 seconds
- disabled: 29.6 seconds to 30.9 seconds

I'm okay with this super minor time increase in the CI if this prevents us from forgetting to set `@pagetitle` in views.