### PR TITLE
Document owner/missing_owner search endpoint with openapi

### DIFF
--- a/src/api/public/apidocs-new/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs-new/OBS-v2.10.50.yaml
@@ -171,6 +171,8 @@ paths:
 
   /search/owner:
     $ref: 'paths/search_owner.yaml'
+  /search/missing_owner:
+    $ref: 'paths/missing_owner.yaml'
 
   /service:
     $ref: 'paths/service.yaml'

--- a/src/api/public/apidocs-new/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs-new/OBS-v2.10.50.yaml
@@ -17,6 +17,7 @@ tags:
   - name: Person
   - name: Published Binaries
   - name: Requests
+  - name: Search
   - name: Sources
   - name: Sources - Projects
   - name: Trigger
@@ -167,6 +168,9 @@ paths:
     $ref: 'paths/request_id.yaml'
   /request/{id}?cmd=diff:
     $ref: 'paths/request_id_cmd_diff.yaml'
+
+  /search/owner:
+    $ref: 'paths/search_owner.yaml'
 
   /service:
     $ref: 'paths/service.yaml'

--- a/src/api/public/apidocs-new/components/schemas/missing_owner_collection.yaml
+++ b/src/api/public/apidocs-new/components/schemas/missing_owner_collection.yaml
@@ -1,0 +1,24 @@
+type: object
+properties:
+  missing_owner:
+    type: array
+    items:
+      type: object
+      properties:
+        rootproject:
+          type: string
+          example: 'openSUSE'
+          xml:
+            attribute: true
+        project:
+          type: string
+          example: 'openSUSE:Factory'
+          xml:
+            attribute: true
+        package:
+          type: string
+          example: 'yast2-branding-openSUSE'
+          xml:
+            attribute: true
+xml:
+  name: collection

--- a/src/api/public/apidocs-new/components/schemas/owner_collection.yaml
+++ b/src/api/public/apidocs-new/components/schemas/owner_collection.yaml
@@ -1,0 +1,54 @@
+type: object
+properties:
+  owner:
+    type: array
+    items:
+      type: object
+      properties:
+        rootproject:
+          type: string
+          example: 'openSUSE'
+          xml:
+            attribute: true
+        project:
+          type: string
+          example: 'openSUSE:Factory'
+          xml:
+            attribute: true
+        package:
+          type: string
+          example: 'yast2-branding-openSUSE'
+          xml:
+            attribute: true
+        person:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+                example: 'foo'
+                xml:
+                  attribute: true
+              role:
+                type: string
+                example: 'bugowner'
+                xml:
+                  attribute: true
+        group:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+                example: 'bar'
+                xml:
+                  attribute: true
+              role:
+                type: string
+                example: 'maintainer'
+                xml:
+                  attribute: true
+xml:
+  name: collection

--- a/src/api/public/apidocs-new/paths/missing_owner.yaml
+++ b/src/api/public/apidocs-new/paths/missing_owner.yaml
@@ -1,0 +1,60 @@
+get:
+  summary: |
+    Search for packages that miss the definition for a by default
+    responsible person or group.
+  security:
+    - basic_authentication: []
+  parameters:
+    - in: query
+      name: project
+      schema:
+        type: string
+      description: Only return results for a given project.
+    - in: query
+      name: filter
+      schema:
+        type: string
+      description: |
+        A comma separated list of role names that should be
+        taken into account in the result.
+      example: 'bugowner,maintainer'
+    - in: query
+      name: attribute
+      schema:
+        type: string
+      description: |
+        Choose the attribute name that marks the rootproject which defines the
+        owner's for all corresponding subprojects and limit the returned results
+        to those. The default value is `OBS:OwnerRootProject`.
+  responses:
+    '200':
+      description: OK. The request has succeeded.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/missing_owner_collection.yaml'
+    '400':
+      description: Bad request
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          example:
+            code: invalid_attribute
+            summary: |
+              Attribute 'foo' must be in the $NAMESPACE:$NAME style
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '404':
+      description: Not Found
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          examples:
+            Not Found:
+              value:
+                code: unknown_project
+                summary: 'Project not found: bla'
+  tags:
+    - Search

--- a/src/api/public/apidocs-new/paths/search_owner.yaml
+++ b/src/api/public/apidocs-new/paths/search_owner.yaml
@@ -1,0 +1,100 @@
+get:
+  summary: Search for the default responsible person or group (the owner).
+  description: |
+    Search for the default responsible person or group (the owner) by a user, group
+    or binary name.
+  security:
+    - basic_authentication: []
+  parameters:
+    - in: query
+      name: binary
+      schema:
+        type: string
+      description: |
+        The name of a build binary. Either the `binary`, `user` or `group`
+        parameter must be provided.
+    - in: query
+      name: user
+      schema:
+        type: string
+      description: |
+        The login of a user. Either the `binary`, `user` or `group`
+        parameter must be provided.
+    - in: query
+      name: group
+      schema:
+        type: string
+      description: |
+        The title of a group. Either the `binary`, `user` or `group`
+        parameter must be provided.
+    - in: query
+      name: limit
+      schema:
+        type: string
+      description: |
+        Limit the number of returned results. This is only available for
+        the search with the `binary` parameter. The default is set to `1`,
+        use `0` to receive all results or `-1` for the deepest match.
+    - in: query
+      name: devel
+      schema:
+        type: string
+        enum:
+        - true
+        - false
+        - 1
+        - 0
+      description: Include/exclude devel package definitions in the result.
+    - in: query
+      name: project
+      schema:
+        type: string
+      description: Only return results for a given project.
+    - in: query
+      name: filter
+      schema:
+        type: string
+      description: |
+        A comma separated list of role names that should be
+        taken into account in the result.
+      example: 'bugowner,maintainer'
+    - in: query
+      name: attribute
+      schema:
+        type: string
+      description: |
+        Choose the attribute name that marks the rootproject which defines the
+        owner's for all corresponding subprojects and limit the returned results
+        to those. The default value is `OBS:OwnerRootProject`.
+  responses:
+    '200':
+      description: OK. The request has succeeded.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/owner_collection.yaml'
+    '400':
+      description: Bad request
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          example:
+            code: no_binary
+            summary: |
+              The search needs at least a 'binary' or 'user' parameter
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '404':
+      description: Not Found
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          examples:
+            Not Found:
+              value:
+                code: unknown_project
+                summary: 'Project not found: bla'
+  tags:
+    - Search


### PR DESCRIPTION
FYI: The current api documentation lists the `limit` and `devel` parameter also for the missing owner search. Both are not used in the code and therefore not documented with openapi