### PR TITLE
Unify texts for links to Notifications Configuration

### DIFF
--- a/src/api/app/views/webui/users/notifications/_index_actions.html.haml
+++ b/src/api/app/views/webui/users/notifications/_index_actions.html.haml
@@ -1,5 +1,5 @@
 - content_for :actions do
   %li.nav-item
-    = link_to(my_subscriptions_path, class: 'nav-link', title: 'Manage Subscriptions') do
+    = link_to(my_subscriptions_path, class: 'nav-link', title: 'Change Your Notifications') do
       %i.fas.fa-edit.fa-lg.mr-2
-      %span.nav-item-name Manage Subscriptions
+      %span.nav-item-name Change Your Notifications


### PR DESCRIPTION
We have the same link in two places (notifications and profile pages) but they have different texts. We change the text to unify them and also to stop using "subscriptions" in favour of "notifications".

![notifications_manage_notifications](https://user-images.githubusercontent.com/2581944/146374709-ba1d4a2f-546e-4116-b488-6dfc0786e667.png)

![notifications_configuration](https://user-images.githubusercontent.com/2581944/146374952-df1f3d75-6e6e-4c38-9217-57150229d944.png)
