### PR TITLE
[api] support request history search by time

### DIFF
--- a/src/api/lib/xpath_engine.rb
+++ b/src/api/lib/xpath_engine.rb
@@ -1,4 +1,5 @@
 # rubocop:disable Layout/LineLength
+# rubocop:disable Metrics/MethodLength
 class XpathEngine
   require 'rexml/parsers/xpathparser'
 
@@ -220,7 +221,10 @@ class XpathEngine
         'review/@by_group' => { cpart: 'r.by_group', joins: 'LEFT JOIN reviews r ON r.bs_request_id = bs_requests.id' },
         'review/@by_project' => { cpart: 'r.by_project', joins: 'LEFT JOIN reviews r ON r.bs_request_id = bs_requests.id' },
         'review/@by_package' => { cpart: 'r.by_package', joins: 'LEFT JOIN reviews r ON r.bs_request_id = bs_requests.id' },
+        'review/@when' => { cpart: 'bs_requests.updated_at', joins: 'LEFT JOIN reviews r ON r.bs_request_id = bs_requests.id' },
         'review/@state' => { cpart: 'r.state', joins: 'LEFT JOIN reviews r ON r.bs_request_id = bs_requests.id' },
+        'review/history/@when' => { cpart: 'he.created_at', joins: "LEFT JOIN reviews r ON r.bs_request_id = bs_requests.id LEFT JOIN history_elements he ON (he.op_object_id = r.id AND he.type IN (\"#{HistoryElement::Review.descendants.join('","')}\") )" },
+        'history/@when' => { cpart: 'he.created_at', joins: "LEFT JOIN history_elements he ON (he.op_object_id = bs_requests.id AND he.type IN (\"#{HistoryElement::Request.descendants.join('","')}\") )" },
         'history/@who' => { cpart: 'husers.login', joins: ["LEFT JOIN history_elements he ON (he.op_object_id = bs_requests.id AND he.type IN (\"#{HistoryElement::Request.descendants.join('","')}\") )",
                                                            'LEFT JOIN users husers ON he.user_id = husers.id'] },
 
@@ -648,3 +652,4 @@ class XpathEngine
   end
 end
 # rubocop:enable Layout/LineLength
+# rubocop:enable Metrics/MethodLength

--- a/src/api/test/functional/channel_maintenance_test.rb
+++ b/src/api/test/functional/channel_maintenance_test.rb
@@ -129,6 +129,10 @@ class ChannelMaintenanceTests < ActionDispatch::IntegrationTest
     post "/request/#{id1}?cmd=changestate&newstate=accepted"
     assert_response :success
 
+    get '/search/request', params: { match: 'history/@when>="2021-08-26"' }
+    assert_response :success
+    assert_xml_tag tag: 'request', attributes: { id: '1042' }
+
     get "/request/#{id1}"
     assert_response :success
     data = REXML::Document.new(@response.body)

--- a/src/api/test/functional/maintenance_test.rb
+++ b/src/api/test/functional/maintenance_test.rb
@@ -1410,6 +1410,16 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     assert_xml_tag(parent: { tag: 'review' }, tag: 'comment', content: 'blahfasel')
     assert_xml_tag(parent: { tag: 'state' }, tag: 'comment', content: 'All reviewers accepted request')
 
+    get '/search/request', params: { match: 'review/@when>="2010-07-12"' }
+    print @response.body
+    assert_response :success
+    assert_xml_tag tag: 'request', attributes: { id: reqid }
+
+    get '/search/request', params: { match: 'review/history/@when>="1975-07-12"' }
+    print @response.body
+    assert_response :success
+    assert_xml_tag tag: 'request', attributes: { id: reqid }
+
     SendEventEmailsJob.new.perform
     ActionMailer::Base.deliveries.clear
 


### PR DESCRIPTION
Support xpath search for

 review/@when
 review/history/@when
 history/@when

attributes (OBS-149)

_Replace this line with a description of your changes. Please follow the suggestions in the comment below._

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
