### PR TITLE
Show meaningful data for each workflow run

### DIFF
--- a/src/api/app/components/workflow_run_detail_component.html.haml
+++ b/src/api/app/components/workflow_run_detail_component.html.haml
@@ -1,0 +1,26 @@
+%ul.nav.nav-tabs#workflow-run-tabs{ role: 'tablist' }
+  %li.nav-item{ role: 'presentation' }
+    %a.nav-link.active{ id: "request-tab#{id}", data: { toggle: 'tab' }, href: "#request-tab-content#{id}",
+                        role: 'tab', aria: { controls: "request-tab-content#{id}", selected: 'true' } }
+      Request
+  %li.nav-item{ role: 'presentation' }
+    %a.nav-link{ id: "response-tab#{id}", data: { toggle: 'tab' }, href: "#response-tab-content#{id}",
+                  role: 'tab', aria: { controls: "response-tab-content#{id}", selected: 'false' } }
+      Response
+.tab-content.p-3#workflow-run-tabs-content
+  .tab-pane.fade.show.active{ id: "request-tab-content#{id}", role: 'tabpanel',
+                              aria: { labelledby: "request-tab#{id}" } }
+    %h5 Request Headers
+    %pre.border.p-2#request-headers
+      = request_headers
+    %h5 Request Payload
+    %pre.border.p-2#request-payload
+      = pretty_request_payload
+  .tab-pane.fade{ id: "response-tab-content#{id}", role: 'tabpanel',
+                  aria: { labelledby: "response-tab#{id}" } }
+    %h5 Response URL
+    %pre.border.p-2#response-url
+      = response_url
+    %h5 Response Body
+    %pre.border.p-2#response-body
+      = response_body

--- a/src/api/app/components/workflow_run_detail_component.rb
+++ b/src/api/app/components/workflow_run_detail_component.rb
@@ -1,0 +1,21 @@
+class WorkflowRunDetailComponent < ApplicationComponent
+  attr_reader :id, :request_headers, :pretty_request_payload,
+              :response_url, :response_body
+
+  def initialize(workflow_run:)
+    super
+    @id = workflow_run.id
+    @request_headers = workflow_run.request_headers
+    @pretty_request_payload = parse_payload(workflow_run)
+    @response_url = workflow_run.response_url
+    @response_body = workflow_run.response_body
+  end
+
+  private
+
+  def parse_payload(workflow_run)
+    JSON.pretty_generate(JSON.parse(workflow_run.request_payload))
+  rescue JSON::ParserError
+    workflow_run.request_payload
+  end
+end

--- a/src/api/app/components/workflow_run_row_component.html.haml
+++ b/src/api/app/components/workflow_run_row_component.html.haml
@@ -1,0 +1,14 @@
+.col-1.text-left
+  %i{ title: status_title, class: status_icon }
+.col.text-left
+  #{hook_event.humanize} event
+  - if hook_action
+    %span.badge.badge-primary= hook_action.humanize
+.col.text-left
+  = link_to_if repository_url, repository_name, repository_url
+  - if hook_source_name
+    = link_to formatted_hook_source_name, hook_source_url, { class: 'link-secondary' }
+  - else
+    Unknown source
+.col.text-right
+  = workflow_run.created_at

