### PR TITLE
Store changes on the backend in repositories_configuration step

### DIFF
--- a/src/api/app/models/workflow/step/configure_repositories.rb
+++ b/src/api/app/models/workflow/step/configure_repositories.rb
@@ -24,6 +24,10 @@ class Workflow::Step::ConfigureRepositories < Workflow::Step
         repository.architectures << @supported_architectures.select { |architecture| architecture.name == architecture_name }
       end
     end
+
+    # We have to store the changes on the backend
+    target_project.store(comment: "Added the following repositories to the project: #{step_instructions[:repositories].pluck(:name).compact.to_sentence}",
+                         login: @token.user.login)
   end
 
   private


### PR DESCRIPTION
In order to properly set the repositories on a project through
the workflows, we need to tell the backend about the changes as well,
otherwise the packages won't start to build against those repos.