### PR TITLE
Enable UI for Flipper

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -58,6 +58,7 @@ gem 'xmlrpc'
 # Multiple feature switch
 gem 'flipper'
 gem 'flipper-active_record'
+gem 'flipper-ui'
 # for kerberos authentication
 gem 'gssapi', require: false
 # for sending events to rabbitmq

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -185,6 +185,11 @@ GEM
     flipper-active_record (0.22.1)
       activerecord (>= 4.2, < 7)
       flipper (~> 0.22.1)
+    flipper-ui (0.22.1)
+      erubi (>= 1.0.0, < 2.0.0)
+      flipper (~> 0.22.1)
+      rack (>= 1.4, < 3)
+      rack-protection (>= 1.5.3, < 2.2.0)
     flot-rails (0.0.7)
       jquery-rails
     font-awesome-sass (5.15.1)
@@ -313,6 +318,8 @@ GEM
       activesupport (>= 3.0.0)
     racc (1.5.2)
     rack (2.2.3)
+    rack-protection (2.1.0)
+      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (6.1.4)
@@ -530,6 +537,7 @@ DEPENDENCIES
   faker
   flipper
   flipper-active_record
+  flipper-ui
   flot-rails
   font-awesome-sass
   gitlab

--- a/src/api/app/lib/routes_helper/role_matcher.rb
+++ b/src/api/app/lib/routes_helper/role_matcher.rb
@@ -1,0 +1,14 @@
+module RoutesHelper
+  class RoleMatcher
+    def self.matches?(request)
+      return false if request.bot?
+
+      return false unless WebuiControllerService::UserChecker.new(http_request: request, config: CONFIG).call
+
+      current_user_login = request.session[:login]
+      current_user = current_user_login.present? ? User.find_by_login(current_user_login) : User.possibly_nobody
+
+      current_user.is_admin? || current_user.is_staff?
+    end
+  end
+end

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -4,6 +4,10 @@ OBSApi::Application.routes.draw do
   constraints(RoutesHelper::WebuiMatcher) do
     root 'webui/main#index'
 
+    constraints(RoutesHelper::RoleMatcher) do
+      mount Flipper::UI.app(Flipper) => '/flipper'
+    end
+
     resources :status_messages, only: [:new, :create, :destroy], controller: 'webui/status_messages'
 
     controller 'webui/feeds' do

--- a/src/api/spec/lib/routes_helper/role_matcher_spec.rb
+++ b/src/api/spec/lib/routes_helper/role_matcher_spec.rb
@@ -1,0 +1,79 @@
+require 'rails_helper'
+
+RSpec.describe RoutesHelper::RoleMatcher do
+  describe '.matches?' do
+    subject { described_class.matches?(request) }
+
+    context 'when the request is from a bot' do
+      let(:request) { instance_double(ActionDispatch::Request, bot?: true) }
+
+      it { is_expected.to eq(false) }
+    end
+
+    context 'when the request is from a user with a disabled account' do
+      let(:request) { instance_double(ActionDispatch::Request, bot?: false) }
+      let(:user_checker) { instance_double(WebuiControllerService::UserChecker, call: false) }
+
+      before do
+        allow(WebuiControllerService::UserChecker).to receive(:new).and_return(user_checker)
+      end
+
+      it { is_expected.to eq(false) }
+    end
+
+    context 'when the request is from an anonymous user' do
+      let(:request) { instance_double(ActionDispatch::Request, bot?: false, session: session) }
+      let(:session) { instance_double(ActionDispatch::Request::Session) }
+      let(:user_checker) { instance_double(WebuiControllerService::UserChecker, call: true) }
+
+      before do
+        allow(WebuiControllerService::UserChecker).to receive(:new).and_return(user_checker)
+        allow(session).to receive(:[]).with(:login).and_return(nil)
+      end
+
+      it { is_expected.to eq(false) }
+    end
+
+    context 'when the request is from a user without any role' do
+      let(:request) { instance_double(ActionDispatch::Request, bot?: false, session: session) }
+      let(:session) { instance_double(ActionDispatch::Request::Session) }
+      let(:user_checker) { instance_double(WebuiControllerService::UserChecker, call: true) }
+      let(:user) { create(:confirmed_user) }
+
+      before do
+        allow(WebuiControllerService::UserChecker).to receive(:new).and_return(user_checker)
+        allow(session).to receive(:[]).with(:login).and_return(user.login)
+      end
+
+      it { is_expected.to eq(false) }
+    end
+
+    context 'when the request is from a staff user' do
+      let(:request) { instance_double(ActionDispatch::Request, bot?: false, session: session) }
+      let(:session) { instance_double(ActionDispatch::Request::Session) }
+      let(:user_checker) { instance_double(WebuiControllerService::UserChecker, call: true) }
+      let(:user) { create(:staff_user) }
+
+      before do
+        allow(WebuiControllerService::UserChecker).to receive(:new).and_return(user_checker)
+        allow(session).to receive(:[]).with(:login).and_return(user.login)
+      end
+
+      it { is_expected.to eq(true) }
+    end
+
+    context 'when the request is from an admin user' do
+      let(:request) { instance_double(ActionDispatch::Request, bot?: false, session: session) }
+      let(:session) { instance_double(ActionDispatch::Request::Session) }
+      let(:user_checker) { instance_double(WebuiControllerService::UserChecker, call: true) }
+      let(:user) { create(:admin_user) }
+
+      before do
+        allow(WebuiControllerService::UserChecker).to receive(:new).and_return(user_checker)
+        allow(session).to receive(:[]).with(:login).and_return(user.login)
+      end
+
+      it { is_expected.to eq(true) }
+    end
+  end
+end


### PR DESCRIPTION
This UI is only available to users with the Staff or Admin roles. It allows us to quickly manage which feature toggles are enabled/disabled without having to run commands directly on the server where our application is hosted. 

Upstream docs for the Flipper UI:
https://github.com/jnunemaker/flipper/blob/4da0b9a596465310882c368fa5292dcbbde48399/docs/ui/README.md

Once this PR is merged, this will have to be documented in our developer wiki: https://github.com/openSUSE/open-build-service/wiki/Feature-Toggles