### PR TITLE
Add missing "Tokens" link in breadcrumbs in "Trigger Token" page

### DIFF
--- a/src/api/app/views/webui/users/token_triggers/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui/users/token_triggers/_breadcrumb_items.html.haml
@@ -2,5 +2,7 @@
   = link_to('Your Profile', user_path(User.session!))
 
 - if action_name == 'show'
+  %li.breadcrumb-item
+    = link_to 'Tokens', tokens_path
   %li.breadcrumb-item.active{ 'aria-current' => 'page' }
     Trigger Token

--- a/src/api/app/views/webui/users/tokens/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui/users/tokens/_breadcrumb_items.html.haml
@@ -6,12 +6,12 @@
   %li.breadcrumb-item.active{ 'aria-current' => 'page' }
     Tokens
 - when 'new'
-  %li.breadcrumb-item{ 'aria-current' => 'page' }
+  %li.breadcrumb-item
     = link_to 'Tokens', tokens_path
   %li.breadcrumb-item.active{ 'aria-current' => 'page' }
     Create Token
 - when 'edit'
-  %li.breadcrumb-item{ 'aria-current' => 'page' }
+  %li.breadcrumb-item
     = link_to 'Tokens', tokens_path
   %li.breadcrumb-item.active{ 'aria-current' => 'page' }
     Edit Token


### PR DESCRIPTION
Before:

![Screenshot from 2021-09-13 15-59-34](https://user-images.githubusercontent.com/24919/133097414-9c96410b-eddb-44a8-bcb7-6868d31fa483.png)

After:

![Screenshot from 2021-09-13 15-59-53](https://user-images.githubusercontent.com/24919/133097444-54d79b24-f029-4906-81f0-f918f166186e.png)
