### PR TITLE
Label PRs with Markdown files

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -7,6 +7,7 @@ Backend:
 
 "Documentation :book:":
 - docs/**/*
+- '**/*.md'
 
 "Test Suite / CI :syringe:":
 - .circleci/**/*


### PR DESCRIPTION
Quotes are needed to prevent a `YAMLException: unidentified alias` error.