### PR TITLE
[api][backend] compability mode for scmsync

### DIFF
--- a/src/api/app/controllers/public_controller.rb
+++ b/src/api/app/controllers/public_controller.rb
@@ -36,7 +36,11 @@ class PublicController < ApplicationController
     # project visible/known ?
     Project.get_by_name(params[:project])
 
-    pass_to_backend(unshift_public(request.path_info))
+    path = unshift_public(request.path_info)
+    # we should do this via user agent instead, but BSRPC is not only used for interconnect.
+    # so we do not have a way atm.
+    path += '?interconnect=1'
+    pass_to_backend(path)
   end
 
   # GET /public/source/:project
@@ -92,7 +96,11 @@ class PublicController < ApplicationController
   def package_meta
     check_package_access(params[:project], params[:package], false)
 
-    pass_to_backend(unshift_public(request.path_info))
+    path = unshift_public(request.path_info)
+    # we should do this via user agent instead, but BSRPC is not only used for interconnect.
+    # so we do not have a way atm.
+    path += '?interconnect=1'
+    pass_to_backend(path)
   end
 
   # GET /public/source/:project/:package/:filename

--- a/src/api/spec/cassettes/PublicController/GET_binary_packages/1_11_1.yml
+++ b/src/api/spec/cassettes/PublicController/GET_binary_packages/1_11_1.yml
@@ -1,6 +1,158 @@
 ---
 http_interactions:
 - request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/_meta?user=user_3
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '131'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description></description>
+        </project>
+  recorded_at: Wed, 15 Dec 2021 16:30:50 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_meta?user=user_4
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>All Passion Spent</title>
+          <description>Alias magni harum ipsa.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '178'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>All Passion Spent</title>
+          <description>Alias magni harum ipsa.</description>
+        </package>
+  recorded_at: Wed, 15 Dec 2021 16:30:50 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_config
+    body:
+      encoding: UTF-8
+      string: Fugit debitis deleniti. Non consequatur nemo. Tempora odit repellendus.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="3" vrev="3">
+          <srcmd5>f145717950346d17559dd144c45d5396</srcmd5>
+          <version>unknown</version>
+          <time>1639585850</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 15 Dec 2021 16:30:50 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Ut eum maiores. Error iusto cupiditate. Natus dolore necessitatibus.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="4" vrev="4">
+          <srcmd5>8b7ff7321695c1bdbba2afc163a59600</srcmd5>
+          <version>unknown</version>
+          <time>1639585850</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 15 Dec 2021 16:30:50 GMT
+- request:
     method: get
     uri: http://backend:5352/search/published/binary/id?match=@project='public_controller_project'%20and%20@package='public_controller_package'
     body:
@@ -31,5 +183,5 @@ http_interactions:
       string: |
         <collection matches="0">
         </collection>
-  recorded_at: Fri, 23 Oct 2020 09:01:24 GMT
+  recorded_at: Wed, 15 Dec 2021 16:30:50 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/PublicController/GET_binary_packages/1_11_2.yml
+++ b/src/api/spec/cassettes/PublicController/GET_binary_packages/1_11_2.yml
@@ -1,6 +1,156 @@
 ---
 http_interactions:
 - request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/_meta?user=user_1
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '131'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description></description>
+        </project>
+  recorded_at: Wed, 15 Dec 2021 16:30:49 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_meta?user=user_2
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>Françoise Sagan</title>
+          <description>Dolorum enim occaecati inventore.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '187'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        PHBhY2thZ2UgbmFtZT0icHVibGljX2NvbnRyb2xsZXJfcGFja2FnZSIgcHJvamVjdD0icHVibGljX2NvbnRyb2xsZXJfcHJvamVjdCI+CiAgPHRpdGxlPkZyYW7Dp29pc2UgU2FnYW48L3RpdGxlPgogIDxkZXNjcmlwdGlvbj5Eb2xvcnVtIGVuaW0gb2NjYWVjYXRpIGludmVudG9yZS48L2Rlc2NyaXB0aW9uPgo8L3BhY2thZ2U+Cg==
+  recorded_at: Wed, 15 Dec 2021 16:30:49 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_config
+    body:
+      encoding: UTF-8
+      string: Quos placeat ad. Sint ipsum saepe. Odio sapiente veniam.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="1" vrev="1">
+          <srcmd5>3b7bd35f8a342416a26ee380322c7c42</srcmd5>
+          <version>unknown</version>
+          <time>1639585849</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 15 Dec 2021 16:30:49 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Exercitationem perferendis voluptatem. Ipsum eaque totam. Quae fuga
+        porro.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="2" vrev="2">
+          <srcmd5>b70a237fb57ea853975cabf0de3ba0bb</srcmd5>
+          <version>unknown</version>
+          <time>1639585849</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 15 Dec 2021 16:30:49 GMT
+- request:
     method: get
     uri: http://backend:5352/search/published/binary/id?match=@project='public_controller_project'%20and%20@package='public_controller_package'
     body:
@@ -31,5 +181,5 @@ http_interactions:
       string: |
         <collection matches="0">
         </collection>
-  recorded_at: Fri, 23 Oct 2020 09:01:24 GMT
+  recorded_at: Wed, 15 Dec 2021 16:30:49 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/PublicController/GET_build/1_2_1.yml
+++ b/src/api/spec/cassettes/PublicController/GET_build/1_2_1.yml
@@ -1,6 +1,44 @@
 ---
 http_interactions:
 - request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/_meta?user=user_58
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '131'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description></description>
+        </project>
+  recorded_at: Wed, 15 Dec 2021 16:31:02 GMT
+- request:
     method: get
     uri: http://backend:5352/build/public_controller_project
     body:
@@ -31,5 +69,5 @@ http_interactions:
       string: |
         <directory>
         </directory>
-  recorded_at: Fri, 23 Oct 2020 09:01:22 GMT
+  recorded_at: Wed, 15 Dec 2021 16:31:02 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/PublicController/GET_build/1_2_2.yml
+++ b/src/api/spec/cassettes/PublicController/GET_build/1_2_2.yml
@@ -1,6 +1,44 @@
 ---
 http_interactions:
 - request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/_meta?user=user_59
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '131'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description></description>
+        </project>
+  recorded_at: Wed, 15 Dec 2021 16:31:02 GMT
+- request:
     method: get
     uri: http://backend:5352/build/public_controller_project
     body:
@@ -31,5 +69,5 @@ http_interactions:
       string: |
         <directory>
         </directory>
-  recorded_at: Fri, 23 Oct 2020 09:01:22 GMT
+  recorded_at: Wed, 15 Dec 2021 16:31:02 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/PublicController/GET_package_index/1_7_1.yml
+++ b/src/api/spec/cassettes/PublicController/GET_package_index/1_7_1.yml
@@ -1,6 +1,158 @@
 ---
 http_interactions:
 - request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/_meta?user=user_48
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '131'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description></description>
+        </project>
+  recorded_at: Wed, 15 Dec 2021 16:31:00 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_meta?user=user_49
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>Waiting for the Barbarians</title>
+          <description>Eos nihil eius eum.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '183'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>Waiting for the Barbarians</title>
+          <description>Eos nihil eius eum.</description>
+        </package>
+  recorded_at: Wed, 15 Dec 2021 16:31:00 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_config
+    body:
+      encoding: UTF-8
+      string: Quia ullam minus. Incidunt rerum animi. Velit nobis non.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="27" vrev="27">
+          <srcmd5>b19f5516cde2816d63086617aeaa95a3</srcmd5>
+          <version>unknown</version>
+          <time>1639585860</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 15 Dec 2021 16:31:00 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Et et illum. In suscipit distinctio. Quam iste quae.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="28" vrev="28">
+          <srcmd5>3529758223a4f3abafac2b8e61843e66</srcmd5>
+          <version>unknown</version>
+          <time>1639585860</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 15 Dec 2021 16:31:00 GMT
+- request:
     method: get
     uri: http://backend:5352/source/public_controller_project/public_controller_package
     body:
@@ -25,13 +177,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '314'
+      - '312'
     body:
       encoding: UTF-8
       string: |
-        <directory name="public_controller_package" rev="108" vrev="108" srcmd5="ab8d34688dc73760067e8371dc7f7f82">
-          <entry name="_config" md5="a02b16b9794fafd093ea729bb95bc9f4" size="69" mtime="1603405346"/>
-          <entry name="somefile.txt" md5="73c94fa9ad268a4448660a6c2947429b" size="56" mtime="1603405346"/>
+        <directory name="public_controller_package" rev="28" vrev="28" srcmd5="3529758223a4f3abafac2b8e61843e66">
+          <entry name="_config" md5="3f40f8ea15d0b355d70873319e2b4007" size="56" mtime="1639585860"/>
+          <entry name="somefile.txt" md5="7c524fbac53b2d459c97f1d47c3feca5" size="52" mtime="1639585860"/>
         </directory>
-  recorded_at: Fri, 23 Oct 2020 09:01:22 GMT
+  recorded_at: Wed, 15 Dec 2021 16:31:00 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/PublicController/GET_package_index/1_7_2.yml
+++ b/src/api/spec/cassettes/PublicController/GET_package_index/1_7_2.yml
@@ -1,6 +1,159 @@
 ---
 http_interactions:
 - request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/_meta?user=user_52
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '131'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description></description>
+        </project>
+  recorded_at: Wed, 15 Dec 2021 16:31:00 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_meta?user=user_53
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>Things Fall Apart</title>
+          <description>Et possimus tempore voluptatibus.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '188'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>Things Fall Apart</title>
+          <description>Et possimus tempore voluptatibus.</description>
+        </package>
+  recorded_at: Wed, 15 Dec 2021 16:31:01 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_config
+    body:
+      encoding: UTF-8
+      string: Mollitia eligendi repellendus. Doloremque enim in. Repellendus recusandae
+        numquam.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="31" vrev="31">
+          <srcmd5>b892f335b17b0480d29de0207baeb270</srcmd5>
+          <version>unknown</version>
+          <time>1639585861</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 15 Dec 2021 16:31:01 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Deleniti exercitationem sit. Sint quia voluptatem. Deserunt sed hic.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="32" vrev="32">
+          <srcmd5>5618a389ea4622756459275bb4fb2973</srcmd5>
+          <version>unknown</version>
+          <time>1639585861</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 15 Dec 2021 16:31:01 GMT
+- request:
     method: get
     uri: http://backend:5352/source/public_controller_project/public_controller_package
     body:
@@ -25,13 +178,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '314'
+      - '312'
     body:
       encoding: UTF-8
       string: |
-        <directory name="public_controller_package" rev="108" vrev="108" srcmd5="ab8d34688dc73760067e8371dc7f7f82">
-          <entry name="_config" md5="a02b16b9794fafd093ea729bb95bc9f4" size="69" mtime="1603405346"/>
-          <entry name="somefile.txt" md5="73c94fa9ad268a4448660a6c2947429b" size="56" mtime="1603405346"/>
+        <directory name="public_controller_package" rev="32" vrev="32" srcmd5="5618a389ea4622756459275bb4fb2973">
+          <entry name="_config" md5="d8452e8a63be2a80e00f53e8a5d8559c" size="82" mtime="1639585861"/>
+          <entry name="somefile.txt" md5="3ba4513d4019a859ad670e2b1745b838" size="68" mtime="1639585861"/>
         </directory>
-  recorded_at: Fri, 23 Oct 2020 09:01:22 GMT
+  recorded_at: Wed, 15 Dec 2021 16:31:01 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/PublicController/GET_package_index/1_7_3.yml
+++ b/src/api/spec/cassettes/PublicController/GET_package_index/1_7_3.yml
@@ -1,6 +1,159 @@
 ---
 http_interactions:
 - request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/_meta?user=user_50
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '131'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description></description>
+        </project>
+  recorded_at: Wed, 15 Dec 2021 16:31:00 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_meta?user=user_51
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>Many Waters</title>
+          <description>Necessitatibus at nobis similique.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '183'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>Many Waters</title>
+          <description>Necessitatibus at nobis similique.</description>
+        </package>
+  recorded_at: Wed, 15 Dec 2021 16:31:00 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_config
+    body:
+      encoding: UTF-8
+      string: Ducimus occaecati et. Veritatis provident aut. Fugiat ea nam.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="29" vrev="29">
+          <srcmd5>cf2864ab0c835f6c810ff34e3ba08dad</srcmd5>
+          <version>unknown</version>
+          <time>1639585860</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 15 Dec 2021 16:31:00 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Necessitatibus ratione suscipit. Facilis id dolor. Voluptates labore
+        soluta.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="30" vrev="30">
+          <srcmd5>d9932303d7223f4547850b4b75c16921</srcmd5>
+          <version>unknown</version>
+          <time>1639585860</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 15 Dec 2021 16:31:00 GMT
+- request:
     method: get
     uri: http://backend:5352/source/public_controller_project/public_controller_package
     body:
@@ -25,13 +178,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '314'
+      - '312'
     body:
       encoding: UTF-8
       string: |
