### PR TITLE
Revert "Update bundler version 2.2.27"

### DIFF
--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -598,4 +598,4 @@ DEPENDENCIES
   yajl-ruby
 
 BUNDLED WITH
-   2.2.27
+   1.17.2

--- a/src/api/Gemfile.next.lock
+++ b/src/api/Gemfile.next.lock
@@ -581,4 +581,4 @@ DEPENDENCIES
   yajl-ruby
 
 BUNDLED WITH
-   2.2.27
+   1.17.2


### PR DESCRIPTION
Reverts openSUSE/open-build-service#11682

Again some problems with obs-service-bundle_gems that need fixing there first....