### PR TITLE
Support push events for tags in TriggerControllerService::ScmExtractor

### DIFF
--- a/src/api/spec/services/trigger_controller_service/scm_extractor_spec.rb
+++ b/src/api/spec/services/trigger_controller_service/scm_extractor_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe TriggerControllerService::ScmExtractor do
         end
       end
 
-      context 'for a push event' do
+      context 'with a push event for a commit' do
         let(:event) { 'push' }
         let(:payload) do
           {
@@ -80,7 +80,8 @@ RSpec.describe TriggerControllerService::ScmExtractor do
             },
             sender: {
               url: 'https://api.github.com'
-            }
+            },
+            base_ref: nil
           }
         end
         let(:expected_hash) do
@@ -93,6 +94,41 @@ RSpec.describe TriggerControllerService::ScmExtractor do
             source_repository_full_name: 'iggy/repo123',
             target_repository_full_name: 'iggy/repo123',
             ref: 'refs/heads/main/fix-bug'
+          }
+        end
+
+        it 'returns an instance of ScmWebhook with the extracted data from the GitHub payload' do
+          expect(scm_webhook).to be_instance_of(ScmWebhook)
+          expect(scm_webhook.payload).to eq(expected_hash)
+        end
+      end
+
+      context 'with a push event for a tag' do
+        let(:event) { 'push' }
+        let(:payload) do
+          {
+            ref: 'refs/tags/release_abc',
+            after: '9e0ea1fd99c9000cbb8b8c9d28763d0ddace0b65',
+            repository: {
+              full_name: 'iggy/repo123'
+            },
+            sender: {
+              url: 'https://api.github.com'
+            },
+            base_ref: 'refs/heads/main'
+          }
+        end
+        let(:expected_hash) do
+          {
+            scm: 'github',
+            event: 'push',
+            api_endpoint: 'https://api.github.com',
+            commit_sha: '9e0ea1fd99c9000cbb8b8c9d28763d0ddace0b65',
+            target_branch: 'main',
+            source_repository_full_name: 'iggy/repo123',
+            target_repository_full_name: 'iggy/repo123',
+            ref: 'refs/tags/release_abc',
+            tag_name: 'release_abc'
           }
         end
 
@@ -151,7 +187,7 @@ RSpec.describe TriggerControllerService::ScmExtractor do
         end
       end
 
-      context 'for a push event' do
+      context 'with a push event for a commit' do
         let(:event) { 'Push Hook' }
         let(:payload) do
           {
@@ -177,6 +213,40 @@ RSpec.describe TriggerControllerService::ScmExtractor do
             event: 'Push Hook',
             api_endpoint: 'https://gitlab.com',
             ref: 'refs/heads/main/fix-bug'
+          }
+        end
+
+        it 'returns an instance of ScmWebhook with the extracted data from the GitLab payload' do
+          expect(scm_webhook).to be_instance_of(ScmWebhook)
+          expect(scm_webhook.payload).to eq(expected_hash)
+        end
+      end
+
+      context 'with a push event for a tag' do
+        let(:event) { 'Tag Push Hook' }
+        let(:payload) do
+          {
+            object_kind: 'tag_push',
+            after: '82b3d5ae55f7080f1e6022629cdb57bfae7cccc7',
+            ref: 'refs/tags/release_abc',
+            project: {
+              http_url: 'https://gitlab.com/jane/doe.git',
+              path_with_namespace: 'jane/doe'
+            }
+          }
+        end
+        let(:expected_hash) do
+          {
+            scm: 'gitlab',
+            object_kind: 'tag_push',
+            http_url: 'https://gitlab.com/jane/doe.git',
+            event: 'Tag Push Hook',
+            api_endpoint: 'https://gitlab.com',
+            tag_name: 'release_abc',
+            target_branch: '82b3d5ae55f7080f1e6022629cdb57bfae7cccc7',
+            path_with_namespace: 'jane/doe',
+            ref: 'refs/tags/release_abc',
+            commit_sha: '82b3d5ae55f7080f1e6022629cdb57bfae7cccc7'
           }
         end
 


### PR DESCRIPTION
This will be used in #11832, but it's easy to review here without all the other changes.

This is safe to be merged since it doesn't change how workflows run. 