### PR TITLE
Fix typos in Linter::SetPagetitleInView

### DIFF
--- a/src/api/lib/haml-lint/custom_linters/set_pagetitle_in_view.rb
+++ b/src/api/lib/haml-lint/custom_linters/set_pagetitle_in_view.rb
@@ -1,9 +1,9 @@
-# This custom linter for haml-lint will report an offense if @pagetitle is not set in a Haml view. Partials aren't ignored by this linter.
+# This custom linter for haml-lint will report an offense if @pagetitle is not set in a Haml view. Partials are ignored by this linter.
 module HamlLint
   class Linter::SetPagetitleInView < Linter
     include LinterRegistry
 
-    # Report an offense if the instance variable @pagetitle is not set in a Haml view. Partials aren't ignored by this linter.
+    # Report an offense if the instance variable @pagetitle is not set in a Haml view. Partials are ignored by this linter.
     #
     # @param [HamlLint::Tree::RootNode] the root of a syntax tree
     def visit_root(root_node)


### PR DESCRIPTION
This wasn't true. It's the opposite, partials *are* ignored.