### PR TITLE
Collect artifacts created on every run worflow step

### DIFF
--- a/src/api/app/models/token/workflow.rb
+++ b/src/api/app/models/token/workflow.rb
@@ -15,7 +15,7 @@ class Token::Workflow < Token
 
     options[:workflow_run].update(response_url: @scm_webhook.payload[:api_endpoint])
     yaml_file = Workflows::YAMLDownloader.new(@scm_webhook.payload, token: self).call
-    @workflows = Workflows::YAMLToWorkflowsService.new(yaml_file: yaml_file, scm_webhook: @scm_webhook, token: self).call
+    @workflows = Workflows::YAMLToWorkflowsService.new(yaml_file: yaml_file, scm_webhook: @scm_webhook, token: self, workflow_run_id: options[:workflow_run].id).call
 
     @workflows.each(&:call) if validation_errors.none?
 

--- a/src/api/app/models/workflow.rb
+++ b/src/api/app/models/workflow.rb
@@ -10,7 +10,7 @@ class Workflow
 
   SUPPORTED_FILTERS = [:architectures, :branches, :event, :repositories].freeze
 
-  attr_accessor :workflow_instructions, :scm_webhook, :token
+  attr_accessor :workflow_instructions, :scm_webhook, :token, :workflow_run_id
 
   def initialize(attributes = {})
     super

--- a/src/api/app/models/workflow.rb
+++ b/src/api/app/models/workflow.rb
@@ -31,9 +31,14 @@ class Workflow
       restore_target_projects
     when scm_webhook.new_pull_request?, scm_webhook.updated_pull_request?, scm_webhook.push_event?, scm_webhook.tag_push_event?
       steps.each do |step|
-        step.call({ workflow_filters: filters })
+        call_step_and_collect_artifacts(step)
       end
     end
+  end
+
+  # ArtifactsCollector can only be called if the step.call doesn't return nil because of a validation error
+  def call_step_and_collect_artifacts(step)
+    step.call({ workflow_filters: filters }) && Workflows::ArtifactsCollector.new(step: step, workflow_run_id: workflow_run_id).call
   end
 
   def steps

--- a/src/api/app/models/workflow_artifacts_per_step.rb
+++ b/src/api/app/models/workflow_artifacts_per_step.rb
@@ -1,0 +1,26 @@
+# One instance of this model represents a bunch of artifacts (related to one step).
+# We chose WorkflowArtifactsPerStep name over names like WorkflowArtifact or WorkflowArtifacts
+# because it fits better semantically and follows Rails convention of being singular.
+class WorkflowArtifactsPerStep < ApplicationRecord
+  belongs_to :workflow_run, optional: false
+
+  serialize :artifacts, JSON
+
+  validates :step, :artifacts, presence: true
+end
+
+# == Schema Information
+#
+# Table name: workflow_artifacts_per_steps
+#
+#  id              :integer          not null, primary key
+#  artifacts       :text(65535)
+#  step            :string(255)
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  workflow_run_id :integer          not null, indexed
+#
+# Indexes
+#
+#  index_workflow_artifacts_per_steps_on_workflow_run_id  (workflow_run_id)
+#

--- a/src/api/app/models/workflow_run.rb
+++ b/src/api/app/models/workflow_run.rb
@@ -3,6 +3,8 @@ class WorkflowRun < ApplicationRecord
   validates :request_headers, :status, presence: true
 
   belongs_to :token, class_name: 'Token::Workflow', optional: true
+  has_many :artifacts, class_name: 'WorkflowArtifactsPerStep', dependent: :destroy
+
   paginates_per 20
 
   enum status: {

--- a/src/api/app/services/workflows/artifacts_collector.rb
+++ b/src/api/app/services/workflows/artifacts_collector.rb
@@ -1,0 +1,24 @@
+module Workflows
+  class ArtifactsCollector
+    def initialize(step:, workflow_run_id:)
+      @step = step
+      @workflow_run_id = workflow_run_id
+    end
+
+    def call
+      artifacts = case @step.class.name
+                  when 'Workflow::Step::BranchPackageStep', 'Workflow::Step::LinkPackageStep'
+                    {
+                      source_project: @step.step_instructions[:source_project],
+                      source_package: @step.step_instructions[:source_package],
+                      target_project: @step.target_project_name,
+                      target_package: @step.target_package_name
+                    }
+                  when 'Workflow::Step::RebuildPackage', 'Workflow::Step::ConfigureRepositories'
+                    @step.step_instructions
+                  end
+
+      WorkflowArtifactsPerStep.find_or_create_by(workflow_run_id: @workflow_run_id, step: @step.class.name, artifacts: artifacts.to_json)
+    end
+  end
+end

--- a/src/api/app/services/workflows/yaml_to_workflows_service.rb
+++ b/src/api/app/services/workflows/yaml_to_workflows_service.rb
@@ -1,9 +1,10 @@
 module Workflows
   class YAMLToWorkflowsService
-    def initialize(yaml_file:, scm_webhook:, token:)
+    def initialize(yaml_file:, scm_webhook:, token:, workflow_run_id:)
       @yaml_file = yaml_file
       @scm_webhook = scm_webhook
       @token = token
+      @workflow_run_id = workflow_run_id
     end
 
     def call
@@ -20,7 +21,10 @@ module Workflows
       end
 
       parsed_workflows_yaml
-        .map { |_workflow_name, workflow_instructions| Workflow.new(workflow_instructions: workflow_instructions, scm_webhook: @scm_webhook, token: @token) }
+        .map do |_workflow_name, workflow_instructions|
+        Workflow.new(workflow_instructions: workflow_instructions, scm_webhook: @scm_webhook, token: @token,
+                     workflow_run_id: @workflow_run_id)
+      end
     end
   end
 end

--- a/src/api/db/migrate/20220126155601_create_workflow_artifacts_per_steps.rb
+++ b/src/api/db/migrate/20220126155601_create_workflow_artifacts_per_steps.rb
@@ -1,0 +1,11 @@
+class CreateWorkflowArtifactsPerSteps < ActiveRecord::Migration[6.1]
+  def change
+    create_table :workflow_artifacts_per_steps, id: :integer do |t|
+      t.belongs_to :workflow_run, index: true, null: false, type: :integer
+      t.string :step
+      t.text :artifacts
+
+      t.timestamps
+    end
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_14_111900) do
+ActiveRecord::Schema.define(version: 2022_01_26_155601) do
 
   create_table "architectures", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false, collation: "utf8_general_ci"
@@ -1055,6 +1055,15 @@ ActiveRecord::Schema.define(version: 2021_12_14_111900) do
     t.integer "user_id", default: 0, null: false
     t.integer "project_id", null: false
     t.index ["user_id"], name: "watched_projects_users_fk_1"
+  end
+
+  create_table "workflow_artifacts_per_steps", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.integer "workflow_run_id", null: false
+    t.string "step"
+    t.text "artifacts"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["workflow_run_id"], name: "index_workflow_artifacts_per_steps_on_workflow_run_id"
   end
 
   create_table "workflow_runs", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|

