### PR TITLE
Fix inconsistent target project name

### DIFF
--- a/src/api/app/models/workflow/step/branch_package_step.rb
+++ b/src/api/app/models/workflow/step/branch_package_step.rb
@@ -11,6 +11,10 @@ class Workflow::Step::BranchPackageStep < ::Workflow::Step
 
   private
 
+  def target_project_base_name
+    step_instructions[:target_project]
+  end
+
   def branch_package(workflow_filters = {})
     create_branched_package if scm_webhook.new_pull_request? || (scm_webhook.updated_pull_request? && target_package.blank?) || scm_webhook.push_event?
 

--- a/src/api/app/models/workflow/step/link_package_step.rb
+++ b/src/api/app/models/workflow/step/link_package_step.rb
@@ -21,6 +21,10 @@ class Workflow::Step::LinkPackageStep < ::Workflow::Step
     target_package
   end
 
+  def target_project_base_name
+    step_instructions[:target_project]
+  end
+
   def target_project
     Project.find_by(name: target_project_name)
   end

--- a/src/api/spec/models/workflow/step/configure_repositories_spec.rb
+++ b/src/api/spec/models/workflow/step/configure_repositories_spec.rb
@@ -7,10 +7,7 @@ RSpec.describe Workflow::Step::ConfigureRepositories do
   describe '#call' do
     let(:project) { create(:project, name: 'openSUSE:Factory') }
     let!(:repository) { create(:repository, project: project, name: 'snapshot', architectures: ['i586', 'aarch64']) }
-    let(:target_project_name) do
-      'OBS:Server:Unstable:openSUSE-repo123:PR-1'
-    end
-    let(:target_project) { create(:project, name: target_project_name, maintainer: user) }
+    let(:target_project) { create(:project, name: 'OBS:Server:Unstable:openSUSE:repo123:PR-1', maintainer: user) }
     let(:step_instructions) do
       {
         project: 'OBS:Server:Unstable',
@@ -301,87 +298,7 @@ RSpec.describe Workflow::Step::ConfigureRepositories do
       end
 
       it 'raises an error due to an inexistent target project' do
-        expect { subject.call }.to raise_error(Project::Errors::UnknownObjectError, "Project not found: #{target_project_name}")
-      end
-    end
-  end
-
-  describe '#target_project_name' do
-    let(:step_instructions) do
-      {
-        project: 'OBS:Server:Unstable',
-        repositories:
-          [
-            {
-              name: 'openSUSE_Tumbleweed',
-              target_project: 'openSUSE:Factory',
-              target_repository: 'snapshot',
-              architectures: [
-                'x86_64',
-                'ppc'
-              ]
-            }
-          ]
-      }
-    end
-    let(:scm_webhook) { ScmWebhook.new(payload: payload) }
-
-    subject do
-      described_class.new(step_instructions: step_instructions,
-                          scm_webhook: scm_webhook,
-                          token: token).target_project_name
-    end
-
-    context 'for an unsupported event' do
-      let(:payload) do
-        {
-          scm: 'github',
-          event: 'unsupported'
-        }
-      end
-
-      it { is_expected.to be_nil }
-    end
-
-    context 'for a pull request webhook event' do
-      context 'from GitHub' do
-        let(:payload) do
-          {
-            scm: 'github',
-            event: 'pull_request',
-            pr_number: 1,
-            target_repository_full_name: 'openSUSE/repo123'
-          }
-        end
-
-        it { is_expected.to eq('OBS:Server:Unstable:openSUSE-repo123:PR-1') }
-      end
-
-      context 'from GitLab' do
-        let(:payload) do
-          {
-            scm: 'gitlab',
-            event: 'Merge Request Hook',
-            pr_number: 1,
-            path_with_namespace: 'openSUSE/repo123'
-          }
-        end
-
-        it { is_expected.to eq('OBS:Server:Unstable:openSUSE-repo123:PR-1') }
-      end
-    end
-
-    context 'for a push webhook event' do
-      context 'from GitHub' do
-        let(:payload) { { scm: 'github', event: 'push' } }
-
-        it { is_expected.to eq('OBS:Server:Unstable') }
-      end
-
-      context 'from GitLab' do
-        let(:payload) { { scm: 'gitlab', event: 'Push Hook' } }
-
-        it { is_expected.to eq('OBS:Server:Unstable') }
+        expect { subject.call }.to raise_error(Project::Errors::UnknownObjectError, "Project not found: #{subject.target_project_name}")
       end
     end
   end

--- a/src/api/spec/models/workflow/step_spec.rb
+++ b/src/api/spec/models/workflow/step_spec.rb
@@ -1,0 +1,93 @@
+require 'rails_helper'
+
+RSpec.describe Workflow::Step do
+  let(:user) { create(:confirmed_user, :with_home, login: 'Iggy') }
+  let(:token) { create(:workflow_token, user: user) }
+  let(:step) do
+    Class.new(described_class) do
+      def target_project_base_name
+        'OBS:Server:Unstable'
+      end
+    end
+  end
+
+  describe '#target_project_name' do
+    let(:step_instructions) do
+      {
+        project: 'OBS:Server:Unstable',
+        repositories:
+          [
+            {
+              name: 'openSUSE_Tumbleweed',
+              target_project: 'openSUSE:Factory',
+              target_repository: 'snapshot',
+              architectures: [
+                'x86_64',
+                'ppc'
+              ]
+            }
+          ]
+      }
+    end
+    let(:scm_webhook) { ScmWebhook.new(payload: payload) }
+
+    subject do
+      step.new(step_instructions: step_instructions,
+               scm_webhook: scm_webhook,
+               token: token).target_project_name
+    end
+
+    context 'for an unsupported event' do
+      let(:payload) do
+        {
+          scm: 'github',
+          event: 'unsupported'
+        }
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'for a pull request webhook event' do
+      context 'from GitHub' do
+        let(:payload) do
+          {
+            scm: 'github',
+            event: 'pull_request',
+            pr_number: 1,
+            target_repository_full_name: 'openSUSE/repo123'
+          }
+        end
+
+        it { is_expected.to eq('OBS:Server:Unstable:openSUSE:repo123:PR-1') }
+      end
+
+      context 'from GitLab' do
+        let(:payload) do
+          {
+            scm: 'gitlab',
+            event: 'Merge Request Hook',
+            pr_number: 1,
+            path_with_namespace: 'openSUSE/repo123'
+          }
+        end
+
+        it { is_expected.to eq('OBS:Server:Unstable:openSUSE:repo123:PR-1') }
+      end
+    end
+
+    context 'for a push webhook event' do
+      context 'from GitHub' do
+        let(:payload) { { scm: 'github', event: 'push' } }
+
+        it { is_expected.to eq('OBS:Server:Unstable') }
+      end
+
+      context 'from GitLab' do
+        let(:payload) { { scm: 'gitlab', event: 'Push Hook' } }
+
+        it { is_expected.to eq('OBS:Server:Unstable') }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #11854

The `Workflow::Step::ConfigureRepositories#target_project_name` method was a redefinition of the `Workflow::Step#target_project_name`.

They should be identical except for the YAML key containing the project name. So there is no need to keep both. In fact, this is leading to inconsistencies. For example with the format of the name (using "-" or ":").

Now we only have one definition of the method. The only part we redefine is the project name. For this, we have the `target_project_base_name` method implemented on each step.