### PR TITLE
Mark `/announcements` endpoints as deprecated in the OpenAPI documentation

### DIFF
--- a/src/api/public/apidocs-new/paths/announcements.yaml
+++ b/src/api/public/apidocs-new/paths/announcements.yaml
@@ -1,4 +1,5 @@
 get:
+  deprecated: true
   summary: List all announcements.
   description: List all messages from type announcement.
   security:
@@ -12,6 +13,7 @@ get:
     - Announcements
 
 post:
+  deprecated: true
   summary: Create an announcement.
   description: |
     Create an announcement.

--- a/src/api/public/apidocs-new/paths/announcements_announcement_id.yaml
+++ b/src/api/public/apidocs-new/paths/announcements_announcement_id.yaml
@@ -1,4 +1,5 @@
 get:
+  deprecated: true
   summary: Show an announcement.
   description: Show the content of an announcement.
   security:
@@ -34,6 +35,7 @@ get:
     - Announcements
 
 put:
+  deprecated: true
   summary: Update an announcement.
   description: |
     Update the content of an announcement.
@@ -92,6 +94,7 @@ put:
     - Announcements
 
 delete:
+  deprecated: true
   summary: Delete an announcement.
   description: |
     Delete an announcement.


### PR DESCRIPTION
The `/announcements` endpoints are deprecated. See next release notes: https://github.com/openSUSE/open-build-service/blob/b55647b736c747d771bf1828d9b0a565f1aa2c77/ReleaseNotes-2.11#L76-L78

This pull request mark them as deprecated in the OpenAPI documentation:

![Screenshot from 2021-10-18 14-54-52](https://user-images.githubusercontent.com/24919/137734862-40a9bd47-8a45-4c1b-b29c-1f2da7c07780.png)

