### PR TITLE
Unify containers images used by CI and development environment 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,21 +7,21 @@ images:
       NOKOGIRI_USE_SYSTEM_LIBRARIES: 1
 
   - &mariadb
-    image: registry.opensuse.org/obs/server/unstable/container/ci/containers/openbuildservice/mariadb:latest
+    image: registry.opensuse.org/obs/server/unstable/containers/containers/openbuildservice/mariadb:latest
     command: |
       /bin/bash -c 'echo -e "[mysqld]\ndatadir = /dev/shm" > /etc/my.cnf.d/obs.cnf && cp -a /var/lib/mysql/* /dev/shm && /usr/lib/mysql/mysql-systemd-helper start'
     name: db
 
-  - &backend registry.opensuse.org/obs/server/unstable/container/ci/containers/openbuildservice/backend:latest
+  - &backend registry.opensuse.org/obs/server/unstable/containers/containers/openbuildservice/backend:latest
 
   - &frontend_backend
-    image: registry.opensuse.org/obs/server/unstable/container/ci/containers/openbuildservice/frontend-backend:latest
+    image: registry.opensuse.org/obs/server/unstable/containers/containers/openbuildservice/frontend-backend:latest
     <<: *common_frontend_config
     environment:
       EAGER_LOAD: 1
 
   - &frontend_base
-    image: registry.opensuse.org/obs/server/unstable/container/ci/containers/openbuildservice/frontend-base:latest
+    image: registry.opensuse.org/obs/server/unstable/containers/containers/openbuildservice/frontend-base:latest
     <<: *common_frontend_config
 
 aliases:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,17 @@
 version: "2.1"
 services:
   db:
-    image: registry.opensuse.org/obs/server/unstable/container/leap153/containers/openbuildservice/mariadb
+    image: registry.opensuse.org/obs/server/unstable/containers/containers/openbuildservice/mariadb
     ports:
       - "3306:3306"
     command: /usr/lib/mysql/mysql-systemd-helper start
   cache:
-    image: registry.opensuse.org/obs/server/unstable/container/leap153/containers/openbuildservice/memcached
+    image: registry.opensuse.org/obs/server/unstable/containers/containers/openbuildservice/memcached
     ports:
       - "11211:11211"
     command: /usr/sbin/memcached -u memcached
   backend:
-    image: registry.opensuse.org/obs/server/unstable/container/leap153/containers/openbuildservice/backend
+    image: registry.opensuse.org/obs/server/unstable/containers/containers/openbuildservice/backend
     volumes:
       - .:/obs
       - ./dist/aws_credentials:/etc/obs/cloudupload/.aws/config
@@ -19,7 +19,7 @@ services:
       - ./dist/clouduploader.rb:/usr/bin/clouduploader
     command: /obs/contrib/start_development_backend -d /obs
   worker:
-    image: registry.opensuse.org/obs/server/unstable/container/leap153/containers/openbuildservice/backend
+    image: registry.opensuse.org/obs/server/unstable/containers/containers/openbuildservice/backend
     volumes:
       - .:/obs
     privileged: true

--- a/src/api/docker-files/Dockerfile
+++ b/src/api/docker-files/Dockerfile
@@ -3,7 +3,7 @@
 # contained rails app generating files in the git checkout with
 # some strange user...
 
-FROM registry.opensuse.org/obs/server/unstable/container/leap153/containers/openbuildservice/frontend-base
+FROM registry.opensuse.org/obs/server/unstable/containers/containers/openbuildservice/frontend-base
 ARG CONTAINER_USERID
 
 # for lint task

--- a/src/api/docker-files/Dockerfile.minitest
+++ b/src/api/docker-files/Dockerfile.minitest
@@ -2,7 +2,7 @@
 # sure different users can run it without the contained rails app generating
 # files in the git checkout with some strange user...
 
-FROM registry.opensuse.org/obs/server/unstable/container/leap153/containers/openbuildservice/frontend-backend
+FROM registry.opensuse.org/obs/server/unstable/containers/containers/openbuildservice/frontend-backend
 
 # Configure our user
 ARG CONTAINER_USERID

--- a/src/api/spec/support/capybara.rb
+++ b/src/api/spec/support/capybara.rb
@@ -11,6 +11,7 @@ Selenium::WebDriver::Chrome::Service.driver_path = '/usr/lib64/chromium/chromedr
 Capybara.register_driver :desktop do |app|
   Capybara::Selenium::Driver.load_selenium
   browser_options = ::Selenium::WebDriver::Chrome::Options.new
