### PR TITLE
Add GitHub workflow to apply labels to PRs

### DIFF
--- a/.github/workflows/pull_request_labeler.yml
+++ b/.github/workflows/pull_request_labeler.yml
@@ -1,0 +1,11 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  pull_request_labeler:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v3
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
I totally forgot this part in #11461. That PR configured the pull request labeler, but it didn't run since there was no GitHub workflow... Oopsie!