### PR TITLE
Update brakeman to fix false positive warnings for view components

### DIFF
--- a/src/api/docker-files/Dockerfile
+++ b/src/api/docker-files/Dockerfile
@@ -9,7 +9,7 @@ ARG CONTAINER_USERID
 # for lint task
 RUN npm install -g jshint
 # Same brakeman version is pinned in our CI configuration to have reproducible builds (the license forbids us from shipping the gem in our appliance)
-RUN gem install --no-format-executable brakeman --version 5.0.2
+RUN gem install --no-format-executable brakeman --version 5.1.1
 
 # Configure our user
 RUN usermod -u $CONTAINER_USERID frontend


### PR DESCRIPTION
We use [brakeman](https://github.com/presidentbeef/brakeman) in the code checkout pipeline. It throws false positive warnings for view components that are fixed in the later version. For more details see this [issue](https://github.com/presidentbeef/brakeman/issues/1616)