### PR TITLE
[api] fix source revisions for channel submissions in maintenance_rel…

### DIFF
--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -131,7 +131,7 @@ Lint/UselessMethodDefinition:
 # Offense count: 832
 # Configuration parameters: IgnoredMethods, CountRepeatedAttributes.
 Metrics/AbcSize:
-  Max: 235
+  Max: 241
 
 # Offense count: 17
 # Configuration parameters: CountBlocks, Max.

--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -430,7 +430,6 @@ class BsRequestAction < ApplicationRecord
       # FIXME: this is currently handling local project links for packages with multiple spec files.
       #        This can be removed when we handle this as shadow packages in the backend.
       tpkg = ltpkg    = pkg.name
-      rev             = source_rev
       data            = nil
       missing_ok_link = false
       suffix          = ''
@@ -552,9 +551,14 @@ class BsRequestAction < ApplicationRecord
         new_action.target_project = tprj.name
         new_action.target_package = tpkg + incident_suffix
       end
-      new_action.source_rev = rev if rev
       if is_maintenance_release? || is_release?
         if pkg.is_channel?
+
+          if new_action.source_rev.blank?
+            # set revision
+            dir = Xmlhash.parse(Backend::Api::Sources::Package.files(new_action.source_project, new_action.source_package, { expand: 1 }))
+            new_action.source_rev = dir['srcmd5']
+          end
 
           # create submit request for possible changes in the _channel file
           submit_action = create_submit_action(source_package: new_action.source_package, source_project: new_action.source_project,

--- a/src/api/test/functional/channel_maintenance_test.rb
+++ b/src/api/test/functional/channel_maintenance_test.rb
@@ -645,7 +645,7 @@ class ChannelMaintenanceTests < ActionDispatch::IntegrationTest
     assert_no_xml_tag tag: 'source', attributes: { project: 'My:Maintenance:0', package: 'BaseDistro3.Channel' },
                       parent: { tag: 'action', attributes: { type: 'maintenance_release' } }
     # but it has a source change, so submit action
-    assert_xml_tag tag: 'source', attributes: { project: 'My:Maintenance:0', package: 'BaseDistro3.Channel' },
+    assert_xml_tag tag: 'source', attributes: { project: 'My:Maintenance:0', package: 'BaseDistro3.Channel', rev: 'b8629db76e8cfb1346acf3be7501b25c' },
                    parent: { tag: 'action', attributes: { type: 'submit' } }
     # no release patchinfo into channel
     assert_no_xml_tag tag: 'target', attributes: { project: 'Channel', package: 'patchinfo.0' },

--- a/src/api/test/functional/maintenance_test.rb
+++ b/src/api/test/functional/maintenance_test.rb
@@ -1411,12 +1411,10 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     assert_xml_tag(parent: { tag: 'state' }, tag: 'comment', content: 'All reviewers accepted request')
 
     get '/search/request', params: { match: 'review/@when>="2010-07-12"' }
-    print @response.body
     assert_response :success
     assert_xml_tag tag: 'request', attributes: { id: reqid }
 
     get '/search/request', params: { match: 'review/history/@when>="1975-07-12"' }
-    print @response.body
     assert_response :success
     assert_xml_tag tag: 'request', attributes: { id: reqid }
 


### PR DESCRIPTION
…ease

submit actions when creating maintenance_release requests lacked them so far