### PR TITLE
Enable belongs to required by default

### DIFF
--- a/src/api/app/models/attrib.rb
+++ b/src/api/app/models/attrib.rb
@@ -8,8 +8,8 @@ class Attrib < ApplicationRecord
   delegate :namespace, to: :attrib_type
 
   #### Associations macros (Belongs to, Has one, Has many)
-  belongs_to :package
-  belongs_to :project
+  belongs_to :package, optional: true
+  belongs_to :project, optional: true
   belongs_to :attrib_type
   has_many :attrib_issues
   has_many :issues, through: :attrib_issues, dependent: :destroy
@@ -21,7 +21,6 @@ class Attrib < ApplicationRecord
   #### Validations macros
   validates_associated :values
   validates_associated :issues
-  validates :attrib_type, presence: true
   # Either we belong to a project or to a package
   validates :package, presence: true, if: proc { |attrib| attrib.project_id.nil? }
   validates :package_id, absence: { message: "can't also be present" }, if: proc { |attrib| attrib.project_id.present? }

--- a/src/api/app/models/attrib_default_value.rb
+++ b/src/api/app/models/attrib_default_value.rb
@@ -1,5 +1,5 @@
 class AttribDefaultValue < ApplicationRecord
-  belongs_to :attrib_type
+  belongs_to :attrib_type, optional: true
   acts_as_list scope: :attrib_type
 end
 

--- a/src/api/app/models/attrib_namespace_modifiable_by.rb
+++ b/src/api/app/models/attrib_namespace_modifiable_by.rb
@@ -1,7 +1,7 @@
 class AttribNamespaceModifiableBy < ApplicationRecord
   belongs_to :attrib_namespace
-  belongs_to :user
-  belongs_to :group
+  belongs_to :user, optional: true
+  belongs_to :group, optional: true
 end
 
 # == Schema Information

--- a/src/api/app/models/attrib_type_modifiable_by.rb
+++ b/src/api/app/models/attrib_type_modifiable_by.rb
@@ -1,8 +1,8 @@
 class AttribTypeModifiableBy < ApplicationRecord
   belongs_to :attrib_type
-  belongs_to :user
-  belongs_to :group
-  belongs_to :role
+  belongs_to :user, optional: true
+  belongs_to :group, optional: true
+  belongs_to :role, optional: true
 end
 
 # == Schema Information

--- a/src/api/app/models/attrib_value.rb
+++ b/src/api/app/models/attrib_value.rb
@@ -1,6 +1,6 @@
 class AttribValue < ApplicationRecord
   acts_as_list scope: :attrib
-  belongs_to :attrib
+  belongs_to :attrib, optional: true
 
   after_initialize :set_default_value
   before_validation :universal_newlines

--- a/src/api/app/models/backend_package.rb
+++ b/src/api/app/models/backend_package.rb
@@ -6,7 +6,7 @@ class BackendPackage < ApplicationRecord
 
   #### Attributes
   #### Associations macros (Belongs to, Has one, Has many)
-  belongs_to :links_to, class_name: 'Package'
+  belongs_to :links_to, class_name: 'Package', optional: true
   belongs_to :package, inverse_of: :backend_package
 
   #### Callbacks macros: before_save, after_save, etc.

--- a/src/api/app/models/binary_release.rb
+++ b/src/api/app/models/binary_release.rb
@@ -2,8 +2,8 @@ class BinaryRelease < ApplicationRecord
   class SaveError < APIError; end
 
   belongs_to :repository
-  belongs_to :release_package, class_name: 'Package' # optional
-  belongs_to :on_medium, class_name: 'BinaryRelease'
+  belongs_to :release_package, class_name: 'Package', optional: true
+  belongs_to :on_medium, class_name: 'BinaryRelease', optional: true
 
   before_create :set_release_time
 

--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -77,7 +77,7 @@ class BsRequest < ApplicationRecord
   has_many :review_history_elements, through: :reviews, source: :history_elements
   has_many :status_reports, as: :checkable, class_name: 'Status::Report', dependent: :destroy
   has_many :target_project_objects, through: :bs_request_actions
-  belongs_to :staging_project, class_name: 'Project'
+  belongs_to :staging_project, class_name: 'Project', optional: true
   has_one :request_exclusion, class_name: 'Staging::RequestExclusion', dependent: :destroy
   has_many :not_accepted_reviews, -> { where.not(state: :accepted) }, class_name: 'Review'
   has_many :notifications, as: :notifiable, dependent: :delete_all

--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -10,11 +10,11 @@ class BsRequestAction < ApplicationRecord
   #### Attributes
 
   #### Associations macros (Belongs to, Has one, Has many)
-  belongs_to :bs_request, touch: true
+  belongs_to :bs_request, touch: true, optional: true
   has_one :bs_request_action_accept_info, dependent: :delete
 
