### PR TITLE
Support closed, merged and reopened pull/merge requests in OBS workflows 

### DIFF
--- a/src/api/app/models/scm_webhook.rb
+++ b/src/api/app/models/scm_webhook.rb
@@ -27,6 +27,11 @@ class ScmWebhook
       (gitlab_merge_request? && ['close', 'merge'].include?(@payload[:action]))
   end
 
+  def reopened_pull_request?
+    (github_pull_request? && @payload[:action] == 'reopened') ||
+      (gitlab_merge_request? && @payload[:action] == 'reopen')
+  end
+
   private
 
   def github_pull_request?

--- a/src/api/app/models/scm_webhook.rb
+++ b/src/api/app/models/scm_webhook.rb
@@ -22,6 +22,11 @@ class ScmWebhook
       (gitlab_merge_request? && @payload[:action] == 'update')
   end
 
+  def closed_merged_pull_request?
+    (github_pull_request? && @payload[:action] == 'closed') ||
+      (gitlab_merge_request? && ['close', 'merge'].include?(@payload[:action]))
+  end
+
   private
 
   def github_pull_request?

--- a/src/api/app/validators/scm_webhook_event_validator.rb
+++ b/src/api/app/validators/scm_webhook_event_validator.rb
@@ -2,8 +2,8 @@ class ScmWebhookEventValidator < ActiveModel::Validator
   ALLOWED_GITHUB_EVENTS = ['pull_request'].freeze
   ALLOWED_GITLAB_EVENTS = ['Merge Request Hook'].freeze
 
-  ALLOWED_PULL_REQUEST_ACTIONS = ['closed', 'opened', 'synchronize'].freeze
-  ALLOWED_MERGE_REQUEST_ACTIONS = ['close', 'merge', 'open', 'update'].freeze
+  ALLOWED_PULL_REQUEST_ACTIONS = ['closed', 'opened', 'reopened', 'synchronize'].freeze
+  ALLOWED_MERGE_REQUEST_ACTIONS = ['close', 'merge', 'open', 'reopen', 'update'].freeze
 
   def validate(record)
     @record = record

--- a/src/api/app/validators/scm_webhook_event_validator.rb
+++ b/src/api/app/validators/scm_webhook_event_validator.rb
@@ -2,8 +2,8 @@ class ScmWebhookEventValidator < ActiveModel::Validator
   ALLOWED_GITHUB_EVENTS = ['pull_request'].freeze
   ALLOWED_GITLAB_EVENTS = ['Merge Request Hook'].freeze
 
-  ALLOWED_PULL_REQUEST_ACTIONS = ['opened', 'synchronize'].freeze
-  ALLOWED_MERGE_REQUEST_ACTIONS = ['open', 'update'].freeze
+  ALLOWED_PULL_REQUEST_ACTIONS = ['closed', 'opened', 'synchronize'].freeze
+  ALLOWED_MERGE_REQUEST_ACTIONS = ['close', 'merge', 'open', 'update'].freeze
 
   def validate(record)
     @record = record

--- a/src/api/spec/models/scm_webhook_spec.rb
+++ b/src/api/spec/models/scm_webhook_spec.rb
@@ -92,4 +92,56 @@ RSpec.describe ScmWebhook, type: :model do
       it { is_expected.to be true }
     end
   end
+
+  describe '#closed_merged_pull_request?' do
+    subject { described_class.new(payload: payload).closed_merged_pull_request? }
+
+    context 'for an unsupported SCM' do
+      let(:payload) { { scm: 'GitHoob', event: 'pull_request', action: 'closed' } }
+
+      it { is_expected.to be false }
+    end
+
+    context 'for an unsupported event from GitHub' do
+      let(:payload) { { scm: 'github', event: 'something', action: 'closed' } }
+
+      it { is_expected.to be false }
+    end
+
+    context 'for an unsupported action from GitHub' do
+      let(:payload) { { scm: 'github', event: 'pull_request', action: 'something' } }
+
+      it { is_expected.to be false }
+    end
+
+    context 'for a closed/merged pull request from GitHub' do
+      let(:payload) { { scm: 'github', event: 'pull_request', action: 'closed' } }
+
+      it { is_expected.to be true }
+    end
+
+    context 'for an unsupported event from GitLab' do
+      let(:payload) { { scm: 'gitlab', event: 'something', action: 'close' } }
+
+      it { is_expected.to be false }
+    end
+
+    context 'for an unsupported action from GitLab' do
+      let(:payload) { { scm: 'gitlab', event: 'Merge Request Hook', action: 'something' } }
+
+      it { is_expected.to be false }
+    end
+
+    context 'for a closed merge request from GitLab' do
+      let(:payload) { { scm: 'gitlab', event: 'Merge Request Hook', action: 'close' } }
+
+      it { is_expected.to be true }
+    end
+
+    context 'for a merged merge request from GitLab' do
+      let(:payload) { { scm: 'gitlab', event: 'Merge Request Hook', action: 'merge' } }
+
+      it { is_expected.to be true }
+    end
+  end
 end

