### PR TITLE
Hide unsupported actions in WorkflowRun's index page

### DIFF
--- a/src/api/app/components/workflow_run_row_component.rb
+++ b/src/api/app/components/workflow_run_row_component.rb
@@ -11,8 +11,6 @@ class WorkflowRunRowComponent < ApplicationComponent
   def hook_action
     return payload['action'] if
       hook_event == 'pull_request' && ScmWebhookEventValidator::ALLOWED_PULL_REQUEST_ACTIONS.include?(payload['action'])
-
-    'Unsupported'
   end
 
   def hook_event

--- a/src/api/spec/components/workflow_run_row_component_spec.rb
+++ b/src/api/spec/components/workflow_run_row_component_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe WorkflowRunRowComponent, type: :component do
       end
 
       it 'does not show the action anywhere' do
-        expect(rendered_component).to have_text('Unsupported')
+        expect(rendered_component).not_to have_text('Unsupported')
       end
     end
   end


### PR DESCRIPTION
We do not want to show anything if the action is not supported.

This fixes #12077 showing "unsupported" tags in the view.

## Before
![image](https://user-images.githubusercontent.com/2650/149926690-3ee60f47-ad25-40fd-b27d-b396bfe3b45f.png)

## After
![image](https://user-images.githubusercontent.com/2650/149926835-6c62bf32-0738-49b8-899b-58d6d161fef9.png)