--- a/src/api/spec/cassettes/Workflow/_steps/with_a_supported_step/1_2_1_2.yml
+++ b/src/api/spec/cassettes/Workflow/_steps/with_a_supported_step/1_2_1_2.yml
@@ -1,0 +1,793 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/home:cameron/_meta?user=cameron
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:cameron">
+          <title/>
+          <description/>
+          <person userid="cameron" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '136'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:cameron">
+          <title></title>
+          <description></description>
+          <person userid="cameron" role="maintainer"/>
+        </project>
+  recorded_at: Mon, 31 Jan 2022 18:23:58 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/test-project/_meta?user=cameron
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="test-project">
+          <title>The Cricket on the Hearth</title>
+          <description/>
+          <person userid="cameron" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '161'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="test-project">
+          <title>The Cricket on the Hearth</title>
+          <description></description>
+          <person userid="cameron" role="maintainer"/>
+        </project>
+  recorded_at: Mon, 31 Jan 2022 18:23:58 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/test-project/test-package/_meta?user=cameron
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test-package" project="test-project">
+          <title>Beneath the Bleeding</title>
+          <description>Veritatis et esse non.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '154'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test-package" project="test-project">
+          <title>Beneath the Bleeding</title>
+          <description>Veritatis et esse non.</description>
+        </package>
+  recorded_at: Mon, 31 Jan 2022 18:23:58 GMT
+- request:
+    method: post
+    uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22test-package%22%20and%20linkinfo/@project=%22test-project%22%20and%20@project=%22test-project%22)
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '27'
+    body:
+      encoding: UTF-8
+      string: |
+        <collection>
+        </collection>
+  recorded_at: Mon, 31 Jan 2022 18:23:58 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/_meta?user=cameron
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="test-project:iggy:test-project:PR-1">
+          <title>Branch project for package test-package</title>
+          <description>This project was created for package test-package via attribute OBS:Maintained</description>
+          <person userid="cameron" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '276'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="test-project:iggy:test-project:PR-1">
+          <title>Branch project for package test-package</title>
+          <description>This project was created for package test-package via attribute OBS:Maintained</description>
+          <person userid="cameron" role="maintainer"/>
+        </project>
+  recorded_at: Mon, 31 Jan 2022 18:23:58 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/test-package/_meta?user=cameron
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test-package" project="test-project:iggy:test-project:PR-1">
+          <title>Beneath the Bleeding</title>
+          <description>Veritatis et esse non.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '177'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test-package" project="test-project:iggy:test-project:PR-1">
+          <title>Beneath the Bleeding</title>
+          <description>Veritatis et esse non.</description>
+        </package>
+  recorded_at: Mon, 31 Jan 2022 18:23:59 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/test-package?cmd=branch&noservice=1&opackage=test-package&oproject=test-project&user=cameron
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="15" vrev="15">
+          <srcmd5>411c6fd260778a3381a135e5cc0c1797</srcmd5>
+          <version>unknown</version>
+          <time>1643653439</time>
+          <user>cameron</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Mon, 31 Jan 2022 18:23:59 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/test-package/_meta?user=cameron
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test-package" project="test-project:iggy:test-project:PR-1">
+          <title>Beneath the Bleeding</title>
+          <description>Veritatis et esse non.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '177'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test-package" project="test-project:iggy:test-project:PR-1">
+          <title>Beneath the Bleeding</title>
+          <description>Veritatis et esse non.</description>
+        </package>
+  recorded_at: Mon, 31 Jan 2022 18:23:59 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/test-package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '430'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test-package" rev="15" vrev="15" srcmd5="411c6fd260778a3381a135e5cc0c1797">
+          <linkinfo project="test-project" package="test-package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="6dee1c1851207b12d4c251e1946048c7" lsrcmd5="411c6fd260778a3381a135e5cc0c1797"/>
+          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1643650952"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 18:23:59 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/test-package?view=info
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '333'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourceinfo package="test-package" rev="15" vrev="15" srcmd5="6dee1c1851207b12d4c251e1946048c7" lsrcmd5="411c6fd260778a3381a135e5cc0c1797" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
+          <error>bad build configuration, no build type defined or detected</error>
+          <linked project="test-project" package="test-package"/>
+        </sourceinfo>
+  recorded_at: Mon, 31 Jan 2022 18:23:59 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/test-package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '430'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test-package" rev="15" vrev="15" srcmd5="411c6fd260778a3381a135e5cc0c1797">
+          <linkinfo project="test-project" package="test-package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="6dee1c1851207b12d4c251e1946048c7" lsrcmd5="411c6fd260778a3381a135e5cc0c1797"/>
+          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1643650952"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 18:23:59 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/test-package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '357'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="e5c4c70b498c19448585de8595326dba">
+          <old project="test-project:iggy:test-project:PR-1" package="test-package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="test-project:iggy:test-project:PR-1" package="test-package" rev="15" srcmd5="411c6fd260778a3381a135e5cc0c1797"/>
+          <files/>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Mon, 31 Jan 2022 18:23:59 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/test-package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '372'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="85da91d1d2f470e82628bc15a0f30cf0">
+          <old project="test-project" package="test-package" rev="d41d8cd98f00b204e9800998ecf8427e" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="test-project:iggy:test-project:PR-1" package="test-package" rev="6dee1c1851207b12d4c251e1946048c7" srcmd5="6dee1c1851207b12d4c251e1946048c7"/>
+          <files/>
+        </sourcediff>
+  recorded_at: Mon, 31 Jan 2022 18:23:59 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/_meta?user=cameron
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="test-project:iggy:test-project:PR-1">
+          <title>Branch project for package test-package</title>
+          <description>This project was created for package test-package via attribute OBS:Maintained</description>
+          <person userid="cameron" role="maintainer"/>
+          <publish>
+            <disable/>
+          </publish>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '316'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="test-project:iggy:test-project:PR-1">
+          <title>Branch project for package test-package</title>
+          <description>This project was created for package test-package via attribute OBS:Maintained</description>
+          <person userid="cameron" role="maintainer"/>
+          <publish>
+            <disable/>
+          </publish>
+        </project>
+  recorded_at: Mon, 31 Jan 2022 18:23:59 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/test-package/_branch_request?user=cameron
+    body:
+      encoding: UTF-8
+      string: '{"action":"opened","pull_request":{"head":{"repo":{"full_name":null},"sha":null}}}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="16" vrev="16">
+          <srcmd5>ecaed09bd00635972ad5b7008a349eef</srcmd5>
+          <version>unknown</version>
+          <time>1643653439</time>
+          <user>cameron</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Mon, 31 Jan 2022 18:23:59 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/test-package/_meta?user=cameron
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test-package" project="test-project:iggy:test-project:PR-1">
+          <title>Beneath the Bleeding</title>
+          <description>Veritatis et esse non.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '177'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test-package" project="test-project:iggy:test-project:PR-1">
+          <title>Beneath the Bleeding</title>
+          <description>Veritatis et esse non.</description>
+        </package>
+  recorded_at: Mon, 31 Jan 2022 18:23:59 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/test-package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '532'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test-package" rev="16" vrev="16" srcmd5="ecaed09bd00635972ad5b7008a349eef">
+          <linkinfo project="test-project" package="test-package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="3f2794130d6c60ddbfc7b7caa9ff69c6" lsrcmd5="ecaed09bd00635972ad5b7008a349eef"/>
+          <entry name="_branch_request" md5="5d8aefeee8f093120d1d26f3aeebbdfb" size="82" mtime="1643650998"/>
+          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1643650952"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 18:23:59 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/test-package?view=info
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '333'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourceinfo package="test-package" rev="16" vrev="16" srcmd5="3f2794130d6c60ddbfc7b7caa9ff69c6" lsrcmd5="ecaed09bd00635972ad5b7008a349eef" verifymd5="f069616f8884480463bb7cde6d9c83cc">
+          <error>bad build configuration, no build type defined or detected</error>
+          <linked project="test-project" package="test-package"/>
+        </sourceinfo>
+  recorded_at: Mon, 31 Jan 2022 18:23:59 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/test-package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '532'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test-package" rev="16" vrev="16" srcmd5="ecaed09bd00635972ad5b7008a349eef">
+          <linkinfo project="test-project" package="test-package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="3f2794130d6c60ddbfc7b7caa9ff69c6" lsrcmd5="ecaed09bd00635972ad5b7008a349eef"/>
+          <entry name="_branch_request" md5="5d8aefeee8f093120d1d26f3aeebbdfb" size="82" mtime="1643650998"/>
+          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1643650952"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 18:23:59 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/test-package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '357'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="11b66ac7037517046421ab713c8a29f2">
+          <old project="test-project:iggy:test-project:PR-1" package="test-package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="test-project:iggy:test-project:PR-1" package="test-package" rev="16" srcmd5="ecaed09bd00635972ad5b7008a349eef"/>
+          <files/>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Mon, 31 Jan 2022 18:23:59 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/test-package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '395'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="343af923fc271646ff558432f11d0cf7">
+          <old project="test-project" package="test-package" rev="d41d8cd98f00b204e9800998ecf8427e" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="test-project:iggy:test-project:PR-1" package="test-package" rev="3f2794130d6c60ddbfc7b7caa9ff69c6" srcmd5="3f2794130d6c60ddbfc7b7caa9ff69c6"/>
+          <files/>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Mon, 31 Jan 2022 18:23:59 GMT
+recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow/_steps/with_no_steps_specified/1_2_4_2.yml
+++ b/src/api/spec/cassettes/Workflow/_steps/with_no_steps_specified/1_2_4_2.yml
@@ -1,0 +1,43 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/home:cameron/_meta?user=cameron
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:cameron">
+          <title/>
+          <description/>
+          <person userid="cameron" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '136'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:cameron">
+          <title></title>
+          <description></description>
+          <person userid="cameron" role="maintainer"/>
+        </project>
+  recorded_at: Mon, 31 Jan 2022 18:23:21 GMT
+recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow/_steps/with_one_unsupported_step/1_2_3_2.yml
+++ b/src/api/spec/cassettes/Workflow/_steps/with_one_unsupported_step/1_2_3_2.yml
@@ -1,0 +1,793 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/home:cameron/_meta?user=cameron
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:cameron">
+          <title/>
+          <description/>
+          <person userid="cameron" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '136'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:cameron">
+          <title></title>
+          <description></description>
+          <person userid="cameron" role="maintainer"/>
+        </project>
+  recorded_at: Mon, 31 Jan 2022 18:23:34 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/test-project/_meta?user=cameron
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="test-project">
+          <title>Taming a Sea Horse</title>
+          <description/>
+          <person userid="cameron" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '154'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="test-project">
+          <title>Taming a Sea Horse</title>
+          <description></description>
+          <person userid="cameron" role="maintainer"/>
+        </project>
+  recorded_at: Mon, 31 Jan 2022 18:23:34 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/test-project/test-package/_meta?user=cameron
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test-package" project="test-project">
+          <title>The Cricket on the Hearth</title>
+          <description>Consectetur ut voluptas at.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '164'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test-package" project="test-project">
+          <title>The Cricket on the Hearth</title>
+          <description>Consectetur ut voluptas at.</description>
+        </package>
+  recorded_at: Mon, 31 Jan 2022 18:23:34 GMT
+- request:
+    method: post
+    uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22test-package%22%20and%20linkinfo/@project=%22test-project%22%20and%20@project=%22test-project%22)
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '27'
+    body:
+      encoding: UTF-8
+      string: |
+        <collection>
+        </collection>
+  recorded_at: Mon, 31 Jan 2022 18:23:34 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/_meta?user=cameron
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="test-project:iggy:test-project:PR-1">
+          <title>Branch project for package test-package</title>
+          <description>This project was created for package test-package via attribute OBS:Maintained</description>
+          <person userid="cameron" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '276'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="test-project:iggy:test-project:PR-1">
+          <title>Branch project for package test-package</title>
+          <description>This project was created for package test-package via attribute OBS:Maintained</description>
+          <person userid="cameron" role="maintainer"/>
+        </project>
+  recorded_at: Mon, 31 Jan 2022 18:23:34 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/test-package/_meta?user=cameron
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test-package" project="test-project:iggy:test-project:PR-1">
+          <title>The Cricket on the Hearth</title>
+          <description>Consectetur ut voluptas at.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '187'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test-package" project="test-project:iggy:test-project:PR-1">
+          <title>The Cricket on the Hearth</title>
+          <description>Consectetur ut voluptas at.</description>
+        </package>
+  recorded_at: Mon, 31 Jan 2022 18:23:34 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/test-package?cmd=branch&noservice=1&opackage=test-package&oproject=test-project&user=cameron
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="11" vrev="11">
+          <srcmd5>411c6fd260778a3381a135e5cc0c1797</srcmd5>
+          <version>unknown</version>
+          <time>1643653414</time>
+          <user>cameron</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Mon, 31 Jan 2022 18:23:34 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/test-package/_meta?user=cameron
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test-package" project="test-project:iggy:test-project:PR-1">
+          <title>The Cricket on the Hearth</title>
+          <description>Consectetur ut voluptas at.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '187'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test-package" project="test-project:iggy:test-project:PR-1">
+          <title>The Cricket on the Hearth</title>
+          <description>Consectetur ut voluptas at.</description>
+        </package>
+  recorded_at: Mon, 31 Jan 2022 18:23:34 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/test-package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '430'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test-package" rev="11" vrev="11" srcmd5="411c6fd260778a3381a135e5cc0c1797">
+          <linkinfo project="test-project" package="test-package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="6dee1c1851207b12d4c251e1946048c7" lsrcmd5="411c6fd260778a3381a135e5cc0c1797"/>
+          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1643650952"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 18:23:34 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/test-package?view=info
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '333'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourceinfo package="test-package" rev="11" vrev="11" srcmd5="6dee1c1851207b12d4c251e1946048c7" lsrcmd5="411c6fd260778a3381a135e5cc0c1797" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
+          <error>bad build configuration, no build type defined or detected</error>
+          <linked project="test-project" package="test-package"/>
+        </sourceinfo>
+  recorded_at: Mon, 31 Jan 2022 18:23:34 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/test-package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '430'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test-package" rev="11" vrev="11" srcmd5="411c6fd260778a3381a135e5cc0c1797">
+          <linkinfo project="test-project" package="test-package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="6dee1c1851207b12d4c251e1946048c7" lsrcmd5="411c6fd260778a3381a135e5cc0c1797"/>
+          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1643650952"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 18:23:34 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/test-package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '357'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="1b2235e6b3831eb0acf43abf9faba6d8">
+          <old project="test-project:iggy:test-project:PR-1" package="test-package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="test-project:iggy:test-project:PR-1" package="test-package" rev="11" srcmd5="411c6fd260778a3381a135e5cc0c1797"/>
+          <files/>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Mon, 31 Jan 2022 18:23:34 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/test-package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '372'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="85da91d1d2f470e82628bc15a0f30cf0">
+          <old project="test-project" package="test-package" rev="d41d8cd98f00b204e9800998ecf8427e" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="test-project:iggy:test-project:PR-1" package="test-package" rev="6dee1c1851207b12d4c251e1946048c7" srcmd5="6dee1c1851207b12d4c251e1946048c7"/>
+          <files/>
+        </sourcediff>
+  recorded_at: Mon, 31 Jan 2022 18:23:34 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/_meta?user=cameron
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="test-project:iggy:test-project:PR-1">
+          <title>Branch project for package test-package</title>
+          <description>This project was created for package test-package via attribute OBS:Maintained</description>
+          <person userid="cameron" role="maintainer"/>
+          <publish>
+            <disable/>
+          </publish>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '316'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="test-project:iggy:test-project:PR-1">
+          <title>Branch project for package test-package</title>
+          <description>This project was created for package test-package via attribute OBS:Maintained</description>
+          <person userid="cameron" role="maintainer"/>
+          <publish>
+            <disable/>
+          </publish>
+        </project>
+  recorded_at: Mon, 31 Jan 2022 18:23:34 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/test-package/_branch_request?user=cameron
+    body:
+      encoding: UTF-8
+      string: '{"action":"opened","pull_request":{"head":{"repo":{"full_name":null},"sha":null}}}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="12" vrev="12">
+          <srcmd5>ecaed09bd00635972ad5b7008a349eef</srcmd5>
+          <version>unknown</version>
+          <time>1643653415</time>
+          <user>cameron</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Mon, 31 Jan 2022 18:23:35 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/test-package/_meta?user=cameron
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test-package" project="test-project:iggy:test-project:PR-1">
+          <title>The Cricket on the Hearth</title>
+          <description>Consectetur ut voluptas at.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '187'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test-package" project="test-project:iggy:test-project:PR-1">
+          <title>The Cricket on the Hearth</title>
+          <description>Consectetur ut voluptas at.</description>
+        </package>
+  recorded_at: Mon, 31 Jan 2022 18:23:35 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/test-package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '532'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test-package" rev="12" vrev="12" srcmd5="ecaed09bd00635972ad5b7008a349eef">
+          <linkinfo project="test-project" package="test-package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="3f2794130d6c60ddbfc7b7caa9ff69c6" lsrcmd5="ecaed09bd00635972ad5b7008a349eef"/>
+          <entry name="_branch_request" md5="5d8aefeee8f093120d1d26f3aeebbdfb" size="82" mtime="1643650998"/>
+          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1643650952"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 18:23:35 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/test-package?view=info
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '333'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourceinfo package="test-package" rev="12" vrev="12" srcmd5="3f2794130d6c60ddbfc7b7caa9ff69c6" lsrcmd5="ecaed09bd00635972ad5b7008a349eef" verifymd5="f069616f8884480463bb7cde6d9c83cc">
+          <error>bad build configuration, no build type defined or detected</error>
+          <linked project="test-project" package="test-package"/>
+        </sourceinfo>
+  recorded_at: Mon, 31 Jan 2022 18:23:35 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/test-package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '532'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test-package" rev="12" vrev="12" srcmd5="ecaed09bd00635972ad5b7008a349eef">
+          <linkinfo project="test-project" package="test-package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="3f2794130d6c60ddbfc7b7caa9ff69c6" lsrcmd5="ecaed09bd00635972ad5b7008a349eef"/>
+          <entry name="_branch_request" md5="5d8aefeee8f093120d1d26f3aeebbdfb" size="82" mtime="1643650998"/>
+          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1643650952"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 18:23:35 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/test-package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '357'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="47bbedb1aba42ae5d42034c20fbfba6c">
+          <old project="test-project:iggy:test-project:PR-1" package="test-package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="test-project:iggy:test-project:PR-1" package="test-package" rev="12" srcmd5="ecaed09bd00635972ad5b7008a349eef"/>
+          <files/>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Mon, 31 Jan 2022 18:23:35 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/test-package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '395'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="343af923fc271646ff558432f11d0cf7">
+          <old project="test-project" package="test-package" rev="d41d8cd98f00b204e9800998ecf8427e" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="test-project:iggy:test-project:PR-1" package="test-package" rev="3f2794130d6c60ddbfc7b7caa9ff69c6" srcmd5="3f2794130d6c60ddbfc7b7caa9ff69c6"/>
+          <files/>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Mon, 31 Jan 2022 18:23:35 GMT
+recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow/_steps/with_several_supported_steps/creates_no_artifacts_because_an_exception_is_raised.yml
+++ b/src/api/spec/cassettes/Workflow/_steps/with_several_supported_steps/creates_no_artifacts_because_an_exception_is_raised.yml
@@ -1,0 +1,827 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/home:cameron/_meta?user=cameron
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:cameron">
+          <title/>
+          <description/>
+          <person userid="cameron" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '136'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:cameron">
+          <title></title>
+          <description></description>
+          <person userid="cameron" role="maintainer"/>
+        </project>
+  recorded_at: Mon, 31 Jan 2022 18:23:45 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/test-project/_meta?user=cameron
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="test-project">
+          <title>I Know Why the Caged Bird Sings</title>
+          <description/>
+          <person userid="cameron" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '167'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="test-project">
+          <title>I Know Why the Caged Bird Sings</title>
+          <description></description>
+          <person userid="cameron" role="maintainer"/>
+        </project>
+  recorded_at: Mon, 31 Jan 2022 18:23:45 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/test-project/test-package/_meta?user=cameron
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test-package" project="test-project">
+          <title>Time To Murder And Create</title>
+          <description>Consequuntur in mollitia ut.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '165'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test-package" project="test-project">
+          <title>Time To Murder And Create</title>
+          <description>Consequuntur in mollitia ut.</description>
+        </package>
+  recorded_at: Mon, 31 Jan 2022 18:23:45 GMT
+- request:
+    method: post
+    uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22test-package%22%20and%20linkinfo/@project=%22test-project%22%20and%20@project=%22test-project%22)
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '27'
+    body:
+      encoding: UTF-8
+      string: |
+        <collection>
+        </collection>
+  recorded_at: Mon, 31 Jan 2022 18:23:46 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/_meta?user=cameron
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="test-project:iggy:test-project:PR-1">
+          <title>Branch project for package test-package</title>
+          <description>This project was created for package test-package via attribute OBS:Maintained</description>
+          <person userid="cameron" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '276'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="test-project:iggy:test-project:PR-1">
+          <title>Branch project for package test-package</title>
+          <description>This project was created for package test-package via attribute OBS:Maintained</description>
+          <person userid="cameron" role="maintainer"/>
+        </project>
+  recorded_at: Mon, 31 Jan 2022 18:23:46 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/test-package/_meta?user=cameron
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test-package" project="test-project:iggy:test-project:PR-1">
+          <title>Time To Murder And Create</title>
+          <description>Consequuntur in mollitia ut.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '188'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test-package" project="test-project:iggy:test-project:PR-1">
+          <title>Time To Murder And Create</title>
+          <description>Consequuntur in mollitia ut.</description>
+        </package>
+  recorded_at: Mon, 31 Jan 2022 18:23:46 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/test-package?cmd=branch&noservice=1&opackage=test-package&oproject=test-project&user=cameron
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="13" vrev="13">
+          <srcmd5>411c6fd260778a3381a135e5cc0c1797</srcmd5>
+          <version>unknown</version>
+          <time>1643653426</time>
+          <user>cameron</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Mon, 31 Jan 2022 18:23:46 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/test-package/_meta?user=cameron
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test-package" project="test-project:iggy:test-project:PR-1">
+          <title>Time To Murder And Create</title>
+          <description>Consequuntur in mollitia ut.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '188'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test-package" project="test-project:iggy:test-project:PR-1">
+          <title>Time To Murder And Create</title>
+          <description>Consequuntur in mollitia ut.</description>
+        </package>
+  recorded_at: Mon, 31 Jan 2022 18:23:46 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/test-package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '430'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test-package" rev="13" vrev="13" srcmd5="411c6fd260778a3381a135e5cc0c1797">
+          <linkinfo project="test-project" package="test-package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="6dee1c1851207b12d4c251e1946048c7" lsrcmd5="411c6fd260778a3381a135e5cc0c1797"/>
+          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1643650952"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 18:23:46 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/test-package?view=info
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '333'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourceinfo package="test-package" rev="13" vrev="13" srcmd5="6dee1c1851207b12d4c251e1946048c7" lsrcmd5="411c6fd260778a3381a135e5cc0c1797" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
+          <error>bad build configuration, no build type defined or detected</error>
+          <linked project="test-project" package="test-package"/>
+        </sourceinfo>
+  recorded_at: Mon, 31 Jan 2022 18:23:46 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/test-package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '430'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test-package" rev="13" vrev="13" srcmd5="411c6fd260778a3381a135e5cc0c1797">
+          <linkinfo project="test-project" package="test-package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="6dee1c1851207b12d4c251e1946048c7" lsrcmd5="411c6fd260778a3381a135e5cc0c1797"/>
+          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1643650952"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 18:23:46 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/test-package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '357'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="a9f229a7d5fb285b6939f7cd886b6ac4">
+          <old project="test-project:iggy:test-project:PR-1" package="test-package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="test-project:iggy:test-project:PR-1" package="test-package" rev="13" srcmd5="411c6fd260778a3381a135e5cc0c1797"/>
+          <files/>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Mon, 31 Jan 2022 18:23:46 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/test-package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '372'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="85da91d1d2f470e82628bc15a0f30cf0">
+          <old project="test-project" package="test-package" rev="d41d8cd98f00b204e9800998ecf8427e" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="test-project:iggy:test-project:PR-1" package="test-package" rev="6dee1c1851207b12d4c251e1946048c7" srcmd5="6dee1c1851207b12d4c251e1946048c7"/>
+          <files/>
+        </sourcediff>
+  recorded_at: Mon, 31 Jan 2022 18:23:46 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/_meta?user=cameron
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="test-project:iggy:test-project:PR-1">
+          <title>Branch project for package test-package</title>
+          <description>This project was created for package test-package via attribute OBS:Maintained</description>
+          <person userid="cameron" role="maintainer"/>
+          <publish>
+            <disable/>
+          </publish>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '316'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="test-project:iggy:test-project:PR-1">
+          <title>Branch project for package test-package</title>
+          <description>This project was created for package test-package via attribute OBS:Maintained</description>
+          <person userid="cameron" role="maintainer"/>
+          <publish>
+            <disable/>
+          </publish>
+        </project>
+  recorded_at: Mon, 31 Jan 2022 18:23:46 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/test-package/_branch_request?user=cameron
+    body:
+      encoding: UTF-8
+      string: '{"action":"opened","pull_request":{"head":{"repo":{"full_name":null},"sha":null}}}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="14" vrev="14">
+          <srcmd5>ecaed09bd00635972ad5b7008a349eef</srcmd5>
+          <version>unknown</version>
+          <time>1643653426</time>
+          <user>cameron</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Mon, 31 Jan 2022 18:23:46 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/test-package/_meta?user=cameron
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test-package" project="test-project:iggy:test-project:PR-1">
+          <title>Time To Murder And Create</title>
+          <description>Consequuntur in mollitia ut.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '188'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test-package" project="test-project:iggy:test-project:PR-1">
+          <title>Time To Murder And Create</title>
+          <description>Consequuntur in mollitia ut.</description>
+        </package>
+  recorded_at: Mon, 31 Jan 2022 18:23:46 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/test-package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '532'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test-package" rev="14" vrev="14" srcmd5="ecaed09bd00635972ad5b7008a349eef">
+          <linkinfo project="test-project" package="test-package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="3f2794130d6c60ddbfc7b7caa9ff69c6" lsrcmd5="ecaed09bd00635972ad5b7008a349eef"/>
+          <entry name="_branch_request" md5="5d8aefeee8f093120d1d26f3aeebbdfb" size="82" mtime="1643650998"/>
+          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1643650952"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 18:23:46 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/test-package?view=info
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '333'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourceinfo package="test-package" rev="14" vrev="14" srcmd5="3f2794130d6c60ddbfc7b7caa9ff69c6" lsrcmd5="ecaed09bd00635972ad5b7008a349eef" verifymd5="f069616f8884480463bb7cde6d9c83cc">
+          <error>bad build configuration, no build type defined or detected</error>
+          <linked project="test-project" package="test-package"/>
+        </sourceinfo>
+  recorded_at: Mon, 31 Jan 2022 18:23:46 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/test-package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '532'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test-package" rev="14" vrev="14" srcmd5="ecaed09bd00635972ad5b7008a349eef">
+          <linkinfo project="test-project" package="test-package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="3f2794130d6c60ddbfc7b7caa9ff69c6" lsrcmd5="ecaed09bd00635972ad5b7008a349eef"/>
+          <entry name="_branch_request" md5="5d8aefeee8f093120d1d26f3aeebbdfb" size="82" mtime="1643650998"/>
+          <entry name="_link" md5="7ab3a1829b804e8f1739b15e9d7904a7" size="120" mtime="1643650952"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 18:23:46 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/test-package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '357'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="a98d5a440a7b8d48bb64acb3f6fd23ba">
+          <old project="test-project:iggy:test-project:PR-1" package="test-package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="test-project:iggy:test-project:PR-1" package="test-package" rev="14" srcmd5="ecaed09bd00635972ad5b7008a349eef"/>
+          <files/>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Mon, 31 Jan 2022 18:23:46 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/test-project:iggy:test-project:PR-1/test-package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '395'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="343af923fc271646ff558432f11d0cf7">
+          <old project="test-project" package="test-package" rev="d41d8cd98f00b204e9800998ecf8427e" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="test-project:iggy:test-project:PR-1" package="test-package" rev="3f2794130d6c60ddbfc7b7caa9ff69c6" srcmd5="3f2794130d6c60ddbfc7b7caa9ff69c6"/>
+          <files/>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Mon, 31 Jan 2022 18:23:46 GMT
+- request:
+    method: post
+    uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22test-package%22%20and%20linkinfo/@project=%22test-project%22%20and%20@project=%22test-project%22)
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '27'
+    body:
+      encoding: UTF-8
+      string: |
+        <collection>
+        </collection>
+  recorded_at: Mon, 31 Jan 2022 18:23:46 GMT
+recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow/_steps/with_step_with_invalid_intructions/1_2_5_2.yml
+++ b/src/api/spec/cassettes/Workflow/_steps/with_step_with_invalid_intructions/1_2_5_2.yml
@@ -1,0 +1,121 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/home:cameron/_meta?user=cameron
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:cameron">
+          <title/>
+          <description/>
+          <person userid="cameron" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '136'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:cameron">
+          <title></title>
+          <description></description>
+          <person userid="cameron" role="maintainer"/>
+        </project>
+  recorded_at: Mon, 31 Jan 2022 18:23:09 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/test-project/_meta?user=cameron
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="test-project">
+          <title>Oh! To be in England</title>
+          <description/>
+          <person userid="cameron" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '156'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="test-project">
+          <title>Oh! To be in England</title>
+          <description></description>
+          <person userid="cameron" role="maintainer"/>
+        </project>
+  recorded_at: Mon, 31 Jan 2022 18:23:09 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/test-project/test-package/_meta?user=cameron
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test-package" project="test-project">
+          <title>The Heart Is Deceitful Above All Things</title>
+          <description>Optio quo sed cupiditate.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '176'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test-package" project="test-project">
+          <title>The Heart Is Deceitful Above All Things</title>
+          <description>Optio quo sed cupiditate.</description>
+        </package>
+  recorded_at: Mon, 31 Jan 2022 18:23:09 GMT
+recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow/_steps/with_step_with_invalid_project_name/1_2_6_2.yml
+++ b/src/api/spec/cassettes/Workflow/_steps/with_step_with_invalid_project_name/1_2_6_2.yml
@@ -1,0 +1,121 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/home:cameron/_meta?user=cameron
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:cameron">
+          <title/>
+          <description/>
+          <person userid="cameron" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '136'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:cameron">
+          <title></title>
+          <description></description>
+          <person userid="cameron" role="maintainer"/>
+        </project>
+  recorded_at: Mon, 31 Jan 2022 18:22:51 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/test-project/_meta?user=cameron
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="test-project">
+          <title>Ah, Wilderness!</title>
+          <description/>
+          <person userid="cameron" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '151'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="test-project">
+          <title>Ah, Wilderness!</title>
+          <description></description>
+          <person userid="cameron" role="maintainer"/>
+        </project>
+  recorded_at: Mon, 31 Jan 2022 18:22:52 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/test-project/test-package/_meta?user=cameron
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test-package" project="test-project">
+          <title>Of Mice and Men</title>
+          <description>Aut sunt porro esse.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '147'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test-package" project="test-project">
+          <title>Of Mice and Men</title>
+          <description>Aut sunt porro esse.</description>
+        </package>
+  recorded_at: Mon, 31 Jan 2022 18:22:52 GMT
+recorded_with: VCR 6.0.0

