### PR TITLE
Use jobs in _constraints if available instead of worker jobs

### DIFF
--- a/src/backend/BSDispatcher/Constraints.pm
+++ b/src/backend/BSDispatcher/Constraints.pm
@@ -111,7 +111,7 @@ sub oracle {
     my $memory = ($worker->{'hardware'}->{'memory'} || 0);
     my $swap = ($worker->{'hardware'}->{'swap'} || 0);
     return 0 if $constraints->{'hardware'}->{'memory'} && getmbsize($constraints->{'hardware'}->{'memory'}) > ( $memory + $swap );
-    return 0 if $constraints->{'hardware'}->{'memoryperjob'} && getmbsize($constraints->{'hardware'}->{'memoryperjob'}) * ($worker->{'hardware'}->{'jobs'} || 1) > ( $memory + $swap );
+    return 0 if $constraints->{'hardware'}->{'memoryperjob'} && getmbsize($constraints->{'hardware'}->{'memoryperjob'}) * ($constraints->{'hardware'}->{'jobs'} || $worker->{'hardware'}->{'jobs'} || 1) > ( $memory + $swap );
     return 0 if $constraints->{'hardware'}->{'physicalmemory'} && getmbsize($constraints->{'hardware'}->{'physicalmemory'}) > $memory;
     if ($constraints->{'hardware'}->{'cpu'}) {
       my %workerflags = map {$_ => 1} @{$worker->{'hardware'}->{'cpu'}->{'flag'} || []};


### PR DESCRIPTION
When multiplying the memoryperjob by the jobs to check if a worker
has enough memory, use the "jobs" value set in the _constraint
file if available instead of the worker jobs (core count) (which
is still used if "jobs" is not specified in order to keep the
current behaviour).

Multiplying memoryperjob by the worker's jobs (which I assume to be
the number of cpu cores) is basically wrong because usually the
number of concurrent jobs are set by dividing the total memory by
the memoryperjob (for example, with the %memory_limit macro) so,
if the check is done multiplying memoryperjob by number of cpu cores
then it can happen as in #10167 or #10093 where workers matching
the constraints can't be found because obs assumes the worker's
number of jobs will be used when the package could limit that
with %limit_build.

At least this allows the constraints to be reduced by setting
both memoryperjob and jobs together in the _constraints file
and would help fix #10167 and #10093.