### PR TITLE
Improve "Mark all as 'Read'" button position on small viewports in Notifications

### DIFF
--- a/src/api/app/components/notification_action_bar_component.html.haml
+++ b/src/api/app/components/notification_action_bar_component.html.haml
@@ -1,13 +1,14 @@
 .card.sticky-top#notification-action-bar
   .card-body.py-3
-    .row.px-0.px-md-1
-      .col
-        .custom-control.custom-checkbox
-          = check_box_tag('select-all-notifications', 1, false, class: 'custom-control-input')
-          %label.custom-control-label.align-middle.mr-4#select-all-label{ for: 'select-all-notifications' } Select All
-          = button_tag(type: 'submit', class: 'btn btn-sm btn-outline-success px-3', id: 'done-button', disabled: 'disabled',
-                       'data-disable-with': disable_with_content) do
-            = button_text
-          - if @show_read_all_button
-            = link_to(button_text(all: true), @update_path, method: :put, remote: true,
-                      class: 'btn btn-sm btn-outline-secondary px-3 ml-4 float-right', 'data-disable-with': disable_with_content(all: true))
+    .d-flex.px-0.px-md-1
+      .custom-control.custom-checkbox
+        = check_box_tag('select-all-notifications', 1, false, class: 'custom-control-input')
+        %label.custom-control-label.align-middle.mr-4#select-all-label{ for: 'select-all-notifications' } Select All
+      .mr-auto
+        = button_tag(type: 'submit', class: 'btn btn-sm btn-outline-success px-3', id: 'done-button', disabled: 'disabled',
+                     'data-disable-with': disable_with_content) do
+          = button_text
+      - if @show_read_all_button
+        .ml-4
+          = link_to(button_text(all: true), @update_path, method: :put, remote: true,
+                    class: 'btn btn-sm btn-outline-secondary px-3', 'data-disable-with': disable_with_content(all: true))


### PR DESCRIPTION
Before:

![read_all_button_bad_position](https://user-images.githubusercontent.com/24919/145821100-88e25fd9-2510-4be0-9dd1-da491e1af32f.png)


After:

![Screenshot from 2021-12-13 14-17-31](https://user-images.githubusercontent.com/24919/145820069-0f81eb59-9e77-436c-a830-a3c4b9f34459.png)