--- a/src/api/spec/models/scm_webhook_spec.rb
+++ b/src/api/spec/models/scm_webhook_spec.rb
@@ -144,4 +144,50 @@ RSpec.describe ScmWebhook, type: :model do
       it { is_expected.to be true }
     end
   end
+
+  describe '#reopened_pull_request?' do
+    subject { described_class.new(payload: payload).reopened_pull_request? }
+
+    context 'for an unsupported SCM' do
+      let(:payload) { { scm: 'GitHoob', event: 'pull_request', action: 'reopened' } }
+
+      it { is_expected.to be false }
+    end
+
+    context 'for an unsupported event from GitHub' do
+      let(:payload) { { scm: 'github', event: 'something', action: 'reopened' } }
+
+      it { is_expected.to be false }
+    end
+
+    context 'for an unsupported action from GitHub' do
+      let(:payload) { { scm: 'github', event: 'pull_request', action: 'something' } }
+
+      it { is_expected.to be false }
+    end
+
+    context 'for a reopened pull request from GitHub' do
+      let(:payload) { { scm: 'github', event: 'pull_request', action: 'reopened' } }
+
+      it { is_expected.to be true }
+    end
+
+    context 'for an unsupported event from GitLab' do
+      let(:payload) { { scm: 'gitlab', event: 'something', action: 'reopen' } }
+
+      it { is_expected.to be false }
+    end
+
+    context 'for an unsupported action from GitLab' do
+      let(:payload) { { scm: 'gitlab', event: 'Merge Request Hook', action: 'something' } }
+
+      it { is_expected.to be false }
+    end
+
+    context 'for a reopened merge request from GitLab' do
+      let(:payload) { { scm: 'gitlab', event: 'Merge Request Hook', action: 'reopen' } }
+
+      it { is_expected.to be true }
+    end
+  end
 end

--- a/src/api/spec/validators/scm_webhook_event_validator_spec.rb
+++ b/src/api/spec/validators/scm_webhook_event_validator_spec.rb
@@ -74,6 +74,13 @@ RSpec.describe ScmWebhookEventValidator do
 
         it { is_expected.to be_valid }
       end
+
+      context 'for a pull request which was reopened' do
+        let(:event) { 'pull_request' }
+        let(:action) { 'reopened' }
+
+        it { is_expected.to be_valid }
+      end
     end
 
     context 'when the SCM is GitLab' do
@@ -123,6 +130,13 @@ RSpec.describe ScmWebhookEventValidator do
       context 'for a merge request which was merged' do
         let(:event) { 'Merge Request Hook' }
         let(:action) { 'merge' }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'for a merge request which was reopened' do
+        let(:event) { 'Merge Request Hook' }
+        let(:action) { 'reopen' }
 
         it { is_expected.to be_valid }
       end

--- a/src/api/spec/validators/scm_webhook_event_validator_spec.rb
+++ b/src/api/spec/validators/scm_webhook_event_validator_spec.rb
@@ -67,6 +67,13 @@ RSpec.describe ScmWebhookEventValidator do
 
         it { is_expected.to be_valid }
       end
+
+      context 'for a pull request which was closed/merged' do
+        let(:event) { 'pull_request' }
+        let(:action) { 'closed' }
+
+        it { is_expected.to be_valid }
+      end
     end
 
     context 'when the SCM is GitLab' do
@@ -102,6 +109,20 @@ RSpec.describe ScmWebhookEventValidator do
       context 'for a merge request which was updated' do
         let(:event) { 'Merge Request Hook' }
         let(:action) { 'update' }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'for a merge request which was closed' do
+        let(:event) { 'Merge Request Hook' }
+        let(:action) { 'close' }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'for a merge request which was merged' do
+        let(:event) { 'Merge Request Hook' }
+        let(:action) { 'merge' }
 
         it { is_expected.to be_valid }
       end


### PR DESCRIPTION
This allows us to implement different logic for workflow steps depending on the webhook events. This will be in upcoming PRs.