-  belongs_to :target_package_object, class_name: 'Package', foreign_key: 'target_package_id'
-  belongs_to :target_project_object, class_name: 'Project', foreign_key: 'target_project_id'
+  belongs_to :target_package_object, class_name: 'Package', foreign_key: 'target_package_id', optional: true
+  belongs_to :target_project_object, class_name: 'Project', foreign_key: 'target_project_id', optional: true
 
   scope :bs_request_ids_of_involved_projects, ->(project_ids) { where(target_project_id: project_ids).select(:bs_request_id) }
   scope :bs_request_ids_of_involved_packages, ->(package_ids) { where(target_package_id: package_ids).select(:bs_request_id) }

--- a/src/api/app/models/bs_request_action_accept_info.rb
+++ b/src/api/app/models/bs_request_action_accept_info.rb
@@ -5,7 +5,7 @@ class BsRequestActionAcceptInfo < ApplicationRecord
   #### Attributes
 
   #### Associations macros (Belongs to, Has one, Has many)
-  belongs_to :bs_request_action
+  belongs_to :bs_request_action, optional: true
 
   #### Callbacks macros: before_save, after_save, etc.
   #### Scopes (first the default_scope macro if is used)

--- a/src/api/app/models/channel_binary.rb
+++ b/src/api/app/models/channel_binary.rb
@@ -1,8 +1,8 @@
 class ChannelBinary < ApplicationRecord
   belongs_to :channel_binary_list
-  belongs_to :project
-  belongs_to :repository
-  belongs_to :architecture
+  belongs_to :project, optional: true
+  belongs_to :repository, optional: true
+  belongs_to :architecture, optional: true
 
   validate do |channel_binary|
     if channel_binary.project && channel_binary.repository

--- a/src/api/app/models/channel_binary_list.rb
+++ b/src/api/app/models/channel_binary_list.rb
@@ -1,8 +1,8 @@
 class ChannelBinaryList < ApplicationRecord
   belongs_to :channel
-  belongs_to :project
-  belongs_to :repository
-  belongs_to :architecture
+  belongs_to :project, optional: true
+  belongs_to :repository, optional: true
+  belongs_to :architecture, optional: true
   has_many :channel_binaries, dependent: :delete_all
 
   def self._sync_keys

--- a/src/api/app/models/cloud/azure/configuration.rb
+++ b/src/api/app/models/cloud/azure/configuration.rb
@@ -8,7 +8,7 @@ module Cloud
 
       before_save :encrypt_credentials
 
-      belongs_to :user
+      belongs_to :user, optional: true
 
       def self.table_name_prefix
         'cloud_azure_'

--- a/src/api/app/models/cloud/ec2/configuration.rb
+++ b/src/api/app/models/cloud/ec2/configuration.rb
@@ -20,7 +20,7 @@ module Cloud
       ].freeze
 
       has_secure_token :external_id
-      belongs_to :user
+      belongs_to :user, optional: true
 
       validates :external_id, uniqueness: { case_sensitive: true }
       validates :arn, uniqueness: { case_sensitive: true }, allow_nil: true

--- a/src/api/app/models/cloud/user/upload_job.rb
+++ b/src/api/app/models/cloud/user/upload_job.rb
@@ -1,7 +1,7 @@
 module Cloud
   module User
     class UploadJob < ApplicationRecord
-      belongs_to :user, class_name: '::User'
+      belongs_to :user, class_name: '::User', optional: true
 
       validates :job_id, presence: true, uniqueness: true
 

--- a/src/api/app/models/comment.rb
+++ b/src/api/app/models/comment.rb
@@ -4,7 +4,7 @@ class Comment < ApplicationRecord
   belongs_to :commentable, polymorphic: true # belongs to a Project, Package or BsRequest
   belongs_to :user, inverse_of: :comments
 
