### PR TITLE
Add '/source/{project_name}?cmd=undelete' endpoint

### DIFF
--- a/src/api/public/apidocs-new/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs-new/OBS-v2.10.50.yaml
@@ -200,6 +200,8 @@ paths:
     $ref: 'paths/source_project_name_cmd_createpatchinfo.yaml'
   /source/{project_name}?cmd=lock:
     $ref: 'paths/source_project_name_cmd_lock.yaml'
+  /source/{project_name}?cmd=undelete:
+    $ref: 'paths/source_project_name_cmd_undelete.yaml'
   /source/{project_name}?cmd=unlock:
     $ref: 'paths/source_project_name_cmd_unlock.yaml'
   /source/{project_name}?cmd=extendkey:

--- a/src/api/public/apidocs-new/paths/source_project_name_cmd_undelete.yaml
+++ b/src/api/public/apidocs-new/paths/source_project_name_cmd_undelete.yaml
@@ -1,0 +1,43 @@
+post:
+  summary: Restore a deleted project.
+  description: |
+    If the given project was previously deleted, you can restore it.
+    You can only restore it if you have the permissions to do so.
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/project_name.yaml'
+  responses:
+    '200':
+      $ref: '../components/responses/succeeded.yaml'
+    '403':
+      description: Forbidden
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          example:
+            code: cmd_execution_no_permission
+            summary: no permission to execute command 'undelete'.
+    '404':
+      description: Not Found.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          example:
+            code: not_found
+            summary: |
+              <status code="not_found">
+                <summary>
+                  &lt;status code="404"&gt;
+                  &lt;summary&gt;project 'Sandbox' already exists&lt;/summary&gt;
+                  &lt;details&gt;404 project 'Sandbox' already exists&lt;/details&gt;
+                  &lt;/status&gt;
+                </summary>
+              </status>
+            description: Response when trying to "undelete" a project that was not deleted previously.
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+  tags:
+    - Sources - Projects


### PR DESCRIPTION
Document the endpoint following the OpenAPI specifications.

**NOTE**: The responses of this endpoint are not like the ones we see in other endpoints. We don't get a `200 OK` even if the `undelete` is performed correctly.
And one of the error responses looks weird since it's embedding a XML inside another.