### PR TITLE
[backend] remove special casing of the obs-scm-bridge in bs_service

### DIFF
--- a/src/backend/BSSrcServer/Service.pm
+++ b/src/backend/BSSrcServer/Service.pm
@@ -343,10 +343,18 @@ sub doservicerpc {
   # add new service files
   eval {
     die(readstr("$odir/.errors") || "empty .errors file\n") if -e "$odir/.errors";
-    for my $pfile (ls($odir)) {
-      die("service returned a non-_service file: $pfile\n") if !$noprefix && $pfile !~ /^_service[_:]/;
-      BSVerify::verify_filename($pfile);
-      $files->{$pfile} = BSSrcrep::addfile($projid, $packid, "$odir/$pfile", $pfile);
+    for my $pfile (sort {$b cmp $a} ls($odir)) {
+      my $qfile = $pfile;
+      if ($noprefix) {
+	$qfile = $1 if /^_service:.*:(.*?)$/s;
+	next if $files->{$qfile};
+	next if $qfile eq '_service';	# hmm?
+	die("service returned forbidden file: $qfile\n") if $qfile eq '_link' || $qfile eq '_meta';
+      } else {
+        die("service returned a non-_service file: $qfile\n") if $qfile !~ /^_service[_:]/;
+      }
+      BSVerify::verify_filename($qfile);
+      $files->{$qfile} = BSSrcrep::addfile($projid, $packid, "$odir/$pfile", $qfile);
     }
   };
   my $error = $@;

--- a/src/backend/bs_service
+++ b/src/backend/bs_service
@@ -166,8 +166,6 @@ sub run_source_update {
 
   # run all services
   my $error;
-  my $obs_scm_bridge;
-  my $nservice = 0;
   for my $sf ('_service', '_serviceproject') {
     next unless -e $sf;
     my $infoxml = readstr($sf);
@@ -179,16 +177,13 @@ sub run_source_update {
         print "Skip $name\n";
         next;
       }
-      $nservice++;
       BSUtil::printlog("Run for $name");
       my $servicedef;
       if ($name eq 'obs_scm_bridge') {
 	$servicedef = $servicedef_obs_scm_bridge;
-	$obs_scm_bridge = 1;
       } else {
         $servicedef = readxml("$rootservicedir/$name.service", $BSXML::servicetype);
       }
-      die("obs_scm_bridge must be the only service\n") if $obs_scm_bridge && $nservice != 1;
       my @run;
       if (defined $BSConfig::service_wrapper->{$name} ) {
         push @run, $BSConfig::service_wrapper->{$name};
@@ -241,10 +236,8 @@ sub run_source_update {
         for my $file (grep {!/^[:\.]/} ls("$myworkdir/out")) {
 	  next if -l "$myworkdir/out/$file" || ! -f _;	# only plain files for now
 	  my $tfile = $file;
-          if (!$obs_scm_bridge) {
-	    $tfile =~ s/^_service://s;
-	    $tfile = "_service:$name:$tfile";
-          }
+	  $tfile =~ s/^_service://s;
+	  $tfile = "_service:$name:$tfile";
 	  rename("$myworkdir/out/$file", $tfile) || die("rename $myworkdir/out/$file $tfile: $!\n");
         }
       } else { 
@@ -272,8 +265,7 @@ sub run_source_update {
 
   # get all generate files
   my @send = sort(ls('.'));
-  @send = grep {/^_service[_:]/} @send unless $obs_scm_bridge;
-  @send = grep {$_ ne '_service'} @send if $obs_scm_bridge;
+  @send = grep {/^_service[_:]/} @send;
   @send = map {{'name' => $_, 'filename' => "$_"}} @send;
 
   # check for non files (symlinks or directories)


### PR DESCRIPTION
It's much easier and less error prone to let bs_service do
the _service: prefixing like with all other services and
unprefix again in the file receiver code.