### PR TITLE
[api] Fix undelete error response

### DIFF
--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -532,8 +532,12 @@ class SourceController < ApplicationController
   def project_command_undelete
     raise CmdExecutionNoPermission, "no permission to execute command 'undelete'" unless User.session!.can_create_project?(params[:project])
 
-    Project.restore(params[:project])
-    render_ok
+    if Project.restore(params[:project])
+      render_ok
+    else
+      render_error status: 400, errorcode: 'not_removed_project',
+                   message: "The project '#{params[:project]}' already exists, it can't be undeleted."
+    end
   end
 
   # POST /source/<project>?cmd=release

--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -533,6 +533,7 @@ class SourceController < ApplicationController
     raise CmdExecutionNoPermission, "no permission to execute command 'undelete'" unless User.session!.can_create_project?(params[:project])
 
     Project.restore(params[:project])
+    render_ok
   end
 
   # POST /source/<project>?cmd=release

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -129,6 +129,8 @@ class Project < ApplicationRecord
     end
 
     def restore(project_name, backend_opts = {})
+      return nil if find_by_name(project_name)
+
       Backend::Api::Sources::Project.undelete(project_name, backend_opts)
 
       # read meta data from backend to restore database object

--- a/src/api/test/functional/source_controller_test.rb
+++ b/src/api/test/functional/source_controller_test.rb
@@ -2030,8 +2030,8 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
 
     # undelete project again
     post '/source/kde4', params: { cmd: :undelete }
-    assert_response 404
-    assert_match(/project 'kde4' already exists/, @response.body)
+    assert_response 400
+    assert_match(/project 'kde4' already exists, it can't be undeleted/, @response.body)
   end
 
   def test_remove_project_and_verify_repositories

--- a/src/api/test/functional/source_controller_test.rb
+++ b/src/api/test/functional/source_controller_test.rb
@@ -2009,7 +2009,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
 
     login_king
     post '/source/kde4', params: { cmd: :undelete }
-    assert_response :success
+    assert_response 200
 
     # content got restored ?
     get '/source/kde4'


### PR DESCRIPTION
Follow-up #11932

Before, the output was an error in XML format embedded in another XML structure. Like this:

```
 <status code="not_found">
    <summary>
         &lt;status code="404"&gt;
          &lt;summary&gt;project 'Sandbox' already exists&lt;/summary&gt;
          &lt;details&gt;404 project 'Sandbox' already exists&lt;/details&gt;
          &lt;/status&gt;
    </summary>
</status>
```

Now we get one single XML containing the error, using `400` code instead of `404`. Like this:

```
<status code="not_removed_project">
  <summary>The project 'sand3' already exists, it can't be undeleted.</summary>
</status>
```