-        <directory name="public_controller_package" rev="108" vrev="108" srcmd5="ab8d34688dc73760067e8371dc7f7f82">
-          <entry name="_config" md5="a02b16b9794fafd093ea729bb95bc9f4" size="69" mtime="1603405346"/>
-          <entry name="somefile.txt" md5="73c94fa9ad268a4448660a6c2947429b" size="56" mtime="1603405346"/>
+        <directory name="public_controller_package" rev="30" vrev="30" srcmd5="d9932303d7223f4547850b4b75c16921">
+          <entry name="_config" md5="1b8be6c60a71059a6d625b01ec4cc372" size="61" mtime="1639585860"/>
+          <entry name="somefile.txt" md5="40b1ddbe3c69179250c57a1ffd154ac9" size="76" mtime="1639585860"/>
         </directory>
-  recorded_at: Fri, 23 Oct 2020 09:01:22 GMT
+  recorded_at: Wed, 15 Dec 2021 16:31:00 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/PublicController/GET_package_meta/1_8_1.yml
+++ b/src/api/spec/cassettes/PublicController/GET_package_meta/1_8_1.yml
@@ -1,8 +1,160 @@
 ---
 http_interactions:
 - request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/_meta?user=user_38
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '131'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description></description>
+        </project>
+  recorded_at: Wed, 15 Dec 2021 16:30:57 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_meta?user=user_39
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>A Time of Gifts</title>
+          <description>Alias repellat quisquam qui.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '181'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>A Time of Gifts</title>
+          <description>Alias repellat quisquam qui.</description>
+        </package>
+  recorded_at: Wed, 15 Dec 2021 16:30:57 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_config
+    body:
+      encoding: UTF-8
+      string: Sit necessitatibus nulla. Eum est error. Corporis consequatur molestias.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="25" vrev="25">
+          <srcmd5>6bdb218def95c7779cd5ee7c8fd427ac</srcmd5>
+          <version>unknown</version>
+          <time>1639585857</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 15 Dec 2021 16:30:57 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Quaerat omnis sit. Et ut quos. Velit totam error.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="26" vrev="26">
+          <srcmd5>85c60e9e41acd1cbbca6d4c4c0fa3590</srcmd5>
+          <version>unknown</version>
+          <time>1639585857</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 15 Dec 2021 16:30:57 GMT
+- request:
     method: get
-    uri: http://backend:5352/source/public_controller_project/public_controller_package/_meta
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_meta?interconnect=1
     body:
       encoding: US-ASCII
       string: ''
@@ -25,13 +177,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '183'
+      - '181'
     body:
       encoding: UTF-8
       string: |
         <package name="public_controller_package" project="public_controller_project">
-          <title>I Will Fear No Evil</title>
-          <description>Natus facilis ratione est.</description>
+          <title>A Time of Gifts</title>
+          <description>Alias repellat quisquam qui.</description>
         </package>
-  recorded_at: Fri, 23 Oct 2020 09:01:21 GMT
+  recorded_at: Wed, 15 Dec 2021 16:30:57 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/PublicController/GET_package_meta/1_8_2.yml
+++ b/src/api/spec/cassettes/PublicController/GET_package_meta/1_8_2.yml
@@ -1,8 +1,160 @@
 ---
 http_interactions:
 - request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/_meta?user=user_36
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '131'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description></description>
+        </project>
+  recorded_at: Wed, 15 Dec 2021 16:30:56 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_meta?user=user_37
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>Rosemary Sutcliff</title>
+          <description>Quas quibusdam qui nemo.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '179'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>Rosemary Sutcliff</title>
+          <description>Quas quibusdam qui nemo.</description>
+        </package>
+  recorded_at: Wed, 15 Dec 2021 16:30:56 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_config
+    body:
+      encoding: UTF-8
+      string: Vero dolore est. Sunt incidunt repudiandae. Fuga voluptates dolorem.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="23" vrev="23">
+          <srcmd5>ac9d843ae96997d87cff51af80cc52c1</srcmd5>
+          <version>unknown</version>
+          <time>1639585856</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 15 Dec 2021 16:30:56 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Officiis enim non. Voluptas consequuntur modi. Quia quo aut.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="24" vrev="24">
+          <srcmd5>b005dbfd92bdf039bfb6c614a9e0b49f</srcmd5>
+          <version>unknown</version>
+          <time>1639585856</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 15 Dec 2021 16:30:57 GMT
+- request:
     method: get
-    uri: http://backend:5352/source/public_controller_project/public_controller_package/_meta
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_meta?interconnect=1
     body:
       encoding: US-ASCII
       string: ''
@@ -25,13 +177,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '183'
+      - '179'
     body:
       encoding: UTF-8
       string: |
         <package name="public_controller_package" project="public_controller_project">
-          <title>I Will Fear No Evil</title>
-          <description>Natus facilis ratione est.</description>
+          <title>Rosemary Sutcliff</title>
+          <description>Quas quibusdam qui nemo.</description>
         </package>
-  recorded_at: Fri, 23 Oct 2020 09:01:21 GMT
+  recorded_at: Wed, 15 Dec 2021 16:30:57 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/PublicController/GET_package_meta/1_8_3.yml
+++ b/src/api/spec/cassettes/PublicController/GET_package_meta/1_8_3.yml
@@ -1,8 +1,160 @@
 ---
 http_interactions:
 - request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/_meta?user=user_34
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '131'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description></description>
+        </project>
+  recorded_at: Wed, 15 Dec 2021 16:30:56 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_meta?user=user_35
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>His Dark Materials</title>
+          <description>Et accusamus qui est.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '177'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>His Dark Materials</title>
+          <description>Et accusamus qui est.</description>
+        </package>
+  recorded_at: Wed, 15 Dec 2021 16:30:56 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_config
+    body:
+      encoding: UTF-8
+      string: Culpa vero officiis. At id ad. Aperiam aspernatur qui.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="21" vrev="21">
+          <srcmd5>0085962da6067ed411aa4ab2f765b120</srcmd5>
+          <version>unknown</version>
+          <time>1639585856</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 15 Dec 2021 16:30:56 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: In doloremque sit. Assumenda eos officia. Dignissimos ut labore.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="22" vrev="22">
+          <srcmd5>916d523937111246cebcd2c3b7347be9</srcmd5>
+          <version>unknown</version>
+          <time>1639585856</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 15 Dec 2021 16:30:56 GMT
+- request:
     method: get
-    uri: http://backend:5352/source/public_controller_project/public_controller_package/_meta
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_meta?interconnect=1
     body:
       encoding: US-ASCII
       string: ''
@@ -25,13 +177,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '183'
+      - '177'
     body:
       encoding: UTF-8
       string: |
         <package name="public_controller_package" project="public_controller_project">
-          <title>I Will Fear No Evil</title>
-          <description>Natus facilis ratione est.</description>
+          <title>His Dark Materials</title>
+          <description>Et accusamus qui est.</description>
         </package>
-  recorded_at: Fri, 23 Oct 2020 09:01:21 GMT
+  recorded_at: Wed, 15 Dec 2021 16:30:56 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/PublicController/GET_project_file/1_6_1.yml
+++ b/src/api/spec/cassettes/PublicController/GET_project_file/1_6_1.yml
@@ -1,6 +1,44 @@
 ---
 http_interactions:
 - request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/_meta?user=user_40
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '131'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description></description>
+        </project>
+  recorded_at: Wed, 15 Dec 2021 16:30:57 GMT
+- request:
     method: get
     uri: http://backend:5352/source/public_controller_project/_config
     body:
@@ -29,5 +67,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-  recorded_at: Fri, 23 Oct 2020 09:01:23 GMT
+  recorded_at: Wed, 15 Dec 2021 16:30:57 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/PublicController/GET_project_file/1_6_3.yml
+++ b/src/api/spec/cassettes/PublicController/GET_project_file/1_6_3.yml
@@ -1,11 +1,15 @@
 ---
 http_interactions:
 - request:
-    method: get
-    uri: http://backend:5352/source/public_controller_project/_config
+    method: put
+    uri: http://backend:5352/source/public_controller_project/_meta?user=user_41
     body:
-      encoding: US-ASCII
-      string: ''
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description/>
+        </project>
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -19,17 +23,21 @@ http_interactions:
       message: OK
     headers:
       Content-Type:
-      - text/plain
+      - text/xml
       Cache-Control:
       - no-cache
       Connection:
       - close
       Content-Length:
-      - '0'
+      - '131'
     body:
       encoding: UTF-8
-      string: ''
-  recorded_at: Fri, 23 Oct 2020 09:01:23 GMT
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description></description>
+        </project>
+  recorded_at: Wed, 15 Dec 2021 16:30:57 GMT
 - request:
     method: get
     uri: http://backend:5352/source/public_controller_project/_config
@@ -59,5 +67,35 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-  recorded_at: Fri, 23 Oct 2020 09:01:23 GMT
+  recorded_at: Wed, 15 Dec 2021 16:30:57 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/public_controller_project/_config
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Wed, 15 Dec 2021 16:30:57 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/PublicController/GET_project_index/with_info_view_specified/and_nofilename_is_equal_1_/1_5_2_2_1.yml
+++ b/src/api/spec/cassettes/PublicController/GET_project_index/with_info_view_specified/and_nofilename_is_equal_1_/1_5_2_2_1.yml
@@ -1,6 +1,44 @@
 ---
 http_interactions:
 - request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/_meta?user=user_23
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '131'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description></description>
+        </project>
+  recorded_at: Wed, 15 Dec 2021 16:30:53 GMT
+- request:
     method: get
     uri: http://backend:5352/source/public_controller_project?nofilename=1&view=info
     body:
@@ -25,12 +63,12 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '195'
+      - '193'
     body:
       encoding: UTF-8
       string: |
         <sourceinfolist>
-          <sourceinfo package="public_controller_package" rev="108" vrev="108" srcmd5="ab8d34688dc73760067e8371dc7f7f82" verifymd5="ab8d34688dc73760067e8371dc7f7f82"/>
+          <sourceinfo package="public_controller_package" rev="12" vrev="12" srcmd5="9d45ffd57d530020adf0e20f5249e7aa" verifymd5="9d45ffd57d530020adf0e20f5249e7aa"/>
         </sourceinfolist>
-  recorded_at: Fri, 23 Oct 2020 09:01:20 GMT
+  recorded_at: Wed, 15 Dec 2021 16:30:53 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/PublicController/GET_project_index/with_info_view_specified/and_nofilename_is_equal_1_/1_5_2_2_2.yml
+++ b/src/api/spec/cassettes/PublicController/GET_project_index/with_info_view_specified/and_nofilename_is_equal_1_/1_5_2_2_2.yml
@@ -1,6 +1,44 @@
 ---
 http_interactions:
 - request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/_meta?user=user_25
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '131'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description></description>
+        </project>
+  recorded_at: Wed, 15 Dec 2021 16:30:54 GMT
+- request:
     method: get
     uri: http://backend:5352/source/public_controller_project?nofilename=1&view=info
     body:
@@ -25,12 +63,12 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '195'
+      - '193'
     body:
       encoding: UTF-8
       string: |
         <sourceinfolist>
-          <sourceinfo package="public_controller_package" rev="108" vrev="108" srcmd5="ab8d34688dc73760067e8371dc7f7f82" verifymd5="ab8d34688dc73760067e8371dc7f7f82"/>
+          <sourceinfo package="public_controller_package" rev="12" vrev="12" srcmd5="9d45ffd57d530020adf0e20f5249e7aa" verifymd5="9d45ffd57d530020adf0e20f5249e7aa"/>
         </sourceinfolist>
-  recorded_at: Fri, 23 Oct 2020 09:01:20 GMT
+  recorded_at: Wed, 15 Dec 2021 16:30:54 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/PublicController/GET_project_index/with_info_view_specified/and_nofilename_is_equal_1_/1_5_2_2_3.yml
+++ b/src/api/spec/cassettes/PublicController/GET_project_index/with_info_view_specified/and_nofilename_is_equal_1_/1_5_2_2_3.yml
@@ -1,6 +1,44 @@
 ---
 http_interactions:
 - request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/_meta?user=user_24
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '131'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description></description>
+        </project>
+  recorded_at: Wed, 15 Dec 2021 16:30:54 GMT
+- request:
     method: get
     uri: http://backend:5352/source/public_controller_project?nofilename=1&view=info
     body:
@@ -25,12 +63,12 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '195'
+      - '193'
     body:
       encoding: UTF-8
       string: |
         <sourceinfolist>
-          <sourceinfo package="public_controller_package" rev="108" vrev="108" srcmd5="ab8d34688dc73760067e8371dc7f7f82" verifymd5="ab8d34688dc73760067e8371dc7f7f82"/>
+          <sourceinfo package="public_controller_package" rev="12" vrev="12" srcmd5="9d45ffd57d530020adf0e20f5249e7aa" verifymd5="9d45ffd57d530020adf0e20f5249e7aa"/>
         </sourceinfolist>
-  recorded_at: Fri, 23 Oct 2020 09:01:20 GMT
+  recorded_at: Wed, 15 Dec 2021 16:30:54 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/PublicController/GET_project_index/with_info_view_specified/and_nofilename_is_not_equal_1_/1_5_2_1_1.yml
+++ b/src/api/spec/cassettes/PublicController/GET_project_index/with_info_view_specified/and_nofilename_is_not_equal_1_/1_5_2_1_1.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/public_controller_project/_meta?user=user_42
+    uri: http://backend:5352/source/public_controller_project/_meta?user=user_21
     body:
       encoding: UTF-8
       string: |
