### PR TITLE
Rename source project to project for workflows

### DIFF
--- a/src/api/app/models/workflow/step.rb
+++ b/src/api/app/models/workflow/step.rb
@@ -1,7 +1,6 @@
 class Workflow::Step
   include ActiveModel::Model
 
-  validates :source_project_name, presence: true
   validate :validate_step_instructions
 
   attr_accessor :scm_webhook, :step_instructions, :token
@@ -42,10 +41,6 @@ class Workflow::Step
     self.class::REQUIRED_KEYS.each do |required_key|
       errors.add(:base, "The '#{required_key}' key is missing") unless step_instructions.key?(required_key)
     end
-  end
-
-  def source_project_name
-    step_instructions[:source_project]
   end
 
   def source_package_name

--- a/src/api/app/models/workflow/step/branch_package_step.rb
+++ b/src/api/app/models/workflow/step/branch_package_step.rb
@@ -1,5 +1,7 @@
 class Workflow::Step::BranchPackageStep < ::Workflow::Step
   REQUIRED_KEYS = [:source_project, :source_package].freeze
+
+  validates :source_project_name, presence: true
   validates :source_package_name, presence: true
 
   def call(options = {})
@@ -7,6 +9,10 @@ class Workflow::Step::BranchPackageStep < ::Workflow::Step
 
     workflow_filters = options.fetch(:workflow_filters, {})
     branch_package(workflow_filters)
+  end
+
+  def source_project_name
+    step_instructions[:source_project]
   end
 
   private

--- a/src/api/app/models/workflow/step/configure_repositories.rb
+++ b/src/api/app/models/workflow/step/configure_repositories.rb
@@ -27,6 +27,10 @@ class Workflow::Step::ConfigureRepositories < Workflow::Step
     step_instructions[:project]
   end
 
+  def target_project_name
+    "home:#{@token.user.login}:#{project_name}:PR-#{scm_webhook.payload[:pr_number]}"
+  end
+
   private
 
   def validate_repositories

--- a/src/api/app/models/workflow/step/configure_repositories.rb
+++ b/src/api/app/models/workflow/step/configure_repositories.rb
@@ -1,7 +1,8 @@
 class Workflow::Step::ConfigureRepositories < Workflow::Step
-  REQUIRED_KEYS = [:source_project, :repositories].freeze
+  REQUIRED_KEYS = [:project, :repositories].freeze
   REQUIRED_REPOSITORY_KEYS = [:architectures, :name, :target_project, :target_repository].freeze
 
+  validates :project_name, presence: true
   validate :validate_repositories
   validate :validate_architectures
 
@@ -20,6 +21,10 @@ class Workflow::Step::ConfigureRepositories < Workflow::Step
         repository.architectures << @supported_architectures.select { |architecture| architecture.name == architecture_name }
       end
     end
+  end
+
+  def project_name
+    step_instructions[:project]
   end
 
   private

--- a/src/api/app/models/workflow/step/link_package_step.rb
+++ b/src/api/app/models/workflow/step/link_package_step.rb
@@ -1,5 +1,7 @@
 class Workflow::Step::LinkPackageStep < ::Workflow::Step
   REQUIRED_KEYS = [:source_project, :source_package].freeze
+
+  validates :source_project_name, presence: true
   validates :source_package_name, presence: true
 
   def call(options = {})
@@ -7,6 +9,10 @@ class Workflow::Step::LinkPackageStep < ::Workflow::Step
 
     workflow_filters = options.fetch(:workflow_filters, {})
     link_package(workflow_filters)
+  end
+
+  def source_project_name
+    step_instructions[:source_project]
   end
 
   private

