### PR TITLE
Document various endpoints under '/search' with OpenAPI, part I

### DIFF
--- a/src/api/public/apidocs-new/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs-new/OBS-v2.10.50.yaml
@@ -173,6 +173,12 @@ paths:
     $ref: 'paths/search_owner.yaml'
   /search/missing_owner:
     $ref: 'paths/missing_owner.yaml'
+  /search/published/binary/id:
+    $ref: 'paths/search_published_binary_id.yaml'
+  /search/published/repoinfo/id:
+    $ref: 'paths/search_published_repoinfo_id.yaml'
+  /search/published/pattern/id:
+    $ref: 'paths/search_published_pattern_id.yaml'
 
   /service:
     $ref: 'paths/service.yaml'

--- a/src/api/public/apidocs-new/components/parameters/limit.yaml
+++ b/src/api/public/apidocs-new/components/parameters/limit.yaml
@@ -1,0 +1,6 @@
+in: query
+name: limit
+schema:
+  type: integer
+description: Override default maximum value of 1000 entries to be returned.
+example: 20

--- a/src/api/public/apidocs-new/components/parameters/withdownloadurl.yaml
+++ b/src/api/public/apidocs-new/components/parameters/withdownloadurl.yaml
@@ -1,0 +1,12 @@
+in: query
+name: withdownloadurl
+schema:
+  type: integer
+  enum:
+    - 0
+    - 1
+description: |
+  Add the download url in the results as attribute `downloadurl`.
+
+  A value `0` means without the download url. A value `1` means with the download url.
+example: 1

--- a/src/api/public/apidocs-new/components/responses/search/published_binary_id.yaml
+++ b/src/api/public/apidocs-new/components/responses/search/published_binary_id.yaml
@@ -1,0 +1,130 @@
+description: OK. The request has succeeded.
+content:
+  application/xml; charset=utf-8:
+    schema:
+      type: object
+      properties:
+        matches:
+          type: integer
+          xml:
+            attribute: true
+        limited:
+          type: boolean
+          xml:
+            attribute: true
+        binary:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+                xml:
+                  attribute: true
+              project:
+                type: string
+                xml:
+                  attribute: true
+              package:
+                type: string
+                xml:
+                  attribute: true
+              repository:
+                type: string
+                xml:
+                  attribute: true
+              version:
+                type: string
+                xml:
+                  attribute: true
+              release:
+                type: string
+                xml:
+                  attribute: true
+              arch:
+                type: string
+                xml:
+                  attribute: true
+              filename:
+                type: string
+                xml:
+                  attribute: true
+              filepath:
+                type: string
+                xml:
+                  attribute: true
+              baseproject:
+                type: string
+                xml:
+                  attribute: true
+              type:
+                type: string
+                xml:
+                  attribute: true
+              downloadurl:
+                type: string
+                xml:
+                  attribute: true
+      xml:
+        name: collection
+        wrapped: true
+    examples:
+      including_download_urls:
+        value:
+          matches: 2
+          binary:
+            - name: package_name
+              project: home:foo
+              package: package_name
+              repository: openSUSE_Tumbleweed
+              version: 20201220
+              release: 3.1
+              arch: src
+              filename: package_name-20201220-3.1.src.rpm
+              filepath: home:/foo/openSUSE_Tumbleweed/src/package_name-20201220-3.1.src.rpm
+              baseproject: home:bar
+              type: rpm
+              downloadurl: https://server1.myorg.org/repositories/home:/foo/openSUSE_Tumbleweed/src/package_name-20201220-3.1.src.rpm
+            - name: package_name2
+              project: home:foo
+              package: package_name2
+              repository: openSUSE_Tumbleweed
+              version: 20201220
+              release: 3.1
+              arch: src
+              filename: package_name2-20201220-3.1.src.rpm
+              filepath: home:/foo/openSUSE_Tumbleweed/src/package_name2-20201220-3.1.src.rpm
+              baseproject: home:bar
+              type: rpm
+              downloadurl: https://server1.myorg.org/repositories/home:/foo/openSUSE_Tumbleweed/src/package_name2-20201220-3.1.src.rpm
+        summary: Including download urls
+        description: Result after adding the `withdownloadurl=1` parameter/value pair to the request.
+      with_limit:
+        value:
+          matches: 2
+          limited: true
+          binary:
+            - name: package_name
+              project: home:foo
+              repository: openSUSE_Tumbleweed
+              package: package_name
+              version: 20201220
+              release: 3.1
+              arch: src
+              filename: package_name-20201220-3.1.src.rpm
+              filepath: home:/foo/openSUSE_Tumbleweed/src/package_name-20201220-3.1.src.rpm
+              baseproject: home:bar
+              type: rpm
+            - name: package_name2
+              project: home:foo
+              package: package_name2
+              repository: openSUSE_Tumbleweed
+              version: 20201220
+              release: 3.1
+              arch: src
+              filename: package_name2-20201220-3.1.src.rpm
+              filepath: home:/foo/openSUSE_Tumbleweed/src/package_name2-20201220-3.1.src.rpm
+              baseproject: home:bar
+              type: rpm
+        summary: Limiting results
+        description: Result after adding `limit=2` parameter/value pair to the request.

