### PR TITLE
Fix measuring request duration

### DIFF
--- a/src/api/app/views/webui/request/_show_side_links.html.haml
+++ b/src/api/app/views/webui/request/_show_side_links.html.haml
@@ -26,7 +26,7 @@
   - if bs_request.accept_at.present?
     %li
       %i.fas.fa-exclamation-circle.text-danger
-      - if BsRequest::FINAL_REQUEST_STATES.include?(bs_request.state.to_s)
+      - if BsRequest::FINAL_REQUEST_STATES.include?(bs_request.state)
         Auto-accept was set to
         %span.fuzzy-time{ title: "#{l bs_request.accept_at}" }
         = succeed '.' do


### PR DESCRIPTION
The `state` getter if overloaded and transforms the string to a symbol
(why???), we cover for that now.

Also simplifying the method a bit.
