### PR TITLE
Enable docker layer caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,8 @@ jobs:
       - <<: *frontend_base
     steps:
       - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
       - run:
           name: Run scripts linters
           command: make -C dist scripts_linters


### PR DESCRIPTION
Based on https://circleci.com/docs/2.0/docker-layer-caching/ we could enable layer caching.

The documentation says that one could just profit from that changes, when build the containers locally, but as saw here https://app.circleci.com/pipelines/github/vpereira/open-build-service/775/workflows/e0f6685d-9755-498c-bb47-d7622c13e7cc/jobs/14209, it caches as well the downloaded layers.

extracted from #11758