### PR TITLE
Align code style of component specs

### DIFF
--- a/src/api/spec/components/notification_action_bar_component_spec.rb
+++ b/src/api/spec/components/notification_action_bar_component_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe NotificationActionBarComponent, type: :component do
   context 'for unread notifications' do
     before do
       User.session = create(:user)
-      render_inline(described_class.new(type: 'unread', update_path: 'my/notifications', show_read_all_button: true)).to_html
+      render_inline(described_class.new(type: 'unread', update_path: 'my/notifications', show_read_all_button: true))
     end
 
     it do
@@ -27,7 +27,7 @@ RSpec.describe NotificationActionBarComponent, type: :component do
   context 'for read notifications' do
     before do
       User.session = create(:user)
-      render_inline(described_class.new(type: 'read', update_path: 'my/notifications?type=read', show_read_all_button: true)).to_html
+      render_inline(described_class.new(type: 'read', update_path: 'my/notifications?type=read', show_read_all_button: true))
     end
 
     it do

--- a/src/api/spec/components/notification_filter_link_component_spec.rb
+++ b/src/api/spec/components/notification_filter_link_component_spec.rb
@@ -4,60 +4,60 @@ RSpec.describe NotificationFilterLinkComponent, type: :component do
   context 'the filter item matches the selected filter and the amount is greater than 0' do
     let(:link_selector) { 'a.active[href="/my/notifications?type=comments"]' }
 
-    subject do
+    before do
       render_inline(described_class.new(text: 'Comments', filter_item: { type: 'comments' },
-                                        selected_filter: { type: 'comments' }, amount: 20)).to_html
+                                        selected_filter: { type: 'comments' }, amount: 20))
     end
 
     it 'displays a link with the active class and containing a badge of the light color' do
-      expect(subject).to have_css(link_selector, text: 'Comments')
+      expect(rendered_component).to have_css(link_selector, text: 'Comments')
 
-      expect(subject).to have_css("#{link_selector} span.badge.badge-light", text: 20)
+      expect(rendered_component).to have_css("#{link_selector} span.badge.badge-light", text: 20)
     end
   end
 
   context 'the filter item matches the selected filter and the amount is not greater than 0' do
     let(:link_selector) { 'a.active[href="/my/notifications?project=home%3AAdmin"]' }
 
-    subject do
+    before do
       render_inline(described_class.new(text: 'home:Admin', filter_item: { project: 'home:Admin' },
-                                        selected_filter: { project: 'home:Admin' }, amount: 0)).to_html
+                                        selected_filter: { project: 'home:Admin' }, amount: 0))
     end
 
     it 'displays a link with the active class, but without a badge' do
-      expect(subject).to have_css(link_selector, text: 'home:Admin')
+      expect(rendered_component).to have_css(link_selector, text: 'home:Admin')
 
-      expect(subject).not_to have_css("#{link_selector} span.badge")
+      expect(rendered_component).not_to have_css("#{link_selector} span.badge")
     end
   end
 
   context 'the filter item does not match the selected filter and the amount is greater than 0' do
     let(:link_selector) { 'a[href="/my/notifications?group=iron_maiden"]' }
 
-    subject do
+    before do
       render_inline(described_class.new(text: 'iron_maiden', filter_item: { group: 'iron_maiden' },
-                                        selected_filter: { type: 'requests' }, amount: 10)).to_html
+                                        selected_filter: { type: 'requests' }, amount: 10))
     end
 
     it 'displays a link without the active class, but containing a badge of the primary color' do
-      expect(subject).to have_css(link_selector, text: 'iron_maiden')
+      expect(rendered_component).to have_css(link_selector, text: 'iron_maiden')
 
-      expect(subject).to have_css("#{link_selector} span.badge.badge-primary", text: 10)
+      expect(rendered_component).to have_css("#{link_selector} span.badge.badge-primary", text: 10)
     end
   end
 
   context 'the filter item does not match the selected filter and the amount is not greater than 0' do
     let(:link_selector) { 'a[href="/my/notifications?group=iron_maiden"]' }
 
-    subject do
+    before do
       render_inline(described_class.new(text: 'iron_maiden', filter_item: { group: 'iron_maiden' },
-                                        selected_filter: { type: 'requests' }, amount: 0)).to_html
+                                        selected_filter: { type: 'requests' }, amount: 0))
     end
 
     it 'displays a link without the active class and a badge' do