@@ -37,35 +37,5 @@ http_interactions:
           <title>The Public Controller Project</title>
           <description></description>
         </project>
-  recorded_at: Wed, 15 Dec 2021 16:30:58 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/public_controller_project/_config
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '0'
-    body:
-      encoding: UTF-8
-      string: ''
-  recorded_at: Wed, 15 Dec 2021 16:30:58 GMT
+  recorded_at: Wed, 15 Dec 2021 16:30:53 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/PublicController/GET_project_index/with_info_view_specified/and_nofilename_is_not_equal_1_/1_5_2_1_2.yml
+++ b/src/api/spec/cassettes/PublicController/GET_project_index/with_info_view_specified/and_nofilename_is_not_equal_1_/1_5_2_1_2.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/public_controller_project/_meta?user=user_42
+    uri: http://backend:5352/source/public_controller_project/_meta?user=user_22
     body:
       encoding: UTF-8
       string: |
@@ -37,35 +37,5 @@ http_interactions:
           <title>The Public Controller Project</title>
           <description></description>
         </project>
-  recorded_at: Wed, 15 Dec 2021 16:30:58 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/public_controller_project/_config
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '0'
-    body:
-      encoding: UTF-8
-      string: ''
-  recorded_at: Wed, 15 Dec 2021 16:30:58 GMT
+  recorded_at: Wed, 15 Dec 2021 16:30:53 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/PublicController/GET_project_index/with_productlist_view_specified/1_5_4_1.yml
+++ b/src/api/spec/cassettes/PublicController/GET_project_index/with_productlist_view_specified/1_5_4_1.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/public_controller_project/_meta?user=user_42
+    uri: http://backend:5352/source/public_controller_project/_meta?user=user_6
     body:
       encoding: UTF-8
       string: |
@@ -37,35 +37,5 @@ http_interactions:
           <title>The Public Controller Project</title>
           <description></description>
         </project>
-  recorded_at: Wed, 15 Dec 2021 16:30:58 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/public_controller_project/_config
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '0'
-    body:
-      encoding: UTF-8
-      string: ''
-  recorded_at: Wed, 15 Dec 2021 16:30:58 GMT
+  recorded_at: Wed, 15 Dec 2021 16:30:50 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/PublicController/GET_project_index/with_productlist_view_specified/1_5_4_2.yml
+++ b/src/api/spec/cassettes/PublicController/GET_project_index/with_productlist_view_specified/1_5_4_2.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/public_controller_project/_meta?user=user_42
+    uri: http://backend:5352/source/public_controller_project/_meta?user=user_7
     body:
       encoding: UTF-8
       string: |
@@ -37,35 +37,5 @@ http_interactions:
           <title>The Public Controller Project</title>
           <description></description>
         </project>
-  recorded_at: Wed, 15 Dec 2021 16:30:58 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/public_controller_project/_config
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '0'
-    body:
-      encoding: UTF-8
-      string: ''
-  recorded_at: Wed, 15 Dec 2021 16:30:58 GMT
+  recorded_at: Wed, 15 Dec 2021 16:30:50 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/PublicController/GET_project_index/with_productlist_view_specified/1_5_4_3.yml
+++ b/src/api/spec/cassettes/PublicController/GET_project_index/with_productlist_view_specified/1_5_4_3.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/public_controller_project/_meta?user=user_42
+    uri: http://backend:5352/source/public_controller_project/_meta?user=user_5
     body:
       encoding: UTF-8
       string: |
@@ -37,35 +37,5 @@ http_interactions:
           <title>The Public Controller Project</title>
           <description></description>
         </project>
-  recorded_at: Wed, 15 Dec 2021 16:30:58 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/public_controller_project/_config
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '0'
-    body:
-      encoding: UTF-8
-      string: ''
-  recorded_at: Wed, 15 Dec 2021 16:30:58 GMT
+  recorded_at: Wed, 15 Dec 2021 16:30:50 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/PublicController/GET_project_index/with_productlist_view_specified/1_5_4_4.yml
+++ b/src/api/spec/cassettes/PublicController/GET_project_index/with_productlist_view_specified/1_5_4_4.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/public_controller_project/_meta?user=user_42
+    uri: http://backend:5352/source/public_controller_project/_meta?user=user_8
     body:
       encoding: UTF-8
       string: |
@@ -37,35 +37,5 @@ http_interactions:
           <title>The Public Controller Project</title>
           <description></description>
         </project>
-  recorded_at: Wed, 15 Dec 2021 16:30:58 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/public_controller_project/_config
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '0'
-    body:
-      encoding: UTF-8
-      string: ''
-  recorded_at: Wed, 15 Dec 2021 16:30:58 GMT
+  recorded_at: Wed, 15 Dec 2021 16:30:51 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/PublicController/GET_project_index/with_verboseproductlist_view_specified/1_5_3_1.yml
+++ b/src/api/spec/cassettes/PublicController/GET_project_index/with_verboseproductlist_view_specified/1_5_3_1.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/public_controller_project/_meta?user=user_42
+    uri: http://backend:5352/source/public_controller_project/_meta?user=user_17
     body:
       encoding: UTF-8
       string: |
@@ -37,35 +37,5 @@ http_interactions:
           <title>The Public Controller Project</title>
           <description></description>
         </project>
-  recorded_at: Wed, 15 Dec 2021 16:30:58 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/public_controller_project/_config
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '0'
-    body:
-      encoding: UTF-8
-      string: ''
-  recorded_at: Wed, 15 Dec 2021 16:30:58 GMT
+  recorded_at: Wed, 15 Dec 2021 16:30:52 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/PublicController/GET_project_index/with_verboseproductlist_view_specified/1_5_3_2.yml
+++ b/src/api/spec/cassettes/PublicController/GET_project_index/with_verboseproductlist_view_specified/1_5_3_2.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/public_controller_project/_meta?user=user_42
+    uri: http://backend:5352/source/public_controller_project/_meta?user=user_18
     body:
       encoding: UTF-8
       string: |
@@ -37,35 +37,5 @@ http_interactions:
           <title>The Public Controller Project</title>
           <description></description>
         </project>
-  recorded_at: Wed, 15 Dec 2021 16:30:58 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/public_controller_project/_config
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '0'
-    body:
-      encoding: UTF-8
-      string: ''
-  recorded_at: Wed, 15 Dec 2021 16:30:58 GMT
+  recorded_at: Wed, 15 Dec 2021 16:30:52 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/PublicController/GET_project_index/with_verboseproductlist_view_specified/1_5_3_3.yml
+++ b/src/api/spec/cassettes/PublicController/GET_project_index/with_verboseproductlist_view_specified/1_5_3_3.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/public_controller_project/_meta?user=user_42
+    uri: http://backend:5352/source/public_controller_project/_meta?user=user_20
     body:
       encoding: UTF-8
       string: |
@@ -37,35 +37,5 @@ http_interactions:
           <title>The Public Controller Project</title>
           <description></description>
         </project>
-  recorded_at: Wed, 15 Dec 2021 16:30:58 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/public_controller_project/_config
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '0'
-    body:
-      encoding: UTF-8
-      string: ''
-  recorded_at: Wed, 15 Dec 2021 16:30:58 GMT
+  recorded_at: Wed, 15 Dec 2021 16:30:53 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/PublicController/GET_project_index/with_verboseproductlist_view_specified/1_5_3_4.yml
+++ b/src/api/spec/cassettes/PublicController/GET_project_index/with_verboseproductlist_view_specified/1_5_3_4.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/public_controller_project/_meta?user=user_42
+    uri: http://backend:5352/source/public_controller_project/_meta?user=user_19
     body:
       encoding: UTF-8
       string: |
@@ -37,35 +37,5 @@ http_interactions:
           <title>The Public Controller Project</title>
           <description></description>
         </project>
-  recorded_at: Wed, 15 Dec 2021 16:30:58 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/public_controller_project/_config
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '0'
-    body:
-      encoding: UTF-8
-      string: ''
-  recorded_at: Wed, 15 Dec 2021 16:30:58 GMT
+  recorded_at: Wed, 15 Dec 2021 16:30:53 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/PublicController/GET_project_index/without_view_specified/1_5_1_1.yml
+++ b/src/api/spec/cassettes/PublicController/GET_project_index/without_view_specified/1_5_1_1.yml
@@ -1,6 +1,158 @@
 ---
 http_interactions:
 - request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/_meta?user=user_13
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '131'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description></description>
+        </project>
+  recorded_at: Wed, 15 Dec 2021 16:30:51 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_meta?user=user_14
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>Number the Stars</title>
+          <description>Id consequatur quia hic.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '178'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>Number the Stars</title>
+          <description>Id consequatur quia hic.</description>
+        </package>
+  recorded_at: Wed, 15 Dec 2021 16:30:51 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_config
+    body:
+      encoding: UTF-8
+      string: Est reiciendis molestiae. Qui et voluptates. Doloremque qui omnis.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="9" vrev="9">
+          <srcmd5>cfc2e7cd1f0d1bc500e411a3337f4b66</srcmd5>
+          <version>unknown</version>
+          <time>1639585852</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 15 Dec 2021 16:30:52 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Corrupti dolor earum. Nemo amet id. Eaque alias voluptatem.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="10" vrev="10">
+          <srcmd5>9c72cbecc6bdfaca65094e8b59f8feff</srcmd5>
+          <version>unknown</version>
+          <time>1639585852</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 15 Dec 2021 16:30:52 GMT
+- request:
     method: get
     uri: http://backend:5352/source/public_controller_project?expand=1&noorigins=1
     body:
@@ -32,5 +184,5 @@ http_interactions:
         <directory>
           <entry name="public_controller_package"/>
         </directory>
-  recorded_at: Fri, 23 Oct 2020 09:01:21 GMT
+  recorded_at: Wed, 15 Dec 2021 16:30:52 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/PublicController/GET_project_index/without_view_specified/1_5_1_2.yml
+++ b/src/api/spec/cassettes/PublicController/GET_project_index/without_view_specified/1_5_1_2.yml
@@ -1,6 +1,158 @@
 ---
 http_interactions:
 - request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/_meta?user=user_15
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '131'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description></description>
+        </project>
+  recorded_at: Wed, 15 Dec 2021 16:30:52 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_meta?user=user_16
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>A Catskill Eagle</title>
+          <description>Ad aut iste sint.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '171'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>A Catskill Eagle</title>
+          <description>Ad aut iste sint.</description>
+        </package>
+  recorded_at: Wed, 15 Dec 2021 16:30:52 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_config
+    body:
+      encoding: UTF-8
+      string: Et ut eius. Odit velit fugiat. At et ipsum.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="11" vrev="11">
+          <srcmd5>2c0d168188ff40dba7b474e3b5249ebc</srcmd5>
+          <version>unknown</version>
+          <time>1639585852</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 15 Dec 2021 16:30:52 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Non quidem et. Est velit magnam. Corrupti molestiae laboriosam.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="12" vrev="12">
+          <srcmd5>9d45ffd57d530020adf0e20f5249e7aa</srcmd5>
+          <version>unknown</version>
+          <time>1639585852</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 15 Dec 2021 16:30:52 GMT
+- request:
     method: get
     uri: http://backend:5352/source/public_controller_project?expand=1&noorigins=1
     body:
@@ -32,5 +184,5 @@ http_interactions:
         <directory>
           <entry name="public_controller_package"/>
         </directory>
-  recorded_at: Fri, 23 Oct 2020 09:01:21 GMT
+  recorded_at: Wed, 15 Dec 2021 16:30:52 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/PublicController/GET_project_index/without_view_specified/1_5_1_3.yml
+++ b/src/api/spec/cassettes/PublicController/GET_project_index/without_view_specified/1_5_1_3.yml
@@ -1,6 +1,158 @@
 ---
 http_interactions:
 - request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/_meta?user=user_9
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '131'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description></description>
+        </project>
+  recorded_at: Wed, 15 Dec 2021 16:30:51 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_meta?user=user_10
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>Let Us Now Praise Famous Men</title>
+          <description>Velit aperiam quidem perferendis.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '199'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>Let Us Now Praise Famous Men</title>
+          <description>Velit aperiam quidem perferendis.</description>
+        </package>
+  recorded_at: Wed, 15 Dec 2021 16:30:51 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_config
+    body:
+      encoding: UTF-8
+      string: Ut quo deleniti. Animi unde possimus. Ad consequatur quod.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="5" vrev="5">
+          <srcmd5>30cefa996fec042080f1066472ab073c</srcmd5>
+          <version>unknown</version>
+          <time>1639585851</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 15 Dec 2021 16:30:51 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Deserunt praesentium placeat. Non accusamus tenetur. Molestiae est voluptas.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="6" vrev="6">
+          <srcmd5>f95b5ec35034ff0b1e3a65b6f404b63f</srcmd5>
+          <version>unknown</version>
+          <time>1639585851</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 15 Dec 2021 16:30:51 GMT
+- request:
     method: get
     uri: http://backend:5352/source/public_controller_project?expand=1&noorigins=1
     body:
