### PR TITLE
Remove the project name from the checkbox in project status page

### DIFF
--- a/src/api/app/views/webui/projects/status/show.html.haml
+++ b/src/api/app/views/webui/projects/status/show.html.haml
@@ -20,7 +20,7 @@
             = select_tag(:filter_devel, options_for_select(@develprojects, @current_develproject), class: 'form-control')
       .custom-control.custom-checkbox
         = check_box_tag(:ignore_pending, true, @ignore_pending, class: 'custom-control-input')
-        = label_tag(:ignore_pending, "Ignore packages with pending requests to #{@project.name}", class: 'custom-control-label')
+        = label_tag(:ignore_pending, 'Ignore packages with pending requests to this project', class: 'custom-control-label')
       .custom-control.custom-checkbox
         = check_box_tag(:limit_to_fails, true, @limit_to_fails, class: 'custom-control-input')
         = label_tag(:limit_to_fails, 'Limit to currently failing packages', class: 'custom-control-label')


### PR DESCRIPTION
We don't really need the potentially long project name because it's right above the
checkbox.

## Before
![image](https://user-images.githubusercontent.com/2650/137980689-e3f4f8b7-224e-4670-a678-a5a24ae2451b.png)

## After
![image](https://user-images.githubusercontent.com/2650/137981291-6a6bbce2-77b2-436f-99f0-d4bf28f1483b.png)

