### PR TITLE
Add source project name Apidoc endpoint

### DIFF
--- a/src/api/public/apidocs-new/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs-new/OBS-v2.10.50.yaml
@@ -4,20 +4,20 @@ servers:
   - url: '/'
 
 tags:
-  - name: General Information
   - name: Announcements
-  - name: Attributes
   - name: Attribute Namespaces
+  - name: Attributes
   - name: Build
   - name: Configuration
   - name: Distributions
+  - name: General Information
   - name: Groups
   - name: Issue Trackers
   - name: Notifications
   - name: Person
   - name: Published Binaries
   - name: Requests
-  - name: Sources
+  - name: Sources - Projects
   - name: Trigger
   - name: Workers
 
@@ -176,6 +176,8 @@ paths:
     $ref: 'paths/source_branch.yaml'
   /source?cmd=orderkiwirepos:
     $ref: 'paths/source_orderkiwirepos.yaml'
+  /source/{project_name}?cmd=addchannels:
+    $ref: 'paths/source_project_name_cmd_addchannels.yaml'
 
   /trigger/{operation}:
     $ref: 'paths/trigger_operation.yaml'

--- a/src/api/public/apidocs-new/paths/source_project_name_cmd_addchannels.yaml
+++ b/src/api/public/apidocs-new/paths/source_project_name_cmd_addchannels.yaml
@@ -1,0 +1,33 @@
+post:
+  summary: Add channels and extend repository list.
+  description: |
+    Add channels for each one of the provided project packages.
+    If the mode parameter is provided, that mode is added to the package channel.
+    The mode parameter can be:
+      - 'skip_disabled'
+      - 'enable_all'
+      - 'add_disabled' being the default.
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/project_name.yaml'
+    - in: path
+      name: mode
+      schema:
+        type: string
+        enum:
+          - skip_disabled
+          - enable_all
+          - add_disabled
+      required: false
+      description: The channel will be added to the package using this mode.
+      example: "add_disabled"
+  responses:
+    '200':
+      $ref: '../components/responses/succeeded.yaml'
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '404':
+      $ref: '../components/responses/unknown_project.yaml'
+  tags:
+    - Sources - Projects


### PR DESCRIPTION
This is the new ApiDoc endpoint that will eventually replace the current endpoint here https://build.opensuse.org/apidocs/index#44 