### PR TITLE
Fix long project names in the comment section of project details page

### DIFF
--- a/src/api/app/assets/stylesheets/webui/long-text.scss
+++ b/src/api/app/assets/stylesheets/webui/long-text.scss
@@ -1,4 +1,4 @@
-.smart-overflow {
+.overflow, .smart-overflow {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/src/api/app/views/webui/project/show.html.haml
+++ b/src/api/app/views/webui/project/show.html.haml
@@ -54,9 +54,10 @@
           = render partial: 'project_inherited_packages', locals: { project: @project, inherited_packages: @inherited_packages }
   .comments
     .card#comments-list
-      %h5.card-header.text-word-break-all
-        Comments for #{@project}
-        %span.badge.badge-primary{ id: "comment-counter-project-#{@project.id}" }
+      %h5.card-header.text-word-break-all.d-flex.d-flex-row.justify-content-start
+        .overflow
+          Comments for #{@project}
+        .badge.badge-primary{ id: "comment-counter-project-#{@project.id}" }
           = @comments.length
       .card-body#comments
         = render partial: 'webui/comment/show', locals: { commentable: @project,


### PR DESCRIPTION
In this case it does not implement the "click-to-reveal" from #11687 because we have the full name of the project at the top, so we are not loosing any information here.

## Before
![Screenshot_20211007_093619](https://user-images.githubusercontent.com/2650/136340705-51ae915b-a73c-49d4-86ab-67daa0dcc376.png)

## After
![Screenshot_20211007_093537](https://user-images.githubusercontent.com/2650/136340732-126fed05-e4b9-4a2d-aed5-4cfa5debe9c9.png)