@@ -32,5 +184,5 @@ http_interactions:
         <directory>
           <entry name="public_controller_package"/>
         </directory>
-  recorded_at: Fri, 23 Oct 2020 09:01:21 GMT
+  recorded_at: Wed, 15 Dec 2021 16:30:51 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/PublicController/GET_project_index/without_view_specified/1_5_1_4.yml
+++ b/src/api/spec/cassettes/PublicController/GET_project_index/without_view_specified/1_5_1_4.yml
@@ -1,6 +1,158 @@
 ---
 http_interactions:
 - request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/_meta?user=user_11
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '131'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description></description>
+        </project>
+  recorded_at: Wed, 15 Dec 2021 16:30:51 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_meta?user=user_12
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>O Jerusalem!</title>
+          <description>Cupiditate blanditiis facilis aspernatur.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '191'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>O Jerusalem!</title>
+          <description>Cupiditate blanditiis facilis aspernatur.</description>
+        </package>
+  recorded_at: Wed, 15 Dec 2021 16:30:51 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_config
+    body:
+      encoding: UTF-8
+      string: Laborum rerum quam. Dolorem minima qui. Quis officia quas.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="7" vrev="7">
+          <srcmd5>83b74101b4df1ea30eed6e3f3c9e9145</srcmd5>
+          <version>unknown</version>
+          <time>1639585851</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 15 Dec 2021 16:30:51 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Harum accusantium error. Ab at qui. Voluptatibus repellendus commodi.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="8" vrev="8">
+          <srcmd5>7c2a49c9179e7922275c57880074bef1</srcmd5>
+          <version>unknown</version>
+          <time>1639585851</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 15 Dec 2021 16:30:51 GMT
+- request:
     method: get
     uri: http://backend:5352/source/public_controller_project?expand=1&noorigins=1
     body:
@@ -32,5 +184,5 @@ http_interactions:
         <directory>
           <entry name="public_controller_package"/>
         </directory>
-  recorded_at: Fri, 23 Oct 2020 09:01:21 GMT
+  recorded_at: Wed, 15 Dec 2021 16:30:51 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/PublicController/GET_project_meta/1_4_1.yml
+++ b/src/api/spec/cassettes/PublicController/GET_project_meta/1_4_1.yml
@@ -1,8 +1,46 @@
 ---
 http_interactions:
 - request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/_meta?user=user_47
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '131'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description></description>
+        </project>
+  recorded_at: Wed, 15 Dec 2021 16:30:59 GMT
+- request:
     method: get
-    uri: http://backend:5352/source/public_controller_project/_meta
+    uri: http://backend:5352/source/public_controller_project/_meta?interconnect=1
     body:
       encoding: US-ASCII
       string: ''
@@ -33,5 +71,5 @@ http_interactions:
           <title>The Public Controller Project</title>
           <description></description>
         </project>
-  recorded_at: Fri, 23 Oct 2020 09:01:21 GMT
+  recorded_at: Wed, 15 Dec 2021 16:30:59 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/PublicController/GET_project_meta/1_4_2.yml
+++ b/src/api/spec/cassettes/PublicController/GET_project_meta/1_4_2.yml
@@ -1,8 +1,46 @@
 ---
 http_interactions:
 - request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/_meta?user=user_46
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '131'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description></description>
+        </project>
+  recorded_at: Wed, 15 Dec 2021 16:30:59 GMT
+- request:
     method: get
-    uri: http://backend:5352/source/public_controller_project/_meta
+    uri: http://backend:5352/source/public_controller_project/_meta?interconnect=1
     body:
       encoding: US-ASCII
       string: ''
@@ -33,5 +71,5 @@ http_interactions:
           <title>The Public Controller Project</title>
           <description></description>
         </project>
-  recorded_at: Fri, 23 Oct 2020 09:01:21 GMT
+  recorded_at: Wed, 15 Dec 2021 16:30:59 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/PublicController/GET_project_meta/1_4_3.yml
+++ b/src/api/spec/cassettes/PublicController/GET_project_meta/1_4_3.yml
@@ -1,8 +1,46 @@
 ---
 http_interactions:
 - request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/_meta?user=user_45
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '131'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description></description>
+        </project>
+  recorded_at: Wed, 15 Dec 2021 16:30:58 GMT
+- request:
     method: get
-    uri: http://backend:5352/source/public_controller_project/_meta
+    uri: http://backend:5352/source/public_controller_project/_meta?interconnect=1
     body:
       encoding: US-ASCII
       string: ''
@@ -33,5 +71,5 @@ http_interactions:
           <title>The Public Controller Project</title>
           <description></description>
         </project>
-  recorded_at: Fri, 23 Oct 2020 09:01:21 GMT
+  recorded_at: Wed, 15 Dec 2021 16:30:58 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/PublicController/GET_source_file/1_1_1.yml
+++ b/src/api/spec/cassettes/PublicController/GET_source_file/1_1_1.yml
@@ -1,6 +1,158 @@
 ---
 http_interactions:
 - request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/_meta?user=user_56
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '131'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description></description>
+        </project>
+  recorded_at: Wed, 15 Dec 2021 16:31:01 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_meta?user=user_57
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>To Your Scattered Bodies Go</title>
+          <description>Quia laborum soluta est.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '189'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>To Your Scattered Bodies Go</title>
+          <description>Quia laborum soluta est.</description>
+        </package>
+  recorded_at: Wed, 15 Dec 2021 16:31:01 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_config
+    body:
+      encoding: UTF-8
+      string: Sed vitae labore. Reiciendis velit voluptas. Reprehenderit harum assumenda.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="35" vrev="35">
+          <srcmd5>658345e146815a0872325fea3102b5f7</srcmd5>
+          <version>unknown</version>
+          <time>1639585861</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 15 Dec 2021 16:31:01 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Et ex enim. Et vitae rerum. Similique possimus occaecati.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="36" vrev="36">
+          <srcmd5>f113ffcd32df0f84f716a124414adc68</srcmd5>
+          <version>unknown</version>
+          <time>1639585861</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 15 Dec 2021 16:31:01 GMT
+- request:
     method: get
     uri: http://backend:5352/source/public_controller_project/public_controller_package/somefile.txt
     body:
@@ -21,13 +173,13 @@ http_interactions:
       Content-Type:
       - application/octet-stream
       Content-Length:
-      - '56'
+      - '57'
       Cache-Control:
       - no-cache
       Connection:
       - close
     body:
       encoding: UTF-8
-      string: Ex quo eos. Eos laborum laudantium. Est recusandae quia.
-  recorded_at: Fri, 23 Oct 2020 09:01:24 GMT
+      string: Et ex enim. Et vitae rerum. Similique possimus occaecati.
+  recorded_at: Wed, 15 Dec 2021 16:31:01 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/PublicController/GET_source_file/1_1_2.yml
+++ b/src/api/spec/cassettes/PublicController/GET_source_file/1_1_2.yml
@@ -1,11 +1,15 @@
 ---
 http_interactions:
 - request:
-    method: get
-    uri: http://backend:5352/source/public_controller_project/public_controller_package/somefile.txt
+    method: put
+    uri: http://backend:5352/source/public_controller_project/_meta?user=user_54
     body:
-      encoding: US-ASCII
-      string: ''
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description/>
+        </project>
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -19,17 +23,135 @@ http_interactions:
       message: OK
     headers:
       Content-Type:
-      - application/octet-stream
-      Content-Length:
-      - '56'
+      - text/xml
       Cache-Control:
       - no-cache
       Connection:
       - close
+      Content-Length:
+      - '131'
     body:
       encoding: UTF-8
-      string: Ex quo eos. Eos laborum laudantium. Est recusandae quia.
-  recorded_at: Fri, 23 Oct 2020 09:01:24 GMT
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description></description>
+        </project>
+  recorded_at: Wed, 15 Dec 2021 16:31:01 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_meta?user=user_55
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>Let Us Now Praise Famous Men</title>
+          <description>Reprehenderit doloribus maxime delectus.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '206'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>Let Us Now Praise Famous Men</title>
+          <description>Reprehenderit doloribus maxime delectus.</description>
+        </package>
+  recorded_at: Wed, 15 Dec 2021 16:31:01 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_config
+    body:
+      encoding: UTF-8
+      string: Voluptatibus harum fugit. Sed quasi doloremque. Mollitia dolores deleniti.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="33" vrev="33">
+          <srcmd5>5d93b7864ae3ee0558b3b0be9cf8efbf</srcmd5>
+          <version>unknown</version>
+          <time>1639585861</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 15 Dec 2021 16:31:01 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Facilis eveniet rerum. Aut dolorum repellendus. Qui qui dolorem.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="34" vrev="34">
+          <srcmd5>8a044f9fc6c65e62c769297fccc48784</srcmd5>
+          <version>unknown</version>
+          <time>1639585861</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 15 Dec 2021 16:31:01 GMT
 - request:
     method: get
     uri: http://backend:5352/source/public_controller_project/public_controller_package/somefile.txt
@@ -51,13 +173,43 @@ http_interactions:
       Content-Type:
       - application/octet-stream
       Content-Length:
-      - '56'
+      - '64'
       Cache-Control:
       - no-cache
       Connection:
       - close
     body:
       encoding: UTF-8
-      string: Ex quo eos. Eos laborum laudantium. Est recusandae quia.
-  recorded_at: Fri, 23 Oct 2020 09:01:24 GMT
+      string: Facilis eveniet rerum. Aut dolorum repellendus. Qui qui dolorem.
+  recorded_at: Wed, 15 Dec 2021 16:31:01 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/somefile.txt
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Content-Length:
+      - '64'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: Facilis eveniet rerum. Aut dolorum repellendus. Qui qui dolorem.
+  recorded_at: Wed, 15 Dec 2021 16:31:01 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/PublicController/GET_source_file_history/with_history_limited_to_1/1_12_2_1.yml
+++ b/src/api/spec/cassettes/PublicController/GET_source_file_history/with_history_limited_to_1/1_12_2_1.yml
@@ -1,6 +1,158 @@
 ---
 http_interactions:
 - request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/_meta?user=user_28
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '131'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description></description>
+        </project>
+  recorded_at: Wed, 15 Dec 2021 16:30:54 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_meta?user=user_29
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>His Dark Materials</title>
+          <description>Omnis eum nihil ullam.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '178'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>His Dark Materials</title>
+          <description>Omnis eum nihil ullam.</description>
+        </package>
+  recorded_at: Wed, 15 Dec 2021 16:30:54 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_config
+    body:
+      encoding: UTF-8
+      string: Accusantium praesentium adipisci. Quasi qui molestiae. Cum dolorem et.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="15" vrev="15">
+          <srcmd5>7a049a5715704fd8fb07392202b1cfc6</srcmd5>
+          <version>unknown</version>
+          <time>1639585854</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 15 Dec 2021 16:30:55 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Ducimus et amet. Consequatur et voluptatem. Qui aut eaque.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="16" vrev="16">
+          <srcmd5>60131e00e7de2df2f00b8f76d123a83c</srcmd5>
+          <version>unknown</version>
+          <time>1639585855</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 15 Dec 2021 16:30:55 GMT
+- request:
     method: get
     uri: http://backend:5352/source/public_controller_project/public_controller_package/_history?limit=1
     body:
@@ -25,17 +177,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '217'
+      - '215'
     body:
       encoding: UTF-8
       string: |
         <revisionlist>
-          <revision rev="108" vrev="108">
-            <srcmd5>ab8d34688dc73760067e8371dc7f7f82</srcmd5>
+          <revision rev="16" vrev="16">
+            <srcmd5>60131e00e7de2df2f00b8f76d123a83c</srcmd5>
             <version>unknown</version>
-            <time>1603405346</time>
+            <time>1639585855</time>
             <user>unknown</user>
           </revision>
         </revisionlist>
-  recorded_at: Fri, 23 Oct 2020 09:01:23 GMT
+  recorded_at: Wed, 15 Dec 2021 16:30:55 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/PublicController/GET_source_file_history/with_history_limited_to_1/1_12_2_2.yml
+++ b/src/api/spec/cassettes/PublicController/GET_source_file_history/with_history_limited_to_1/1_12_2_2.yml
@@ -1,6 +1,158 @@
 ---
 http_interactions:
 - request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/_meta?user=user_26
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '131'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description></description>
+        </project>
+  recorded_at: Wed, 15 Dec 2021 16:30:54 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_meta?user=user_27
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>Tirra Lirra by the River</title>
+          <description>Quidem tempora dolorum assumenda.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '195'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>Tirra Lirra by the River</title>
+          <description>Quidem tempora dolorum assumenda.</description>
+        </package>
+  recorded_at: Wed, 15 Dec 2021 16:30:54 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_config
+    body:
+      encoding: UTF-8
+      string: Non molestiae et. Mollitia minima nisi. Fuga et ab.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="13" vrev="13">
+          <srcmd5>4e92cdfec6542cb534554d0feb3b84a4</srcmd5>
+          <version>unknown</version>
+          <time>1639585854</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 15 Dec 2021 16:30:54 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Magni doloremque consequatur. Fugiat odio illum. Corporis velit maxime.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="14" vrev="14">
+          <srcmd5>45042f2a3942dcf2279df1bd992c2bd8</srcmd5>
+          <version>unknown</version>
+          <time>1639585854</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 15 Dec 2021 16:30:54 GMT
+- request:
     method: get
     uri: http://backend:5352/source/public_controller_project/public_controller_package/_history?limit=1
     body:
