### PR TITLE
Remove `GET /service/:service` API endpoint

### DIFF
--- a/src/api/app/controllers/service_controller.rb
+++ b/src/api/app/controllers/service_controller.rb
@@ -2,8 +2,4 @@ class ServiceController < ApplicationController
   def index
     pass_to_backend
   end
-
-  def index_service
-    pass_to_backend
-  end
 end

--- a/src/api/config/routes/api_routes.rb
+++ b/src/api/config/routes/api_routes.rb
@@ -42,7 +42,6 @@ OBSApi::Application.routes.draw do
 
     ### /service
     get 'service' => 'service#index'
-    get 'service/:service' => 'service#index_service', constraints: cons
 
     ### /source
     get 'source/:project/_keyinfo' => 'source/key_info#show', constraints: cons


### PR DESCRIPTION
It was never used, and commented in the backend. Let's ~comment~ remove it by now, and introduce it when it is implemented in the backend.

See this endpoint commented in the backend here: [src/backend/bs_srcserver](https://github.com/openSUSE/open-build-service/blob/5e8b3e2c574ae5b115bb52a641043ef7820d8363/src/backend/bs_srcserver#L7308).