### PR TITLE
[backend] support a new "ccachetype" build flag

### DIFF
--- a/src/backend/BSSched/BuildJob.pm
+++ b/src/backend/BSSched/BuildJob.pm
@@ -1012,6 +1012,7 @@ sub create {
 
   my $kiwimode;
   $kiwimode = $buildtype if $buildtype eq 'kiwi-image' || $buildtype eq 'kiwi-product' || $buildtype eq 'docker' || $buildtype eq 'fissile';
+  my $ccache;
 
   my $syspath;
   my $searchpath = path2buildinfopath($gctx, $ctx->{'prpsearchpath'});
@@ -1067,7 +1068,8 @@ sub create {
     my $opackid = $packid;
     $opackid = $pdata->{'releasename'} if $pdata->{'releasename'};
     if (grep {$_ eq "useccache:$opackid" || $_ eq "useccache:$packid"} @{$bconf->{'buildflags'} || []}) {
-      push @bdeps, @{$bconf->{'substitute'}->{'build-packages:ccache'} || [ 'ccache' ] };
+      $ccache = $bconf->{'buildflags:ccachetype'} || 'ccache';
+      push @bdeps, @{$bconf->{'substitute'}->{"build-packages:$ccache"} || [ $ccache ] };
     }
   }
 
@@ -1186,6 +1188,7 @@ sub create {
   $binfo->{'constraintsmd5'} = $pdata->{'constraintsmd5'} if $pdata->{'constraintsmd5'};
   $binfo->{'prjconfconstraint'} = $bconf->{'constraint'} if @{$bconf->{'constraint'} || []};
   $binfo->{'nounchanged'} = 1 if $info->{'nounchanged'};
+  $binfo->{'ccache'} = $ccache if $ccache;
   if (!$ctx->{'isreposerver'} && ($proj->{'kind'} || '') eq 'maintenance_incident' && $pdata->{'releasename'}) {
     $binfo->{'releasename'} = $pdata->{'releasename'};
   }

--- a/src/backend/BSXML.pm
+++ b/src/backend/BSXML.pm
@@ -564,6 +564,7 @@ our $buildinfo = [
 	'release',
         'config',
 	'debuginfo',
+	'ccache',
 	'constraintsmd5',
       [ 'prjconfconstraint' ],
       [ 'subpack' ],

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -3332,13 +3332,8 @@ sub dobuild {
 
 
   my $bconf = Build::read_config($buildinfo->{'arch'}, "$buildroot/.build.config");
-  my $useccache = 0;
-  if (exists $bconf->{'buildflags:useccache'}) {
-      my $opackid = $buildinfo->{'releasename'} || $packid;
-      if (grep {$_ eq "useccache:$opackid" || $_ eq "useccache:$packid"} @{$bconf->{'buildflags'} || []}) {
-        $useccache = 1;
-    }
-  }
+  my $useccache = $buildinfo->{'ccache'} ? 1 : 0;
+  my $ccachetype = $useccache ? $buildinfo->{'ccache'} : undef;
 
   if ($buildinfo->{'modularity_meta'}) {
     getmodulemddata($buildinfo, $srcdir, $bconf);
@@ -3493,6 +3488,8 @@ sub dobuild {
   push @args, '--arch', $arch;
   push @args, '--jobs', $jobs if $jobs;
   push @args, '--ccache' if $useccache && $oldpkgdir;
+  push @args, '--ccache-create-archive' if $useccache && $oldpkgdir;
+  push @args, "--ccache-type=$ccachetype" if $useccache && $oldpkgdir && $ccachetype;
   push @args, '--threads', $threads if $threads;
   push @args, '--reason', "Building $packid for project '$projid' repository '$repoid' arch '$arch' srcmd5 '$buildinfo->{'srcmd5'}'";
   push @args, '--disturl', $disturl;


### PR DESCRIPTION
This specifies the compiler cache type to use. We also put the
type in the job file, so that the worker does not need to guess
what thr scheduler used for dependency expansion.