### PR TITLE
Move SCM integration from branch package to link package

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -1,14 +1,16 @@
 workflow:
   steps:
-    - branch_package:
+    - link_package:
         source_project: OBS:Server:Unstable
         source_package: obs-server
         target_project: home:bs-team
+    - configure_repositories:
+        project: home:bs-team
+        repositories:
+          - name: 15.3
+            target_project: SUSE:SLE-15-SP3:GA
+            target_repository: standard
+            architectures:
+              - x86_64
   filters:
     event: pull_request
-    architectures:
-      only:
-        - x86_64
-    repositories:
-      only:
-        - 15.3


### PR DESCRIPTION
To be able to restrict the building architectures and repositories,
switch the SCM integration strategy from branch package to link package

Reference:
https://github.com/openSUSE/open-build-service/wiki/Better-SCM-CI-Integration#link-a-package-to-a-project