### PR TITLE
[api] fix ignore releasetarget project on maintenance_incident requests

### DIFF
--- a/src/api/app/models/branch_package.rb
+++ b/src/api/app/models/branch_package.rb
@@ -257,7 +257,11 @@ class BranchPackage
 
     if params[:newinstance]
       p[:link_target_project] = Project.get_by_name(params[:project])
-      p[:target_package] = p[:package].name
+      p[:target_package] = if p[:package].is_a?(Package)
+                             p[:package].name
+                           else
+                             p[:package]
+                           end
       p[:target_package] += ".#{p[:link_target_project].name}" if @extend_names
     end
     if @extend_names

--- a/src/api/app/models/bs_request_action_maintenance_incident.rb
+++ b/src/api/app/models/bs_request_action_maintenance_incident.rb
@@ -143,6 +143,7 @@ class BsRequestActionMaintenanceIncident < BsRequestAction
                         requestid: bs_request.number,
                         maintenance: 1,
                         force: 1,
+                        newinstance: 1,
                         comment: 'Initial new branch from specified release project',
                         project: target_releaseproject, package: package_name }
       # accept branching from former update incidents or GM (for kgraft case)


### PR DESCRIPTION
This makes it possible to submit a package to a higher service pack level again.

Also fixed a crash when using a remote package as source here.