### PR TITLE
Fix the hashbangs in scripts

### DIFF
--- a/dist/gem_build_cleanup.sh
+++ b/dist/gem_build_cleanup.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-if [ ${#*} = 1 ] ; then
+if [ $# = 1 ] ; then
     if [ -d "$1" ] ; then
         find $1 \
         \( -name \*.o -o -name Makefile -o -name config.log -o -name config.status -o -name Makefile.html -o -name gem_make.out -o -name mkmf.log -o -name \*.bak -o -name .deps -o -name .libs -o -name CVS \) \

--- a/dist/obs_admin
+++ b/dist/obs_admin
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/bin/sh
 exec /usr/lib/obs/server/bs_admin "$@"

--- a/dist/obs_productconvert
+++ b/dist/obs_productconvert
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/bin/sh
 exec /usr/lib/obs/server/bs_productconvert "$@"

--- a/dist/obs_rebuild_db
+++ b/dist/obs_rebuild_db
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 
 echo "This script rebuilds the DB for an OBS system from an existing backend"

--- a/dist/obs_serverstatus
+++ b/dist/obs_serverstatus
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/bin/sh
 exec /usr/lib/obs/server/bs_serverstatus "$@"

--- a/dist/obsstoragesetup
+++ b/dist/obsstoragesetup
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 # Copyright (c) 2010-12, SUSE Inc.
 #
 # Author: adrian@suse.de

--- a/dist/obsworker
+++ b/dist/obsworker
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 # Copyright (c) 2007-2011, SUSE Inc.
 #
 # Author: adrian@suse.de


### PR DESCRIPTION
There is some discrepancy between the features used by shells and interpreters declared in hashbangs.
On systems where `/bin/sh` is provided by bash, it doesn’t matter, but if it is in fact dash, ksh or busybox, scripts either run suboptimally or fail.
This PR fixes this situation.