### PR TITLE
Remove deleted project and package records from sphinx indexes

### DIFF
--- a/src/api/app/jobs/delete_from_sphinx_job.rb
+++ b/src/api/app/jobs/delete_from_sphinx_job.rb
@@ -1,0 +1,21 @@
+class DeleteFromSphinxJob < ApplicationJob
+  queue_as :quick
+
+  def perform(id, klass)
+    delete_from_sphinx(id: id, klass: klass)
+  end
+
+  private
+
+  def delete_from_sphinx(id:, klass:)
+    indices(klass: klass).each do |index|
+      ThinkingSphinx::Deletion.perform(index, id)
+    end
+  end
+
+  def indices(klass:)
+    ThinkingSphinx::Configuration.instance.index_set_class.new(
+      classes: [klass]
+    ).to_a
+  end
+end

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -1408,11 +1408,7 @@ class Package < ApplicationRecord
   end
 
   def populate_to_sphinx
-    if new_record? ||
-       title_previously_changed? ||
-       description_previously_changed?
-      PopulateToSphinxJob.perform_later(id: id, model_name: :package)
-    end
+    PopulateToSphinxJob.perform_later(id: id, model_name: :package)
   end
 end
 # rubocop: enable Metrics/ClassLength

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -68,6 +68,7 @@ class Package < ApplicationRecord
   before_destroy :remove_linked_packages
   before_destroy :remove_devel_packages
 
+  after_destroy :delete_from_sphinx
   after_save :write_to_backend
   after_save :populate_to_sphinx
 
@@ -1409,6 +1410,10 @@ class Package < ApplicationRecord
 
   def populate_to_sphinx
     PopulateToSphinxJob.perform_later(id: id, model_name: :package)
+  end
+
+  def delete_from_sphinx
+    DeleteFromSphinxJob.perform_later(id, self.class)
   end
 end
 # rubocop: enable Metrics/ClassLength

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -21,6 +21,7 @@ class Project < ApplicationRecord
   before_destroy :cleanup_before_destroy, prepend: true
   after_destroy_commit :delete_on_backend
 
+  after_destroy :delete_from_sphinx
   after_save :discard_cache
   after_save :populate_to_sphinx
 
@@ -1522,6 +1523,10 @@ class Project < ApplicationRecord
 
   def populate_to_sphinx
     PopulateToSphinxJob.perform_later(id: id, model_name: :project)
+  end
+
+  def delete_from_sphinx
+    DeleteFromSphinxJob.perform_later(id, self.class)
   end
 end
 

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -1521,11 +1521,7 @@ class Project < ApplicationRecord
   end
 
   def populate_to_sphinx
-    if new_record? ||
-       title_previously_changed? ||
-       description_previously_changed?
-      PopulateToSphinxJob.perform_later(id: id, model_name: :project)
-    end
+    PopulateToSphinxJob.perform_later(id: id, model_name: :project)
   end
 end
 


### PR DESCRIPTION
At the moment we only populate new records to sphinx. But we
don't remove those indexes after those records get deleted from
the database.
Usually the Thinking Sphinx gem is taking care of this automatically,
but since we differ from the regular setup by writing to the sphinx
index in a delayed job, we also have to consider the deletion.

There are still other issues, when updating/deleting associated attributes on the package/project. But this needs still more investigation, and will be part of another PR.