### PR TITLE
Improve gem caching circleci and make linters job mandatory before rspec, minitest and feature jobs

### DIFF
--- a/.circleci/conditional_config.yml
+++ b/.circleci/conditional_config.yml
@@ -463,10 +463,10 @@ workflows:
             - checkout_code
       - rspec:
           requires:
-            - checkout_code
+            - linters
       - minitest:
           requires:
-            - checkout_code
+            - linters
       - spider:
           requires:
             - rspec
@@ -479,5 +479,5 @@ workflows:
             - feature
       - feature:
           requires:
-            - checkout_code
+            - linters
 

--- a/.circleci/conditional_config.yml
+++ b/.circleci/conditional_config.yml
@@ -53,7 +53,7 @@ aliases:
   - &install_dependencies
     name: install dependencies
     command: |
-      cd ./src/api && bundle install --jobs=4 --retry=3
+      cd ./src/api && bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs=4 --retry=3
   - &wait_for_database
     name: Wait for DB
     command: mysqladmin ping -h db
@@ -99,7 +99,17 @@ aliases:
       curl -o circleci https://circle-downloads.s3.amazonaws.com/releases/build_agent_wrapper/circleci
       chmod +x circleci
 
-
+  - &restore_gem_cache
+    restore_cache:
+      key: circlev2-{{ .Branch }}-{{ checksum "./src/api/Gemfile.lock" }}
+  - &save_gem_cache
+    save_cache:
+      key: circlev2-{{ .Branch }}-{{ checksum "./src/api/Gemfile.lock" }}
+      paths:
+        - vendor/bundle
+        - src/api/tmp/rubocop_cache_root_dir
+        - src/api/tmp/rubocop_cache_rails_dir
+ 
 jobs:
   pipeline_settings:
     docker:
@@ -130,11 +140,11 @@ jobs:
       - when:
           condition: << pipeline.parameters.run-root-rubocop >> 
           steps:   
+            - *restore_gem_cache
             - run: 
                 name: Run rubocop on root
                 command: |
                   cd src/api
-                  bundle install
                   bundle exec rake dev:lint:rubocop:root
             - run:
                 name: Run dist linters
@@ -145,6 +155,7 @@ jobs:
       - when:
           condition: << pipeline.parameters.run-haml-linter >>
           steps:
+            - *restore_gem_cache
             - run:
                 name: Run HAML linter
                 command: |
@@ -165,20 +176,15 @@ jobs:
       - <<: *frontend_base
     steps:
       - checkout
+      - *restore_gem_cache
       - run: *install_dependencies
+      - *save_gem_cache
       - run: *install_circle_cli
-      - restore_cache:
-          key: v4-lint
       - run:
           name: Run src/api rubocop
           command: |
             cd src/api;
             bundle exec rake dev:lint:rubocop:rails
-      - save_cache:
-          key: v4-lint-{{ epoch }}
-          paths:
-            - src/api/tmp/rubocop_cache_root_dir
-            - src/api/tmp/rubocop_cache_rails_dir
       - run: rm -rf src/api/tmp/rubocop*
       - run:
           name: Setup application
@@ -196,6 +202,7 @@ jobs:
     steps:
       - attach_workspace:
          at: .
+      - *restore_gem_cache
       - run: *install_dependencies
       - run: *wait_for_database
       - run: *create_test_db
@@ -236,6 +243,7 @@ jobs:
     steps:
       - attach_workspace:
          at: .
+      - *restore_gem_cache
       - run: *install_dependencies
       - run: *init_git_submodule
       - run: *wait_for_database
@@ -272,6 +280,7 @@ jobs:
     steps:
       - attach_workspace:
          at: .
+      - *restore_gem_cache
       - run: *install_dependencies
       - run: *init_git_submodule
       - run: *wait_for_database
@@ -291,6 +300,7 @@ jobs:
     steps:
       - attach_workspace:
          at: .
+      - *restore_gem_cache
       - run: *install_dependencies
       - run: *init_git_submodule
       - run: *wait_for_database
@@ -320,6 +330,7 @@ jobs:
     steps:
       - attach_workspace:
          at: .
+      - *restore_gem_cache
       - run: *install_dependencies
       - run:
           name: Merge and check coverage
@@ -342,6 +353,7 @@ jobs:
     steps:
       - attach_workspace:
          at: .
+      - *restore_gem_cache
       - run: *install_dependencies
       - run: *wait_for_database
       - run: *create_test_db


### PR DESCRIPTION
In this PR, we improved the caching among jobs, dropping around 2 minutes in average while running `minitest`, `specs` and `feature` jobs.

i.e: https://app.circleci.com/pipelines/github/vpereira/open-build-service/817/workflows/a4476512-e2e7-4260-b59f-9b3747e357ee/jobs/14592

Beside that now, we just start `rspec`, `minitest` and `feature` jobs if `linter` runs successfully. 