### PR TITLE
[backend] assume obsrepositories:/ if we do not have a container anno…

### DIFF
--- a/src/backend/BSSched/BuildJob/Docker.pm
+++ b/src/backend/BSSched/BuildJob/Docker.pm
@@ -148,7 +148,10 @@ sub check {
     my $haveobsrepositories = grep {$_->{'project'} eq '_obsrepositories'} @infopath;
     my @newpath;
     my $annotation = BSSched::BuildJob::getcontainerannotation($cpool, $lastp, $lastbdep);
-    if ($annotation && !$haveobsrepositories) {
+    if (!$annotation && !$haveobsrepositories) {
+      # no annotation, assume obsrepositories:/
+      push @newpath, {'project' => '_obsrepositories', 'repository' => ''};
+    } elsif ($annotation && !$haveobsrepositories) {
       # map all repos and add to path
       my $remoteprojs = $gctx->{'remoteprojs'} || {};
       my $rproj = $remoteprojs->{$lastbdep->{'project'}};

--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -715,7 +715,7 @@ sub createrepo_rpmmd {
   if ($data->{'modulemds'}) {
     writestr("$extrep/repodata/modules-unfiltered.yaml", undef, $data->{'modulemds'});
     # unpack primary xml file
-    qsystem('chdir', "$extrep/repodata", 'stdout', 'modules.yaml', "$INC[0]/build/writemodulemd", '--filtered', 'modules-unfiltered.yaml', '.') && die("    writemodulemd failed: $?\n");
+    qsystem('chdir', "$extrep/repodata", 'stdout', 'modules.yaml', "$INC[0]/build/writemodulemd", '--filter', 'modules-unfiltered.yaml', '.') && die("    writemodulemd failed: $?\n");
     unlink("$extrep/repodata/modules-unfiltered.yaml");
     if (-s "$extrep/repodata/modules.yaml") {
       qsystem($modifyrepo_bin, "$extrep/repodata/modules.yaml", "$extrep/repodata", @legacyargs) && die("    modifyrepo failed: $?\n");


### PR DESCRIPTION
…tation

Before, we simply continued without any repository path at all. This will
not work for Download on Demand containers.

_Replace this line with a description of your changes. Please follow the suggestions in the comment below._

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
