### PR TITLE
[dist] add openslp to Requires of obs-worker

### DIFF
--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -257,7 +257,8 @@ Requires:       screen
 Requires:       psmisc
 # For runlevel script:
 Requires:       curl
-Recommends:     openslp lvm2
+Requires:       openslp
+Recommends:     lvm2
 Requires:       bash
 Requires:       binutils
 Requires:       bsdtar


### PR DESCRIPTION
Fix 'slptool: command not found' error when installing obs-worker in docker container.