### PR TITLE
Remove mention to Beta in notifications API docs

### DIFF
--- a/src/api/public/apidocs-new/paths/my_notifications.yaml
+++ b/src/api/public/apidocs-new/paths/my_notifications.yaml
@@ -1,6 +1,9 @@
 get:
   summary: List the notifications of the authenticated user.
-  description:  "**(Beta/Unstable)** List user's notifications."
+  description:  |
+    **(Unstable)** List user's notifications.
+
+    **NOTE:** Available only in OBS Unstable.
   security:
     - basic_authentication: []
   parameters:

--- a/src/api/public/apidocs-new/paths/my_notifications_id.yaml
+++ b/src/api/public/apidocs-new/paths/my_notifications_id.yaml
@@ -1,7 +1,9 @@
 put:
   summary: Mark a notification as read/unread.
   description: |
-    **(Beta/Unstable)** If a notification is unread, it will be marked as read. If a notification is read, it will be marked as unread.
+    **(Unstable)** If a notification is unread, it will be marked as read. If a notification is read, it will be marked as unread.
+
+    **NOTE:** Available only in OBS Unstable.
   security:
     - basic_authentication: []
   parameters:


### PR DESCRIPTION
The `notifications_redesign` is no longer a beta feature, now it's rolled out for every single user.