### PR TITLE
Increase Capybara maximum wait time in smoke tests

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -16,6 +16,7 @@ Backend:
 - .obs/**/*
 - .rubocop.yml
 - .rubocop_todo.yml
+- dist/t/**/*
 - src/api/.rubocop.yml
 - src/api/.rubocop_todo.yml
 - .codeclimate.yml

--- a/dist/t/spec/features/0020_interconnect_spec.rb
+++ b/dist/t/spec/features/0020_interconnect_spec.rb
@@ -14,8 +14,9 @@ RSpec.describe "Interconnect", type: :feature do
     within('div[data-interconnect="openSUSE.org"]') do
       click_button('Connect')
     end
-    sleep(10)
-    visit "/project/show/openSUSE.org"
+    using_wait_time 10 do
+      click_link('openSUSE.org')
+    end
 
     expect(page).to have_content("Standard OBS instance at build.opensuse.org")
     expect(page).to have_content("https://api.opensuse.org/public")

--- a/dist/t/spec/features/0040_package_spec.rb
+++ b/dist/t/spec/features/0040_package_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "Package", type: :feature do
   it "should be able to successfully build" do
     100.downto(1) do |counter|
       visit("/package/show/home:Admin/hello_world")
-      # wait for the build results ajax call
+      # Force to wait for the build results ajax call. page.all doesn't wait for AJAX calls to finish
       sleep(5)
       puts "Refreshed build results, #{counter} retries left."
       builds_in_final_state = page.all('a', class: /build-state-(succeeded|failed)/).length

--- a/dist/t/spec/support/capybara.rb
+++ b/dist/t/spec/support/capybara.rb
@@ -16,6 +16,7 @@ Capybara.register_driver :selenium_chrome_headless do |app|
 end
 
 Capybara.default_driver = :selenium_chrome_headless
+Capybara.default_max_wait_time = 6
 Capybara.javascript_driver = :selenium_chrome_headless
 Capybara.save_path = '/tmp/rspec_screens'
 # Attempt to click the associated label element if a checkbox/radio button are non-visible (This is especially useful for Bootstrap custom controls)


### PR DESCRIPTION
Increase maximum number of seconds from 2 to 6 that Capybara waits for asynchronous processes to finish.