@@ -25,17 +177,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '217'
+      - '215'
     body:
       encoding: UTF-8
       string: |
         <revisionlist>
-          <revision rev="108" vrev="108">
-            <srcmd5>ab8d34688dc73760067e8371dc7f7f82</srcmd5>
+          <revision rev="14" vrev="14">
+            <srcmd5>45042f2a3942dcf2279df1bd992c2bd8</srcmd5>
             <version>unknown</version>
-            <time>1603405346</time>
+            <time>1639585854</time>
             <user>unknown</user>
           </revision>
         </revisionlist>
-  recorded_at: Fri, 23 Oct 2020 09:01:23 GMT
+  recorded_at: Wed, 15 Dec 2021 16:30:54 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/PublicController/GET_source_file_history/with_history_unlimited/1_12_1_1.yml
+++ b/src/api/spec/cassettes/PublicController/GET_source_file_history/with_history_unlimited/1_12_1_1.yml
@@ -1,6 +1,158 @@
 ---
 http_interactions:
 - request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/_meta?user=user_32
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '131'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description></description>
+        </project>
+  recorded_at: Wed, 15 Dec 2021 16:30:55 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_meta?user=user_33
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>The Violent Bear It Away</title>
+          <description>Ad quia et deserunt.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '182'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>The Violent Bear It Away</title>
+          <description>Ad quia et deserunt.</description>
+        </package>
+  recorded_at: Wed, 15 Dec 2021 16:30:55 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_config
+    body:
+      encoding: UTF-8
+      string: Rerum occaecati eius. Dolore eum aut. Aperiam natus ut.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="19" vrev="19">
+          <srcmd5>e0978613b826d47c33a48b93bfca7993</srcmd5>
+          <version>unknown</version>
+          <time>1639585855</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 15 Dec 2021 16:30:55 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Accusantium voluptatem et. Ea dolores quia. Et consequatur sequi.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="20" vrev="20">
+          <srcmd5>d6d2ed55ed04ec66bd594d8f1ce4c1ba</srcmd5>
+          <version>unknown</version>
+          <time>1639585855</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 15 Dec 2021 16:30:55 GMT
+- request:
     method: get
     uri: http://backend:5352/source/public_controller_project/public_controller_package/_history
     body:
@@ -25,659 +177,131 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '19903'
+      - '3693'
     body:
       encoding: UTF-8
       string: |
         <revisionlist>
           <revision rev="1" vrev="1">
-            <srcmd5>fd57745121de38e9834003e16110a87e</srcmd5>
+            <srcmd5>3b7bd35f8a342416a26ee380322c7c42</srcmd5>
             <version>unknown</version>
-            <time>1603405168</time>
+            <time>1639585849</time>
             <user>unknown</user>
           </revision>
           <revision rev="2" vrev="2">
-            <srcmd5>57fca94f406b4f75364149d7ca3f1125</srcmd5>
+            <srcmd5>b70a237fb57ea853975cabf0de3ba0bb</srcmd5>
             <version>unknown</version>
-            <time>1603405168</time>
+            <time>1639585849</time>
             <user>unknown</user>
           </revision>
           <revision rev="3" vrev="3">
-            <srcmd5>88609ad8fa53e3365bb9baf63f664e72</srcmd5>
+            <srcmd5>f145717950346d17559dd144c45d5396</srcmd5>
             <version>unknown</version>
-            <time>1603405168</time>
+            <time>1639585850</time>
             <user>unknown</user>
           </revision>
           <revision rev="4" vrev="4">
-            <srcmd5>593b5565866ebb83bed1861fdcf04faa</srcmd5>
+            <srcmd5>8b7ff7321695c1bdbba2afc163a59600</srcmd5>
             <version>unknown</version>
-            <time>1603405168</time>
+            <time>1639585850</time>
             <user>unknown</user>
           </revision>
           <revision rev="5" vrev="5">
-            <srcmd5>ef33d09c2eec8954598231b5e6b58559</srcmd5>
+            <srcmd5>30cefa996fec042080f1066472ab073c</srcmd5>
             <version>unknown</version>
-            <time>1603405168</time>
+            <time>1639585851</time>
             <user>unknown</user>
           </revision>
           <revision rev="6" vrev="6">
-            <srcmd5>e581b96762f61ae9db7a21c911d3d090</srcmd5>
+            <srcmd5>f95b5ec35034ff0b1e3a65b6f404b63f</srcmd5>
             <version>unknown</version>
-            <time>1603405168</time>
+            <time>1639585851</time>
             <user>unknown</user>
           </revision>
           <revision rev="7" vrev="7">
-            <srcmd5>1dc8a7f6d6c6b5812d39e528ce422cdd</srcmd5>
+            <srcmd5>83b74101b4df1ea30eed6e3f3c9e9145</srcmd5>
             <version>unknown</version>
-            <time>1603405168</time>
+            <time>1639585851</time>
             <user>unknown</user>
           </revision>
           <revision rev="8" vrev="8">
-            <srcmd5>57423269b804c866cc1c0a7cb2aafec5</srcmd5>
+            <srcmd5>7c2a49c9179e7922275c57880074bef1</srcmd5>
             <version>unknown</version>
-            <time>1603405168</time>
+            <time>1639585851</time>
             <user>unknown</user>
           </revision>
           <revision rev="9" vrev="9">
-            <srcmd5>66a0fbea22feb3e5668b36a0a5117234</srcmd5>
+            <srcmd5>cfc2e7cd1f0d1bc500e411a3337f4b66</srcmd5>
             <version>unknown</version>
-            <time>1603405171</time>
+            <time>1639585852</time>
             <user>unknown</user>
           </revision>
           <revision rev="10" vrev="10">
-            <srcmd5>969187159982f51841581d4e41b9248c</srcmd5>
+            <srcmd5>9c72cbecc6bdfaca65094e8b59f8feff</srcmd5>
             <version>unknown</version>
-            <time>1603405171</time>
+            <time>1639585852</time>
             <user>unknown</user>
           </revision>
           <revision rev="11" vrev="11">
-            <srcmd5>fa7e17ff2c38948325f513ecc2b68774</srcmd5>
+            <srcmd5>2c0d168188ff40dba7b474e3b5249ebc</srcmd5>
             <version>unknown</version>
-            <time>1603405172</time>
+            <time>1639585852</time>
             <user>unknown</user>
           </revision>
           <revision rev="12" vrev="12">
-            <srcmd5>0523a3baaae31b543ca50d9abebcdfaf</srcmd5>
+            <srcmd5>9d45ffd57d530020adf0e20f5249e7aa</srcmd5>
             <version>unknown</version>
-            <time>1603405172</time>
+            <time>1639585852</time>
             <user>unknown</user>
           </revision>
           <revision rev="13" vrev="13">
-            <srcmd5>1d9eae381c69a96c86fd4e1d1698e40c</srcmd5>
+            <srcmd5>4e92cdfec6542cb534554d0feb3b84a4</srcmd5>
             <version>unknown</version>
-            <time>1603405172</time>
+            <time>1639585854</time>
             <user>unknown</user>
           </revision>
           <revision rev="14" vrev="14">
-            <srcmd5>d5cb2d9fb3e415da376ab8dca71d016a</srcmd5>
+            <srcmd5>45042f2a3942dcf2279df1bd992c2bd8</srcmd5>
             <version>unknown</version>
-            <time>1603405172</time>
+            <time>1639585854</time>
             <user>unknown</user>
           </revision>
           <revision rev="15" vrev="15">
-            <srcmd5>830330b33a4bef296f2eb107c5920f27</srcmd5>
+            <srcmd5>7a049a5715704fd8fb07392202b1cfc6</srcmd5>
             <version>unknown</version>
-            <time>1603405172</time>
+            <time>1639585854</time>
             <user>unknown</user>
           </revision>
           <revision rev="16" vrev="16">
-            <srcmd5>22a372aea451c9349fc922c1d3a52ac4</srcmd5>
+            <srcmd5>60131e00e7de2df2f00b8f76d123a83c</srcmd5>
             <version>unknown</version>
-            <time>1603405172</time>
+            <time>1639585855</time>
             <user>unknown</user>
           </revision>
           <revision rev="17" vrev="17">
-            <srcmd5>dd80b055b58b9af08f1b9ad4b04f2b04</srcmd5>
+            <srcmd5>3b05ddf27039bf2295e6e6259525b7d1</srcmd5>
             <version>unknown</version>
-            <time>1603405172</time>
+            <time>1639585855</time>
             <user>unknown</user>
           </revision>
           <revision rev="18" vrev="18">
-            <srcmd5>54a68490c3bcf693c71b9d931fc68b2a</srcmd5>
+            <srcmd5>a1945b58aab547d9ef6851e5a38127bd</srcmd5>
             <version>unknown</version>
-            <time>1603405172</time>
+            <time>1639585855</time>
             <user>unknown</user>
           </revision>
           <revision rev="19" vrev="19">
-            <srcmd5>5e7c434f33d1a05a9c07657f6e3e7173</srcmd5>
+            <srcmd5>e0978613b826d47c33a48b93bfca7993</srcmd5>
             <version>unknown</version>
-            <time>1603405172</time>
+            <time>1639585855</time>
             <user>unknown</user>
           </revision>
           <revision rev="20" vrev="20">
-            <srcmd5>1635a809d68135d39d62acfff6123127</srcmd5>
+            <srcmd5>d6d2ed55ed04ec66bd594d8f1ce4c1ba</srcmd5>
             <version>unknown</version>
