### PR TITLE
Simplify comments' section header

### DIFF
--- a/src/api/app/views/webui/package/show.html.haml
+++ b/src/api/app/views/webui/package/show.html.haml
@@ -68,8 +68,7 @@
   .comments
     .card#comments-list
       %h5.card-header.text-word-break-all
-        Comments for
-        = @package.name
+        Comments
         %span.badge.badge-primary{ id: "comment-counter-package-#{@package.id}" }
           = @comments.length
       .card-body#comments

--- a/src/api/app/views/webui/project/show.html.haml
+++ b/src/api/app/views/webui/project/show.html.haml
@@ -55,7 +55,7 @@
   .comments
     .card#comments-list
       %h5.card-header.text-word-break-all
-        Comments for #{@project}
+        Comments
         %span.badge.badge-primary{ id: "comment-counter-project-#{@project.id}" }
           = @comments.length
       .card-body#comments


### PR DESCRIPTION
Replace "Comments for X" with simply "Comments" instead of finding a way to shorten the long names.

The comments are displayed in the context of a certain item (project, package) so there is no need to repeat the item's name, which is clear in other parts like the breadcrumbs or the title.

In comparison, we don't display something like `Build results for package-name` even if we have a `Build results` section in the different items pages.

Supersedes: #11688

**Before:**

![Screenshot_2021-10-19 Lorem_ipsum_dolor_sit_amet consectetur_adipiscing_elit Donec_at_luctus_arcu sit_amet_lobortis_lacus](https://user-images.githubusercontent.com/2581944/137945411-3df62995-1bd9-4154-bf44-79bad3244fc2.png)


**After:**

![Screenshot_2021-10-19 Lorem_ipsum_dolor_sit_amet consectetur_adipiscing_elit Donec_at_luctus_arcu sit_amet_lobortis_lacus(1)](https://user-images.githubusercontent.com/2581944/137945429-34c2b182-f0a7-4d8a-9f18-18a9d2f0c3e2.png)
