### PR TITLE
Adjust notifications endpoint API docs

### DIFF
--- a/src/api/public/apidocs-new/paths/my_notifications.yaml
+++ b/src/api/public/apidocs-new/paths/my_notifications.yaml
@@ -4,19 +4,24 @@ get:
   security:
     - basic_authentication: []
   parameters:
-    - in: path
+    - in: query
       name: project
       schema:
         type: string
-    - in: path
+    - in: query
       name: page
       schema:
-        type: int
+        type: integer
     - in: query
       name: show_maximum
       schema:
         type: string
       example: 1
+    - in: query
+      name: notifications_type
+      schema:
+        type: string
+        enum: ['requests', 'incoming_requests', 'outgoing_requests']
   responses:
     '200':
       description: |


### PR DESCRIPTION
All are query parameters and the `notifications_type` parameter, used to filter, was missing.

Follow-up #11960.