### PR TITLE
Update bundler version to a recent one

### DIFF
--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -591,4 +591,4 @@ DEPENDENCIES
   yajl-ruby
 
 BUNDLED WITH
-   1.17.2
+   2.2.24

--- a/src/api/Gemfile.next.lock
+++ b/src/api/Gemfile.next.lock
@@ -581,4 +581,4 @@ DEPENDENCIES
   yajl-ruby
 
 BUNDLED WITH
-   1.17.2
+   2.2.24


### PR DESCRIPTION
CI will never pass as the version of bundler is hardcoded in the CI containers. Changing it would make this PRs CI pass and everyone elses fail. 

You need to trust me and let me commit without CI :)