### PR TITLE
[api] fix encoding on patchinfo creation

### DIFF
--- a/src/api/app/models/patchinfo.rb
+++ b/src/api/app/models/patchinfo.rb
@@ -162,9 +162,9 @@ class Patchinfo
     xml = patchinfo_node(project)
 
     description = req.description || ''
-    xml.add_child("<packager>#{req.creator}</packager>")
-    xml.add_child("<summary>#{description.split(/\n|\r\n/)[0]}</summary>") # first line only
-    xml.add_child("<description>#{description}</description>")
+    xml.add_child("<packager>#{CGI.escapeHTML(req.creator)}</packager>")
+    xml.add_child("<summary>#{CGI.escapeHTML(description.split(/\n|\r\n/)[0] || '')}</summary>") # first line only
+    xml.add_child("<description>#{CGI.escapeHTML(description)}</description>")
 
     xml = update_patchinfo(project, xml, enfore_issue_update: true)
     Backend::Api::Sources::Package.write_patchinfo(@pkg.project.name, @pkg.name, User.session!.login, xml.to_xml,
@@ -210,8 +210,12 @@ class Patchinfo
 
     # create patchinfo XML file
     xml = patchinfo_node(@pkg.project)
-    xml.add_child("<packager>#{User.session!.login}</packager>")
-    xml.add_child("<summary>#{opts[:comment]}</summary>")
+    xml.add_child("<packager>#{CGI.escapeHTML(User.session!.login)}</packager>")
+    if opts[:comment].present?
+      xml.add_child("<summary>#{CGI.escapeHTML(opts[:comment])}</summary>")
+    else
+      xml.add_child('<summary/>')
+    end
     xml.add_child('<description/>')
     xml = update_patchinfo(@pkg.project, xml)
     if CONFIG['global_write_through']

--- a/src/api/test/functional/maintenance_test.rb
+++ b/src/api/test/functional/maintenance_test.rb
@@ -208,12 +208,13 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
                                    <state name="new" />
                                  </request>'
     assert_response :success
+    # note the &lt; inside description to test html encoding for _patchinfo file
     post '/request?cmd=create&addrevision=1', params: '<request>
                                    <action type="maintenance_incident">
                                      <source project="RemoteInstance:kde4" package="kdelibs" />
                                      <target project="My:Maintenance" releaseproject="BaseDistro2.0:LinkedUpdateProject" />
                                    </action>
-                                   <description>To fix my bug</description>
+                                   <description>To fix my &lt;bug</description>
                                    <state name="new" />
                                  </request>'
     assert_response :success
@@ -262,7 +263,7 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     assert_response :success
     assert_xml_tag tag: 'packager', content: 'tom'
     assert_xml_tag(tag: 'patchinfo', attributes: { incident: '0' })
-    assert_xml_tag tag: 'description', content: 'To fix my bug'
+    assert_xml_tag tag: 'description', content: 'To fix my <bug'
 
     # again but find update project automatically and use a linked package
     login_tom
@@ -1411,12 +1412,10 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     assert_xml_tag(parent: { tag: 'state' }, tag: 'comment', content: 'All reviewers accepted request')
 
     get '/search/request', params: { match: 'review/@when>="2010-07-12"' }
-    print @response.body
     assert_response :success
     assert_xml_tag tag: 'request', attributes: { id: reqid }
 
     get '/search/request', params: { match: 'review/history/@when>="1975-07-12"' }
-    print @response.body
     assert_response :success
     assert_xml_tag tag: 'request', attributes: { id: reqid }
 


### PR DESCRIPTION
We need to html encode given text for _patchinfo xml element text