### PR TITLE
Use bootstrap max-width instead of width class for request tabs

### DIFF
--- a/src/api/app/views/webui/request/show.html.haml
+++ b/src/api/app/views/webui/request/show.html.haml
@@ -29,7 +29,7 @@
   .bg-light
     %ul.nav.nav-tabs.bs-request-actions{ role: 'tablist' }
       - @actions.each_with_index do |action, index|
-        %li.nav-item.w-100
+        %li.nav-item.mw-100
           = link_to(action[:name], "##{valid_xml_id(action[:name])}",
             class: "request-tab nav-link text-nowrap text-truncate #{'active' if index.zero?}",
             data: { toggle: 'tab', url: request_action_url(action[:number], action[:id]), tab_pane_id: valid_xml_id(action[:name]), index: index,


### PR DESCRIPTION
Recently the width of the request tabs got set to a 100%
to prevent overflowing tab text on small screen sizes. But
this forces the tabs to always take up all the space even
on big screens. Instead we should only set the max width
to a 100%.

Fixes #11788

Before:
![Screenshot_2021-10-27 Request 10 (new)](https://user-images.githubusercontent.com/22001671/139105799-c3055f01-a7fe-421f-9711-ad396554c6d6.png)

After:
![Screenshot_2021-10-27 Request 10 (new)(1)](https://user-images.githubusercontent.com/22001671/139105863-0aa2b168-0095-4d32-afad-e06fb17c4c3b.png)
