### PR TITLE
Fix flickering smoke test

### DIFF
--- a/dist/t/0060-check_required_services.ts
+++ b/dist/t/0060-check_required_services.ts
@@ -13,7 +13,10 @@ my @active_daemons = qw/obsdispatcher.service  obspublisher.service    obsrepser
 my $out=`systemctl list-units`;
 my $mariadb;
 foreach my $unit (split(/\n/, $out)) {
-  $mariadb = $1 if $unit =~ /^\s*((mysql|mariadb)\.service)\s+/
+  if $unit =~ /^\s*((mysql|mariadb)\.service)\s+/ {
+    $mariadb = $1;
+    last;
+  }
 }
 
 die "could not find mariadb or mysql" if ! $mariadb;


### PR DESCRIPTION
Searching for mariadb and mysql services resulted sometimes in `mariadb`, and some other times in `mysql`.

`systemctl list-units` always return the services in alphabetical order. Rely on this, to stop searching on the first match from `mariadb` or `mysql`.

This will prevent this flickering errors to happen in [openQA tests](https://openqa.opensuse.org/group_overview/62).