### PR TITLE
[backend] implement an obsscm service type

### DIFF
--- a/src/backend/bs_service
+++ b/src/backend/bs_service
@@ -73,6 +73,17 @@ my $proxy = $BSConfig::proxy;
 my $noproxy = $BSConfig::noproxy;
 my $maxchild = $BSConfig::service_maxchild;
 
+my $servicedef_obs_scm_bridge = {
+  'name' => 'obs_scm_bridge',
+  'parameter' => [
+    {
+      'name' => 'url' ,
+      'description' => 'Specify URL to checkout.',
+      'required' => undef,
+    }
+  ],
+};
+
 use warnings;
 
 sub usage {
@@ -155,6 +166,8 @@ sub run_source_update {
 
   # run all services
   my $error;
+  my $obs_scm_bridge;
+  my $nservice = 0;
   for my $sf ('_service', '_serviceproject') {
     next unless -e $sf;
     my $infoxml = readstr($sf);
@@ -166,8 +179,16 @@ sub run_source_update {
         print "Skip $name\n";
         next;
       }
+      $nservice++;
       BSUtil::printlog("Run for $name");
-      my $servicedef = readxml("$rootservicedir/$name.service", $BSXML::servicetype);
+      my $servicedef;
+      if ($name eq 'obs_scm_bridge') {
+	$servicedef = $servicedef_obs_scm_bridge;
+	$obs_scm_bridge = 1;
+      } else {
+        $servicedef = readxml("$rootservicedir/$name.service", $BSXML::servicetype);
+      }
+      die("obs_scm_bridge must be the only service\n") if $obs_scm_bridge && $nservice != 1;
       my @run;
       if (defined $BSConfig::service_wrapper->{$name} ) {
         push @run, $BSConfig::service_wrapper->{$name};
@@ -220,8 +241,10 @@ sub run_source_update {
         for my $file (grep {!/^[:\.]/} ls("$myworkdir/out")) {
 	  next if -l "$myworkdir/out/$file" || ! -f _;	# only plain files for now
 	  my $tfile = $file;
-	  $tfile =~ s/^_service://s;
-	  $tfile = "_service:$name:$tfile";
+          if (!$obs_scm_bridge) {
+	    $tfile =~ s/^_service://s;
+	    $tfile = "_service:$name:$tfile";
+          }
 	  rename("$myworkdir/out/$file", $tfile) || die("rename $myworkdir/out/$file $tfile: $!\n");
         }
       } else { 
@@ -248,11 +271,14 @@ sub run_source_update {
   rm_rf('.old');
 
   # get all generate files
-  my @send = map {{'name' => $_, 'filename' => "$_"}} grep {/^_service[_:]/} ls('.');
+  my @send = sort(ls('.'));
+  @send = grep {/^_service[_:]/} @send unless $obs_scm_bridge;
+  @send = grep {$_ ne '_service'} @send if $obs_scm_bridge;
+  @send = map {{'name' => $_, 'filename' => "$_"}} @send;
 
   # check for non files (symlinks or directories)
   for my $file (@send) {
-    die("Service result contains unreadable file '$file->{'filename'}'\n") unless -f $file->{'filename'};
+    die("Service result contains unreadable file '$file->{'filename'}'\n") unless ! -l $file->{'filename'} && -f _;
   }
 
   # send everything back for real

--- a/src/backend/bs_servicedispatch
+++ b/src/backend/bs_servicedispatch
@@ -65,6 +65,19 @@ sub notify_serviceresult {
   BSNotify::notify($error ? 'SRCSRV_SERVICE_FAIL' : 'SRCSRV_SERVICE_SUCCESS', $p);
 }
 
+sub commitobsscm {
+  my ($projid, $packid, $servicemark, $rev, $files) = @_;
+  my $data = BSSrcrep::readobsscmdata($projid, $packid, $servicemark);
+  return if !$data || $data->{'run'} ne $rev->{'run'};
+  my $srcmd5 = BSSrcrep::addmeta($projid, $packid, $files);
+  my $param = {
+    'uri' => "$BSConfig::srcserver/source/$projid/$packid",
+    'request' => 'POST',
+    'timeout'   => 300,
+  };
+  BSRPC::rpc($param, undef, "cmd=commitobsscm", "srcmd5=$srcmd5", "servicemark=$servicemark", "run=$rev->{'run'}");
+}
+
 sub addrev_service {
   my ($rev, $servicemark, $files, $error, $lxservicemd5) = @_;
 
@@ -81,13 +94,18 @@ sub addrev_service {
   }
   if (!$error) {
     eval {
-      BSSrcrep::addmeta_service($projid, $packid, $files, $servicemark, $rev->{'srcmd5'}, $lxservicemd5);
+      if ($rev->{'rev'} eq 'obsscm') {
+	commitobsscm($projid, $packid, $servicemark, $rev, $files);
+      } else {
+	BSSrcrep::addmeta_service($projid, $packid, $files, $servicemark, $rev->{'srcmd5'}, $lxservicemd5);
+      }
     };
+    die($@) if $@ && $rev->{'rev'} eq 'obsscm' && $@ !~ /^4/;	# retry transient errors
     $error = $@ if $@;
   }
   BSSrcrep::addmeta_serviceerror($projid, $packid, $servicemark, $error) if $error;
   notify_serviceresult($rev, $error);
-  notify_repservers('package', $projid, $packid);
+  notify_repservers('package', $projid, $packid) unless $rev->{'rev'} eq 'obsscm';
 }
 
 
@@ -99,10 +117,8 @@ sub getrev {
 }
 
 sub doservicerpc {
-  my ($projid, $packid, $files, $send) = @_;
+  my ($projid, $packid, $files, $send, $noprefix) = @_;
 
-  my $enforceprefix = $files ? 1 : 0;
-  $files ||= {};
   my $odir = "$uploaddir/runservice$$";
   BSUtil::cleandir($odir) if -d $odir;
   mkdir_p($odir);
@@ -140,7 +156,7 @@ sub doservicerpc {
   eval {
     die(readstr("$odir/.errors") || "empty .errors file\n") if -e "$odir/.errors";
     for my $pfile (ls($odir)) {
-      die("service returned a non-_service file: $pfile\n") if $enforceprefix && $pfile !~ /^_service[_:]/;
+      die("service returned a non-_service file: $pfile\n") if !$noprefix && $pfile !~ /^_service[_:]/;
       BSVerify::verify_filename($pfile);
       $files->{$pfile} = BSSrcrep::addfile($projid, $packid, "$odir/$pfile", $pfile);
     }
@@ -151,10 +167,42 @@ sub doservicerpc {
   return $error;
 }
 
+sub generate_obs_scm_bridge_service {
+  my ($data) = @_;
+  die("bad obs_scm_bridge data\n") unless $data->{'name'} eq 'obs_scm_bridge' && $data->{'url'};
+  my $services = {
+    'service' => [ {
+      'name' => 'obs_scm_bridge',
+      'param' => [ { 'name' => 'url', '_content' => $data->{'url'} } ],
+    } ],
+  };
+  return BSUtil::toxml($services, $BSXML::services);
+}
+
+sub generate_obsscm_rev {
+  my ($projid, $packid, $data) = @_;
+  my $rev = { 'project' => $projid, 'package' => $packid, 'rev' => 'obsscm', 'run' => $data->{'run'}, 'user' => $data->{'user'}, 'comment' => $data->{'comment'} };
+  return $rev;
+}
+
+sub runservice_obsscm {
+  my ($projid, $packid, $servicemark, $run) = @_;
+  my $data = BSSrcrep::readobsscmdata($projid, $packid, $servicemark);
+  return undef unless $data && $data->{'run'} eq $run;	# obsolete run?
+  my $rev = generate_obsscm_rev($projid, $packid, $data);
+  my @send;
+  push @send, { 'name' => '_service', 'data' => generate_obs_scm_bridge_service($data) };
+  my $files = {};
+  my $error = doservicerpc($projid, $packid, $files, \@send, 1);
+  addrev_service($rev, $servicemark, $files, $error);
+  return $error ? 'failed' : 'succeeded';
+}
+
 sub runservice {
   my ($projid, $packid, $servicemark, $srcmd5, $revid, $lxservicemd5, $projectservicesmd5, $oldsrcmd5) = @_;
 
   BSUtil::printlog("dispatching service (timeout: $BSConfig::service_timeout) $projid/$packid $servicemark $srcmd5");
+  return runservice_obsscm($projid, $packid, $servicemark, $srcmd5) if $revid && $revid eq 'obsscm';
   # get revision and file list
   my $rev;
   if ($revid) {

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -340,6 +340,12 @@ sub notify_all_repservers {
 sub triggerservicerun {
   my ($cgi, $projid, $packid) = @_;
   my $rev = getrev($projid, $packid);
+  my $pack = BSRevision::readpack_local($projid, $packid, 1);
+  if ($pack && $pack->{'title'} =~ /^obs-scm:(.*)/) {
+    die("Cannot use the scm bridge with old style services\n") if $BSConfig::old_style_services;
+    BSSrcServer::Service::runservice_obsscm($cgi, $projid, $packid, $1);
+    return $BSStdServer::return_ok;
+  }
   my $linkinfo = {};
   my $files = BSRevision::lsrev($rev, $linkinfo);
   $cgi->{'triggerservicerun'} = 1;	# hack
@@ -364,16 +370,24 @@ sub waitservicerun {
   my ($cgi, $projid, $packid) = @_;
   die("not implemented for old style services\n") if $BSConfig::old_style_services;
   if (!$BSStdServer::isajax) {
-    my $rev = getrev($projid, $packid);
-    my $linkinfo = {};
-    my $files = BSRevision::lsrev($rev, $linkinfo);
-    my $servicemark = $linkinfo->{'xservicemd5'};
-    return $BSStdServer::return_ok unless $servicemark;
-    eval {
-      BSSrcServer::Service::handleservice($rev, $files, $servicemark);
-    };
-    return $BSStdServer::return_ok unless $@;
-    die($@) if $@ !~ /service in progress/;
+    my $servicemark;
+    my $serror;
+    my $pack = BSRevision::readpack_local($projid, $packid, 1);
+    if ($pack && $pack->{'title'} =~ /^obs-scm:(.*)/) {
+      $servicemark = BSSrcServer::Service::genservicemark_obsscm($projid, $packid);
+      $serror = BSSrcrep::getserviceerror($projid, $packid, $servicemark);
+    } else {
+      my $rev = getrev($projid, $packid);
+      my $linkinfo = {};
+      my $files = BSRevision::lsrev($rev, $linkinfo);
+      $servicemark = $linkinfo->{'xservicemd5'};
+      return $BSStdServer::return_ok unless $servicemark;
+      eval { BSSrcServer::Service::handleservice($rev, $files, $servicemark) };
+      $serror = $@;
+      chomp $serror;
+    }
+    return $BSStdServer::return_ok unless $serror;
+    die("$serror\n") if $serror !~ /service in progress/;
     # pass on to ajax
     BSHandoff::handoff("/source/$projid/$packid", undef, 'cmd=waitservice', "servicemark=$servicemark");
   }
@@ -622,6 +636,11 @@ sub addrev {
   die("bad packid\n") if $packid =~ /\// || $packid =~ /^\./;
   die("bad files (slash)\n") if grep {/\// && $_ ne '/SERVICE'} keys %$files;
   die("bad files (glyph)\n") if grep {!/^[0-9a-f]{32}$/} values %$files;
+
+  if ($packid ne '_project' && !$cgi->{'commitobsscm'}) {
+    my $pack = BSRevision::readpack_local($projid, $packid);
+    die("Package $packid is controlled by obs-scm\n") if $pack->{'title'} =~ /^obs-scm:/;
+  }
 
   if ($files->{'_patchinfo'}) {
     die("bad files in patchinfo container\n") if grep {$_ ne '_patchinfo'} keys %$files;
@@ -2869,6 +2888,13 @@ sub getfile {
   } else {
     $files = BSRevision::lsrev($rev);
   }
+  if (!$cgi->{'meta'} && !$cgi->{'deleted'} && !$cgi->{'rev'} && !$files->{$filename} && $filename eq '_serviceerror') {
+    my $pack = BSRevision::readpack_local($projid, $packid, 1);
+    if ($pack && $pack->{'title'} =~ /^obs-scm:/) {
+      $rev = BSRevision::getrev_local($projid, $packid, BSSrcServer::Service::genservicemark_obsscm($projid, $packid));
+      $files = BSRevision::lsrev($rev);
+    }
+  }
   die("404 $filename: no such file\n") unless $files->{$filename};
   my @s = BSRevision::revstat($rev, $filename, $files->{$filename});
   die("$projid/$packid/$files->{$filename}-$filename: $!\n") unless @s;
@@ -3285,6 +3311,24 @@ sub sourcecommitfilelist {
   BSSrcServer::Service::runservice($cgi, $rev, $files) unless $cgi->{'noservice'};
   $cgi->{'rev'} = $rev->{'rev'};
   return getfilelist($cgi, $projid, $packid);
+}
+
+sub sourcecommitobsscm {
+  my ($cgi, $projid, $packid) = @_;
+  my $pack = BSRevision::readpack_local($projid, $packid);
+  die("Package $packid is not controlled by obs-scm\n") unless $pack->{'title'} =~ /^obs-scm:/;
+  my $rev = BSRevision::getrev_local($projid, $packid, $cgi->{'srcmd5'});
+  die("No such revision $cgi->{'srcmd5'}\n") unless $rev;
+  my $linkinfo = {};
+  my $files = BSRevision::lsrev($rev, $linkinfo);
+  die("Weird service run result\n") if %$linkinfo;
+  $rev->{'user'} = $cgi->{'user'} if $cgi->{'user'};
+  $rev->{'comment'} = $cgi->{'comment'} if $cgi->{'comment'};
+  $rev->{'run'} = $cgi->{'run'};
+  my $newrev = BSSrcServer::Service::commitobsscm($projid, $packid, $cgi->{'servicemark'}, $rev, $files) || {};
+  delete $newrev->{'project'};
+  delete $newrev->{'package'};
+  return ($newrev, $BSXML::revision);
 }
 
 # admin only, move entire project
@@ -7223,6 +7267,7 @@ my $dispatches = [
   'POST:/source/$project/$package cmd=servicediff rev? unified:bool? file:filename* filelimit:num? tarlimit:num? view:? withissues:bool? onlyissues:bool? nocache:bool? cacheonly:bool? nodiff:bool?' => \&servicediff,
   'POST:/source/$project/$package cmd=commit rev? user:? comment:? keeplink:bool? repairlink:bool? linkrev? setrev:bool? requestid:num? noservice:bool?' => \&sourcecommit,
   'POST:/source/$project/$package cmd=commitfilelist rev? user:? comment:? keeplink:bool? repairlink:bool? linkrev? setrev:bool? requestid:num? time:num? version:? vrev:? noservice:bool? servicemark:? withvalidate:?' => \&sourcecommitfilelist,
+  'POST:/source/$project/$package cmd=commitobsscm srcmd5 servicemark: run:md5 user:? comment:?' => \&sourcecommitobsscm,
   'POST:/source/$project/$package cmd=copy rev? user:? comment:? orev:rev? oproject:project? opackage:package? expand:bool? keeplink:bool? repairlink:bool? linkrev? setrev:linkrev? olinkrev:linkrev? requestid:num? dontupdatesource:bool? noservice:bool? withvrev:bool? withacceptinfo:bool? makeoriginolder:bool? freezelink:bool? vrevbump:num? instantiate:bool?' => \&sourcecopy,
   'POST:/source/$project/$package cmd=collectbuildenv user:? comment:? orev:rev? oproject:project? opackage:package?' => \&sourcecollectbuildenv,
   'POST:/source/$project/$package cmd=branch rev? user:? comment:? orev:rev? oproject:project? opackage:package? olinkrev:linkrev? requestid:num? force:bool? keepcontent:bool? missingok:bool? noservice:bool? withacceptinfo:bool? time:num? extendvrev:bool? simplelink:bool?' => \&sourcebranch,


### PR DESCRIPTION
An obsscm service is a pseudo service that is not based on
a commit. The service result is not prefixed with _service,
but committed as is.
    
We currently mis-use the 'title' field in the package meta
to configure the obsscm url, this will be changed to some
extra package element.