-            <time>1603405173</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="21" vrev="21">
-            <srcmd5>1ad93877deffe63aaf0e3af25a0d2b8e</srcmd5>
-            <version>unknown</version>
-            <time>1603405173</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="22" vrev="22">
-            <srcmd5>ec60c89ef52d3f29ca81a0021816782b</srcmd5>
-            <version>unknown</version>
-            <time>1603405173</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="23" vrev="23">
-            <srcmd5>9734479bbe220a23b29a410f7b2bcb40</srcmd5>
-            <version>unknown</version>
-            <time>1603405174</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="24" vrev="24">
-            <srcmd5>d0391954bda3b04e4b39c9f40f9d1f86</srcmd5>
-            <version>unknown</version>
-            <time>1603405174</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="25" vrev="25">
-            <srcmd5>75582f0cf8c783750320d551a9e902cf</srcmd5>
-            <version>unknown</version>
-            <time>1603405174</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="26" vrev="26">
-            <srcmd5>fa38dbaaabfac460a52717e97ac10769</srcmd5>
-            <version>unknown</version>
-            <time>1603405174</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="27" vrev="27">
-            <srcmd5>3a2fba313be95d1bb3dfac3ad764be84</srcmd5>
-            <version>unknown</version>
-            <time>1603405174</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="28" vrev="28">
-            <srcmd5>ab5406b9cdf8aee0891726e82640212c</srcmd5>
-            <version>unknown</version>
-            <time>1603405174</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="29" vrev="29">
-            <srcmd5>ba82293a896721a77e41d004fe38d5e3</srcmd5>
-            <version>unknown</version>
-            <time>1603405174</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="30" vrev="30">
-            <srcmd5>59455cc11cd119a578e701f8b0dc55c4</srcmd5>
-            <version>unknown</version>
-            <time>1603405174</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="31" vrev="31">
-            <srcmd5>91e099e241ca34dd838fbd127a2c5f63</srcmd5>
-            <version>unknown</version>
-            <time>1603405175</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="32" vrev="32">
-            <srcmd5>d328d25a88684a0f7cc6b2e6c750eeec</srcmd5>
-            <version>unknown</version>
-            <time>1603405175</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="33" vrev="33">
-            <srcmd5>98b2871e37b04608c9d9155c7f011111</srcmd5>
-            <version>unknown</version>
-            <time>1603405217</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="34" vrev="34">
-            <srcmd5>1f1d06cb346bbab9bd27855f1aeb693b</srcmd5>
-            <version>unknown</version>
-            <time>1603405217</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="35" vrev="35">
-            <srcmd5>fcee25570139cd24e820e00702392f83</srcmd5>
-            <version>unknown</version>
-            <time>1603405217</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="36" vrev="36">
-            <srcmd5>1b55d2380a4da33e92c366ea73792e57</srcmd5>
-            <version>unknown</version>
-            <time>1603405217</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="37" vrev="37">
-            <srcmd5>055b3ca568986cdd201f178297370be7</srcmd5>
-            <version>unknown</version>
-            <time>1603405244</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="38" vrev="38">
-            <srcmd5>ebee1c7cec5cf9901af08c8d8dc26fea</srcmd5>
-            <version>unknown</version>
-            <time>1603405244</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="39" vrev="39">
-            <srcmd5>debc19a9bc989fe5d871eee8cae3d461</srcmd5>
-            <version>unknown</version>
-            <time>1603405245</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="40" vrev="40">
-            <srcmd5>904c314fd46fe5f2beccdc6e2225e8d5</srcmd5>
-            <version>unknown</version>
-            <time>1603405245</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="41" vrev="41">
-            <srcmd5>8bbdefb957e604100b1c7f9ad81319de</srcmd5>
-            <version>unknown</version>
-            <time>1603405245</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="42" vrev="42">
-            <srcmd5>56c70d42507549b33f50fc78deade91f</srcmd5>
-            <version>unknown</version>
-            <time>1603405245</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="43" vrev="43">
-            <srcmd5>729ec22e132ab3be39d5f77e6ba7827c</srcmd5>
-            <version>unknown</version>
-            <time>1603405245</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="44" vrev="44">
-            <srcmd5>70e5554de22a485c56e77d7a079d4e3a</srcmd5>
-            <version>unknown</version>
-            <time>1603405245</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="45" vrev="45">
-            <srcmd5>68b29631100edc654d1542879d95d557</srcmd5>
-            <version>unknown</version>
-            <time>1603405245</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="46" vrev="46">
-            <srcmd5>bd8266fc91d7421feb3443b2f5cb0642</srcmd5>
-            <version>unknown</version>
-            <time>1603405246</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="47" vrev="47">
-            <srcmd5>fed0817faae302685f0297edfccab59e</srcmd5>
-            <version>unknown</version>
-            <time>1603405246</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="48" vrev="48">
-            <srcmd5>523d8bc54330326b337806a55d17150a</srcmd5>
-            <version>unknown</version>
-            <time>1603405246</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="49" vrev="49">
-            <srcmd5>fd2fd303a4d3a63f6432307b26340d4d</srcmd5>
-            <version>unknown</version>
-            <time>1603405246</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="50" vrev="50">
-            <srcmd5>b65eda132280781c9a44e2de2bb7093d</srcmd5>
-            <version>unknown</version>
-            <time>1603405246</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="51" vrev="51">
-            <srcmd5>f5c8056a8d8cc9c5378a9ba68c8fdf12</srcmd5>
-            <version>unknown</version>
-            <time>1603405246</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="52" vrev="52">
-            <srcmd5>bacef8a402bfaf5ab7b750566d7e7b90</srcmd5>
-            <version>unknown</version>
-            <time>1603405247</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="53" vrev="53">
-            <srcmd5>404017e50ea683a3ef0b7f91e26520cf</srcmd5>
-            <version>unknown</version>
-            <time>1603405247</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="54" vrev="54">
-            <srcmd5>ea03d41e766c3c59923112357c9445ee</srcmd5>
-            <version>unknown</version>
-            <time>1603405247</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="55" vrev="55">
-            <srcmd5>46aab5f3ce84021a1d0c012417ba5d41</srcmd5>
-            <version>unknown</version>
-            <time>1603405247</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="56" vrev="56">
-            <srcmd5>d9116a5056894fb2a9508dba1029dccb</srcmd5>
-            <version>unknown</version>
-            <time>1603405247</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="57" vrev="57">
-            <srcmd5>8a0b66a94c90360a71c9159fa256ca41</srcmd5>
-            <version>unknown</version>
-            <time>1603405248</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="58" vrev="58">
-            <srcmd5>52a152d89fd8d41fa0897e40f0f88fad</srcmd5>
-            <version>unknown</version>
-            <time>1603405248</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="59" vrev="59">
-            <srcmd5>cb16dc8abf8d8e211c872cb5cd3e031e</srcmd5>
-            <version>unknown</version>
-            <time>1603405248</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="60" vrev="60">
-            <srcmd5>f09fce199fd101db91fbd7a6162797e6</srcmd5>
-            <version>unknown</version>
-            <time>1603405248</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="61" vrev="61">
-            <srcmd5>db1190166da3f3e5efcc854d7d929e0a</srcmd5>
-            <version>unknown</version>
-            <time>1603405248</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="62" vrev="62">
-            <srcmd5>eb7db890a896b8c1f35135c62dd7b5ba</srcmd5>
-            <version>unknown</version>
-            <time>1603405248</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="63" vrev="63">
-            <srcmd5>a8847945f782789f71e9b55bb2d55b44</srcmd5>
-            <version>unknown</version>
-            <time>1603405248</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="64" vrev="64">
-            <srcmd5>0a6ac8ae1b9d03206bf54e97592ce509</srcmd5>
-            <version>unknown</version>
-            <time>1603405248</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="65" vrev="65">
-            <srcmd5>026f49f5767a6864515ede156fecf2b7</srcmd5>
-            <version>unknown</version>
-            <time>1603405249</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="66" vrev="66">
-            <srcmd5>2af44a29f958174c8a2009b00492f9d0</srcmd5>
-            <version>unknown</version>
-            <time>1603405249</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="67" vrev="67">
-            <srcmd5>7731b7c5598c79a9a4c7a83bb53abbaa</srcmd5>
-            <version>unknown</version>
-            <time>1603405249</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="68" vrev="68">
-            <srcmd5>189a0902fb0759832541eaf41c5a3ab9</srcmd5>
-            <version>unknown</version>
-            <time>1603405249</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="69" vrev="69">
-            <srcmd5>32b49a84cd42ea62bd4c71f01e37266d</srcmd5>
-            <version>unknown</version>
-            <time>1603405250</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="70" vrev="70">
-            <srcmd5>3c7f8e82d705281b8a33a1bd1862dca1</srcmd5>
-            <version>unknown</version>
-            <time>1603405250</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="71" vrev="71">
-            <srcmd5>a5d053e96a3ae1ad33de0112c07cb9df</srcmd5>
-            <version>unknown</version>
-            <time>1603405250</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="72" vrev="72">
-            <srcmd5>1574ed8d20245152980ad0880fc6fdbb</srcmd5>
-            <version>unknown</version>
-            <time>1603405250</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="73" vrev="73">
-            <srcmd5>187c7f098df4ef20487711ae9418561d</srcmd5>
-            <version>unknown</version>
-            <time>1603405338</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="74" vrev="74">
-            <srcmd5>10b8531db5fd0720fdd8cc6fc21a4446</srcmd5>
-            <version>unknown</version>
-            <time>1603405338</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="75" vrev="75">
-            <srcmd5>d9eaf889635f3e1f5a2d563163b58f62</srcmd5>
-            <version>unknown</version>
-            <time>1603405339</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="76" vrev="76">
-            <srcmd5>56c7279c2d3956438d8aaa0d0567da50</srcmd5>
-            <version>unknown</version>
-            <time>1603405339</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="77" vrev="77">
-            <srcmd5>3361064bd2670e9414fc908b2efc45f7</srcmd5>
-            <version>unknown</version>
-            <time>1603405340</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="78" vrev="78">
-            <srcmd5>c873a6af4b175c2bbe2aecffe869f804</srcmd5>
-            <version>unknown</version>
-            <time>1603405340</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="79" vrev="79">
-            <srcmd5>bd7774000cb9992cd3da9cfdb327d39e</srcmd5>
-            <version>unknown</version>
-            <time>1603405340</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="80" vrev="80">
-            <srcmd5>f60fade633bf0871790d321ae51d794c</srcmd5>
-            <version>unknown</version>
-            <time>1603405340</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="81" vrev="81">
-            <srcmd5>05aa1d313391c90327b2cc3a6f411ebb</srcmd5>
-            <version>unknown</version>
-            <time>1603405340</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="82" vrev="82">
-            <srcmd5>590718dcdf3813aff637fccd1775c97b</srcmd5>
-            <version>unknown</version>
-            <time>1603405340</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="83" vrev="83">
-            <srcmd5>4248a0743598a833d22da58bdceb7975</srcmd5>
-            <version>unknown</version>
-            <time>1603405341</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="84" vrev="84">
-            <srcmd5>7201b3bdf4e0e2191484c89d599f5c0c</srcmd5>
-            <version>unknown</version>
-            <time>1603405341</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="85" vrev="85">
-            <srcmd5>11712de5c6f3e1f0a86db6c1416cd5dd</srcmd5>
-            <version>unknown</version>
-            <time>1603405341</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="86" vrev="86">
-            <srcmd5>4d89959b4d1b0e853529d994e494f5ca</srcmd5>
-            <version>unknown</version>
-            <time>1603405342</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="87" vrev="87">
-            <srcmd5>b5163fb2357da727eff42e4e1dd215b1</srcmd5>
-            <version>unknown</version>
-            <time>1603405342</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="88" vrev="88">
-            <srcmd5>c0885119dc14a210414c1da5cff0f69c</srcmd5>
-            <version>unknown</version>
-            <time>1603405342</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="89" vrev="89">
-            <srcmd5>6b18ce7572c96080bfa00cb52d73ee1f</srcmd5>
-            <version>unknown</version>
-            <time>1603405342</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="90" vrev="90">
-            <srcmd5>9da73c6330ca25030295a36e1e0c4610</srcmd5>
-            <version>unknown</version>
-            <time>1603405342</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="91" vrev="91">
-            <srcmd5>974deb68be8c8a2c2bc955538aaf68aa</srcmd5>
-            <version>unknown</version>
-            <time>1603405344</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="92" vrev="92">
-            <srcmd5>bbc614ee2629aa7657066867cdca4d22</srcmd5>
-            <version>unknown</version>
-            <time>1603405344</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="93" vrev="93">
-            <srcmd5>77c621c31f6eae2fd32d4f0f79ef9dfc</srcmd5>
-            <version>unknown</version>
-            <time>1603405344</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="94" vrev="94">
-            <srcmd5>dea2fb220303af62a51428dd1ebf3b66</srcmd5>
-            <version>unknown</version>
-            <time>1603405344</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="95" vrev="95">
-            <srcmd5>89834c5e9e2eb816d4090dee88150b05</srcmd5>
-            <version>unknown</version>
-            <time>1603405344</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="96" vrev="96">
-            <srcmd5>7243793885248e8e28da917e72078495</srcmd5>
-            <version>unknown</version>
-            <time>1603405344</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="97" vrev="97">
-            <srcmd5>d23cbfa1cb1d12027abf86e4f96d9dc4</srcmd5>
-            <version>unknown</version>
-            <time>1603405344</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="98" vrev="98">
-            <srcmd5>a9b2f29a10e452952318b661c6fe781d</srcmd5>
-            <version>unknown</version>
-            <time>1603405344</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="99" vrev="99">
-            <srcmd5>828032f4e3eed6c35818564c07a2a76e</srcmd5>
-            <version>unknown</version>
-            <time>1603405345</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="100" vrev="100">
-            <srcmd5>6cb4f913c76a443e73198cc7160e5607</srcmd5>
-            <version>unknown</version>
-            <time>1603405345</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="101" vrev="101">
-            <srcmd5>956918bc90e12c1fb56711c69bb2c9dc</srcmd5>
-            <version>unknown</version>
-            <time>1603405345</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="102" vrev="102">
-            <srcmd5>212cae2a06754f85ff1180a1d59df0ec</srcmd5>
-            <version>unknown</version>
-            <time>1603405345</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="103" vrev="103">
-            <srcmd5>5565a5f10c7e717bc36ca0b140e6b40b</srcmd5>
-            <version>unknown</version>
-            <time>1603405345</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="104" vrev="104">
-            <srcmd5>e8cb4c62d048cb238ac1eb0ee3185609</srcmd5>
-            <version>unknown</version>
-            <time>1603405345</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="105" vrev="105">
-            <srcmd5>e6b2e1645230c3b2fa9827fe78193d70</srcmd5>
-            <version>unknown</version>
-            <time>1603405346</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="106" vrev="106">
-            <srcmd5>4c45fa684f3668b5c7345541bf5b0830</srcmd5>
-            <version>unknown</version>
-            <time>1603405346</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="107" vrev="107">
-            <srcmd5>3e757fb9bc3400f1542033ed44009402</srcmd5>
-            <version>unknown</version>
-            <time>1603405346</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="108" vrev="108">
-            <srcmd5>ab8d34688dc73760067e8371dc7f7f82</srcmd5>
-            <version>unknown</version>
-            <time>1603405346</time>
+            <time>1639585855</time>
             <user>unknown</user>
           </revision>
         </revisionlist>
-  recorded_at: Fri, 23 Oct 2020 09:01:23 GMT
+  recorded_at: Wed, 15 Dec 2021 16:30:56 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/PublicController/GET_source_file_history/with_history_unlimited/1_12_1_2.yml
+++ b/src/api/spec/cassettes/PublicController/GET_source_file_history/with_history_unlimited/1_12_1_2.yml
@@ -1,6 +1,158 @@
 ---
 http_interactions:
 - request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/_meta?user=user_30
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '131'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="public_controller_project">
+          <title>The Public Controller Project</title>
+          <description></description>
+        </project>
+  recorded_at: Wed, 15 Dec 2021 16:30:55 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_meta?user=user_31
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>A Time of Gifts</title>
+          <description>Fugiat cupiditate aut voluptatem.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '186'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>A Time of Gifts</title>
+          <description>Fugiat cupiditate aut voluptatem.</description>
+        </package>
+  recorded_at: Wed, 15 Dec 2021 16:30:55 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_config
+    body:
+      encoding: UTF-8
+      string: Iste asperiores repellendus. Qui placeat voluptatem. Qui rerum sint.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="17" vrev="17">
+          <srcmd5>3b05ddf27039bf2295e6e6259525b7d1</srcmd5>
+          <version>unknown</version>
+          <time>1639585855</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 15 Dec 2021 16:30:55 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Tempore nulla nam. Asperiores sint et. Dolores non inventore.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="18" vrev="18">
+          <srcmd5>a1945b58aab547d9ef6851e5a38127bd</srcmd5>
+          <version>unknown</version>
+          <time>1639585855</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 15 Dec 2021 16:30:55 GMT
+- request:
     method: get
     uri: http://backend:5352/source/public_controller_project/public_controller_package/_history
     body:
