### PR TITLE
Handle situations where notification payload has no package information

### DIFF
--- a/src/api/app/models/binary_release.rb
+++ b/src/api/app/models/binary_release.rb
@@ -88,6 +88,8 @@ class BinaryRelease < ApplicationRecord
           hash[:binary_updateinfo_version] = binary['updateinfoversion']
         end
         source_package = Package.striping_multibuild_suffix(binary['package'])
+        next if source_package.blank?
+
         rp = Package.find_by_project_and_name(binary['project'], source_package)
         if source_package.include?(':') && !source_package.start_with?('_product:')
           flavor_name = binary['package'].gsub(/^#{source_package}:/, '')

--- a/src/api/app/models/concerns/multibuild_package.rb
+++ b/src/api/app/models/concerns/multibuild_package.rb
@@ -7,6 +7,7 @@ module MultibuildPackage
     end
 
     def striping_multibuild_suffix(name)
+      return if name.blank?
       # exception for package names used to have a collon
       return name if name.start_with?('_patchinfo:', '_product:')
 


### PR DESCRIPTION
Fixes #11629

In some cases the data saved in the notification payload isn't complete, breaking some assumptions made by the delay job processing it.