### PR TITLE
Fix links to package with long project package name combination

### DIFF
--- a/src/api/app/assets/javascripts/webui/collapsible_text.js
+++ b/src/api/app/assets/javascripts/webui/collapsible_text.js
@@ -3,13 +3,16 @@ $(document).ready(function() {
 });
 
 function setCollapsible() {
-  $('.obs-collapsible-textbox').on('click', function() {
-    var selectedText = document.getSelection().toString();
-    if(!selectedText) {
-      $(this).find('.obs-collapsible-text').toggleClass('expanded');
-      $(this).find('.show-content').toggleClass('more less');
-    }
-  });
+  var textbox = $('.obs-collapsible-textbox');
+  if (!textbox.data('ignore-click-to-expand')) {
+    textbox.on('click', function() {
+      var selectedText = document.getSelection().toString();
+      if(!selectedText) {
+        $(this).find('.obs-collapsible-text').toggleClass('expanded');
+        $(this).find('.show-content').toggleClass('more less');
+      }
+    });
+  }
 
   $('.obs-collapsible-text').each(function(_index, element){
     if (element.scrollHeight > element.offsetHeight) {

--- a/src/api/app/assets/stylesheets/webui/collapsible-text.scss
+++ b/src/api/app/assets/stylesheets/webui/collapsible-text.scss
@@ -53,3 +53,8 @@
   @include collapsible($maxHeight: 1.5em);
   .obs-collapsible-textbox {  @extend .pr-0; }
 }
+
+#link-info {
+  @include collapsible($maxHeight: 1.5em, $moreButtonLabel: 'Expand name');
+  .obs-collapsible-textbox { @extend .pr-0; }
+}

--- a/src/api/app/views/webui/package/side_links/_show_linkinfo.html.haml
+++ b/src/api/app/views/webui/package/side_links/_show_linkinfo.html.haml
@@ -1,5 +1,5 @@
 - linked_package = linkinfo[:package]
-%li
+%li#link-info
   %i.fas.fa-link.text-dark
   Links to
   - if linkinfo[:remote_project]
@@ -9,7 +9,10 @@
       \/
       = linked_package
   - else
-    = project_or_package_link(project: linked_package.project.name, package: linked_package.name, short: true)
+    .row
+      .col.obs-collapsible-textbox{ 'data-ignore-click-to-expand': 'true' }
+        .obs-collapsible-text
+          = project_or_package_link(project: linked_package.project.name, package: linked_package.name, short: true, trim_to: nil)
 - if linkinfo[:error]
   %li
     %i.fas.fa-exclamation-circle.text-danger


### PR DESCRIPTION
It uses the same "click to reveal" technique to show the long
project/package name.

Depends on #11697

## Before
![Screenshot_20211019_152449](https://user-images.githubusercontent.com/2650/137918920-a5c0592d-999c-4cfe-85c0-e9e522533ada.png)

## After
![Screenshot_20211019_152359](https://user-images.githubusercontent.com/2650/137918940-2da0540d-6430-4359-8698-86bac17e5d15.png)
