### PR TITLE
Add OBS:EmbargoDate AttribType to DatabaseCleaner

### DIFF
--- a/src/api/spec/factories/attribs.rb
+++ b/src/api/spec/factories/attribs.rb
@@ -64,7 +64,7 @@ FactoryBot.define do
 
     factory :embargo_date_attrib do
       attrib_type { AttribType.find_by_namespace_and_name!('OBS', 'EmbargoDate') }
-      values { [build(:attrib_value, value: '2021-11-11')] }
+      values { [build(:attrib_value, value: (Time.now.utc + 2.days).to_s)] }
     end
 
     factory :attrib_with_default_value do

--- a/src/api/spec/queries/packages_finder_spec.rb
+++ b/src/api/spec/queries/packages_finder_spec.rb
@@ -59,10 +59,6 @@ RSpec.describe PackagesFinder, vcr: true do
     let(:admin_user) { create(:admin_user, login: 'superbad') }
     let(:project) { create(:project, name: 'foo') }
     let!(:package) { create(:package, name: 'foo_pack', project: project) }
-    let!(:embargo_date_attrib_type) do
-      AttribType.create(name: 'EmbargoDate',
-                        attrib_namespace: AttribNamespace.find_by!(name: 'OBS'), value_count: 1)
-    end
     let(:embargo_date_attrib) { create(:embargo_date_attrib, project: project, package: package) }
 
     context 'when package is nil' do
@@ -70,7 +66,7 @@ RSpec.describe PackagesFinder, vcr: true do
         User.session = admin_user
       end
 
-      subject { PackagesFinder.new.find_by_attribute_type_and_value(embargo_date_attrib.attrib_type, '2021-11-11') }
+      subject { PackagesFinder.new.find_by_attribute_type_and_value(embargo_date_attrib.attrib_type, embargo_date_attrib.values.first) }
 
       it { expect(subject).not_to be_empty }
       it { expect(subject).to include(package) }

--- a/src/api/spec/support/database_cleaner.rb
+++ b/src/api/spec/support/database_cleaner.rb
@@ -38,6 +38,7 @@ RSpec.configure do |config|
     create(:obs_attrib_type, name: 'UpdateProject')
     create(:obs_attrib_type, name: 'VeryImportantProject')
     create(:obs_attrib_type, name: 'DelegateRequestTarget')
+    create(:obs_attrib_type, name: 'EmbargoDate', value_count: 1)
     Configuration.first_or_create(name: 'private', title: 'Open Build Service').update(allow_user_to_create_home_project: false)
   end
 


### PR DESCRIPTION
`OBS:EmbargoDate` is a basic AttribType from OBS and we should always assume it exists.


-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
