### PR TITLE
Handle closed, merged and reopened pull/merge requests in OBS workflows

### DIFF
--- a/src/api/app/models/token/workflow.rb
+++ b/src/api/app/models/token/workflow.rb
@@ -13,13 +13,67 @@ class Token::Workflow < Token
 
     yaml_file = Workflows::YAMLDownloader.new(scm_webhook.payload, token: self).call
     workflows = Workflows::YAMLToWorkflowsService.new(yaml_file: yaml_file, scm_webhook: scm_webhook, token: self).call
+
+    case
+    when scm_webhook.closed_merged_pull_request?
+      destroy_target_projects(workflows)
+    when scm_webhook.reopened_pull_request?
+      restore_target_projects(workflows)
+    when scm_webhook.new_pull_request?, scm_webhook.updated_pull_request?
+      call_steps(workflows)
+    end
+  rescue Octokit::Unauthorized, Gitlab::Error::Unauthorized => e
+    raise Token::Errors::SCMTokenInvalid, e.message
+  end
+
+  private
+
+  def destroy_target_projects(workflows)
+    workflows.each do |workflow|
+      # Do not process steps for which there's nothing to do
+      workflow_steps = workflow.steps.reject { |step| step.instance_of?(::Workflow::Step::ConfigureRepositories) }
+      target_packages = workflow_steps.map(&:target_package).uniq.compact
+      delete_subscriptions(target_packages)
+
+      target_project_names = workflow_steps.map(&:target_project_name).uniq.compact
+      destroy_all_target_projects(target_project_names)
+    end
+  end
+
+  # We want the callbacks to run after destroy, so we can't use delete_all
+  def destroy_all_target_projects(target_project_names)
+    Project.where(name: target_project_names).destroy_all
+  end
+
+  def delete_subscriptions(packages)
+    EventSubscription.where(channel: 'scm', token: self, package: packages).delete_all
+  end
+
+  def restore_target_projects(workflows)
+    token_user_login = user.login
+
+    workflows.each do |workflow|
+      # Do not process steps for which there's nothing to do
+      workflow_steps = workflow.steps.reject { |step| step.instance_of?(::Workflow::Step::ConfigureRepositories) }
+      target_project_names = workflow_steps.map(&:target_project_name).uniq.compact
+      target_project_names.each do |target_project_name|
+        Project.restore(target_project_name, user: token_user_login)
+      end
+
+      target_packages = workflow_steps.map(&:target_package).uniq.compact
+      target_packages.each do |target_package|
+        # FIXME: We shouldn't rely on a workflow step to be able to create/update subscriptions
+        workflow_steps.first.create_or_update_subscriptions(target_package, workflow.filters)
+      end
+    end
+  end
+
+  def call_steps(workflows)
     workflows.each do |workflow|
       workflow.steps.each do |step|
         step.call({ workflow_filters: workflow.filters })
       end
     end
-  rescue Octokit::Unauthorized, Gitlab::Error::Unauthorized => e
-    raise Token::Errors::SCMTokenInvalid, e.message
   end
 end
 

--- a/src/api/app/models/workflow/step/configure_repositories.rb
+++ b/src/api/app/models/workflow/step/configure_repositories.rb
@@ -8,9 +8,6 @@ class Workflow::Step::ConfigureRepositories < Workflow::Step
   def call(_options = {})
     return unless valid?
 
-    # FIXME: Support closed/merged/reopened PRs
-    return if scm_webhook.closed_merged_pull_request? || scm_webhook.reopened_pull_request?
-
     step_instructions[:repositories].each do |repository_instructions|
       repository = Repository.includes(:architectures).find_or_create_by(name: repository_instructions[:name], project: Project.get_by_name(target_project_name))
 

--- a/src/api/app/models/workflow/step/link_package_step.rb
+++ b/src/api/app/models/workflow/step/link_package_step.rb
@@ -7,8 +7,9 @@ class Workflow::Step::LinkPackageStep < ::Workflow::Step
 
     workflow_filters = options.fetch(:workflow_filters, {})
 
-    if scm_webhook.updated_pull_request? && target_package.present?
-      update_subscriptions(target_package, workflow_filters)
+    if scm_webhook.updated_pull_request?
+      create_target_package if target_package.blank?
+      create_or_update_subscriptions(target_package, workflow_filters)
     elsif scm_webhook.new_pull_request?
       create_target_package
       create_subscriptions(target_package, workflow_filters)

--- a/src/api/app/models/workflow/step/link_package_step.rb
+++ b/src/api/app/models/workflow/step/link_package_step.rb
@@ -5,15 +5,11 @@ class Workflow::Step::LinkPackageStep < ::Workflow::Step
   def call(options = {})
     return unless valid?
 
-    # FIXME: Support closed/merged/reopened PRs
-    return if scm_webhook.closed_merged_pull_request? || scm_webhook.reopened_pull_request?
-
     workflow_filters = options.fetch(:workflow_filters, {})
 
-    # Updated PR
     if scm_webhook.updated_pull_request? && target_package.present?
       update_subscriptions(target_package, workflow_filters)
-    else # New PR
+    elsif scm_webhook.new_pull_request?
       create_target_package
       create_subscriptions(target_package, workflow_filters)
     end


### PR DESCRIPTION
Whenever the webhook event is for a closed, merged or reopened pull/merge requests, we handle this at the workflow level in the `Token::Workflow` model. There is no need to handle this in every step since we can already tell what has to be restored/deleted.