### PR TITLE
[backend] improve modulemd support

### DIFF
--- a/src/backend/BSSched/Checker.pm
+++ b/src/backend/BSSched/Checker.pm
@@ -414,7 +414,7 @@ sub setup {
     return ('broken', 'cannot build this module') unless $dependency;
     my $errors = BSSched::Modulemd::extend_modules($bconf, $dependency->{'buildrequires'} || []);
     return ('broken', join(', ', @$errors)) if $errors;
-    my $ml = BSSched::Modulemd::calc_modularitylabel($bconf, $modulemd->{'name'}, $modulemd->{'stream'}, $modulemd->{'timestamp'}, $dependency->{'requires'} || []);
+    my $ml = BSSched::Modulemd::calc_modularitylabel($bconf, $modulemd, $dependency->{'requires'} || []);
     return ('broken', 'modularitylabel calculation failed') unless $ml;
     my @ml = split(':', $ml, 4);
     $ctx->{'modularity_label'} = $ml;

--- a/src/backend/BSSched/Modulemd.pm
+++ b/src/backend/BSSched/Modulemd.pm
@@ -30,7 +30,8 @@ sub json_sha1 {
 }
 
 sub calc_modularitylabel {
-  my ($bconf, $name, $stream, $timestamp, $deps) = @_;
+  my ($bconf, $modulemd, $deps) = @_;
+  my $timestamp = $modulemd->{'timestamp'};
   my $pfdata = $bconf->{'buildflags:modulemdplatform'};
   return undef unless $pfdata;
   my ($versionprefix, $distprefix) = split(':', $pfdata, 2);
@@ -49,9 +50,10 @@ sub calc_modularitylabel {
   }
   my $depctx = json_sha1(\%requires);
   my $mdctx = substr(Digest::SHA::sha1_hex("$buildctx:$depctx"), 0, 8);
+  $mdctx = $modulemd->{'context'} if $modulemd->{'context'};
   my @gm = gmtime($timestamp);
-  my $mdversion = $versionprefix.sprintf("%04d%02d%02d%02d%02d%02d", $gm[5] + 1900, $gm[4] + 1, @gm[3,2,1,0]);
-  return "$name:$stream:$mdversion:$mdctx";
+  my $mdversion = $modulemd->{'version'} || sprintf("%04d%02d%02d%02d%02d%02d", $gm[5] + 1900, $gm[4] + 1, @gm[3,2,1,0]);;
+  return "$modulemd->{'name'}:$modulemd->{'stream'}:$versionprefix$mdversion:$mdctx";
 }
 
 sub select_dependency {

--- a/src/backend/BSXML.pm
+++ b/src/backend/BSXML.pm
@@ -305,6 +305,8 @@ our $modulemd = [
     'modulemd' =>
 	'name',
 	'stream',
+	'version',
+	'context',
 	'timestamp',
 	[],
 	'macros',

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -5886,9 +5886,12 @@ sub getmodulemd {
   my @s = BSRevision::revstat($rev, '_modulemd.yaml', $files->{'_modulemd.yaml'});
   die("_modulemd.yaml: maximum size exceeded\n") if $s[7] > 1024*1204;
   my $yaml = BSRevision::revreadstr($rev, '_modulemd.yaml', $files->{'_modulemd.yaml'});
-  my $d = BSSrcServer::Modulemd::read_modulemd($yaml);
-  BSSrcServer::Modulemd::tostream($d, $cgi->{'modules'} || [], $cgi->{'modularitylabel'}, $cgi->{'modularityplatform'});
-  return ($d, \&BSUtil::tostorable, 'Content-Type: application/octet-stream');
+  my $mds = BSSrcServer::Modulemd::read_modulemds($yaml);
+  for my $md (@$mds) {
+    next unless $md->{'document'} eq 'modulemd';
+    BSSrcServer::Modulemd::tostream($md, $cgi->{'modules'} || [], $cgi->{'modularitylabel'}, $cgi->{'modularityplatform'});
+  }
+  return (BSUtil::tostorable($mds), 'Content-Type: application/octet-stream');
 }
 
 ####################################################################

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -1138,13 +1138,17 @@ sub getmodulemddata {
   push @args, map {"module=$_"} @{$buildinfo->{'module'}};
   push @args, "modularityplatform=$buildinfo->{'modularity_platform'}";
   push @args, "modularitylabel=$buildinfo->{'modularity_label'}";
-  my $md = BSRPC::rpc({
+  my $mds = BSRPC::rpc({
     'uri' => "$server/getmodulemd",
     'filename' => "$dir/_modulemd.in",
     'timeout' => $gettimeout,
   }, \&BSUtil::fromstorable, "project=$buildinfo->{'project'}", "package=$buildinfo->{'modularity_package'}", "srcmd5=$buildinfo->{'modularity_srcmd5'}", @args);
-  $md->{'data'}->{'arch'} = $buildinfo->{'arch'};
-  BSUtil::store("$dir/_modulemd.pst", undef, $md);
+  $mds = [ $mds ] if ref($mds) eq 'HASH';
+  for my $md (@$mds) {
+    next unless $md->{'document'} eq 'modulemd';		# should do this in the src server
+    $md->{'data'}->{'arch'} = $buildinfo->{'arch'};
+  }
+  BSUtil::store("$dir/_modulemd.pst", undef, $mds);
 }
 
 sub getsslcert {


### PR DESCRIPTION
Support additional modulemd-defaults documents in the modulemd input.
Also support preset version/context elements. The version prefix
is still prepended, though, as we still want to differentiate
between platforms.

_Replace this line with a description of your changes. Please follow the suggestions in the comment below._

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
