### PR TITLE
Do not use Docker layer caching

### DIFF
--- a/.circleci/conditional_config.yml
+++ b/.circleci/conditional_config.yml
@@ -165,8 +165,6 @@ jobs:
       - <<: *frontend_base
     steps:
       - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
       - run: *install_dependencies
       - run: *install_circle_cli
       - restore_cache:


### PR DESCRIPTION
This feature isn't available for CircleCI customers on the free plan, this includes forks. It prevents us from having our own CircleCI runners in those forks.

Reverts changes from #11764