--- a/src/api/app/components/workflow_run_row_component.rb
+++ b/src/api/app/components/workflow_run_row_component.rb
@@ -1,0 +1,98 @@
+class WorkflowRunRowComponent < ApplicationComponent
+  attr_reader :workflow_run, :status
+
+  def initialize(workflow_run:)
+    super
+
+    @workflow_run = workflow_run
+    @status = workflow_run.status
+  end
+
+  def hook_action
+    return payload['action'] if
+      hook_event == 'pull_request' && ScmWebhookEventValidator::ALLOWED_PULL_REQUEST_ACTIONS.include?(payload['action'])
+
+    'Unsupported'
+  end
+
+  def hook_event
+    parsed_request_headers['HTTP_X_GITHUB_EVENT']
+  end
+
+  def repository_name
+    payload.dig('repository', 'full_name')
+  end
+
+  def repository_url
+    payload.dig('repository', 'html_url')
+  end
+
+  def hook_source_name
+    case hook_event
+    when 'pull_request'
+      payload.dig('pull_request', 'number')
+    when 'push'
+      payload.dig('head_commit', 'id')
+    else
+      payload.dig('repository', 'full_name')
+    end
+  end
+
+  def formatted_hook_source_name
+    case hook_event
+    when 'pull_request'
+      "##{hook_source_name}"
+    else
+      hook_source_name
+    end
+  end
+
+  def hook_source_url
+    case hook_event
+    when 'pull_request'
+      payload.dig('pull_request', 'url')
+    when 'push'
+      payload.dig('head_commit', 'url')
+    else
+      payload.dig('repository', 'html_url')
+    end
+  end
+
+  def status_title
+    case status
+    when 'running'
+      'Status: running'
+    when 'success'
+      'Status: success'
+    else
+      'Status: failed'
+    end
+  end
+
+  def status_icon
+    classes = case status
+              when 'running'
+                ['fas', 'fa-running']
+              when 'success'
+                ['fas', 'fa-check', 'text-primary']
+              else
+                ['fas', 'fa-exclamation-triangle', 'text-danger']
+              end
+    classes.join(' ')
+  end
+
+  private
+
+  def parsed_request_headers
+    workflow_run.request_headers.split("\n").each_with_object({}) do |h, headers|
+      k, v = h.split(':')
+      headers[k] = v.strip
+    end
+  end
+
+  def payload
+    @payload ||= JSON.parse(workflow_run.request_payload)
+  rescue JSON::ParserError
+    {}
+  end
+end

--- a/src/api/app/models/workflow_run.rb
+++ b/src/api/app/models/workflow_run.rb
@@ -14,55 +14,6 @@ class WorkflowRun < ApplicationRecord
   def update_to_fail(message)
     update(response_body: message, status: 'fail')
   end
-
-  def payload
-    @payload ||= JSON.parse(request_payload)
-  end
-
-  def hook_action
-    payload['action']
-  end
-
-  def parsed_request_headers
-    request_headers.split("\n").each_with_object({}) do |h, headers|
-      k, v = h.split(':')
-      headers[k] = v.strip
-    end
-  end
-
-  def hook_event
-    parsed_request_headers['HTTP_X_GITHUB_EVENT']
-  end
-
-  def repository_name
-    payload['repository']['full_name']
-  end
-
-  def repository_url
-    payload['repository']['html_url']
-  end
-
-  def hook_source_name
-    case hook_event
-    when 'pull_request'
-      "##{payload['pull_request']['number']}"
-    when 'push'
-      "#{payload.dig('head_commit', 'id')}"
-    else
-      payload['repository']['full_name']
-    end
-  end
-
-  def hook_source_url
-    case hook_event
-    when 'pull_request'
-      payload['pull_request']['url']
-    when 'push'
-      payload.dig('head_commit', 'url')
-    else
-      payload['repository']['html_url']
-    end
-  end
 end
 
 # == Schema Information

--- a/src/api/app/views/webui/workflow_runs/index.html.haml
+++ b/src/api/app/views/webui/workflow_runs/index.html.haml
@@ -16,52 +16,9 @@
               %button.btn.btn-block{ type: 'button', data: { toggle: 'collapse', target: "#workflow-run#{workflow_run.id}" },
                                       aria: { expanded: 'false', controls: "workflow-run#{workflow_run.id}" } }
                 .row
