### PR TITLE
Mark PUT /my/notifications/{id} endpoint as beta/unstable in API docs

### DIFF
--- a/src/api/public/apidocs-new/paths/my_notifications_id.yaml
+++ b/src/api/public/apidocs-new/paths/my_notifications_id.yaml
@@ -1,7 +1,7 @@
 put:
   summary: Mark a notification as read/unread.
   description: |
-    If a notification is unread, it will be marked as read. If a notification is read, it will be marked as unread.
+    **(Beta/Unstable)** If a notification is unread, it will be marked as read. If a notification is read, it will be marked as unread.
   security:
     - basic_authentication: []
   parameters:


### PR DESCRIPTION
Just like GET /my/notifications