--- a/src/api/spec/models/token/workflow_spec.rb
+++ b/src/api/spec/models/token/workflow_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Token::Workflow do
       let(:scm_webhook) { ScmWebhook.new(payload: github_extractor_payload) }
       let(:yaml_downloader) { Workflows::YAMLDownloader.new(scm_webhook.payload, token: workflow_token) }
       let(:yaml_file) { File.expand_path(Rails.root.join('spec/support/files/workflows.yml')) }
-      let(:yaml_to_workflows_service) { Workflows::YAMLToWorkflowsService.new(yaml_file: yaml_file, scm_webhook: scm_webhook, token: workflow_token) }
+      let(:yaml_to_workflows_service) { Workflows::YAMLToWorkflowsService.new(yaml_file: yaml_file, scm_webhook: scm_webhook, token: workflow_token, workflow_run_id: workflow_run.id) }
       let(:workflow) do
         Workflow.new(scm_webhook: scm_webhook, token: workflow_token,
                      workflow_instructions: { steps: [branch_package: { source_project: 'home:Admin', source_package: 'ctris', target_project: 'dev:tools' }] })
@@ -69,7 +69,8 @@ RSpec.describe Token::Workflow do
         allow(scm_extractor).to receive(:call).and_return(scm_webhook)
         allow(Workflows::YAMLDownloader).to receive(:new).with(scm_webhook.payload, token: workflow_token).and_return(yaml_downloader)
         allow(yaml_downloader).to receive(:call).and_return(yaml_file)
