### PR TITLE
Revert "Change the vendoring path"

### DIFF
--- a/.circleci/conditional_config.yml
+++ b/.circleci/conditional_config.yml
@@ -55,8 +55,7 @@ aliases:
   - &install_dependencies
     name: install dependencies
     command: |
-      cd ./src/api && bundle install --jobs=4 --retry=3 --path vendor/bundle
-
+      cd ./src/api && bundle install --jobs=4 --retry=3
   - &wait_for_database
     name: Wait for DB
     command: mysqladmin ping -h db


### PR DESCRIPTION
This reverts commit cc2a0cff6ed91212b402fb26b8da9ef5f6be7979.

With CircleCI failing in the `linters` step due to a missing gem, the root cause isn't the `bundle install` path and how gems are cached in CircleCI, but the Docker image not being up to date. This can happen if somehow those images aren't building on OBS. This is what happened last time when a server was down, preventing new images from being built for our CI.