### PR TITLE
Cache gems in the system directory

### DIFF
--- a/.circleci/conditional_config.yml
+++ b/.circleci/conditional_config.yml
@@ -53,7 +53,7 @@ aliases:
   - &install_dependencies
     name: install dependencies
     command: |
-      cd ./src/api && bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs=4 --retry=3
+      cd ./src/api && bundle install --jobs=4 --retry=3
   - &wait_for_database
     name: Wait for DB
     command: mysqladmin ping -h db
@@ -106,7 +106,7 @@ aliases:
     save_cache:
       key: circlev2-{{ .Branch }}-{{ checksum "./src/api/Gemfile.lock" }}
       paths:
-        - vendor/bundle
+        - /usr/lib64/ruby/gems/2.5.0/gems
         - src/api/tmp/rubocop_cache_root_dir
         - src/api/tmp/rubocop_cache_rails_dir
  


### PR DESCRIPTION
In the development environment `vendor/` is a directory in the git checkout
that is mounted into the container. We can't use this as place to cache
the gems in the frontend-* images. Use the system directory instead.