### PR TITLE
Implement the improvements in the UI for GitLab too

### DIFF
--- a/src/api/app/components/workflow_run_row_component.html.haml
+++ b/src/api/app/components/workflow_run_row_component.html.haml
@@ -6,8 +6,8 @@
     %span.badge.badge-primary= hook_action.humanize
 .col.text-left
   = link_to_if repository_url, repository_name, repository_url
-  - if hook_source_name
-    = link_to formatted_hook_source_name, hook_source_url, { class: 'link-secondary' }
+  - if event_source_name
+    = link_to formatted_event_source_name, event_source_url, { class: 'link-secondary' }
   - else
     Unknown source
 .col.text-right


### PR DESCRIPTION
This is a follow up/fix for openSUSE#12077 where the logic to render the improved information for a Workflow Run is done also for GitLab-triggered workflows.

Also Fixes openSUSE#12105

This is how it looks now:

![image](https://user-images.githubusercontent.com/2650/150342936-5e41bf40-71a4-42b8-99a3-d16cbc6f4562.png)

Note the Merge requests coming from GitLab