### PR TITLE
[backend] external buildinfo: include modulemd yaml data

### DIFF
--- a/src/backend/BSRepServer/BuildInfo.pm
+++ b/src/backend/BSRepServer/BuildInfo.pm
@@ -186,6 +186,23 @@ sub addurltopath {
   }
 }
 
+sub getmodulemddata {
+  my ($buildinfo) = @_;
+  my @args;
+  push @args, "project=$buildinfo->{'project'}";
+  push @args, "package=$buildinfo->{'modularity_package'}";
+  push @args, "srcmd5=$buildinfo->{'modularity_srcmd5'}";
+  push @args, "arch=$buildinfo->{'arch'}";
+  push @args, map {"module=$_"} @{$buildinfo->{'module'}};
+  push @args, "modularityplatform=$buildinfo->{'modularity_platform'}";
+  push @args, "modularitylabel=$buildinfo->{'modularity_label'}";
+  push @args, "view=yaml";
+  return BSRPC::rpc({
+    'uri' => "$BSConfig::srcserver/getmodulemd",
+    'timeout' => 300,
+  }, undef, @args);
+}
+
 sub fixupbuildinfo {
   my ($ctx, $binfo, $info) = @_;
 
@@ -208,6 +225,7 @@ sub fixupbuildinfo {
   my %preimghdrmd5s = map {delete($_->{'preimghdrmd5'}) => 1} grep {$_->{'preimghdrmd5'}} @{$binfo->{'bdep'}};
   addpreinstallimg($ctx, $binfo, \%preimghdrmd5s);
   $binfo->{'expanddebug'} = ${$ctx->{'expanddebug'}} if $ctx->{'expanddebug'};
+  $binfo->{'modularity_yaml'} = getmodulemddata($binfo) if $binfo->{'modularity_label'};
 }
 
 1;

--- a/src/backend/BSXML.pm
+++ b/src/backend/BSXML.pm
@@ -637,6 +637,7 @@ our $buildinfo = [
         'modularity_label',
         'modularity_platform',
         'modularity_meta',
+        'modularity_yaml',	# external
 
       [ 'preinstallimage' =>
 	    'project',

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -5897,8 +5897,19 @@ sub getmodulemd {
   for my $md (@$mds) {
     next unless $md->{'document'} eq 'modulemd';
     BSSrcServer::Modulemd::tostream($md, $cgi->{'modules'} || [], $cgi->{'modularitylabel'}, $cgi->{'modularityplatform'});
+    $md->{'data'}->{'arch'} = $cgi->{'arch'} if $cgi->{'arch'};
   }
-  return (BSUtil::tostorable($mds), 'Content-Type: application/octet-stream');
+  my $view = $cgi->{'view'} || 'storable';
+  if ($view eq 'yaml') {
+    require Build::Modulemd;
+    my $yaml = '';
+    $yaml .= Build::Modulemd::mdtoyaml($_) for @$mds;
+    return ($yaml, 'Content-Type: application/octet-stream');
+  } elsif ($view eq 'storable') {
+    return (BSUtil::tostorable($mds), 'Content-Type: application/octet-stream');
+  } else {
+    die("unknown view '$view'\n");
+  }
 }
 
 ####################################################################
@@ -7231,7 +7242,7 @@ my $dispatches = [
   '/getbinaries $project $repository $arch binaries: nometa:bool? workerid? now:num? module*' => \&worker_getbinaries,
   '/getbinaryversions $project $repository $arch binaries: nometa:bool? workerid? now:num? module*' => \&worker_getbinaryversions,
   '/getobsgendiffdata $project $repository $arch jobid? workerid?' => \&getobsgendiffdata,
-  '/getmodulemd $project $package $srcmd5:md5 module* modularityplatform: modularitylabel:' => \&getmodulemd,
+  '/getmodulemd $project $package $srcmd5:md5 module* modularityplatform: modularitylabel: arch? view:?' => \&getmodulemd,
 
   # publisher/signer calls
   '/getsignkey $project withpubkey:bool? autoextend:bool? withalgo:bool?' => \&getsignkey,


### PR DESCRIPTION
Clients like osc should put the yaml data into _modulemd.yaml so
that the build tool an pick it up and create the correct modulemd
data as build result.