### PR TITLE
Rely only on Flipper to check if feature toggle is enabled

### DIFF
--- a/src/api/app/controllers/person/notifications_controller.rb
+++ b/src/api/app/controllers/person/notifications_controller.rb
@@ -5,7 +5,7 @@ module Person
     MAX_PER_PAGE = 300
     ALLOWED_FILTERS = ['requests', 'incoming_requests', 'outgoing_requests'].freeze
 
-    before_action :check_feature_and_beta_toggles
+    before_action :check_feature_toggle
     before_action :check_filter_type, except: [:update]
 
     # GET /my/notifications
@@ -54,8 +54,8 @@ module Person
       raise FilterNotSupportedError unless ALLOWED_FILTERS.include?(@filter_type)
     end
 
-    def check_feature_and_beta_toggles
-      raise NotFoundError unless Flipper.enabled?(:notifications_redesign, User.session) && User.session.in_beta?
+    def check_feature_toggle
+      raise NotFoundError unless Flipper.enabled?(:notifications_redesign, User.session)
     end
   end
 end

--- a/src/api/spec/controllers/person/notifications_controller_spec.rb
+++ b/src/api/spec/controllers/person/notifications_controller_spec.rb
@@ -5,19 +5,17 @@ RSpec.describe Person::NotificationsController do
 
   render_views
 
-  describe 'Check if user is in beta or feature flag is enabled' do
-    let(:user) { create(:confirmed_user, :with_home) }
-
+  describe 'Check if feature flag is enabled' do
     before do
       toggle_notifications_redesign
       login user
       get :index, format: :xml
     end
 
-    context 'user not in beta' do
+    context 'Feature :notifications_redesign is enabled' do
       let(:toggle_notifications_redesign) { Flipper[:notifications_redesign].enable }
 
-      it { expect(response).to have_http_status(:not_found) }
+      it { expect(response).to have_http_status(:success) }
     end
 
     context 'Feature :notifications_redesign is disabled' do


### PR DESCRIPTION
Removing this code is needed to be able to roll out the notifications_redesign feature toggle. Otherwise, users in the rollout group would still need to be part of the beta program to use this feature... which is nullifying the purpose of rolling out a feature.