### PR TITLE
Add helper methods for push events to SCMWebhook model

### DIFF
--- a/src/api/app/models/scm_webhook.rb
+++ b/src/api/app/models/scm_webhook.rb
@@ -32,7 +32,19 @@ class ScmWebhook
       (gitlab_merge_request? && @payload[:action] == 'reopen')
   end
 
+  def push_event?
+    github_push_event? || gitlab_push_event?
+  end
+
   private
+
+  def github_push_event?
+    @payload[:scm] == 'github' && @payload[:event] == 'push'
+  end
+
+  def gitlab_push_event?
+    @payload[:scm] == 'gitlab' && @payload[:event] == 'Push Hook'
+  end
 
   def github_pull_request?
     @payload[:scm] == 'github' && @payload[:event] == 'pull_request'

--- a/src/api/spec/models/scm_webhook_spec.rb
+++ b/src/api/spec/models/scm_webhook_spec.rb
@@ -190,4 +190,38 @@ RSpec.describe ScmWebhook, type: :model do
       it { is_expected.to be true }
     end
   end
+
+  describe '#push_event?' do
+    subject { described_class.new(payload: payload).push_event? }
+
+    context 'for an unsupported SCM' do
+      let(:payload) { { scm: 'GitHoob', event: 'push' } }
+
+      it { is_expected.to be false }
+    end
+
+    context 'for an unsupported event from GitHub' do
+      let(:payload) { { scm: 'github', event: 'something' } }
+
+      it { is_expected.to be false }
+    end
+
+    context 'for an unsupported event from GitLab' do
+      let(:payload) { { scm: 'gitlab', event: 'something' } }
+
+      it { is_expected.to be false }
+    end
+
+    context 'for a push event from GitHub' do
+      let(:payload) { { scm: 'github', event: 'push' } }
+
+      it { is_expected.to be true }
+    end
+
+    context 'for a push event from GitLab' do
+      let(:payload) { { scm: 'gitlab', event: 'Push Hook' } }
+
+      it { is_expected.to be true }
+    end
+  end
 end


### PR DESCRIPTION
We need those helper methods to identify push events when
running the workflows