### PR TITLE
[api] Set 200 OK response for undelete action on project

### DIFF
--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -533,6 +533,7 @@ class SourceController < ApplicationController
     raise CmdExecutionNoPermission, "no permission to execute command 'undelete'" unless User.session!.can_create_project?(params[:project])
 
     Project.restore(params[:project])
+    render_ok
   end
 
   # POST /source/<project>?cmd=release


### PR DESCRIPTION
This way, the endpoint will render a `200 OK` response instead of a `204 No Content` response when the 'undelete' is correctly performed.