### PR TITLE
Update influxdb-rail: 1.0.2 → 1.0.3 (minor)

### DIFF
--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -223,7 +223,7 @@ GEM
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     influxdb (0.8.1)
-    influxdb-rails (1.0.2)
+    influxdb-rails (1.0.3)
       influxdb (~> 0.6, >= 0.6.4)
       railties (>= 5.0)
     innertube (1.1.0)


### PR DESCRIPTION
Here is everything you need to know about this update. Please take a good look at what changed and the test results before merging this pull request.

### What changed?

#### ✳️ influxdb-rails (1.0.2 → 1.0.3) · [Repo](https://github.com/influxdata/influxdb-rails/) · [Changelog](https://github.com/influxdata/influxdb-rails/blob/one-stable/CHANGELOG.md)


<details>
<summary>Release Notes</summary>
This release changes how the status of requests that end up in an exception are measured. The ActionController measurement will set the status just like Rails.logger does for some "standard" exceptions like ActiveRecord::RecordNotFound or ActionController::RoutingError. Everything that isn't handled by default in Rails is reported as with a 500 status tag. This makes it easier to distinguish "standard' exceptions from "real" exceptional things.

After dropping support for Ruby 2.4 a while ago, we now require Ruby 2.5.

</details>
