### PR TITLE
Gather information when there is no binary package

### DIFF
--- a/src/api/app/models/binary_release.rb
+++ b/src/api/app/models/binary_release.rb
@@ -87,7 +87,11 @@ class BinaryRelease < ApplicationRecord
           hash[:binary_updateinfo] = binary['updateinfoid']
           hash[:binary_updateinfo_version] = binary['updateinfoversion']
         end
+
+        # Send the binary to Airbrake, to get a deeper understanding when there is no binary['package']
+        Airbrake.notify('Binary release with no package payload', binary: binary) unless binary['package']
         source_package = Package.striping_multibuild_suffix(binary['package'])
+
         rp = Package.find_by_project_and_name(binary['project'], source_package)
         if source_package.include?(':') && !source_package.start_with?('_product:')
           flavor_name = binary['package'].gsub(/^#{source_package}:/, '')


### PR DESCRIPTION
Sometimes we get an error because we're missing data coming from the
backend notifications during a binary release.

This PR attempts to get some more details surrounding this error.

This is a first approach to fix #11629