### PR TITLE
Support push events for tags in Workflow::Step#target_{project,package}_name

### DIFF
--- a/src/api/app/models/workflow/step.rb
+++ b/src/api/app/models/workflow/step.rb
@@ -15,7 +15,7 @@ class Workflow::Step
   end
 
   def target_project_name
-    return target_project_base_name if scm_webhook.push_event?
+    return target_project_base_name if scm_webhook.push_event? || scm_webhook.tag_push_event?
 
     return nil unless scm_webhook.pull_request_event?
 
@@ -74,6 +74,8 @@ class Workflow::Step
       package_name
     when scm_webhook.push_event?
       "#{package_name}-#{scm_webhook.payload[:commit_sha]}"
+    when scm_webhook.tag_push_event?
+      "#{package_name}-#{scm_webhook.payload[:tag_name]}"
     end
   end
 

--- a/src/api/spec/models/workflow/step_spec.rb
+++ b/src/api/spec/models/workflow/step_spec.rb
@@ -1,17 +1,73 @@
 require 'rails_helper'
 
 RSpec.describe Workflow::Step do
-  let(:user) { create(:confirmed_user, :with_home, login: 'Iggy') }
-  let(:token) { create(:workflow_token, user: user) }
-  let(:step) do
-    Class.new(described_class) do
-      def target_project_base_name
-        'OBS:Server:Unstable'
+  describe '#target_package_name' do
+    subject { described_class.new(step_instructions: step_instructions, scm_webhook: scm_webhook).send(:target_package_name) }
+
+    context 'for a pull request_event when target_package is in the step instructions' do
+      let(:step_instructions) { { target_package: 'hello_world' } }
+      let(:scm_webhook) { ScmWebhook.new(payload: { scm: 'github', event: 'pull_request' }) }
+
+      it 'returns the value of target_package' do
+        expect(subject).to eq('hello_world')
+      end
+    end
+
+    context 'for a pull request_event when target_package is not in the step instructions' do
+      let(:step_instructions) { { source_package: 'package123' } }
+      let(:scm_webhook) { ScmWebhook.new(payload: { scm: 'github', event: 'pull_request' }) }
+
+      it 'returns the name of the source package' do
+        expect(subject).to eq('package123')
+      end
+    end
+
+    context 'with a push event for a commit when target_package is in the step instructions' do
+      let(:step_instructions) { { target_package: 'hello_world' } }
+      let(:scm_webhook) { ScmWebhook.new(payload: { scm: 'github', event: 'push', ref: 'refs/heads/main', commit_sha: '456' }) }
+
+      it 'returns the value of target_package with the commit SHA as a suffix' do
+        expect(subject).to eq('hello_world-456')
+      end
+    end
+
+    context 'with a push event for a commit when target_package is not in the step instructions' do
+      let(:step_instructions) { { source_package: 'package123' } }
+      let(:scm_webhook) { ScmWebhook.new(payload: { scm: 'github', event: 'push', ref: 'refs/heads/main', commit_sha: '456' }) }
+
+      it 'returns the name of the source package with the commit SHA as a suffix' do
+        expect(subject).to eq('package123-456')
+      end
+    end
+
+    context 'with a push event for a tag when target_package is in the step instructions' do
+      let(:step_instructions) { { target_package: 'hello_world' } }
+      let(:scm_webhook) { ScmWebhook.new(payload: { scm: 'github', event: 'push', ref: 'refs/tags/release_abc', tag_name: 'release_abc' }) }
+
+      it 'returns the value of target_package with the tag name as a suffix' do
+        expect(subject).to eq('hello_world-release_abc')
+      end
+    end
+
+    context 'with a push event for a tag when target_package is not in the step instructions' do
+      let(:step_instructions) { { source_package: 'package123' } }
+      let(:scm_webhook) { ScmWebhook.new(payload: { scm: 'github', event: 'push', ref: 'refs/tags/release_abc', tag_name: 'release_abc' }) }
+
+      it 'returns the name of the source package with the tag name as a suffix' do
+        expect(subject).to eq('package123-release_abc')
       end
     end
   end
 
   describe '#target_project_name' do
+    let(:step) do
+      Class.new(described_class) do
+        def target_project_base_name
+          'OBS:Server:Unstable'
+        end
+      end
+    end
+
     let(:step_instructions) do
       {
         project: 'OBS:Server:Unstable',
@@ -32,9 +88,7 @@ RSpec.describe Workflow::Step do
     let(:scm_webhook) { ScmWebhook.new(payload: payload) }
 
     subject do
-      step.new(step_instructions: step_instructions,
-               scm_webhook: scm_webhook,
-               token: token).target_project_name
+      step.new(step_instructions: step_instructions, scm_webhook: scm_webhook).target_project_name
     end
 
     context 'for an unsupported event' do
@@ -85,6 +139,20 @@ RSpec.describe Workflow::Step do
 
       context 'from GitLab' do
         let(:payload) { { scm: 'gitlab', event: 'Push Hook' } }
+
+        it { is_expected.to eq('OBS:Server:Unstable') }
+      end
+    end
+
+    context 'with a push webhook event for a tag' do
+      context 'from GitHub' do
+        let(:payload) { { scm: 'github', event: 'push', ref: 'refs/tags/release_abc' } }
+
+        it { is_expected.to eq('OBS:Server:Unstable') }
+      end
+
+      context 'from GitLab' do
+        let(:payload) { { scm: 'gitlab', event: 'Tag Push Hook' } }
 
         it { is_expected.to eq('OBS:Server:Unstable') }
       end


### PR DESCRIPTION
This will be used in #11832, but it's easy to review here without all the other changes.

This is safe to be merged since it doesn't change how workflows run. 