### PR TITLE
Rename @notifications_total to @notifications_count

### DIFF
--- a/src/api/app/controllers/person/notifications_controller.rb
+++ b/src/api/app/controllers/person/notifications_controller.rb
@@ -11,7 +11,7 @@ module Person
     # GET /my/notifications
     def index
       @notifications = paginated_notifications
-      @notifications_total = @notifications.count
+      @notifications_count = @notifications.count
     end
 
     private

--- a/src/api/app/views/person/notifications/index.xml.builder
+++ b/src/api/app/views/person/notifications/index.xml.builder
@@ -1,5 +1,5 @@
-xml.notifications(count: @notifications_total) do
-  if @notifications_total.positive?
+xml.notifications(count: @notifications_count) do
+  if @notifications_count.positive?
     xml.total_pages @notifications.total_pages
     xml.current_page @notifications.current_page
   end


### PR DESCRIPTION
The total refers to the count of all notifications of a user. It's not the count of the notifications to be returned to the user. `@notifications_per_page` isn't a valid name here since it refers to how many notifications are returned per page. This changes depending on the `show_all` query parameter.