### PR TITLE
Add source project name with freezelink command

### DIFF
--- a/src/api/public/apidocs-new/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs-new/OBS-v2.10.50.yaml
@@ -206,6 +206,8 @@ paths:
     $ref: 'paths/source_project_name_cmd_extendkey.yaml'
   /source/{project_name}?cmd=move:
     $ref: 'paths/source_project_name_cmd_move.yaml'
+  /source/{project_name}?cmd=freezelink:
+    $ref: 'paths/source_project_name_cmd_freezelink.yaml'
 
   /trigger/{operation}:
     $ref: 'paths/trigger_operation.yaml'

--- a/src/api/public/apidocs-new/paths/source_project_name_cmd_freezelink.yaml
+++ b/src/api/public/apidocs-new/paths/source_project_name_cmd_freezelink.yaml
@@ -1,0 +1,29 @@
+post:
+  summary: Freeze a project link.
+  description: |
+    Freeze a project link, either creating the freeze or updating it.
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/project_name.yaml'
+    - in: query
+      name: user
+      schema:
+        type: string
+      description: A username
+      example: Admin
+    - in: query
+      name: comment
+      schema:
+        type: string
+      description: A comment that will appear in the project's comment section explaining the reason behind the freezing.
+      example: Project link frozen due to some important reason.
+  responses:
+    '200':
+      $ref: '../components/responses/succeeded.yaml'
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '404':
+      $ref: '../components/responses/unknown_project.yaml'
+  tags:
+    - Sources - Projects


### PR DESCRIPTION
This PR documents the `POST /source/<project>?cmd=freezelink` endpoint
with the new OpenAPI specification.

This endpoint freezes a project link, either creating the freeze or updating it.
