### PR TITLE
Add apidocs linter to the development rake tasks

### DIFF
--- a/src/api/lib/tasks/dev.rake
+++ b/src/api/lib/tasks/dev.rake
@@ -123,6 +123,10 @@ namespace :dev do
     task :haml do
       Rake::Task['haml_lint'].invoke('--parallel')
     end
+    desc 'Run apidocs linter'
+    task :apidocs do
+      sh 'find public/apidocs-new -name  \'*.yaml\' | xargs -P8 -I % ruby -e "require \'yaml\'; YAML.load_file \'%\'"'
+    end
   end
 
   namespace :sre do


### PR DESCRIPTION
We introduced in our CI pipeline an apidocs linter. 

This PR introduces a command to run it via rake.

To run it: `rake dev:lint:apidocs`