### PR TITLE
Create notification update api endpoint

### DIFF
--- a/src/api/app/controllers/person/notifications_controller.rb
+++ b/src/api/app/controllers/person/notifications_controller.rb
@@ -6,12 +6,20 @@ module Person
     ALLOWED_FILTERS = ['requests', 'incoming_requests', 'outgoing_requests'].freeze
 
     before_action :check_feature_and_beta_toggles
-    before_action :check_filter_type
+    before_action :check_filter_type, except: [:update]
 
     # GET /my/notifications
     def index
       @notifications = paginated_notifications
       @notifications_count = @notifications.count
+    end
+
+    def update
+      notification = authorize Notification.find(params[:id])
+
+      notification.toggle(:delivered).save!
+
+      render_ok
     end
 
     private

--- a/src/api/app/policies/notification_policy.rb
+++ b/src/api/app/policies/notification_policy.rb
@@ -10,4 +10,11 @@ class NotificationPolicy < ApplicationPolicy
       NotificationsFinder.new(scope).for_subscribed_user(user)
     end
   end
+
+  def update?
+    return true if record.subscriber_type == 'User' && record.subscriber_id == user.id
+    return true if record.subscriber_type == 'Group' && user.groups.ids.includes?(record.subscriber_id)
+
+    false
+  end
 end

--- a/src/api/config/routes/api_routes.rb
+++ b/src/api/config/routes/api_routes.rb
@@ -25,6 +25,7 @@ OBSApi::Application.routes.draw do
 
     ### notifications
     get '/my/notifications' => 'person/notifications#index'
+    put '/my/notifications/:id' => 'person/notifications#update'
 
     # /FIXME3.0
     get 'person/:login' => 'person#get_userinfo', constraints: cons

--- a/src/api/public/apidocs-new/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs-new/OBS-v2.10.50.yaml
@@ -131,6 +131,8 @@ paths:
 
   /my/notifications:
     $ref: 'paths/my_notifications.yaml'
+  /my/notifications/{id}:
+    $ref: 'paths/my_notifications_id.yaml'
 
   /person:
     $ref: 'paths/person.yaml'

--- a/src/api/public/apidocs-new/paths/my_notifications_id.yaml
+++ b/src/api/public/apidocs-new/paths/my_notifications_id.yaml
@@ -1,0 +1,30 @@
+put:
+  summary: Mark a notification as read/unread.
+  description: |
+    If a notification is unread, it will be marked as read. If a notification is read, it will be marked as unread.
+  security:
+    - basic_authentication: []
+  parameters:
+    - in: path
+      name: id
+      required: true
+      schema:
+        type: integer
+  responses:
+    '200':
+      $ref: '../components/responses/succeeded.yaml'
+    '403':
+      $ref: '../components/responses/unauthorized.yaml'
+    '404':
+      description: Not Found
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          examples:
+            Not Found:
+              value:
+                code: not_found
+                summary: Couldn't find Notification with 'id'=213453
+  tags:
+    - Notifications


### PR DESCRIPTION
Since there is only one attribute for notifications were it makes
sense to change it by hand, the update endpoint doesn't work
with xml payload or a query parameter, but simply toggles the
`delivered` attribute of a notification to mark it as read/unread.