### PR TITLE
Document `GET /service` endpoint with OpenAPI

### DIFF
--- a/src/api/public/apidocs-new/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs-new/OBS-v2.10.50.yaml
@@ -243,6 +243,9 @@ paths:
   /request/{id}?cmd=diff:
     $ref: 'paths/request_id_cmd_diff.yaml'
 
+  /service:
+    $ref: 'paths/service.yaml'
+
   /worker/status:
     $ref: 'paths/worker_status.yaml'
   /worker/{architecture_name}:{worker_id}:

--- a/src/api/public/apidocs-new/components/schemas/servicelist.yaml
+++ b/src/api/public/apidocs-new/components/schemas/servicelist.yaml
@@ -1,0 +1,34 @@
+type: array
+items:
+  type: object
+  properties:
+    name:
+      type: string
+      xml:
+        attribute: true
+    summary:
+      type: string
+    description:
+      type: string
+    parameter:
+      type: array
+      items:
+        type: object
+        properties:
+          name:
+            type: string
+            xml:
+              attribute: true
+          description:
+            type: string
+          allowedvalue:
+            type: array
+            items:
+              type: string
+          required:
+            type: string
+  xml:
+    name: service
+xml:
+  wrapped: true
+  name: servicelist

--- a/src/api/public/apidocs-new/paths/service.yaml
+++ b/src/api/public/apidocs-new/paths/service.yaml
@@ -1,0 +1,33 @@
+get:
+  summary: List all services.
+  description: Get a list of all services known to OBS.
+  security:
+    - basic_authentication: []
+  responses:
+    '200':
+      description: OK. The request has succeeded.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/servicelist.yaml'
+          example:
+            - name: download_url
+              summary: Download a file
+              description: This services uses curl to download files from remote servers via supported protocols.
+              parameter:
+                - name: protocol
+                  description: Used Protocol
+                  allowedvalue:
+                    - ftp
+                    - http
+                    - https
+                - name: host
+                  description: Server Hostname
+                  required: ''
+            - name: source_validator
+              summary: Validate sources
+              description: The default SUSE source validator which catches common pitfalls before build.
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+  tags:
+    - General Information


### PR DESCRIPTION
This endpoint is not yet documented in the original apidocs.

I included this endpoint under the "General Information" section. I thought it was not worth it to add a new section, only for one endpoint.

To make it easier to review this PR, you could access what has been added here directly, in the [review app](https://obs-reviewlab.opensuse.org/eduardoj-document_service_endpoint/apidocs-new/index.html#/General%20Information/get_service).