### PR TITLE
Remove duplicated validation in branch and link package step

### DIFF
--- a/src/api/app/models/workflow/step.rb
+++ b/src/api/app/models/workflow/step.rb
@@ -39,12 +39,21 @@ class Workflow::Step
 
   def validate_step_instructions
     self.class::REQUIRED_KEYS.each do |required_key|
-      errors.add(:base, "The '#{required_key}' key is missing") unless step_instructions.key?(required_key)
+      unless step_instructions.key?(required_key)
+        errors.add(:base, "The '#{required_key}' key is missing")
+        next
+      end
+
+      errors.add(:base, "The '#{required_key}' key must provide a value") if step_instructions[required_key].blank?
     end
   end
 
   def source_package_name
     step_instructions[:source_package]
+  end
+
+  def source_project_name
+    step_instructions[:source_project]
   end
 
   def target_package_name

--- a/src/api/app/models/workflow/step/branch_package_step.rb
+++ b/src/api/app/models/workflow/step/branch_package_step.rb
@@ -1,18 +1,11 @@
 class Workflow::Step::BranchPackageStep < ::Workflow::Step
   REQUIRED_KEYS = [:source_project, :source_package].freeze
 
-  validates :source_project_name, presence: true
-  validates :source_package_name, presence: true
-
   def call(options = {})
     return unless valid?
 
     workflow_filters = options.fetch(:workflow_filters, {})
     branch_package(workflow_filters)
-  end
-
-  def source_project_name
-    step_instructions[:source_project]
   end
 
   private

--- a/src/api/app/models/workflow/step/configure_repositories.rb
+++ b/src/api/app/models/workflow/step/configure_repositories.rb
@@ -2,7 +2,6 @@ class Workflow::Step::ConfigureRepositories < Workflow::Step
   REQUIRED_KEYS = [:project, :repositories].freeze
   REQUIRED_REPOSITORY_KEYS = [:architectures, :name, :target_project, :target_repository].freeze
 
-  validates :project_name, presence: true
   validate :validate_repositories
   validate :validate_architectures
 

--- a/src/api/app/models/workflow/step/link_package_step.rb
+++ b/src/api/app/models/workflow/step/link_package_step.rb
@@ -1,18 +1,11 @@
 class Workflow::Step::LinkPackageStep < ::Workflow::Step
   REQUIRED_KEYS = [:source_project, :source_package].freeze
 
-  validates :source_project_name, presence: true
-  validates :source_package_name, presence: true
-
   def call(options = {})
     return unless valid?
 
     workflow_filters = options.fetch(:workflow_filters, {})
     link_package(workflow_filters)
-  end
-
-  def source_project_name
-    step_instructions[:source_project]
   end
 
   private

--- a/src/api/spec/models/workflow/step/configure_repositories_spec.rb
+++ b/src/api/spec/models/workflow/step/configure_repositories_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe Workflow::Step::ConfigureRepositories do
 
         it 'a validation fails complaining about a missing project' do
           subject.call
-          expect(subject.errors.full_messages).to include("Project name can't be blank")
+          expect(subject.errors.full_messages).to include("The 'project' key is missing")
         end
       end
 

--- a/src/api/spec/validators/workflow_steps_validator_spec.rb
+++ b/src/api/spec/validators/workflow_steps_validator_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe WorkflowStepsValidator do
       it 'is not valid and has an error message' do
         subject.valid?
         expect(subject.errors.full_messages.to_sentence).to eq("The following workflow steps are unsupported: 'unsupported_step' and " \
-                                                               "The 'source_package' key is missing and Source package name can't be blank")
+                                                               "The 'source_package' key is missing")
       end
     end
   end


### PR DESCRIPTION
The super class of the steps already takes care of validating
the presence of the source package and source project names through
the REQUIRED_KEYS constant.