### PR TITLE
Pluralize request tag name in API docs

### DIFF
--- a/src/api/public/apidocs-new/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs-new/OBS-v2.10.50.yaml
@@ -16,7 +16,7 @@ tags:
   - name: Notifications
   - name: Person
   - name: Published Binaries
-  - name: Request
+  - name: Requests
   - name: Trigger
   - name: Workers
 

--- a/src/api/public/apidocs-new/paths/request.yaml
+++ b/src/api/public/apidocs-new/paths/request.yaml
@@ -20,7 +20,7 @@ get:
     '401':
       $ref: '../components/responses/unauthorized.yaml'
   tags:
-    - Request
+    - Requests
 
 post:
   summary: Create a request
@@ -91,5 +91,5 @@ post:
             code: create_bs_request_not_authorized
             summary: You are not authorized to create this Bs request.
   tags:
-    - Request
+    - Requests
 

--- a/src/api/public/apidocs-new/paths/request_id.yaml
+++ b/src/api/public/apidocs-new/paths/request_id.yaml
@@ -22,7 +22,7 @@ get:
             code: not_found
             summary: Couldn't find request with id '5'
   tags:
-    - Request
+    - Requests
 
 post:
   summary: Apply certain actions on a specified request.
@@ -173,7 +173,7 @@ post:
                 code: not_found
                 summary: Couldn't find request with id '120'
   tags:
-    - Request
+    - Requests
 
 put:
   summary: Modify a given request.
@@ -221,7 +221,7 @@ put:
             code: not_found
             summary: Couldn't find request with id '10'
   tags:
-    - Request
+    - Requests
 
 delete:
   summary: Delete a given request.
@@ -245,4 +245,4 @@ delete:
             code: not_found
             summary: Couldn't find request with id '10'
   tags:
-    - Request
+    - Requests

--- a/src/api/public/apidocs-new/paths/request_id_cmd_diff.yaml
+++ b/src/api/public/apidocs-new/paths/request_id_cmd_diff.yaml
@@ -58,5 +58,5 @@ post:
             code: not_found
             summary: Couldn't find request with id '355'
   tags:
-    - Request
+    - Requests
 

--- a/src/api/public/apidocs-new/paths/request_view_collection.yaml
+++ b/src/api/public/apidocs-new/paths/request_view_collection.yaml
@@ -49,4 +49,4 @@ get:
                 code: not_found
                 summary: Couldn't find User with login = foo
   tags:
-    - Request
+    - Requests


### PR DESCRIPTION
We are using plural tags when possible, so we pluralize the request tag for consistency.