@@ -25,659 +177,119 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '19903'
+      - '3325'
     body:
       encoding: UTF-8
       string: |
         <revisionlist>
           <revision rev="1" vrev="1">
-            <srcmd5>fd57745121de38e9834003e16110a87e</srcmd5>
+            <srcmd5>3b7bd35f8a342416a26ee380322c7c42</srcmd5>
             <version>unknown</version>
-            <time>1603405168</time>
+            <time>1639585849</time>
             <user>unknown</user>
           </revision>
           <revision rev="2" vrev="2">
-            <srcmd5>57fca94f406b4f75364149d7ca3f1125</srcmd5>
+            <srcmd5>b70a237fb57ea853975cabf0de3ba0bb</srcmd5>
             <version>unknown</version>
-            <time>1603405168</time>
+            <time>1639585849</time>
             <user>unknown</user>
           </revision>
           <revision rev="3" vrev="3">
-            <srcmd5>88609ad8fa53e3365bb9baf63f664e72</srcmd5>
+            <srcmd5>f145717950346d17559dd144c45d5396</srcmd5>
             <version>unknown</version>
-            <time>1603405168</time>
+            <time>1639585850</time>
             <user>unknown</user>
           </revision>
           <revision rev="4" vrev="4">
-            <srcmd5>593b5565866ebb83bed1861fdcf04faa</srcmd5>
+            <srcmd5>8b7ff7321695c1bdbba2afc163a59600</srcmd5>
             <version>unknown</version>
-            <time>1603405168</time>
+            <time>1639585850</time>
             <user>unknown</user>
           </revision>
           <revision rev="5" vrev="5">
-            <srcmd5>ef33d09c2eec8954598231b5e6b58559</srcmd5>
+            <srcmd5>30cefa996fec042080f1066472ab073c</srcmd5>
             <version>unknown</version>
-            <time>1603405168</time>
+            <time>1639585851</time>
             <user>unknown</user>
           </revision>
           <revision rev="6" vrev="6">
-            <srcmd5>e581b96762f61ae9db7a21c911d3d090</srcmd5>
+            <srcmd5>f95b5ec35034ff0b1e3a65b6f404b63f</srcmd5>
             <version>unknown</version>
-            <time>1603405168</time>
+            <time>1639585851</time>
             <user>unknown</user>
           </revision>
           <revision rev="7" vrev="7">
-            <srcmd5>1dc8a7f6d6c6b5812d39e528ce422cdd</srcmd5>
+            <srcmd5>83b74101b4df1ea30eed6e3f3c9e9145</srcmd5>
             <version>unknown</version>
-            <time>1603405168</time>
+            <time>1639585851</time>
             <user>unknown</user>
           </revision>
           <revision rev="8" vrev="8">
-            <srcmd5>57423269b804c866cc1c0a7cb2aafec5</srcmd5>
+            <srcmd5>7c2a49c9179e7922275c57880074bef1</srcmd5>
             <version>unknown</version>
-            <time>1603405168</time>
+            <time>1639585851</time>
             <user>unknown</user>
           </revision>
           <revision rev="9" vrev="9">
-            <srcmd5>66a0fbea22feb3e5668b36a0a5117234</srcmd5>
+            <srcmd5>cfc2e7cd1f0d1bc500e411a3337f4b66</srcmd5>
             <version>unknown</version>
-            <time>1603405171</time>
+            <time>1639585852</time>
             <user>unknown</user>
           </revision>
           <revision rev="10" vrev="10">
-            <srcmd5>969187159982f51841581d4e41b9248c</srcmd5>
+            <srcmd5>9c72cbecc6bdfaca65094e8b59f8feff</srcmd5>
             <version>unknown</version>
-            <time>1603405171</time>
+            <time>1639585852</time>
             <user>unknown</user>
           </revision>
           <revision rev="11" vrev="11">
-            <srcmd5>fa7e17ff2c38948325f513ecc2b68774</srcmd5>
+            <srcmd5>2c0d168188ff40dba7b474e3b5249ebc</srcmd5>
             <version>unknown</version>
-            <time>1603405172</time>
+            <time>1639585852</time>
             <user>unknown</user>
           </revision>
           <revision rev="12" vrev="12">
-            <srcmd5>0523a3baaae31b543ca50d9abebcdfaf</srcmd5>
+            <srcmd5>9d45ffd57d530020adf0e20f5249e7aa</srcmd5>
             <version>unknown</version>
-            <time>1603405172</time>
+            <time>1639585852</time>
             <user>unknown</user>
           </revision>
           <revision rev="13" vrev="13">
-            <srcmd5>1d9eae381c69a96c86fd4e1d1698e40c</srcmd5>
+            <srcmd5>4e92cdfec6542cb534554d0feb3b84a4</srcmd5>
             <version>unknown</version>
-            <time>1603405172</time>
+            <time>1639585854</time>
             <user>unknown</user>
           </revision>
           <revision rev="14" vrev="14">
-            <srcmd5>d5cb2d9fb3e415da376ab8dca71d016a</srcmd5>
+            <srcmd5>45042f2a3942dcf2279df1bd992c2bd8</srcmd5>
             <version>unknown</version>
-            <time>1603405172</time>
+            <time>1639585854</time>
             <user>unknown</user>
           </revision>
           <revision rev="15" vrev="15">
-            <srcmd5>830330b33a4bef296f2eb107c5920f27</srcmd5>
+            <srcmd5>7a049a5715704fd8fb07392202b1cfc6</srcmd5>
             <version>unknown</version>
-            <time>1603405172</time>
+            <time>1639585854</time>
             <user>unknown</user>
           </revision>
           <revision rev="16" vrev="16">
-            <srcmd5>22a372aea451c9349fc922c1d3a52ac4</srcmd5>
+            <srcmd5>60131e00e7de2df2f00b8f76d123a83c</srcmd5>
             <version>unknown</version>
-            <time>1603405172</time>
+            <time>1639585855</time>
             <user>unknown</user>
           </revision>
           <revision rev="17" vrev="17">
-            <srcmd5>dd80b055b58b9af08f1b9ad4b04f2b04</srcmd5>
+            <srcmd5>3b05ddf27039bf2295e6e6259525b7d1</srcmd5>
             <version>unknown</version>
-            <time>1603405172</time>
+            <time>1639585855</time>
             <user>unknown</user>
           </revision>
           <revision rev="18" vrev="18">
-            <srcmd5>54a68490c3bcf693c71b9d931fc68b2a</srcmd5>
+            <srcmd5>a1945b58aab547d9ef6851e5a38127bd</srcmd5>
             <version>unknown</version>