-      expect(subject).to have_css(link_selector, text: 'iron_maiden')
+      expect(rendered_component).to have_css(link_selector, text: 'iron_maiden')
 
-      expect(subject).not_to have_css("#{link_selector} span.badge")
+      expect(rendered_component).not_to have_css("#{link_selector} span.badge")
     end
   end
 end

--- a/src/api/spec/components/sign_up_component_spec.rb
+++ b/src/api/spec/components/sign_up_component_spec.rb
@@ -5,14 +5,14 @@ RSpec.describe SignUpComponent, type: :component do
     let(:config) { { 'proxy_auth_mode' => :on } }
 
     it do
-      expect(render_inline(described_class.new(config: config)).to_html).to have_text('signing up is currently disabled')
+      expect(render_inline(described_class.new(config: config))).to have_text('signing up is currently disabled')
     end
 
     context 'there is a proxy auth register page' do
       let(:config) { { 'proxy_auth_mode' => :on, 'proxy_auth_register_page' => 'http://foo.org' } }
 
       it do
-        expect(render_inline(described_class.new(config: config)).to_html).to have_text('Use this link to Sign Up')
+        expect(render_inline(described_class.new(config: config))).to have_text('Use this link to Sign Up')
       end
     end
   end

--- a/src/api/spec/components/sourcediff_tab_component_spec.rb
+++ b/src/api/spec/components/sourcediff_tab_component_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe SourcediffTabComponent, type: :component, vcr: true do
     before do
       User.session = create(:user)
       action = bs_request.send(:action_details, opts, xml: bs_request.bs_request_actions.last)
-      render_inline(described_class.new(bs_request: bs_request, action: action, active: action[:name], index: 0, refresh: action[:diff_not_cached])).to_html
+      render_inline(described_class.new(bs_request: bs_request, action: action, active: action[:name], index: 0, refresh: action[:diff_not_cached]))
     end
 
     it do

--- a/src/api/spec/components/sponsors_component_spec.rb
+++ b/src/api/spec/components/sponsors_component_spec.rb
@@ -12,24 +12,32 @@ RSpec.describe SponsorsComponent, type: :component do
     end
     let(:config) { { 'sponsors' => [sponsor] } }
 
-    it do
-      expect(render_inline(described_class.new(config: config)).to_html).to have_text('Open Build Service is sponsored by')
+    before do
+      render_inline(described_class.new(config: config))
     end
 
     it do
-      expect(render_inline(described_class.new(config: config)).to_html).to have_css('.sponsor-item')
+      expect(rendered_component).to have_text('Open Build Service is sponsored by')
+    end
+
+    it do
+      expect(rendered_component).to have_css('.sponsor-item')
     end
   end
 
   context 'without sponsors' do
     let(:config) { {} }
 
-    it do
-      expect(render_inline(described_class.new(config: config)).to_html).not_to have_text('Open Build Service is sponsored by')
+    before do
+      render_inline(described_class.new(config: config))
     end
 
     it do
-      expect(render_inline(described_class.new(config: config)).to_html).not_to have_css('.sponsor-item')
+      expect(rendered_component).not_to have_text('Open Build Service is sponsored by')
+    end
+
+    it do
+      expect(rendered_component).not_to have_css('.sponsor-item')
     end
   end
 end

--- a/src/api/spec/components/status_message_component_spec.rb
+++ b/src/api/spec/components/status_message_component_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe StatusMessageComponent, type: :component do
     let(:status_message) { build(:status_message, message: 'Everything is fine', created_at: Time.zone.now) }
 
     it do
-      expect(render_inline(described_class.new(status_message: status_message)).to_html).to have_text('Everything is fine')
+      expect(render_inline(described_class.new(status_message: status_message))).to have_text('Everything is fine')
     end
   end
 
@@ -14,7 +14,7 @@ RSpec.describe StatusMessageComponent, type: :component do
 
     before do
       User.session = create(:admin_user)
-      render_inline(described_class.new(status_message: status_message)).to_html
+      render_inline(described_class.new(status_message: status_message))
     end
 
     it do


### PR DESCRIPTION
`.to_html` would be needed if we didn't use Capybara. See upstream docs: https://viewcomponent.org/guide/testing.html#without-capybara

Use only `before` blocks instead of a `subject/before` mix.

The [wiki](https://github.com/openSUSE/open-build-service/wiki/View-Components/_compare/9661d2517d582cddf3ba4df13f838d4572e3de24...49bf1f3f3490c455a78edef8f9723f2b92ae920e) was updated to reflect this change.