### PR TITLE
Allow looking up users by an email address

### DIFF
--- a/src/api/app/controllers/person_controller.rb
+++ b/src/api/app/controllers/person_controller.rb
@@ -15,6 +15,8 @@ class PersonController < ApplicationController
   def show
     @list = if params[:prefix]
               User.where('login LIKE ?', params[:prefix] + '%')
+            elsif params[:email]
+              User.where(:email => params[:email])
             else
               User.all
             end


### PR DESCRIPTION
This patch adds an option to look up users by an email address. This is useful for example for tools manipulating or synchronising the user database with other sources.

The new API does not pose any greater privacy or security risk than the currently available APIs, since they already allow finding a user by their email address, albeit much slower (list all users, iterate over users, request emails; possible to optimise by first checking users with usernames similar to their email addresses).

Example of the usage:
```
$ osc --debug api '/person?email=andrew.shadura@collabora.co.uk'
GET https://obs-api/person?email=andrew.shadura@collabora.co.uk
<directory count="1">
  <entry name="andrewsh"/>
</directory>
```