-            <time>1603405172</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="19" vrev="19">
-            <srcmd5>5e7c434f33d1a05a9c07657f6e3e7173</srcmd5>
-            <version>unknown</version>
-            <time>1603405172</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="20" vrev="20">
-            <srcmd5>1635a809d68135d39d62acfff6123127</srcmd5>
-            <version>unknown</version>
-            <time>1603405173</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="21" vrev="21">
-            <srcmd5>1ad93877deffe63aaf0e3af25a0d2b8e</srcmd5>
-            <version>unknown</version>
-            <time>1603405173</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="22" vrev="22">
-            <srcmd5>ec60c89ef52d3f29ca81a0021816782b</srcmd5>
-            <version>unknown</version>
-            <time>1603405173</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="23" vrev="23">
-            <srcmd5>9734479bbe220a23b29a410f7b2bcb40</srcmd5>
-            <version>unknown</version>
-            <time>1603405174</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="24" vrev="24">
-            <srcmd5>d0391954bda3b04e4b39c9f40f9d1f86</srcmd5>
-            <version>unknown</version>
-            <time>1603405174</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="25" vrev="25">
-            <srcmd5>75582f0cf8c783750320d551a9e902cf</srcmd5>
-            <version>unknown</version>
-            <time>1603405174</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="26" vrev="26">
-            <srcmd5>fa38dbaaabfac460a52717e97ac10769</srcmd5>
-            <version>unknown</version>
-            <time>1603405174</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="27" vrev="27">
-            <srcmd5>3a2fba313be95d1bb3dfac3ad764be84</srcmd5>
-            <version>unknown</version>
-            <time>1603405174</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="28" vrev="28">
-            <srcmd5>ab5406b9cdf8aee0891726e82640212c</srcmd5>
-            <version>unknown</version>
-            <time>1603405174</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="29" vrev="29">
-            <srcmd5>ba82293a896721a77e41d004fe38d5e3</srcmd5>
-            <version>unknown</version>
-            <time>1603405174</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="30" vrev="30">
-            <srcmd5>59455cc11cd119a578e701f8b0dc55c4</srcmd5>
-            <version>unknown</version>
-            <time>1603405174</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="31" vrev="31">
-            <srcmd5>91e099e241ca34dd838fbd127a2c5f63</srcmd5>
-            <version>unknown</version>
-            <time>1603405175</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="32" vrev="32">
-            <srcmd5>d328d25a88684a0f7cc6b2e6c750eeec</srcmd5>
-            <version>unknown</version>
-            <time>1603405175</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="33" vrev="33">
-            <srcmd5>98b2871e37b04608c9d9155c7f011111</srcmd5>
-            <version>unknown</version>
-            <time>1603405217</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="34" vrev="34">
-            <srcmd5>1f1d06cb346bbab9bd27855f1aeb693b</srcmd5>
-            <version>unknown</version>
-            <time>1603405217</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="35" vrev="35">
-            <srcmd5>fcee25570139cd24e820e00702392f83</srcmd5>
-            <version>unknown</version>
-            <time>1603405217</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="36" vrev="36">
-            <srcmd5>1b55d2380a4da33e92c366ea73792e57</srcmd5>
-            <version>unknown</version>
-            <time>1603405217</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="37" vrev="37">
-            <srcmd5>055b3ca568986cdd201f178297370be7</srcmd5>
-            <version>unknown</version>
-            <time>1603405244</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="38" vrev="38">
-            <srcmd5>ebee1c7cec5cf9901af08c8d8dc26fea</srcmd5>
-            <version>unknown</version>
-            <time>1603405244</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="39" vrev="39">
-            <srcmd5>debc19a9bc989fe5d871eee8cae3d461</srcmd5>
-            <version>unknown</version>
-            <time>1603405245</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="40" vrev="40">
-            <srcmd5>904c314fd46fe5f2beccdc6e2225e8d5</srcmd5>
-            <version>unknown</version>
-            <time>1603405245</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="41" vrev="41">
-            <srcmd5>8bbdefb957e604100b1c7f9ad81319de</srcmd5>
-            <version>unknown</version>
-            <time>1603405245</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="42" vrev="42">
-            <srcmd5>56c70d42507549b33f50fc78deade91f</srcmd5>
-            <version>unknown</version>
-            <time>1603405245</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="43" vrev="43">
-            <srcmd5>729ec22e132ab3be39d5f77e6ba7827c</srcmd5>
-            <version>unknown</version>
-            <time>1603405245</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="44" vrev="44">
-            <srcmd5>70e5554de22a485c56e77d7a079d4e3a</srcmd5>
-            <version>unknown</version>
-            <time>1603405245</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="45" vrev="45">
-            <srcmd5>68b29631100edc654d1542879d95d557</srcmd5>
-            <version>unknown</version>
-            <time>1603405245</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="46" vrev="46">
-            <srcmd5>bd8266fc91d7421feb3443b2f5cb0642</srcmd5>
-            <version>unknown</version>
-            <time>1603405246</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="47" vrev="47">
-            <srcmd5>fed0817faae302685f0297edfccab59e</srcmd5>
-            <version>unknown</version>
-            <time>1603405246</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="48" vrev="48">
-            <srcmd5>523d8bc54330326b337806a55d17150a</srcmd5>
-            <version>unknown</version>
-            <time>1603405246</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="49" vrev="49">
-            <srcmd5>fd2fd303a4d3a63f6432307b26340d4d</srcmd5>
-            <version>unknown</version>
-            <time>1603405246</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="50" vrev="50">
-            <srcmd5>b65eda132280781c9a44e2de2bb7093d</srcmd5>
-            <version>unknown</version>
-            <time>1603405246</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="51" vrev="51">
-            <srcmd5>f5c8056a8d8cc9c5378a9ba68c8fdf12</srcmd5>
-            <version>unknown</version>
-            <time>1603405246</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="52" vrev="52">
-            <srcmd5>bacef8a402bfaf5ab7b750566d7e7b90</srcmd5>
-            <version>unknown</version>
-            <time>1603405247</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="53" vrev="53">
-            <srcmd5>404017e50ea683a3ef0b7f91e26520cf</srcmd5>
-            <version>unknown</version>
-            <time>1603405247</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="54" vrev="54">
-            <srcmd5>ea03d41e766c3c59923112357c9445ee</srcmd5>
-            <version>unknown</version>
-            <time>1603405247</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="55" vrev="55">
-            <srcmd5>46aab5f3ce84021a1d0c012417ba5d41</srcmd5>
-            <version>unknown</version>
-            <time>1603405247</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="56" vrev="56">
-            <srcmd5>d9116a5056894fb2a9508dba1029dccb</srcmd5>
-            <version>unknown</version>
-            <time>1603405247</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="57" vrev="57">
-            <srcmd5>8a0b66a94c90360a71c9159fa256ca41</srcmd5>
-            <version>unknown</version>
-            <time>1603405248</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="58" vrev="58">
-            <srcmd5>52a152d89fd8d41fa0897e40f0f88fad</srcmd5>
-            <version>unknown</version>
-            <time>1603405248</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="59" vrev="59">
-            <srcmd5>cb16dc8abf8d8e211c872cb5cd3e031e</srcmd5>
-            <version>unknown</version>
-            <time>1603405248</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="60" vrev="60">
-            <srcmd5>f09fce199fd101db91fbd7a6162797e6</srcmd5>
-            <version>unknown</version>
-            <time>1603405248</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="61" vrev="61">
-            <srcmd5>db1190166da3f3e5efcc854d7d929e0a</srcmd5>
-            <version>unknown</version>
-            <time>1603405248</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="62" vrev="62">
-            <srcmd5>eb7db890a896b8c1f35135c62dd7b5ba</srcmd5>
-            <version>unknown</version>
-            <time>1603405248</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="63" vrev="63">
-            <srcmd5>a8847945f782789f71e9b55bb2d55b44</srcmd5>
-            <version>unknown</version>
-            <time>1603405248</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="64" vrev="64">
-            <srcmd5>0a6ac8ae1b9d03206bf54e97592ce509</srcmd5>
-            <version>unknown</version>
-            <time>1603405248</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="65" vrev="65">
-            <srcmd5>026f49f5767a6864515ede156fecf2b7</srcmd5>
-            <version>unknown</version>
-            <time>1603405249</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="66" vrev="66">
-            <srcmd5>2af44a29f958174c8a2009b00492f9d0</srcmd5>
-            <version>unknown</version>
-            <time>1603405249</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="67" vrev="67">
-            <srcmd5>7731b7c5598c79a9a4c7a83bb53abbaa</srcmd5>
-            <version>unknown</version>
-            <time>1603405249</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="68" vrev="68">
-            <srcmd5>189a0902fb0759832541eaf41c5a3ab9</srcmd5>
-            <version>unknown</version>
-            <time>1603405249</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="69" vrev="69">
-            <srcmd5>32b49a84cd42ea62bd4c71f01e37266d</srcmd5>
-            <version>unknown</version>
-            <time>1603405250</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="70" vrev="70">
-            <srcmd5>3c7f8e82d705281b8a33a1bd1862dca1</srcmd5>
-            <version>unknown</version>
-            <time>1603405250</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="71" vrev="71">
-            <srcmd5>a5d053e96a3ae1ad33de0112c07cb9df</srcmd5>
-            <version>unknown</version>
-            <time>1603405250</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="72" vrev="72">
-            <srcmd5>1574ed8d20245152980ad0880fc6fdbb</srcmd5>
-            <version>unknown</version>
-            <time>1603405250</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="73" vrev="73">
-            <srcmd5>187c7f098df4ef20487711ae9418561d</srcmd5>
-            <version>unknown</version>
-            <time>1603405338</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="74" vrev="74">
-            <srcmd5>10b8531db5fd0720fdd8cc6fc21a4446</srcmd5>
-            <version>unknown</version>
-            <time>1603405338</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="75" vrev="75">
-            <srcmd5>d9eaf889635f3e1f5a2d563163b58f62</srcmd5>
-            <version>unknown</version>
-            <time>1603405339</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="76" vrev="76">
-            <srcmd5>56c7279c2d3956438d8aaa0d0567da50</srcmd5>
-            <version>unknown</version>
-            <time>1603405339</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="77" vrev="77">
-            <srcmd5>3361064bd2670e9414fc908b2efc45f7</srcmd5>
-            <version>unknown</version>
-            <time>1603405340</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="78" vrev="78">
-            <srcmd5>c873a6af4b175c2bbe2aecffe869f804</srcmd5>
-            <version>unknown</version>
-            <time>1603405340</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="79" vrev="79">
-            <srcmd5>bd7774000cb9992cd3da9cfdb327d39e</srcmd5>
-            <version>unknown</version>
-            <time>1603405340</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="80" vrev="80">
-            <srcmd5>f60fade633bf0871790d321ae51d794c</srcmd5>
-            <version>unknown</version>
-            <time>1603405340</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="81" vrev="81">
-            <srcmd5>05aa1d313391c90327b2cc3a6f411ebb</srcmd5>
-            <version>unknown</version>
-            <time>1603405340</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="82" vrev="82">
-            <srcmd5>590718dcdf3813aff637fccd1775c97b</srcmd5>
-            <version>unknown</version>
-            <time>1603405340</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="83" vrev="83">
-            <srcmd5>4248a0743598a833d22da58bdceb7975</srcmd5>
-            <version>unknown</version>
-            <time>1603405341</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="84" vrev="84">
-            <srcmd5>7201b3bdf4e0e2191484c89d599f5c0c</srcmd5>
-            <version>unknown</version>
-            <time>1603405341</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="85" vrev="85">
-            <srcmd5>11712de5c6f3e1f0a86db6c1416cd5dd</srcmd5>
-            <version>unknown</version>
-            <time>1603405341</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="86" vrev="86">
-            <srcmd5>4d89959b4d1b0e853529d994e494f5ca</srcmd5>
-            <version>unknown</version>
-            <time>1603405342</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="87" vrev="87">
-            <srcmd5>b5163fb2357da727eff42e4e1dd215b1</srcmd5>
-            <version>unknown</version>
-            <time>1603405342</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="88" vrev="88">
-            <srcmd5>c0885119dc14a210414c1da5cff0f69c</srcmd5>
-            <version>unknown</version>
-            <time>1603405342</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="89" vrev="89">
-            <srcmd5>6b18ce7572c96080bfa00cb52d73ee1f</srcmd5>
-            <version>unknown</version>
-            <time>1603405342</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="90" vrev="90">
-            <srcmd5>9da73c6330ca25030295a36e1e0c4610</srcmd5>
-            <version>unknown</version>
-            <time>1603405342</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="91" vrev="91">
-            <srcmd5>974deb68be8c8a2c2bc955538aaf68aa</srcmd5>
-            <version>unknown</version>
-            <time>1603405344</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="92" vrev="92">
-            <srcmd5>bbc614ee2629aa7657066867cdca4d22</srcmd5>
-            <version>unknown</version>
-            <time>1603405344</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="93" vrev="93">
-            <srcmd5>77c621c31f6eae2fd32d4f0f79ef9dfc</srcmd5>
-            <version>unknown</version>
-            <time>1603405344</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="94" vrev="94">
-            <srcmd5>dea2fb220303af62a51428dd1ebf3b66</srcmd5>
-            <version>unknown</version>
-            <time>1603405344</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="95" vrev="95">
-            <srcmd5>89834c5e9e2eb816d4090dee88150b05</srcmd5>
-            <version>unknown</version>
-            <time>1603405344</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="96" vrev="96">
-            <srcmd5>7243793885248e8e28da917e72078495</srcmd5>
-            <version>unknown</version>
-            <time>1603405344</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="97" vrev="97">
-            <srcmd5>d23cbfa1cb1d12027abf86e4f96d9dc4</srcmd5>
-            <version>unknown</version>
-            <time>1603405344</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="98" vrev="98">
-            <srcmd5>a9b2f29a10e452952318b661c6fe781d</srcmd5>
-            <version>unknown</version>
-            <time>1603405344</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="99" vrev="99">
-            <srcmd5>828032f4e3eed6c35818564c07a2a76e</srcmd5>
-            <version>unknown</version>
-            <time>1603405345</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="100" vrev="100">
-            <srcmd5>6cb4f913c76a443e73198cc7160e5607</srcmd5>
-            <version>unknown</version>
-            <time>1603405345</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="101" vrev="101">
-            <srcmd5>956918bc90e12c1fb56711c69bb2c9dc</srcmd5>
-            <version>unknown</version>
-            <time>1603405345</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="102" vrev="102">
-            <srcmd5>212cae2a06754f85ff1180a1d59df0ec</srcmd5>
-            <version>unknown</version>
-            <time>1603405345</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="103" vrev="103">
-            <srcmd5>5565a5f10c7e717bc36ca0b140e6b40b</srcmd5>
-            <version>unknown</version>
-            <time>1603405345</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="104" vrev="104">
-            <srcmd5>e8cb4c62d048cb238ac1eb0ee3185609</srcmd5>
-            <version>unknown</version>
-            <time>1603405345</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="105" vrev="105">
-            <srcmd5>e6b2e1645230c3b2fa9827fe78193d70</srcmd5>
-            <version>unknown</version>
-            <time>1603405346</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="106" vrev="106">
-            <srcmd5>4c45fa684f3668b5c7345541bf5b0830</srcmd5>
-            <version>unknown</version>
-            <time>1603405346</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="107" vrev="107">
-            <srcmd5>3e757fb9bc3400f1542033ed44009402</srcmd5>
-            <version>unknown</version>
-            <time>1603405346</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="108" vrev="108">
-            <srcmd5>ab8d34688dc73760067e8371dc7f7f82</srcmd5>
-            <version>unknown</version>
-            <time>1603405346</time>
+            <time>1639585855</time>
             <user>unknown</user>
           </revision>
         </revisionlist>
-  recorded_at: Fri, 23 Oct 2020 09:01:23 GMT
+  recorded_at: Wed, 15 Dec 2021 16:30:55 GMT
 recorded_with: VCR 6.0.0

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -1945,9 +1945,11 @@ sub getproject {
     }
     $proj->{'name'} = $projid;
     $proj->{'config'} = defined($config) ? $config : '';
+    delete($proj->{'scmsync'}) if $proj->{'scmsync'} && $cgi->{'interconnect'};
     return ($proj, $BSXML::proj);
   }
   my $proj = readproject($projid, undef, $cgi->{'rev'});
+  delete($proj->{'scmsync'}) if $proj->{'scmsync'} && $cgi->{'interconnect'};
   return ($proj, $BSXML::proj);
 }
 
@@ -2193,9 +2195,17 @@ sub getpackage {
     my $files = BSRevision::lsrev($rev);
     die("404 _meta: no such file\n") unless $files->{'_meta'};
     my $meta = BSRevision::revreadstr($rev, '_meta', $files->{'_meta'});
+    if ($cgi->{'interconnect'}) {
+      my $xml = fromxml("$uploaddir/$$", $BSXML::pack);
+      if ($xml->{'scmsync'}) {
+        delete($xml->{'scmsync'});
+        $meta = toxml($xml, $BSXML::pack);
+      }
+    }
     return ($meta);
   }
   my $pack = readpackage($projid, $proj, $packid, $cgi->{'rev'});
+  delete($pack->{'scmsync'}) if $pack->{'scmsync'} && $cgi->{'interconnect'};
   return ($pack, $BSXML::pack);
 }
 
@@ -7250,7 +7260,7 @@ my $dispatches = [
   '/source/$project deleted:bool? expand:bool? noorigins:bool?' => \&getpackagelist,
 
   'DELETE:/source/$project user:? comment:? requestid:num?' => \&delproject,
-  '/source/$project/_meta rev? withconfig:bool?' => \&getproject,
+  '/source/$project/_meta rev? withconfig:bool? interconnect:?' => \&getproject,
   'PUT:/source/$project/_meta user:? comment:? requestid:num? lowprio:bool?' => \&putproject,
 
   '/source/$project/_pubkey rev?' => \&getpubkey,
@@ -7288,7 +7298,7 @@ my $dispatches = [
   '/source/$project/$package view=info rev? linkrev? parse:bool? nofilename:bool? repository? arch? withchangesmd5:bool? noexpand:bool? withmetamd5:bool?' => \&getpackagesourceinfo,
   '/source/$project/$package rev? linkrev? emptylink:bool? deleted:bool? expand:bool? view:? extension:? lastworking:bool? withlinked:bool? meta:bool? product:?' => \&getfilelist,
   '/source/$project/$package/_history rev? meta:bool? deleted:bool? limit:num?' => \&getpackagehistory,
-  '/source/$project/$package/_meta rev? expand:bool? meta:bool? deleted:bool? view:?' => \&getpackage,
+  '/source/$project/$package/_meta rev? expand:bool? meta:bool? deleted:bool? view:? interconnect:?' => \&getpackage,
   'PUT:/source/$project/$package/_meta user:? comment:? requestid:num?' => \&putpackage,
   'DELETE:/source/$project/$package user:? comment:? requestid:num?' => \&delpackage,
   '/source/$project/$package/$filename rev? expand:bool? meta:bool? deleted:bool? view:?' => \&getfile,


### PR DESCRIPTION
Hiding the tag element for remote OBS instances.

Currently only doing so per /public route, it would be better to do
so by user-agent. Unfortunatly the interconnect is not using an own
identifier so far.