### PR TITLE
Adapt ScmExtractor to support push events

### DIFF
--- a/src/api/app/services/trigger_controller_service/scm_extractor.rb
+++ b/src/api/app/services/trigger_controller_service/scm_extractor.rb
@@ -21,36 +21,62 @@ module TriggerControllerService
     private
 
     def github_extractor_payload
-      {
+      payload = {
         scm: 'github',
-        commit_sha: @payload.dig(:pull_request, :head, :sha),
-        pr_number: @payload[:number],
-        source_branch: @payload.dig(:pull_request, :head, :ref),
-        target_branch: @payload.dig(:pull_request, :base, :ref),
-        action: @payload[:action], # TODO: Names may differ, maybe we need to find our own naming (defer to service?)
-        source_repository_full_name: @payload.dig(:pull_request, :head, :repo, :full_name),
-        target_repository_full_name: @payload.dig(:pull_request, :base, :repo, :full_name),
         event: @event,
         api_endpoint: github_api_endpoint
       }
+
+      case @event
+      when 'pull_request'
+        payload.merge!({ commit_sha: @payload.dig(:pull_request, :head, :sha),
+                         pr_number: @payload[:number],
+                         source_branch: @payload.dig(:pull_request, :head, :ref),
+                         target_branch: @payload.dig(:pull_request, :base, :ref),
+                         action: @payload[:action],
+                         source_repository_full_name: @payload.dig(:pull_request, :head, :repo, :full_name),
+                         target_repository_full_name: @payload.dig(:pull_request, :base, :repo, :full_name) })
+      when 'push'
+        payload.merge!({ commit_sha: @payload[:after],
+                         # We need this for Workflows::YAMLDownloader#download_url
+                         target_branch: @payload[:ref].sub('refs/heads/', ''),
+                         # We need this for Workflow::Step#branch_request_content_github
+                         source_repository_full_name: @payload.dig(:repository, :full_name),
+                         # We need this for SCMStatusReporter#call
+                         target_repository_full_name: @payload.dig(:repository, :full_name) })
+      end
+      payload
     end
 
     def gitlab_extractor_payload
       http_url = @payload.dig(:project, :http_url)
-      {
+
+      payload = {
         scm: 'gitlab',
         object_kind: @payload[:object_kind],
         http_url: http_url,
-        commit_sha: @payload.dig(:object_attributes, :last_commit, :id),
-        pr_number: @payload.dig(:object_attributes, :iid),
-        source_branch: @payload.dig(:object_attributes, :source_branch),
-        target_branch: @payload.dig(:object_attributes, :target_branch),
-        action: @payload.dig(:object_attributes, :action), # TODO: Names may differ, maybe we need to find our own naming (defer to service?)
-        project_id: @payload.dig(:object_attributes, :source_project_id),
-        path_with_namespace: @payload.dig(:project, :path_with_namespace),
         event: @event,
         api_endpoint: gitlab_api_endpoint(http_url)
       }
+
+      case @event
+      when 'Merge Request Hook'
+        payload.merge!({ commit_sha: @payload.dig(:object_attributes, :last_commit, :id),
+                         pr_number: @payload.dig(:object_attributes, :iid),
+                         source_branch: @payload.dig(:object_attributes, :source_branch),
+                         target_branch: @payload.dig(:object_attributes, :target_branch),
+                         action: @payload.dig(:object_attributes, :action),
+                         project_id: @payload.dig(:object_attributes, :source_project_id),
+                         path_with_namespace: @payload.dig(:project, :path_with_namespace) })
+      when 'Push Hook'
+        payload.merge!({ commit_sha: @payload[:after],
+                         # We need this for Workflows::YAMLDownloader#download_url
+                         target_branch: @payload[:ref].sub('refs/heads/', ''),
+                         # We need this for Workflows::YAMLDownloader#download_url
+                         path_with_namespace: @payload.dig(:project, :path_with_namespace),
+                         project_id: @payload[:project_id] })
+      end
+      payload
     end
 
     def github_api_endpoint

--- a/src/api/spec/models/token/workflow_spec.rb
+++ b/src/api/spec/models/token/workflow_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Token::Workflow, vcr: true do
       context 'when the SCM is GitHub' do
         it_behaves_like 'not-allowed event or action' do
           let(:scm) { 'github' }
-          let(:event) { 'push' }
+          let(:event) { 'synchronize' }
           let(:payload) { github_payload }
         end
       end
@@ -86,7 +86,7 @@ RSpec.describe Token::Workflow, vcr: true do
       context 'when the SCM is GitLab' do
         it_behaves_like 'not-allowed event or action' do
           let(:scm) { 'gitlab' }
-          let(:event) { 'Push Hook' }
+          let(:event) { 'Issue Hook' }
           let(:payload) { gitlab_payload }
         end
       end

--- a/src/api/spec/services/trigger_controller_service/scm_extractor_spec.rb
+++ b/src/api/spec/services/trigger_controller_service/scm_extractor_spec.rb
@@ -6,117 +6,188 @@ RSpec.describe TriggerControllerService::ScmExtractor do
       described_class.new(scm, event, payload).call
     end
 
-    context 'when the scm is github' do
-      let(:scm) { 'github' }
-      let(:event) { 'pull_request' }
-      let(:payload) do
-        {
-          action: 'opened',
-          pull_request: {
-            head: {
-              repo: {
-                full_name: 'iggy/source_repo'
-              },
-              ref: 'add-changes',
-              sha: '9e0ea1fd99c9000cbb8b8c9d28763d0ddace0b65'
-            },
-            base: {
-              repo: {
-                full_name: 'iggy/target_repo'
-              },
-              ref: 'main'
-            }
-          },
-          project: {
-            http_url: 'https://gitlab.com/eduardoj2/test.git',
-            id: 26_212_710,
-            path_with_namespace: 'eduardoj2/test'
-          },
-          number: 4,
-          sender: {
-            url: 'https://api.github.com'
-          }
-        }
-      end
-      let(:expected_hash) do
-        {
-          scm: 'github',
-          commit_sha: '9e0ea1fd99c9000cbb8b8c9d28763d0ddace0b65',
-          pr_number: 4,
-          source_branch: 'add-changes',
-          target_branch: 'main',
-          action: 'opened',
-          source_repository_full_name: 'iggy/source_repo',
-          target_repository_full_name: 'iggy/target_repo',
-          event: 'pull_request',
-          api_endpoint: 'https://api.github.com'
-        }
-      end
-
-      it 'returns an instance of ScmWebhook with the extracted data from the GitHub payload' do
-        expect(scm_webhook).to be_instance_of(ScmWebhook)
-        expect(scm_webhook.payload).to include(expected_hash)
-      end
-    end
-
-    context 'when the scm is gitlab' do
-      let(:scm) { 'gitlab' }
-      let(:event) { 'merge_request' }
-      let(:payload) do
-        {
-          object_kind: 'merge_request',
-          project: {
-            http_url: 'https://gitlab.com/eduardoj2/test.git',
-            path_with_namespace: 'eduardoj2/test'
-          },
-          object_attributes: {
-            last_commit: {
-              id: '4b486afefa44177f23b4388d2147ae42407e7f64'
-            },
-            iid: 3,
-            source_project_id: 26_212_710,
-            source_branch: 'nuevo',
-            target_branch: 'master',
-            action: 'open'
-          },
-          action: 'opened'
-        }
-      end
-      let(:expected_hash) do
-        {
-          scm: 'gitlab',
-          object_kind: 'merge_request',
-          http_url: 'https://gitlab.com/eduardoj2/test.git',
-          commit_sha: '4b486afefa44177f23b4388d2147ae42407e7f64',
-          pr_number: 3,
-          source_branch: 'nuevo',
-          target_branch: 'master',
-          action: 'open',
-          project_id: 26_212_710,
-          path_with_namespace: 'eduardoj2/test',
-          event: 'merge_request'
-        }
-      end
-
-      it 'returns an instance of ScmWebhook with the extracted data from the GitLab payload' do
-        expect(scm_webhook).to be_instance_of(ScmWebhook)
-        expect(scm_webhook.payload).to include(expected_hash)
-      end
-    end
-
-    context 'when the scm is neither github nor gitlab' do
+    context 'when the SCM is unsupported' do
       let(:scm) { 'phabricator' }
-      let(:event) { 'dont care' }
+      let(:event) { 'something' }
       let(:payload) { {} }
 
-      it 'returns nil' do
-        expect(scm_webhook).to be_nil
+      it { expect(scm_webhook).to be_nil }
+    end
+
+    context 'when the SCM is GitHub' do
+      let(:scm) { 'github' }
+
+      context 'for a pull request event' do
+        let(:event) { 'pull_request' }
+        let(:payload) do
+          {
+            action: 'opened',
+            pull_request: {
+              head: {
+                repo: {
+                  full_name: 'iggy/source_repo'
+                },
+                ref: 'add-changes',
+                sha: '9e0ea1fd99c9000cbb8b8c9d28763d0ddace0b65'
+              },
+              base: {
+                repo: {
+                  full_name: 'iggy/target_repo'
+                },
+                ref: 'main'
+              }
+            },
+            project: {
+              http_url: 'https://gitlab.com/eduardoj2/test.git',
+              id: 26_212_710,
+              path_with_namespace: 'eduardoj2/test'
+            },
+            number: 4,
+            sender: {
+              url: 'https://api.github.com'
+            }
+          }
+        end
+        let(:expected_hash) do
+          {
+            scm: 'github',
+            commit_sha: '9e0ea1fd99c9000cbb8b8c9d28763d0ddace0b65',
+            pr_number: 4,
+            source_branch: 'add-changes',
+            target_branch: 'main',
+            action: 'opened',
+            source_repository_full_name: 'iggy/source_repo',
+            target_repository_full_name: 'iggy/target_repo',
+            event: 'pull_request',
+            api_endpoint: 'https://api.github.com'
+          }
+        end
+
+        it 'returns an instance of ScmWebhook with the extracted data from the GitHub payload' do
+          expect(scm_webhook).to be_instance_of(ScmWebhook)
+          expect(scm_webhook.payload).to eq(expected_hash)
+        end
+      end
+
+      context 'for a push event' do
+        let(:event) { 'push' }
+        let(:payload) do
+          {
+            ref: 'refs/heads/main/fix-bug',
+            after: '9e0ea1fd99c9000cbb8b8c9d28763d0ddace0b65',
+            repository: {
+              full_name: 'iggy/repo123'
+            },
+            sender: {
+              url: 'https://api.github.com'
+            }
+          }
+        end
+        let(:expected_hash) do
+          {
+            scm: 'github',
+            event: 'push',
+            api_endpoint: 'https://api.github.com',
+            commit_sha: '9e0ea1fd99c9000cbb8b8c9d28763d0ddace0b65',
+            target_branch: 'main/fix-bug',
+            source_repository_full_name: 'iggy/repo123',
+            target_repository_full_name: 'iggy/repo123'
+          }
+        end
+
+        it 'returns an instance of ScmWebhook with the extracted data from the GitHub payload' do
+          expect(scm_webhook).to be_instance_of(ScmWebhook)
+          expect(scm_webhook.payload).to eq(expected_hash)
+        end
+      end
+    end
+
+    context 'when the SCM is GitLab' do
+      let(:scm) { 'gitlab' }
+
+      context 'for a merge request event' do
+        let(:event) { 'Merge Request Hook' }
+        let(:payload) do
+          {
+            object_kind: 'merge_request',
+            project: {
+              http_url: 'https://gitlab.com/eduardoj2/test.git',
+              path_with_namespace: 'eduardoj2/test'
+            },
+            object_attributes: {
+              last_commit: {
+                id: '4b486afefa44177f23b4388d2147ae42407e7f64'
+              },
+              iid: 3,
+              source_project_id: 26_212_710,
+              source_branch: 'nuevo',
+              target_branch: 'master',
+              action: 'open'
+            },
+            action: 'opened'
+          }
+        end
+        let(:expected_hash) do
+          {
+            scm: 'gitlab',
+            object_kind: 'merge_request',
+            http_url: 'https://gitlab.com/eduardoj2/test.git',
+            commit_sha: '4b486afefa44177f23b4388d2147ae42407e7f64',
+            pr_number: 3,
+            source_branch: 'nuevo',
+            target_branch: 'master',
+            action: 'open',
+            project_id: 26_212_710,
+            path_with_namespace: 'eduardoj2/test',
+            event: 'Merge Request Hook',
+            api_endpoint: 'https://gitlab.com'
+          }
+        end
+
+        it 'returns an instance of ScmWebhook with the extracted data from the GitLab payload' do
+          expect(scm_webhook).to be_instance_of(ScmWebhook)
+          expect(scm_webhook.payload).to eq(expected_hash)
+        end
+      end
+
+      context 'for a push event' do
+        let(:event) { 'Push Hook' }
+        let(:payload) do
+          {
+            object_kind: 'push',
+            ref: 'refs/heads/main/fix-bug',
+            after: '9e0ea1fd99c9000cbb8b8c9d28763d0ddace0b65',
+            project_id: 3,
+            project: {
+              http_url: 'https://gitlab.com/eduardoj2/test.git',
+              path_with_namespace: 'eduardoj2/test'
+            }
+          }
+        end
+        let(:expected_hash) do
+          {
+            scm: 'gitlab',
+            object_kind: 'push',
+            http_url: 'https://gitlab.com/eduardoj2/test.git',
+            commit_sha: '9e0ea1fd99c9000cbb8b8c9d28763d0ddace0b65',
+            target_branch: 'main/fix-bug',
+            project_id: 3,
+            path_with_namespace: 'eduardoj2/test',
+            event: 'Push Hook',
+            api_endpoint: 'https://gitlab.com'
+          }
+        end
+
+        it 'returns an instance of ScmWebhook with the extracted data from the GitLab payload' do
+          expect(scm_webhook).to be_instance_of(ScmWebhook)
+          expect(scm_webhook.payload).to eq(expected_hash)
+        end
       end
     end
 
     context 'when some of the payload keys are missing' do
       let(:scm) { 'gitlab' }
-      let(:event) { 'merge_request' }
+      let(:event) { 'Merge Request Hook' }
       let(:payload) do
         {
           project: {
@@ -135,7 +206,7 @@ RSpec.describe TriggerControllerService::ScmExtractor do
           action: nil,
           project_id: nil,
           path_with_namespace: nil,
-          event: 'merge_request',
+          event: 'Merge Request Hook',
           api_endpoint: 'https://gitlab.com',
           http_url: 'https://gitlab.com/eduardoj2/test.git'
         }
@@ -143,7 +214,7 @@ RSpec.describe TriggerControllerService::ScmExtractor do
 
       it 'returns an instance of ScmWebhook with the extracted data' do
         expect(scm_webhook).to be_instance_of(ScmWebhook)
-        expect(scm_webhook.payload).to include(expected_hash)
+        expect(scm_webhook.payload).to eq(expected_hash)
       end
     end
   end


### PR DESCRIPTION
Details on the webhook payloads:
- [GitHub push](https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#push)
- [GitLab push](https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#push-events) 