-  validates :body, :commentable, :user, presence: true
+  validates :body, presence: true
   # FIXME: this probably should be MEDIUMTEXT(16MB) instead of text (64KB)
   validates :body, length: { maximum: 65_535 }
   validates :body, format: { with: /\A[^\u0000]*\Z/,

--- a/src/api/app/models/commit_activity.rb
+++ b/src/api/app/models/commit_activity.rb
@@ -1,7 +1,7 @@
 class CommitActivity < ApplicationRecord
   belongs_to :user
 
-  validates :user, :date, :project, :package, :count, presence: true
+  validates :date, :project, :package, :count, presence: true
 
   validates :count, numericality: { more_than_or_equal_to: 1,
                                     only_integer: true }

--- a/src/api/app/models/concerns/staging_project.rb
+++ b/src/api/app/models/concerns/staging_project.rb
@@ -4,7 +4,7 @@ module StagingProject
 
   included do
     has_many :staged_requests, class_name: 'BsRequest', foreign_key: :staging_project_id, dependent: :nullify
-    belongs_to :staging_workflow, class_name: 'Staging::Workflow'
+    belongs_to :staging_workflow, class_name: 'Staging::Workflow', optional: true
 
     after_save :update_staging_workflow_on_backend, if: :staging_project?
     after_destroy :update_staging_workflow_on_backend, if: :staging_project?

--- a/src/api/app/models/download_repository.rb
+++ b/src/api/app/models/download_repository.rb
@@ -3,7 +3,6 @@ class DownloadRepository < ApplicationRecord
 
   belongs_to :repository
 
-  validates :repository, presence: true
   validates :arch, uniqueness: { scope: :repository_id, case_sensitive: false }, presence: true
   validate :architecture_inclusion
   validates :url, presence: true, format: { with: /\A[a-zA-Z]+:.*\Z/ } # from backend/BSVerify.pm

--- a/src/api/app/models/event_subscription.rb
+++ b/src/api/app/models/event_subscription.rb
@@ -26,10 +26,10 @@ class EventSubscription < ApplicationRecord
 
   serialize :payload, JSON
 
-  belongs_to :user, inverse_of: :event_subscriptions
-  belongs_to :group, inverse_of: :event_subscriptions
-  belongs_to :token, inverse_of: :event_subscriptions
-  belongs_to :package
+  belongs_to :user, inverse_of: :event_subscriptions, optional: true
+  belongs_to :group, inverse_of: :event_subscriptions, optional: true
+  belongs_to :token, inverse_of: :event_subscriptions, optional: true
+  belongs_to :package, optional: true
 
   validates :receiver_role, inclusion: {
     in: [:maintainer, :bugowner, :reader, :source_maintainer, :target_maintainer,

--- a/src/api/app/models/flag.rb
+++ b/src/api/app/models/flag.rb
@@ -1,8 +1,8 @@
 class Flag < ApplicationRecord
-  belongs_to :project, inverse_of: :flags
-  belongs_to :package, inverse_of: :flags
+  belongs_to :project, inverse_of: :flags, optional: true
+  belongs_to :package, inverse_of: :flags, optional: true
 
-  belongs_to :architecture
+  belongs_to :architecture, optional: true
 
   scope :of_type, ->(type) { where(flag: type) }
 

--- a/src/api/app/models/group_maintainer.rb
+++ b/src/api/app/models/group_maintainer.rb
@@ -2,8 +2,6 @@ class GroupMaintainer < ApplicationRecord
   belongs_to :user
   belongs_to :group
 
-  validates :user, presence: true
-  validates :group, presence: true
   validate :validate_duplicates, on: :create
 
   private

--- a/src/api/app/models/groups_user.rb
+++ b/src/api/app/models/groups_user.rb
@@ -4,8 +4,6 @@ class GroupsUser < ApplicationRecord
   belongs_to :user
   belongs_to :group
 
-  validates :user, presence: true
-  validates :group, presence: true
   validate :validate_duplicates, on: :create
   validates_with AllowedUserValidator
 

--- a/src/api/app/models/issue.rb
+++ b/src/api/app/models/issue.rb
@@ -6,7 +6,7 @@ class Issue < ApplicationRecord
   has_many :package_issues, dependent: :delete_all
 
   belongs_to :issue_tracker
-  belongs_to :owner, class_name: 'User'
+  belongs_to :owner, class_name: 'User', optional: true
 
   validate :name_validation, on: :create
 

--- a/src/api/app/models/kiwi/description.rb
+++ b/src/api/app/models/kiwi/description.rb
@@ -1,5 +1,5 @@
 class Kiwi::Description < ApplicationRecord
-  belongs_to :image, inverse_of: :description
+  belongs_to :image, inverse_of: :description, optional: true
 
   enum description_type: {
     system: 0

--- a/src/api/app/models/kiwi/package.rb
+++ b/src/api/app/models/kiwi/package.rb
@@ -1,6 +1,6 @@
 module Kiwi
   class Package < ApplicationRecord
-    belongs_to :package_group
+    belongs_to :package_group, optional: true
     has_one :kiwi_image, through: :package_groups
 
     validates :name, presence: { message: 'can\'t be blank' }

--- a/src/api/app/models/kiwi/package_group.rb
+++ b/src/api/app/models/kiwi/package_group.rb
@@ -1,7 +1,7 @@
 module Kiwi
   class PackageGroup < ApplicationRecord
     has_many :packages, dependent: :destroy, index_errors: true
-    belongs_to :image, inverse_of: :package_groups
+    belongs_to :image, inverse_of: :package_groups, optional: true
 
     # we need to add a prefix, to avoid generating class methods that already
     # exist in Active Record, such as "delete"

--- a/src/api/app/models/kiwi/preference.rb
+++ b/src/api/app/models/kiwi/preference.rb
@@ -1,5 +1,5 @@
 class Kiwi::Preference < ApplicationRecord
-  belongs_to :image, inverse_of: :preferences
+  belongs_to :image, inverse_of: :preferences, optional: true
 
   enum type_image: {
     btrfs: 0,

--- a/src/api/app/models/kiwi/profile.rb
+++ b/src/api/app/models/kiwi/profile.rb
@@ -19,7 +19,6 @@ module Kiwi
     #### Validations macros
     validates :name, presence: true
     validates :description, presence: true
-    validates :image, presence: true
     validates :selected, inclusion: { in: [true, false] }
     validates :name, uniqueness: {
       scope: :image,

--- a/src/api/app/models/kiwi/repository.rb
+++ b/src/api/app/models/kiwi/repository.rb
@@ -11,7 +11,7 @@ module Kiwi
     #### Attributes
 
     #### Associations macros (Belongs to, Has one, Has many)
-    belongs_to :image
+    belongs_to :image, optional: true
 
     #### Callbacks macros: before_save, after_save, etc.
     before_validation :map_to_allowed_repository_types, on: :create

--- a/src/api/app/models/linked_project.rb
+++ b/src/api/app/models/linked_project.rb
@@ -1,6 +1,6 @@
 class LinkedProject < ApplicationRecord
   belongs_to :project, foreign_key: :db_project_id
-  belongs_to :linked_db_project, class_name: 'Project'
+  belongs_to :linked_db_project, class_name: 'Project', optional: true
 
   validate :validate_duplicates
 

--- a/src/api/app/models/maintenance_incident.rb
+++ b/src/api/app/models/maintenance_incident.rb
@@ -1,8 +1,8 @@
 # The maintenance incident class represents the entry in the database.
 #
 class MaintenanceIncident < ApplicationRecord
-  belongs_to :project, class_name: 'Project', foreign_key: :db_project_id
-  belongs_to :maintenance_db_project, class_name: 'Project'
+  belongs_to :project, class_name: 'Project', foreign_key: :db_project_id, optional: true
+  belongs_to :maintenance_db_project, class_name: 'Project', optional: true
 
   # <project> - The maintenance project
   # target_project - The maintenance incident project

--- a/src/api/app/models/notification.rb
+++ b/src/api/app/models/notification.rb
@@ -3,8 +3,8 @@ class Notification < ApplicationRecord
   MAX_RSS_ITEMS_PER_GROUP = 10
   MAX_PER_PAGE = 300
 
-  belongs_to :subscriber, polymorphic: true
-  belongs_to :notifiable, polymorphic: true
+  belongs_to :subscriber, polymorphic: true, optional: true
+  belongs_to :notifiable, polymorphic: true, optional: true
 
   has_many :notified_projects, dependent: :destroy
   has_many :projects, through: :notified_projects

--- a/src/api/app/models/notified_project.rb
+++ b/src/api/app/models/notified_project.rb
@@ -2,9 +2,6 @@ class NotifiedProject < ApplicationRecord
   belongs_to :notification
   belongs_to :project
 
-  validates :notification, presence: true
-  validates :project, presence: true
-
   validates :notification_id, uniqueness: { scope: :project_id, message: 'These notification and project are already associated' }
 end
 

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -21,7 +21,7 @@ class Package < ApplicationRecord
                        '.xpm', '.xz', '.z', '.zip', '.ttf'].freeze
 
   has_many :relationships, dependent: :destroy, inverse_of: :package
-  belongs_to :kiwi_image, class_name: 'Kiwi::Image', inverse_of: :package
+  belongs_to :kiwi_image, class_name: 'Kiwi::Image', inverse_of: :package, optional: true
   accepts_nested_attributes_for :kiwi_image
 
   belongs_to :project, inverse_of: :packages
@@ -37,7 +37,7 @@ class Package < ApplicationRecord
 
   has_many :flags, -> { order(:position) }, dependent: :delete_all, inverse_of: :package
 
-  belongs_to :develpackage, class_name: 'Package'
+  belongs_to :develpackage, class_name: 'Package', optional: true
   has_many :develpackages, class_name: 'Package', foreign_key: 'develpackage_id'
 
   has_many :attribs, dependent: :destroy

--- a/src/api/app/models/package_kind.rb
+++ b/src/api/app/models/package_kind.rb
@@ -1,5 +1,5 @@
 class PackageKind < ApplicationRecord
-  belongs_to :package
+  belongs_to :package, optional: true
 end
 
 # == Schema Information

--- a/src/api/app/models/path_element.rb
+++ b/src/api/app/models/path_element.rb
@@ -6,7 +6,6 @@ class PathElement < ApplicationRecord
   # FIXME: This should be called repository
   belongs_to :link, class_name: 'Repository', foreign_key: 'repository_id', inverse_of: :links
 
-  validates :link, :repository, presence: true
   validates :repository, uniqueness: { scope: [:link, :kind] }
 end
 

--- a/src/api/app/models/product_medium.rb
+++ b/src/api/app/models/product_medium.rb
@@ -1,7 +1,7 @@
 class ProductMedium < ApplicationRecord
-  belongs_to :product
-  belongs_to :repository
-  belongs_to :arch_filter, class_name: 'Architecture'
+  belongs_to :product, optional: true
+  belongs_to :repository, optional: true
+  belongs_to :arch_filter, class_name: 'Architecture', optional: true
 end
 
 # == Schema Information

--- a/src/api/app/models/product_update_repository.rb
+++ b/src/api/app/models/product_update_repository.rb
@@ -1,7 +1,7 @@
 class ProductUpdateRepository < ApplicationRecord
-  belongs_to :product
-  belongs_to :repository
-  belongs_to :arch_filter, class_name: 'Architecture'
+  belongs_to :product, optional: true
+  belongs_to :repository, optional: true
+  belongs_to :arch_filter, class_name: 'Architecture', optional: true
 end
 
 # == Schema Information

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -61,7 +61,7 @@ class Project < ApplicationRecord
 
   # develproject is history, use develpackage instead. FIXME3.0: clean this up
   has_many :develprojects, class_name: 'Project', foreign_key: 'develproject_id'
-  belongs_to :develproject, class_name: 'Project'
+  belongs_to :develproject, class_name: 'Project', optional: true
 
   has_many :comments, as: :commentable, dependent: :destroy
 

--- a/src/api/app/models/project_log_entry.rb
+++ b/src/api/app/models/project_log_entry.rb
@@ -2,8 +2,8 @@
 # Log entries are created from events and deleted after a time threshold
 # @see ProjectLogRotate
 class ProjectLogEntry < ApplicationRecord
-  belongs_to :project
-  belongs_to :bs_request
+  belongs_to :project, optional: true
+  belongs_to :bs_request, optional: true
 
   validates :event_type, :datetime, :project_id, presence: true
 

--- a/src/api/app/models/relationship.rb
+++ b/src/api/app/models/relationship.rb
@@ -2,14 +2,12 @@ class Relationship < ApplicationRecord
   belongs_to :role
 
   # only one is true
-  belongs_to :user, inverse_of: :relationships
-  belongs_to :group, inverse_of: :relationships
+  belongs_to :user, inverse_of: :relationships, optional: true
+  belongs_to :group, inverse_of: :relationships, optional: true
   has_many :groups_users, through: :group
 
-  belongs_to :project, inverse_of: :relationships
-  belongs_to :package, inverse_of: :relationships
-
-  validates :role, presence: true
+  belongs_to :project, inverse_of: :relationships, optional: true
+  belongs_to :package, inverse_of: :relationships, optional: true
 
   validate :check_global_role
 
@@ -25,6 +23,7 @@ class Relationship < ApplicationRecord
   validates :package, presence: {
     message: 'Neither package nor project exists'
   }, unless: proc { |relationship| relationship.project.present? }
+
   validates :package, absence: {
     message: 'Package and project can not exist at the same time'
   }, if: proc { |relationship| relationship.project.present? }
@@ -32,6 +31,7 @@ class Relationship < ApplicationRecord
   validates :user, presence: {
     message: 'Neither user nor group exists'
   }, unless: proc { |relationship| relationship.group.present? }
+
   validates :user, absence: {
     message: 'User and group can not exist at the same time'
   }, if: proc { |relationship| relationship.group.present? }

--- a/src/api/app/models/repository.rb
+++ b/src/api/app/models/repository.rb
@@ -35,8 +35,6 @@ class Repository < ApplicationRecord
   validates :name, uniqueness: { scope: [:db_project_id, :remote_project_name],
                                  case_sensitive: true,
                                  message: '%{value} is already used by a repository of this project' }
-
-  validates :project, presence: true
   # NOTE: remote_project_name cannot be NULL because mysql UNIQUE KEY constraint does considers
   #       two NULL's to be distinct. (See mysql bug #8173)
   validate :remote_project_name_not_nill

--- a/src/api/app/models/repository_architecture.rb
+++ b/src/api/app/models/repository_architecture.rb
@@ -6,7 +6,7 @@ class RepositoryArchitecture < ApplicationRecord
 
   acts_as_list scope: [:repository_id], top_of_list: 0
 
-  validates :repository, :architecture, :position, presence: true
+  validates :position, presence: true
   validates :repository, uniqueness: { scope: :architecture }
 
   def build_id

--- a/src/api/app/models/review.rb
+++ b/src/api/app/models/review.rb
@@ -9,7 +9,7 @@ class Review < ApplicationRecord
 
   VALID_REVIEW_STATES = [:new, :declined, :accepted, :superseded, :obsoleted].freeze
 
-  belongs_to :bs_request, touch: true
+  belongs_to :bs_request, touch: true, optional: true
   has_many :history_elements, -> { order(:created_at) }, class_name: 'HistoryElement::Review', foreign_key: :op_object_id
   has_many :history_elements_assigned, class_name: 'HistoryElement::ReviewAssigned', foreign_key: :op_object_id
   has_many :notifications, as: :notifiable, dependent: :delete_all
@@ -41,7 +41,7 @@ class Review < ApplicationRecord
   belongs_to :project, optional: true
   belongs_to :package, optional: true
 
-  belongs_to :review_assigned_from, class_name: 'Review', foreign_key: :review_id
+  belongs_to :review_assigned_from, class_name: 'Review', foreign_key: :review_id, optional: true
   has_one :review_assigned_to, class_name: 'Review'
 
   scope :assigned, lambda {

--- a/src/api/app/models/review.rb
+++ b/src/api/app/models/review.rb
@@ -36,10 +36,10 @@ class Review < ApplicationRecord
   validate :validate_not_self_assigned
   validates_with AllowedUserValidator
 
-  belongs_to :user
-  belongs_to :group
-  belongs_to :project
-  belongs_to :package
+  belongs_to :user, optional: true
+  belongs_to :group, optional: true
+  belongs_to :project, optional: true
+  belongs_to :package, optional: true
 
   belongs_to :review_assigned_from, class_name: 'Review', foreign_key: :review_id
   has_one :review_assigned_to, class_name: 'Review'

--- a/src/api/app/models/role.rb
+++ b/src/api/app/models/role.rb
@@ -25,11 +25,11 @@ class Role < ApplicationRecord
   validates :title, uniqueness: { case_sensitive: true,
                                   message: 'is the name of an already existing role' }
 
-  belongs_to :groups_roles
-  belongs_to :attrib_type_modifiable_bies
-  belongs_to :relationships
-  belongs_to :roles_static_permissions
-  belongs_to :roles_users
+  belongs_to :groups_roles, optional: true
+  belongs_to :attrib_type_modifiable_bies, optional: true
+  belongs_to :relationships, optional: true
+  belongs_to :roles_static_permissions, optional: true
+  belongs_to :roles_users, optional: true
 
   # roles have n:m relations for users
   has_and_belongs_to_many :users, -> { distinct }

--- a/src/api/app/models/staging/request_exclusion.rb
+++ b/src/api/app/models/staging/request_exclusion.rb
@@ -6,7 +6,7 @@ class Staging::RequestExclusion < ApplicationRecord
   belongs_to :staging_workflow, class_name: 'Staging::Workflow'
   belongs_to :bs_request
 
-  validates :staging_workflow, :number, :description, presence: true
+  validates :number, :description, presence: true
   validates :bs_request_id, numericality: true, uniqueness: { scope: :staging_workflow_id, message: 'is already excluded' }
   validates :description, length: { maximum: 255 }
 

--- a/src/api/app/models/staging/workflow.rb
+++ b/src/api/app/models/staging/workflow.rb
@@ -30,8 +30,6 @@ class Staging::Workflow < ApplicationRecord
   has_many :request_exclusions, class_name: 'Staging::RequestExclusion', foreign_key: 'staging_workflow_id', dependent: :destroy
   has_many :excluded_requests, through: :request_exclusions, source: :bs_request
 
-  validates :managers_group, :project, presence: true
-
   after_create :create_staging_projects
   after_create :add_reviewer_group
   before_update :update_managers_group

--- a/src/api/app/models/status/check.rb
+++ b/src/api/app/models/status/check.rb
@@ -19,7 +19,7 @@ class Status::Check < ApplicationRecord
   validates :name, uniqueness: { scope: :status_report, case_sensitive: true }
 
   #### Associations macros (Belongs to, Has one, Has many)
-  belongs_to :status_report, class_name: 'Status::Report', foreign_key: 'status_reports_id'
+  belongs_to :status_report, class_name: 'Status::Report', foreign_key: 'status_reports_id', optional: true
 
   #### Callbacks macros: before_save, after_save, etc.
 

--- a/src/api/app/models/status/report.rb
+++ b/src/api/app/models/status/report.rb
@@ -17,7 +17,6 @@ class Status::Report < ApplicationRecord
   #### Scopes (first the default_scope macro if is used)
 
   #### Validations macros
-  validates :checkable, presence: true
   validates :uuid, presence: true
 
   validates_each :checkable do |record, attr, value|

--- a/src/api/app/models/status_message.rb
+++ b/src/api/app/models/status_message.rb
@@ -3,7 +3,7 @@ class StatusMessage < ApplicationRecord
   has_many :status_message_acknowledgements, dependent: :destroy
   has_many :users, through: :status_message_acknowledgements
 
-  validates :user, :severity, :message, presence: true
+  validates :severity, :message, presence: true
 
   scope :announcements, -> { order('created_at DESC').where(severity: 'announcement') }
   scope :for_current_user, -> { where(communication_scope: communication_scopes_for_current_user) }

--- a/src/api/app/models/status_message_acknowledgement.rb
+++ b/src/api/app/models/status_message_acknowledgement.rb
@@ -2,9 +2,6 @@ class StatusMessageAcknowledgement < ApplicationRecord
   belongs_to :status_message
   belongs_to :user
 
-  validates :status_message, presence: true
-  validates :user, presence: true
-
   validates :status_message_id, uniqueness: { scope: :user_id, message: 'You have already acknowledged the message' }
 end
 

--- a/src/api/app/models/token.rb
+++ b/src/api/app/models/token.rb
@@ -12,7 +12,6 @@ class Token < ApplicationRecord
   end
 
   validates :name, length: { maximum: 64 }
-  validates :user, presence: true
   validates :string, uniqueness: { case_sensitive: false }
   validates :scm_token, absence: true, if: -> { type != 'Token::Workflow' }
 

--- a/src/api/app/models/token.rb
+++ b/src/api/app/models/token.rb
@@ -1,7 +1,7 @@
 class Token < ApplicationRecord
   belongs_to :user
   has_many :event_subscriptions, dependent: :destroy
-  belongs_to :package, inverse_of: :tokens
+  belongs_to :package, inverse_of: :tokens, optional: true
 
   attr_accessor :object_to_authorize
 

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -28,7 +28,7 @@ class User < ApplicationRecord
 
   has_many :event_subscriptions, inverse_of: :user
 
-  belongs_to :owner, class_name: 'User'
+  belongs_to :owner, class_name: 'User', optional: true
   has_many :subaccounts, class_name: 'User', foreign_key: 'owner_id'
 
   has_many :requests_created, foreign_key: 'creator', primary_key: :login, class_name: 'BsRequest'

--- a/src/api/app/models/watched_project.rb
+++ b/src/api/app/models/watched_project.rb
@@ -2,9 +2,6 @@
 class WatchedProject < ApplicationRecord
   belongs_to :user, inverse_of: :watched_projects
   belongs_to :project, inverse_of: :watched_projects
-
-  validates :project, presence: true
-  validates :user, presence: true
 end
 
 # == Schema Information

--- a/src/api/app/models/workflow_run.rb
+++ b/src/api/app/models/workflow_run.rb
@@ -2,7 +2,7 @@ class WorkflowRun < ApplicationRecord
   validates :response_url, length: { maximum: 255 }
   validates :request_headers, :status, presence: true
 
-  belongs_to :token, class_name: 'Token::Workflow'
+  belongs_to :token, class_name: 'Token::Workflow', optional: true
   paginates_per 20
 
   enum status: {

--- a/src/api/config/application.rb
+++ b/src/api/config/application.rb
@@ -39,8 +39,6 @@ module OBSApi
 
     # Enable rails version 6.0 defaults
     config.load_defaults(6.0)
-    # Require `belongs_to` associations by default. Previous versions had false.
-    config.active_record.belongs_to_required_by_default = false
 
     # Custom directories with classes and modules you want to be autoloadable.
     # config.autoload_paths += %W(#{config.root}/extras)

--- a/src/api/spec/controllers/webui/download_on_demand_controller_spec.rb
+++ b/src/api/spec/controllers/webui/download_on_demand_controller_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Webui::DownloadOnDemandController do
       end
 
       it { is_expected.to redirect_to(root_path) }
-      it { expect(flash[:error]).to eq("Download on Demand can't be created: Validation failed: Architecture can't be blank") }
+      it { expect(flash[:error]).to eq("Download on Demand can't be created: Validation failed: Architecture must exist") }
       it { expect(assigns(:download_on_demand)).to be_kind_of(DownloadRepository) }
       it { expect(DownloadRepository.where(dod_parameters[:download_repository])).not_to exist }
     end

--- a/src/api/spec/controllers/webui/repositories_controller_spec.rb
+++ b/src/api/spec/controllers/webui/repositories_controller_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe Webui::RepositoriesController, vcr: true do
         post :create, params: { project: user.home_project, repository: 'valid_name', target_project: another_project, target_repo: 'non_valid_repo' }
       end
 
-      it { expect(flash[:error]).to eq("Can not add repository: Path elements is invalid and Path Element: Link can't be blank") }
+      it { expect(flash[:error]).to eq('Can not add repository: Path elements is invalid and Path Element: Link must exist') }
       it { is_expected.to redirect_to(root_url) }
     end
 

--- a/src/api/spec/models/bs_request_action_spec.rb
+++ b/src/api/spec/models/bs_request_action_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe BsRequestAction do
     it_behaves_like 'it skips validation for type', 'maintenance_incident'
   end
 
-  it { is_expected.to belong_to(:bs_request).touch(true) }
+  it { is_expected.to belong_to(:bs_request).touch(true).optional }
 
   describe '.set_source_and_target_associations' do
     let(:project) { create(:project_with_package, name: 'Apache', package_name: 'apache2') }

--- a/src/api/spec/models/cloud/ec2/configuration_spec.rb
+++ b/src/api/spec/models/cloud/ec2/configuration_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Cloud::Ec2::Configuration, type: :model, vcr: true do
   describe 'validations' do
-    it { is_expected.to belong_to(:user) }
+    it { is_expected.to belong_to(:user).optional }
     it { is_expected.to validate_uniqueness_of(:external_id) }
     it { is_expected.to validate_uniqueness_of(:arn) }
     it { is_expected.to allow_value('arn:123:45.6/*/tom tom/test-role+=,.@-_').for(:arn) }

--- a/src/api/spec/models/cloud/user/upload_job_spec.rb
+++ b/src/api/spec/models/cloud/user/upload_job_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Cloud::User::UploadJob, type: :model, vcr: true do
   describe 'validations' do
     it { is_expected.to validate_presence_of(:job_id) }
-    it { is_expected.to belong_to(:user) }
+    it { is_expected.to belong_to(:user).optional }
     it { is_expected.to validate_uniqueness_of(:job_id) }
   end
 end

--- a/src/api/spec/models/comment_spec.rb
+++ b/src/api/spec/models/comment_spec.rb
@@ -26,8 +26,6 @@ RSpec.describe Comment do
 
   describe 'validations' do
     it { is_expected.to validate_presence_of(:body) }
-    it { is_expected.to validate_presence_of(:commentable) }
-    it { is_expected.to validate_presence_of(:user) }
 
     it {
       expect { create(:comment_package, parent: comment_package) }.to raise_error(

--- a/src/api/spec/models/commit_activity_spec.rb
+++ b/src/api/spec/models/commit_activity_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe CommitActivity, type: :model do
   describe 'validations' do
     it { is_expected.to validate_presence_of(:project) }
     it { is_expected.to validate_presence_of(:package) }
-    it { is_expected.to validate_presence_of(:user) }
+    it { is_expected.to belong_to(:user) }
     it { is_expected.to validate_presence_of(:date) }
   end
 end

--- a/src/api/spec/models/download_repository_spec.rb
+++ b/src/api/spec/models/download_repository_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe DownloadRepository do
     it { is_expected.to validate_presence_of(:url) }
     it { is_expected.to validate_presence_of(:arch) }
     it { is_expected.to validate_presence_of(:repotype) }
-    it { is_expected.to validate_presence_of(:repository) }
+    it { is_expected.to belong_to(:repository) }
     it { is_expected.to validate_uniqueness_of(:arch).scoped_to(:repository_id).case_insensitive }
 
     it do

--- a/src/api/spec/models/repository_spec.rb
+++ b/src/api/spec/models/repository_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Repository do
   describe 'validations' do
     it { is_expected.to validate_length_of(:name).is_at_least(1).is_at_most(200) }
-    it { is_expected.to validate_presence_of(:project) }
+    it { is_expected.to belong_to(:project) }
 
     it 'validates uniqueness of name' do
       repository = create(:repository)

--- a/src/api/spec/models/review_spec.rb
+++ b/src/api/spec/models/review_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Review do
   let(:user) { create(:user, login: 'King') }
   let(:group) { create(:group, title: 'Staff') }
 
-  it { is_expected.to belong_to(:bs_request).touch(true) }
+  it { is_expected.to belong_to(:bs_request).touch(true).optional }
 
   describe 'validations' do
     it 'is not allowed to specify by_user and any other reviewable' do

--- a/src/api/spec/models/staging/workflow_spec.rb
+++ b/src/api/spec/models/staging/workflow_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe Staging::Workflow, type: :model do
   end
 
   describe 'validations' do
-    it { is_expected.to validate_presence_of(:managers_group) }
-    it { is_expected.to validate_presence_of(:project) }
+    it { is_expected.to belong_to(:managers_group) }
+    it { is_expected.to belong_to(:project) }
   end
 
   context 'when created' do

--- a/src/api/spec/models/status/report_spec.rb
+++ b/src/api/spec/models/status/report_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Status::Report, type: :model do
   describe 'validations' do
-    it { is_expected.to validate_presence_of(:checkable) }
+    it { is_expected.to belong_to(:checkable) }
     it { is_expected.to validate_presence_of(:uuid) }
   end
 end

--- a/src/api/spec/models/token_spec.rb
+++ b/src/api/spec/models/token_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Token, type: :model do
 
     it { expect(release_token).to validate_uniqueness_of(:string).case_insensitive }
     it { is_expected.to have_secure_token(:string) }
-    it { is_expected.to validate_presence_of(:user) }
+    it { is_expected.to belong_to(:user) }
   end
 
   describe '.token_type' do


### PR DESCRIPTION
Since Rails 5.0 `belongs_to` automatically checks for the presence
of the related record. We opted out this behavior in previous Rails
upgrades. It's time to enable the default behavior (also since
rubocop-rails 2.13 introduced a cop that checks for redundant
validation to check for the presence of a record).

Related to https://github.com/openSUSE/open-build-service/pull/12038

After enabling `belongs_to_required_by_default` we have to
explicitly tell rails where the associated record is optional.
I set it to optional where ever it is not disallowed on DB level with the
`not_null` value or where no explicit validation for presence
was set in the past. This way we keep the previous behavior and
don't break any code.