### PR TITLE
[api] avoid delivering notifications to unconfirmed users

### DIFF
--- a/src/api/app/models/event_subscription/find_for_event.rb
+++ b/src/api/app/models/event_subscription/find_for_event.rb
@@ -54,7 +54,7 @@ class EventSubscription
       receivers.each do |receiver|
         case receiver
         when User
-          new_receivers << receiver
+          new_receivers << receiver if receiver.is_active?
 
         when Group
 

--- a/src/api/app/models/event_subscription/form.rb
+++ b/src/api/app/models/event_subscription/form.rb
@@ -29,7 +29,7 @@ class EventSubscription
     def find_or_initialize_subscription(eventtype, receiver_role, channel)
       opts = { eventtype: eventtype, receiver_role: receiver_role, channel: channel }
 
-      if subscriber.is_a?(User)
+      if subscriber.is_a?(User) && subscriber.is_active?
         opts[:user] = subscriber
       elsif subscriber.is_a?(Group)
         opts[:group] = subscriber

--- a/src/api/app/models/group.rb
+++ b/src/api/app/models/group.rb
@@ -140,7 +140,7 @@ class Group < ApplicationRecord
 
   # returns the users that actually want email for this group's notifications
   def email_users
-    User.where(id: groups_users.where(email: true).select(:user_id))
+    User.where(id: groups_users.where(email: true).select(:user_id), state: 'confirmed')
   end
 
   def display_name


### PR DESCRIPTION
eg. do not send out mails anymore when a user got locked