+  browser_options.args << '--disable-gpu'
   browser_options.args << '--headless'
   browser_options.args << '--no-sandbox' # to run in docker
   browser_options.args << '--window-size=1280,1024'
@@ -20,6 +21,7 @@ end
 Capybara.register_driver :mobile do |app|
   Capybara::Selenium::Driver.load_selenium
   browser_options = ::Selenium::WebDriver::Chrome::Options.new
+  browser_options.args << '--disable-gpu'
   browser_options.args << '--headless'
   browser_options.args << '--no-sandbox' # to run in docker
   browser_options.add_emulation(device_metrics: { width: 320, height: 568, pixelRatio: 1, touch: true })

--- a/src/api/spec/support/shared_examples/features/beta/user_tab.rb
+++ b/src/api/spec/support/shared_examples/features/beta/user_tab.rb
@@ -41,7 +41,9 @@ RSpec.shared_examples 'user tab' do
     end
 
     scenario 'Add non existent user' do
-      click_link('Add User')
+      add_user_link = page.find('a', text: 'Add User')
+      page.scroll_to(add_user_link)
+      add_user_link.click
       sleep 1 # FIXME: Needed to avoid a flickering test because the animation of the modal is sometimes faster than capybara
 
       within('#add-user-role-modal') do
@@ -53,7 +55,9 @@ RSpec.shared_examples 'user tab' do
     end
 
     scenario 'Add an existing user' do
-      click_link('Add User')
+      add_user_link = page.find('a', text: 'Add User')
+      page.scroll_to(add_user_link)
+      add_user_link.click
       sleep 1 # FIXME: Needed to avoid a flickering test because the animation of the modal is sometimes faster than capybara
 
       within('#add-user-role-modal') do
@@ -69,7 +73,9 @@ RSpec.shared_examples 'user tab' do
       end
 
       # Adding a user twice...
-      click_link('Add User')
+      add_user_link = page.find('a', text: 'Add User')
+      page.scroll_to(add_user_link)
+      add_user_link.click
       sleep 1 # FIXME: Needed to avoid a flickering test because the animation of the modal is sometimes faster than capybara
 
       within('#add-user-role-modal') do
@@ -148,7 +154,9 @@ RSpec.shared_examples 'user tab' do
     end
 
     scenario 'Add non existent group' do
-      click_link('Add Group')
+      add_group_link = page.find('a', text: 'Add Group')
+      page.scroll_to(add_group_link)
+      add_group_link.click
       sleep 1 # FIXME: Needed to avoid a flickering test because the animation of the modal is sometimes faster than capybara
 
       within('#add-group-role-modal') do
@@ -160,7 +168,9 @@ RSpec.shared_examples 'user tab' do
     end
 
     scenario 'Add an existing group' do
-      click_link('Add Group')
+      add_group_link = page.find('a', text: 'Add Group')
+      page.scroll_to(add_group_link)
+      add_group_link.click
       sleep 1 # FIXME: Needed to avoid a flickering test because the animation of the modal is sometimes faster than capybara
 
       within('#add-group-role-modal') do
@@ -175,7 +185,9 @@ RSpec.shared_examples 'user tab' do
       end
 
       # Adding a group twice...
-      click_link('Add Group')
+      add_group_link = page.find('a', text: 'Add Group')
+      page.scroll_to(add_group_link)
+      add_group_link.click
       sleep 1 # FIXME: Needed to avoid a flickering test because the animation of the modal is sometimes faster than capybara
 
       within('#add-group-role-modal') do


### PR DESCRIPTION
Taking advantage of the binary compatibility of both distributions, SLE 15 SP3 and openSUSE Leap 15.3, and after creating a new source of docker images based in SLE 15 SP3 (see https://build.opensuse.org/project/show/OBS:Server:Unstable:Containers ), we use those docker images for both, our CI setup and our development environment.

Upgrading the version of the distribution also upgraded the Chromium version. Two issues rised:
1. All feature tests failed: this was fixed by adding the `--disable-gpu` flag to the options of Chromium.
1. A false positive in feature package tests was fixed, making the tests for adding a user and adding a group fail. The bad
behavior was, that clicking the links 'Add User' or 'Add Group' was possible, even if the link was outside the visual area. ~Skipping~ Scrolling down to these links in these failing tests in mobile, make the tests pass again. See also [this comment](https://github.com/openSUSE/open-build-service/pull/9559#pullrequestreview-413770036), where it was considered, to scroll down until an element that should be clicked appeared into the visual area.

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
