### PR TITLE
Revert "Update bundler version to a recent one"

### DIFF
--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -591,4 +591,4 @@ DEPENDENCIES
   yajl-ruby
 
 BUNDLED WITH
-   2.2.24
+   1.17.2

--- a/src/api/Gemfile.next.lock
+++ b/src/api/Gemfile.next.lock
@@ -581,4 +581,4 @@ DEPENDENCIES
   yajl-ruby
 
 BUNDLED WITH
-   2.2.24
+   1.17.2


### PR DESCRIPTION
Reverts openSUSE/open-build-service#11550

We need @M0ses to understand why [obs-service-bundle_gems](https://build.opensuse.org/package/show/OBS:Server:Unstable/obs-service-bundle_gems) was reverted.