### PR TITLE
Remove unused parameter `webui_mode` in owner search

### DIFF
--- a/src/api/app/models/owner_search/assignee.rb
+++ b/src/api/app/models/owner_search/assignee.rb
@@ -4,7 +4,6 @@ module OwnerSearch
       @match_all = limit.zero?
       @deepest = limit.negative?
 
-      @instances_without_definition = []
       @maintainers = []
 
       # search in each marked project
@@ -15,8 +14,6 @@ module OwnerSearch
         @lookup_limit = limit.to_i
         @devel_disabled = devel_disabled?(project)
         find_assignees(search_string)
-        webui_mode = params[:webui_mode].present?
-        return @instances_without_definition if webui_mode && @maintainers.empty?
       end
       @maintainers
     end
@@ -101,11 +98,7 @@ module OwnerSearch
 
       m = lookup_package_owner(pkg)
 
-      unless m
-        # collect all no matched entries
-        @instances_without_definition << create_owner(pkg)
-        return false
-      end
+      return false unless m
 
       # remember as deepest candidate
       if @deepest

--- a/src/api/test/functional/search_controller_test.rb
+++ b/src/api/test/functional/search_controller_test.rb
@@ -593,13 +593,6 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     assert_no_xml_tag tag: 'owner', attributes: { project: 'home:coolo:test' }
     assert_xml_tag tag: 'group', attributes: { name: 'test_group', role: 'bugowner' }
 
-    get '/search/owner?project=TEMPORARY&binary=package&filter=reviewer&webui_mode=true'
-    assert_response :success
-    assert_xml_tag tag: 'owner', attributes: { rootproject: 'TEMPORARY', project: 'TEMPORARY', package: 'pack' },
-                   children: { count: 0 }
-    assert_xml_tag tag: 'owner', attributes: { rootproject: 'TEMPORARY', project: 'home:Iggy', package: 'TestPack' },
-                   children: { count: 0 }
-
     # deepest package definition
     get '/search/owner?project=TEMPORARY&binary=package&limit=-1'
     assert_response :success


### PR DESCRIPTION
This parameter is not documented, and it is not used in the rest of the codebase.