### PR TITLE
Add response_url back to workflow_runs

### DIFF
--- a/src/api/app/models/workflow_run.rb
+++ b/src/api/app/models/workflow_run.rb
@@ -1,4 +1,5 @@
 class WorkflowRun < ApplicationRecord
+  validates :response_url, length: { maximum: 255 }
   validates :request_headers, :request_payload, :status, presence: true
 
   belongs_to :token, class_name: 'Token::Workflow'
@@ -18,6 +19,7 @@ end
 #  request_headers :text(65535)      not null
 #  request_payload :text(65535)      not null
 #  response_body   :text(65535)
+#  response_url    :string(255)
 #  status          :integer          default("running"), not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null

--- a/src/api/db/migrate/20211116111900_add_response_url_to_workflow_runs.rb
+++ b/src/api/db/migrate/20211116111900_add_response_url_to_workflow_runs.rb
@@ -1,0 +1,5 @@
+class AddResponseUrlToWorkflowRuns < ActiveRecord::Migration[6.1]
+  def change
+    add_column :workflow_runs, :response_url, :string
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_12_134215) do
+ActiveRecord::Schema.define(version: 2021_11_16_111900) do
 
   create_table "architectures", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false, collation: "utf8_general_ci"
@@ -1063,6 +1063,7 @@ ActiveRecord::Schema.define(version: 2021_11_12_134215) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "token_id", null: false
+    t.string "response_url"
     t.index ["token_id"], name: "index_workflow_runs_on_token_id"
   end
 


### PR DESCRIPTION
After the discussion, we decided to keep this field in the table so it's easier for users to recognize the SCM instance which triggered the workflow.

Co-authored-by: Eduardo Navarro <enavarro@suse.com>