### PR TITLE
Keep columns sort and shown entries per page in datatable state 

### DIFF
--- a/src/api/app/assets/javascripts/webui/datatables.js
+++ b/src/api/app/assets/javascripts/webui/datatables.js
@@ -17,7 +17,14 @@ var DEFAULT_DT_PARAMS = {
   pageLength: 25,
   stateSave: true,
   pagingType: 'full',
-  stateDuration: 0 // forever
+  stateDuration: 0, // forever
+  // Save the state of the columns sort and the number of shown entries per page
+  stateSaveParams: function (_settings, data) {
+    // Do not keep the selected page in the datatable state
+    data.start = 0;
+    // Do not save the state of the search string
+    data.search.search = "";
+  }
 };
 
 function initializeDataTable(cssSelector, params){ // jshint ignore:line

--- a/src/api/app/assets/javascripts/webui/requests_table.js
+++ b/src/api/app/assets/javascripts/webui/requests_table.js
@@ -43,7 +43,14 @@ $(document).ready(function() {
         }
       },
       stateSave: true,
-      stateDuration: 0 // forever
+      stateDuration: 0, // forever
+      // Save the state of the columns sort and the number of shown entries per page
+      stateSaveParams: function (_settings, data) {
+        // Do not keep the selected page in the datatable state
+        data.start = 0;
+        // Do not save the state of the search string
+        data.search.search = "";
+      }
     });
   });
 });

--- a/src/api/app/views/webui/projects/status/show.html.haml
+++ b/src/api/app/views/webui/projects/status/show.html.haml
@@ -78,7 +78,6 @@
                 %td{ data: { package_name: package['name'] } }
                   = render partial: 'webui/project/status_comment', locals: { package_name: package['name'], editable: package['firstfail'].present?,
                                                                 comment: package['failedcomment'], project: @project }
-
         - content_for :ready_function do
           :plain
             $('#status-table').dataTable({
@@ -86,7 +85,14 @@
               responsive: true,
               columnDefs: [ { 'width': '20%', 'targets': 0 } ],
               stateSave: true,
-              stateDuration: #{2.days}
+              stateDuration: 0, // forever
+              // Save the state of the columns sort and the number of shown entries per page
+              stateSaveParams: function (_settings, data) {
+                // Do not keep the selected page in the datatable state
+                data.start = 0;
+                // Do not save the state of the search string
+                data.search.search = "";
+              }
             });
 
 - if User.possibly_nobody.can_modify?(@project) && parsed_result[:comments_to_clear].present?

--- a/src/api/app/views/webui/staging/workflows/_staging_projects_table.html.haml
+++ b/src/api/app/views/webui/staging/workflows/_staging_projects_table.html.haml
@@ -26,7 +26,14 @@
       searching: false,
       info: false,
       stateSave: true,
-      stateDuration: #{2.days},
+      stateDuration: 0, // forever
+      // Save the state of the columns sort and the number of shown entries per page
+      stateSaveParams: function (_settings, data) {
+        // Do not keep the selected page in the datatable state
+        data.start = 0;
+        // Do not save the state of the search string
+        data.search.search = "";
+      },
       columnDefs: [
         { width: null, targets: 0 },
         { width: '75%', targets: 1 },


### PR DESCRIPTION
The selected page and the search string aren't saved in the datatable state. This was often confusing users.

Fixes #7535