### PR TITLE
Fix XML tag name for notifications schema

### DIFF
--- a/src/api/public/apidocs-new/components/schemas/notifications.yaml
+++ b/src/api/public/apidocs-new/components/schemas/notifications.yaml
@@ -27,3 +27,5 @@ properties:
           type: string
         event_type:
           type: string
+xml:
+  name: notifications


### PR DESCRIPTION
Have `<notifications>` instead of `<notifications.yaml>`

Before:
![before](https://user-images.githubusercontent.com/1102934/145833542-014cccb2-7d61-41ac-9d6b-19046b81a583.png)

Preview:
![api-example](https://user-images.githubusercontent.com/1102934/145833303-1f61e36c-2861-4305-adb5-608b941f46ec.png)