### PR TITLE
[backend] suppor the 'lastbuild' option in docommand

### DIFF
--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -3001,7 +3001,21 @@ sub docommand {
     if (%code) {
       my $ps = readpackstatus($prpa);
       fixpackstatus($prpa, $ps, \%buildingjobs);
-      @packids = grep {$code{$ps->{'packstatus'}->{$_} || 'unknown'}} @packids;
+      if ($cgi->{'lastbuild'}) {
+	for my $packid (splice @packids) {
+	  my $code;
+	  if (-e "$reporoot/$prpa/:logfiles.fail/$packid") {
+	    $code = 'failed';
+	  } elsif (-e "$reporoot/$prpa/:logfiles.success/$packid") {
+	    $code = 'succeeded';
+	  } else {
+	    $code = $ps->{'packstatus'}->{$packid} || 'unknown';
+	  }
+	  push @packids, $packid if $code{$code};
+	}
+      } else {
+        @packids = grep {$code{$ps->{'packstatus'}->{$_} || 'unknown'}} @packids;
+      }
     }
     if ($cmd eq 'rebuild') {
       if (@packids) {
@@ -4445,7 +4459,7 @@ my $dispatches = [
 
   '/_result $prpa+ oldstate:md5? package* code:* lastbuild:bool? withbinarylist:bool? withstats:bool? summary:bool? withversrel:bool?' => \&getresult,
   '/_jobhistory $prpa+ package* code:* limit:num? endtime_start:num? endtime_end:num?' => \&getjobhistory_project,
-  'POST:/_command $cmd: $prpa+ package* code:* sysrq:?' => \&docommand,
+  'POST:/_command $cmd: $prpa+ package* code:* lastbuild:bool? sysrq:?' => \&docommand,
 
   '/serverstatus' => \&BSStdServer::serverstatus,
   '/ajaxstatus' => \&getajaxstatus,

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -4162,6 +4162,7 @@ sub docommand {
   my $reposerver = $BSConfig::partitioning ? BSSrcServer::Partition::projid2reposerver($projid) : $BSConfig::reposerver;
   my $res;
   my @args;
+  push @args, 'lastbuild' if $cgi->{'lastbuild'};
   push @args, map {"prpa=$_"} @prpas;
   push @args, map {"package=$_"} @packids;
   push @args, map {"code=$_"} @{$cgi->{'code'} || []};
@@ -7308,7 +7309,7 @@ my $dispatches = [
   'PUT:/build/_dispatchprios' => \&putdispatchprios,
   '/build/_dispatchprios' => \&getdispatchprios,
   '/build/$project/_availablebinaries url:* path:prp* arch*' => \&getavailablebinaries,
-  'POST:/build/$project cmd: repository* arch* package* code:* wipe:* comment:? sysrq:?' => \&docommand,
+  'POST:/build/$project cmd: repository* arch* package* code:* lastbuild:bool? wipe:* comment:? sysrq:?' => \&docommand,
   '/build/$project' => \&getrepositorylist,
   '/build/$project/_result oldstate:md5? view:resultview* lastbuild:bool? repository* arch* package* code:* multibuild:bool? locallink:bool?' => \&getresult,
   '/build/$project/_jobhistory package* code:* limit:num? endtime_start:num? endtime_end:num?' => \&getjobhistory_project,


### PR DESCRIPTION
This can be used to trigger a package rebuild even if the package
is currently blocked (e.g. because of cycle builds).