### PR TITLE
Update bundler version 2.2.27

### DIFF
--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -598,4 +598,4 @@ DEPENDENCIES
   yajl-ruby
 
 BUNDLED WITH
-   1.17.2
+   2.2.27

--- a/src/api/Gemfile.next.lock
+++ b/src/api/Gemfile.next.lock
@@ -581,4 +581,4 @@ DEPENDENCIES
   yajl-ruby
 
 BUNDLED WITH
-   1.17.2
+   2.2.27


### PR DESCRIPTION
The [package in O:S:U](https://build.opensuse.org/package/show/OBS:Server:Unstable/rubygem-bundler) is updated, the container is on it's way.