### PR TITLE
Allow searching by real name in users DataTable

### DIFF
--- a/src/api/app/assets/javascripts/webui/users_groups.js
+++ b/src/api/app/assets/javascripts/webui/users_groups.js
@@ -5,6 +5,7 @@ function initializeUserConfigurationDatatable(ldapEnabled) { // jshint ignore:li
       pageLength: 50,
       columns: [
         { 'data': 'name' },
+        { 'data': 'realname', 'visible': false },
         { 'data': 'local_user', 'visible': ldapEnabled === 'true' },
         { 'data': 'state'},
         { 'data': 'actions', 'orderable': false, 'searchable': false }

--- a/src/api/app/datatables/user_configuration_datatable.rb
+++ b/src/api/app/datatables/user_configuration_datatable.rb
@@ -5,9 +5,10 @@ class UserConfigurationDatatable < Datatable
   def view_columns
     @view_columns ||= {
       name: { source: 'User.login' },
+      realname: { source: 'User.realname' },
       local_user: { source: 'User.ignore_auth_services', searchable: false },
       state: { source: 'User.state' },
-      actions: {}
+      actions: { searchable: false }
     }
   end
 
@@ -21,6 +22,7 @@ class UserConfigurationDatatable < Datatable
     records.map do |record|
       {
         name: user_with_realname_and_icon(record),
+        realname: record.realname,
         local_user: record.ignore_auth_services,
         state: record.state,
         actions: user_actions(record)

--- a/src/api/app/views/webui/users/index.html.haml
+++ b/src/api/app/views/webui/users/index.html.haml
@@ -10,6 +10,8 @@
           %th
             User
           %th
+            Real Name
+          %th
             Local User
           %th
             State


### PR DESCRIPTION
The existent "User" column contains a combination of the user's realname and the user's login, but it is only possible to search by one of them, "login" in this case. As it is not possible to search by both of them, a new hidden column has been added to allow searching by user's realname too.

This is a follow-up to PR #11529