### PR TITLE
Refactor BranchPackageStep and LinkPackageStep

### DIFF
--- a/src/api/app/models/workflow/step.rb
+++ b/src/api/app/models/workflow/step.rb
@@ -145,5 +145,16 @@ class Workflow::Step
 
     architectures
   end
+
+  def report_to_scm(workflow_filters)
+    workflow_repositories(target_project_name, workflow_filters).each do |repository|
+      # TODO: Fix n+1 queries
+      workflow_architectures(repository, workflow_filters).each do |architecture|
+        # We cannot report multibuild flavors here... so they will be missing from the initial report
+        SCMStatusReporter.new({ project: target_project_name, package: target_package_name, repository: repository.name, arch: architecture.name },
+                              scm_webhook.payload, @token.scm_token).call
+      end
+    end
+  end
 end
 # rubocop:enable Metrics/ClassLength

--- a/src/api/app/models/workflow/step.rb
+++ b/src/api/app/models/workflow/step.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/ClassLength
 class Workflow::Step
   include ActiveModel::Model
 
@@ -24,8 +23,6 @@ class Workflow::Step
     Package.find_by_project_and_name(target_project_name, target_package_name)
   end
 
-  # FIXME: Remove this and use create_subscriptions and update_subscriptions as soon as BranchPackageStep and Token::Workflow are refactored
-  #        This method is public since it has to be called from Token::Workflow. This shouldn't be needed.
   def create_or_update_subscriptions(package, workflow_filters)
     ['Event::BuildFail', 'Event::BuildSuccess'].each do |build_event|
       subscription = EventSubscription.find_or_create_by!(eventtype: build_event,
@@ -67,7 +64,7 @@ class Workflow::Step
     Project.find_remote_project(source_project_name).present?
   end
 
-  def add_or_update_branch_request_file(package:)
+  def add_branch_request_file(package:)
     branch_request_file = case scm_webhook.payload[:scm]
                           when 'github'
                             branch_request_content_github
@@ -97,29 +94,6 @@ class Workflow::Step
     { object_kind: scm_webhook.payload[:object_kind],
       project: { http_url: scm_webhook.payload[:http_url] },
       object_attributes: { source: { default_branch: scm_webhook.payload[:commit_sha] } } }.to_json
-  end
-
-  def create_subscriptions(package, workflow_filters)
-    ['Event::BuildFail', 'Event::BuildSuccess'].each do |build_event|
-      EventSubscription.create!(eventtype: build_event,
-                                receiver_role: 'reader', # We pass a valid value, but we don't need this.
-                                user: @token.user,
-                                channel: 'scm',
-                                enabled: true,
-                                token: @token,
-                                package: package,
-                                payload: scm_webhook.payload.merge({ workflow_filters: workflow_filters }))
-    end
-  end
-
-  def update_subscriptions(package, workflow_filters)
-    ['Event::BuildFail', 'Event::BuildSuccess'].each do |build_event|
-      subscription = EventSubscription.find_by(eventtype: build_event,
-                                               channel: 'scm',
-                                               token: @token,
-                                               package: package)
-      subscription.update!(payload: scm_webhook.payload.merge({ workflow_filters: workflow_filters }))
-    end
   end
 
   # TODO: Move to a query object.
@@ -157,4 +131,3 @@ class Workflow::Step
     end
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/src/api/app/models/workflow/step/branch_package_step.rb
+++ b/src/api/app/models/workflow/step/branch_package_step.rb
@@ -18,14 +18,7 @@ class Workflow::Step::BranchPackageStep < ::Workflow::Step
 
     create_or_update_subscriptions(branched_package, workflow_filters)
 
-    workflow_repositories(target_project_name, workflow_filters).each do |repository|
-      # TODO: Fix n+1 queries
-      workflow_architectures(repository, workflow_filters).each do |architecture|
-        # We cannot report multibuild flavors here... so they will be missing from the initial report
-        SCMStatusReporter.new({ project: target_project_name, package: target_package_name, repository: repository.name, arch: architecture.name },
-                              scm_webhook.payload, @token.scm_token).call
-      end
-    end
+    report_to_scm(workflow_filters)
 
     branched_package
   end

--- a/src/api/app/models/workflow/step/link_package_step.rb
+++ b/src/api/app/models/workflow/step/link_package_step.rb
@@ -83,15 +83,4 @@ class Workflow::Step::LinkPackageStep < ::Workflow::Step
     # "<link package=\"foo\" project=\"bar\" />"
     Nokogiri::XML::Builder.new { |x| x.link(opts) }.doc.root.to_s
   end
-
-  def report_to_scm(workflow_filters)
-    workflow_repositories(target_project_name, workflow_filters).each do |repository|
-      # TODO: Fix n+1 queries
-      workflow_architectures(repository, workflow_filters).each do |architecture|
-        # We cannot report multibuild flavors here... so they will be missing from the initial report
-        SCMStatusReporter.new({ project: target_project_name, package: target_package_name, repository: repository.name, arch: architecture.name },
-                              scm_webhook.payload, @token.scm_token).call
-      end
-    end
-  end
 end


### PR DESCRIPTION
Refactor BranchPackageStep the same way we did with LinkPackageStep.

- Unify variable names
- Simplify methods
- Split creation and update code following the [KISS principle](https://www.interaction-design.org/literature/topics/keep-it-simple-stupid). Except for `create_or_update_subscriptions`.
- Move common code to Workflow::Step

Follow up of #11413

*NOTE:* I tried to make every commit as simple as possible, they can be squash before merging.