-                  .col-1.text-left
-                    - case workflow_run.status
-                      - when 'running'
-                        %i.fas.fa-running{ title: 'Status: running' }
-                      - when 'success'
-                        %i.fas.fa-check.text-primary{ title: 'Status: success' }
-                      - else
-                        %i.fas.fa-exclamation-triangle.text-danger{ title: 'Status: failed' }
-                  .col.text-left
-                    = workflow_run.hook_event.humanize
-                    Event
-                    - if workflow_run.hook_action
-                      %span.badge.badge-primary= workflow_run.hook_action.humanize
-                  .col.text-left
-                    = link_to workflow_run.repository_name, workflow_run.repository_url
-                    - if workflow_run.hook_source_name
-                      = link_to workflow_run.hook_source_name, workflow_run.hook_source_url, { class: 'link-secondary' }
-                  .col.text-right
-                    = workflow_run.created_at
+                  = render(WorkflowRunRowComponent.new(workflow_run: workflow_run))
           .collapse{ id: "workflow-run#{workflow_run.id}", aria: { labelledby: "#workflow-run-heading#{workflow_run.id}" },
                       data: { parent: '#workflow-runs-accordion' } }
             .card-body
-              %ul.nav.nav-tabs#workflow-run-tabs{ role: 'tablist' }
-                %li.nav-item{ role: 'presentation' }
-                  %a.nav-link.active{ id: "request-tab#{workflow_run.id}", data: { toggle: 'tab' }, href: "#request-tab-content#{workflow_run.id}",
-                                      role: 'tab', aria: { controls: "request-tab-content#{workflow_run.id}", selected: 'true' } }
-                    Request
-                %li.nav-item{ role: 'presentation' }
-                  %a.nav-link{ id: "response-tab#{workflow_run.id}", data: { toggle: 'tab' }, href: "#response-tab-content#{workflow_run.id}",
-                                role: 'tab', aria: { controls: "response-tab-content#{workflow_run.id}", selected: 'false' } }
-                    Response
-              .tab-content.p-3#workflow-run-tabs-content
-                .tab-pane.fade.show.active{ id: "request-tab-content#{workflow_run.id}", role: 'tabpanel',
-                                            aria: { labelledby: "request-tab#{workflow_run.id}" } }
-                  %h5 Request Headers
-                  %pre.border.p-2#request-headers
-                    = workflow_run.request_headers
-                  %h5 Request Payload
-                  %pre.border.p-2#request-payload
-                    = JSON.pretty_generate(JSON.parse(workflow_run.request_payload))
-                .tab-pane.fade{ id: "response-tab-content#{workflow_run.id}", role: 'tabpanel',
-                                aria: { labelledby: "response-tab#{workflow_run.id}" } }
-                  %h5 Response URL
-                  %pre.border.p-2#response-url
-                    = workflow_run.response_url
-                  %h5 Response Body
-                  %pre.border.p-2#response-body
-                    = workflow_run.response_body
+              = render(WorkflowRunDetailComponent.new(workflow_run: workflow_run))
         = paginate @workflow_runs, views_prefix: 'webui'

--- a/src/api/app/views/webui/workflow_runs/index.html.haml
+++ b/src/api/app/views/webui/workflow_runs/index.html.haml
@@ -25,7 +25,14 @@
                       - else
                         %i.fas.fa-exclamation-triangle.text-danger{ title: 'Status: failed' }
                   .col.text-left
