### PR TITLE
[api] fix access to build area for git projects

### DIFF
--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -162,6 +162,8 @@ class Package < ApplicationRecord
     prj = internal_get_project(project)
     return unless prj # remote prjs
 
+    return nil if prj.scmsync.present?
+
     if pkg.nil? && opts[:follow_project_links]
       pkg = prj.find_package(package, opts[:check_update_project])
     elsif pkg.nil?


### PR DESCRIPTION
Package objects do not exist in such projects
(same behavior as with remote projects)

should fix webui behaviour as well