-        allow(Workflows::YAMLToWorkflowsService).to receive(:new).with(yaml_file: yaml_file, scm_webhook: scm_webhook, token: workflow_token).and_return(yaml_to_workflows_service)
+        allow(Workflows::YAMLToWorkflowsService).to receive(:new).with(yaml_file: yaml_file, scm_webhook: scm_webhook, token: workflow_token,
+                                                                       workflow_run_id: workflow_run.id).and_return(yaml_to_workflows_service)
         allow(yaml_to_workflows_service).to receive(:call).and_return(workflows)
       end
 
@@ -114,7 +115,7 @@ RSpec.describe Token::Workflow do
       let(:scm_webhook) { ScmWebhook.new(payload: github_extractor_payload) }
       let(:yaml_downloader) { Workflows::YAMLDownloader.new(scm_webhook.payload, token: workflow_token) }
       let(:yaml_file) { File.expand_path(Rails.root.join('spec/support/files/workflows.yml')) }
-      let(:yaml_to_workflows_service) { Workflows::YAMLToWorkflowsService.new(yaml_file: yaml_file, scm_webhook: scm_webhook, token: workflow_token) }
+      let(:yaml_to_workflows_service) { Workflows::YAMLToWorkflowsService.new(yaml_file: yaml_file, scm_webhook: scm_webhook, token: workflow_token, workflow_run_id: workflow_run.id) }
       let(:workflows) { [Workflow.new(scm_webhook: scm_webhook, token: workflow_token, workflow_instructions: {})] }
 
       before do
