### PR TITLE
Rename method valid_filters? to validate_filters

### DIFF
--- a/src/api/app/validators/workflow_filters_validator.rb
+++ b/src/api/app/validators/workflow_filters_validator.rb
@@ -5,12 +5,12 @@ class WorkflowFiltersValidator < ActiveModel::Validator
     @workflow = record
     @workflow_instructions = record.workflow_instructions
 
-    valid_filters?
+    validate_filters
   end
 
   private
 
-  def valid_filters?
+  def validate_filters
     # Filters aren't mandatory in a workflow
     return unless @workflow_instructions.key?(:filters)
 


### PR DESCRIPTION
The method `valid_filters?` wasn't returning a boolean, therefore the name was adapted to `validate_filters`