### PR TITLE
Run validations upfront, then report any error back to the SCM

### DIFF
--- a/src/api/app/controllers/trigger_workflow_controller.rb
+++ b/src/api/app/controllers/trigger_workflow_controller.rb
@@ -6,8 +6,13 @@ class TriggerWorkflowController < TriggerController
   def create
     authorize @token, :trigger?
     @token.user.run_as do
-      @token.call(scm: scm, event: event, payload: payload)
-      render_ok
+      validation_errors = @token.call(scm: scm, event: event, payload: payload)
+
+      if validation_errors.none?
+        render_ok
+      else
+        render_error status: 400, message: validation_errors.to_sentence
+      end
     end
   end
 

--- a/src/api/app/models/token/errors.rb
+++ b/src/api/app/models/token/errors.rb
@@ -9,6 +9,10 @@ module Token::Errors
     setup 404
   end
 
+  class MissingPayload < APIError
+    setup 400
+  end
+
   class SCMTokenInvalid < APIError
     setup 401
   end

--- a/src/api/app/services/workflows/yaml_to_workflows_service.rb
+++ b/src/api/app/services/workflows/yaml_to_workflows_service.rb
@@ -21,7 +21,6 @@ module Workflows
 
       parsed_workflows_yaml
         .map { |_workflow_name, workflow_instructions| Workflow.new(workflow_instructions: workflow_instructions, scm_webhook: @scm_webhook, token: @token) }
-        .select(&:valid?)
     end
   end
 end

--- a/src/api/spec/controllers/trigger_workflow_controller_spec.rb
+++ b/src/api/spec/controllers/trigger_workflow_controller_spec.rb
@@ -1,38 +1,27 @@
 require 'rails_helper'
 
 RSpec.describe TriggerWorkflowController, type: :controller, beta: true do
-  let(:user) { create(:confirmed_user, :in_beta, login: 'foo') }
-  let(:token) { Token::Workflow.create(user: user) }
-  let(:token_extractor_instance) { instance_double(::TriggerControllerService::TokenExtractor) }
-  let(:github_payload) do
-    {
-      action: 'opened',
-      pull_request: {
-        head: {
-          repo: {
-            full_name: 'username/test_repo'
-          }
-        },
-        base: {
-          ref: 'main',
-          repo: {
-            full_name: 'rubhanazeem/hello_world'
-          }
-        }
-      },
-      number: 4,
-      sender: {
-        url: 'https://api.github.com'
-      }
-    }
-  end
-
-  render_views
-
   describe 'POST :create' do
     context 'workflows.yml do not exist' do
       let(:octokit_client) { instance_double(Octokit::Client) }
       let(:token_extractor_instance) { instance_double(::TriggerControllerService::TokenExtractor) }
+      let(:token) { create(:workflow_token, user: create(:confirmed_user, :in_beta)) }
+      let(:github_payload) do
+        {
+          action: 'opened',
+          pull_request: {
+            head: {
+              repo: { full_name: 'username/test_repo' }
+            },
+            base: {
+              ref: 'main',
+              repo: { full_name: 'rubhanazeem/hello_world' }
+            }
+          },
+          number: 4,
+          sender: { url: 'https://api.github.com' }
+        }
+      end
 
       before do
         allow(::TriggerControllerService::TokenExtractor).to receive(:new).and_return(token_extractor_instance)
@@ -52,6 +41,9 @@ RSpec.describe TriggerWorkflowController, type: :controller, beta: true do
     end
 
     context 'scm event is invalid' do
+      let(:token_extractor_instance) { instance_double(::TriggerControllerService::TokenExtractor) }
+      let(:token) { build_stubbed(:workflow_token, user: build_stubbed(:confirmed_user, :in_beta)) }
+
       before do
         allow(::TriggerControllerService::TokenExtractor).to receive(:new).and_return(token_extractor_instance)
         allow(token_extractor_instance).to receive(:call).and_return(token)
@@ -63,6 +55,9 @@ RSpec.describe TriggerWorkflowController, type: :controller, beta: true do
     end
 
     context 'scm payload is invalid' do
+      let(:token_extractor_instance) { instance_double(::TriggerControllerService::TokenExtractor) }
+      let(:token) { build_stubbed(:workflow_token, user: build_stubbed(:confirmed_user, :in_beta)) }
+
       before do
         allow(::TriggerControllerService::TokenExtractor).to receive(:new).and_return(token_extractor_instance)
         allow(token_extractor_instance).to receive(:call).and_return(token)
@@ -83,6 +78,44 @@ RSpec.describe TriggerWorkflowController, type: :controller, beta: true do
         end
 
         it { expect(response).to have_http_status(:bad_request) }
+      end
+    end
+
+    context 'validation errors happening when triggering the token' do
+      let(:token_extractor_instance) { instance_double(::TriggerControllerService::TokenExtractor) }
+      let(:token) { build_stubbed(:workflow_token, user: build_stubbed(:confirmed_user, :in_beta)) }
+      let(:github_payload) do
+        {
+          action: 'opened',
+          pull_request: {
+            head: {
+              repo: { full_name: 'username/test_repo' }
+            },
+            base: {
+              ref: 'main',
+              repo: { full_name: 'rubhanazeem/hello_world' }
+            }
+          },
+          number: 4,
+          sender: { url: 'https://api.github.com' }
+        }
+      end
+
+      before do
+        allow(token).to receive(:call).and_return(['Event not supported.', 'Workflow steps are not present'])
+
+        allow(::TriggerControllerService::TokenExtractor).to receive(:new).and_return(token_extractor_instance)
+        allow(token_extractor_instance).to receive(:call).and_return(token)
+
+        request.headers['HTTP_X_GITHUB_EVENT'] = 'pull_request'
+
+        post :create, params: { format: :json }, body: github_payload.to_json
+      end
+
+      it { expect(response).to have_http_status(:bad_request) }
+
+      it 'includes validation errors in the response body' do
+        expect(response.body).to include('Event not supported. and Workflow steps are not present')
       end
     end
   end


### PR DESCRIPTION
This will help users debug their workflows if something is wrong in their `.obs/workflows.yml`.