@@ -122,7 +123,8 @@ RSpec.describe Token::Workflow do
         allow(scm_extractor).to receive(:call).and_return(scm_webhook)
         allow(Workflows::YAMLDownloader).to receive(:new).with(scm_webhook.payload, token: workflow_token).and_return(yaml_downloader)
         allow(yaml_downloader).to receive(:call).and_return(yaml_file)
-        allow(Workflows::YAMLToWorkflowsService).to receive(:new).with(yaml_file: yaml_file, scm_webhook: scm_webhook, token: workflow_token).and_return(yaml_to_workflows_service)
+        allow(Workflows::YAMLToWorkflowsService).to receive(:new).with(yaml_file: yaml_file, scm_webhook: scm_webhook, token: workflow_token,
+                                                                       workflow_run_id: workflow_run.id).and_return(yaml_to_workflows_service)
         allow(yaml_to_workflows_service).to receive(:call).and_return(workflows)
       end
 

--- a/src/api/spec/models/workflow_artifacts_per_step_spec.rb
+++ b/src/api/spec/models/workflow_artifacts_per_step_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe WorkflowArtifactsPerStep, type: :model do
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:step) }
+    it { is_expected.to validate_presence_of(:artifacts) }
+  end
+end

--- a/src/api/spec/models/workflow_spec.rb
+++ b/src/api/spec/models/workflow_spec.rb
@@ -2,10 +2,11 @@ require 'rails_helper'
 
 RSpec.describe Workflow, type: :model do
   let(:user) { create(:confirmed_user, :with_home, login: 'cameron') }
