### PR TITLE
Reintroduce checking for `Token` string

### DIFF
--- a/src/api/app/services/trigger_controller_service/token_extractor.rb
+++ b/src/api/app/services/trigger_controller_service/token_extractor.rb
@@ -16,9 +16,15 @@ module TriggerControllerService
 
     private
 
+    def extract_token_string_from_authorization_header
+      http_auth = @http_request.env['HTTP_AUTHORIZATION']
+
+      http_auth.slice(6..-1) if http_auth.present? && http_auth[0..4] == 'Token'
+    end
+
     def extract_auth_token_from_headers
       auth_token = @http_request.env['HTTP_X_GITLAB_TOKEN'] ||
-                   @http_request.env['HTTP_AUTHORIZATION'].to_s.slice(6..-1)
+                   extract_token_string_from_authorization_header
 
       return unless auth_token
 

--- a/src/api/spec/services/trigger_controller_service/token_extractor_spec.rb
+++ b/src/api/spec/services/trigger_controller_service/token_extractor_spec.rb
@@ -75,15 +75,15 @@ RSpec.describe ::TriggerControllerService::TokenExtractor do
                        env: { 'HTTP_AUTHORIZATION' => token.string })
       end
 
-      it 'raises ActiveRecord::RecordNotFound' do
-        expect { subject }.to raise_error(ActiveRecord::RecordNotFound, "Couldn't find Token")
+      it 'returns nil' do
+        expect(subject).to be_nil
       end
     end
 
     context 'with a token in the HTTP header HTTP_AUTHORIZATION' do
       let(:request) do
         OpenStruct.new(params: {}, body: StringIO.new(request_body),
-                       env: { 'HTTP_AUTHORIZATION' => "Basic #{token.string}" })
+                       env: { 'HTTP_AUTHORIZATION' => "Token #{token.string}" })
       end
 
       it 'returns the token' do


### PR DESCRIPTION
Token authentication can be performed by passing a token string through an 'Authorization' HTTP header. The format to pass this token follows this expression:

`Token TOKEN_STRING`

This changed in commit deea2dfcd9eea704eaed0532793160f7c7ba88b6, where the check for the 'Token' string was removed.

Reintroduce the check for the 'Token' string, as was initially defined, and is described in the API documentation.