### PR TITLE
Use bundler_ext instead of bundler if Gemfile.in file present

### DIFF
--- a/src/api/config/application.rb
+++ b/src/api/config/application.rb
@@ -10,8 +10,25 @@ require 'action_view/railtie'
 require 'sprockets/railtie'
 require 'rails/test_unit/railtie'
 
-# Assets should be precompiled for production (so we don't need the gems loaded then)
-Bundler.require(*Rails.groups(assets: ['development', 'test']))
+# The bundler_ext rubygem disables enforcement of gem versions in
+# `Gemfile.lock` in favour of the basic constraints defined in the file
+# `Gemfile.in`. The bundler_ext rubygem is not part of the OBS bundle, so you
+# need to explicitly install it, however you install gems on your system. Eg.
+# with gem or your system package manager. Then create the appropriate file
+# with `cp Gemfile Gemfile.in`. For more information see the bundler_ext
+# documentation.
+
+# WARNING: You will be on your own with problems if you use bundler_ext, we
+# only ensure our app works with the exact gems specified in our Gemfile.lock
+gemfile_in = File.expand_path('../Gemfile.in', __dir__)
+if File.exist?(gemfile_in)
+  require 'bundler_ext'
+  BundlerExt.system_require(gemfile_in, *Rails.groups(assets: ['development', 'test']))
+else
+  # Assets should be precompiled for production (so we don't need the gems loaded then)
+  Bundler.require(*Rails.groups(assets: ['development', 'test']))
+end
+
 require_relative '../lib/rabbitmq_bus'
 
 module OBSApi

--- a/src/api/config/boot.rb
+++ b/src/api/config/boot.rb
@@ -1,3 +1,5 @@
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
+unless File.exist?(File.expand_path('../Gemfile.in', __dir__))
+  ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
-require 'bundler/setup' # Set up gems listed in the Gemfile.
+  require 'bundler/setup' # Set up gems listed in the Gemfile.
+end


### PR DESCRIPTION
This gem disables Bundler's enforcement of exact gem versions in favour of basic constraint checks written in `Gemfile.in` file.

It's not included in `Gemfile`, so it should be installed explicitly by your system's package manager (as a dependency of OBS API package, for example) in order to allow system manager to take over responsibility of gem management from Bundler.

Also, it's packager's responsibility to place appropriate `Gemfile.in` file to enable this feature.


This is needed for installations where Ruby gems are managed by system package manager (like RPM or APT),
so bundler should not interfere with that and refuse to start application if gems with versions slightly different than ones mentioned in `Gemfile.lock` are installed in the system.