### PR TITLE
Ignore temporarily closed, merged and reopened PRs/MRs

### DIFF
--- a/src/api/app/models/workflow/step/branch_package_step.rb
+++ b/src/api/app/models/workflow/step/branch_package_step.rb
@@ -4,6 +4,9 @@ class Workflow::Step::BranchPackageStep < ::Workflow::Step
   def call(options = {})
     return unless valid?
 
+    # FIXME: Support closed/merged/reopened PRs
+    return if scm_webhook.closed_merged_pull_request? || scm_webhook.reopened_pull_request?
+
     branched_package = find_or_create_branched_package
 
     add_or_update_branch_request_file(package: branched_package)

--- a/src/api/app/models/workflow/step/configure_repositories.rb
+++ b/src/api/app/models/workflow/step/configure_repositories.rb
@@ -9,6 +9,9 @@ class Workflow::Step::ConfigureRepositories < Workflow::Step
   def call(_options = {})
     return unless valid?
 
+    # FIXME: Support closed/merged/reopened PRs
+    return if scm_webhook.closed_merged_pull_request? || scm_webhook.reopened_pull_request?
+
     step_instructions[:repositories].each do |repository_instructions|
       repository = Repository.includes(:architectures).find_or_create_by(name: repository_instructions[:name], project: Project.get_by_name(target_project_name))
 

--- a/src/api/app/models/workflow/step/link_package_step.rb
+++ b/src/api/app/models/workflow/step/link_package_step.rb
@@ -4,6 +4,9 @@ class Workflow::Step::LinkPackageStep < ::Workflow::Step
   def call(options = {})
     return unless valid?
 
+    # FIXME: Support closed/merged/reopened PRs
+    return if scm_webhook.closed_merged_pull_request? || scm_webhook.reopened_pull_request?
+
     workflow_filters = options.fetch(:workflow_filters, {})
 
     # Updated PR


### PR DESCRIPTION
This is to avoid errors while we adapt workflow steps to support closed, merged and reopened PRs/MRs.