### PR TITLE
Consider multibuild suffix when retriggering package build through webui

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -504,9 +504,8 @@ class Webui::PackageController < Webui::WebuiController
   end
 
   def trigger_rebuild
-    rebuild_trigger = PackageControllerService::RebuildTrigger.new(package: @package, project: @project,
-                                                                   repository: params[:repository],
-                                                                   arch: params[:arch])
+    rebuild_trigger = PackageControllerService::RebuildTrigger.new(package_object: @package, package_name_with_multibuild_suffix: params[:package],
+                                                                   project: @project, repository: params[:repository], arch: params[:arch])
     authorize rebuild_trigger.policy_object, :update?
 
     if rebuild_trigger.rebuild?

--- a/src/api/app/services/package_controller_service/rebuild_trigger.rb
+++ b/src/api/app/services/package_controller_service/rebuild_trigger.rb
@@ -1,31 +1,32 @@
 module PackageControllerService
   class RebuildTrigger
     def initialize(options = {})
-      @package = options[:package]
+      @package_object = options[:package_object]
+      @package_name_with_multibuild_suffix = options[:package_name_with_multibuild_suffix]
       @project = options[:project]
       @repository = options[:repository]
       @arch = options[:arch]
     end
 
     def rebuild?
-      @package.rebuild(package: @package, project: @project, repository: @repository, arch: @arch)
+      @package_object.rebuild(package: @package_name_with_multibuild_suffix, project: @project, repository: @repository, arch: @arch)
     end
 
     # When we're in a linked project, the package's project points to some other
     # project, not the one we're triggering the build from.
     # Here we detect that, and if so, we authorize against the linked project.
     def policy_object
-      return @project if @project != @package.project
+      return @project if @project != @package_object.project
 
-      @package
+      @package_object
     end
 
     def success_message
-      "Triggered rebuild for #{@project.name}/#{@package.name} successfully."
+      "Triggered rebuild for #{@project.name}/#{@package_name_with_multibuild_suffix} successfully."
     end
 
     def error_message
-      "Error while triggering rebuild for #{@project.name}/#{@package.name}: #{@package.errors.full_messages.to_sentence}."
+      "Error while triggering rebuild for #{@project.name}/#{@package_name_with_multibuild_suffix}: #{@package_object.errors.full_messages.to_sentence}."
     end
   end
 end

--- a/src/api/spec/services/package_controller_service/rebuild_trigger_spec.rb
+++ b/src/api/spec/services/package_controller_service/rebuild_trigger_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ::PackageControllerService::RebuildTrigger do
   let(:project) { OpenStruct.new(name: 'bar') }
   let(:package) { OpenStruct.new(name: 'foo', project: project) }
   let(:params) { {} }
-  let(:rebuild_trigger) { described_class.new(package: package, project: project, params: params) }
+  let(:rebuild_trigger) { described_class.new(package_object: package, package_name_with_multibuild_suffix: package.name, project: project, params: params) }
 
   it { expect(rebuild_trigger.policy_object).to eq(package) }
 


### PR DESCRIPTION
We need to pass the full package name (including the multibuild suffix) to the backend
when retriggering a package build through the webui.
Currently we pass the package name of the package object
to the backend, which will cause a rebuild of all
multibuild flavors.

Fixes #11598