### PR TITLE
Since 1/9/2021, github won't accept unauthenticated git

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/backend/build"]
-	path = src/backend/build
-	url = git://github.com/openSUSE/obs-build.git
+  path = src/backend/build
+  url = https://github.com/openSUSE/obs-build.git


### PR DESCRIPTION
More details: https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git