### PR TITLE
Rename "Show all" in notifications API and web UI

### DIFF
--- a/src/api/app/controllers/person/notifications_controller.rb
+++ b/src/api/app/controllers/person/notifications_controller.rb
@@ -16,7 +16,7 @@ module Person
 
     private
 
-    def show_all(notifications)
+    def show_maximum(notifications)
       total = notifications.size
       notifications.page(params[:page]).per([total, MAX_PER_PAGE].min)
     end
@@ -36,7 +36,7 @@ module Person
     def paginated_notifications
       notifications = fetch_notifications
       params[:page] = notifications.page(params[:page]).total_pages if notifications.page(params[:page]).out_of_range?
-      params[:show_all] ? show_all(notifications) : notifications.page(params[:page])
+      params[:show_maximum] ? show_maximum(notifications) : notifications.page(params[:page])
     end
 
     # The 'requests' type will be the default value unless another allowed

--- a/src/api/app/controllers/webui/users/notifications_controller.rb
+++ b/src/api/app/controllers/webui/users/notifications_controller.rb
@@ -63,7 +63,7 @@ class Webui::Users::NotificationsController < Webui::WebuiController
     feature_enabled?(:notifications_redesign)
   end
 
-  def show_all(notifications)
+  def show_more(notifications)
     total = notifications.size
     flash.now[:info] = "You have too many notifications. Displaying a maximum of #{Notification::MAX_PER_PAGE} notifications per page." if total > Notification::MAX_PER_PAGE
     notifications.page(params[:page]).per([total, Notification::MAX_PER_PAGE].min)
@@ -83,7 +83,7 @@ class Webui::Users::NotificationsController < Webui::WebuiController
   def paginated_notifications
     notifications = fetch_notifications
     params[:page] = notifications.page(params[:page]).total_pages if notifications.page(params[:page]).out_of_range?
-    params[:show_all] ? show_all(notifications) : notifications.page(params[:page])
+    params[:show_more] ? show_more(notifications) : notifications.page(params[:page])
   end
 
   def show_read_all_button?

--- a/src/api/app/helpers/webui/notification_helper.rb
+++ b/src/api/app/helpers/webui/notification_helper.rb
@@ -1,9 +1,9 @@
 module Webui::NotificationHelper
-  def link_to_all
-    parameters = params.slice(:show_all, :type, :project).permit!
-    all_or_less = parameters[:show_all] ? 'less' : 'all'
-    parameters[:show_all] = parameters[:show_all] ? nil : '1'
-    link_to("Show #{all_or_less}", my_notifications_path(parameters))
+  def link_to_show_less_or_more
+    parameters = params.slice(:show_more, :type, :project).permit!
+    less_or_more = parameters[:show_more] ? 'less' : 'more'
+    parameters[:show_more] = parameters[:show_more] ? nil : '1'
+    link_to("Show #{less_or_more}", my_notifications_path(parameters))
   end
 
   def request_badge_color(state)

--- a/src/api/app/views/webui/users/notifications/_notifications_list.html.haml
+++ b/src/api/app/views/webui/users/notifications/_notifications_list.html.haml
@@ -12,14 +12,14 @@
 - else
   :ruby
     update_path = my_notifications_path(type: selected_filter[:type], project: selected_filter[:project],
-                                          page: params[:page], show_all: params[:show_all])
+                                          page: params[:page], show_more: params[:show_more])
   = form_tag(update_path, method: :put, remote: true) do
     = render(NotificationActionBarComponent.new(type: selected_filter[:type], update_path: update_path, show_read_all_button: show_read_all_button))
     .card
       .card-body
         .text-center
           %span.ml-3= page_entries_info notifications, entry_name: ''
-          = link_to_all unless notifications.total_pages == 1 && params['show_all'].nil?
+          = link_to_show_less_or_more unless notifications.total_pages == 1 && params[:show_more].nil?
         .list-group.list-group-flush.mt-3
           - notifications.each do |n|
             - notification = NotificationPresenter.new(n)
@@ -48,7 +48,7 @@
                         title, icon = notification.unread? ? ['Mark as "Read"', 'fa-check'] : ['Mark as "Unread"', 'fa-undo']
                         update_path = my_notifications_path(notification_ids: [notification.id], type: selected_filter[:type],
                                                             project: selected_filter[:project], page: params[:page],
-                                                            show_all: params[:show_all])
+                                                            show_more: params[:show_more])
                       = link_to(update_path, id: format('update-notification-%d', notification.id),
                                 method: :put, class: 'btn btn-sm btn-outline-success px-3', title: title,
                                 data: { remote: true, 'disable-with': tag.i(class: 'fas fa-spinner fa-spin') }) do

--- a/src/api/public/apidocs-new/paths/my_notifications.yaml
+++ b/src/api/public/apidocs-new/paths/my_notifications.yaml
@@ -6,14 +6,17 @@ get:
   parameters:
     - in: path
       name: project
-      required: false
       schema:
         type: string
     - in: path
       name: page
-      required: false
       schema:
         type: int
+    - in: query
+      name: show_maximum
+      schema:
+        type: string
+      example: 1
   responses:
     '200':
       description: |


### PR DESCRIPTION
It never showed all notifications. The "Show all" link and parameter show a maximum number of notifications (300 right now).