### PR TITLE
Automatically apply labels to PRs based on the changed files

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,13 @@
+# Configuration for pull request labeler: https://github.com/actions/labeler
+Frontend:
+- src/api/**/*
+
+Backend:
+- src/backend/**/*
+
+"Documentation :book:":
+- docs/**/*
+
+"Test Suite / CI :syringe:":
+- .circleci/**/*
+- .github/**/*


### PR DESCRIPTION
This is done with the help of the GitHub action [pull request labeler](https://github.com/actions/labeler).

We sometimes forget to apply labels. Having labels on PRs is useful to categorize them and knowing what they changed.