--- a/src/api/spec/models/workflow/step/configure_repositories_spec.rb
+++ b/src/api/spec/models/workflow/step/configure_repositories_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Workflow::Step::ConfigureRepositories do
     let(:target_project) { create(:project, name: target_project_name) }
     let(:step_instructions) do
       {
-        source_project: 'OBS:Server:Unstable',
+        project: 'OBS:Server:Unstable',
         repositories:
           [
             {
@@ -83,7 +83,7 @@ RSpec.describe Workflow::Step::ConfigureRepositories do
       context 'and there is no source project in the configuration file' do
         let(:step_instructions) do
           {
-            project: 'OBS:Server:Unstable',
+            fake_project: 'OBS:Server:Unstable',
             repositories:
               [
                 {
@@ -109,16 +109,16 @@ RSpec.describe Workflow::Step::ConfigureRepositories do
           expect { subject.call({}) }.not_to change(Architecture, :count)
         end
 
-        it 'a validation fails complaining about a missing source project' do
+        it 'a validation fails complaining about a missing project' do
           subject.call
-          expect(subject.errors.full_messages).to include("Source project name can't be blank")
+          expect(subject.errors.full_messages).to include("Project name can't be blank")
         end
       end
 
       context 'and there is no target project defined in the repository definition' do
         let(:step_instructions) do
           {
-            source_project: 'OBS:Server:Unstable',
+            project: 'OBS:Server:Unstable',
             repositories:
               [
                 {
@@ -143,7 +143,7 @@ RSpec.describe Workflow::Step::ConfigureRepositories do
       context 'and there is no target repository in the repository definition' do
         let(:step_instructions) do
           {
-            source_project: 'OBS:Server:Unstable',
+            project: 'OBS:Server:Unstable',
             repositories:
               [
                 {
@@ -168,7 +168,7 @@ RSpec.describe Workflow::Step::ConfigureRepositories do
       context 'and the target repository already exist in the database' do
         let(:step_instructions) do
           {
-            source_project: 'OBS:Server:Unstable',
+            project: 'OBS:Server:Unstable',
             repositories:
               [
                 {
@@ -196,7 +196,7 @@ RSpec.describe Workflow::Step::ConfigureRepositories do
       context 'and there are no architectures in the repository definition' do
         let(:step_instructions) do
           {
-            source_project: 'OBS:Server:Unstable',
+            project: 'OBS:Server:Unstable',
             repositories:
               [
                 {
@@ -218,7 +218,7 @@ RSpec.describe Workflow::Step::ConfigureRepositories do
       context "and the architectures in the repository definition don't exist" do
         let(:step_instructions) do
           {
-            source_project: 'OBS:Server:Unstable',
+            project: 'OBS:Server:Unstable',
             repositories:
               [
                 {
@@ -254,7 +254,7 @@ RSpec.describe Workflow::Step::ConfigureRepositories do
     context 'when there is no target project in the database' do
       let(:step_instructions) do
         {
-          source_project: 'OBS:Server:Unstable',
+          project: 'OBS:Server:Unstable',
           repositories:
             [
               {

--- a/src/api/spec/models/workflow_spec.rb
+++ b/src/api/spec/models/workflow_spec.rb
@@ -142,8 +142,8 @@ RSpec.describe Workflow, type: :model do
 
       it 'sets validation errors' do
         expect(subject.errors.full_messages).to match_array(
-          ["Invalid workflow step definition: Source project name can't be blank, The 'source_project' key is missing, The 'source_package' key is missing, \
-and Source package name can't be blank"]
+          ["Invalid workflow step definition: The 'source_project' key is missing, The 'source_package' key is missing, \
+Source project name can't be blank, and Source package name can't be blank"]
         )
       end
     end
@@ -169,8 +169,8 @@ and Source package name can't be blank"]
 
       it 'sets validation errors' do
         expect(subject.errors.full_messages).to match_array(
-          ["Invalid workflow step definition: unsupported_step_1 is not a supported step, Source project name can't be blank, \
-The 'source_package' key is missing, and Source package name can't be blank"]
+          ["Invalid workflow step definition: unsupported_step_1 is not a supported step, The 'source_package' key is missing, \
+Source project name can't be blank, and Source package name can't be blank"]
         )
       end
     end


### PR DESCRIPTION
Replace `source_project` by `project` in ConfigureRepositoriesStep 

The 'source_project_name' shouldn't be required for ConfigureRepositoriesStep anymore. For this step, I create a new method `project_name` and add the corresponding validation.

As a consequence, the `target_project_name` method is affected so the definition is moved to each type of step: BranchPackageStep, LinkPackageStep and ConfigureRepositoriesStep