### PR TITLE
[backend] fix KiwiProduct context pool use with 'local' as arch

### DIFF
--- a/src/backend/bs_sched
+++ b/src/backend/bs_sched
@@ -1116,6 +1116,8 @@ eval {
     Build::forgetdeps($bconf);
     delete $ctx->{'expander'};
     delete $ctx->{'pool'};
+    delete $ctx->{'pool_host'};
+    delete $ctx->{'pool_local'};
 
     my $wasfinished = $gctx->{'prpfinished'}->{$prp};
 


### PR DESCRIPTION
We can't simply reuse the context pool, as it uses the wrong arch.
Instead, cache the pool in $ctx->{pool_local}.