### PR TITLE
Capitalize GPG in API documentation

### DIFF
--- a/src/api/public/apidocs-new/paths/source_project_name_cmd_createkey.yaml
+++ b/src/api/public/apidocs-new/paths/source_project_name_cmd_createkey.yaml
@@ -1,6 +1,6 @@
 post:
-  summary: Generate a new gpg key for a project.
-  description: Generate a new gpg key. If the project already has a gpg key, the old key is discarded.
+  summary: Generate a new GPG key for a project.
+  description: Generate a new GPG key. If the project already has a GPG key, the old key is discarded.
   security:
     - basic_authentication: []
   parameters:

--- a/src/api/public/apidocs-new/paths/source_project_name_cmd_extendkey.yaml
+++ b/src/api/public/apidocs-new/paths/source_project_name_cmd_extendkey.yaml
@@ -1,6 +1,6 @@
 post:
-  summary: Extend the expiration date of gpg keys.
-  description: Extend the expiration date of gpg key for the given project.
+  summary: Extend the expiration date of GPG keys.
+  description: Extend the expiration date of GPG key for the given project.
   security:
     - basic_authentication: []
   parameters:


### PR DESCRIPTION
GPG refers to a proper noun, so it needs to be capitalized.