### PR TITLE
Fix DataTable search for User#index

### DIFF
--- a/src/api/app/datatables/user_configuration_datatable.rb
+++ b/src/api/app/datatables/user_configuration_datatable.rb
@@ -7,7 +7,7 @@ class UserConfigurationDatatable < Datatable
       name: { source: 'User.login' },
       local_user: { source: 'User.ignore_auth_services', searchable: false },
       state: { source: 'User.state' },
-      actions: {}
+      actions: { searchable: false }
     }
   end
 


### PR DESCRIPTION
The search failed because the actions column was considered a searchable one but it is not.
Now the search by user `login` and `state` works fine.

Fixes #11470