### PR TITLE
Simplify token creation code

### DIFF
--- a/src/api/app/components/copy_to_clipboard_input_component.html.haml
+++ b/src/api/app/components/copy_to_clipboard_input_component.html.haml
@@ -1,5 +1,4 @@
--# TODO: Relying on a form builder is a bit weird. We could perhaps directly use `text_field_tag` instead and pass an input value to the component.
-= @form_builder.text_field(:string_readonly, id: 'copy-to-clipboard-readonly', class: 'form-control', readonly: true)
+= text_field_tag(nil, @token_string, readonly: true, id: 'copy-to-clipboard-readonly', class: 'form-control')
 .input-group-append#copy-to-clipboard
   %span.input-group-text
     %i.fas.fa-clipboard

--- a/src/api/app/components/copy_to_clipboard_input_component.rb
+++ b/src/api/app/components/copy_to_clipboard_input_component.rb
@@ -1,6 +1,6 @@
 class CopyToClipboardInputComponent < ApplicationComponent
-  def initialize(form_builder:)
+  def initialize(token_string:)
     super
-    @form_builder = form_builder
+    @token_string = token_string
   end
 end

--- a/src/api/app/components/token_card_component.html.haml
+++ b/src/api/app/components/token_card_component.html.haml
@@ -1,10 +1,11 @@
 .card.m-1.p-2
   .card-body
-    - if @token.name.present?
-      %h5.card-title
-        = @token.name
-    - else
-      %h5.card-title.font-italic No name
+    = link_to token_path(@token) do
+      - if @token.name.present?
+        %h5.card-title
+          = @token.name
+      - else
+        %h5.card-title.font-italic No name
     %p.card-text
       Id: #{@token.id}
     %p.card-text
@@ -21,7 +22,7 @@
         - if policy(@token).edit?
           = link_to(edit_token_path(@token), title: 'Edit Token') do
             %i.fas.fa-edit
-        - if policy(@token).show?
+        - if policy(@token).webui_trigger?
           = link_to(token_trigger_path(@token), title: 'Trigger Token') do
             %i.fas.fa-project-diagram
         = link_to '#', title: 'Delete Token',

--- a/src/api/app/policies/token_policy.rb
+++ b/src/api/app/policies/token_policy.rb
@@ -43,6 +43,6 @@ class TokenPolicy < ApplicationPolicy
   end
 
   def show?
-    webui_trigger?
+    record.user == user && !record.type.in?(['Token::Rss'])
   end
 end

--- a/src/api/app/views/webui/users/tokens/_actions.html.haml
+++ b/src/api/app/views/webui/users/tokens/_actions.html.haml
@@ -1,1 +1,1 @@
-= link_to('Back to List of Tokens', tokens_path, title: 'Back to List of Tokens', class: 'btn btn-outline-secondary px-4 mt-3 mt-sm-0')
+= link_to('Back to the list of tokens', tokens_path, title: 'Back to the list of tokens', class: 'btn btn-outline-secondary btn-sm')

--- a/src/api/app/views/webui/users/tokens/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui/users/tokens/_breadcrumb_items.html.haml
@@ -5,7 +5,7 @@
 - when 'index'
   %li.breadcrumb-item.active{ 'aria-current' => 'page' }
     Tokens
-- when 'new'
+- when 'new', 'create'
   %li.breadcrumb-item
     = link_to 'Tokens', tokens_path
   %li.breadcrumb-item.active{ 'aria-current' => 'page' }
@@ -15,3 +15,8 @@
     = link_to 'Tokens', tokens_path
   %li.breadcrumb-item.active{ 'aria-current' => 'page' }
     Edit Token
+- when 'show'
+  %li.breadcrumb-item
+    = link_to 'Tokens', tokens_path
+  %li.breadcrumb-item.active{ 'aria-current' => 'page' }
+    Show Token

--- a/src/api/app/views/webui/users/tokens/_create.js.erb
+++ b/src/api/app/views/webui/users/tokens/_create.js.erb
@@ -1,8 +1,0 @@
-$('#flash').html("<%= escape_javascript(render(layout: false, partial: 'layouts/webui/flash', object: flash)) %>");
-<% if flash[:error].blank? %>
-  $('#token-id span').text("<%= @token.id %>")
-  $('.visible-when-created').removeClass('d-none');
-  $('#copy-to-clipboard-readonly').val("<%= escape_javascript(string) %>");
-  $('.form-row :input').not('#copy-to-clipboard-readonly').prop('disabled', true);
-  $('.actions').html("<%= escape_javascript(render partial: 'actions') %>");
-<% end %>

--- a/src/api/app/views/webui/users/tokens/edit.html.haml
+++ b/src/api/app/views/webui/users/tokens/edit.html.haml
@@ -12,7 +12,7 @@
               %fieldset.form-group
                 = f.label(:string_readonly, 'Your new OBS Personal Access Token Secret', class: 'col-form-label col-form-label-lg')
                 .input-group
-                  = render CopyToClipboardInputComponent.new(form_builder: f)
+                  = render CopyToClipboardInputComponent.new(token_string: @token.string)
               %hr
 
           .form-row

--- a/src/api/app/views/webui/users/tokens/new.html.haml
+++ b/src/api/app/views/webui/users/tokens/new.html.haml
@@ -7,24 +7,7 @@
 
     .row
       .col-12.col-md-10.col-lg-8
