### PR TITLE
Run haml-lint in parallel

### DIFF
--- a/src/api/lib/tasks/dev.rake
+++ b/src/api/lib/tasks/dev.rake
@@ -68,7 +68,7 @@ namespace :dev do
 
   desc 'Run all linters we use'
   task :lint do
-    Rake::Task['haml_lint'].invoke
+    Rake::Task['dev:lint:haml'].invoke
     Rake::Task['dev:lint:rubocop:all'].invoke
     sh 'jshint ./app/assets/javascripts/'
   end
@@ -121,7 +121,7 @@ namespace :dev do
     end
     desc 'Run the haml linter'
     task :haml do
-      Rake::Task['haml_lint'].invoke
+      Rake::Task['haml_lint'].invoke('--parallel')
     end
   end
 


### PR DESCRIPTION
It runs more than 2 times faster with parallel.

Benchmarks with `time bundle exec rake dev:lint:haml`.

With parallel:

  real 0m12.114s
  user 0m57.818s
  sys  0m2.152s

Without parallel:

  real 0m29.000s
  user 0m27.482s
  sys  0m1.460s