### PR TITLE
Show token id after creation

### DIFF
--- a/src/api/app/views/webui/users/tokens/_create.js.erb
+++ b/src/api/app/views/webui/users/tokens/_create.js.erb
@@ -1,6 +1,7 @@
 $('#flash').html("<%= escape_javascript(render(layout: false, partial: 'layouts/webui/flash', object: flash)) %>");
 <% if flash[:error].blank? %>
-  $('#created-token').removeClass('d-none');
+  $('#token-id span').text("<%= @token.id %>")
+  $('.visible-when-created').removeClass('d-none');
   $('#copy-to-clipboard-readonly').val("<%= escape_javascript(string) %>");
   $('.form-row :input').not('#copy-to-clipboard-readonly').prop('disabled', true);
   $('.actions').html("<%= escape_javascript(render partial: 'actions') %>");

--- a/src/api/app/views/webui/users/tokens/new.html.haml
+++ b/src/api/app/views/webui/users/tokens/new.html.haml
@@ -28,7 +28,7 @@
           .form-row
             .col
               .form-group
-                = f.label(:type, class: 'col-form-label col-form-label-lg mr-2')
+                = f.label(:type, 'Type:', class: 'col-form-label mr-2')
                 .w-100.d-sm-none
                 = f.collection_radio_buttons(:type, type_options, :to_s, :to_s, class: 'custom-control-input', required: true) do |radio|
                   .custom-control.custom-radio.custom-control-inline
@@ -38,7 +38,7 @@
           .form-row
             .col-sm
               .form-group.ui-front
-                = f.label(:name, 'Name')
+                = f.label(:name, 'Name:')
                 = f.text_field(:name, class: 'form-control', placeholder: 'Eg: Rebuild vim package')
                 .form-text.text-muted
                   Optional: provide a name to identify your token.
@@ -57,7 +57,7 @@
           .form-row
             .col-12.col-md-10.col-lg-9
               .form-group.d-none#fieldset-token-scm-token
-                = f.label(:scm_token, 'SCM Token')
+                = f.label(:scm_token, 'SCM Token:')
                 %abbr.text-danger{ title: 'required' } *
                 = f.password_field(:scm_token, size: 80, class: 'form-control', placeholder: 'Please enter your SCM token')
 

--- a/src/api/app/views/webui/users/tokens/new.html.haml
+++ b/src/api/app/views/webui/users/tokens/new.html.haml
@@ -8,13 +8,22 @@
     .row
       .col-12.col-md-10.col-lg-8
         = form_with(model: @token, method: :post, local: false) do |f|
-          .form-row.d-none#created-token
-            .col-12.col-md-10.col-lg-9
-              %fieldset.form-group
-                = f.label(:string_readonly, 'Your new OBS Personal Access Token Secret', class: 'col-form-label col-form-label-lg')
-                .input-group
-                  = render CopyToClipboardInputComponent.new(form_builder: f)
-              %hr
+          .visible-when-created.d-none
+            %p.font-weight-bold Your new OBS Personal Access Token
+
+            .form-row#token-id
+              .col-sm
+                .form-group.mb-0
+                  = f.label(:id, 'Id:')
+                  %span= @token.id
+
+            .form-row#created-token
+              .col-12.col-md-10.col-lg-9
+                %fieldset.form-group
+                  = f.label(:string_readonly, 'Secret:', class: 'col-form-label')
+                  .input-group
+                    = render CopyToClipboardInputComponent.new(form_builder: f)
+                %hr
 
           .form-row
             .col


### PR DESCRIPTION
I was tempted to refactor the code to display a kind of a show view right after the token is created. Then the view wouldn't contain read-only text fields but text values.

However, I opted to follow the easy path and simply add the ID value in the current version of the code. The refactoring can be done in the near future.

![Screenshot_2021-11-11 Open Build Service(3)](https://user-images.githubusercontent.com/2581944/141306165-4d86d8c4-a5f6-4d0c-ab39-8ec0ca72cd33.png)