-  let!(:token) { create(:workflow_token, user: user) }
+  let(:token) { create(:workflow_token, user: user) }
+  let!(:workflow_run) { create(:workflow_run, token: token) }
 
   subject do
-    described_class.new(workflow_instructions: yaml, scm_webhook: ScmWebhook.new(payload: extractor_payload), token: token)
+    described_class.new(workflow_instructions: yaml, scm_webhook: ScmWebhook.new(payload: extractor_payload), token: token, workflow_run_id: workflow_run.id)
   end
 
   describe '#call' do

--- a/src/api/spec/models/workflow_spec.rb
+++ b/src/api/spec/models/workflow_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Workflow, type: :model do
+RSpec.describe Workflow, type: :model, vcr: true do
   let(:user) { create(:confirmed_user, :with_home, login: 'cameron') }
   let(:token) { create(:workflow_token, user: user) }
   let!(:workflow_run) { create(:workflow_run, token: token) }
@@ -297,47 +297,69 @@ RSpec.describe Workflow, type: :model do
   end
 
   describe '#steps' do
+    let(:project) { create(:project, name: 'test-project', maintainer: user) }
+    let(:package) { create(:package, name: 'test-package', project: project) }
     let(:extractor_payload) do
       {
         scm: 'github',
         action: 'opened',
-        event: 'pull_request'
+        event: 'pull_request',
+        pr_number: 1,
+        target_repository_full_name: 'iggy/test-project'
       }
+    end
+
+    before do
+      login user
     end
 
     context 'with a supported step' do
       let(:yaml) do
-        { 'steps' => [{ 'branch_package' => { 'source_project' => 'test-project', 'source_package' => 'test-package' } }] }
+        { 'steps' => [{ branch_package: { source_project: project.name, source_package: package.name, target_project: project.name } }] }
       end
 
       it 'initializes the supported step objects' do
         expect(subject.steps.first).to be_a(Workflow::Step::BranchPackageStep)
       end
+
+      # This example requires VCR
+      it { expect { subject.call }.to change(WorkflowArtifactsPerStep, :count).by(1) }
     end
 
     context 'with several supported steps' do
       let(:yaml) do
-        { 'steps' => [{ 'branch_package' => { source_project: 'project',
-                                              source_package: 'package' } },
-                      { 'branch_package' => { source_project: 'project',
-                                              source_package: 'package' } }] }
+        { 'steps' => [{ 'branch_package' => { source_project: project.name,
+                                              source_package: package.name,
+                                              target_project: project.name } },
+                      { 'branch_package' => { source_project: project.name,
+                                              source_package: package.name,
+                                              target_project: project.name } }] }
       end
 
       it 'returns an array with two items' do
         expect(subject.steps.count).to be 2
