### PR TITLE
Remove unused code in SearchFinder

### DIFF
--- a/src/api/app/models/search_finder.rb
+++ b/src/api/app/models/search_finder.rb
@@ -1,7 +1,7 @@
 class SearchFinder
   include ActiveModel::Validations
 
-  attr_reader :included_classes, :relation, :what, :render_all, :search_items, :preloaded_classes
+  attr_reader :included_classes, :relation, :what, :render_all, :search_items
 
   validates :what, inclusion: [:package, :project, :repository, :request, :person, :channel, :channel_binary, :released_binary, :issue]
 
@@ -10,7 +10,6 @@ class SearchFinder
     @render_all = render_all
     @search_items = search_items
     @included_classes = []
-    @preloaded_classes = []
   end
 
   def call
@@ -25,7 +24,6 @@ class SearchFinder
       @relation = repositories
     when :request
       @relation = bs_requests
-      @preloads = bs_request_preloads
     when :person
       @relation = users
     when :channel, :channel_binary
@@ -35,15 +33,10 @@ class SearchFinder
     when :issue
       @relation = issues
     end
-    @relation.includes(@included_classes).references(@included_classes).preload(@preloaded_classes)
+    @relation.includes(@included_classes).references(@included_classes)
   end
 
   private
-
-  def bs_request_preloads
-    [:reviews, { review_history_elements: :user },
-     { bs_request_actions: :bs_request_action_accept_info }]
-  end
 
   def packages
     @included_classes = [:project]


### PR DESCRIPTION
The `@preloaded_classes` class variable was never modified.

The `@preloads` variable was only assigned for "request" searches. Even if it considered a typo, and `@preloads` is substituted by `@preloaded_classes`, this could led to always apply a `preload` to the final query. This can improve the `GET /search/request` endpoint, but it is not the desirable behavior for the `GET /search/request/id` endpoint.