### PR TITLE
[backend] Add experimental forcebinaryidmeta build flag

### DIFF
--- a/src/backend/BSSched/BuildJob.pm
+++ b/src/backend/BSSched/BuildJob.pm
@@ -311,6 +311,7 @@ sub writejob {
   $binfo->{'srcserver'} ||= $workersrcserver;
   $binfo->{'reposerver'} ||= $workerreposerver;
   $binfo->{'genmetaalgo'} = $ctx->{'genmetaalgo'} if $ctx->{'genmetaalgo'};
+  $binfo->{'forcebinaryidmeta'} = $ctx->{'forcebinaryidmeta'} if $ctx->{'forcebinaryidmeta'};
 
   my $myjobsdir = $gctx->{'myjobsdir'};
   $ctx->{'otherjobscache'} ||= [ grep {/-[0-9a-f]{32}$/} grep {!/^\./} ls($myjobsdir) ];

--- a/src/backend/BSSched/Checker.pm
+++ b/src/backend/BSSched/Checker.pm
@@ -341,6 +341,7 @@ sub setup {
   BSBuild::setgenmetaalgo($genmetaalgo);
   BSSolv::setgenmetaalgo($genmetaalgo) if $gctx->{'maxgenmetaalgo'};
   $ctx->{'genmetaalgo'} = $genmetaalgo;
+  $ctx->{'forcebinaryidmeta'} = 1 if $bconf->{'buildflags:forcebinaryidmeta'};
 
   # check for package blacklist
   if (exists $bconf->{'buildflags:excludebuild'}) {

--- a/src/backend/BSSched/Checker.pm
+++ b/src/backend/BSSched/Checker.pm
@@ -859,6 +859,11 @@ sub calcrelsynctrigger {
   my $gdst = $ctx->{'gdst'};
   my $projid = $ctx->{'project'};
 
+  if ($ctx->{'conf'}->{'buildflags:norelsync'}) {
+    $ctx->{'relsynctrigger'} = {};
+    $ctx->{'relsyncmax'} = undef;
+    return;
+  }
   my $relsyncmax;
   my %relsynctrigger;
 

--- a/src/backend/BSSched/Modulemd.pm
+++ b/src/backend/BSSched/Modulemd.pm
@@ -109,9 +109,9 @@ sub extend_modules {
   my ($versionprefix, $distprefix, @distprovides) = split(':', $pfdata);
   # automatically enable the module we're building
   if (!$bconf->{'expandflags:noautoenablemodule'}) {
-    my $ourmodule = "$modulemd->{'name'}:$modulemd->{'stream'}";
+    my $ourmodule = "$modulemd->{'name'}-$modulemd->{'stream'}";
     if (!grep {$_ eq $ourmodule} @{$bconf->{'modules'} || []}) {
-      $bconf->{'modules'} = [ sort (@{$bconf->{'modules'}}, $ourmodule) ];
+      $bconf->{'modules'} = [ sort (@{$bconf->{'modules'} || []}, $ourmodule) ];
     }
   }
   my %distprovides = map {$_ => 1} @distprovides;

--- a/src/backend/BSXML.pm
+++ b/src/backend/BSXML.pm
@@ -571,6 +571,7 @@ our $buildinfo = [
 	'nodbgpkgs',	# kiwi
 	'nosrcpkgs',	# kiwi
 	'genmetaalgo',	# internal
+	'forcebinaryidmeta',	# internal
 	'logidlelimit',	# internal
 	'logsizelimit',	# internal
 	'genbuildreqs',	# internal

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -2004,6 +2004,7 @@ sub getpreinstallimage {
     my $server = $repo->{'server'} || $buildinfo->{'reposerver'};
     my $nometa = $repo->{'project'} ne $projid || $repo->{'repository'} ne $repoid ? 1 : 0;
     $nometa = 1 if $buildinfo->{'file'} eq '_preinstallimage';
+    $nometa = 1 if $buildinfo->{'forcebinaryidmeta'};
     $nometa = 1 if $buildinfo->{'crossarch'};	# preinstallimage is always native
     my $callers_time = time();
     my @args;
@@ -2612,9 +2613,9 @@ sub getbinaries {
   for my $repo (@{$buildinfo->{'path'} || []}) {
     last unless @todo;
     my $repoprp = "$repo->{'project'}/$repo->{'repository'}";
-    my $nometa = 0;
-    $nometa = 1 if $repo->{'project'} ne $projid || $repo->{'repository'} ne $repoid;
+    my $nometa = $repo->{'project'} ne $projid || $repo->{'repository'} ne $repoid ? 1 : 0;
     $nometa = 1 if $buildinfo->{'file'} eq '_preinstallimage';
+    $nometa = 1 if $buildinfo->{'forcebinaryidmeta'};
     my $server = $repo->{'server'} || $buildinfo->{'reposerver'};
     my $arch = $buildinfo->{'arch'};
     my $binaryprefix = $cross ? '__sysroot__' : '';


### PR DESCRIPTION
This always uses the binary id instead of the sourcemd5 in
the meta file. Turning this on easily leads to endless rebuilds
if the project contains build cycles and there is no other
means like build compare to end builds.