### PR TITLE
Fail if the Workflow token does not have a payload

### DIFF
--- a/src/api/app/controllers/trigger_controller.rb
+++ b/src/api/app/controllers/trigger_controller.rb
@@ -29,6 +29,8 @@ class TriggerController < ApplicationController
       @token.call(opts)
       render_ok
     end
+  rescue ArgumentError => e
+    render_error status: 400, message: e
   end
 
   private

--- a/src/api/app/models/token/workflow.rb
+++ b/src/api/app/models/token/workflow.rb
@@ -6,6 +6,8 @@ class Token::Workflow < Token
   end
 
   def call(options)
+    raise ArgumentError, 'A payload is required' if options[:payload].nil?
+
     extractor = TriggerControllerService::ScmExtractor.new(options[:scm], options[:event], options[:payload])
     return unless extractor.allowed_event_and_action?
 


### PR DESCRIPTION
It's possible to trigger a workflow token via the API. But doing so makes no sense as we cannot provide a payload (the token gets the required data from the payload. If there is no payload, we can't get the required data).

This PR ensures the API gets a proper error when trying to trigger a Workflow Token without a payload.

Fixes #11535 