### PR TITLE
Remove outdated comments in Workflow model

### DIFF
--- a/src/api/app/models/workflow.rb
+++ b/src/api/app/models/workflow.rb
@@ -21,9 +21,7 @@ class Workflow
   validates_with WorkflowFiltersValidator
 
   def call
-    # TODO: This could be in a custom validator WorkflowEventFilterValidator
     return unless event_matches_event_filter?
-    # TODO: This could be in a custom validator WorkflowBranchesFilterValidator
     return unless branch_matches_branches_filter?
 
     case


### PR DESCRIPTION
This is following up on the two cards we ended up closing last week:
- [Turn Workflow#branch_matches_branches_filter? into a ActiveModel::Validator](https://trello.com/c/K8AXlIvb/1798-turn-workflowbranchmatchesbranchesfilter-into-a-activemodelvalidator)
- [Turn Workflow#event_matches_event_filter? into a ActiveModel::Validator](https://trello.com/c/4U9DYiNb/1799-turn-workfloweventmatcheseventfilter-into-a-activemodelvalidator)

Those methods shouldn't be custom validators since they wouldn't produce validation errors on which the users can act. Informing users why workflows are run/skipped would be nice, but this is too much work for now.