--- a/src/api/public/apidocs-new/components/responses/search/published_pattern_id.yaml
+++ b/src/api/public/apidocs-new/components/responses/search/published_pattern_id.yaml
@@ -1,0 +1,96 @@
+description: OK. The request has succeeded.
+content:
+  application/xml; charset=utf-8:
+    schema:
+      type: object
+      properties:
+        matches:
+          type: integer
+          xml:
+            attribute: true
+        limited:
+          type: boolean
+          xml:
+            attribute: true
+        pattern:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+                xml:
+                  attribute: true
+              project:
+                type: string
+                xml:
+                  attribute: true
+              repository:
+                type: string
+                xml:
+                  attribute: true
+              filename:
+                type: string
+                xml:
+                  attribute: true
+              filepath:
+                type: string
+                xml:
+                  attribute: true
+              baseproject:
+                type: string
+                xml:
+                  attribute: true
+              type:
+                type: string
+                xml:
+                  attribute: true
+              downloadurl:
+                type: string
+                xml:
+                  attribute: true
+      xml:
+        name: collection
+        wrapped: true
+    examples:
+      including_download_urls:
+        value:
+          matches: 1
+          pattern:
+            - name: OBS_Server
+              project: OBS:Server:Unstable
+              repository: SLE_12_SP4
+              filename: OBS_Server.ymp
+              filepath: OBS:/Server:/Unstable/SLE_12_SP4/OBS_Server.ymp
+              baseproject: SUSE:SLE-12:SLE-Module-Adv-Systems-Management
+              type: ymp
+              downloadurl: https://download.opensuse.org/repositories/OBS:/Server:/Unstable/SLE_12_SP4/SLE_12_SP4/OBS_Server.ymp
+        summary: Including download urls
+        description: Result after adding the `withdownloadurl=1` parameter/value pair to the request.
+      with_limit:
+        value:
+          matches: 9
+          limited: true
+          pattern:
+            - name: OBS_Server
+              project: OBS:Server:Unstable
+              repository: 15.3
+              filename: OBS_Server.ymp
+              filepath: OBS:/Server:/Unstable/15.3/OBS_Server.ymp
+              baseproject: SUSE:SLE-15:GA
+              type: ymp
+            - name: OBS_Server
+              project: OBS:Server:Unstable
+              repository: SLE_12_SP4
+              filename: OBS_Server.ymp
+              filepath: OBS:/Server:/Unstable/SLE_12_SP4/OBS_Server.ymp
+              baseproject: SUSE:SLE-12:SLE-Module-Adv-Systems-Management
+              type: ymp
+        summary: Limiting results
+        description: Result after adding `limit=2` parameter/value pair to the request.
+      without_matches:
+        value:
+          matches: 0
+        summary: No matches
+        description: |
+          Empty result, when there is no matches. For example: `?match=project='home:bs-team:OBS'`.

