### PR TITLE
[backend] modularity: allow to pin the distindex in the modulemd file

### DIFF
--- a/src/backend/BSSched/BuildJob.pm
+++ b/src/backend/BSSched/BuildJob.pm
@@ -916,12 +916,13 @@ sub create_jobdata {
   $debuginfo = BSUtil::enabled($repoid, $pdata->{'debuginfo'}, $debuginfo, $myarch);
   $binfo->{'debuginfo'} = 1 if $debuginfo;
   if ($ctx->{'modularity_label'}) {
+    my $distindex = $ctx->{'modularity_distindex'} || $binfo->{'bcnt'} || 1;
     $binfo->{'modularity_package'} = $ctx->{'modularity_package'};
     $binfo->{'modularity_srcmd5'} = $ctx->{'modularity_srcmd5'};
     $binfo->{'modularity_meta'} = $ctx->{'modularity_meta'};
     $binfo->{'modularity_platform'} = $ctx->{'modularity_platform'};
     $binfo->{'modularity_label'} = $ctx->{'modularity_label'};
-    $binfo->{'modularity_macros'} = BSSched::Modulemd::calc_macros($bconf, $ctx->{'modularity_label'}, $binfo->{'bcnt'} || 1, $ctx->{'modularity_extramacros'});
+    $binfo->{'modularity_macros'} = BSSched::Modulemd::calc_macros($bconf, $ctx->{'modularity_label'}, $distindex, $ctx->{'modularity_extramacros'});
   }
   return $binfo;
 }

--- a/src/backend/BSSched/Checker.pm
+++ b/src/backend/BSSched/Checker.pm
@@ -423,6 +423,7 @@ sub setup {
     $ctx->{'modularity_meta'} = Digest::MD5::md5_hex("$ml[0]:$ml[1]:$ml[3]:$pdata->{'srcmd5'}")."  $ctx->{'modularity_package'}";
     $ctx->{'modularity_extramacros'} = $modulemd->{'macros'} if $modulemd->{'macros'};
     $ctx->{'modularity_platform'} = $bconf->{'buildflags:modulemdplatform'};
+    $ctx->{'modularity_distindex'} = $modulemd->{'distindex'} if $modulemd->{'distindex'};
   }
 
   return ('scheduling', undef);

--- a/src/backend/BSSched/Modulemd.pm
+++ b/src/backend/BSSched/Modulemd.pm
@@ -125,20 +125,20 @@ sub extend_modules {
 }
 
 sub calc_dist {
-  my ($bconf, $ml, $bcnt) = @_;
+  my ($bconf, $ml, $distindex) = @_;
   my $pfdata = $bconf->{'buildflags:modulemdplatform'};
   return undef unless $pfdata;
   my ($versionprefix, $distprefix) = split(':', $pfdata);
   return undef unless $distprefix;
   my $ml_x = $ml;
   $ml_x =~ s/:/./g;
-  return "$distprefix+$bcnt+".substr(Digest::SHA::sha1_hex($ml_x), 0, 8);
+  return "$distprefix+$distindex+".substr(Digest::SHA::sha1_hex($ml_x), 0, 8);
 }
 
 sub calc_macros {
-  my ($bconf, $ml, $bcnt, $extramacros) = @_;
+  my ($bconf, $ml, $distindex, $extramacros) = @_;
   my @ml = split(':', $ml, 4);
-  my $dist = calc_dist($bconf, $ml, $bcnt);
+  my $dist = calc_dist($bconf, $ml, $distindex);
   my $macros = '';
   $macros .= "%dist $dist\n" if defined $dist;
   $macros .= "%modularitylabel $ml\n";

--- a/src/backend/BSSrcServer/Modulemd.pm
+++ b/src/backend/BSSrcServer/Modulemd.pm
@@ -77,6 +77,7 @@ sub parse_modulemd {
   $r->{'stream'} = assert_str($d->{'stream'}, 'stream');
   $r->{'version'} = assert_str($d->{'version'}, 'version') if defined $d->{'version'};
   $r->{'context'} = assert_str($d->{'context'}, 'context') if defined $d->{'context'};
+  $r->{'distindex'} = assert_str($d->{'distindex'}, 'distindex') if defined $d->{'distindex'};
   $d->{'dependencies'} = [ $d->{'dependencies'} ] if ref($d->{'dependencies'}) eq 'HASH';
   for my $dd (@{$d->{'dependencies'} || []}) {
     die("dependency block must be hash\n") unless ref($dd) eq 'HASH';
@@ -111,7 +112,6 @@ sub tostream {
     die("unsupported md version\n");
   }
   $md = $md->{'data'};
-  return unless $md->{'dependencies'};
   my ($versionprefix, $distprefix, @distprovides) = split(':', $modularityplatform);
   my %distprovides = map {$_ => 1} @distprovides;
   for (@distprovides) {
@@ -169,6 +169,7 @@ sub tostream {
   }
   die("could not select dependency block\n") unless $newdeps;
   $md->{'dependencies'} = [ $newdeps ];
+  delete $md->{'distindex'};
   my @l = split(':', $modularitylabel);
   $md->{'name'} = $l[0];
   $md->{'stream'} = $l[1];

--- a/src/backend/BSXML.pm
+++ b/src/backend/BSXML.pm
@@ -308,6 +308,7 @@ our $modulemd = [
 	'version',
 	'context',
 	'timestamp',
+	'distindex',
 	[],
 	'macros',
      [[ 'dependency' =>


### PR DESCRIPTION
This can be done with the non-standard "distindex" tag in the
modulemd.yaml input file.

_Replace this line with a description of your changes. Please follow the suggestions in the comment below._

-----------------

If this PR requires any particular action or consideration before deployment,
please check the reasons or add your own to the list:

* [ ] Requires a database migration that can cause downtime. Postpone deployment until maintenance window[1].
* [ ] Contains a data migration that can cause temporary inconsistency, so should be run at a specific point of time.
* [ ] Changes some configuration files (e.g. options.yml), so the changes have to be applied manually in the reference server.
* [ ] A new Feature Toggle[2] should be enabled in the reference server.
* [ ] Proper documentation or announcement has to be published upfront since the introduced changes can confuse the users.

[1] https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org#when-there-are-migrations
[2] https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles-%28Flipper%29#you-want-real-people-to-test-your-feature

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

If this PR requires any particular action or consideration before deployment,
set out the reasons by checking the items in the list or adding your own items.
-->
