### PR TITLE
[api] fix crash on project runservice command

### DIFF
--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -1056,7 +1056,7 @@ class SourceController < ApplicationController
     path += build_query_from_hash(params, [:cmd, :comment, :user])
     pass_to_backend(path)
 
-    @package.sources_changed
+    @package.sources_changed unless params[:package] == '_project'
   end
 
   # POST /source/<project>/<package>?cmd=deleteuploadrev


### PR DESCRIPTION
api can not update backend_data since no package object exists for "_project" package