### PR TITLE
Discard StagingProjectAcceptJob on InvalidStateError

### DIFF
--- a/src/api/app/jobs/staging_project_accept_job.rb
+++ b/src/api/app/jobs/staging_project_accept_job.rb
@@ -1,6 +1,8 @@
 class StagingProjectAcceptJob < ApplicationJob
   queue_as :staging
 
+  discard_on BsRequest::Errors::InvalidStateError
+
   def perform(payload)
     User.find_by!(login: payload[:user_login]).run_as do
       accept(Project.find(payload[:project_id]))


### PR DESCRIPTION
This can happen when at the same time of scheduling the job
there will be a new request selected to the staging project.
Or somehow a staged request changes state in the same time.

If we discard the job on this error, the staging project state
calcuclation will be done again.

Partially addresses #10636