### PR TITLE
Disable editor's save button while it is saving

### DIFF
--- a/src/api/app/assets/javascripts/webui/cm2/use-codemirror.js
+++ b/src/api/app/assets/javascripts/webui/cm2/use-codemirror.js
@@ -81,6 +81,7 @@ function use_codemirror(id, read_only, mode, big_editor) {
       var data = textarea.data('data');
       data[data['submit']] = editors[id].getValue();
       data['comment'] = $("#comment_" + id).val();
+      $(this).prop('disabled', true);
       $("#loading_" + id).attr('disabled', true).removeClass("d-none");
       $.ajax({
         url: textarea.data('save-url'),


### PR DESCRIPTION
After pressing the save button, the saving can take a while. During that time a progress bar appears and the save button should be disabled to avoid getting many save requests and, consequently, duplicated revisions of the file.

Fixes #11247

How to test?

- Go to review-app link
- Open any package's file or `Meta`
- Edit the file
- Click on `Save`
- You'll see the button is disabled while the progress bar is present
