### PR TITLE
Fetch only the group IDs in NotificationsFinder

### DIFF
--- a/src/api/app/queries/notifications_finder.rb
+++ b/src/api/app/queries/notifications_finder.rb
@@ -21,7 +21,7 @@ class NotificationsFinder
 
   def for_subscribed_user(user = User.session)
     @relation.where("(subscriber_type = 'User' AND subscriber_id = ?) OR (subscriber_type = 'Group' AND subscriber_id IN (?))",
-                    user, user.groups.map(&:id))
+                    user, user.groups.pluck(:id))
   end
 
   def for_incoming_requests(user = User.session)


### PR DESCRIPTION
This is more efficient than fetching all group attributes to only take IDs.