### PR TITLE
Measure finer grained namespaces for requests

### DIFF
--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -852,7 +852,8 @@ class BsRequest < ApplicationRecord
                state: state,
                when: updated_when.strftime('%Y-%m-%dT%H:%M:%S'),
                comment: comment,
-               author: creator }
+               author: creator,
+               namespace: namespace }
 
     params[:oldstate] = state_was if state_changed?
     params[:who] = commenter if commenter.present?
@@ -863,6 +864,21 @@ class BsRequest < ApplicationRecord
       params[:actions] << a.notify_params
     end
     params
+  end
+
+  def namespace
+    maintained_request? ? target_project_name : target_project_name.split(':').first
+  end
+
+  def maintained_request?
+    maintenance_project = Project.get_maintenance_project
+    return false unless maintenance_project
+
+    maintenance_project.maintained_project_names.include?(target_project_name)
+  end
+
+  def target_project_name
+    bs_request_actions&.first&.target_project.to_s
   end
 
   def auto_accept

--- a/src/api/app/models/event/request.rb
+++ b/src/api/app/models/event/request.rb
@@ -2,7 +2,7 @@ module Event
   class Request < Base
     self.description = 'Request was updated'
     self.abstract_class = true
-    payload_keys :author, :comment, :description, :id, :number, :actions, :state, :when, :who
+    payload_keys :author, :comment, :description, :id, :number, :actions, :state, :when, :who, :namespace
     shortenable_key :description
 
     DIFF_LIMIT = 120

--- a/src/api/app/models/event/request_statechange.rb
+++ b/src/api/app/models/event/request_statechange.rb
@@ -18,7 +18,7 @@ module Event
     private
 
     def metric_tags
-      payload.slice('oldstate', 'state')
+      payload.slice('oldstate', 'state', 'namespace')
     end
 
     def metric_fields


### PR DESCRIPTION
If a request against a project that is maintainer changes it's state, record
the full project name as namespace tag. Allows us to have finer grained
measurements for important projects.