### PR TITLE
Send the whole groups state

### DIFF
--- a/src/api/app/views/webui/users/subscriptions/index.html.haml
+++ b/src/api/app/views/webui/users/subscriptions/index.html.haml
@@ -8,12 +8,13 @@
       %h4.card-title Groups
       .card-text#notifications-groups
         %p You will receive emails from the checked groups
-        - @groups_users.each do |group_user|
-          .custom-control.custom-checkbox.custom-control-inline
-            = check_box_tag group_user.group, '1', group_user.email, class: 'custom-control-input', id: "checkbox-#{group_user.group}",
-              data: { url: update_my_subscriptions_path, method: :put, remote: true }
-            = label_tag nil, group_user.group.title, class: 'custom-control-label', for: "checkbox-#{group_user.group}"
-            %i.fas.fa-spinner.invisible
+        = form_tag(update_my_subscriptions_path, method: :put, remote: true) do
+          - @groups_users.each do |group_user|
+            .custom-control.custom-checkbox.custom-control-inline
+              = check_box_tag group_user.group, '1', group_user.email, class: 'custom-control-input', id: "checkbox-#{group_user.group}",
+                onclick: "javascript:$('#notifications-groups form').submit();"
+              = label_tag nil, group_user.group.title, class: 'custom-control-label', for: "checkbox-#{group_user.group}"
+              %i.fas.fa-spinner.invisible
   .card-body
     %h4.card-title Events
     %p Choose events you want to get notified about and the corresponding channels.


### PR DESCRIPTION
Previously this view sent the clicked group only, and the backend code updated all the groups at once.

If you had this:
![Screenshot_20211008_135942](https://user-images.githubusercontent.com/2650/136553329-79385dbc-ef29-4cdc-8c63-d559acec083e.png)

and clicked on the "review-team" checkbox everything looked good (because we're using ajax and we don't reload the whole page). But if you reloaded the page, you would see this, instead:
![Screenshot_20211008_140024](https://user-images.githubusercontent.com/2650/136553579-a91e64a9-9f36-466f-9879-3c2e98ba0cfd.png)

This was effectively behaving like a radio button group. 

This PR allows us to update all group users at once, so the backend code now plays nicely with the ui code and everything works as expected.

TODO:
- [ ] Make the spinner work again.