### PR TITLE
[backend] add hdrmd5 as part of buildinfo

### DIFF
--- a/src/backend/BSSched/BuildJob.pm
+++ b/src/backend/BSSched/BuildJob.pm
@@ -1161,6 +1161,7 @@ sub create {
         $_->{'version'}    = $d->{'version'};
         $_->{'release'}    = $d->{'release'} if defined $d->{'release'};
         $_->{'arch'}       = $d->{'arch'} if $d->{'arch'};
+        $_->{'hdrmd5'}     = $d->{'hdrmd5'} if $d->{'hdrmd5'};
         $_->{'preimghdrmd5'} = $d->{'hdrmd5'} if !$_->{'noinstall'} && $d->{'hdrmd5'};
 	$_->{'repoarch'}   = $BSConfig::localarch if $myarch eq 'local' && $BSConfig::localarch;
       }


### PR DESCRIPTION
osc needs it to validate it's cache for repositories which do not increase
build numbers on rebuild.