### PR TITLE
Add spec to BinaryRelease model

### DIFF
--- a/src/api/app/models/binary_release.rb
+++ b/src/api/app/models/binary_release.rb
@@ -195,18 +195,22 @@ class BinaryRelease < ApplicationRecord
   end
 
   def identical_to?(binary_hash)
-    # handle nil/NULL case
-    buildtime = binary_hash['buildtime'].blank? ? nil : Time.strptime(binary_hash['buildtime'].to_s, '%s')
-
     # We ignore not set binary_id in db because it got introduced later
     # we must not touch the modification time in that case
     binary_disturl == binary_hash['disturl'] &&
       binary_supportstatus == binary_hash['supportstatus'] &&
       (binary_id.nil? || binary_id == binary_hash['binaryid']) &&
-      binary_buildtime == buildtime
+      binary_buildtime == binary_hash_build_time(binary_hash)
   end
 
   private
+
+  def binary_hash_build_time(binary_hash)
+    # handle nil/NULL case
+    return if binary_hash['buildtime'].blank?
+
+    Time.strptime(binary_hash['buildtime'].to_s, '%s')
+  end
 
   def product_medium
     repository.product_medium.find_by(name: medium)

--- a/src/api/spec/factories/binary_releases.rb
+++ b/src/api/spec/factories/binary_releases.rb
@@ -1,0 +1,14 @@
+FactoryBot.define do
+  factory :binary_release do
+    binary_arch { 'aarch64' }
+    binary_buildtime { '2021-12-29 17:16:30 +0000' }
+    binary_disturl { '/foo/bar' }
+    binary_name { 'foo' }
+    binary_supportstatus { 'bar' }
+    binary_id { '31337' }
+    binary_version { '0' }
+    binary_release { '0' }
+    repository { repository }
+    flavor { 'bar' }
+  end
+end

--- a/src/api/spec/models/binary_release_spec.rb
+++ b/src/api/spec/models/binary_release_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe BinaryRelease do
+  let(:binary_hash) do 
+    {
+      'disturl' => '/foo/bar',
+      'supportstatus' => 'foo',
+      'binaryid' => '31337',
+      'buildtime' => '1640772016'
+    }
+  end
+
+  describe '#identical_to?' do
+    context 'binary_release and binary_hash are identical' do
+      let(:binary_release) do 
+        BinaryRelease.new(
+          binary_disturl: binary_hash['disturl'],
+          binary_supportstatus: binary_hash['supportstatus'],
+          binary_id: binary_hash['binaryid'],
+          binary_buildtime: Time.strptime(binary_hash['buildtime'], '%s')
+        )
+      end
+
+      it { expect(binary_release).to be_identical_to(binary_hash) }
+    end
+    context 'binary_release and binary_hash are not identical' do
+      let(:binary_release) do 
+        BinaryRelease.new(
+          binary_disturl: binary_hash['disturl'],
+          binary_supportstatus: binary_hash['supportstatus'],
+          binary_id: binary_hash['binaryid'],
+          binary_buildtime: nil
+        )
+      end
+
+      it { expect(binary_release).not_to be_identical_to(binary_hash) }
+    end
+  end
+end
+ 

--- a/src/api/spec/models/binary_release_spec.rb
+++ b/src/api/spec/models/binary_release_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe BinaryRelease do
-  let(:binary_hash) do 
+  let(:binary_hash) do
     {
       'disturl' => '/foo/bar',
       'supportstatus' => 'foo',
@@ -10,9 +10,52 @@ RSpec.describe BinaryRelease do
     }
   end
 
+  describe '.update_binary_releases_via_json' do
+    let(:user) { create(:confirmed_user, :with_home, login: 'foo') }
+    let!(:repository) { create(:repository, project: user.home_project) }
+
+    context 'with empty json' do
+      it { expect { described_class.update_binary_releases_via_json(repository, []) }.not_to raise_error }
+    end
+
+    context 'with a repository to be released' do
+      let!(:binary_release) { create(:binary_release, repository: repository) }
+      let(:repeated_binary_hash) do
+        {
+          'disturl' => binary_release.binary_disturl,
+          'supportstatus' => binary_release.binary_supportstatus,
+          'binaryid' => binary_release.binary_id,
+          'buildtime' => binary_release.binary_buildtime,
+          'name' => binary_release.binary_name,
+          'binaryarch' => binary_release.binary_arch
+        }
+      end
+
+      it { expect { described_class.update_binary_releases_via_json(repository, [repeated_binary_hash]) }.not_to raise_error }
+    end
+
+    context 'with repeated binary_releases' do
+      let!(:binary_releases) { create_list(:binary_release, 2, repository: repository) }
+      let(:repeated_binary_hash) do
+        {
+          'disturl' => binary_releases.first.binary_disturl,
+          'supportstatus' => binary_releases.first.binary_supportstatus,
+          'binaryid' => binary_releases.first.binary_id,
+          'buildtime' => binary_releases.first.binary_buildtime.to_i,
+          'name' => binary_releases.first.binary_name,
+          'binaryarch' => binary_releases.first.binary_arch
+        }
+      end
+
+      subject { described_class.update_binary_releases_via_json(repository, [repeated_binary_hash]) }
+
+      it { expect { subject }.to change(BinaryRelease, :count).by(-1) }
+    end
+  end
+
   describe '#identical_to?' do
     context 'binary_release and binary_hash are identical' do
-      let(:binary_release) do 
+      let(:binary_release) do
         BinaryRelease.new(
           binary_disturl: binary_hash['disturl'],
           binary_supportstatus: binary_hash['supportstatus'],
@@ -23,8 +66,9 @@ RSpec.describe BinaryRelease do
 
       it { expect(binary_release).to be_identical_to(binary_hash) }
     end
+
     context 'binary_release and binary_hash are not identical' do
-      let(:binary_release) do 
+      let(:binary_release) do
         BinaryRelease.new(
           binary_disturl: binary_hash['disturl'],
           binary_supportstatus: binary_hash['supportstatus'],
@@ -37,4 +81,3 @@ RSpec.describe BinaryRelease do
     end
   end
 end
- 


### PR DESCRIPTION
The `BinaryRelease` model has no spec. So I'm adding some specs and did a light refactoring around some methods. The main idea of this PR, however is to spec the public API.