### PR TITLE
Fix combination of Group filter and Mark all as read

### DIFF
--- a/src/api/app/views/webui/users/notifications/_notifications_list.html.haml
+++ b/src/api/app/views/webui/users/notifications/_notifications_list.html.haml
@@ -11,8 +11,8 @@
           There are no notifications, but there's a world of opportunities!
 - else
   :ruby
-    update_path = my_notifications_path(type: selected_filter[:type], project: selected_filter[:project],
-                                          page: params[:page], show_more: params[:show_more])
+    update_path = my_notifications_path(type: selected_filter[:type], project: selected_filter[:project], group: selected_filter[:group],
+                                        page: params[:page], show_more: params[:show_more])
   = form_tag(update_path, method: :put, remote: true) do
     = render(NotificationActionBarComponent.new(type: selected_filter[:type], update_path: update_path, show_read_all_button: show_read_all_button))
     .card


### PR DESCRIPTION
When we filter notifications by group and then mark them all as read, we only want to mark those affected by the filter, not every single notification.

The bug was found thanks to this issue: https://github.com/openSUSE/open-build-service/issues/12007