### PR TITLE
Measure finer grained namespaces for builds

### DIFF
--- a/src/api/app/models/concerns/project_maintenance.rb
+++ b/src/api/app/models/concerns/project_maintenance.rb
@@ -73,4 +73,15 @@ module ProjectMaintenance
            .joins(repositories: :release_targets)
            .where('release_targets.trigger = "maintenance"').includes(target_repositories: :project)
   end
+
+  def maintained_namespace
+    default = name.split(':').first
+
+    maintenance_project = Project.get_maintenance_project
+    return default unless maintenance_project
+
+    return maintenance_project.name if name.start_with?(maintenance_project.name)
+
+    maintenance_project.maintained_project_names.sort_by(&:length).reverse.find { |maintained_project_name| maintained_project_name.in?(name) } || default
+  end
 end

--- a/src/api/app/models/event/build.rb
+++ b/src/api/app/models/event/build.rb
@@ -19,11 +19,12 @@ module Event
 
     def metric_tags
       {
-        namespace: payload['project'].split(':').first,
+        namespace: ::Project.find_by_name(payload['project'])&.maintained_namespace,
         worker: payload['workerid'],
         arch: payload['arch'],
         reason: reason,
-        state: state
+        state: state,
+        buildtype: payload['buildtype']
       }
     end
 

--- a/src/api/spec/models/project/project_maintained_namespace_spec.rb
+++ b/src/api/spec/models/project/project_maintained_namespace_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe Project do
+  describe '.maintained_namespace' do
+    let(:maintenance_project) { create(:project, name: 'openSUSE:Maintenance') }
+    let(:project) { create(:project) }
+
+    before do
+      allow(Project).to receive(:get_maintenance_project).and_return(maintenance_project)
+      allow(maintenance_project).to receive(:maintained_project_names).and_return(['franz', 'franz:is', 'franz:is:cool'])
+    end
+
+    it 'returns first field by default' do
+      allow(project).to receive(:name).and_return('peter:paul')
+      expect(project.maintained_namespace).to eq('peter')
+    end
+
+    it 'returns maintenance project name sub-projects' do
+      allow(project).to receive(:name).and_return('openSUSE:Maintenance:Incidents:1234')
+      expect(project.maintained_namespace).to eq('openSUSE:Maintenance')
+    end
+
+    it 'returns maintained project name' do
+      allow(project).to receive(:name).and_return('franz')
+      expect(project.maintained_namespace).to eq('franz')
+    end
+
+    it 'returns maintained project name for sub-projects' do
+      allow(project).to receive(:name).and_return('franz:is:cool:indeed')
+      expect(project.maintained_namespace).to eq('franz:is:cool')
+    end
+  end
+end


### PR DESCRIPTION
If a build happens in a project that is maintained, record the full project
name as namespace tag. Allows us to have finer grained measurements for
important projects.

Additionally start measuring the new buildtype payload.