-                    Workflow Run #{workflow_run.id}
+                    = workflow_run.hook_event.humanize
+                    Event
+                    - if workflow_run.hook_action
+                      %span.badge.badge-primary= workflow_run.hook_action.humanize
+                  .col.text-left
+                    = link_to workflow_run.repository_name, workflow_run.repository_url
+                    - if workflow_run.hook_source_name
+                      = link_to workflow_run.hook_source_name, workflow_run.hook_source_url, { class: 'link-secondary' }
                   .col.text-right
                     = workflow_run.created_at
           .collapse{ id: "workflow-run#{workflow_run.id}", aria: { labelledby: "#workflow-run-heading#{workflow_run.id}" },

--- a/src/api/spec/components/workflow_run_detail_component_spec.rb
+++ b/src/api/spec/components/workflow_run_detail_component_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe WorkflowRunDetailComponent, type: :component do
+  let(:workflow_token) { create(:workflow_token) }
+  let(:request_headers) do
+    <<~END_OF_HEADERS
+      HTTP_X_GITHUB_EVENT: pull_request
+    END_OF_HEADERS
+  end
+  let(:request_payload) do
+    <<-END_OF_PAYLOAD
+    {
+      "foo": "bar"
+    }
+    END_OF_PAYLOAD
+  end
+  let(:workflow_run) do
+    create(:workflow_run,
+           token: workflow_token,
+           request_headers: request_headers,
+           request_payload: request_payload)
+  end
+
+  before do
+    render_inline(described_class.new(workflow_run: workflow_run))
+  end
+
+  context 'every single workflow run' do
+    it { expect(rendered_component).to have_text('Request') }
+    it { expect(rendered_component).to have_text('Response') }
+    it { expect(rendered_component).to have_text('pull_request') }
+    it { expect(rendered_component).to have_text('foo') }
+  end
+
+  context 'when the payload cannot be parsed' do
+    let(:request_payload) { 'Unparseable payload' }
+
+    it 'shows nothing on the payload tab' do
+      expect(rendered_component).to have_text('Unparseable payload')
+    end
+  end
+end

--- a/src/api/spec/components/workflow_run_row_component_spec.rb
+++ b/src/api/spec/components/workflow_run_row_component_spec.rb
@@ -1,0 +1,205 @@
+require 'rails_helper'
+
+RSpec.describe WorkflowRunRowComponent, type: :component do
+  let(:workflow_token) { create(:workflow_token) }
+  let(:request_headers) do
+    <<~END_OF_HEADERS
+      HTTP_X_GITHUB_EVENT: pull_request
+    END_OF_HEADERS
+  end
+  let(:workflow_run) do
+    create(:workflow_run,
+           token: workflow_token,
+           request_headers: request_headers,
+           request_payload: request_payload)
+  end
+
+  before do
+    render_inline(described_class.new(workflow_run: workflow_run))
+  end
+
+  context 'every single workflow run' do
+    let(:request_payload) do
+      <<~END_OF_REQUEST
+        {
+          "pull_request": {
+            "url": "https://example.com/pr/1",
+            "number": "1"
+          },
+          "repository": {
+            "full_name": "Example Repository",
+            "html_url": "https://example.com"
+          }
+        }
+      END_OF_REQUEST
+    end
+
+    it 'shows the date the workflow run was created' do
+      expect(rendered_component).to have_text(workflow_run.created_at)
+    end
+  end
+
+  context 'when there is no repository present' do
+    let(:request_payload) do
+      <<~END_OF_REQUEST
+        {
+          "pull_request": {
+            "url": "https://example.com/pr/1"
+          }
+        }
+      END_OF_REQUEST
+    end
+
+    it { expect(rendered_component).to have_text('Unknown source') }
+    it { expect(rendered_component).not_to have_link }
+  end
+
+  context 'when the workflow comes from a pull request event' do
+    let(:request_payload) do
+      <<~END_OF_REQUEST
+        {
+          "pull_request": {
+            "url": "https://example.com/pr/1",
+            "number": "1"
+          },
+          "repository": {
+            "full_name": "Example Repository",
+            "html_url": "https://example.com"
+          }
+        }
+      END_OF_REQUEST
+    end
+
+    it { expect(rendered_component).to have_text 'Pull request event' }
+
+    it 'shows a link to the repository' do
+      expect(rendered_component).to have_link('Example Repository', href: 'https://example.com')
+    end
+
+    it 'shows a link to the pull request' do
+      expect(rendered_component).to have_link('#1', href: 'https://example.com/pr/1')
+    end
+
+    # TODO: What happens with stuff from GitLab?
+    ['closed', 'opened', 'reopened', 'synchronize'].each do |action|
+      context "and the action is '#{action}'" do
+        let(:request_payload) do
+          <<~END_OF_REQUEST
+            {
+              "action": "#{action}",
+              "pull_request": {
+                "url": "https://example.com/pr/1",
+                "number": "1"
+              },
+              "repository": {
+                "full_name": "Example Repository",
+                "html_url": "https://example.com"
+              }
+            }
+          END_OF_REQUEST
+        end
+
+        it { expect(rendered_component).to have_text action.humanize }
+      end
+    end
+
+    context 'and the action is unsupported' do
+      let(:request_payload) do
+        <<~END_OF_REQUEST
+          {
+            "action": "edited",
+            "pull_request": {
+              "url": "https://example.com/pr/1",
+              "number": "1"
+            },
+            "repository": {
+              "full_name": "Example Repository",
+              "html_url": "https://example.com"
+            }
+          }
+        END_OF_REQUEST
+      end
+
+      it 'does not show the action anywhere' do
+        expect(rendered_component).to have_text('Unsupported')
+      end
+    end
+  end
+
+  context 'when the workflow comes from a push event' do
+    let(:request_headers) do
+      <<~END_OF_HEADERS
+        HTTP_X_GITHUB_EVENT: push
+      END_OF_HEADERS
+    end
+    let(:request_payload) do
+      <<~END_OF_REQUEST
+        {
+          "head_commit": {
+            "id": "1234",
+            "url": "https://example.com/commit/1234"
+          },
+          "repository": {
+            "full_name": "Example Repository",
+            "html_url": "https://example.com"
+          }
+        }
+      END_OF_REQUEST
+    end
+
+    it { expect(rendered_component).to have_text 'Push event' }
+
+    it 'shows a link to the repository' do
+      expect(rendered_component).to have_link('Example Repository', href: 'https://example.com')
+    end
+
+    it 'shows a link to the pushed commit' do
+      expect(rendered_component).to have_link('1234', href: 'https://example.com/commit/1234')
+    end
+  end
+
+  context 'when the workflow is still running' do
+    let(:workflow_run) do
+      create(:workflow_run,
+             status: 'running',
+             token: workflow_token,
+             request_headers: request_headers,
+             request_payload: request_payload)
+    end
+    let(:request_payload) { {} }
+
+    it 'shows a green check mark' do
+      expect(rendered_component).to have_selector('i', class: 'fas fa-running')
+    end
+  end
+
+  context 'when the workflow runs successfully' do
+    let(:workflow_run) do
+      create(:workflow_run,
+             status: 'success',
+             token: workflow_token,
+             request_headers: request_headers,
+             request_payload: request_payload)
+    end
+    let(:request_payload) { {} }
+
+    it 'shows a green check mark' do
+      expect(rendered_component).to have_selector('i', class: 'fas fa-check text-primary')
+    end
+  end
+
+  context 'when the workflow fails' do
+    let(:workflow_run) do
+      create(:workflow_run,
+             status: 'fail',
+             token: workflow_token,
+             request_headers: request_headers,
+             request_payload: request_payload)
+    end
+    let(:request_payload) { {} }
+
+    it 'shows an exclamation mark' do
+      expect(rendered_component).to have_selector('i', class: 'fas fa-exclamation-triangle text-danger')
+    end
+  end
+end


### PR DESCRIPTION
This PR changes the Workflow Run index page to show a bit more of detail on each displayed item to quickly identify each run.

## Before
![image](https://user-images.githubusercontent.com/2650/149488240-1eb0e762-dd9d-4a50-9242-a05b88688499.png)

## After
![image](https://user-images.githubusercontent.com/2650/149373630-cf13be80-b07d-4fb8-913e-d1652c43acd7.png)

Missing:
- [x] Refactor the view to use View Components
- [x] Write specs
- [x] Improve the code a bit more