-        = form_with(model: @token, method: :post, local: false) do |f|
-          .visible-when-created.d-none
-            %p.font-weight-bold Your new OBS Personal Access Token
-
-            .form-row#token-id
-              .col-sm
-                .form-group.mb-0
-                  = f.label(:id, 'Id:')
-                  %span= @token.id
-
-            .form-row#created-token
-              .col-12.col-md-10.col-lg-9
-                %fieldset.form-group
-                  = f.label(:string_readonly, 'Secret:', class: 'col-form-label')
-                  .input-group
-                    = render CopyToClipboardInputComponent.new(form_builder: f)
-                %hr
-
+        = form_with(model: @token ||= Token.new, method: :post, local: true) do |f|
           .form-row
             .col
               .form-group

--- a/src/api/app/views/webui/users/tokens/show.html.haml
+++ b/src/api/app/views/webui/users/tokens/show.html.haml
@@ -1,0 +1,68 @@
+- @pagetitle = "Token - #{@token.name.presence || 'No name'}"
+
+.card
+  .card-body
+    %h3.mb-3
+      = @pagetitle
+
+    .row
+      .col-12.col-md-10.col-lg-8
+        - if session[:show_token]
+          %p.font-weight-bold Your new OBS Personal Access Token
+
+        .form-row
+          .col-sm
+            %label.font-weight-bold
+              Id:
+            %span
+              = @token.id
+
+        - if session[:show_token]
+          - session[:show_token] = nil # Ensure we're only showing the token once
+          .form-row
+            .col-12.col-md-10.col-lg-9
+              %fieldset.form-group
+                %label.col-form-label.font-weight-bold
+                  Secret:
+                .input-group
+                  = render CopyToClipboardInputComponent.new(token_string: @token.string)
+              %hr
+
+        .form-row
+          .col
+            .form-group
+              %label.col-form-label.mr-2.font-weight-bold
+                Type:
+              %span
+                = @token.token_name
+
+        - if @token.package
+          .form-row
+            .col-sm
+              .form-group.ui-front
+                %label.font-weight-bold
+                  Project:
+                %span
+                  = link_to(@token.package.project.name, project_show_path(@token.package.project))
+
+          .form-row
+            .col-sm
+              .form-group.ui-front
+                %label.font-weight-bold
+                  Package:
+                %span
+                  = link_to(@token.package.name, package_show_path(@token.package.project, @token.package))
+
+        .actions
+          - if policy(@token).edit?
+            = link_to(edit_token_path(@token), class: 'pl-2', title: 'Edit') do
+              %i.fas.fa-edit
+              %span.nav-item-name Edit
+          - if policy(@token).webui_trigger?
+            = link_to(token_trigger_path(@token), class: 'pl-2', title: 'Trigger Token') do
+              %i.fas.fa-project-diagram
+              %span.nav-item-name Trigger Token
+          - if @token.type == 'Token::Workflow'
+            = link_to(token_workflow_runs_path(@token.id), class: 'pl-2', title: 'Workflow Runs') do
+              %i.fas.fa-book-open
+              %span.nav-item-name Workflow Runs

--- a/src/api/spec/controllers/webui/users/tokens_controller_spec.rb
+++ b/src/api/spec/controllers/webui/users/tokens_controller_spec.rb
@@ -58,6 +58,7 @@ RSpec.describe Webui::Users::TokensController, type: :controller do
       let(:form_parameters) { { token: { type: 'runservice', name: 'My first token' } } }
 
       include_examples 'check for flashing a success'
+      it { is_expected.to redirect_to(token_path(Token.last)) }
     end
 
     context 'type is release, with project parameter, without package parameter' do
@@ -74,6 +75,7 @@ RSpec.describe Webui::Users::TokensController, type: :controller do
       include_examples 'check for flashing a success'
 
       it { expect { subject }.to change(Token, :count).from(0).to(1) }
+      it { is_expected.to redirect_to(token_path(Token.last)) }
     end
 
     context 'type is workflow' do
@@ -83,6 +85,7 @@ RSpec.describe Webui::Users::TokensController, type: :controller do
         include_examples 'check for flashing a success'
 
         it { expect { subject }.to change(Token, :count).from(0).to(1) }
+        it { is_expected.to redirect_to(token_path(Token.last)) }
       end
 
       context 'without SCM' do

--- a/src/api/spec/policies/token_policy_spec.rb
+++ b/src/api/spec/policies/token_policy_spec.rb
@@ -13,8 +13,15 @@ RSpec.describe TokenPolicy do
   permissions :webui_trigger?, :show? do
     it { is_expected.not_to permit(other_user, user_token) }
     it { is_expected.not_to permit(token_user, rss_token) }
-    it { is_expected.not_to permit(token_user, workflow_token) }
 
     it { is_expected.to permit(token_user, user_token) }
+  end
+
+  permissions :show? do
+    it { is_expected.to permit(token_user, workflow_token) }
+  end
+
+  permissions :webui_trigger? do
+    it { is_expected.not_to permit(token_user, workflow_token) }
   end
 end


### PR DESCRIPTION
Right now, we don't have `token#show` and the only way to view a token is using `tokens#edit`. And we reuse the view `tokens/new` to show the token after creating a token, it is full of hidden fields and it's confusing.

This PR introduces `tokens#show` to simplify the token creation process and to have a new page to view tokens.
The token creation code is much simpler now and it's following Rails convention.