### PR TITLE
Create workflow runs index view

### DIFF
--- a/src/api/app/components/token_card_component.html.haml
+++ b/src/api/app/components/token_card_component.html.haml
@@ -27,3 +27,6 @@
         = link_to '#', title: 'Delete Token',
           data: { toggle: 'modal', target: '#delete-token-modal', token_id: @token.id, action: token_path(@token) } do
           %i.fas.fa-times-circle.text-danger
+        - if @token.type == 'Token::Workflow'
+          = link_to(token_workflow_runs_path(@token.id), title: 'Workflow Runs') do
+            %i.fas.fa-book-open

--- a/src/api/app/controllers/webui/workflow_runs_controller.rb
+++ b/src/api/app/controllers/webui/workflow_runs_controller.rb
@@ -1,5 +1,5 @@
 class Webui::WorkflowRunsController < Webui::WebuiController
   def index
-    @workflow_runs = WorkflowRunPolicy::Scope.new(User.session, WorkflowRun, { token_id: params[:token_id] }).resolve
+    @workflow_runs = WorkflowRunPolicy::Scope.new(User.session, WorkflowRun, { token_id: params[:token_id] }).resolve.page(params[:page])
   end
 end

--- a/src/api/app/controllers/webui/workflow_runs_controller.rb
+++ b/src/api/app/controllers/webui/workflow_runs_controller.rb
@@ -1,0 +1,5 @@
+class Webui::WorkflowRunsController < Webui::WebuiController
+  def index
+    @workflow_runs = WorkflowRunPolicy::Scope.new(User.session, WorkflowRun, { token_id: params[:token_id] }).resolve
+  end
+end

--- a/src/api/app/models/workflow_run.rb
+++ b/src/api/app/models/workflow_run.rb
@@ -3,6 +3,7 @@ class WorkflowRun < ApplicationRecord
   validates :request_headers, :status, presence: true
 
   belongs_to :token, class_name: 'Token::Workflow'
