### PR TITLE
Fix deprecation warning for view_component

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -91,7 +91,7 @@ gem 'octokit'
 # Ruby wrapper and CLI for the GitLab REST API
 gem 'gitlab'
 # Build reusable, testable & encapsulated view components in Ruby on Rails
-gem 'view_component', require: 'view_component/engine'
+gem 'view_component'
 
 group :development, :production do
   # to have the delayed job daemon


### PR DESCRIPTION
Requiring the enigne isn't needed anymore since view_component 2.43.0 and the deprecation message was added in 2.45.0.

This was the deprecation message:

> DEPRECATION WARNING: This manually engine loading is deprecated and will be removed in v3.0.0. Remove `require "view_component/engine"`. (called from <top (required)> at /obs/src/api/config/application.rb:29)