### PR TITLE
Don't run project/package name validations if the keys are missing

### DIFF
--- a/src/api/app/models/workflow/step.rb
+++ b/src/api/app/models/workflow/step.rb
@@ -150,11 +150,8 @@ class Workflow::Step
 
   # Only used in LinkPackageStep and BranchPackageStep.
   def validate_source_project_and_package_name
-    errors.add(:base, "invalid source project '#{source_project_name}'") unless Project.valid_name?(source_project_name)
-    errors.add(:base, "invalid source package '#{source_package_name}'") unless Package.valid_name?(source_package_name)
-
-    return if step_instructions[:target_project].blank?
-
-    errors.add(:base, "invalid target project '#{step_instructions[:target_project]}'") unless Project.valid_name?(step_instructions[:target_project])
+    errors.add(:base, "invalid source project '#{source_project_name}'") if step_instructions[:source_project] && !Project.valid_name?(source_project_name)
+    errors.add(:base, "invalid source package '#{source_package_name}'") if step_instructions[:source_package] && !Package.valid_name?(source_package_name)
+    errors.add(:base, "invalid target project '#{step_instructions[:target_project]}'") if step_instructions[:target_project] && !Project.valid_name?(step_instructions[:target_project])
   end
 end

--- a/src/api/app/models/workflow/step/configure_repositories.rb
+++ b/src/api/app/models/workflow/step/configure_repositories.rb
@@ -70,7 +70,7 @@ class Workflow::Step::ConfigureRepositories < Workflow::Step
   end
 
   def validate_project_name
-    return if Project.valid_name?(project_name)
+    return if step_instructions[:project].blank? || Project.valid_name?(project_name)
 
     errors.add(:base, "invalid project '#{project_name}'")
   end

--- a/src/api/app/models/workflow/step/rebuild_package.rb
+++ b/src/api/app/models/workflow/step/rebuild_package.rb
@@ -37,7 +37,7 @@ class Workflow::Step::RebuildPackage < ::Workflow::Step
   end
 
   def validate_project_and_package_name
-    errors.add(:base, "invalid project '#{step_instructions[:project]}'") unless Project.valid_name?(step_instructions[:project])
-    errors.add(:base, "invalid package '#{step_instructions[:package]}'") unless Package.valid_name?(step_instructions[:package])
+    errors.add(:base, "invalid project '#{step_instructions[:project]}'") if step_instructions[:project] && !Project.valid_name?(step_instructions[:project])
+    errors.add(:base, "invalid package '#{step_instructions[:package]}'") if step_instructions[:package] && !Package.valid_name?(step_instructions[:package])
   end
 end

--- a/src/api/spec/validators/workflow_steps_validator_spec.rb
+++ b/src/api/spec/validators/workflow_steps_validator_spec.rb
@@ -51,8 +51,7 @@ RSpec.describe WorkflowStepsValidator do
       it 'is not valid and has an error message' do
         subject.valid?
         expect(subject.errors.full_messages.to_sentence).to eq("The following workflow steps are unsupported: 'unsupported_step' and " \
-                                                               "The 'source_package' key is missing, The 'target_project' key is missing, " \
-                                                               "and invalid source package ''")
+                                                               "The 'source_package' key is missing and The 'target_project' key is missing")
       end
     end
   end


### PR DESCRIPTION
Validating a project/package should happen only if the key is present in the step instructions to avoid duplication in error messages.
