### PR TITLE
Introduces Project.get_maintenance_project!

### DIFF
--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -409,7 +409,7 @@ class SourceController < ApplicationController
     end
 
     # find maintenance project via attribute
-    prj = Project.get_maintenance_project(at)
+    prj = Project.get_maintenance_project!(at)
     actually_create_incident(prj)
   end
 

--- a/src/api/app/models/bs_request_action_maintenance_incident.rb
+++ b/src/api/app/models/bs_request_action_maintenance_incident.rb
@@ -92,7 +92,7 @@ class BsRequestActionMaintenanceIncident < BsRequestAction
     if target_project
       maintenance_project = Project.get_by_name(target_project)
     else
-      maintenance_project = Project.get_maintenance_project
+      maintenance_project = Project.get_maintenance_project!
       self.target_project = maintenance_project.name
     end
     unless maintenance_project.is_maintenance_incident? || maintenance_project.is_maintenance?

--- a/src/api/app/models/channel_binary.rb
+++ b/src/api/app/models/channel_binary.rb
@@ -18,7 +18,7 @@ class ChannelBinary < ApplicationRecord
     project = Project.find_by_name(project) if project.is_a?(String)
 
     # find maintained projects filter
-    maintained_projects = Project.get_maintenance_project.expand_maintained_projects
+    maintained_projects = Project.get_maintenance_project!.expand_maintained_projects
 
     # gsub(/\s+/, "") makes sure there are no additional newlines and whitespaces
     query = <<-SQL.squish.gsub(/\s+/, ' ')

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -258,12 +258,17 @@ class Project < ApplicationRecord
     end
 
     def get_maintenance_project(at = nil)
-      # hardcoded default. frontends can lookup themselfs a different target via attribute search
       at ||= AttribType.find_by_namespace_and_name!('OBS', 'MaintenanceProject')
       maintenance_project = Project.find_by_attribute_type(at).first
-      unless maintenance_project && check_access?(maintenance_project)
-        raise Project::Errors::UnknownObjectError, 'There is no project flagged as maintenance project on server and no target in request defined.'
-      end
+
+      return unless maintenance_project && check_access?(maintenance_project)
+
+      maintenance_project
+    end
+
+    def get_maintenance_project!(at = nil)
+      maintenance_project = get_maintenance_project(at)
+      raise Project::Errors::UnknownObjectError, 'There is no project flagged as maintenance project on server and no target in request defined.' unless maintenance_project
 
       maintenance_project
     end


### PR DESCRIPTION
Sometimes we want to call this without an exception if there
is no project with that attribute.
