### PR TITLE
Add constraints to user requests endpoint

### DIFF
--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -435,7 +435,7 @@ OBSApi::Application.routes.draw do
     # in check_display_user before filter. Overwriting of the parameter is not
     # possible for nested resources atm.
     controller 'webui/users/bs_requests' do
-      get 'users/(:user)/requests' => :index, as: 'user_requests'
+      get 'users/(:user)/requests' => :index, constraints: cons, as: 'user_requests'
     end
 
     controller 'webui/groups/bs_requests' do


### PR DESCRIPTION
This fix is already present in the main branch, but 2.10 is missing constraints for this endpoint, which breaks with usernames with dots in them. Tested on a local installation, fixes #10951