--- a/src/api/public/apidocs-new/components/responses/search/published_repoinfo_id.yaml
+++ b/src/api/public/apidocs-new/components/responses/search/published_repoinfo_id.yaml
@@ -1,0 +1,57 @@
+description: OK. The request has succeeded.
+content:
+  application/xml; charset=utf-8:
+    schema:
+      type: object
+      properties:
+        matches:
+          type: integer
+          xml:
+            attribute: true
+        limited:
+          type: boolean
+          xml:
+            attribute: true
+        repoinfo:
+          type: array
+          items:
+            type: object
+            properties:
+              project:
+                type: string
+                xml:
+                  attribute: true
+              repository:
+                type: string
+                xml:
+                  attribute: true
+      xml:
+        name: collection
+        wrapped: true
+    examples:
+      including_download_urls:
+        value:
+          matches: 1
+          repoinfo:
+            - project: OBS:Server:Unstable
+              repository: SLE_12_SP4
+              downloadurl: https://download.opensuse.org/repositories/OBS:/Server:/Unstable/SLE_12_SP4/SLE_12_SP4/OBS_Server.ymp
+        summary: Including download urls
+        description: Result after adding the `withdownloadurl=1` parameter/value pair to the request.
+      with_limit:
+        value:
+          matches: 2
+          limited: true
+          repoinfo:
+            - project: OBS:Server:Unstable
+              repository: SLE_12_SP4
+            - project: OBS:Server:Unstable
+              repository: SLE_12_SP5
+        summary: Limiting results
+        description: Result after adding `limit=2` parameter/value pair to the request.
+      without_matches:
+        value:
+          matches: 0
+        summary: No matches
+        description: |
+          Empty result, when there is no matches. For example: `?match=project='home:bs-team:OBS'`.

--- a/src/api/public/apidocs-new/paths/search_published_binary_id.yaml
+++ b/src/api/public/apidocs-new/paths/search_published_binary_id.yaml
@@ -1,0 +1,43 @@
+get:
+  summary: Search for currently available binaries in the publish area.
+  security:
+    - basic_authentication: []
+  parameters:
+    - in: query
+      name: match
+      schema:
+        type: string
+      required: true
+      description: XPath expression.
+      example: project='home:foo'+and+name='bar'
+    - $ref: '../components/parameters/limit.yaml'
+    - $ref: '../components/parameters/withdownloadurl.yaml'
+  responses:
+    '200':
+      $ref: '../components/responses/search/published_binary_id.yaml'
+    '400':
+      description: Bad Request
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          example:
+            code: 400
+            summary: missing string terminator 
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '404':
+      description: Not Found.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          examples:
+            project_not_found:
+              value:
+                code: 404
+                summary: project 'home:foo' does not exist
+                description: 404 project 'home:foo' does not exist
+              summary: Not Found
+  tags:
+    - Search

--- a/src/api/public/apidocs-new/paths/search_published_pattern_id.yaml
+++ b/src/api/public/apidocs-new/paths/search_published_pattern_id.yaml
@@ -1,0 +1,30 @@
+get:
+  summary: Search for published patterns.
+  security:
+    - basic_authentication: []
+  parameters:
+    - in: query
+      name: match
+      schema:
+        type: string
+      required: true
+      description: XPath expression.
+      example: project='home:foo'+and+name='bar'
+    - $ref: '../components/parameters/limit.yaml'
+    - $ref: '../components/parameters/withdownloadurl.yaml'
+  responses:
+    '200':
+      $ref: '../components/responses/search/published_pattern_id.yaml'
+    '400':
+      description: Bad Request
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          example:
+            code: 400
+            summary: missing string terminator 
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+  tags:
+    - Search

--- a/src/api/public/apidocs-new/paths/search_published_repoinfo_id.yaml
+++ b/src/api/public/apidocs-new/paths/search_published_repoinfo_id.yaml
@@ -1,0 +1,30 @@
+get:
+  summary: Search for currently available repositories in the publish area.
+  security:
+    - basic_authentication: []
+  parameters:
+    - in: query
+      name: match
+      schema:
+        type: string
+      required: true
+      description: XPath expression.
+      example: project='home:foo'
+    - $ref: '../components/parameters/limit.yaml'
+    - $ref: '../components/parameters/withdownloadurl.yaml'
+  responses:
+    '200':
+      $ref: '../components/responses/search/published_repoinfo_id.yaml'
+    '400':
+      description: Bad Request
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          example:
+            code: 400
+            summary: missing string terminator 
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+  tags:
+    - Search


### PR DESCRIPTION
- [ ] ~`/search`~ Will be addressed in a following pull request.
- [x] `/search/published/binary/id`
- [x] `/search/published/repoinfo/id`
- [x] `/search/published/pattern/id`