+      end
+
+      # This example requires VCR
+      it 'creates no artifacts because an exception is raised' do
+        expect { subject.call }.to raise_error BranchPackage::Errors::DoubleBranchPackageError
       end
     end
 
     context 'with one unsupported step' do
       let(:yaml) do
         { 'steps' => [{ 'unsupported_step' => {} },
-                      { 'branch_package' => { source_project: 'project',
-                                              source_package: 'package' } }] }
+                      { 'branch_package' => { source_project: project.name,
+                                              source_package: package.name,
+                                              target_project: project.name } }] }
       end
 
       it 'returns an array with only one item' do
         expect(subject.steps.count).to be 1
       end
+
+      # This example requires VCR
+      it { expect { subject.call }.to change(WorkflowArtifactsPerStep, :count).by(1) }
     end
 
     context 'with no steps specified' do
@@ -348,6 +370,37 @@ RSpec.describe Workflow, type: :model do
       it 'returns an empty array' do
         expect(subject.steps).to be_empty
       end
+
+      # This example requires VCR
+      it { expect { subject.call }.to change(WorkflowArtifactsPerStep, :count).by(0) }
+    end
+
+    context 'with step with invalid intructions' do
+      let(:yaml) do
+        { 'steps' => [{ branch_package: { source_package: package.name, target_project: project.name } }] }
+      end
+
+      it 'initializes the supported step objects' do
+        expect(subject.steps.first).to be_a(Workflow::Step::BranchPackageStep)
+      end
+
+      # This example requires VCR
+      it { expect { subject.call }.to change(WorkflowArtifactsPerStep, :count).by(0) }
+    end
+
+    context 'with step with invalid project name' do
+      let(:yaml) do
+        { 'steps' => [{ 'branch_package' => { source_project: '0', # invalid project name
+                                              source_package: package.name,
+                                              target_project: project.name } }] }
+      end
+
+      it 'initializes the supported step objects' do
+        expect(subject.steps.first).to be_a(Workflow::Step::BranchPackageStep)
+      end
+
+      # This example requires VCR
+      it { expect { subject.call }.to change(WorkflowArtifactsPerStep, :count).by(0) }
     end
   end
 