+  paginates_per 20
 
   enum status: {
     running: 0,

--- a/src/api/app/policies/workflow_run_policy.rb
+++ b/src/api/app/policies/workflow_run_policy.rb
@@ -1,0 +1,21 @@
+class WorkflowRunPolicy < ApplicationPolicy
+  class Scope
+    def initialize(user, scope, opts = {})
+      @user = user
+      @scope = scope
+      @opts = opts
+    end
+
+    def resolve
+      token = Token.find_by(id: opts[:token_id])
+      raise Pundit::NotAuthorizedError, 'you are not authorized to access those workflow runs' unless token.user == user
+      raise Pundit::NotAuthorizedError, 'the token is not of type workflow' unless token.type == 'Token::Workflow'
+
+      scope.where(token_id: token.id).order(created_at: :desc)
+    end
+
+    private
+
+    attr_reader :user, :scope, :opts
+  end
+end

--- a/src/api/app/views/webui/workflow_runs/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui/workflow_runs/_breadcrumb_items.html.haml
@@ -1,0 +1,6 @@
+%li.breadcrumb-item
+  = link_to('Your Profile', user_path(User.session!))
+%li.breadcrumb-item
+  = link_to 'Tokens', tokens_path
+%li.breadcrumb-item.active
+  Workflow Runs

--- a/src/api/app/views/webui/workflow_runs/index.html.haml
+++ b/src/api/app/views/webui/workflow_runs/index.html.haml
@@ -6,6 +6,8 @@
     - if @workflow_runs.blank?
       %p There are no workflow runs for this token yet
     - else
+      .text-center
+        %span.ml-3= page_entries_info @workflow_runs, entry_name: ''
       .accordion.pt-3#workflow-runs-accordion
         .card
         - @workflow_runs.each do |workflow_run|
@@ -55,3 +57,4 @@
                   %h3 Response Body
                   %pre.border.p-2#response-body
                     = workflow_run.response_body
+        = paginate @workflow_runs, views_prefix: 'webui'

--- a/src/api/app/views/webui/workflow_runs/index.html.haml
+++ b/src/api/app/views/webui/workflow_runs/index.html.haml
@@ -1,0 +1,57 @@
+- @pagetitle = 'Workflow Runs'
+
+.card
+  .card-body
+    %h3= @pagetitle
+    - if @workflow_runs.blank?
+      %p There are no workflow runs for this token yet
+    - else
+      .accordion.pt-3#workflow-runs-accordion
+        .card
+        - @workflow_runs.each do |workflow_run|
+          .card-header{ id: "workflow-run-heading#{workflow_run.id}" }
+            .mb-0
+              %button.btn.btn-block{ type: 'button', data: { toggle: 'collapse', target: "#workflow-run#{workflow_run.id}" },
+                                      aria: { expanded: 'false', controls: "workflow-run#{workflow_run.id}" } }
+                .row
+                  .col-1.text-left
+                    - case workflow_run.status
+                      - when 'running'
+                        %i.fas.fa-running{ title: 'Status: running' }
+                      - when 'success'
+                        %i.fas.fa-check.text-primary{ title: 'Status: success' }
+                      - else
+                        %i.fas.fa-exclamation-triangle.text-danger{ title: 'Status: failed' }
+                  .col.text-left
+                    Workflow Run #{workflow_run.id}
+                  .col.text-right
+                    = workflow_run.created_at
+          .collapse{ id: "workflow-run#{workflow_run.id}", aria: { labelledby: "#workflow-run-heading#{workflow_run.id}" },
+                      data: { parent: '#workflow-runs-accordion' } }
+            .card-body
+              %ul.nav.nav-tabs#workflow-run-tabs{ role: 'tablist' }
+                %li.nav-item{ role: 'presentation' }
+                  %a.nav-link.active{ id: "request-tab#{workflow_run.id}", data: { toggle: 'tab' }, href: "#request-tab-content#{workflow_run.id}",
+                                      role: 'tab', aria: { controls: "request-tab-content#{workflow_run.id}", selected: 'true' } }
+                    Request
+                %li.nav-item{ role: 'presentation' }
+                  %a.nav-link{ id: "response-tab#{workflow_run.id}", data: { toggle: 'tab' }, href: "#response-tab-content#{workflow_run.id}",
+                                role: 'tab', aria: { controls: "response-tab-content#{workflow_run.id}", selected: 'false' } }
+                    Response
+              .tab-content.p-3#workflow-run-tabs-content
+                .tab-pane.fade.show.active{ id: "request-tab-content#{workflow_run.id}", role: 'tabpanel',
+                                            aria: { labelledby: "request-tab#{workflow_run.id}" } }
+                  %h3 Request Headers
+                  %pre.border.p-2#request-headers
+                    = workflow_run.request_headers
+                  %h3 Request Payload
+                  %pre.border.p-2#request-payload
+                    = workflow_run.request_payload
+                .tab-pane.fade{ id: "response-tab-content#{workflow_run.id}", role: 'tabpanel',
+                                aria: { labelledby: "response-tab#{workflow_run.id}" } }
+                  %h3 Response URL
+                  %pre.border.p-2#response-url
+                    = workflow_run.response_url
+                  %h3 Response Body
+                  %pre.border.p-2#response-body
+                    = workflow_run.response_body

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -336,7 +336,9 @@ OBSApi::Application.routes.draw do
       post 'rss_tokens' => :create, controller: 'webui/users/rss_tokens', as: :my_rss_token
       post 'status_messages/:id' => :acknowledge, controller: 'webui/status_messages', as: :acknowledge_status_message
 
-      resources :tokens, controller: 'webui/users/tokens'
+      resources :tokens, controller: 'webui/users/tokens' do
+        resources :workflow_runs, only: [:index], controller: 'webui/workflow_runs'
+      end
       resources :token_triggers, only: [:show, :update], controller: 'webui/users/token_triggers'
     end
 

--- a/src/api/spec/components/token_card_component_spec.rb
+++ b/src/api/spec/components/token_card_component_spec.rb
@@ -39,4 +39,10 @@ RSpec.describe TokenCardComponent, type: :component do
 
     it { expect(rendered_component).to have_text("Last trigger on #{time_now}") }
   end
+
+  context 'token of type workflow' do
+    let(:token) { build_stubbed(:workflow_token, user: user) }
+
+    it { expect(rendered_component).to have_link(href: "/my/tokens/#{token.id}/workflow_runs") }
+  end
 end

--- a/src/api/spec/controllers/webui/workflow_runs_controller_spec.rb
+++ b/src/api/spec/controllers/webui/workflow_runs_controller_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe Webui::WorkflowRunsController, type: :controller do
+  describe 'GET #index' do
+    let(:token_user) { create(:confirmed_user) }
+    let(:workflow_token) { create(:workflow_token, user: token_user) }
+    let!(:workflow_run) { create(:workflow_run, token: workflow_token) }
+
+    before do
+      login token_user
+      get :index, params: { token_id: workflow_token.id }
+    end
+
+    it { expect(assigns(:workflow_runs).count).to eq(1) }
+  end
+end

--- a/src/api/spec/policies/workflow_run_policy_spec.rb
+++ b/src/api/spec/policies/workflow_run_policy_spec.rb
@@ -4,41 +4,35 @@ RSpec.describe WorkflowRunPolicy do
   describe '#resolve' do
     subject { WorkflowRunPolicy::Scope }
 
-    let(:token_user) { create(:confirmed_user) }
+    let(:token_user) { create(:confirmed_user, login: 'foo') }
     let(:workflow_token) { create(:workflow_token, user: token_user) }
     let!(:workflow_run) { create(:workflow_run, token: workflow_token) }
 
-    context 'when the user has permission' do
-      before do
-        User.session = token_user
-      end
-
-      it 'returns the workflow runs' do
-        expect(subject.new(token_user, WorkflowRun, { token_id: workflow_token.id }).resolve.count).to eq(1)
-      end
+    before do
+      User.session = token_user
     end
 
-    context 'when the user does not have permission' do
-      let(:another_user) { create(:confirmed_user) }
-
-      before do
-        User.session = another_user
-      end
-
-      it 'raises a not authorized error' do
-        expect { subject.new(another_user, WorkflowRun, { token_id: workflow_token.id }).resolve }.to raise_error(Pundit::NotAuthorizedError)
+    context 'when the user has permission' do
+      it 'returns the workflow runs' do
+        expect(subject.new(User.session, WorkflowRun, { token_id: workflow_token.id }).resolve.count).to eq(1)
       end
     end
 
     context 'when token type is not of type workflow' do
       let(:release_token) { create(:release_token, user: token_user) }
 
+      it 'raise a not authorized error' do
+        expect { subject.new(User.session, WorkflowRun, { token_id: release_token.id }).resolve }.to raise_error(Pundit::NotAuthorizedError)
+      end
+    end
+
+    context 'when the user does not have permission' do
       before do
-        User.session = token_user
+        User.session = create(:confirmed_user, login: 'bar')
       end
 
-      it 'raise a not authorized error' do
-        expect { subject.new(token_user, WorkflowRun, { token_id: release_token.id }).resolve }.to raise_error(Pundit::NotAuthorizedError)
+      it 'raises a not authorized error' do
+        expect { subject.new(User.session, WorkflowRun, { token_id: workflow_token.id }).resolve }.to raise_error(Pundit::NotAuthorizedError)
       end
     end
   end

--- a/src/api/spec/policies/workflow_run_policy_spec.rb
+++ b/src/api/spec/policies/workflow_run_policy_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe WorkflowRunPolicy do
+  describe '#resolve' do
+    subject { WorkflowRunPolicy::Scope }
+
+    let(:token_user) { create(:confirmed_user) }
+    let(:workflow_token) { create(:workflow_token, user: token_user) }
+    let!(:workflow_run) { create(:workflow_run, token: workflow_token) }
+
+    context 'when the user has permission' do
+      before do
+        User.session = token_user
+      end
+
+      it 'returns the workflow runs' do
+        expect(subject.new(token_user, WorkflowRun, { token_id: workflow_token.id }).resolve.count).to eq(1)
+      end
+    end
+
+    context 'when the user does not have permission' do
+      let(:another_user) { create(:confirmed_user) }
+
+      before do
+        User.session = another_user
+      end
+
+      it 'raises a not authorized error' do
+        expect { subject.new(another_user, WorkflowRun, { token_id: workflow_token.id }).resolve }.to raise_error(Pundit::NotAuthorizedError)
+      end
+    end
+
+    context 'when token type is not of type workflow' do
+      let(:release_token) { create(:release_token, user: token_user) }
+
+      before do
+        User.session = token_user
+      end
+
+      it 'raise a not authorized error' do
+        expect { subject.new(token_user, WorkflowRun, { token_id: release_token.id }).resolve }.to raise_error(Pundit::NotAuthorizedError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
We are tracking executed workflow runs and the current state of them
through the `WorkflowRun` model.
Now that this data is available for the users we need the corresponding
webui elements in order to access those infos.

TODO:

- [x] add pagination
- [x] add controller and policy specs 
- [x] add the breadcrumbs
- [ ] ~~maybe split the index view into components~~

Example screenshots (data is fake):

![2021-11-19_15-31](https://user-images.githubusercontent.com/22001671/142639489-0f95b012-0ed4-461b-b6d5-ab49a25d9af2.png)

![2021-11-19_15-27](https://user-images.githubusercontent.com/22001671/142638913-e0d0f26e-0d96-4c58-992e-e855df2ead3f.png)

![2021-11-19_15-27_1](https://user-images.githubusercontent.com/22001671/142638923-c9b930b8-45b9-4e4d-91c1-98694fd26528.png)

![2021-11-19_15-27_2](https://user-images.githubusercontent.com/22001671/142638930-88ce8dfd-26ec-4f40-9704-3986ea8dc430.png)

