### PR TITLE
Change the bundle install vendoring path on CircleCI jobs

### DIFF
--- a/.circleci/conditional_config.yml
+++ b/.circleci/conditional_config.yml
@@ -55,7 +55,8 @@ aliases:
   - &install_dependencies
     name: install dependencies
     command: |
-      cd ./src/api && bundle install --jobs=4 --retry=3
+      cd ./src/api && bundle install --jobs=4 --retry=3 --path vendor/bundle
+
   - &wait_for_database
     name: Wait for DB
     command: mysqladmin ping -h db


### PR DESCRIPTION
We use workspaces to save transfer artifacts between CircleCI jobs
steps.

On the [install dependencies](https://github.com/openSUSE/open-build-service/blob/23d535ca29ed957b578b607f735c6b139fccf8b0/.circleci/conditional_config.yml#L55) step of the `checkout_code` job we
install the gems present on the `Gemfile.lock` system wide, on
`/usr/lib64/ruby2.5.0`. That directory is not being taken into account
when performing the [persist_to_workspace](https://github.com/openSUSE/open-build-service/blob/23d535ca29ed957b578b607f735c6b139fccf8b0/.circleci/conditional_config.yml#L194) step, and that's why we get
errors regarding missing gems on the linters.

Changing the vendoring path so it will be included in the workspace
persitence fixes that. When the workspace is [restored](https://github.com/openSUSE/open-build-service/blob/23d535ca29ed957b578b607f735c6b139fccf8b0/.circleci/conditional_config.yml#L131) the gems are there.