### PR TITLE
Add view_file path to robots.txt

### DIFF
--- a/src/api/public/robots.txt
+++ b/src/api/public/robots.txt
@@ -6,6 +6,7 @@ Disallow: /project/monitor
 Disallow: /project/buildresult
 Disallow: /package/dependency
 Disallow: /package/reload_buildstatus
+Disallow: /package/view_file
 Disallow: /project/buildstatus
 Disallow: /project/status
 Disallow: /stage


### PR DESCRIPTION
This route is really expensive to call and does not bring
much value for search engine results.