### PR TITLE
Add a delay to wait for the AJAX call

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -16,6 +16,7 @@ Backend:
 - .obs/**/*
 - .rubocop.yml
 - .rubocop_todo.yml
+- dist/t/**/*
 - src/api/.rubocop.yml
 - src/api/.rubocop_todo.yml
 - .codeclimate.yml

--- a/dist/t/spec/features/0030_project_spec.rb
+++ b/dist/t/spec/features/0030_project_spec.rb
@@ -24,6 +24,8 @@ RSpec.describe "Project", type: :feature do
     click_link('Repositories')
     click_link('Add from a Distribution')
     check('openSUSE Leap 15.3')
+    # wait for the ajax call to finish
+    sleep(3)
     visit current_path
     expect(page).to have_checked_field('openSUSE Leap 15.3')
   end


### PR DESCRIPTION
This should prevent a race condition to happen between clicking the checkbox and reloading the page.

In the past we tried [waiting with javascript](https://github.com/openSUSE/open-build-service/pull/10754). Then we opted for [not using javascript](https://github.com/openSUSE/open-build-service/pull/10782).