### PR TITLE
Handle Octokit::InvalidRepository on YAMLDownloader

### DIFF
--- a/src/api/app/models/token/errors.rb
+++ b/src/api/app/models/token/errors.rb
@@ -5,6 +5,10 @@ module Token::Errors
     setup 404
   end
 
+  class NonExistentRepository < APIError
+    setup 404
+  end
+
   class NonExistentWorkflowsFile < APIError
     setup 404
   end

--- a/src/api/app/services/workflows/yaml_downloader.rb
+++ b/src/api/app/services/workflows/yaml_downloader.rb
@@ -27,6 +27,8 @@ module Workflows
       when 'gitlab'
         "#{@scm_payload[:api_endpoint]}/#{@scm_payload[:path_with_namespace]}/-/raw/#{@scm_payload[:target_branch]}/.obs/workflows.yml"
       end
+    rescue Octokit::InvalidRepository => e
+      raise Token::Errors::NonExistentRepository, e.message
     rescue Octokit::NotFound => e
       raise Token::Errors::NonExistentWorkflowsFile, ".obs/workflows.yml could not be downloaded from the SCM branch #{@scm_payload[:target_branch]}: #{e.message}"
     end


### PR DESCRIPTION
Give users the right feedback in case the repository doesnt exist
anymore when trying to download the `workflows.yml`

The issue https://errbit.opensuse.org/apps/5620ca2bdc71fa00b1000000/problems/60bff83684bf4607a946599e has two root causes (to investigate them, just navigate through them, clicking on Older/Newer): 

a) When the repository doesn't exist while downloading the YAML file
b) When the repository was removed, but OBS still reporting to github, i.e PR is open, but the repository was deleted. 

This PR fixes just the first case