### PR TITLE
Document endpoints regarding project lock and unlock

### DIFF
--- a/src/api/public/apidocs-new/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs-new/OBS-v2.10.50.yaml
@@ -194,6 +194,8 @@ paths:
     $ref: 'paths/source_project_name_cmd_createpatchinfo.yaml'
   /source/{project_name}?cmd=lock:
     $ref: 'paths/source_project_name_cmd_lock.yaml'
+  /source/{project_name}?cmd=unlock:
+    $ref: 'paths/source_project_name_cmd_unlock.yaml'
 
   /trigger/{operation}:
     $ref: 'paths/trigger_operation.yaml'

--- a/src/api/public/apidocs-new/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs-new/OBS-v2.10.50.yaml
@@ -186,12 +186,14 @@ paths:
     $ref: 'paths/source_project_name_cmd_addchannels.yaml'
   /source/{project_name}?cmd=copy:
     $ref: 'paths/source_project_name_cmd_copy.yaml'
+  /source/{project_name}?cmd=createkey:
+    $ref: 'paths/source_project_name_cmd_createkey.yaml'
   /source/{project_name}?cmd=createmaintenanceincident:
     $ref: 'paths/source_project_name_cmd_createmaintenanceincident.yaml'
   /source/{project_name}?cmd=createpatchinfo:
     $ref: 'paths/source_project_name_cmd_createpatchinfo.yaml'
-  /source/{project_name}?cmd=createkey:
-    $ref: 'paths/source_project_name_cmd_createkey.yaml'
+  /source/{project_name}?cmd=lock:
+    $ref: 'paths/source_project_name_cmd_lock.yaml'
 
   /trigger/{operation}:
     $ref: 'paths/trigger_operation.yaml'

--- a/src/api/public/apidocs-new/paths/source_project_name_cmd_lock.yaml
+++ b/src/api/public/apidocs-new/paths/source_project_name_cmd_lock.yaml
@@ -1,0 +1,34 @@
+post:
+  summary: Locks the project.
+  description: |
+    Locks the project given as parameter. You can pass a comment with the reason of the lock.
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/project_name.yaml'
+    - in: query
+      name: comment
+      schema:
+        type: string
+      description: Comment that can be added to describe the reasoning behind the lock.
+      example: Locked project beacause A, B and C.
+  responses:
+    '200':
+      $ref: '../components/responses/succeeded.yaml'
+    '403':
+      description: |
+        No permission to execute command 'lock' because the project is already locked or
+        because the user do not have permission to modify the project.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          example:
+            code: 'cmd_execution_no_permission'
+            summary: no permission to execute command 'lock'.
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '404':
+      $ref: '../components/responses/unknown_project.yaml'
+  tags:
+    - Sources - Projects

--- a/src/api/public/apidocs-new/paths/source_project_name_cmd_unlock.yaml
+++ b/src/api/public/apidocs-new/paths/source_project_name_cmd_unlock.yaml
@@ -1,0 +1,54 @@
+post:
+  summary: Unlocks the project.
+  description: |
+    Unlocks the previously locked project, given as parameter. You can pass a comment with the reason of the lock.
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/project_name.yaml'
+    - in: query
+      name: comment
+      required: true
+      schema:
+        type: string
+      description: Comment that should be added to describe the reasoning behind the unlock.
+      example: Unlocked project beacause A, B and C.
+  responses:
+    '200':
+      $ref: '../components/responses/succeeded.yaml'
+    '400':
+      description: |
+        Bad Request.
+
+        XML Schema used for body validation: [status.xsd](../schema/status.xsd)
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          examples:
+            missing_parameter:
+              value:
+                code: missing_parameter
+                summary: Required Parameter comment missing.
+              summary: Missing Parameter
+            not_locked:
+              value:
+                code: not_locked
+                summary: project 'Sandbox' is not locked.
+              summary: Not Locked
+    '403':
+      description: |
+        No permission to execute command 'unlock' because the user do not have permission to modify the project.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          example:
+            code: 'cmd_execution_no_permission'
+            summary: no permission to execute command 'unlock'.
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '404':
+      $ref: '../components/responses/unknown_project.yaml'
+  tags:
+    - Sources - Projects


### PR DESCRIPTION
Document these two endpoints following OpenAPI specifications:

- [x] `/source/{project_name}?cmd=lock`
- [x] `/source/{project_name}?cmd=unlock`