--- a/src/api/spec/services/workflows/artifacts_collector_spec.rb
+++ b/src/api/spec/services/workflows/artifacts_collector_spec.rb
@@ -1,0 +1,330 @@
+require 'rails_helper'
+
+RSpec.describe Workflows::ArtifactsCollector, type: :service do
+  let(:user) { create(:confirmed_user) }
+  let(:token) { create(:workflow_token, user: user) }
+  let(:workflow_run) { create(:workflow_run, token: token) }
+
+  subject { described_class.new(workflow_run_id: workflow_run.id, step: step) }
+
+  describe '#call' do
+    context 'for a branch_package step' do
+      let(:step) do
+        Workflow::Step::BranchPackageStep.new(step_instructions: step_instructions,
+                                              scm_webhook: scm_webhook,
+                                              token: token)
+      end
+
+      let(:step_instructions) do
+        {
+          source_project: 'home:Iggy',
+          source_package: 'hello_world',
+          target_project: 'home:Iggy:sandbox'
+        }
+      end
+
+      context 'and pull_request event' do
+        let(:scm_webhook) do
+          ScmWebhook.new(payload: {
+                           scm: 'github',
+                           event: 'pull_request',
+                           pr_number: 1,
+                           target_branch: 'master',
+                           action: 'opened',
+                           source_repository_full_name: 'iggy/hello_world',
+                           target_repository_full_name: 'iggy/hello_world'
+                         })
+        end
+
+        let(:artifacts) do
+          {
+            source_project: step_instructions[:source_project],
+            source_package: step_instructions[:source_package],
+            target_project: 'home:Iggy:sandbox:iggy:hello_world:PR-1',
+            target_package: step_instructions[:source_package]
+          }
+        end
+
+        it { expect { subject.call }.to change(WorkflowArtifactsPerStep, :count).by(1) }
+
+        it do
+          subject.call
+          expect(WorkflowArtifactsPerStep.last.artifacts).to eq(artifacts.to_json)
+          expect(WorkflowArtifactsPerStep.last.step).to eq('Workflow::Step::BranchPackageStep')
+        end
+      end
+
+      context 'and push for commit event' do
+        let(:scm_webhook) do
+          ScmWebhook.new(payload: {
+                           scm: 'github',
+                           event: 'push',
+                           target_branch: 'main',
+                           source_repository_full_name: 'iggy/hello_world',
+                           commit_sha: '2a6b530bcdf7a54d881c62333c9f13b6ce16f3fc',
+                           target_repository_full_name: 'iggy/hello_world',
+                           ref: 'refs/heads/branch_123'
+                         })
+        end
+
+        let(:artifacts) do
+          {
+            source_project: step_instructions[:source_project],
+            source_package: step_instructions[:source_package],
+            target_project: step_instructions[:target_project],
+            target_package: 'hello_world-2a6b530bcdf7a54d881c62333c9f13b6ce16f3fc'
+          }
+        end
+
+        it { expect { subject.call }.to change(WorkflowArtifactsPerStep, :count).by(1) }
+
+        it do
+          subject.call
+          expect(WorkflowArtifactsPerStep.last.artifacts).to eq(artifacts.to_json)
+          expect(WorkflowArtifactsPerStep.last.step).to eq('Workflow::Step::BranchPackageStep')
+        end
+      end
+
+      context 'and push for tag event' do
+        let(:scm_webhook) do
+          ScmWebhook.new(payload: {
+                           scm: 'github',
+                           event: 'push',
+                           target_branch: 'main',
+                           source_repository_full_name: 'iggy/hello_world',
+                           commit_sha: '2a6b530bcdf7a54d881c62333c9f13b6ce16f3fc',
+                           target_repository_full_name: 'iggy/hello_world',
+                           tag_name: 'release_abc',
+                           ref: 'refs/tags/release_abc'
+                         })
+        end
+
+        let(:artifacts) do
+          {
+            source_project: step_instructions[:source_project],
+            source_package: step_instructions[:source_package],
+            target_project: step_instructions[:target_project],
+            target_package: 'hello_world-release_abc'
+          }
+        end
+
+        it { expect { subject.call }.to change(WorkflowArtifactsPerStep, :count).by(1) }
+
+        it do
+          subject.call
+          expect(WorkflowArtifactsPerStep.last.artifacts).to eq(artifacts.to_json)
+          expect(WorkflowArtifactsPerStep.last.step).to eq('Workflow::Step::BranchPackageStep')
+        end
+      end
+    end
+
+    context 'for a link_package step' do
+      let(:step) do
+        Workflow::Step::LinkPackageStep.new(step_instructions: step_instructions,
+                                            scm_webhook: scm_webhook,
+                                            token: token)
+      end
+
+      let(:step_instructions) do
+        {
+          source_project: 'home:Iggy',
+          source_package: 'hello_world',
+          target_project: 'home:Iggy:sandbox'
+        }
+      end
+
+      context 'and pull_request event' do
+        let(:scm_webhook) do
+          ScmWebhook.new(payload: {
+                           scm: 'github',
+                           event: 'pull_request',
+                           pr_number: 1,
+                           target_branch: 'master',
+                           action: 'opened',
+                           source_repository_full_name: 'iggy/hello_world',
+                           target_repository_full_name: 'iggy/hello_world'
+                         })
+        end
+
+        let(:artifacts) do
+          {
+            source_project: step_instructions[:source_project],
+            source_package: step_instructions[:source_package],
+            target_project: 'home:Iggy:sandbox:iggy:hello_world:PR-1',
+            target_package: step_instructions[:source_package]
+          }
+        end
+
+        it { expect { subject.call }.to change(WorkflowArtifactsPerStep, :count).by(1) }
+
+        it do
+          subject.call
+          expect(WorkflowArtifactsPerStep.last.artifacts).to eq(artifacts.to_json)
+          expect(WorkflowArtifactsPerStep.last.step).to eq('Workflow::Step::LinkPackageStep')
+        end
+      end
+
+      context 'and push for commit event' do
+        let(:scm_webhook) do
+          ScmWebhook.new(payload: {
+                           scm: 'github',
+                           event: 'push',
+                           target_branch: 'main',
+                           source_repository_full_name: 'iggy/hello_world',
+                           commit_sha: '2a6b530bcdf7a54d881c62333c9f13b6ce16f3fc',
+                           target_repository_full_name: 'iggy/hello_world',
+                           ref: 'refs/heads/branch_123'
+                         })
+        end
+
+        let(:artifacts) do
+          {
+            source_project: step_instructions[:source_project],
+            source_package: step_instructions[:source_package],
+            target_project: step_instructions[:target_project],
+            target_package: 'hello_world-2a6b530bcdf7a54d881c62333c9f13b6ce16f3fc'
+          }
+        end
+
+        it { expect { subject.call }.to change(WorkflowArtifactsPerStep, :count).by(1) }
+
+        it do
+          subject.call
+          expect(WorkflowArtifactsPerStep.last.artifacts).to eq(artifacts.to_json)
+          expect(WorkflowArtifactsPerStep.last.step).to eq('Workflow::Step::LinkPackageStep')
+        end
+      end
+
+      context 'and push for tag event' do
+        let(:scm_webhook) do
+          ScmWebhook.new(payload: {
+                           scm: 'github',
+                           event: 'push',
+                           target_branch: 'main',
+                           source_repository_full_name: 'iggy/hello_world',
+                           commit_sha: '2a6b530bcdf7a54d881c62333c9f13b6ce16f3fc',
+                           target_repository_full_name: 'iggy/hello_world',
+                           tag_name: 'release_abc',
+                           ref: 'refs/tags/release_abc'
+                         })
+        end
+
+        let(:artifacts) do
+          {
+            source_project: step_instructions[:source_project],
+            source_package: step_instructions[:source_package],
+            target_project: step_instructions[:target_project],
+            target_package: 'hello_world-release_abc'
+          }
+        end
+
+        it { expect { subject.call }.to change(WorkflowArtifactsPerStep, :count).by(1) }
+
+        it do
+          subject.call
+          expect(WorkflowArtifactsPerStep.last.artifacts).to eq(artifacts.to_json)
+          expect(WorkflowArtifactsPerStep.last.step).to eq('Workflow::Step::LinkPackageStep')
+        end
+      end
+    end
+
+    context 'for a rebuild_package step' do
+      let(:step) do
+        Workflow::Step::RebuildPackage.new(step_instructions: step_instructions,
+                                           scm_webhook: scm_webhook,
+                                           token: token)
+      end
+
+      let(:step_instructions) do
+        {
+          project: 'home:Iggy',
+          package: 'hello_world'
+        }
+      end
+
+      let(:scm_webhook) do
+        ScmWebhook.new(payload: {
+                         scm: 'github',
+                         event: 'pull_request',
+                         pr_number: 1,
+                         target_branch: 'master',
+                         action: 'opened',
+                         source_repository_full_name: 'iggy/hello_world',
+                         target_repository_full_name: 'iggy/hello_world'
+                       })
+      end
+
+      let(:artifacts) { step_instructions }
+
+      it { expect { subject.call }.to change(WorkflowArtifactsPerStep, :count).by(1) }
+
+      it do
+        subject.call
+        expect(WorkflowArtifactsPerStep.last.artifacts).to eq(artifacts.to_json)
+        expect(WorkflowArtifactsPerStep.last.step).to eq('Workflow::Step::RebuildPackage')
+      end
+    end
+
+    context 'for a configure_repositories step' do
+      let(:step) do
+        Workflow::Step::ConfigureRepositories.new(step_instructions: step_instructions,
+                                                  scm_webhook: scm_webhook,
+                                                  token: token)
+      end
+
+      let(:step_instructions) do
+        {
+          project: 'home:Iggy',
+          repositories:
+            [
+              {
+                name: 'openSUSE_Tumbleweed',
+                paths: [
+                  {
+                    target_project: 'openSUSE:Factory',
+                    target_repository: 'snapshot'
+                  }
+                ],
+                architectures: [
+                  'x86_64',
+                  'ppc'
+                ]
+              },
+              {
+                name: 'openSUSE_Leap_15.3',
+                paths: [
+                  { target_project: 'openSUSE:Leap:15.3',
+                    target_repository: 'standard' }
+                ],
+                architectures: [
+                  'x86_64'
+                ]
+              }
+            ]
+        }
+      end
+
+      let(:scm_webhook) do
+        ScmWebhook.new(payload: {
+                         scm: 'github',
+                         event: 'pull_request',
+                         pr_number: 1,
+                         target_branch: 'master',
+                         action: 'opened',
+                         source_repository_full_name: 'iggy/hello_world',
+                         target_repository_full_name: 'iggy/hello_world'
+                       })
+      end
+
+      let(:artifacts) { step_instructions }
+
+      it { expect { subject.call }.to change(WorkflowArtifactsPerStep, :count).by(1) }
+
+      it do
+        subject.call
+        expect(WorkflowArtifactsPerStep.last.artifacts).to eq(artifacts.to_json)
+        expect(WorkflowArtifactsPerStep.last.step).to eq('Workflow::Step::ConfigureRepositories')
+      end
+    end
+  end
+end

--- a/src/api/spec/services/workflows/yaml_to_workflows_service_spec.rb
+++ b/src/api/spec/services/workflows/yaml_to_workflows_service_spec.rb
@@ -31,10 +31,11 @@ RSpec.describe Workflows::YAMLToWorkflowsService, type: :service do
   end
   let(:workflows_yml_file) { File.expand_path(Rails.root.join('spec/support/files/workflows.yml')) }
   let(:token) { create(:workflow_token) }
+  let(:workflow_run) { create(:workflow_run, token: token) }
 
   describe '#call' do
     subject do
-      Workflows::YAMLToWorkflowsService.new(yaml_file: workflows_yml_file, scm_webhook: ScmWebhook.new(payload: payload), token: token).call
+      Workflows::YAMLToWorkflowsService.new(yaml_file: workflows_yml_file, scm_webhook: ScmWebhook.new(payload: payload), token: token, workflow_run_id: workflow_run.id).call
     end
 
     context 'it supports many workflows' do


### PR DESCRIPTION
On every webhook OBS receives from an SCM, OBS follows the instructions given by `workflows.yml` performing the steps on it.

Those steps can handle or create different bunches of artifacts. For example, _repositories_ and _architectures_ if the step is `configure_repositories` or _projects_ and _packages_ in steps like `link_package` etc.

After each workflow run, we want to display all the artifacts involved so the user can better understand what was going on.

In this PR, we are collecting the main information about the artifacts we get on every step and storing them in DB with JSON format.

The JSON for a _link_package_ step can look like this:

```
{
  "source_project": "<source project name>",
  "source_package": "<source package name>",
  "target_project": "<target project name>",
  "target_package": "<target package name>"
}
```

With the information in JSON, we can later display a text and even a link to the artifact from the WorkflowRun show view. 

The view should look like this:

![image (1)](https://user-images.githubusercontent.com/2581944/151948231-d29e92c1-2f87-4a85-8833-3e5d0db7c98e.png)
