### PR TITLE
Disable RuboCop Style/EmptyCaseCondition cop

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -12,3 +12,7 @@ Backend:
 - .circleci/**/*
 - .github/**/*
 - .obs/**/*
+- .rubocop.yml
+- .rubocop_todo.yml
+- src/api/.rubocop.yml
+- src/api/.rubocop_todo.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -45,6 +45,10 @@ Style/CommandLiteral:
 Style/Documentation:
   Enabled: false
 
+# Using an empty case is sometimes clearer than `if/elsif/elsif/else`
+Style/EmptyCaseCondition:
+  Enabled: false
+
 Style/RedundantReturn:
   Enabled: false
 

--- a/src/api/.rubocop.yml
+++ b/src/api/.rubocop.yml
@@ -35,6 +35,10 @@ Style/CommentAnnotation:
   # especially when a comment starts with "review" since we have those in OBS
   Keywords: ['TODO', 'FIXME']
 
+# Using an empty case is sometimes clearer than `if/elsif/elsif/else`
+Style/EmptyCaseCondition:
+  Enabled: false
+
 # We need to allow some variables related to rabbiMQ.
 Style/GlobalVars:
   AllowedVariables: ['$rabbitmq_conn', '$rabbitmq_exchange', '$rabbitmq_channel']


### PR DESCRIPTION
Using an empty case is sometimes clearer than `if/elsif/elsif/else`.

https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/EmptyCaseCondition