### PR TITLE
Derive repositories through OBS:Server:Unstable project in our CI workflows

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -8,8 +8,8 @@ workflow:
         project: home:bs-team
         repositories:
           - name: 15.3
-            target_project: SUSE:SLE-15-SP3:GA
-            target_repository: standard
+            target_project: OBS:Server:Unstable
+            target_repository: 15.3
             architectures:
               - x86_64
   filters:


### PR DESCRIPTION
In order to resolve all dependencies properly when building the
obs_server package in our CI workflows, we need to setup the
repositories through the obs unstable project, since a lot of
dependencies live in this project. We cannot directly use
the 15.3/SLE-SP3 repos.