### PR TITLE
Prevent silent failure on submit request when service is in progress

### DIFF
--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -26,6 +26,8 @@ class Webui::RequestController < Webui::WebuiController
       flash[:error] = "Unable to submit: The source of package #{params[:project_name]}/#{params[:package_name]} is broken"
     rescue APIError, ActiveRecord::RecordInvalid => e
       flash[:error] = e.message
+    rescue Backend::Error => e
+      flash[:error] = e.summary
     end
 
     if params.key?(:package_name)


### PR DESCRIPTION
We do not catch the exception from the backend when a submit
request, created through the webui, fails due to a running service
on the target.

Fixes #11683

![Screenshot_2021-10-06 obs-server](https://user-images.githubusercontent.com/22001671/136214422-7a971f4d-4259-4747-9829-5c7e2efabfd4.png)