### PR TITLE
Drop response_url from workflow_runs

### DIFF
--- a/src/api/app/models/workflow_run.rb
+++ b/src/api/app/models/workflow_run.rb
@@ -1,5 +1,4 @@
 class WorkflowRun < ApplicationRecord
-  validates :response_url, length: { maximum: 255 }
   validates :request_headers, :request_payload, :status, presence: true
 
   belongs_to :token, class_name: 'Token::Workflow'
@@ -19,7 +18,6 @@ end
 #  request_headers :text(65535)      not null
 #  request_payload :text(65535)      not null
 #  response_body   :text(65535)
-#  response_url    :string(255)
 #  status          :integer          default("running"), not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null

--- a/src/api/db/migrate/20211112134215_remove_response_url_from_workflow_runs.rb
+++ b/src/api/db/migrate/20211112134215_remove_response_url_from_workflow_runs.rb
@@ -1,0 +1,5 @@
+class RemoveResponseUrlFromWorkflowRuns < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured { remove_column :workflow_runs, :response_url, :string }
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_10_142710) do
+ActiveRecord::Schema.define(version: 2021_11_12_134215) do
 
   create_table "architectures", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false, collation: "utf8_general_ci"
@@ -1060,7 +1060,6 @@ ActiveRecord::Schema.define(version: 2021_11_10_142710) do
     t.text "request_payload", null: false
     t.integer "status", limit: 1, default: 0, null: false
     t.text "response_body"
-    t.string "response_url"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "token_id", null: false


### PR DESCRIPTION
Initially, we thought that we needed the field response_url to report
back to SCM.  We just realise we are not responding back to SCM.

Co-authored-by: Eduardo Navarro <enavarro@suse.com>