### PR TITLE
Fix initial report to SCM call when using link_package step

### DIFF
--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -1331,7 +1331,7 @@ class Package < ApplicationRecord
   end
 
   def file_exists?(filename)
-    dir_hash.key?('entry') && [dir_hash['entry']].flatten.any? { |item| item['name'] == filename }
+    dir_hash.key?('entry') && [dir_hash(expand: 1)['entry']].flatten.any? { |item| item['name'] == filename }
   end
 
   def has_icon?

--- a/src/api/spec/cassettes/ImageTemplates/branching/branch_Kiwi_image_template.yml
+++ b/src/api/spec/cassettes/ImageTemplates/branching/branch_Kiwi_image_template.yml
@@ -39,8 +39,7 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:15 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/_meta?user=user_1
@@ -48,7 +47,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="my_project">
-          <title>The Way Through the Woods</title>
+          <title>The Painted Veil</title>
           <description/>
         </project>
     headers:
@@ -70,16 +69,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '112'
+      - '103'
     body:
       encoding: UTF-8
       string: |
         <project name="my_project">
-          <title>The Way Through the Woods</title>
+          <title>The Painted Veil</title>
           <description></description>
         </project>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:15 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/first_package/_meta?user=user_2
@@ -88,7 +86,7 @@ http_interactions:
       string: |
         <package name="first_package" project="my_project">
           <title>a</title>
-          <description>Perspiciatis earum eligendi deleniti.</description>
+          <description>Tempore assumenda impedit alias.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,23 +107,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '149'
+      - '144'
     body:
       encoding: UTF-8
       string: |
         <package name="first_package" project="my_project">
           <title>a</title>
-          <description>Perspiciatis earum eligendi deleniti.</description>
+          <description>Tempore assumenda impedit alias.</description>
         </package>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:15 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/first_package/_config
     body:
       encoding: UTF-8
-      string: Quod modi possimus. Molestiae doloribus vitae. Reprehenderit repellendus
-        enim.
+      string: Et non fugit. Dolorem in voluptatum. Ut et provident.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -150,21 +146,20 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="1" vrev="1">
-          <srcmd5>32e658732b899becc2fb0fa37585d17f</srcmd5>
+          <srcmd5>31a04da9ccf69f2cb98c9316206af50c</srcmd5>
           <version>unknown</version>
-          <time>1590054675</time>
+          <time>1643644487</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:15 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/first_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Rerum vel rerum. Perferendis totam nam. Est illum error.
+      string: Facere nostrum et. Ut assumenda ea. Voluptas sit ab.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -189,15 +184,14 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="2" vrev="2">
-          <srcmd5>b30743d25034407da355418772d9ab16</srcmd5>
+          <srcmd5>847c5ab9cc25895ea20bb935d0e2814d</srcmd5>
           <version>unknown</version>
-          <time>1590054675</time>
+          <time>1643644487</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:15 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/second_package/_meta?user=user_3
@@ -206,7 +200,7 @@ http_interactions:
       string: |
         <package name="second_package" project="my_project">
           <title>c</title>
-          <description>Quisquam temporibus aliquid quidem.</description>
+          <description>Tempora officiis odio vel.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -227,22 +221,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '148'
+      - '139'
     body:
       encoding: UTF-8
       string: |
         <package name="second_package" project="my_project">
           <title>c</title>
-          <description>Quisquam temporibus aliquid quidem.</description>
+          <description>Tempora officiis odio vel.</description>
         </package>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:15 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/second_package/_config
     body:
       encoding: UTF-8
-      string: Iste iure non. Rerum et hic. Pariatur aliquid atque.
+      string: Cum ut aspernatur. Ducimus officia et. Similique consectetur quisquam.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -267,21 +260,20 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="1" vrev="1">
-          <srcmd5>355b9fa6918d571f5ed286eaf676e426</srcmd5>
+          <srcmd5>15d84e800700397ae8b0c068f691e96d</srcmd5>
           <version>unknown</version>
-          <time>1590054675</time>
+          <time>1643644487</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:15 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/second_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Quia ut aperiam. Dolor est tempora. Mollitia at aliquam.
+      string: Vero laudantium voluptas. Rerum suscipit sit. Placeat blanditiis voluptatum.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -306,15 +298,14 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="2" vrev="2">
-          <srcmd5>a41da3a5d35db6e7caed85cf7be7f250</srcmd5>
+          <srcmd5>e4153cba8e7038e487d9caf3fc3d6f6a</srcmd5>
           <version>unknown</version>
-          <time>1590054675</time>
+          <time>1643644487</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:15 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/third_package/_meta?user=user_4
@@ -323,7 +314,7 @@ http_interactions:
       string: |
         <package name="third_package" project="my_project">
           <title>b</title>
-          <description>Iusto voluptatem consequatur tempore.</description>
+          <description>Excepturi voluptas officiis et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -344,23 +335,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '149'
+      - '143'
     body:
       encoding: UTF-8
       string: |
         <package name="third_package" project="my_project">
           <title>b</title>
-          <description>Iusto voluptatem consequatur tempore.</description>
+          <description>Excepturi voluptas officiis et.</description>
         </package>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:15 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/third_package/_config
     body:
       encoding: UTF-8
-      string: Accusamus aliquid dolores. Voluptatibus laboriosam consequatur. Dolorem
-        nulla ea.
+      string: Non debitis voluptatem. Illo rerum qui. Enim mollitia voluptatem.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -385,21 +374,20 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="1" vrev="1">
-          <srcmd5>1fea47c06430a39eae9a2d9f65a5a79c</srcmd5>
+          <srcmd5>55737e988ea30ff4da120f113696309a</srcmd5>
           <version>unknown</version>
-          <time>1590054675</time>
+          <time>1643644487</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:16 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/third_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Itaque nam ut. Cum temporibus tempore. At voluptates voluptatem.
+      string: Enim quo cum. Nam ullam voluptatem. Qui facilis et.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -424,15 +412,14 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="2" vrev="2">
-          <srcmd5>fa823af400271b16334f47c33c204e6c</srcmd5>
+          <srcmd5>3e29a3e81b7e182c27984512804c37bb</srcmd5>
           <version>unknown</version>
-          <time>1590054676</time>
+          <time>1643644487</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:16 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/package_with_kiwi_image/_meta?user=user_5
@@ -440,8 +427,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="my_project">
-          <title>Ah, Wilderness!</title>
-          <description>Vitae occaecati eius ex.</description>
+          <title>The Sun Also Rises</title>
+          <description>Non earum soluta et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -462,16 +449,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '160'
+      - '159'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="my_project">
-          <title>Ah, Wilderness!</title>
-          <description>Vitae occaecati eius ex.</description>
+          <title>The Sun Also Rises</title>
+          <description>Non earum soluta et.</description>
         </package>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:16 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:48 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/package_with_kiwi_image/package_with_kiwi_image.kiwi
@@ -508,13 +494,12 @@ http_interactions:
         <revision rev="1" vrev="1">
           <srcmd5>801c545be09c1c468ff2d99b40415aac</srcmd5>
           <version>0.0.1</version>
-          <time>1590054676</time>
+          <time>1643644488</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:16 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:48 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/package_with_kiwi_image/_meta?user=user_5
@@ -522,8 +507,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="my_project">
-          <title>Ah, Wilderness!</title>
-          <description>Vitae occaecati eius ex.</description>
+          <title>The Sun Also Rises</title>
+          <description>Non earum soluta et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -544,16 +529,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '160'
+      - '159'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="my_project">
-          <title>Ah, Wilderness!</title>
-          <description>Vitae occaecati eius ex.</description>
+          <title>The Sun Also Rises</title>
+          <description>Non earum soluta et.</description>
         </package>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:16 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:48 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/package_with_kiwi_image
@@ -584,10 +568,9 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="package_with_kiwi_image" rev="1" vrev="1" srcmd5="801c545be09c1c468ff2d99b40415aac">
-          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1590054676"/>
+          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1643644488"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:16 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:48 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/_project/_attribute?meta=1&user=tom
@@ -620,15 +603,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2">
-          <srcmd5>0375ccb89a361c9f2b7f5b64a2d20b91</srcmd5>
-          <time>1590054676</time>
+        <revision rev="3">
+          <srcmd5>a9a43dba44add59e9010adb585c0ae64</srcmd5>
+          <time>1643644488</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:16 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:48 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/first_package
@@ -636,6 +618,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 2cf9ceeb-1eff-4de2-bbc9-a91f0ffa6934
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -658,19 +642,20 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="first_package" rev="2" vrev="2" srcmd5="b30743d25034407da355418772d9ab16">
-          <entry name="_config" md5="32ed589d618beb3323f5e311f9c422c0" size="78" mtime="1590054675"/>
-          <entry name="somefile.txt" md5="3e78692fb34ae2f972d304a6fe210580" size="56" mtime="1590054675"/>
+        <directory name="first_package" rev="2" vrev="2" srcmd5="847c5ab9cc25895ea20bb935d0e2814d">
+          <entry name="_config" md5="ea99062e3a7a62d3d16f3a4e4e878d57" size="53" mtime="1643644487"/>
+          <entry name="somefile.txt" md5="e32547862619a3222ca4390ea5549935" size="52" mtime="1643644487"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:16 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:52 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/my_project/first_package
+    uri: http://backend:5352/source/my_project/first_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 2cf9ceeb-1eff-4de2-bbc9-a91f0ffa6934
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -693,12 +678,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="first_package" rev="2" vrev="2" srcmd5="b30743d25034407da355418772d9ab16">
-          <entry name="_config" md5="32ed589d618beb3323f5e311f9c422c0" size="78" mtime="1590054675"/>
-          <entry name="somefile.txt" md5="3e78692fb34ae2f972d304a6fe210580" size="56" mtime="1590054675"/>
+        <directory name="first_package" rev="2" vrev="2" srcmd5="847c5ab9cc25895ea20bb935d0e2814d">
+          <entry name="_config" md5="ea99062e3a7a62d3d16f3a4e4e878d57" size="53" mtime="1643644487"/>
+          <entry name="somefile.txt" md5="e32547862619a3222ca4390ea5549935" size="52" mtime="1643644487"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:16 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:52 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/second_package
@@ -706,6 +690,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 2cf9ceeb-1eff-4de2-bbc9-a91f0ffa6934
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -728,19 +714,20 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="second_package" rev="2" vrev="2" srcmd5="a41da3a5d35db6e7caed85cf7be7f250">
-          <entry name="_config" md5="d5296f9b65005faf8204d7fc00dd4577" size="52" mtime="1590054675"/>
-          <entry name="somefile.txt" md5="50fab3b71fcb9eb16a863cbd21a1ce43" size="56" mtime="1590054675"/>
+        <directory name="second_package" rev="2" vrev="2" srcmd5="e4153cba8e7038e487d9caf3fc3d6f6a">
+          <entry name="_config" md5="1acd09cec24d6e16f520d3777fa75cd4" size="70" mtime="1643644487"/>
+          <entry name="somefile.txt" md5="41c537ed86f8cf5ba5fa45c1446e2dc5" size="76" mtime="1643644487"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:16 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:52 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/my_project/second_package
+    uri: http://backend:5352/source/my_project/second_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 2cf9ceeb-1eff-4de2-bbc9-a91f0ffa6934
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -763,12 +750,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="second_package" rev="2" vrev="2" srcmd5="a41da3a5d35db6e7caed85cf7be7f250">
-          <entry name="_config" md5="d5296f9b65005faf8204d7fc00dd4577" size="52" mtime="1590054675"/>
-          <entry name="somefile.txt" md5="50fab3b71fcb9eb16a863cbd21a1ce43" size="56" mtime="1590054675"/>
+        <directory name="second_package" rev="2" vrev="2" srcmd5="e4153cba8e7038e487d9caf3fc3d6f6a">
+          <entry name="_config" md5="1acd09cec24d6e16f520d3777fa75cd4" size="70" mtime="1643644487"/>
+          <entry name="somefile.txt" md5="41c537ed86f8cf5ba5fa45c1446e2dc5" size="76" mtime="1643644487"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:16 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:52 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/third_package
@@ -776,6 +762,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 2cf9ceeb-1eff-4de2-bbc9-a91f0ffa6934
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -798,19 +786,20 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="third_package" rev="2" vrev="2" srcmd5="fa823af400271b16334f47c33c204e6c">
-          <entry name="_config" md5="3fe2cb61b51d6cc59c996fbaecd4baa6" size="81" mtime="1590054675"/>
-          <entry name="somefile.txt" md5="7843bceb0c9a28916f93d940ca706b01" size="64" mtime="1590054676"/>
+        <directory name="third_package" rev="2" vrev="2" srcmd5="3e29a3e81b7e182c27984512804c37bb">
+          <entry name="_config" md5="ad6436bf7b342a0337f5be8b73a3382d" size="65" mtime="1643644487"/>
+          <entry name="somefile.txt" md5="01f5683d372040d19bec3e6a47885171" size="51" mtime="1643644487"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:16 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:52 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/my_project/third_package
+    uri: http://backend:5352/source/my_project/third_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 2cf9ceeb-1eff-4de2-bbc9-a91f0ffa6934
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -833,12 +822,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="third_package" rev="2" vrev="2" srcmd5="fa823af400271b16334f47c33c204e6c">
-          <entry name="_config" md5="3fe2cb61b51d6cc59c996fbaecd4baa6" size="81" mtime="1590054675"/>
-          <entry name="somefile.txt" md5="7843bceb0c9a28916f93d940ca706b01" size="64" mtime="1590054676"/>
+        <directory name="third_package" rev="2" vrev="2" srcmd5="3e29a3e81b7e182c27984512804c37bb">
+          <entry name="_config" md5="ad6436bf7b342a0337f5be8b73a3382d" size="65" mtime="1643644487"/>
+          <entry name="somefile.txt" md5="01f5683d372040d19bec3e6a47885171" size="51" mtime="1643644487"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:16 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:52 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/package_with_kiwi_image
@@ -846,6 +834,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 2cf9ceeb-1eff-4de2-bbc9-a91f0ffa6934
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -869,17 +859,18 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="package_with_kiwi_image" rev="1" vrev="1" srcmd5="801c545be09c1c468ff2d99b40415aac">
-          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1590054676"/>
+          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1643644488"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:16 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:52 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/my_project/package_with_kiwi_image
+    uri: http://backend:5352/source/my_project/package_with_kiwi_image?expand=1
     body:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 2cf9ceeb-1eff-4de2-bbc9-a91f0ffa6934
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -903,10 +894,9 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="package_with_kiwi_image" rev="1" vrev="1" srcmd5="801c545be09c1c468ff2d99b40415aac">
-          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1590054676"/>
+          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1643644488"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:16 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:52 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom/_result?code=unresolvable&view=status
@@ -914,6 +904,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 93c8e4e0-f50f-4c9f-9d37-cf0dbde19ab0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -938,8 +930,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:18 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:53 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom/_keyinfo?donotcreatecert=1&withsslcert=1
@@ -947,6 +938,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 93c8e4e0-f50f-4c9f-9d37-cf0dbde19ab0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -969,8 +962,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "<keyinfo/>\n"
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:18 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:54 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom/_result?view=summary
@@ -978,6 +970,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - fa469ba5-cc10-4b25-ad59-9ee146f8c913
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1002,8 +996,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:18 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:54 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/first_package
@@ -1011,6 +1004,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 4156e3e4-fdb9-4bc9-8564-ee9a61f2af27
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1033,19 +1028,20 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="first_package" rev="2" vrev="2" srcmd5="b30743d25034407da355418772d9ab16">
-          <entry name="_config" md5="32ed589d618beb3323f5e311f9c422c0" size="78" mtime="1590054675"/>
-          <entry name="somefile.txt" md5="3e78692fb34ae2f972d304a6fe210580" size="56" mtime="1590054675"/>
+        <directory name="first_package" rev="2" vrev="2" srcmd5="847c5ab9cc25895ea20bb935d0e2814d">
+          <entry name="_config" md5="ea99062e3a7a62d3d16f3a4e4e878d57" size="53" mtime="1643644487"/>
+          <entry name="somefile.txt" md5="e32547862619a3222ca4390ea5549935" size="52" mtime="1643644487"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:18 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:54 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/my_project/first_package
+    uri: http://backend:5352/source/my_project/first_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 4156e3e4-fdb9-4bc9-8564-ee9a61f2af27
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1068,12 +1064,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="first_package" rev="2" vrev="2" srcmd5="b30743d25034407da355418772d9ab16">
-          <entry name="_config" md5="32ed589d618beb3323f5e311f9c422c0" size="78" mtime="1590054675"/>
-          <entry name="somefile.txt" md5="3e78692fb34ae2f972d304a6fe210580" size="56" mtime="1590054675"/>
+        <directory name="first_package" rev="2" vrev="2" srcmd5="847c5ab9cc25895ea20bb935d0e2814d">
+          <entry name="_config" md5="ea99062e3a7a62d3d16f3a4e4e878d57" size="53" mtime="1643644487"/>
+          <entry name="somefile.txt" md5="e32547862619a3222ca4390ea5549935" size="52" mtime="1643644487"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:18 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:54 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/second_package
@@ -1081,6 +1076,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 4156e3e4-fdb9-4bc9-8564-ee9a61f2af27
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1103,19 +1100,20 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="second_package" rev="2" vrev="2" srcmd5="a41da3a5d35db6e7caed85cf7be7f250">
-          <entry name="_config" md5="d5296f9b65005faf8204d7fc00dd4577" size="52" mtime="1590054675"/>
-          <entry name="somefile.txt" md5="50fab3b71fcb9eb16a863cbd21a1ce43" size="56" mtime="1590054675"/>
+        <directory name="second_package" rev="2" vrev="2" srcmd5="e4153cba8e7038e487d9caf3fc3d6f6a">
+          <entry name="_config" md5="1acd09cec24d6e16f520d3777fa75cd4" size="70" mtime="1643644487"/>
+          <entry name="somefile.txt" md5="41c537ed86f8cf5ba5fa45c1446e2dc5" size="76" mtime="1643644487"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:18 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:54 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/my_project/second_package
+    uri: http://backend:5352/source/my_project/second_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 4156e3e4-fdb9-4bc9-8564-ee9a61f2af27
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1138,12 +1136,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="second_package" rev="2" vrev="2" srcmd5="a41da3a5d35db6e7caed85cf7be7f250">
-          <entry name="_config" md5="d5296f9b65005faf8204d7fc00dd4577" size="52" mtime="1590054675"/>
-          <entry name="somefile.txt" md5="50fab3b71fcb9eb16a863cbd21a1ce43" size="56" mtime="1590054675"/>
+        <directory name="second_package" rev="2" vrev="2" srcmd5="e4153cba8e7038e487d9caf3fc3d6f6a">
+          <entry name="_config" md5="1acd09cec24d6e16f520d3777fa75cd4" size="70" mtime="1643644487"/>
+          <entry name="somefile.txt" md5="41c537ed86f8cf5ba5fa45c1446e2dc5" size="76" mtime="1643644487"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:18 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:54 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/third_package
@@ -1151,6 +1148,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 4156e3e4-fdb9-4bc9-8564-ee9a61f2af27
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1173,19 +1172,20 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="third_package" rev="2" vrev="2" srcmd5="fa823af400271b16334f47c33c204e6c">
-          <entry name="_config" md5="3fe2cb61b51d6cc59c996fbaecd4baa6" size="81" mtime="1590054675"/>
-          <entry name="somefile.txt" md5="7843bceb0c9a28916f93d940ca706b01" size="64" mtime="1590054676"/>
+        <directory name="third_package" rev="2" vrev="2" srcmd5="3e29a3e81b7e182c27984512804c37bb">
+          <entry name="_config" md5="ad6436bf7b342a0337f5be8b73a3382d" size="65" mtime="1643644487"/>
+          <entry name="somefile.txt" md5="01f5683d372040d19bec3e6a47885171" size="51" mtime="1643644487"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:18 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:54 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/my_project/third_package
+    uri: http://backend:5352/source/my_project/third_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 4156e3e4-fdb9-4bc9-8564-ee9a61f2af27
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1208,12 +1208,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="third_package" rev="2" vrev="2" srcmd5="fa823af400271b16334f47c33c204e6c">
-          <entry name="_config" md5="3fe2cb61b51d6cc59c996fbaecd4baa6" size="81" mtime="1590054675"/>
-          <entry name="somefile.txt" md5="7843bceb0c9a28916f93d940ca706b01" size="64" mtime="1590054676"/>
+        <directory name="third_package" rev="2" vrev="2" srcmd5="3e29a3e81b7e182c27984512804c37bb">
+          <entry name="_config" md5="ad6436bf7b342a0337f5be8b73a3382d" size="65" mtime="1643644487"/>
+          <entry name="somefile.txt" md5="01f5683d372040d19bec3e6a47885171" size="51" mtime="1643644487"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:18 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:54 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/package_with_kiwi_image
@@ -1221,6 +1220,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 4156e3e4-fdb9-4bc9-8564-ee9a61f2af27
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1244,44 +1245,9 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="package_with_kiwi_image" rev="1" vrev="1" srcmd5="801c545be09c1c468ff2d99b40415aac">
-          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1590054676"/>
+          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1643644488"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:18 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/my_project/package_with_kiwi_image
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '231'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="package_with_kiwi_image" rev="1" vrev="1" srcmd5="801c545be09c1c468ff2d99b40415aac">
-          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1590054676"/>
-        </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:19 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:54 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/package_with_kiwi_image?expand=1
@@ -1289,6 +1255,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 4156e3e4-fdb9-4bc9-8564-ee9a61f2af27
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1312,10 +1280,44 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="package_with_kiwi_image" rev="1" vrev="1" srcmd5="801c545be09c1c468ff2d99b40415aac">
-          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1590054676"/>
+          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1643644488"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:19 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:54 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/my_project/package_with_kiwi_image?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - f7140070-887c-4a68-a6af-6488a36d4962
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '231'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_with_kiwi_image" rev="1" vrev="1" srcmd5="801c545be09c1c468ff2d99b40415aac">
+          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1643644488"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:54:55 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/package_with_kiwi_image?rev=1
@@ -1323,6 +1325,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - f7140070-887c-4a68-a6af-6488a36d4962
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1346,10 +1350,9 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="package_with_kiwi_image" rev="1" vrev="1" srcmd5="801c545be09c1c468ff2d99b40415aac">
-          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1590054676"/>
+          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1643644488"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:19 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:55 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22package_with_kiwi_image%22%20and%20linkinfo/@project=%22my_project%22%20and%20@project=%22my_project%22)
@@ -1383,8 +1386,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:19 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:55 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:my_project/_meta?user=tom
@@ -1397,6 +1399,8 @@ http_interactions:
           <person userid="tom" role="maintainer"/>
         </project>
     headers:
+      X-Request-Id:
+      - f7140070-887c-4a68-a6af-6488a36d4962
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1424,8 +1428,7 @@ http_interactions:
           <description>This project was created for package package_with_kiwi_image via attribute OBS:Maintained</description>
           <person userid="tom" role="maintainer"/>
         </project>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:19 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:55 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:my_project/_project/_attribute?meta=1&user=tom
@@ -1434,10 +1437,12 @@ http_interactions:
       string: |
         <attributes>
           <attribute name="AutoCleanup" namespace="OBS">
-            <value>2020-06-04 09:51:19 +0000</value>
+            <value>2022-02-14 15:54:55 +0000</value>
           </attribute>
         </attributes>
     headers:
+      X-Request-Id:
+      - f7140070-887c-4a68-a6af-6488a36d4962
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1461,14 +1466,13 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="2">
-          <srcmd5>916a6459c4f0245d79f892046e279e11</srcmd5>
-          <time>1590054679</time>
+          <srcmd5>45fd6303c3bdb771a55c2d27c3daa3a1</srcmd5>
+          <time>1643644495</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:19 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:55 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image/_meta?user=tom
@@ -1476,8 +1480,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="home:tom:branches:my_project">
-          <title>Ah, Wilderness!</title>
-          <description>Vitae occaecati eius ex.</description>
+          <title>The Sun Also Rises</title>
+          <description>Non earum soluta et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1498,16 +1502,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '178'
+      - '177'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="home:tom:branches:my_project">
-          <title>Ah, Wilderness!</title>
-          <description>Vitae occaecati eius ex.</description>
+          <title>The Sun Also Rises</title>
+          <description>Non earum soluta et.</description>
         </package>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:19 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:55 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image?cmd=branch&noservice=1&opackage=package_with_kiwi_image&oproject=my_project&orev=801c545be09c1c468ff2d99b40415aac&user=tom
@@ -1542,13 +1545,12 @@ http_interactions:
         <revision rev="1" vrev="1">
           <srcmd5>00d929e44f732106a7aa255543b32f11</srcmd5>
           <version>unknown</version>
-          <time>1590054679</time>
+          <time>1643644495</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:19 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:55 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image/_meta?user=tom
@@ -1556,8 +1558,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="home:tom:branches:my_project">
-          <title>Ah, Wilderness!</title>
-          <description>Vitae occaecati eius ex.</description>
+          <title>The Sun Also Rises</title>
+          <description>Non earum soluta et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1578,16 +1580,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '178'
+      - '177'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="home:tom:branches:my_project">
-          <title>Ah, Wilderness!</title>
-          <description>Vitae occaecati eius ex.</description>
+          <title>The Sun Also Rises</title>
+          <description>Non earum soluta et.</description>
         </package>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:19 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:55 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image
@@ -1619,11 +1620,10 @@ http_interactions:
       string: |
         <directory name="package_with_kiwi_image" rev="1" vrev="1" srcmd5="00d929e44f732106a7aa255543b32f11">
           <linkinfo project="my_project" package="package_with_kiwi_image" rev="801c545be09c1c468ff2d99b40415aac" srcmd5="801c545be09c1c468ff2d99b40415aac" baserev="801c545be09c1c468ff2d99b40415aac" xsrcmd5="067709a3aecd96cf74107fa909e67564" lsrcmd5="00d929e44f732106a7aa255543b32f11"/>
-          <entry name="_link" md5="4e48143c1ab3ebf7faf55f7286d870d4" size="157" mtime="1590054679"/>
-          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1590054676"/>
+          <entry name="_link" md5="4e48143c1ab3ebf7faf55f7286d870d4" size="157" mtime="1643644495"/>
+          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1643644488"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:19 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:55 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image?view=info
@@ -1631,6 +1631,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - f7140070-887c-4a68-a6af-6488a36d4962
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1657,8 +1659,7 @@ http_interactions:
           <filename>package_with_kiwi_image.kiwi</filename>
           <linked project="my_project" package="package_with_kiwi_image"/>
         </sourceinfo>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:19 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:55 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image
@@ -1666,6 +1667,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - f7140070-887c-4a68-a6af-6488a36d4962
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1690,11 +1693,10 @@ http_interactions:
       string: |
         <directory name="package_with_kiwi_image" rev="1" vrev="1" srcmd5="00d929e44f732106a7aa255543b32f11">
           <linkinfo project="my_project" package="package_with_kiwi_image" rev="801c545be09c1c468ff2d99b40415aac" srcmd5="801c545be09c1c468ff2d99b40415aac" baserev="801c545be09c1c468ff2d99b40415aac" xsrcmd5="067709a3aecd96cf74107fa909e67564" lsrcmd5="00d929e44f732106a7aa255543b32f11"/>
-          <entry name="_link" md5="4e48143c1ab3ebf7faf55f7286d870d4" size="157" mtime="1590054679"/>
-          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1590054676"/>
+          <entry name="_link" md5="4e48143c1ab3ebf7faf55f7286d870d4" size="157" mtime="1643644495"/>
+          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1643644488"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:19 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:55 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -1733,8 +1735,7 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:19 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:55 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -1771,8 +1772,7 @@ http_interactions:
           <new project="home:tom:branches:my_project" package="package_with_kiwi_image" rev="067709a3aecd96cf74107fa909e67564" srcmd5="067709a3aecd96cf74107fa909e67564"/>
           <files/>
         </sourcediff>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:19 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:55 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:my_project/_meta?user=tom
@@ -1788,6 +1788,8 @@ http_interactions:
           </publish>
         </project>
     headers:
+      X-Request-Id:
+      - f7140070-887c-4a68-a6af-6488a36d4962
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1818,8 +1820,7 @@ http_interactions:
             <disable/>
           </publish>
         </project>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:19 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:55 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image
@@ -1827,6 +1828,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - f7140070-887c-4a68-a6af-6488a36d4962
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1851,11 +1854,10 @@ http_interactions:
       string: |
         <directory name="package_with_kiwi_image" rev="1" vrev="1" srcmd5="00d929e44f732106a7aa255543b32f11">
           <linkinfo project="my_project" package="package_with_kiwi_image" rev="801c545be09c1c468ff2d99b40415aac" srcmd5="801c545be09c1c468ff2d99b40415aac" baserev="801c545be09c1c468ff2d99b40415aac" xsrcmd5="067709a3aecd96cf74107fa909e67564" lsrcmd5="00d929e44f732106a7aa255543b32f11"/>
-          <entry name="_link" md5="4e48143c1ab3ebf7faf55f7286d870d4" size="157" mtime="1590054679"/>
-          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1590054676"/>
+          <entry name="_link" md5="4e48143c1ab3ebf7faf55f7286d870d4" size="157" mtime="1643644495"/>
+          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1643644488"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:19 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:55 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image
@@ -1863,6 +1865,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 880ec4a6-af7a-421f-b6d4-0c2f54e3770d
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1887,11 +1891,10 @@ http_interactions:
       string: |
         <directory name="package_with_kiwi_image" rev="1" vrev="1" srcmd5="00d929e44f732106a7aa255543b32f11">
           <linkinfo project="my_project" package="package_with_kiwi_image" rev="801c545be09c1c468ff2d99b40415aac" srcmd5="801c545be09c1c468ff2d99b40415aac" baserev="801c545be09c1c468ff2d99b40415aac" xsrcmd5="067709a3aecd96cf74107fa909e67564" lsrcmd5="00d929e44f732106a7aa255543b32f11"/>
-          <entry name="_link" md5="4e48143c1ab3ebf7faf55f7286d870d4" size="157" mtime="1590054679"/>
-          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1590054676"/>
+          <entry name="_link" md5="4e48143c1ab3ebf7faf55f7286d870d4" size="157" mtime="1643644495"/>
+          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1643644488"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:20 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:55 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image/package_with_kiwi_image.kiwi
@@ -1925,8 +1928,7 @@ http_interactions:
         \   <preferences>\n      <version>0.0.1</version>\n      <type image=\"oem\"
         primary=\"true\" boot=\"oemboot/suse-13.2\"/>\n    </preferences>\n  </image>\n
         \ "
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:20 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:55 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image
@@ -1934,6 +1936,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 880ec4a6-af7a-421f-b6d4-0c2f54e3770d
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1958,11 +1962,10 @@ http_interactions:
       string: |
         <directory name="package_with_kiwi_image" rev="1" vrev="1" srcmd5="00d929e44f732106a7aa255543b32f11">
           <linkinfo project="my_project" package="package_with_kiwi_image" rev="801c545be09c1c468ff2d99b40415aac" srcmd5="801c545be09c1c468ff2d99b40415aac" baserev="801c545be09c1c468ff2d99b40415aac" xsrcmd5="067709a3aecd96cf74107fa909e67564" lsrcmd5="00d929e44f732106a7aa255543b32f11"/>
-          <entry name="_link" md5="4e48143c1ab3ebf7faf55f7286d870d4" size="157" mtime="1590054679"/>
-          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1590054676"/>
+          <entry name="_link" md5="4e48143c1ab3ebf7faf55f7286d870d4" size="157" mtime="1643644495"/>
+          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1643644488"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:20 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:55 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image/_meta?user=tom
@@ -1970,8 +1973,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="home:tom:branches:my_project">
-          <title>Ah, Wilderness!</title>
-          <description>Vitae occaecati eius ex.</description>
+          <title>The Sun Also Rises</title>
+          <description>Non earum soluta et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1992,16 +1995,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '178'
+      - '177'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="home:tom:branches:my_project">
-          <title>Ah, Wilderness!</title>
-          <description>Vitae occaecati eius ex.</description>
+          <title>The Sun Also Rises</title>
+          <description>Non earum soluta et.</description>
         </package>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:20 GMT
+  recorded_at: Mon, 31 Jan 2022 15:54:55 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image/_meta?user=tom
@@ -2009,8 +2011,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="home:tom:branches:my_project">
-          <title>Ah, Wilderness!</title>
-          <description>Vitae occaecati eius ex.</description>
+          <title>The Sun Also Rises</title>
+          <description>Non earum soluta et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -2031,14 +2033,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '178'
+      - '177'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="home:tom:branches:my_project">
-          <title>Ah, Wilderness!</title>
-          <description>Vitae occaecati eius ex.</description>
+          <title>The Sun Also Rises</title>
+          <description>Non earum soluta et.</description>
         </package>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:20 GMT
-recorded_with: VCR 5.1.0
+  recorded_at: Mon, 31 Jan 2022 15:54:55 GMT
+recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/ImageTemplates/branching/branch_image_template.yml
+++ b/src/api/spec/cassettes/ImageTemplates/branching/branch_image_template.yml
@@ -39,16 +39,15 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:25 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/my_project/_meta?user=user_6
+    uri: http://backend:5352/source/my_project/_meta?user=user_1
     body:
       encoding: UTF-8
       string: |
         <project name="my_project">
-          <title>A Glass of Blessings</title>
+          <title>A Summer Bird-Cage</title>
           <description/>
         </project>
     headers:
@@ -70,25 +69,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '107'
+      - '105'
     body:
       encoding: UTF-8
       string: |
         <project name="my_project">
-          <title>A Glass of Blessings</title>
+          <title>A Summer Bird-Cage</title>
           <description></description>
         </project>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:26 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/my_project/first_package/_meta?user=user_7
+    uri: http://backend:5352/source/my_project/first_package/_meta?user=user_2
     body:
       encoding: UTF-8
       string: |
         <package name="first_package" project="my_project">
           <title>a</title>
-          <description>Vel consequuntur dignissimos ex.</description>
+          <description>Placeat beatae sit modi.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,22 +107,22 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '144'
+      - '136'
     body:
       encoding: UTF-8
       string: |
         <package name="first_package" project="my_project">
           <title>a</title>
-          <description>Vel consequuntur dignissimos ex.</description>
+          <description>Placeat beatae sit modi.</description>
         </package>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:26 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/first_package/_config
     body:
       encoding: UTF-8
-      string: Vel nisi nesciunt. Perspiciatis tenetur natus. Laborum ea iste.
+      string: Labore animi ipsam. Architecto autem commodi. Repudiandae explicabo
+        eaque.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -149,21 +147,20 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="3" vrev="3">
-          <srcmd5>1207f439007ae4b3cb437368d9eaaa3a</srcmd5>
+          <srcmd5>26f8f52b6e5b11c18a912951d2bada2c</srcmd5>
           <version>unknown</version>
-          <time>1590054681</time>
+          <time>1643644526</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:26 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/first_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Non ad saepe. Magnam recusandae ullam. Et voluptatem nulla.
+      string: Non iusto aperiam. Officiis quam aliquid. Recusandae veritatis optio.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -188,24 +185,23 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="4" vrev="4">
-          <srcmd5>f3e6eb1ff4134170e42c68a627b55385</srcmd5>
+          <srcmd5>6f39711441a75534e478e15af5bed5f8</srcmd5>
           <version>unknown</version>
-          <time>1590054681</time>
+          <time>1643644526</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:26 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/my_project/second_package/_meta?user=user_8
+    uri: http://backend:5352/source/my_project/second_package/_meta?user=user_3
     body:
       encoding: UTF-8
       string: |
         <package name="second_package" project="my_project">
           <title>c</title>
-          <description>Et aliquid quis aut.</description>
+          <description>Libero sint aliquam nesciunt.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -226,23 +222,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '133'
+      - '142'
     body:
       encoding: UTF-8
       string: |
         <package name="second_package" project="my_project">
           <title>c</title>
-          <description>Et aliquid quis aut.</description>
+          <description>Libero sint aliquam nesciunt.</description>
         </package>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:26 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/second_package/_config
     body:
       encoding: UTF-8
-      string: Temporibus debitis eum. Non necessitatibus explicabo. Velit inventore
-        et.
+      string: Necessitatibus dolorem voluptates. Quo ullam voluptas. Iure enim sed.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -267,21 +261,20 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="3" vrev="3">
-          <srcmd5>15fcb884c519d0036baba01b37669f6e</srcmd5>
+          <srcmd5>f1659ae86dadd668bd3944ada4184e0d</srcmd5>
           <version>unknown</version>
-          <time>1590054681</time>
+          <time>1643644526</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:26 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/second_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Et officia vel. Minima qui est. Consectetur voluptatem et.
+      string: Voluptatum distinctio sed. Harum atque ut. Rerum et quia.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -306,24 +299,23 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="4" vrev="4">
-          <srcmd5>f9286f75b5815e2d417f2786585802a1</srcmd5>
+          <srcmd5>14bba0670e068393a480920efd0d7456</srcmd5>
           <version>unknown</version>
-          <time>1590054681</time>
+          <time>1643644526</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:26 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/my_project/third_package/_meta?user=user_9
+    uri: http://backend:5352/source/my_project/third_package/_meta?user=user_4
     body:
       encoding: UTF-8
       string: |
         <package name="third_package" project="my_project">
           <title>b</title>
-          <description>Doloremque porro eligendi rerum.</description>
+          <description>Quaerat non veniam possimus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -344,22 +336,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '144'
+      - '140'
     body:
       encoding: UTF-8
       string: |
         <package name="third_package" project="my_project">
           <title>b</title>
-          <description>Doloremque porro eligendi rerum.</description>
+          <description>Quaerat non veniam possimus.</description>
         </package>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:26 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/third_package/_config
     body:
       encoding: UTF-8
-      string: Autem et fuga. Vel neque quos. Est eum tempore.
+      string: Quas eum sit. Saepe dignissimos qui. Ut vel vero.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -384,21 +375,20 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="3" vrev="3">
-          <srcmd5>7f4ac45ec3323fd0ce125268c3935fe6</srcmd5>
+          <srcmd5>16b387bb7efc9117262d43a4e3e590e3</srcmd5>
           <version>unknown</version>
-          <time>1590054681</time>
+          <time>1643644526</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:26 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/third_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Deserunt numquam non. Doloremque nam aut. Non aliquam qui.
+      string: Et a magnam. Et est aspernatur. Sequi vel qui.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -423,24 +413,23 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="4" vrev="4">
-          <srcmd5>f85c631d5ede28d20eb5e63d4d621d5e</srcmd5>
+          <srcmd5>417bb8b692e0ea672935306566d989b0</srcmd5>
           <version>unknown</version>
-          <time>1590054681</time>
+          <time>1643644526</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:26 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/my_project/package_with_kiwi_image/_meta?user=user_10
+    uri: http://backend:5352/source/my_project/package_with_kiwi_image/_meta?user=user_5
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="my_project">
-          <title>Terrible Swift Sword</title>
-          <description>Ut porro et voluptatem.</description>
+          <title>The Skull Beneath the Skin</title>
+          <description>Et explicabo commodi quisquam.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -461,16 +450,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '164'
+      - '177'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="my_project">
-          <title>Terrible Swift Sword</title>
-          <description>Ut porro et voluptatem.</description>
+          <title>The Skull Beneath the Skin</title>
+          <description>Et explicabo commodi quisquam.</description>
         </package>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:26 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/package_with_kiwi_image/package_with_kiwi_image.kiwi
@@ -507,22 +495,21 @@ http_interactions:
         <revision rev="2" vrev="2">
           <srcmd5>801c545be09c1c468ff2d99b40415aac</srcmd5>
           <version>0.0.1</version>
-          <time>1590054682</time>
+          <time>1643644526</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:26 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/my_project/package_with_kiwi_image/_meta?user=user_10
+    uri: http://backend:5352/source/my_project/package_with_kiwi_image/_meta?user=user_5
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="my_project">
-          <title>Terrible Swift Sword</title>
-          <description>Ut porro et voluptatem.</description>
+          <title>The Skull Beneath the Skin</title>
+          <description>Et explicabo commodi quisquam.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -543,16 +530,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '164'
+      - '177'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="my_project">
-          <title>Terrible Swift Sword</title>
-          <description>Ut porro et voluptatem.</description>
+          <title>The Skull Beneath the Skin</title>
+          <description>Et explicabo commodi quisquam.</description>
         </package>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:26 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/package_with_kiwi_image
@@ -583,10 +569,9 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="package_with_kiwi_image" rev="2" vrev="2" srcmd5="801c545be09c1c468ff2d99b40415aac">
-          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1590054676"/>
+          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1643644488"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:26 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/_project/_attribute?meta=1&user=tom
@@ -619,15 +604,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="4">
-          <srcmd5>81c06141dbbfb996f2cb51206c88b696</srcmd5>
-          <time>1590054682</time>
+        <revision rev="5">
+          <srcmd5>3122889573881abcb26a4e17233ba903</srcmd5>
+          <time>1643644526</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:26 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/first_package
@@ -635,6 +619,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 194e2d54-e733-43ba-8913-75c2fa62d5f6
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -657,19 +643,20 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="first_package" rev="4" vrev="4" srcmd5="f3e6eb1ff4134170e42c68a627b55385">
-          <entry name="_config" md5="c9aa42c3ae9937f5d179392604bf8440" size="63" mtime="1590054681"/>
-          <entry name="somefile.txt" md5="49a60109a9a95fd1e4c590ec28e5fd31" size="59" mtime="1590054681"/>
+        <directory name="first_package" rev="4" vrev="4" srcmd5="6f39711441a75534e478e15af5bed5f8">
+          <entry name="_config" md5="d5fa3568fccf2d71c587915e058da434" size="74" mtime="1643644526"/>
+          <entry name="somefile.txt" md5="e2dd39527025da19f9e6baf3e8e9ac61" size="69" mtime="1643644526"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:30 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/my_project/first_package
+    uri: http://backend:5352/source/my_project/first_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 194e2d54-e733-43ba-8913-75c2fa62d5f6
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -692,12 +679,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="first_package" rev="4" vrev="4" srcmd5="f3e6eb1ff4134170e42c68a627b55385">
-          <entry name="_config" md5="c9aa42c3ae9937f5d179392604bf8440" size="63" mtime="1590054681"/>
-          <entry name="somefile.txt" md5="49a60109a9a95fd1e4c590ec28e5fd31" size="59" mtime="1590054681"/>
+        <directory name="first_package" rev="4" vrev="4" srcmd5="6f39711441a75534e478e15af5bed5f8">
+          <entry name="_config" md5="d5fa3568fccf2d71c587915e058da434" size="74" mtime="1643644526"/>
+          <entry name="somefile.txt" md5="e2dd39527025da19f9e6baf3e8e9ac61" size="69" mtime="1643644526"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:30 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/second_package
@@ -705,6 +691,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 194e2d54-e733-43ba-8913-75c2fa62d5f6
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -727,19 +715,20 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="second_package" rev="4" vrev="4" srcmd5="f9286f75b5815e2d417f2786585802a1">
-          <entry name="_config" md5="b3d0adf98c6a84156d40b3b2c4c3ed5e" size="73" mtime="1590054681"/>
-          <entry name="somefile.txt" md5="ef3ffa2319e3dde507e7fd46ef4076db" size="58" mtime="1590054681"/>
+        <directory name="second_package" rev="4" vrev="4" srcmd5="14bba0670e068393a480920efd0d7456">
+          <entry name="_config" md5="29a031707c5267ad5d4fc25fb3c50a99" size="69" mtime="1643644526"/>
+          <entry name="somefile.txt" md5="b1667746342b2de730026bac5997d938" size="57" mtime="1643644526"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:30 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/my_project/second_package
+    uri: http://backend:5352/source/my_project/second_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 194e2d54-e733-43ba-8913-75c2fa62d5f6
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -762,12 +751,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="second_package" rev="4" vrev="4" srcmd5="f9286f75b5815e2d417f2786585802a1">
-          <entry name="_config" md5="b3d0adf98c6a84156d40b3b2c4c3ed5e" size="73" mtime="1590054681"/>
-          <entry name="somefile.txt" md5="ef3ffa2319e3dde507e7fd46ef4076db" size="58" mtime="1590054681"/>
+        <directory name="second_package" rev="4" vrev="4" srcmd5="14bba0670e068393a480920efd0d7456">
+          <entry name="_config" md5="29a031707c5267ad5d4fc25fb3c50a99" size="69" mtime="1643644526"/>
+          <entry name="somefile.txt" md5="b1667746342b2de730026bac5997d938" size="57" mtime="1643644526"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:30 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/third_package
@@ -775,6 +763,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 194e2d54-e733-43ba-8913-75c2fa62d5f6
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -797,19 +787,20 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="third_package" rev="4" vrev="4" srcmd5="f85c631d5ede28d20eb5e63d4d621d5e">
-          <entry name="_config" md5="711cd04e49936ec9ad0ac6499ca891c3" size="47" mtime="1590054681"/>
-          <entry name="somefile.txt" md5="a962f43f8c939941d9d12d640a22c678" size="58" mtime="1590054681"/>
+        <directory name="third_package" rev="4" vrev="4" srcmd5="417bb8b692e0ea672935306566d989b0">
+          <entry name="_config" md5="6431ef5738abeb5317e59c6d7f1d4956" size="49" mtime="1643644526"/>
+          <entry name="somefile.txt" md5="80d8cf118340713eb9f59cd37cbfabfd" size="46" mtime="1643644526"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:30 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/my_project/third_package
+    uri: http://backend:5352/source/my_project/third_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 194e2d54-e733-43ba-8913-75c2fa62d5f6
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -832,12 +823,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="third_package" rev="4" vrev="4" srcmd5="f85c631d5ede28d20eb5e63d4d621d5e">
-          <entry name="_config" md5="711cd04e49936ec9ad0ac6499ca891c3" size="47" mtime="1590054681"/>
-          <entry name="somefile.txt" md5="a962f43f8c939941d9d12d640a22c678" size="58" mtime="1590054681"/>
+        <directory name="third_package" rev="4" vrev="4" srcmd5="417bb8b692e0ea672935306566d989b0">
+          <entry name="_config" md5="6431ef5738abeb5317e59c6d7f1d4956" size="49" mtime="1643644526"/>
+          <entry name="somefile.txt" md5="80d8cf118340713eb9f59cd37cbfabfd" size="46" mtime="1643644526"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:30 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/package_with_kiwi_image
@@ -845,6 +835,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 194e2d54-e733-43ba-8913-75c2fa62d5f6
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -868,17 +860,18 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="package_with_kiwi_image" rev="2" vrev="2" srcmd5="801c545be09c1c468ff2d99b40415aac">
-          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1590054676"/>
+          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1643644488"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:31 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/my_project/package_with_kiwi_image
+    uri: http://backend:5352/source/my_project/package_with_kiwi_image?expand=1
     body:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 194e2d54-e733-43ba-8913-75c2fa62d5f6
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -902,10 +895,9 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="package_with_kiwi_image" rev="2" vrev="2" srcmd5="801c545be09c1c468ff2d99b40415aac">
-          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1590054676"/>
+          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1643644488"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:31 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom/_result?code=unresolvable&view=status
@@ -913,6 +905,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 0a2c97d8-1269-4bdb-b731-1aff4a5e6e3b
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -937,8 +931,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:33 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom/_keyinfo?donotcreatecert=1&withsslcert=1
@@ -946,6 +939,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 0a2c97d8-1269-4bdb-b731-1aff4a5e6e3b
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -968,8 +963,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "<keyinfo/>\n"
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:33 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom/_result?view=summary
@@ -977,6 +971,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 6ef36a0e-1b7b-4918-b940-f45cc3aaa0b0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1001,8 +997,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:33 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/first_package
@@ -1010,6 +1005,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - f21b1201-e831-430c-a90e-46a0268d8572
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1032,19 +1029,20 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="first_package" rev="4" vrev="4" srcmd5="f3e6eb1ff4134170e42c68a627b55385">
-          <entry name="_config" md5="c9aa42c3ae9937f5d179392604bf8440" size="63" mtime="1590054681"/>
-          <entry name="somefile.txt" md5="49a60109a9a95fd1e4c590ec28e5fd31" size="59" mtime="1590054681"/>
+        <directory name="first_package" rev="4" vrev="4" srcmd5="6f39711441a75534e478e15af5bed5f8">
+          <entry name="_config" md5="d5fa3568fccf2d71c587915e058da434" size="74" mtime="1643644526"/>
+          <entry name="somefile.txt" md5="e2dd39527025da19f9e6baf3e8e9ac61" size="69" mtime="1643644526"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:33 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/my_project/first_package
+    uri: http://backend:5352/source/my_project/first_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - f21b1201-e831-430c-a90e-46a0268d8572
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1067,12 +1065,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="first_package" rev="4" vrev="4" srcmd5="f3e6eb1ff4134170e42c68a627b55385">
-          <entry name="_config" md5="c9aa42c3ae9937f5d179392604bf8440" size="63" mtime="1590054681"/>
-          <entry name="somefile.txt" md5="49a60109a9a95fd1e4c590ec28e5fd31" size="59" mtime="1590054681"/>
+        <directory name="first_package" rev="4" vrev="4" srcmd5="6f39711441a75534e478e15af5bed5f8">
+          <entry name="_config" md5="d5fa3568fccf2d71c587915e058da434" size="74" mtime="1643644526"/>
+          <entry name="somefile.txt" md5="e2dd39527025da19f9e6baf3e8e9ac61" size="69" mtime="1643644526"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:33 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/second_package
@@ -1080,6 +1077,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - f21b1201-e831-430c-a90e-46a0268d8572
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1102,185 +1101,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="second_package" rev="4" vrev="4" srcmd5="f9286f75b5815e2d417f2786585802a1">
-          <entry name="_config" md5="b3d0adf98c6a84156d40b3b2c4c3ed5e" size="73" mtime="1590054681"/>
-          <entry name="somefile.txt" md5="ef3ffa2319e3dde507e7fd46ef4076db" size="58" mtime="1590054681"/>
+        <directory name="second_package" rev="4" vrev="4" srcmd5="14bba0670e068393a480920efd0d7456">
+          <entry name="_config" md5="29a031707c5267ad5d4fc25fb3c50a99" size="69" mtime="1643644526"/>
+          <entry name="somefile.txt" md5="b1667746342b2de730026bac5997d938" size="57" mtime="1643644526"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:23 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/my_project/second_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '299'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="second_package" rev="4" vrev="4" srcmd5="f9286f75b5815e2d417f2786585802a1">
-          <entry name="_config" md5="b3d0adf98c6a84156d40b3b2c4c3ed5e" size="73" mtime="1590054681"/>
-          <entry name="somefile.txt" md5="ef3ffa2319e3dde507e7fd46ef4076db" size="58" mtime="1590054681"/>
-        </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:23 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/my_project/third_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '298'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="third_package" rev="4" vrev="4" srcmd5="f85c631d5ede28d20eb5e63d4d621d5e">
-          <entry name="_config" md5="711cd04e49936ec9ad0ac6499ca891c3" size="47" mtime="1590054681"/>
-          <entry name="somefile.txt" md5="a962f43f8c939941d9d12d640a22c678" size="58" mtime="1590054681"/>
-        </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:23 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/my_project/third_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '298'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="third_package" rev="4" vrev="4" srcmd5="f85c631d5ede28d20eb5e63d4d621d5e">
-          <entry name="_config" md5="711cd04e49936ec9ad0ac6499ca891c3" size="47" mtime="1590054681"/>
-          <entry name="somefile.txt" md5="a962f43f8c939941d9d12d640a22c678" size="58" mtime="1590054681"/>
-        </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:23 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/my_project/package_with_kiwi_image
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '231'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="package_with_kiwi_image" rev="2" vrev="2" srcmd5="801c545be09c1c468ff2d99b40415aac">
-          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1590054676"/>
-        </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:23 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/my_project/package_with_kiwi_image
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '231'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="package_with_kiwi_image" rev="2" vrev="2" srcmd5="801c545be09c1c468ff2d99b40415aac">
-          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1590054676"/>
-        </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:33 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/second_package?expand=1
@@ -1288,6 +1113,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - f21b1201-e831-430c-a90e-46a0268d8572
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1310,12 +1137,189 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="second_package" rev="4" vrev="4" srcmd5="f9286f75b5815e2d417f2786585802a1">
-          <entry name="_config" md5="b3d0adf98c6a84156d40b3b2c4c3ed5e" size="73" mtime="1590054681"/>
-          <entry name="somefile.txt" md5="ef3ffa2319e3dde507e7fd46ef4076db" size="58" mtime="1590054681"/>
+        <directory name="second_package" rev="4" vrev="4" srcmd5="14bba0670e068393a480920efd0d7456">
+          <entry name="_config" md5="29a031707c5267ad5d4fc25fb3c50a99" size="69" mtime="1643644526"/>
+          <entry name="somefile.txt" md5="b1667746342b2de730026bac5997d938" size="57" mtime="1643644526"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:33 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/my_project/third_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - f21b1201-e831-430c-a90e-46a0268d8572
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '298'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="third_package" rev="4" vrev="4" srcmd5="417bb8b692e0ea672935306566d989b0">
+          <entry name="_config" md5="6431ef5738abeb5317e59c6d7f1d4956" size="49" mtime="1643644526"/>
+          <entry name="somefile.txt" md5="80d8cf118340713eb9f59cd37cbfabfd" size="46" mtime="1643644526"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:55:33 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/my_project/third_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - f21b1201-e831-430c-a90e-46a0268d8572
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '298'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="third_package" rev="4" vrev="4" srcmd5="417bb8b692e0ea672935306566d989b0">
+          <entry name="_config" md5="6431ef5738abeb5317e59c6d7f1d4956" size="49" mtime="1643644526"/>
+          <entry name="somefile.txt" md5="80d8cf118340713eb9f59cd37cbfabfd" size="46" mtime="1643644526"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:55:33 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/my_project/package_with_kiwi_image
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - f21b1201-e831-430c-a90e-46a0268d8572
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '231'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_with_kiwi_image" rev="2" vrev="2" srcmd5="801c545be09c1c468ff2d99b40415aac">
+          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1643644488"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:55:33 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/my_project/package_with_kiwi_image?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - f21b1201-e831-430c-a90e-46a0268d8572
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '231'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_with_kiwi_image" rev="2" vrev="2" srcmd5="801c545be09c1c468ff2d99b40415aac">
+          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1643644488"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:55:33 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/my_project/second_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - d8d586d0-286c-432d-8d7e-37a8c579cfcc
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '299'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="second_package" rev="4" vrev="4" srcmd5="14bba0670e068393a480920efd0d7456">
+          <entry name="_config" md5="29a031707c5267ad5d4fc25fb3c50a99" size="69" mtime="1643644526"/>
+          <entry name="somefile.txt" md5="b1667746342b2de730026bac5997d938" size="57" mtime="1643644526"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:55:34 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/second_package?rev=4
@@ -1323,6 +1327,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - d8d586d0-286c-432d-8d7e-37a8c579cfcc
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1345,12 +1351,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="second_package" rev="4" vrev="4" srcmd5="f9286f75b5815e2d417f2786585802a1">
-          <entry name="_config" md5="b3d0adf98c6a84156d40b3b2c4c3ed5e" size="73" mtime="1590054681"/>
-          <entry name="somefile.txt" md5="ef3ffa2319e3dde507e7fd46ef4076db" size="58" mtime="1590054681"/>
+        <directory name="second_package" rev="4" vrev="4" srcmd5="14bba0670e068393a480920efd0d7456">
+          <entry name="_config" md5="29a031707c5267ad5d4fc25fb3c50a99" size="69" mtime="1643644526"/>
+          <entry name="somefile.txt" md5="b1667746342b2de730026bac5997d938" size="57" mtime="1643644526"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:34 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22second_package%22%20and%20linkinfo/@project=%22my_project%22%20and%20@project=%22my_project%22)
@@ -1384,8 +1389,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:34 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:my_project/_meta?user=tom
@@ -1398,6 +1402,8 @@ http_interactions:
           <person userid="tom" role="maintainer"/>
         </project>
     headers:
+      X-Request-Id:
+      - d8d586d0-286c-432d-8d7e-37a8c579cfcc
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1425,8 +1431,7 @@ http_interactions:
           <description>This project was created for package second_package via attribute OBS:Maintained</description>
           <person userid="tom" role="maintainer"/>
         </project>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:34 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:my_project/_project/_attribute?meta=1&user=tom
@@ -1435,10 +1440,12 @@ http_interactions:
       string: |
         <attributes>
           <attribute name="AutoCleanup" namespace="OBS">
-            <value>2020-06-04 09:51:24 +0000</value>
+            <value>2022-02-14 15:55:34 +0000</value>
           </attribute>
         </attributes>
     headers:
+      X-Request-Id:
+      - d8d586d0-286c-432d-8d7e-37a8c579cfcc
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1462,14 +1469,13 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="5">
-          <srcmd5>05c781758e8f7dc4bc67ce15f5cdd494</srcmd5>
-          <time>1590054684</time>
+          <srcmd5>beb5d85261fa21c0dc33ff4cfc1b9993</srcmd5>
+          <time>1643644534</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:34 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:my_project/custom_name/_meta?user=tom
@@ -1478,7 +1484,7 @@ http_interactions:
       string: |
         <package name="custom_name" project="home:tom:branches:my_project">
           <title>c</title>
-          <description>Et aliquid quis aut.</description>
+          <description>Libero sint aliquam nesciunt.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1499,19 +1505,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '148'
+      - '157'
     body:
       encoding: UTF-8
       string: |
         <package name="custom_name" project="home:tom:branches:my_project">
           <title>c</title>
-          <description>Et aliquid quis aut.</description>
+          <description>Libero sint aliquam nesciunt.</description>
         </package>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:35 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:tom:branches:my_project/custom_name?cmd=branch&noservice=1&opackage=second_package&oproject=my_project&orev=f9286f75b5815e2d417f2786585802a1&user=tom
+    uri: http://backend:5352/source/home:tom:branches:my_project/custom_name?cmd=branch&noservice=1&opackage=second_package&oproject=my_project&orev=14bba0670e068393a480920efd0d7456&user=tom
     body:
       encoding: UTF-8
       string: ''
@@ -1541,15 +1546,14 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="1" vrev="1">
-          <srcmd5>427f959183a4108715bbfa77bf3514af</srcmd5>
+          <srcmd5>d082b898fd18f15fd684c8dd9a8e73e9</srcmd5>
           <version>unknown</version>
-          <time>1590054684</time>
+          <time>1643644535</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:35 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:my_project/custom_name/_meta?user=tom
@@ -1558,7 +1562,7 @@ http_interactions:
       string: |
         <package name="custom_name" project="home:tom:branches:my_project">
           <title>c</title>
-          <description>Et aliquid quis aut.</description>
+          <description>Libero sint aliquam nesciunt.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1579,16 +1583,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '148'
+      - '157'
     body:
       encoding: UTF-8
       string: |
         <package name="custom_name" project="home:tom:branches:my_project">
           <title>c</title>
-          <description>Et aliquid quis aut.</description>
+          <description>Libero sint aliquam nesciunt.</description>
         </package>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:35 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/custom_name
@@ -1618,14 +1621,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="custom_name" rev="1" vrev="1" srcmd5="427f959183a4108715bbfa77bf3514af">
-          <linkinfo project="my_project" package="second_package" rev="f9286f75b5815e2d417f2786585802a1" srcmd5="f9286f75b5815e2d417f2786585802a1" baserev="f9286f75b5815e2d417f2786585802a1" xsrcmd5="d987d6a23dda68216963149362673f89" lsrcmd5="427f959183a4108715bbfa77bf3514af"/>
-          <entry name="_config" md5="b3d0adf98c6a84156d40b3b2c4c3ed5e" size="73" mtime="1590054681"/>
-          <entry name="_link" md5="634bed4e7e970369207cd84654492cad" size="182" mtime="1590054684"/>
-          <entry name="somefile.txt" md5="ef3ffa2319e3dde507e7fd46ef4076db" size="58" mtime="1590054681"/>
+        <directory name="custom_name" rev="1" vrev="1" srcmd5="d082b898fd18f15fd684c8dd9a8e73e9">
+          <linkinfo project="my_project" package="second_package" rev="14bba0670e068393a480920efd0d7456" srcmd5="14bba0670e068393a480920efd0d7456" baserev="14bba0670e068393a480920efd0d7456" xsrcmd5="43d57e9ace0a9b1931f0c70d8360b397" lsrcmd5="d082b898fd18f15fd684c8dd9a8e73e9"/>
+          <entry name="_config" md5="29a031707c5267ad5d4fc25fb3c50a99" size="69" mtime="1643644526"/>
+          <entry name="_link" md5="f7b6e134388d91934098a398243a19cc" size="182" mtime="1643644535"/>
+          <entry name="somefile.txt" md5="b1667746342b2de730026bac5997d938" size="57" mtime="1643644526"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:35 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/custom_name?view=info
@@ -1633,6 +1635,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - d8d586d0-286c-432d-8d7e-37a8c579cfcc
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1655,12 +1659,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="custom_name" rev="1" vrev="1" srcmd5="d987d6a23dda68216963149362673f89" lsrcmd5="427f959183a4108715bbfa77bf3514af" verifymd5="f9286f75b5815e2d417f2786585802a1">
+        <sourceinfo package="custom_name" rev="1" vrev="1" srcmd5="43d57e9ace0a9b1931f0c70d8360b397" lsrcmd5="d082b898fd18f15fd684c8dd9a8e73e9" verifymd5="14bba0670e068393a480920efd0d7456">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="my_project" package="second_package"/>
         </sourceinfo>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:35 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/custom_name
@@ -1668,6 +1671,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - d8d586d0-286c-432d-8d7e-37a8c579cfcc
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1690,14 +1695,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="custom_name" rev="1" vrev="1" srcmd5="427f959183a4108715bbfa77bf3514af">
-          <linkinfo project="my_project" package="second_package" rev="f9286f75b5815e2d417f2786585802a1" srcmd5="f9286f75b5815e2d417f2786585802a1" baserev="f9286f75b5815e2d417f2786585802a1" xsrcmd5="d987d6a23dda68216963149362673f89" lsrcmd5="427f959183a4108715bbfa77bf3514af"/>
-          <entry name="_config" md5="b3d0adf98c6a84156d40b3b2c4c3ed5e" size="73" mtime="1590054681"/>
-          <entry name="_link" md5="634bed4e7e970369207cd84654492cad" size="182" mtime="1590054684"/>
-          <entry name="somefile.txt" md5="ef3ffa2319e3dde507e7fd46ef4076db" size="58" mtime="1590054681"/>
+        <directory name="custom_name" rev="1" vrev="1" srcmd5="d082b898fd18f15fd684c8dd9a8e73e9">
+          <linkinfo project="my_project" package="second_package" rev="14bba0670e068393a480920efd0d7456" srcmd5="14bba0670e068393a480920efd0d7456" baserev="14bba0670e068393a480920efd0d7456" xsrcmd5="43d57e9ace0a9b1931f0c70d8360b397" lsrcmd5="d082b898fd18f15fd684c8dd9a8e73e9"/>
+          <entry name="_config" md5="29a031707c5267ad5d4fc25fb3c50a99" size="69" mtime="1643644526"/>
+          <entry name="_link" md5="f7b6e134388d91934098a398243a19cc" size="182" mtime="1643644535"/>
+          <entry name="somefile.txt" md5="b1667746342b2de730026bac5997d938" size="57" mtime="1643644526"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:35 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:my_project/custom_name?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -1729,15 +1733,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="5315fd1adca23942d54937c9942ad4fa">
+        <sourcediff key="9aa939adff28a25afbad81766b06c7b9">
           <old project="home:tom:branches:my_project" package="custom_name" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:tom:branches:my_project" package="custom_name" rev="1" srcmd5="427f959183a4108715bbfa77bf3514af"/>
+          <new project="home:tom:branches:my_project" package="custom_name" rev="1" srcmd5="d082b898fd18f15fd684c8dd9a8e73e9"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:35 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:my_project/custom_name?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -1769,15 +1772,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="5cb63572434006ac6998868e145f2382">
-          <old project="my_project" package="second_package" rev="f9286f75b5815e2d417f2786585802a1" srcmd5="f9286f75b5815e2d417f2786585802a1"/>
-          <new project="home:tom:branches:my_project" package="custom_name" rev="d987d6a23dda68216963149362673f89" srcmd5="d987d6a23dda68216963149362673f89"/>
+        <sourcediff key="d41e4d19d79635e9cae71e7f0de1cf99">
+          <old project="my_project" package="second_package" rev="14bba0670e068393a480920efd0d7456" srcmd5="14bba0670e068393a480920efd0d7456"/>
+          <new project="home:tom:branches:my_project" package="custom_name" rev="43d57e9ace0a9b1931f0c70d8360b397" srcmd5="43d57e9ace0a9b1931f0c70d8360b397"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:35 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:my_project/_meta?user=tom
@@ -1793,6 +1795,8 @@ http_interactions:
           </publish>
         </project>
     headers:
+      X-Request-Id:
+      - d8d586d0-286c-432d-8d7e-37a8c579cfcc
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1823,8 +1827,7 @@ http_interactions:
             <disable/>
           </publish>
         </project>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:35 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/custom_name
@@ -1832,6 +1835,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - d8d586d0-286c-432d-8d7e-37a8c579cfcc
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1854,14 +1859,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="custom_name" rev="1" vrev="1" srcmd5="427f959183a4108715bbfa77bf3514af">
-          <linkinfo project="my_project" package="second_package" rev="f9286f75b5815e2d417f2786585802a1" srcmd5="f9286f75b5815e2d417f2786585802a1" baserev="f9286f75b5815e2d417f2786585802a1" xsrcmd5="d987d6a23dda68216963149362673f89" lsrcmd5="427f959183a4108715bbfa77bf3514af"/>
-          <entry name="_config" md5="b3d0adf98c6a84156d40b3b2c4c3ed5e" size="73" mtime="1590054681"/>
-          <entry name="_link" md5="634bed4e7e970369207cd84654492cad" size="182" mtime="1590054684"/>
-          <entry name="somefile.txt" md5="ef3ffa2319e3dde507e7fd46ef4076db" size="58" mtime="1590054681"/>
+        <directory name="custom_name" rev="1" vrev="1" srcmd5="d082b898fd18f15fd684c8dd9a8e73e9">
+          <linkinfo project="my_project" package="second_package" rev="14bba0670e068393a480920efd0d7456" srcmd5="14bba0670e068393a480920efd0d7456" baserev="14bba0670e068393a480920efd0d7456" xsrcmd5="43d57e9ace0a9b1931f0c70d8360b397" lsrcmd5="d082b898fd18f15fd684c8dd9a8e73e9"/>
+          <entry name="_config" md5="29a031707c5267ad5d4fc25fb3c50a99" size="69" mtime="1643644526"/>
+          <entry name="_link" md5="f7b6e134388d91934098a398243a19cc" size="182" mtime="1643644535"/>
+          <entry name="somefile.txt" md5="b1667746342b2de730026bac5997d938" size="57" mtime="1643644526"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:35 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/second_package?view=info
@@ -1869,6 +1873,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - ac500048-9c48-4224-a557-0074a952693e
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1891,11 +1897,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="second_package" rev="4" vrev="4" srcmd5="f9286f75b5815e2d417f2786585802a1" verifymd5="f9286f75b5815e2d417f2786585802a1">
+        <sourceinfo package="second_package" rev="4" vrev="4" srcmd5="14bba0670e068393a480920efd0d7456" verifymd5="14bba0670e068393a480920efd0d7456">
           <error>bad build configuration, no build type defined or detected</error>
         </sourceinfo>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:35 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/second_package
@@ -1903,6 +1908,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - ac500048-9c48-4224-a557-0074a952693e
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1925,12 +1932,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="second_package" rev="4" vrev="4" srcmd5="f9286f75b5815e2d417f2786585802a1">
-          <entry name="_config" md5="b3d0adf98c6a84156d40b3b2c4c3ed5e" size="73" mtime="1590054681"/>
-          <entry name="somefile.txt" md5="ef3ffa2319e3dde507e7fd46ef4076db" size="58" mtime="1590054681"/>
+        <directory name="second_package" rev="4" vrev="4" srcmd5="14bba0670e068393a480920efd0d7456">
+          <entry name="_config" md5="29a031707c5267ad5d4fc25fb3c50a99" size="69" mtime="1643644526"/>
+          <entry name="somefile.txt" md5="b1667746342b2de730026bac5997d938" size="57" mtime="1643644526"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:35 GMT
 - request:
     method: post
     uri: http://backend:5352/source/my_project/second_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -1962,15 +1968,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="477a1e4f790d17f73f67885497fe08cc">
+        <sourcediff key="feebc02ebea8b7a2d0ca626ff19f6fc8">
           <old project="my_project" package="second_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="my_project" package="second_package" rev="4" srcmd5="f9286f75b5815e2d417f2786585802a1"/>
+          <new project="my_project" package="second_package" rev="4" srcmd5="14bba0670e068393a480920efd0d7456"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:35 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/custom_name
@@ -1978,6 +1983,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - ac500048-9c48-4224-a557-0074a952693e
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -2000,14 +2007,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="custom_name" rev="1" vrev="1" srcmd5="427f959183a4108715bbfa77bf3514af">
-          <linkinfo project="my_project" package="second_package" rev="f9286f75b5815e2d417f2786585802a1" srcmd5="f9286f75b5815e2d417f2786585802a1" baserev="f9286f75b5815e2d417f2786585802a1" xsrcmd5="d987d6a23dda68216963149362673f89" lsrcmd5="427f959183a4108715bbfa77bf3514af"/>
-          <entry name="_config" md5="b3d0adf98c6a84156d40b3b2c4c3ed5e" size="73" mtime="1590054681"/>
-          <entry name="_link" md5="634bed4e7e970369207cd84654492cad" size="182" mtime="1590054684"/>
-          <entry name="somefile.txt" md5="ef3ffa2319e3dde507e7fd46ef4076db" size="58" mtime="1590054681"/>
+        <directory name="custom_name" rev="1" vrev="1" srcmd5="d082b898fd18f15fd684c8dd9a8e73e9">
+          <linkinfo project="my_project" package="second_package" rev="14bba0670e068393a480920efd0d7456" srcmd5="14bba0670e068393a480920efd0d7456" baserev="14bba0670e068393a480920efd0d7456" xsrcmd5="43d57e9ace0a9b1931f0c70d8360b397" lsrcmd5="d082b898fd18f15fd684c8dd9a8e73e9"/>
+          <entry name="_config" md5="29a031707c5267ad5d4fc25fb3c50a99" size="69" mtime="1643644526"/>
+          <entry name="_link" md5="f7b6e134388d91934098a398243a19cc" size="182" mtime="1643644535"/>
+          <entry name="somefile.txt" md5="b1667746342b2de730026bac5997d938" size="57" mtime="1643644526"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:35 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/custom_name?expand=1&rev=1
@@ -2037,13 +2043,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="custom_name" rev="d987d6a23dda68216963149362673f89" vrev="1" srcmd5="d987d6a23dda68216963149362673f89">
-          <linkinfo project="my_project" package="second_package" rev="f9286f75b5815e2d417f2786585802a1" srcmd5="f9286f75b5815e2d417f2786585802a1" baserev="f9286f75b5815e2d417f2786585802a1" lsrcmd5="427f959183a4108715bbfa77bf3514af"/>
-          <entry name="_config" md5="b3d0adf98c6a84156d40b3b2c4c3ed5e" size="73" mtime="1590054681"/>
-          <entry name="somefile.txt" md5="ef3ffa2319e3dde507e7fd46ef4076db" size="58" mtime="1590054681"/>
+        <directory name="custom_name" rev="43d57e9ace0a9b1931f0c70d8360b397" vrev="1" srcmd5="43d57e9ace0a9b1931f0c70d8360b397">
+          <linkinfo project="my_project" package="second_package" rev="14bba0670e068393a480920efd0d7456" srcmd5="14bba0670e068393a480920efd0d7456" baserev="14bba0670e068393a480920efd0d7456" lsrcmd5="d082b898fd18f15fd684c8dd9a8e73e9"/>
+          <entry name="_config" md5="29a031707c5267ad5d4fc25fb3c50a99" size="69" mtime="1643644526"/>
+          <entry name="somefile.txt" md5="b1667746342b2de730026bac5997d938" size="57" mtime="1643644526"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:35 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/custom_name
@@ -2051,6 +2056,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - ac500048-9c48-4224-a557-0074a952693e
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -2073,14 +2080,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="custom_name" rev="1" vrev="1" srcmd5="427f959183a4108715bbfa77bf3514af">
-          <linkinfo project="my_project" package="second_package" rev="f9286f75b5815e2d417f2786585802a1" srcmd5="f9286f75b5815e2d417f2786585802a1" baserev="f9286f75b5815e2d417f2786585802a1" xsrcmd5="d987d6a23dda68216963149362673f89" lsrcmd5="427f959183a4108715bbfa77bf3514af"/>
-          <entry name="_config" md5="b3d0adf98c6a84156d40b3b2c4c3ed5e" size="73" mtime="1590054681"/>
-          <entry name="_link" md5="634bed4e7e970369207cd84654492cad" size="182" mtime="1590054684"/>
-          <entry name="somefile.txt" md5="ef3ffa2319e3dde507e7fd46ef4076db" size="58" mtime="1590054681"/>
+        <directory name="custom_name" rev="1" vrev="1" srcmd5="d082b898fd18f15fd684c8dd9a8e73e9">
+          <linkinfo project="my_project" package="second_package" rev="14bba0670e068393a480920efd0d7456" srcmd5="14bba0670e068393a480920efd0d7456" baserev="14bba0670e068393a480920efd0d7456" xsrcmd5="43d57e9ace0a9b1931f0c70d8360b397" lsrcmd5="d082b898fd18f15fd684c8dd9a8e73e9"/>
+          <entry name="_config" md5="29a031707c5267ad5d4fc25fb3c50a99" size="69" mtime="1643644526"/>
+          <entry name="_link" md5="f7b6e134388d91934098a398243a19cc" size="182" mtime="1643644535"/>
+          <entry name="somefile.txt" md5="b1667746342b2de730026bac5997d938" size="57" mtime="1643644526"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:35 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/custom_name
@@ -2088,6 +2094,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - ac500048-9c48-4224-a557-0074a952693e
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -2110,14 +2118,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="custom_name" rev="1" vrev="1" srcmd5="427f959183a4108715bbfa77bf3514af">
-          <linkinfo project="my_project" package="second_package" rev="f9286f75b5815e2d417f2786585802a1" srcmd5="f9286f75b5815e2d417f2786585802a1" baserev="f9286f75b5815e2d417f2786585802a1" xsrcmd5="d987d6a23dda68216963149362673f89" lsrcmd5="427f959183a4108715bbfa77bf3514af"/>
-          <entry name="_config" md5="b3d0adf98c6a84156d40b3b2c4c3ed5e" size="73" mtime="1590054681"/>
-          <entry name="_link" md5="634bed4e7e970369207cd84654492cad" size="182" mtime="1590054684"/>
-          <entry name="somefile.txt" md5="ef3ffa2319e3dde507e7fd46ef4076db" size="58" mtime="1590054681"/>
+        <directory name="custom_name" rev="1" vrev="1" srcmd5="d082b898fd18f15fd684c8dd9a8e73e9">
+          <linkinfo project="my_project" package="second_package" rev="14bba0670e068393a480920efd0d7456" srcmd5="14bba0670e068393a480920efd0d7456" baserev="14bba0670e068393a480920efd0d7456" xsrcmd5="43d57e9ace0a9b1931f0c70d8360b397" lsrcmd5="d082b898fd18f15fd684c8dd9a8e73e9"/>
+          <entry name="_config" md5="29a031707c5267ad5d4fc25fb3c50a99" size="69" mtime="1643644526"/>
+          <entry name="_link" md5="f7b6e134388d91934098a398243a19cc" size="182" mtime="1643644535"/>
+          <entry name="somefile.txt" md5="b1667746342b2de730026bac5997d938" size="57" mtime="1643644526"/>
         </directory>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:35 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/custom_name/_history
@@ -2149,14 +2156,13 @@ http_interactions:
       string: |
         <revisionlist>
           <revision rev="1" vrev="1">
-            <srcmd5>427f959183a4108715bbfa77bf3514af</srcmd5>
+            <srcmd5>d082b898fd18f15fd684c8dd9a8e73e9</srcmd5>
             <version>unknown</version>
-            <time>1590054684</time>
+            <time>1643644535</time>
             <user>tom</user>
           </revision>
         </revisionlist>
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:55:35 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:my_project/_result?package=custom_name&view=status
@@ -2164,6 +2170,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 34e0c04f-3bf5-46b5-97db-12bb8006d183
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -2188,6 +2196,5 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-    http_version: null
-  recorded_at: Thu, 21 May 2020 09:51:25 GMT
-recorded_with: VCR 5.1.0
+  recorded_at: Mon, 31 Jan 2022 15:55:36 GMT
+recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Package/_file_exists_/_multibuild_file_should_exist/1_4_1_1.yml
+++ b/src/api/spec/cassettes/Package/_file_exists_/_multibuild_file_should_exist/1_4_1_1.yml
@@ -1,0 +1,225 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '128'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer"/>
+        </project>
+  recorded_at: Mon, 31 Jan 2022 09:46:09 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/test/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test" project="home:tom">
+          <title>In a Dry Season</title>
+          <description>Ea numquam consequatur laudantium.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '149'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test" project="home:tom">
+          <title>In a Dry Season</title>
+          <description>Ea numquam consequatur laudantium.</description>
+        </package>
+  recorded_at: Mon, 31 Jan 2022 09:46:10 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/test/_config
+    body:
+      encoding: UTF-8
+      string: Quia cum laborum. Animi voluptate dignissimos. Nulla error quis.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="1" vrev="1">
+          <srcmd5>b1fa90238ea47bf1d57f2db7b1912469</srcmd5>
+          <version>unknown</version>
+          <time>1643622370</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Mon, 31 Jan 2022 09:46:10 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/test/_multibuild
+    body:
+      encoding: UTF-8
+      string: "<multibuild><flavor>flavor_a</flavor><flavor>flavor_b</flavor></multibuild>"
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="2" vrev="2">
+          <srcmd5>022c0ef1747c645f56c68c20a8c4ef9f</srcmd5>
+          <version>unknown</version>
+          <time>1643622370</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Mon, 31 Jan 2022 09:46:10 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom/test
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '288'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test" rev="2" vrev="2" srcmd5="022c0ef1747c645f56c68c20a8c4ef9f">
+          <entry name="_config" md5="cd1ad23638712ccc23eec971ae4d6bd9" size="64" mtime="1643622370"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643622370"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 09:46:10 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom/test?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '288'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test" rev="2" vrev="2" srcmd5="022c0ef1747c645f56c68c20a8c4ef9f">
+          <entry name="_config" md5="cd1ad23638712ccc23eec971ae4d6bd9" size="64" mtime="1643622370"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643622370"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 09:46:10 GMT
+recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Package/_file_exists_/with_more_than_one_file/returns_false_if_the_file_does_not_exist.yml
+++ b/src/api/spec/cassettes/Package/_file_exists_/with_more_than_one_file/returns_false_if_the_file_does_not_exist.yml
@@ -30,17 +30,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '129'
+      - '128'
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom">
           <title></title>
           <description></description>
-          <person userid="tom" role="maintainer" />
+          <person userid="tom" role="maintainer"/>
         </project>
-    http_version: 
-  recorded_at: Thu, 06 Sep 2018 10:45:39 GMT
+  recorded_at: Mon, 31 Jan 2022 13:29:44 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/package_with_files/_meta?user=tom
@@ -48,8 +47,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_files" project="home:tom">
-          <title>Jesting Pilate</title>
-          <description>Porro est sed accusamus.</description>
+          <title>Precious Bane</title>
+          <description>Perspiciatis alias laborum veritatis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,61 +69,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '152'
+      - '164'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_files" project="home:tom">
-          <title>Jesting Pilate</title>
-          <description>Porro est sed accusamus.</description>
+          <title>Precious Bane</title>
+          <description>Perspiciatis alias laborum veritatis.</description>
         </package>
-    http_version: 
-  recorded_at: Thu, 06 Sep 2018 10:45:39 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:tom/package_with_files/_meta?user=tom
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="package_with_files" project="home:tom">
-          <title>Jesting Pilate</title>
-          <description>Porro est sed accusamus.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '152'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="package_with_files" project="home:tom">
-          <title>Jesting Pilate</title>
-          <description>Porro est sed accusamus.</description>
-        </package>
-    http_version: 
-  recorded_at: Thu, 06 Sep 2018 10:45:39 GMT
+  recorded_at: Mon, 31 Jan 2022 13:29:44 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/package_with_files/_config
     body:
       encoding: UTF-8
-      string: Omnis commodi aut. Ut voluptates consectetur. Est eveniet sit.
+      string: Suscipit officia est. Mollitia veritatis quia. Et quo maiores.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -144,26 +103,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '207'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="408" vrev="408">
-          <srcmd5>f607e5ff94fd480d4eed521436509a3a</srcmd5>
+        <revision rev="1" vrev="1">
+          <srcmd5>65e2d1156a1859e142f14391021c1b72</srcmd5>
           <version>unknown</version>
-          <time>1536230739</time>
+          <time>1643635784</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: 
-  recorded_at: Thu, 06 Sep 2018 10:45:39 GMT
+  recorded_at: Mon, 31 Jan 2022 13:29:44 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/package_with_files/somefile.txt
     body:
       encoding: UTF-8
-      string: A adipisci ducimus. Est eum id. Non ut nobis.
+      string: Neque iste maiores. Reiciendis dolorum aut. Animi ratione quia.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -183,20 +141,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '207'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="409" vrev="409">
-          <srcmd5>a1e8b611a980f984f424db49389b5d33</srcmd5>
+        <revision rev="2" vrev="2">
+          <srcmd5>4e2e13990b74a66011e7f498cfcb15b0</srcmd5>
           <version>unknown</version>
-          <time>1536230739</time>
+          <time>1643635784</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: 
-  recorded_at: Thu, 06 Sep 2018 10:45:39 GMT
+  recorded_at: Mon, 31 Jan 2022 13:29:44 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom/package_with_files
@@ -222,20 +179,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '402'
+      - '303'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_files" rev="409" vrev="409" srcmd5="a1e8b611a980f984f424db49389b5d33">
-          <entry name="_config" md5="5ffde518500d598d9eb2f367042774f4" size="62" mtime="1536230739" />
-          <entry name="_icon" md5="63145ba980e361af320c5314bbe06c54" size="60" mtime="1536230739" />
-          <entry name="somefile.txt" md5="d42c395c0d5293831f52ab98c573c981" size="45" mtime="1536230739" />
+        <directory name="package_with_files" rev="2" vrev="2" srcmd5="4e2e13990b74a66011e7f498cfcb15b0">
+          <entry name="_config" md5="859cbdc58cb3d2c763093a409f666b10" size="62" mtime="1643635784"/>
+          <entry name="somefile.txt" md5="e6e03fc54696c5d2d0d73f742e31fd4a" size="63" mtime="1643635784"/>
         </directory>
-    http_version: 
-  recorded_at: Thu, 06 Sep 2018 10:45:39 GMT
+  recorded_at: Mon, 31 Jan 2022 13:29:44 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:tom/package_with_files
+    uri: http://backend:5352/source/home:tom/package_with_files?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -258,15 +213,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '402'
+      - '303'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_files" rev="409" vrev="409" srcmd5="a1e8b611a980f984f424db49389b5d33">
-          <entry name="_config" md5="5ffde518500d598d9eb2f367042774f4" size="62" mtime="1536230739" />
-          <entry name="_icon" md5="63145ba980e361af320c5314bbe06c54" size="60" mtime="1536230739" />
-          <entry name="somefile.txt" md5="d42c395c0d5293831f52ab98c573c981" size="45" mtime="1536230739" />
+        <directory name="package_with_files" rev="2" vrev="2" srcmd5="4e2e13990b74a66011e7f498cfcb15b0">
+          <entry name="_config" md5="859cbdc58cb3d2c763093a409f666b10" size="62" mtime="1643635784"/>
+          <entry name="somefile.txt" md5="e6e03fc54696c5d2d0d73f742e31fd4a" size="63" mtime="1643635784"/>
         </directory>
-    http_version: 
-  recorded_at: Thu, 06 Sep 2018 10:45:39 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Mon, 31 Jan 2022 13:29:44 GMT
+recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Package/_file_exists_/with_more_than_one_file/returns_true_if_the_file_exist.yml
+++ b/src/api/spec/cassettes/Package/_file_exists_/with_more_than_one_file/returns_true_if_the_file_exist.yml
@@ -30,17 +30,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '129'
+      - '128'
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom">
           <title></title>
           <description></description>
-          <person userid="tom" role="maintainer" />
+          <person userid="tom" role="maintainer"/>
         </project>
-    http_version: 
-  recorded_at: Thu, 06 Sep 2018 10:45:39 GMT
+  recorded_at: Mon, 31 Jan 2022 13:30:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/package_with_files/_meta?user=tom
@@ -48,8 +47,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_files" project="home:tom">
-          <title>The Skull Beneath the Skin</title>
-          <description>Sed eos exercitationem placeat.</description>
+          <title>No Highway</title>
+          <description>Quae quaerat inventore suscipit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,61 +69,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '156'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_files" project="home:tom">
-          <title>The Skull Beneath the Skin</title>
-          <description>Sed eos exercitationem placeat.</description>
+          <title>No Highway</title>
+          <description>Quae quaerat inventore suscipit.</description>
         </package>
-    http_version: 
-  recorded_at: Thu, 06 Sep 2018 10:45:39 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:tom/package_with_files/_meta?user=tom
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="package_with_files" project="home:tom">
-          <title>The Skull Beneath the Skin</title>
-          <description>Sed eos exercitationem placeat.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '171'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="package_with_files" project="home:tom">
-          <title>The Skull Beneath the Skin</title>
-          <description>Sed eos exercitationem placeat.</description>
-        </package>
-    http_version: 
-  recorded_at: Thu, 06 Sep 2018 10:45:39 GMT
+  recorded_at: Mon, 31 Jan 2022 13:30:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/package_with_files/_config
     body:
       encoding: UTF-8
-      string: Ut qui quo. Id eaque consequatur. Dignissimos repellendus voluptatem.
+      string: Adipisci dolores id. Autem neque et. Voluptatem sit vero.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -144,26 +103,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '207'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="410" vrev="410">
-          <srcmd5>bf10ee2b78231cd4e422b59c029ca7b9</srcmd5>
+        <revision rev="3" vrev="3">
+          <srcmd5>e555c4f006c64d55db53ddfd70252fda</srcmd5>
           <version>unknown</version>
-          <time>1536230739</time>
+          <time>1643635853</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: 
-  recorded_at: Thu, 06 Sep 2018 10:45:39 GMT
+  recorded_at: Mon, 31 Jan 2022 13:30:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/package_with_files/somefile.txt
     body:
       encoding: UTF-8
-      string: Aperiam odit autem. Aperiam vitae soluta. Tempore culpa accusantium.
+      string: Delectus in voluptatem. Commodi quaerat ut. Alias explicabo rerum.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -183,20 +141,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '207'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="411" vrev="411">
-          <srcmd5>5dcb82a2e4ce4ebc27533914a8fdc601</srcmd5>
+        <revision rev="4" vrev="4">
+          <srcmd5>da9ddad6a1af9c3f26808e9b0839a0cf</srcmd5>
           <version>unknown</version>
-          <time>1536230739</time>
+          <time>1643635853</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: 
-  recorded_at: Thu, 06 Sep 2018 10:45:39 GMT
+  recorded_at: Mon, 31 Jan 2022 13:30:53 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom/package_with_files
@@ -222,20 +179,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '402'
+      - '303'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_files" rev="411" vrev="411" srcmd5="5dcb82a2e4ce4ebc27533914a8fdc601">
-          <entry name="_config" md5="2d2262ee959301d9d874ef159d3510fc" size="69" mtime="1536230739" />
-          <entry name="_icon" md5="63145ba980e361af320c5314bbe06c54" size="60" mtime="1536230739" />
-          <entry name="somefile.txt" md5="4dfa422adc4484aa5b32a7a3848c6ef6" size="68" mtime="1536230739" />
+        <directory name="package_with_files" rev="4" vrev="4" srcmd5="da9ddad6a1af9c3f26808e9b0839a0cf">
+          <entry name="_config" md5="1cba0683a396e3a297eda3fad8177265" size="57" mtime="1643635853"/>
+          <entry name="somefile.txt" md5="6ac62664efd6370cad9880b2b1973c1e" size="66" mtime="1643635853"/>
         </directory>
-    http_version: 
-  recorded_at: Thu, 06 Sep 2018 10:45:39 GMT
+  recorded_at: Mon, 31 Jan 2022 13:30:53 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:tom/package_with_files
+    uri: http://backend:5352/source/home:tom/package_with_files?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -258,15 +213,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '402'
+      - '303'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_files" rev="411" vrev="411" srcmd5="5dcb82a2e4ce4ebc27533914a8fdc601">
-          <entry name="_config" md5="2d2262ee959301d9d874ef159d3510fc" size="69" mtime="1536230739" />
-          <entry name="_icon" md5="63145ba980e361af320c5314bbe06c54" size="60" mtime="1536230739" />
-          <entry name="somefile.txt" md5="4dfa422adc4484aa5b32a7a3848c6ef6" size="68" mtime="1536230739" />
+        <directory name="package_with_files" rev="4" vrev="4" srcmd5="da9ddad6a1af9c3f26808e9b0839a0cf">
+          <entry name="_config" md5="1cba0683a396e3a297eda3fad8177265" size="57" mtime="1643635853"/>
+          <entry name="somefile.txt" md5="6ac62664efd6370cad9880b2b1973c1e" size="66" mtime="1643635853"/>
         </directory>
-    http_version: 
-  recorded_at: Thu, 06 Sep 2018 10:45:39 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Mon, 31 Jan 2022 13:30:53 GMT
+recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Package/_file_exists_/with_one_file/returns_false_if_the_file_does_not_exist.yml
+++ b/src/api/spec/cassettes/Package/_file_exists_/with_one_file/returns_false_if_the_file_does_not_exist.yml
@@ -30,17 +30,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '129'
+      - '128'
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom">
           <title></title>
           <description></description>
-          <person userid="tom" role="maintainer" />
+          <person userid="tom" role="maintainer"/>
         </project>
-    http_version: 
-  recorded_at: Thu, 06 Sep 2018 10:45:39 GMT
+  recorded_at: Mon, 31 Jan 2022 13:32:14 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/package_with_one_file/_meta?user=tom
@@ -48,8 +47,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_one_file" project="home:tom">
-          <title>The Wings of the Dove</title>
-          <description>Error vel odit qui.</description>
+          <title>Blood's a Rover</title>
+          <description>Explicabo necessitatibus sapiente atque.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,55 +69,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '157'
+      - '172'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_one_file" project="home:tom">
-          <title>The Wings of the Dove</title>
-          <description>Error vel odit qui.</description>
+          <title>Blood's a Rover</title>
+          <description>Explicabo necessitatibus sapiente atque.</description>
         </package>
-    http_version: 
-  recorded_at: Thu, 06 Sep 2018 10:45:40 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:tom/package_with_one_file/_meta?user=tom
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="package_with_one_file" project="home:tom">
-          <title>The Wings of the Dove</title>
-          <description>Error vel odit qui.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '157'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="package_with_one_file" project="home:tom">
-          <title>The Wings of the Dove</title>
-          <description>Error vel odit qui.</description>
-        </package>
-    http_version: 
-  recorded_at: Thu, 06 Sep 2018 10:45:40 GMT
+  recorded_at: Mon, 31 Jan 2022 13:32:14 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/package_with_one_file/_service
@@ -144,20 +103,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '209'
+      - '207'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="24" vrev="24">
-          <srcmd5>d7c054c3ba040e07fbd35572ef717967</srcmd5>
+        <revision rev="2" vrev="2">
+          <srcmd5>a6090b7ebcebcbc18a00764227ccd7bf</srcmd5>
           <version>unknown</version>
-          <time>1536230740</time>
+          <time>1643635934</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: 
-  recorded_at: Thu, 06 Sep 2018 10:45:40 GMT
+  recorded_at: Mon, 31 Jan 2022 13:32:14 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom/package_with_one_file
@@ -183,19 +141,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '289'
+      - '285'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_one_file" rev="24" vrev="24" srcmd5="d7c054c3ba040e07fbd35572ef717967">
-          <serviceinfo code="succeeded" xsrcmd5="d7649f315b00292d2d203ddc7c0a208d" />
-          <entry name="_service" md5="53b4f5c97c7a2122b964e5182c8325a2" size="11" mtime="1536154852" />
+        <directory name="package_with_one_file" rev="2" vrev="2" srcmd5="a6090b7ebcebcbc18a00764227ccd7bf">
+          <serviceinfo code="succeeded" xsrcmd5="858cb875439f0346222b1fe788dc282a"/>
+          <entry name="_service" md5="53b4f5c97c7a2122b964e5182c8325a2" size="11" mtime="1643635889"/>
         </directory>
-    http_version: 
-  recorded_at: Thu, 06 Sep 2018 10:45:40 GMT
+  recorded_at: Mon, 31 Jan 2022 13:32:14 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:tom/package_with_one_file
+    uri: http://backend:5352/source/home:tom/package_with_one_file?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -218,14 +175,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '289'
+      - '285'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_one_file" rev="24" vrev="24" srcmd5="d7c054c3ba040e07fbd35572ef717967">
-          <serviceinfo code="succeeded" xsrcmd5="d7649f315b00292d2d203ddc7c0a208d" />
-          <entry name="_service" md5="53b4f5c97c7a2122b964e5182c8325a2" size="11" mtime="1536154852" />
+        <directory name="package_with_one_file" rev="2" vrev="2" srcmd5="858cb875439f0346222b1fe788dc282a">
+          <serviceinfo code="succeeded" lsrcmd5="a6090b7ebcebcbc18a00764227ccd7bf"/>
+          <entry name="_service" md5="53b4f5c97c7a2122b964e5182c8325a2" size="11" mtime="1643635889"/>
         </directory>
-    http_version: 
-  recorded_at: Thu, 06 Sep 2018 10:45:40 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Mon, 31 Jan 2022 13:32:14 GMT
+recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Package/_file_exists_/with_one_file/returns_true_if_the_file_exist.yml
+++ b/src/api/spec/cassettes/Package/_file_exists_/with_one_file/returns_true_if_the_file_exist.yml
@@ -30,17 +30,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '129'
+      - '128'
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom">
           <title></title>
           <description></description>
-          <person userid="tom" role="maintainer" />
+          <person userid="tom" role="maintainer"/>
         </project>
-    http_version: 
-  recorded_at: Thu, 06 Sep 2018 10:45:39 GMT
+  recorded_at: Mon, 31 Jan 2022 13:31:29 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/package_with_one_file/_meta?user=tom
@@ -48,8 +47,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_one_file" project="home:tom">
-          <title>No Highway</title>
-          <description>Molestiae est necessitatibus rerum.</description>
+          <title>Dulce et Decorum Est</title>
+          <description>Corrupti quis dolor reprehenderit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,55 +69,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '162'
+      - '171'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_one_file" project="home:tom">
-          <title>No Highway</title>
-          <description>Molestiae est necessitatibus rerum.</description>
+          <title>Dulce et Decorum Est</title>
+          <description>Corrupti quis dolor reprehenderit.</description>
         </package>
-    http_version: 
-  recorded_at: Thu, 06 Sep 2018 10:45:39 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:tom/package_with_one_file/_meta?user=tom
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="package_with_one_file" project="home:tom">
-          <title>No Highway</title>
-          <description>Molestiae est necessitatibus rerum.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '162'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="package_with_one_file" project="home:tom">
-          <title>No Highway</title>
-          <description>Molestiae est necessitatibus rerum.</description>
-        </package>
-    http_version: 
-  recorded_at: Thu, 06 Sep 2018 10:45:39 GMT
+  recorded_at: Mon, 31 Jan 2022 13:31:29 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/package_with_one_file/_service
@@ -144,20 +103,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '209'
+      - '207'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="23" vrev="23">
-          <srcmd5>7594101f47d163de1eaff18f8b90c39f</srcmd5>
+        <revision rev="1" vrev="1">
+          <srcmd5>3aa6f0a366464f6678c6842d9802cdd1</srcmd5>
           <version>unknown</version>
-          <time>1536230739</time>
+          <time>1643635889</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: 
-  recorded_at: Thu, 06 Sep 2018 10:45:39 GMT
+  recorded_at: Mon, 31 Jan 2022 13:31:29 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom/package_with_one_file
@@ -183,19 +141,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '289'
+      - '240'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_one_file" rev="23" vrev="23" srcmd5="7594101f47d163de1eaff18f8b90c39f">
-          <serviceinfo code="succeeded" xsrcmd5="432d149c3b1c1c6ad62084620da6ad2f" />
-          <entry name="_service" md5="53b4f5c97c7a2122b964e5182c8325a2" size="11" mtime="1536154852" />
+        <directory name="package_with_one_file" rev="1" vrev="1" srcmd5="3aa6f0a366464f6678c6842d9802cdd1">
+          <serviceinfo code="running"/>
+          <entry name="_service" md5="53b4f5c97c7a2122b964e5182c8325a2" size="11" mtime="1643635889"/>
         </directory>
-    http_version: 
-  recorded_at: Thu, 06 Sep 2018 10:45:39 GMT
+  recorded_at: Mon, 31 Jan 2022 13:31:29 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:tom/package_with_one_file
+    uri: http://backend:5352/source/home:tom/package_with_one_file?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -218,14 +175,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '289'
+      - '285'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_one_file" rev="23" vrev="23" srcmd5="7594101f47d163de1eaff18f8b90c39f">
-          <serviceinfo code="succeeded" xsrcmd5="432d149c3b1c1c6ad62084620da6ad2f" />
-          <entry name="_service" md5="53b4f5c97c7a2122b964e5182c8325a2" size="11" mtime="1536154852" />
+        <directory name="package_with_one_file" rev="1" vrev="1" srcmd5="bb5a0e800164c58640d2ea211a183d72">
+          <serviceinfo code="succeeded" lsrcmd5="3aa6f0a366464f6678c6842d9802cdd1"/>
+          <entry name="_service" md5="53b4f5c97c7a2122b964e5182c8325a2" size="11" mtime="1643635889"/>
         </directory>
-    http_version: 
-  recorded_at: Thu, 06 Sep 2018 10:45:39 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Mon, 31 Jan 2022 13:31:29 GMT
+recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Package/_has_icon_/returns_false_if_the_icon_does_not_exist.yml
+++ b/src/api/spec/cassettes/Package/_has_icon_/returns_false_if_the_icon_does_not_exist.yml
@@ -30,17 +30,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '129'
+      - '128'
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom">
           <title></title>
           <description></description>
-          <person userid="tom" role="maintainer" />
+          <person userid="tom" role="maintainer"/>
         </project>
-    http_version: 
-  recorded_at: Thu, 06 Sep 2018 10:45:39 GMT
+  recorded_at: Mon, 31 Jan 2022 13:33:29 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/test_package/_meta?user=tom
@@ -48,8 +47,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>The Line of Beauty</title>
-          <description>Et ullam non eum.</description>
+          <title>The Moving Toyshop</title>
+          <description>Voluptates molestias reiciendis quia.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,55 +69,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '143'
+      - '163'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>The Line of Beauty</title>
-          <description>Et ullam non eum.</description>
+          <title>The Moving Toyshop</title>
+          <description>Voluptates molestias reiciendis quia.</description>
         </package>
-    http_version: 
-  recorded_at: Thu, 06 Sep 2018 10:45:39 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:tom/test_package/_meta?user=tom
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>The Line of Beauty</title>
-          <description>Et ullam non eum.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '143'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>The Line of Beauty</title>
-          <description>Et ullam non eum.</description>
-        </package>
-    http_version: 
-  recorded_at: Thu, 06 Sep 2018 10:45:39 GMT
+  recorded_at: Mon, 31 Jan 2022 13:33:29 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom/test_package
@@ -144,49 +103,11 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '300'
+      - '87'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="34" vrev="34" srcmd5="9b1c1ddcaab8327d31b5f9d882782630">
-          <entry name="foo.kiwi.txz" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1536154844" />
-          <entry name="foo.spec" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1536154843" />
+        <directory name="test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-    http_version: 
-  recorded_at: Thu, 06 Sep 2018 10:45:39 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:tom/test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '300'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="test_package" rev="34" vrev="34" srcmd5="9b1c1ddcaab8327d31b5f9d882782630">
-          <entry name="foo.kiwi.txz" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1536154844" />
-          <entry name="foo.spec" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1536154843" />
-        </directory>
-    http_version: 
-  recorded_at: Thu, 06 Sep 2018 10:45:39 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Mon, 31 Jan 2022 13:33:29 GMT
+recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Package/_has_icon_/returns_true_if_the_icon_exist.yml
+++ b/src/api/spec/cassettes/Package/_has_icon_/returns_true_if_the_icon_exist.yml
@@ -30,17 +30,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '129'
+      - '128'
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom">
           <title></title>
           <description></description>
-          <person userid="tom" role="maintainer" />
+          <person userid="tom" role="maintainer"/>
         </project>
-    http_version: 
-  recorded_at: Thu, 06 Sep 2018 10:45:38 GMT
+  recorded_at: Mon, 31 Jan 2022 13:32:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/package_with_files/_meta?user=tom
@@ -48,8 +47,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_files" project="home:tom">
-          <title>Fear and Trembling</title>
-          <description>Beatae quo aut delectus.</description>
+          <title>A Time of Gifts</title>
+          <description>Optio ut ipsum nisi.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,61 +69,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '156'
+      - '149'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_files" project="home:tom">
-          <title>Fear and Trembling</title>
-          <description>Beatae quo aut delectus.</description>
+          <title>A Time of Gifts</title>
+          <description>Optio ut ipsum nisi.</description>
         </package>
-    http_version: 
-  recorded_at: Thu, 06 Sep 2018 10:45:38 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:tom/package_with_files/_meta?user=tom
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="package_with_files" project="home:tom">
-          <title>Fear and Trembling</title>
-          <description>Beatae quo aut delectus.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '156'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="package_with_files" project="home:tom">
-          <title>Fear and Trembling</title>
-          <description>Beatae quo aut delectus.</description>
-        </package>
-    http_version: 
-  recorded_at: Thu, 06 Sep 2018 10:45:38 GMT
+  recorded_at: Mon, 31 Jan 2022 13:32:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/package_with_files/_config
     body:
       encoding: UTF-8
-      string: Tempore vel temporibus. Itaque et aut. Modi dolorum omnis.
+      string: Animi eos dolorum. Laudantium quam quas. Consequuntur vitae enim.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -144,26 +103,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '207'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="405" vrev="405">
-          <srcmd5>d2155e64fe9010642d8dea5b2a39f045</srcmd5>
+        <revision rev="5" vrev="5">
+          <srcmd5>8e889582031b31e4008565d1289e4ade</srcmd5>
           <version>unknown</version>
-          <time>1536230738</time>
+          <time>1643635969</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: 
-  recorded_at: Thu, 06 Sep 2018 10:45:39 GMT
+  recorded_at: Mon, 31 Jan 2022 13:32:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/package_with_files/somefile.txt
     body:
       encoding: UTF-8
-      string: Consectetur voluptatem et. Non et quis. Quis error molestiae.
+      string: Facilis laborum quos. Eius veritatis qui. Voluptatem iusto officia.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -183,26 +141,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '207'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="406" vrev="406">
-          <srcmd5>26025fa8c36e956f90c4ee50314c9825</srcmd5>
+        <revision rev="6" vrev="6">
+          <srcmd5>5694b5cfd3cc9027f7af28bc61285d64</srcmd5>
           <version>unknown</version>
-          <time>1536230739</time>
+          <time>1643635969</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: 
-  recorded_at: Thu, 06 Sep 2018 10:45:39 GMT
+  recorded_at: Mon, 31 Jan 2022 13:32:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/package_with_files/_icon
     body:
       encoding: UTF-8
-      string: Iusto ut aperiam. Doloremque inventore optio. Porro quo eum.
+      string: Sequi est earum. Sunt totam quidem. Sunt velit libero.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -222,20 +179,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '207'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="407" vrev="407">
-          <srcmd5>ce5bc619ba766c05d0cf2236881b3fdd</srcmd5>
+        <revision rev="7" vrev="7">
+          <srcmd5>6797b9d77d5c5c9db667d8c8dcc20424</srcmd5>
           <version>unknown</version>
-          <time>1536230739</time>
+          <time>1643635969</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: 
-  recorded_at: Thu, 06 Sep 2018 10:45:39 GMT
+  recorded_at: Mon, 31 Jan 2022 13:32:49 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom/package_with_files
@@ -261,20 +217,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '402'
+      - '395'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_files" rev="407" vrev="407" srcmd5="ce5bc619ba766c05d0cf2236881b3fdd">
-          <entry name="_config" md5="0ea98eba48eb426fa534e1fae2bebbf8" size="58" mtime="1536230738" />
-          <entry name="_icon" md5="63145ba980e361af320c5314bbe06c54" size="60" mtime="1536230739" />
-          <entry name="somefile.txt" md5="5db57f2973f99920861e6d6726945ee1" size="61" mtime="1536230739" />
+        <directory name="package_with_files" rev="7" vrev="7" srcmd5="6797b9d77d5c5c9db667d8c8dcc20424">
+          <entry name="_config" md5="6f181bb0c12e284afc8416551337c807" size="65" mtime="1643635969"/>
+          <entry name="_icon" md5="afce14d0bf5298f2e3b018600f4759e5" size="54" mtime="1643635969"/>
+          <entry name="somefile.txt" md5="72b4385cc0897b5ec82766a20d2b51fa" size="67" mtime="1643635969"/>
         </directory>
-    http_version: 
-  recorded_at: Thu, 06 Sep 2018 10:45:39 GMT
+  recorded_at: Mon, 31 Jan 2022 13:32:49 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:tom/package_with_files
+    uri: http://backend:5352/source/home:tom/package_with_files?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -297,15 +252,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '402'
+      - '395'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_files" rev="407" vrev="407" srcmd5="ce5bc619ba766c05d0cf2236881b3fdd">
-          <entry name="_config" md5="0ea98eba48eb426fa534e1fae2bebbf8" size="58" mtime="1536230738" />
-          <entry name="_icon" md5="63145ba980e361af320c5314bbe06c54" size="60" mtime="1536230739" />
-          <entry name="somefile.txt" md5="5db57f2973f99920861e6d6726945ee1" size="61" mtime="1536230739" />
+        <directory name="package_with_files" rev="7" vrev="7" srcmd5="6797b9d77d5c5c9db667d8c8dcc20424">
+          <entry name="_config" md5="6f181bb0c12e284afc8416551337c807" size="65" mtime="1643635969"/>
+          <entry name="_icon" md5="afce14d0bf5298f2e3b018600f4759e5" size="54" mtime="1643635969"/>
+          <entry name="somefile.txt" md5="72b4385cc0897b5ec82766a20d2b51fa" size="67" mtime="1643635969"/>
         </directory>
-    http_version: 
-  recorded_at: Thu, 06 Sep 2018 10:45:39 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Mon, 31 Jan 2022 13:32:49 GMT
+recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Package/_ignored_requests/when_the_package_has_an_ignored_requests_file/parses_the_content_as_YAML_and_returns_a_hash.yml
+++ b/src/api/spec/cassettes/Package/_ignored_requests/when_the_package_has_an_ignored_requests_file/parses_the_content_as_YAML_and_returns_a_hash.yml
@@ -30,17 +30,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '129'
+      - '128'
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom">
           <title></title>
           <description></description>
-          <person userid="tom" role="maintainer" />
+          <person userid="tom" role="maintainer"/>
         </project>
-    http_version: 
-  recorded_at: Thu, 06 Sep 2018 10:45:36 GMT
+  recorded_at: Mon, 31 Jan 2022 13:29:10 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/_meta?user=tom
@@ -48,7 +47,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="my_project">
-          <title>Endless Night</title>
+          <title>Tirra Lirra by the River</title>
           <description/>
         </project>
     headers:
@@ -70,16 +69,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '100'
+      - '111'
     body:
       encoding: UTF-8
       string: |
         <project name="my_project">
-          <title>Endless Night</title>
+          <title>Tirra Lirra by the River</title>
           <description></description>
         </project>
-    http_version: 
-  recorded_at: Thu, 06 Sep 2018 10:45:36 GMT
+  recorded_at: Mon, 31 Jan 2022 13:29:10 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/dashboard_1/_meta?user=tom
@@ -87,8 +85,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="dashboard_1" project="my_project">
-          <title>The Wings of the Dove</title>
-          <description>Rerum temporibus nisi et.</description>
+          <title>A Time to Kill</title>
+          <description>Alias aut laudantium quia.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,61 +107,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '155'
+      - '149'
     body:
       encoding: UTF-8
       string: |
         <package name="dashboard_1" project="my_project">
-          <title>The Wings of the Dove</title>
-          <description>Rerum temporibus nisi et.</description>
+          <title>A Time to Kill</title>
+          <description>Alias aut laudantium quia.</description>
         </package>
-    http_version: 
-  recorded_at: Thu, 06 Sep 2018 10:45:36 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/my_project/dashboard_1/_meta?user=tom
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="dashboard_1" project="my_project">
-          <title>The Wings of the Dove</title>
-          <description>Rerum temporibus nisi et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '155'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="dashboard_1" project="my_project">
-          <title>The Wings of the Dove</title>
-          <description>Rerum temporibus nisi et.</description>
-        </package>
-    http_version: 
-  recorded_at: Thu, 06 Sep 2018 10:45:36 GMT
+  recorded_at: Mon, 31 Jan 2022 13:29:10 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/dashboard_1/_config
     body:
       encoding: UTF-8
-      string: Libero eligendi nulla. Recusandae autem eligendi. Ipsum similique nihil.
+      string: Qui in velit. Iure ea pariatur. Asperiores amet quaerat.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -183,20 +141,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '209'
+      - '207'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="23" vrev="23">
-          <srcmd5>48d0673d36115b67425421897984578b</srcmd5>
+        <revision rev="1" vrev="1">
+          <srcmd5>ea72d516b7fdce40d0c95f3c21638ff0</srcmd5>
           <version>unknown</version>
-          <time>1536230736</time>
+          <time>1643635750</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: 
-  recorded_at: Thu, 06 Sep 2018 10:45:36 GMT
+  recorded_at: Mon, 31 Jan 2022 13:29:10 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/dashboard_1/ignored_requests
@@ -222,20 +179,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '209'
+      - '207'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="24" vrev="24">
-          <srcmd5>48d0673d36115b67425421897984578b</srcmd5>
+        <revision rev="2" vrev="2">
+          <srcmd5>fd6e74a31ddf7c5a4b99d0e607a151eb</srcmd5>
           <version>unknown</version>
-          <time>1536230736</time>
+          <time>1643635750</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: 
-  recorded_at: Thu, 06 Sep 2018 10:45:36 GMT
+  recorded_at: Mon, 31 Jan 2022 13:29:11 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/dashboard_1
@@ -261,19 +217,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '303'
+      - '299'
     body:
       encoding: UTF-8
       string: |
-        <directory name="dashboard_1" rev="24" vrev="24" srcmd5="48d0673d36115b67425421897984578b">
-          <entry name="_config" md5="56452786dd612e766f48a902b8057c38" size="72" mtime="1536230736" />
-          <entry name="ignored_requests" md5="e1dcf98b4c823827be0a0524052ae95a" size="8" mtime="1536154843" />
+        <directory name="dashboard_1" rev="2" vrev="2" srcmd5="fd6e74a31ddf7c5a4b99d0e607a151eb">
+          <entry name="_config" md5="7a96487ed5f23706cfa5a3c8f9d034dc" size="56" mtime="1643635750"/>
+          <entry name="ignored_requests" md5="e1dcf98b4c823827be0a0524052ae95a" size="8" mtime="1643635750"/>
         </directory>
-    http_version: 
-  recorded_at: Thu, 06 Sep 2018 10:45:36 GMT
+  recorded_at: Mon, 31 Jan 2022 13:29:11 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/my_project/dashboard_1
+    uri: http://backend:5352/source/my_project/dashboard_1?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -296,16 +251,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '303'
+      - '299'
     body:
       encoding: UTF-8
       string: |
-        <directory name="dashboard_1" rev="24" vrev="24" srcmd5="48d0673d36115b67425421897984578b">
-          <entry name="_config" md5="56452786dd612e766f48a902b8057c38" size="72" mtime="1536230736" />
-          <entry name="ignored_requests" md5="e1dcf98b4c823827be0a0524052ae95a" size="8" mtime="1536154843" />
+        <directory name="dashboard_1" rev="2" vrev="2" srcmd5="fd6e74a31ddf7c5a4b99d0e607a151eb">
+          <entry name="_config" md5="7a96487ed5f23706cfa5a3c8f9d034dc" size="56" mtime="1643635750"/>
+          <entry name="ignored_requests" md5="e1dcf98b4c823827be0a0524052ae95a" size="8" mtime="1643635750"/>
         </directory>
-    http_version: 
-  recorded_at: Thu, 06 Sep 2018 10:45:36 GMT
+  recorded_at: Mon, 31 Jan 2022 13:29:11 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/dashboard_1/ignored_requests
@@ -335,6 +289,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 'foo: bar'
-    http_version: 
-  recorded_at: Thu, 06 Sep 2018 10:45:36 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Mon, 31 Jan 2022 13:29:11 GMT
+recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/but_we_don_t_provide_a_source_package/behaves_like_source_package_not_provided/1_1_1_2_1_1.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/but_we_don_t_provide_a_source_package/behaves_like_source_package_not_provided/1_1_1_2_1_1.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:46 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:06 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_288
+    uri: http://backend:5352/source/foo_project/_meta?user=user_1
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Have His Carcase</title>
+          <title>Cabbages and Kings</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '148'
+      - '150'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Have His Carcase</title>
+          <title>Cabbages and Kings</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:46 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:06 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_289
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_2
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>A Time of Gifts</title>
-          <description>Ad consequuntur mollitia nemo.</description>
+          <title>The Millstone</title>
+          <description>Expedita quibusdam eos sint.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '155'
+      - '151'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>A Time of Gifts</title>
-          <description>Ad consequuntur mollitia nemo.</description>
+          <title>The Millstone</title>
+          <description>Expedita quibusdam eos sint.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:46 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Quidem magni ut. Cum ex enim. Ut corrupti rerum.
+      string: Ut qui ut. Itaque aut ipsam. Minima qui dolorum.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1675" vrev="1675">
-          <srcmd5>024b51b25fda33f5f47070c073d24d0c</srcmd5>
+        <revision rev="17" vrev="17">
+          <srcmd5>e403c966cf4d9a51e0389ee3b61438ac</srcmd5>
           <version>unknown</version>
-          <time>1642674766</time>
+          <time>1643641506</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:46 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Et officiis atque. Dolor eum accusamus. Magni rerum molestiae.
+      string: Incidunt tenetur magni. Veritatis commodi quas. Autem delectus quisquam.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,17 +181,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1676" vrev="1676">
-          <srcmd5>0022a226387a4b1c2b270891fae4e53c</srcmd5>
+        <revision rev="18" vrev="18">
+          <srcmd5>4a3e00558064448e35d4be4fd3ad1caf</srcmd5>
           <version>unknown</version>
-          <time>1642674766</time>
+          <time>1643641506</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:46 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:06 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/but_we_don_t_provide_source_project/behaves_like_source_project_not_provided/1_1_1_1_1_1.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/but_we_don_t_provide_source_project/behaves_like_source_project_not_provided/1_1_1_1_1_1.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:44 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_360
+    uri: http://backend:5352/source/foo_project/_meta?user=user_53
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>No Highway</title>
+          <title>His Dark Materials</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '142'
+      - '150'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>No Highway</title>
+          <title>His Dark Materials</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:44 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_361
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_54
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Widening Gyre</title>
-          <description>Id nostrum veritatis quaerat.</description>
+          <title>Bury My Heart at Wounded Knee</title>
+          <description>Unde aperiam molestias ipsa.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '156'
+      - '167'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Widening Gyre</title>
-          <description>Id nostrum veritatis quaerat.</description>
+          <title>Bury My Heart at Wounded Knee</title>
+          <description>Unde aperiam molestias ipsa.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:44 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Tempora eveniet assumenda. Est odit quia. Qui id adipisci.
+      string: Aspernatur expedita veritatis. At quis impedit. Est temporibus qui.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1739" vrev="1739">
-          <srcmd5>96436a327ec6ac7a2d424a663de17be3</srcmd5>
+        <revision rev="61" vrev="61">
+          <srcmd5>7ed92ac8db0508e5f85eeeee94c2a721</srcmd5>
           <version>unknown</version>
-          <time>1642674804</time>
+          <time>1643641544</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:44 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Ex aut occaecati. Quibusdam et recusandae. Asperiores aspernatur magnam.
+      string: Rem corrupti soluta. Aut necessitatibus nisi. Similique qui voluptas.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,17 +181,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1740" vrev="1740">
-          <srcmd5>1fcf34f6d276435499b48f2ce419cdda</srcmd5>
+        <revision rev="62" vrev="62">
+          <srcmd5>5d9d2d598aa078dba76a13d827f9ddeb</srcmd5>
           <version>unknown</version>
-          <time>1642674804</time>
+          <time>1643641544</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:44 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_a_multibuild_package/1_1_1_4_1.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_a_multibuild_package/1_1_1_4_1.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:55 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:27 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_310
+    uri: http://backend:5352/source/foo_project/_meta?user=user_29
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>The Golden Apples of the Sun</title>
+          <title>Where Angels Fear to Tread</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '160'
+      - '158'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>The Golden Apples of the Sun</title>
+          <title>Where Angels Fear to Tread</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:55 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:27 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/multibuild_package/_meta?user=user_311
+    uri: http://backend:5352/source/foo_project/multibuild_package/_meta?user=user_30
     body:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="foo_project">
-          <title>The Moon by Night</title>
-          <description>Eveniet modi molestias voluptatum.</description>
+          <title>Fear and Trembling</title>
+          <description>Nostrum quibusdam tenetur ut.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '168'
+      - '164'
     body:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="foo_project">
-          <title>The Moon by Night</title>
-          <description>Eveniet modi molestias voluptatum.</description>
+          <title>Fear and Trembling</title>
+          <description>Nostrum quibusdam tenetur ut.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:55 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:27 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/multibuild_package/_config
     body:
       encoding: UTF-8
-      string: In rem ipsum. Magnam reprehenderit atque. Molestiae fugit eos.
+      string: Qui nemo et. Impedit aut eum. Ad minus quae.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -147,15 +147,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="43" vrev="43">
-          <srcmd5>523aae6299f19484faefbb6ff3c08a08</srcmd5>
+        <revision rev="27" vrev="27">
+          <srcmd5>9541baaffb6e3316602e0cc01b08723b</srcmd5>
           <version>unknown</version>
-          <time>1642674775</time>
+          <time>1643641527</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:55 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:27 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/multibuild_package/_multibuild
@@ -185,15 +185,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="44" vrev="44">
-          <srcmd5>523aae6299f19484faefbb6ff3c08a08</srcmd5>
+        <revision rev="28" vrev="28">
+          <srcmd5>9541baaffb6e3316602e0cc01b08723b</srcmd5>
           <version>unknown</version>
-          <time>1642674775</time>
+          <time>1643641527</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:55 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:27 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22multibuild_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -227,7 +227,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:32:55 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:27 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -267,7 +267,7 @@ http_interactions:
           <description>This project was created for package multibuild_package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:56 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:27 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_meta?user=Iggy
@@ -275,8 +275,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Moon by Night</title>
-          <description>Eveniet modi molestias voluptatum.</description>
+          <title>Fear and Trembling</title>
+          <description>Nostrum quibusdam tenetur ut.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -297,15 +297,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '199'
+      - '195'
     body:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Moon by Night</title>
-          <description>Eveniet modi molestias voluptatum.</description>
+          <title>Fear and Trembling</title>
+          <description>Nostrum quibusdam tenetur ut.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:56 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:28 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?cmd=branch&noservice=1&opackage=multibuild_package&oproject=foo_project&user=Iggy
@@ -337,15 +337,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="57" vrev="57">
-          <srcmd5>ff2e774573cf20f001bfde50e7a6afa7</srcmd5>
+        <revision rev="27" vrev="27">
+          <srcmd5>c5b2a77da9fd88ae5274f6254ac5b49a</srcmd5>
           <version>unknown</version>
-          <time>1642674776</time>
+          <time>1643641528</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:56 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:28 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_meta?user=Iggy
@@ -353,8 +353,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Moon by Night</title>
-          <description>Eveniet modi molestias voluptatum.</description>
+          <title>Fear and Trembling</title>
+          <description>Nostrum quibusdam tenetur ut.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -375,15 +375,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '199'
+      - '195'
     body:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Moon by Night</title>
-          <description>Eveniet modi molestias voluptatum.</description>
+          <title>Fear and Trembling</title>
+          <description>Nostrum quibusdam tenetur ut.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:56 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:28 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -413,13 +413,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="57" vrev="57" srcmd5="ff2e774573cf20f001bfde50e7a6afa7">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="523aae6299f19484faefbb6ff3c08a08" baserev="523aae6299f19484faefbb6ff3c08a08" xsrcmd5="4b143c458373d90b942e490948338f01" lsrcmd5="ff2e774573cf20f001bfde50e7a6afa7"/>
-          <entry name="_config" md5="0a99b4bc0babd3d32a93f5649d5e2781" size="62" mtime="1642674775"/>
-          <entry name="_link" md5="3b5fbc8402c4e7b6fa62027a2c716b9f" size="119" mtime="1642674776"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="27" vrev="27" srcmd5="c5b2a77da9fd88ae5274f6254ac5b49a">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="9541baaffb6e3316602e0cc01b08723b" baserev="9541baaffb6e3316602e0cc01b08723b" xsrcmd5="62ea3c7e6668ed0fda578a365dafe262" lsrcmd5="c5b2a77da9fd88ae5274f6254ac5b49a"/>
+          <entry name="_config" md5="12c3cd3ca436ad78ec58e113e4fe4a0c" size="44" mtime="1643641527"/>
+          <entry name="_link" md5="b1d9876b2c3e7eb635910c70f41121d4" size="119" mtime="1643641528"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:56 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:28 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?view=info
@@ -445,15 +445,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '345'
+      - '344'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="multibuild_package" rev="57" vrev="101" srcmd5="4b143c458373d90b942e490948338f01" lsrcmd5="ff2e774573cf20f001bfde50e7a6afa7" verifymd5="523aae6299f19484faefbb6ff3c08a08">
+        <sourceinfo package="multibuild_package" rev="27" vrev="55" srcmd5="62ea3c7e6668ed0fda578a365dafe262" lsrcmd5="c5b2a77da9fd88ae5274f6254ac5b49a" verifymd5="9541baaffb6e3316602e0cc01b08723b">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="multibuild_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:56 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:28 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -483,13 +483,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="57" vrev="57" srcmd5="ff2e774573cf20f001bfde50e7a6afa7">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="523aae6299f19484faefbb6ff3c08a08" baserev="523aae6299f19484faefbb6ff3c08a08" xsrcmd5="4b143c458373d90b942e490948338f01" lsrcmd5="ff2e774573cf20f001bfde50e7a6afa7"/>
-          <entry name="_config" md5="0a99b4bc0babd3d32a93f5649d5e2781" size="62" mtime="1642674775"/>
-          <entry name="_link" md5="3b5fbc8402c4e7b6fa62027a2c716b9f" size="119" mtime="1642674776"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="27" vrev="27" srcmd5="c5b2a77da9fd88ae5274f6254ac5b49a">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="9541baaffb6e3316602e0cc01b08723b" baserev="9541baaffb6e3316602e0cc01b08723b" xsrcmd5="62ea3c7e6668ed0fda578a365dafe262" lsrcmd5="c5b2a77da9fd88ae5274f6254ac5b49a"/>
+          <entry name="_config" md5="12c3cd3ca436ad78ec58e113e4fe4a0c" size="44" mtime="1643641527"/>
+          <entry name="_link" md5="b1d9876b2c3e7eb635910c70f41121d4" size="119" mtime="1643641528"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:56 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:28 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -521,14 +521,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="93d6a1bd414765945222187f24813db2">
+        <sourcediff key="dd880d8cfb5807b7565837965ec540d1">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="57" srcmd5="ff2e774573cf20f001bfde50e7a6afa7"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="27" srcmd5="c5b2a77da9fd88ae5274f6254ac5b49a"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:56 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:28 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -560,12 +560,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="cb91d12873d8a2616f5b726d86a01ed1">
-          <old project="foo_project" package="multibuild_package" rev="523aae6299f19484faefbb6ff3c08a08" srcmd5="523aae6299f19484faefbb6ff3c08a08"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="4b143c458373d90b942e490948338f01" srcmd5="4b143c458373d90b942e490948338f01"/>
+        <sourcediff key="7cf6f86f67521b55b9671475765e7b19">
+          <old project="foo_project" package="multibuild_package" rev="9541baaffb6e3316602e0cc01b08723b" srcmd5="9541baaffb6e3316602e0cc01b08723b"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="62ea3c7e6668ed0fda578a365dafe262" srcmd5="62ea3c7e6668ed0fda578a365dafe262"/>
           <files/>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:56 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:28 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -633,7 +633,7 @@ http_interactions:
             <arch>aarch64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:56 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:28 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_branch_request?user=Iggy
@@ -663,15 +663,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="58" vrev="58">
-          <srcmd5>c94332bf02c524805c54215ec913a548</srcmd5>
+        <revision rev="28" vrev="28">
+          <srcmd5>40e7491eafda73011aa829d69ed60a7c</srcmd5>
           <version>unknown</version>
-          <time>1642674776</time>
+          <time>1643641528</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:56 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:28 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_meta?user=Iggy
@@ -679,8 +679,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Moon by Night</title>
-          <description>Eveniet modi molestias voluptatum.</description>
+          <title>Fear and Trembling</title>
+          <description>Nostrum quibusdam tenetur ut.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -701,15 +701,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '199'
+      - '195'
     body:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Moon by Night</title>
-          <description>Eveniet modi molestias voluptatum.</description>
+          <title>Fear and Trembling</title>
+          <description>Nostrum quibusdam tenetur ut.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:56 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:28 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -735,19 +735,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="58" vrev="58" srcmd5="c94332bf02c524805c54215ec913a548">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="523aae6299f19484faefbb6ff3c08a08" baserev="523aae6299f19484faefbb6ff3c08a08" xsrcmd5="286301dd8dac44704a5703ecd213f63f" lsrcmd5="c94332bf02c524805c54215ec913a548"/>
-          <serviceinfo code="succeeded" xsrcmd5="49f54ea80dce3348172aed050f845c90"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="0a99b4bc0babd3d32a93f5649d5e2781" size="62" mtime="1642674775"/>
-          <entry name="_link" md5="3b5fbc8402c4e7b6fa62027a2c716b9f" size="119" mtime="1642674776"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="28" vrev="28" srcmd5="40e7491eafda73011aa829d69ed60a7c">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="9541baaffb6e3316602e0cc01b08723b" baserev="9541baaffb6e3316602e0cc01b08723b" xsrcmd5="ee0a9588fa98b048cb55253494e83e48" lsrcmd5="40e7491eafda73011aa829d69ed60a7c"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="12c3cd3ca436ad78ec58e113e4fe4a0c" size="44" mtime="1643641527"/>
+          <entry name="_link" md5="b1d9876b2c3e7eb635910c70f41121d4" size="119" mtime="1643641528"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:56 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:28 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?view=info
@@ -773,15 +772,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '345'
+      - '344'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="multibuild_package" rev="58" vrev="102" srcmd5="2d0a398412fde0da9e755c3cc02e4c7e" lsrcmd5="49f54ea80dce3348172aed050f845c90" verifymd5="9811d045f419ec88f1ba28d3ac668501">
+        <sourceinfo package="multibuild_package" rev="28" vrev="56" srcmd5="ee0a9588fa98b048cb55253494e83e48" lsrcmd5="40e7491eafda73011aa829d69ed60a7c" verifymd5="3a5ac3af20cd68c74693a0337661b123">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="multibuild_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:56 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:28 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -807,19 +806,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="58" vrev="58" srcmd5="c94332bf02c524805c54215ec913a548">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="523aae6299f19484faefbb6ff3c08a08" baserev="523aae6299f19484faefbb6ff3c08a08" xsrcmd5="286301dd8dac44704a5703ecd213f63f" lsrcmd5="c94332bf02c524805c54215ec913a548"/>
-          <serviceinfo code="succeeded" xsrcmd5="49f54ea80dce3348172aed050f845c90"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="0a99b4bc0babd3d32a93f5649d5e2781" size="62" mtime="1642674775"/>
-          <entry name="_link" md5="3b5fbc8402c4e7b6fa62027a2c716b9f" size="119" mtime="1642674776"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="28" vrev="28" srcmd5="40e7491eafda73011aa829d69ed60a7c">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="9541baaffb6e3316602e0cc01b08723b" baserev="9541baaffb6e3316602e0cc01b08723b" xsrcmd5="ee0a9588fa98b048cb55253494e83e48" lsrcmd5="40e7491eafda73011aa829d69ed60a7c"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="12c3cd3ca436ad78ec58e113e4fe4a0c" size="44" mtime="1643641527"/>
+          <entry name="_link" md5="b1d9876b2c3e7eb635910c70f41121d4" size="119" mtime="1643641528"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:56 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:28 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -851,14 +849,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="f5d6639edb20a08748509b89229b2651">
+        <sourcediff key="d394dc4d8db104a1a53cf84578b31cae">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="58" srcmd5="c94332bf02c524805c54215ec913a548"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="28" srcmd5="40e7491eafda73011aa829d69ed60a7c"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:56 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:28 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -890,14 +888,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="a0fbf69933f579995de5555562d6eb4a">
-          <old project="foo_project" package="multibuild_package" rev="523aae6299f19484faefbb6ff3c08a08" srcmd5="523aae6299f19484faefbb6ff3c08a08"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="2d0a398412fde0da9e755c3cc02e4c7e" srcmd5="2d0a398412fde0da9e755c3cc02e4c7e"/>
+        <sourcediff key="53c0dbb66606a3fdd1a74396f1cedd06">
+          <old project="foo_project" package="multibuild_package" rev="9541baaffb6e3316602e0cc01b08723b" srcmd5="9541baaffb6e3316602e0cc01b08723b"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="ee0a9588fa98b048cb55253494e83e48" srcmd5="ee0a9588fa98b048cb55253494e83e48"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:56 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:28 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -923,22 +921,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="58" vrev="58" srcmd5="c94332bf02c524805c54215ec913a548">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="523aae6299f19484faefbb6ff3c08a08" baserev="523aae6299f19484faefbb6ff3c08a08" xsrcmd5="286301dd8dac44704a5703ecd213f63f" lsrcmd5="c94332bf02c524805c54215ec913a548"/>
-          <serviceinfo code="succeeded" xsrcmd5="49f54ea80dce3348172aed050f845c90"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="0a99b4bc0babd3d32a93f5649d5e2781" size="62" mtime="1642674775"/>
-          <entry name="_link" md5="3b5fbc8402c4e7b6fa62027a2c716b9f" size="119" mtime="1642674776"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="28" vrev="28" srcmd5="40e7491eafda73011aa829d69ed60a7c">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="9541baaffb6e3316602e0cc01b08723b" baserev="9541baaffb6e3316602e0cc01b08723b" xsrcmd5="ee0a9588fa98b048cb55253494e83e48" lsrcmd5="40e7491eafda73011aa829d69ed60a7c"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="12c3cd3ca436ad78ec58e113e4fe4a0c" size="44" mtime="1643641527"/>
+          <entry name="_link" md5="b1d9876b2c3e7eb635910c70f41121d4" size="119" mtime="1643641528"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:56 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:28 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -961,19 +958,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '629'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="58" vrev="58" srcmd5="c94332bf02c524805c54215ec913a548">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="523aae6299f19484faefbb6ff3c08a08" baserev="523aae6299f19484faefbb6ff3c08a08" xsrcmd5="286301dd8dac44704a5703ecd213f63f" lsrcmd5="c94332bf02c524805c54215ec913a548"/>
-          <serviceinfo code="succeeded" xsrcmd5="49f54ea80dce3348172aed050f845c90"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="0a99b4bc0babd3d32a93f5649d5e2781" size="62" mtime="1642674775"/>
-          <entry name="_link" md5="3b5fbc8402c4e7b6fa62027a2c716b9f" size="119" mtime="1642674776"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="ee0a9588fa98b048cb55253494e83e48" vrev="56" srcmd5="ee0a9588fa98b048cb55253494e83e48">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="9541baaffb6e3316602e0cc01b08723b" baserev="9541baaffb6e3316602e0cc01b08723b" lsrcmd5="40e7491eafda73011aa829d69ed60a7c"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="12c3cd3ca436ad78ec58e113e4fe4a0c" size="44" mtime="1643641527"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:56 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:28 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_multibuild
@@ -1003,7 +998,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "<multibuild><flavor>flavor_a</flavor><flavor>flavor_b</flavor></multibuild>"
-  recorded_at: Thu, 20 Jan 2022 10:32:56 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:28 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -1029,22 +1024,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="58" vrev="58" srcmd5="c94332bf02c524805c54215ec913a548">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="523aae6299f19484faefbb6ff3c08a08" baserev="523aae6299f19484faefbb6ff3c08a08" xsrcmd5="286301dd8dac44704a5703ecd213f63f" lsrcmd5="c94332bf02c524805c54215ec913a548"/>
-          <serviceinfo code="succeeded" xsrcmd5="49f54ea80dce3348172aed050f845c90"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="0a99b4bc0babd3d32a93f5649d5e2781" size="62" mtime="1642674775"/>
-          <entry name="_link" md5="3b5fbc8402c4e7b6fa62027a2c716b9f" size="119" mtime="1642674776"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="28" vrev="28" srcmd5="40e7491eafda73011aa829d69ed60a7c">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="9541baaffb6e3316602e0cc01b08723b" baserev="9541baaffb6e3316602e0cc01b08723b" xsrcmd5="ee0a9588fa98b048cb55253494e83e48" lsrcmd5="40e7491eafda73011aa829d69ed60a7c"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="12c3cd3ca436ad78ec58e113e4fe4a0c" size="44" mtime="1643641527"/>
+          <entry name="_link" md5="b1d9876b2c3e7eb635910c70f41121d4" size="119" mtime="1643641528"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:56 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:28 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1067,19 +1061,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '629'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="58" vrev="58" srcmd5="c94332bf02c524805c54215ec913a548">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="523aae6299f19484faefbb6ff3c08a08" baserev="523aae6299f19484faefbb6ff3c08a08" xsrcmd5="286301dd8dac44704a5703ecd213f63f" lsrcmd5="c94332bf02c524805c54215ec913a548"/>
-          <serviceinfo code="succeeded" xsrcmd5="49f54ea80dce3348172aed050f845c90"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="0a99b4bc0babd3d32a93f5649d5e2781" size="62" mtime="1642674775"/>
-          <entry name="_link" md5="3b5fbc8402c4e7b6fa62027a2c716b9f" size="119" mtime="1642674776"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="ee0a9588fa98b048cb55253494e83e48" vrev="56" srcmd5="ee0a9588fa98b048cb55253494e83e48">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="9541baaffb6e3316602e0cc01b08723b" baserev="9541baaffb6e3316602e0cc01b08723b" lsrcmd5="40e7491eafda73011aa829d69ed60a7c"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="12c3cd3ca436ad78ec58e113e4fe4a0c" size="44" mtime="1643641527"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:56 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:28 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_multibuild
@@ -1109,7 +1101,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "<multibuild><flavor>flavor_a</flavor><flavor>flavor_b</flavor></multibuild>"
-  recorded_at: Thu, 20 Jan 2022 10:32:56 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:28 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -1135,22 +1127,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="58" vrev="58" srcmd5="c94332bf02c524805c54215ec913a548">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="523aae6299f19484faefbb6ff3c08a08" baserev="523aae6299f19484faefbb6ff3c08a08" xsrcmd5="286301dd8dac44704a5703ecd213f63f" lsrcmd5="c94332bf02c524805c54215ec913a548"/>
-          <serviceinfo code="succeeded" xsrcmd5="49f54ea80dce3348172aed050f845c90"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="0a99b4bc0babd3d32a93f5649d5e2781" size="62" mtime="1642674775"/>
-          <entry name="_link" md5="3b5fbc8402c4e7b6fa62027a2c716b9f" size="119" mtime="1642674776"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="28" vrev="28" srcmd5="40e7491eafda73011aa829d69ed60a7c">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="9541baaffb6e3316602e0cc01b08723b" baserev="9541baaffb6e3316602e0cc01b08723b" xsrcmd5="ee0a9588fa98b048cb55253494e83e48" lsrcmd5="40e7491eafda73011aa829d69ed60a7c"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="12c3cd3ca436ad78ec58e113e4fe4a0c" size="44" mtime="1643641527"/>
+          <entry name="_link" md5="b1d9876b2c3e7eb635910c70f41121d4" size="119" mtime="1643641528"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:56 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:28 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1173,19 +1164,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '629'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="58" vrev="58" srcmd5="c94332bf02c524805c54215ec913a548">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="523aae6299f19484faefbb6ff3c08a08" baserev="523aae6299f19484faefbb6ff3c08a08" xsrcmd5="286301dd8dac44704a5703ecd213f63f" lsrcmd5="c94332bf02c524805c54215ec913a548"/>
-          <serviceinfo code="succeeded" xsrcmd5="49f54ea80dce3348172aed050f845c90"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="0a99b4bc0babd3d32a93f5649d5e2781" size="62" mtime="1642674775"/>
-          <entry name="_link" md5="3b5fbc8402c4e7b6fa62027a2c716b9f" size="119" mtime="1642674776"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="ee0a9588fa98b048cb55253494e83e48" vrev="56" srcmd5="ee0a9588fa98b048cb55253494e83e48">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="9541baaffb6e3316602e0cc01b08723b" baserev="9541baaffb6e3316602e0cc01b08723b" lsrcmd5="40e7491eafda73011aa829d69ed60a7c"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="12c3cd3ca436ad78ec58e113e4fe4a0c" size="44" mtime="1643641527"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:56 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:28 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_multibuild
@@ -1215,7 +1204,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "<multibuild><flavor>flavor_a</flavor><flavor>flavor_b</flavor></multibuild>"
-  recorded_at: Thu, 20 Jan 2022 10:32:56 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:28 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -1241,22 +1230,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="58" vrev="58" srcmd5="c94332bf02c524805c54215ec913a548">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="523aae6299f19484faefbb6ff3c08a08" baserev="523aae6299f19484faefbb6ff3c08a08" xsrcmd5="286301dd8dac44704a5703ecd213f63f" lsrcmd5="c94332bf02c524805c54215ec913a548"/>
-          <serviceinfo code="succeeded" xsrcmd5="49f54ea80dce3348172aed050f845c90"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="0a99b4bc0babd3d32a93f5649d5e2781" size="62" mtime="1642674775"/>
-          <entry name="_link" md5="3b5fbc8402c4e7b6fa62027a2c716b9f" size="119" mtime="1642674776"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="28" vrev="28" srcmd5="40e7491eafda73011aa829d69ed60a7c">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="9541baaffb6e3316602e0cc01b08723b" baserev="9541baaffb6e3316602e0cc01b08723b" xsrcmd5="ee0a9588fa98b048cb55253494e83e48" lsrcmd5="40e7491eafda73011aa829d69ed60a7c"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="12c3cd3ca436ad78ec58e113e4fe4a0c" size="44" mtime="1643641527"/>
+          <entry name="_link" md5="b1d9876b2c3e7eb635910c70f41121d4" size="119" mtime="1643641528"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:56 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:28 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1279,19 +1267,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '629'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="58" vrev="58" srcmd5="c94332bf02c524805c54215ec913a548">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="523aae6299f19484faefbb6ff3c08a08" baserev="523aae6299f19484faefbb6ff3c08a08" xsrcmd5="286301dd8dac44704a5703ecd213f63f" lsrcmd5="c94332bf02c524805c54215ec913a548"/>
-          <serviceinfo code="succeeded" xsrcmd5="49f54ea80dce3348172aed050f845c90"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="0a99b4bc0babd3d32a93f5649d5e2781" size="62" mtime="1642674775"/>
-          <entry name="_link" md5="3b5fbc8402c4e7b6fa62027a2c716b9f" size="119" mtime="1642674776"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="ee0a9588fa98b048cb55253494e83e48" vrev="56" srcmd5="ee0a9588fa98b048cb55253494e83e48">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="9541baaffb6e3316602e0cc01b08723b" baserev="9541baaffb6e3316602e0cc01b08723b" lsrcmd5="40e7491eafda73011aa829d69ed60a7c"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="12c3cd3ca436ad78ec58e113e4fe4a0c" size="44" mtime="1643641527"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:56 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:28 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_multibuild
@@ -1321,7 +1307,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "<multibuild><flavor>flavor_a</flavor><flavor>flavor_b</flavor></multibuild>"
-  recorded_at: Thu, 20 Jan 2022 10:32:56 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:29 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -1347,22 +1333,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="58" vrev="58" srcmd5="c94332bf02c524805c54215ec913a548">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="523aae6299f19484faefbb6ff3c08a08" baserev="523aae6299f19484faefbb6ff3c08a08" xsrcmd5="286301dd8dac44704a5703ecd213f63f" lsrcmd5="c94332bf02c524805c54215ec913a548"/>
-          <serviceinfo code="succeeded" xsrcmd5="49f54ea80dce3348172aed050f845c90"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="0a99b4bc0babd3d32a93f5649d5e2781" size="62" mtime="1642674775"/>
-          <entry name="_link" md5="3b5fbc8402c4e7b6fa62027a2c716b9f" size="119" mtime="1642674776"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="28" vrev="28" srcmd5="40e7491eafda73011aa829d69ed60a7c">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="9541baaffb6e3316602e0cc01b08723b" baserev="9541baaffb6e3316602e0cc01b08723b" xsrcmd5="ee0a9588fa98b048cb55253494e83e48" lsrcmd5="40e7491eafda73011aa829d69ed60a7c"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="12c3cd3ca436ad78ec58e113e4fe4a0c" size="44" mtime="1643641527"/>
+          <entry name="_link" md5="b1d9876b2c3e7eb635910c70f41121d4" size="119" mtime="1643641528"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:56 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:29 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1385,19 +1370,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '629'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="58" vrev="58" srcmd5="c94332bf02c524805c54215ec913a548">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="523aae6299f19484faefbb6ff3c08a08" baserev="523aae6299f19484faefbb6ff3c08a08" xsrcmd5="286301dd8dac44704a5703ecd213f63f" lsrcmd5="c94332bf02c524805c54215ec913a548"/>
-          <serviceinfo code="succeeded" xsrcmd5="49f54ea80dce3348172aed050f845c90"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="0a99b4bc0babd3d32a93f5649d5e2781" size="62" mtime="1642674775"/>
-          <entry name="_link" md5="3b5fbc8402c4e7b6fa62027a2c716b9f" size="119" mtime="1642674776"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="ee0a9588fa98b048cb55253494e83e48" vrev="56" srcmd5="ee0a9588fa98b048cb55253494e83e48">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="9541baaffb6e3316602e0cc01b08723b" baserev="9541baaffb6e3316602e0cc01b08723b" lsrcmd5="40e7491eafda73011aa829d69ed60a7c"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="12c3cd3ca436ad78ec58e113e4fe4a0c" size="44" mtime="1643641527"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:56 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:29 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_multibuild
@@ -1427,5 +1410,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "<multibuild><flavor>flavor_a</flavor><flavor>flavor_b</flavor></multibuild>"
-  recorded_at: Thu, 20 Jan 2022 10:32:56 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:29 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_a_multibuild_package/1_1_1_4_2.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_a_multibuild_package/1_1_1_4_2.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:00 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:23 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_316
+    uri: http://backend:5352/source/foo_project/_meta?user=user_25
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>The Line of Beauty</title>
+          <title>To a God Unknown</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '150'
+      - '148'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>The Line of Beauty</title>
+          <title>To a God Unknown</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:00 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:23 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/multibuild_package/_meta?user=user_317
+    uri: http://backend:5352/source/foo_project/multibuild_package/_meta?user=user_26
     body:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="foo_project">
-          <title>Things Fall Apart</title>
-          <description>Minima voluptatem mollitia debitis.</description>
+          <title>Dance Dance Dance</title>
+          <description>Id voluptatem quibusdam earum.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '169'
+      - '164'
     body:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="foo_project">
-          <title>Things Fall Apart</title>
-          <description>Minima voluptatem mollitia debitis.</description>
+          <title>Dance Dance Dance</title>
+          <description>Id voluptatem quibusdam earum.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:00 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:23 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/multibuild_package/_config
     body:
       encoding: UTF-8
-      string: Eum magni qui. Illum sed voluptatem. Adipisci placeat sequi.
+      string: Enim minima at. Sit voluptatibus accusamus. Dolorem eveniet optio.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -147,15 +147,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="49" vrev="49">
-          <srcmd5>bdc247e93bf2c793fda407e7f6e9777f</srcmd5>
+        <revision rev="23" vrev="23">
+          <srcmd5>49a00a8b94fffdfe0186259917ea3059</srcmd5>
           <version>unknown</version>
-          <time>1642674780</time>
+          <time>1643641523</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:00 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:23 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/multibuild_package/_multibuild
@@ -185,15 +185,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="50" vrev="50">
-          <srcmd5>bdc247e93bf2c793fda407e7f6e9777f</srcmd5>
+        <revision rev="24" vrev="24">
+          <srcmd5>49a00a8b94fffdfe0186259917ea3059</srcmd5>
           <version>unknown</version>
-          <time>1642674780</time>
+          <time>1643641523</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:00 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:23 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22multibuild_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -227,7 +227,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:33:00 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:24 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -267,7 +267,7 @@ http_interactions:
           <description>This project was created for package multibuild_package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:00 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:24 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_meta?user=Iggy
@@ -275,8 +275,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Things Fall Apart</title>
-          <description>Minima voluptatem mollitia debitis.</description>
+          <title>Dance Dance Dance</title>
+          <description>Id voluptatem quibusdam earum.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -297,15 +297,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '200'
+      - '195'
     body:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Things Fall Apart</title>
-          <description>Minima voluptatem mollitia debitis.</description>
+          <title>Dance Dance Dance</title>
+          <description>Id voluptatem quibusdam earum.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:00 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:24 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?cmd=branch&noservice=1&opackage=multibuild_package&oproject=foo_project&user=Iggy
@@ -337,15 +337,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="63" vrev="63">
-          <srcmd5>fc279cc2d57569ea36dd4b4a33be16d1</srcmd5>
+        <revision rev="23" vrev="23">
+          <srcmd5>17a4302ed9ef77fdebd9a3343db1e206</srcmd5>
           <version>unknown</version>
-          <time>1642674780</time>
+          <time>1643641524</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:00 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:24 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_meta?user=Iggy
@@ -353,8 +353,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Things Fall Apart</title>
-          <description>Minima voluptatem mollitia debitis.</description>
+          <title>Dance Dance Dance</title>
+          <description>Id voluptatem quibusdam earum.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -375,15 +375,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '200'
+      - '195'
     body:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Things Fall Apart</title>
-          <description>Minima voluptatem mollitia debitis.</description>
+          <title>Dance Dance Dance</title>
+          <description>Id voluptatem quibusdam earum.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:00 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:24 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -413,13 +413,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="63" vrev="63" srcmd5="fc279cc2d57569ea36dd4b4a33be16d1">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="bdc247e93bf2c793fda407e7f6e9777f" baserev="bdc247e93bf2c793fda407e7f6e9777f" xsrcmd5="5d97afa65ef53fbd72def505a15753aa" lsrcmd5="fc279cc2d57569ea36dd4b4a33be16d1"/>
-          <entry name="_config" md5="b3b3b7730c17b4d4b5cdf03e36abb207" size="60" mtime="1642674780"/>
-          <entry name="_link" md5="5e5869e9703b6dd2545eed8fc8b5d399" size="119" mtime="1642674780"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="23" vrev="23" srcmd5="17a4302ed9ef77fdebd9a3343db1e206">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="49a00a8b94fffdfe0186259917ea3059" baserev="49a00a8b94fffdfe0186259917ea3059" xsrcmd5="5e5cc857518b6e015052783856bb83d8" lsrcmd5="17a4302ed9ef77fdebd9a3343db1e206"/>
+          <entry name="_config" md5="107266b07531c01029f287d305f1b6c3" size="66" mtime="1643641523"/>
+          <entry name="_link" md5="b00becf6df59350696f81a4708a2fe1f" size="119" mtime="1643641524"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:00 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:24 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?view=info
@@ -445,15 +445,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '345'
+      - '344'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="multibuild_package" rev="63" vrev="113" srcmd5="5d97afa65ef53fbd72def505a15753aa" lsrcmd5="fc279cc2d57569ea36dd4b4a33be16d1" verifymd5="bdc247e93bf2c793fda407e7f6e9777f">
+        <sourceinfo package="multibuild_package" rev="23" vrev="47" srcmd5="5e5cc857518b6e015052783856bb83d8" lsrcmd5="17a4302ed9ef77fdebd9a3343db1e206" verifymd5="49a00a8b94fffdfe0186259917ea3059">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="multibuild_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:00 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:24 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -483,13 +483,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="63" vrev="63" srcmd5="fc279cc2d57569ea36dd4b4a33be16d1">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="bdc247e93bf2c793fda407e7f6e9777f" baserev="bdc247e93bf2c793fda407e7f6e9777f" xsrcmd5="5d97afa65ef53fbd72def505a15753aa" lsrcmd5="fc279cc2d57569ea36dd4b4a33be16d1"/>
-          <entry name="_config" md5="b3b3b7730c17b4d4b5cdf03e36abb207" size="60" mtime="1642674780"/>
-          <entry name="_link" md5="5e5869e9703b6dd2545eed8fc8b5d399" size="119" mtime="1642674780"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="23" vrev="23" srcmd5="17a4302ed9ef77fdebd9a3343db1e206">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="49a00a8b94fffdfe0186259917ea3059" baserev="49a00a8b94fffdfe0186259917ea3059" xsrcmd5="5e5cc857518b6e015052783856bb83d8" lsrcmd5="17a4302ed9ef77fdebd9a3343db1e206"/>
+          <entry name="_config" md5="107266b07531c01029f287d305f1b6c3" size="66" mtime="1643641523"/>
+          <entry name="_link" md5="b00becf6df59350696f81a4708a2fe1f" size="119" mtime="1643641524"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:00 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:24 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -521,14 +521,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="6443fc4d5c335c6ef20415780142899d">
+        <sourcediff key="0116dae6124d8a99d7e27ea38057491d">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="63" srcmd5="fc279cc2d57569ea36dd4b4a33be16d1"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="23" srcmd5="17a4302ed9ef77fdebd9a3343db1e206"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:01 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:24 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -560,12 +560,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="b7f0800f3ba9972d29a6077ca77fd1ee">
-          <old project="foo_project" package="multibuild_package" rev="bdc247e93bf2c793fda407e7f6e9777f" srcmd5="bdc247e93bf2c793fda407e7f6e9777f"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="5d97afa65ef53fbd72def505a15753aa" srcmd5="5d97afa65ef53fbd72def505a15753aa"/>
+        <sourcediff key="a38cd71b148f4d4674e4a330df8d793b">
+          <old project="foo_project" package="multibuild_package" rev="49a00a8b94fffdfe0186259917ea3059" srcmd5="49a00a8b94fffdfe0186259917ea3059"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="5e5cc857518b6e015052783856bb83d8" srcmd5="5e5cc857518b6e015052783856bb83d8"/>
           <files/>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:01 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:24 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -633,7 +633,7 @@ http_interactions:
             <arch>aarch64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:01 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:24 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_branch_request?user=Iggy
@@ -663,15 +663,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="64" vrev="64">
-          <srcmd5>08ed87cf681b1a16625ff13fa7124007</srcmd5>
+        <revision rev="24" vrev="24">
+          <srcmd5>063f025ac456fbb7a4574d28b2a06754</srcmd5>
           <version>unknown</version>
-          <time>1642674781</time>
+          <time>1643641524</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:01 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:24 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_meta?user=Iggy
@@ -679,8 +679,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Things Fall Apart</title>
-          <description>Minima voluptatem mollitia debitis.</description>
+          <title>Dance Dance Dance</title>
+          <description>Id voluptatem quibusdam earum.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -701,15 +701,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '200'
+      - '195'
     body:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Things Fall Apart</title>
-          <description>Minima voluptatem mollitia debitis.</description>
+          <title>Dance Dance Dance</title>
+          <description>Id voluptatem quibusdam earum.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:01 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:24 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -735,19 +735,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="64" vrev="64" srcmd5="08ed87cf681b1a16625ff13fa7124007">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="bdc247e93bf2c793fda407e7f6e9777f" baserev="bdc247e93bf2c793fda407e7f6e9777f" xsrcmd5="ddde96d02aefc39471765df47631316a" lsrcmd5="08ed87cf681b1a16625ff13fa7124007"/>
-          <serviceinfo code="succeeded" xsrcmd5="91528517ed211319b3853cd552c5333c"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="b3b3b7730c17b4d4b5cdf03e36abb207" size="60" mtime="1642674780"/>
-          <entry name="_link" md5="5e5869e9703b6dd2545eed8fc8b5d399" size="119" mtime="1642674780"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="24" vrev="24" srcmd5="063f025ac456fbb7a4574d28b2a06754">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="49a00a8b94fffdfe0186259917ea3059" baserev="49a00a8b94fffdfe0186259917ea3059" xsrcmd5="3d231821ab7a3e5faffb9e56c09af835" lsrcmd5="063f025ac456fbb7a4574d28b2a06754"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="107266b07531c01029f287d305f1b6c3" size="66" mtime="1643641523"/>
+          <entry name="_link" md5="b00becf6df59350696f81a4708a2fe1f" size="119" mtime="1643641524"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:01 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:24 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?view=info
@@ -773,15 +772,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '345'
+      - '344'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="multibuild_package" rev="64" vrev="114" srcmd5="e90fcd46bc0632b1a4b3bd157bb2ea9f" lsrcmd5="91528517ed211319b3853cd552c5333c" verifymd5="122bb71f825367d2e9d10fa72c95b3ab">
+        <sourceinfo package="multibuild_package" rev="24" vrev="48" srcmd5="3d231821ab7a3e5faffb9e56c09af835" lsrcmd5="063f025ac456fbb7a4574d28b2a06754" verifymd5="e6d80e950c5186bdf8c1182aafc96e36">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="multibuild_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:01 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:24 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -807,19 +806,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="64" vrev="64" srcmd5="08ed87cf681b1a16625ff13fa7124007">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="bdc247e93bf2c793fda407e7f6e9777f" baserev="bdc247e93bf2c793fda407e7f6e9777f" xsrcmd5="ddde96d02aefc39471765df47631316a" lsrcmd5="08ed87cf681b1a16625ff13fa7124007"/>
-          <serviceinfo code="succeeded" xsrcmd5="91528517ed211319b3853cd552c5333c"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="b3b3b7730c17b4d4b5cdf03e36abb207" size="60" mtime="1642674780"/>
-          <entry name="_link" md5="5e5869e9703b6dd2545eed8fc8b5d399" size="119" mtime="1642674780"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="24" vrev="24" srcmd5="063f025ac456fbb7a4574d28b2a06754">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="49a00a8b94fffdfe0186259917ea3059" baserev="49a00a8b94fffdfe0186259917ea3059" xsrcmd5="3d231821ab7a3e5faffb9e56c09af835" lsrcmd5="063f025ac456fbb7a4574d28b2a06754"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="107266b07531c01029f287d305f1b6c3" size="66" mtime="1643641523"/>
+          <entry name="_link" md5="b00becf6df59350696f81a4708a2fe1f" size="119" mtime="1643641524"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:01 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:24 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -851,14 +849,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="1d024f088522946ccced475fd4cd7b56">
+        <sourcediff key="1de8685c81ee53a3d29b4ae04777cfe1">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="64" srcmd5="08ed87cf681b1a16625ff13fa7124007"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="24" srcmd5="063f025ac456fbb7a4574d28b2a06754"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:01 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:24 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -890,14 +888,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="e40081d8179c0c8af22dfc36a992da04">
-          <old project="foo_project" package="multibuild_package" rev="bdc247e93bf2c793fda407e7f6e9777f" srcmd5="bdc247e93bf2c793fda407e7f6e9777f"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="e90fcd46bc0632b1a4b3bd157bb2ea9f" srcmd5="e90fcd46bc0632b1a4b3bd157bb2ea9f"/>
+        <sourcediff key="0d675e4e182e213cf3d9c57aaae5dc9b">
+          <old project="foo_project" package="multibuild_package" rev="49a00a8b94fffdfe0186259917ea3059" srcmd5="49a00a8b94fffdfe0186259917ea3059"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="3d231821ab7a3e5faffb9e56c09af835" srcmd5="3d231821ab7a3e5faffb9e56c09af835"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:01 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:24 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -923,22 +921,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="64" vrev="64" srcmd5="08ed87cf681b1a16625ff13fa7124007">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="bdc247e93bf2c793fda407e7f6e9777f" baserev="bdc247e93bf2c793fda407e7f6e9777f" xsrcmd5="ddde96d02aefc39471765df47631316a" lsrcmd5="08ed87cf681b1a16625ff13fa7124007"/>
-          <serviceinfo code="succeeded" xsrcmd5="91528517ed211319b3853cd552c5333c"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="b3b3b7730c17b4d4b5cdf03e36abb207" size="60" mtime="1642674780"/>
-          <entry name="_link" md5="5e5869e9703b6dd2545eed8fc8b5d399" size="119" mtime="1642674780"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="24" vrev="24" srcmd5="063f025ac456fbb7a4574d28b2a06754">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="49a00a8b94fffdfe0186259917ea3059" baserev="49a00a8b94fffdfe0186259917ea3059" xsrcmd5="3d231821ab7a3e5faffb9e56c09af835" lsrcmd5="063f025ac456fbb7a4574d28b2a06754"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="107266b07531c01029f287d305f1b6c3" size="66" mtime="1643641523"/>
+          <entry name="_link" md5="b00becf6df59350696f81a4708a2fe1f" size="119" mtime="1643641524"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:01 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:25 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -961,19 +958,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '629'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="64" vrev="64" srcmd5="08ed87cf681b1a16625ff13fa7124007">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="bdc247e93bf2c793fda407e7f6e9777f" baserev="bdc247e93bf2c793fda407e7f6e9777f" xsrcmd5="ddde96d02aefc39471765df47631316a" lsrcmd5="08ed87cf681b1a16625ff13fa7124007"/>
-          <serviceinfo code="succeeded" xsrcmd5="91528517ed211319b3853cd552c5333c"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="b3b3b7730c17b4d4b5cdf03e36abb207" size="60" mtime="1642674780"/>
-          <entry name="_link" md5="5e5869e9703b6dd2545eed8fc8b5d399" size="119" mtime="1642674780"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="3d231821ab7a3e5faffb9e56c09af835" vrev="48" srcmd5="3d231821ab7a3e5faffb9e56c09af835">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="49a00a8b94fffdfe0186259917ea3059" baserev="49a00a8b94fffdfe0186259917ea3059" lsrcmd5="063f025ac456fbb7a4574d28b2a06754"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="107266b07531c01029f287d305f1b6c3" size="66" mtime="1643641523"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:01 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:25 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_multibuild
@@ -1003,7 +998,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "<multibuild><flavor>flavor_a</flavor><flavor>flavor_b</flavor></multibuild>"
-  recorded_at: Thu, 20 Jan 2022 10:33:01 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:25 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -1029,22 +1024,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="64" vrev="64" srcmd5="08ed87cf681b1a16625ff13fa7124007">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="bdc247e93bf2c793fda407e7f6e9777f" baserev="bdc247e93bf2c793fda407e7f6e9777f" xsrcmd5="ddde96d02aefc39471765df47631316a" lsrcmd5="08ed87cf681b1a16625ff13fa7124007"/>
-          <serviceinfo code="succeeded" xsrcmd5="91528517ed211319b3853cd552c5333c"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="b3b3b7730c17b4d4b5cdf03e36abb207" size="60" mtime="1642674780"/>
-          <entry name="_link" md5="5e5869e9703b6dd2545eed8fc8b5d399" size="119" mtime="1642674780"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="24" vrev="24" srcmd5="063f025ac456fbb7a4574d28b2a06754">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="49a00a8b94fffdfe0186259917ea3059" baserev="49a00a8b94fffdfe0186259917ea3059" xsrcmd5="3d231821ab7a3e5faffb9e56c09af835" lsrcmd5="063f025ac456fbb7a4574d28b2a06754"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="107266b07531c01029f287d305f1b6c3" size="66" mtime="1643641523"/>
+          <entry name="_link" md5="b00becf6df59350696f81a4708a2fe1f" size="119" mtime="1643641524"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:01 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:25 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1067,19 +1061,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '629'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="64" vrev="64" srcmd5="08ed87cf681b1a16625ff13fa7124007">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="bdc247e93bf2c793fda407e7f6e9777f" baserev="bdc247e93bf2c793fda407e7f6e9777f" xsrcmd5="ddde96d02aefc39471765df47631316a" lsrcmd5="08ed87cf681b1a16625ff13fa7124007"/>
-          <serviceinfo code="succeeded" xsrcmd5="91528517ed211319b3853cd552c5333c"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="b3b3b7730c17b4d4b5cdf03e36abb207" size="60" mtime="1642674780"/>
-          <entry name="_link" md5="5e5869e9703b6dd2545eed8fc8b5d399" size="119" mtime="1642674780"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="3d231821ab7a3e5faffb9e56c09af835" vrev="48" srcmd5="3d231821ab7a3e5faffb9e56c09af835">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="49a00a8b94fffdfe0186259917ea3059" baserev="49a00a8b94fffdfe0186259917ea3059" lsrcmd5="063f025ac456fbb7a4574d28b2a06754"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="107266b07531c01029f287d305f1b6c3" size="66" mtime="1643641523"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:01 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:25 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_multibuild
@@ -1109,7 +1101,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "<multibuild><flavor>flavor_a</flavor><flavor>flavor_b</flavor></multibuild>"
-  recorded_at: Thu, 20 Jan 2022 10:33:01 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:25 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -1135,22 +1127,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="64" vrev="64" srcmd5="08ed87cf681b1a16625ff13fa7124007">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="bdc247e93bf2c793fda407e7f6e9777f" baserev="bdc247e93bf2c793fda407e7f6e9777f" xsrcmd5="ddde96d02aefc39471765df47631316a" lsrcmd5="08ed87cf681b1a16625ff13fa7124007"/>
-          <serviceinfo code="succeeded" xsrcmd5="91528517ed211319b3853cd552c5333c"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="b3b3b7730c17b4d4b5cdf03e36abb207" size="60" mtime="1642674780"/>
-          <entry name="_link" md5="5e5869e9703b6dd2545eed8fc8b5d399" size="119" mtime="1642674780"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="24" vrev="24" srcmd5="063f025ac456fbb7a4574d28b2a06754">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="49a00a8b94fffdfe0186259917ea3059" baserev="49a00a8b94fffdfe0186259917ea3059" xsrcmd5="3d231821ab7a3e5faffb9e56c09af835" lsrcmd5="063f025ac456fbb7a4574d28b2a06754"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="107266b07531c01029f287d305f1b6c3" size="66" mtime="1643641523"/>
+          <entry name="_link" md5="b00becf6df59350696f81a4708a2fe1f" size="119" mtime="1643641524"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:01 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:25 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1173,19 +1164,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '629'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="64" vrev="64" srcmd5="08ed87cf681b1a16625ff13fa7124007">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="bdc247e93bf2c793fda407e7f6e9777f" baserev="bdc247e93bf2c793fda407e7f6e9777f" xsrcmd5="ddde96d02aefc39471765df47631316a" lsrcmd5="08ed87cf681b1a16625ff13fa7124007"/>
-          <serviceinfo code="succeeded" xsrcmd5="91528517ed211319b3853cd552c5333c"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="b3b3b7730c17b4d4b5cdf03e36abb207" size="60" mtime="1642674780"/>
-          <entry name="_link" md5="5e5869e9703b6dd2545eed8fc8b5d399" size="119" mtime="1642674780"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="3d231821ab7a3e5faffb9e56c09af835" vrev="48" srcmd5="3d231821ab7a3e5faffb9e56c09af835">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="49a00a8b94fffdfe0186259917ea3059" baserev="49a00a8b94fffdfe0186259917ea3059" lsrcmd5="063f025ac456fbb7a4574d28b2a06754"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="107266b07531c01029f287d305f1b6c3" size="66" mtime="1643641523"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:01 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:25 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_multibuild
@@ -1215,7 +1204,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "<multibuild><flavor>flavor_a</flavor><flavor>flavor_b</flavor></multibuild>"
-  recorded_at: Thu, 20 Jan 2022 10:33:01 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:25 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -1241,22 +1230,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="64" vrev="64" srcmd5="08ed87cf681b1a16625ff13fa7124007">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="bdc247e93bf2c793fda407e7f6e9777f" baserev="bdc247e93bf2c793fda407e7f6e9777f" xsrcmd5="ddde96d02aefc39471765df47631316a" lsrcmd5="08ed87cf681b1a16625ff13fa7124007"/>
-          <serviceinfo code="succeeded" xsrcmd5="91528517ed211319b3853cd552c5333c"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="b3b3b7730c17b4d4b5cdf03e36abb207" size="60" mtime="1642674780"/>
-          <entry name="_link" md5="5e5869e9703b6dd2545eed8fc8b5d399" size="119" mtime="1642674780"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="24" vrev="24" srcmd5="063f025ac456fbb7a4574d28b2a06754">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="49a00a8b94fffdfe0186259917ea3059" baserev="49a00a8b94fffdfe0186259917ea3059" xsrcmd5="3d231821ab7a3e5faffb9e56c09af835" lsrcmd5="063f025ac456fbb7a4574d28b2a06754"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="107266b07531c01029f287d305f1b6c3" size="66" mtime="1643641523"/>
+          <entry name="_link" md5="b00becf6df59350696f81a4708a2fe1f" size="119" mtime="1643641524"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:01 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:25 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1279,19 +1267,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '629'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="64" vrev="64" srcmd5="08ed87cf681b1a16625ff13fa7124007">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="bdc247e93bf2c793fda407e7f6e9777f" baserev="bdc247e93bf2c793fda407e7f6e9777f" xsrcmd5="ddde96d02aefc39471765df47631316a" lsrcmd5="08ed87cf681b1a16625ff13fa7124007"/>
-          <serviceinfo code="succeeded" xsrcmd5="91528517ed211319b3853cd552c5333c"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="b3b3b7730c17b4d4b5cdf03e36abb207" size="60" mtime="1642674780"/>
-          <entry name="_link" md5="5e5869e9703b6dd2545eed8fc8b5d399" size="119" mtime="1642674780"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="3d231821ab7a3e5faffb9e56c09af835" vrev="48" srcmd5="3d231821ab7a3e5faffb9e56c09af835">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="49a00a8b94fffdfe0186259917ea3059" baserev="49a00a8b94fffdfe0186259917ea3059" lsrcmd5="063f025ac456fbb7a4574d28b2a06754"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="107266b07531c01029f287d305f1b6c3" size="66" mtime="1643641523"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:01 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:25 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_multibuild
@@ -1321,7 +1307,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "<multibuild><flavor>flavor_a</flavor><flavor>flavor_b</flavor></multibuild>"
-  recorded_at: Thu, 20 Jan 2022 10:33:01 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:25 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -1347,22 +1333,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="64" vrev="64" srcmd5="08ed87cf681b1a16625ff13fa7124007">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="bdc247e93bf2c793fda407e7f6e9777f" baserev="bdc247e93bf2c793fda407e7f6e9777f" xsrcmd5="ddde96d02aefc39471765df47631316a" lsrcmd5="08ed87cf681b1a16625ff13fa7124007"/>
-          <serviceinfo code="succeeded" xsrcmd5="91528517ed211319b3853cd552c5333c"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="b3b3b7730c17b4d4b5cdf03e36abb207" size="60" mtime="1642674780"/>
-          <entry name="_link" md5="5e5869e9703b6dd2545eed8fc8b5d399" size="119" mtime="1642674780"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="24" vrev="24" srcmd5="063f025ac456fbb7a4574d28b2a06754">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="49a00a8b94fffdfe0186259917ea3059" baserev="49a00a8b94fffdfe0186259917ea3059" xsrcmd5="3d231821ab7a3e5faffb9e56c09af835" lsrcmd5="063f025ac456fbb7a4574d28b2a06754"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="107266b07531c01029f287d305f1b6c3" size="66" mtime="1643641523"/>
+          <entry name="_link" md5="b00becf6df59350696f81a4708a2fe1f" size="119" mtime="1643641524"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:01 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:25 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1385,19 +1370,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '629'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="64" vrev="64" srcmd5="08ed87cf681b1a16625ff13fa7124007">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="bdc247e93bf2c793fda407e7f6e9777f" baserev="bdc247e93bf2c793fda407e7f6e9777f" xsrcmd5="ddde96d02aefc39471765df47631316a" lsrcmd5="08ed87cf681b1a16625ff13fa7124007"/>
-          <serviceinfo code="succeeded" xsrcmd5="91528517ed211319b3853cd552c5333c"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="b3b3b7730c17b4d4b5cdf03e36abb207" size="60" mtime="1642674780"/>
-          <entry name="_link" md5="5e5869e9703b6dd2545eed8fc8b5d399" size="119" mtime="1642674780"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="3d231821ab7a3e5faffb9e56c09af835" vrev="48" srcmd5="3d231821ab7a3e5faffb9e56c09af835">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="49a00a8b94fffdfe0186259917ea3059" baserev="49a00a8b94fffdfe0186259917ea3059" lsrcmd5="063f025ac456fbb7a4574d28b2a06754"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="107266b07531c01029f287d305f1b6c3" size="66" mtime="1643641523"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:01 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:25 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_multibuild
@@ -1427,5 +1410,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "<multibuild><flavor>flavor_a</flavor><flavor>flavor_b</flavor></multibuild>"
-  recorded_at: Thu, 20 Jan 2022 10:33:01 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:25 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_a_multibuild_package/1_1_1_4_3.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_a_multibuild_package/1_1_1_4_3.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:59 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:32 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_314
+    uri: http://backend:5352/source/foo_project/_meta?user=user_35
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Dance Dance Dance</title>
+          <title>The Waste Land</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '149'
+      - '146'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Dance Dance Dance</title>
+          <title>The Waste Land</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:59 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:32 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/multibuild_package/_meta?user=user_315
+    uri: http://backend:5352/source/foo_project/multibuild_package/_meta?user=user_36
     body:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="foo_project">
-          <title>No Highway</title>
-          <description>Ut qui quaerat explicabo.</description>
+          <title>The Way Through the Woods</title>
+          <description>Velit fugiat itaque nulla.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,22 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '152'
+      - '168'
     body:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="foo_project">
-          <title>No Highway</title>
-          <description>Ut qui quaerat explicabo.</description>
+          <title>The Way Through the Woods</title>
+          <description>Velit fugiat itaque nulla.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:59 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:32 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/multibuild_package/_config
     body:
       encoding: UTF-8
-      string: Doloremque minus eius. Voluptatibus est quaerat. Repudiandae similique
-        et.
+      string: Ut qui velit. A facilis sit. Tempore eum ab.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -148,15 +147,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="47" vrev="47">
-          <srcmd5>c90426f4f77aab1d9616b140c656ad9d</srcmd5>
+        <revision rev="33" vrev="33">
+          <srcmd5>0907be8b2674c011d92041661796fc6c</srcmd5>
           <version>unknown</version>
-          <time>1642674779</time>
+          <time>1643641532</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:59 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:33 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/multibuild_package/_multibuild
@@ -186,15 +185,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="48" vrev="48">
-          <srcmd5>c90426f4f77aab1d9616b140c656ad9d</srcmd5>
+        <revision rev="34" vrev="34">
+          <srcmd5>0907be8b2674c011d92041661796fc6c</srcmd5>
           <version>unknown</version>
-          <time>1642674779</time>
+          <time>1643641533</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:59 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:33 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22multibuild_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -228,7 +227,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:32:59 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:33 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -268,7 +267,7 @@ http_interactions:
           <description>This project was created for package multibuild_package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:59 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:33 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_meta?user=Iggy
@@ -276,8 +275,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>No Highway</title>
-          <description>Ut qui quaerat explicabo.</description>
+          <title>The Way Through the Woods</title>
+          <description>Velit fugiat itaque nulla.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -298,15 +297,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '183'
+      - '199'
     body:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>No Highway</title>
-          <description>Ut qui quaerat explicabo.</description>
+          <title>The Way Through the Woods</title>
+          <description>Velit fugiat itaque nulla.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:59 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:33 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?cmd=branch&noservice=1&opackage=multibuild_package&oproject=foo_project&user=Iggy
@@ -338,15 +337,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="61" vrev="61">
-          <srcmd5>84af1708e16f56b18e8bae637317cd2e</srcmd5>
+        <revision rev="33" vrev="33">
+          <srcmd5>3072f6da3f6d52220e7e77a0f6b4d1c3</srcmd5>
           <version>unknown</version>
-          <time>1642674779</time>
+          <time>1643641533</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:59 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:33 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_meta?user=Iggy
@@ -354,8 +353,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>No Highway</title>
-          <description>Ut qui quaerat explicabo.</description>
+          <title>The Way Through the Woods</title>
+          <description>Velit fugiat itaque nulla.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -376,15 +375,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '183'
+      - '199'
     body:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>No Highway</title>
-          <description>Ut qui quaerat explicabo.</description>
+          <title>The Way Through the Woods</title>
+          <description>Velit fugiat itaque nulla.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:59 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:33 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -414,13 +413,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="61" vrev="61" srcmd5="84af1708e16f56b18e8bae637317cd2e">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="c90426f4f77aab1d9616b140c656ad9d" baserev="c90426f4f77aab1d9616b140c656ad9d" xsrcmd5="b77732f83c9863c0a2e6f828f0a24f1e" lsrcmd5="84af1708e16f56b18e8bae637317cd2e"/>
-          <entry name="_config" md5="42a3abd604781814e37e30345b87326e" size="74" mtime="1642674779"/>
-          <entry name="_link" md5="b30522db2c904986c73938d66d7c7873" size="119" mtime="1642674779"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="33" vrev="33" srcmd5="3072f6da3f6d52220e7e77a0f6b4d1c3">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="0907be8b2674c011d92041661796fc6c" baserev="0907be8b2674c011d92041661796fc6c" xsrcmd5="3bea20d8ee7b99d9cedf78d1154ad19f" lsrcmd5="3072f6da3f6d52220e7e77a0f6b4d1c3"/>
+          <entry name="_config" md5="1d3597560f82a330b8b187e0ab076d26" size="44" mtime="1643641532"/>
+          <entry name="_link" md5="e2a98ec941fa509ed1649c8f92c153d3" size="119" mtime="1643641533"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:59 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:33 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?view=info
@@ -446,15 +445,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '345'
+      - '344'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="multibuild_package" rev="61" vrev="109" srcmd5="b77732f83c9863c0a2e6f828f0a24f1e" lsrcmd5="84af1708e16f56b18e8bae637317cd2e" verifymd5="c90426f4f77aab1d9616b140c656ad9d">
+        <sourceinfo package="multibuild_package" rev="33" vrev="67" srcmd5="3bea20d8ee7b99d9cedf78d1154ad19f" lsrcmd5="3072f6da3f6d52220e7e77a0f6b4d1c3" verifymd5="0907be8b2674c011d92041661796fc6c">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="multibuild_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:59 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:33 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -484,13 +483,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="61" vrev="61" srcmd5="84af1708e16f56b18e8bae637317cd2e">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="c90426f4f77aab1d9616b140c656ad9d" baserev="c90426f4f77aab1d9616b140c656ad9d" xsrcmd5="b77732f83c9863c0a2e6f828f0a24f1e" lsrcmd5="84af1708e16f56b18e8bae637317cd2e"/>
-          <entry name="_config" md5="42a3abd604781814e37e30345b87326e" size="74" mtime="1642674779"/>
-          <entry name="_link" md5="b30522db2c904986c73938d66d7c7873" size="119" mtime="1642674779"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="33" vrev="33" srcmd5="3072f6da3f6d52220e7e77a0f6b4d1c3">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="0907be8b2674c011d92041661796fc6c" baserev="0907be8b2674c011d92041661796fc6c" xsrcmd5="3bea20d8ee7b99d9cedf78d1154ad19f" lsrcmd5="3072f6da3f6d52220e7e77a0f6b4d1c3"/>
+          <entry name="_config" md5="1d3597560f82a330b8b187e0ab076d26" size="44" mtime="1643641532"/>
+          <entry name="_link" md5="e2a98ec941fa509ed1649c8f92c153d3" size="119" mtime="1643641533"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:59 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:33 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -522,14 +521,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="c4ff874c7bd942db6fd77901712e3621">
+        <sourcediff key="36d9c9411748ed559efd9f797223931c">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="61" srcmd5="84af1708e16f56b18e8bae637317cd2e"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="33" srcmd5="3072f6da3f6d52220e7e77a0f6b4d1c3"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:59 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:33 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -561,12 +560,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="41ce1a9e50a2f8795c4d45c19b32039a">
-          <old project="foo_project" package="multibuild_package" rev="c90426f4f77aab1d9616b140c656ad9d" srcmd5="c90426f4f77aab1d9616b140c656ad9d"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="b77732f83c9863c0a2e6f828f0a24f1e" srcmd5="b77732f83c9863c0a2e6f828f0a24f1e"/>
+        <sourcediff key="e7d913d5959fc61da9ed74755622364a">
+          <old project="foo_project" package="multibuild_package" rev="0907be8b2674c011d92041661796fc6c" srcmd5="0907be8b2674c011d92041661796fc6c"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="3bea20d8ee7b99d9cedf78d1154ad19f" srcmd5="3bea20d8ee7b99d9cedf78d1154ad19f"/>
           <files/>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:59 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:33 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -634,7 +633,7 @@ http_interactions:
             <arch>aarch64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:59 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:33 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_branch_request?user=Iggy
@@ -664,15 +663,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="62" vrev="62">
-          <srcmd5>76733dd88c97d6866355f40f56ad7f04</srcmd5>
+        <revision rev="34" vrev="34">
+          <srcmd5>5610c6c6e164af37f2321d50dbb8303e</srcmd5>
           <version>unknown</version>
-          <time>1642674779</time>
+          <time>1643641533</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:59 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:33 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_meta?user=Iggy
@@ -680,8 +679,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>No Highway</title>
-          <description>Ut qui quaerat explicabo.</description>
+          <title>The Way Through the Woods</title>
+          <description>Velit fugiat itaque nulla.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -702,15 +701,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '183'
+      - '199'
     body:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>No Highway</title>
-          <description>Ut qui quaerat explicabo.</description>
+          <title>The Way Through the Woods</title>
+          <description>Velit fugiat itaque nulla.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:59 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:34 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -736,19 +735,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="62" vrev="62" srcmd5="76733dd88c97d6866355f40f56ad7f04">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="c90426f4f77aab1d9616b140c656ad9d" baserev="c90426f4f77aab1d9616b140c656ad9d" xsrcmd5="c50f630d703e587b66ad21a27e7b9b23" lsrcmd5="76733dd88c97d6866355f40f56ad7f04"/>
-          <serviceinfo code="succeeded" xsrcmd5="79961c3ba9ba876655a690d12bd98881"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="42a3abd604781814e37e30345b87326e" size="74" mtime="1642674779"/>
-          <entry name="_link" md5="b30522db2c904986c73938d66d7c7873" size="119" mtime="1642674779"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="34" vrev="34" srcmd5="5610c6c6e164af37f2321d50dbb8303e">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="0907be8b2674c011d92041661796fc6c" baserev="0907be8b2674c011d92041661796fc6c" xsrcmd5="756b43081b7b19273447377cca7bdd13" lsrcmd5="5610c6c6e164af37f2321d50dbb8303e"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="1d3597560f82a330b8b187e0ab076d26" size="44" mtime="1643641532"/>
+          <entry name="_link" md5="e2a98ec941fa509ed1649c8f92c153d3" size="119" mtime="1643641533"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:59 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:34 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?view=info
@@ -774,15 +772,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '345'
+      - '344'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="multibuild_package" rev="62" vrev="110" srcmd5="75580c482b384a1345a01fec5604e285" lsrcmd5="79961c3ba9ba876655a690d12bd98881" verifymd5="4fcf641ef40bea5808314924e463599c">
+        <sourceinfo package="multibuild_package" rev="34" vrev="68" srcmd5="756b43081b7b19273447377cca7bdd13" lsrcmd5="5610c6c6e164af37f2321d50dbb8303e" verifymd5="eab4eca114b2a52d759cd2baf4c5bf50">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="multibuild_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:00 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:34 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -808,19 +806,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="62" vrev="62" srcmd5="76733dd88c97d6866355f40f56ad7f04">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="c90426f4f77aab1d9616b140c656ad9d" baserev="c90426f4f77aab1d9616b140c656ad9d" xsrcmd5="c50f630d703e587b66ad21a27e7b9b23" lsrcmd5="76733dd88c97d6866355f40f56ad7f04"/>
-          <serviceinfo code="succeeded" xsrcmd5="79961c3ba9ba876655a690d12bd98881"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="42a3abd604781814e37e30345b87326e" size="74" mtime="1642674779"/>
-          <entry name="_link" md5="b30522db2c904986c73938d66d7c7873" size="119" mtime="1642674779"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="34" vrev="34" srcmd5="5610c6c6e164af37f2321d50dbb8303e">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="0907be8b2674c011d92041661796fc6c" baserev="0907be8b2674c011d92041661796fc6c" xsrcmd5="756b43081b7b19273447377cca7bdd13" lsrcmd5="5610c6c6e164af37f2321d50dbb8303e"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="1d3597560f82a330b8b187e0ab076d26" size="44" mtime="1643641532"/>
+          <entry name="_link" md5="e2a98ec941fa509ed1649c8f92c153d3" size="119" mtime="1643641533"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:00 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:34 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -852,14 +849,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="78a75c6f287a7a5a8665bc97d1863158">
+        <sourcediff key="c4d19a9c2132d0417b807ab5c6c9efcd">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="62" srcmd5="76733dd88c97d6866355f40f56ad7f04"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="34" srcmd5="5610c6c6e164af37f2321d50dbb8303e"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:00 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:34 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -891,14 +888,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="39fadaf462aaed6f242aa9dc262223e4">
-          <old project="foo_project" package="multibuild_package" rev="c90426f4f77aab1d9616b140c656ad9d" srcmd5="c90426f4f77aab1d9616b140c656ad9d"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="75580c482b384a1345a01fec5604e285" srcmd5="75580c482b384a1345a01fec5604e285"/>
+        <sourcediff key="737c9cfd647e7ce0f14d4508a29e9727">
+          <old project="foo_project" package="multibuild_package" rev="0907be8b2674c011d92041661796fc6c" srcmd5="0907be8b2674c011d92041661796fc6c"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="756b43081b7b19273447377cca7bdd13" srcmd5="756b43081b7b19273447377cca7bdd13"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:00 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:34 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -924,22 +921,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="62" vrev="62" srcmd5="76733dd88c97d6866355f40f56ad7f04">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="c90426f4f77aab1d9616b140c656ad9d" baserev="c90426f4f77aab1d9616b140c656ad9d" xsrcmd5="c50f630d703e587b66ad21a27e7b9b23" lsrcmd5="76733dd88c97d6866355f40f56ad7f04"/>
-          <serviceinfo code="succeeded" xsrcmd5="79961c3ba9ba876655a690d12bd98881"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="42a3abd604781814e37e30345b87326e" size="74" mtime="1642674779"/>
-          <entry name="_link" md5="b30522db2c904986c73938d66d7c7873" size="119" mtime="1642674779"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="34" vrev="34" srcmd5="5610c6c6e164af37f2321d50dbb8303e">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="0907be8b2674c011d92041661796fc6c" baserev="0907be8b2674c011d92041661796fc6c" xsrcmd5="756b43081b7b19273447377cca7bdd13" lsrcmd5="5610c6c6e164af37f2321d50dbb8303e"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="1d3597560f82a330b8b187e0ab076d26" size="44" mtime="1643641532"/>
+          <entry name="_link" md5="e2a98ec941fa509ed1649c8f92c153d3" size="119" mtime="1643641533"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:00 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:34 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -962,19 +958,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '629'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="62" vrev="62" srcmd5="76733dd88c97d6866355f40f56ad7f04">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="c90426f4f77aab1d9616b140c656ad9d" baserev="c90426f4f77aab1d9616b140c656ad9d" xsrcmd5="c50f630d703e587b66ad21a27e7b9b23" lsrcmd5="76733dd88c97d6866355f40f56ad7f04"/>
-          <serviceinfo code="succeeded" xsrcmd5="79961c3ba9ba876655a690d12bd98881"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="42a3abd604781814e37e30345b87326e" size="74" mtime="1642674779"/>
-          <entry name="_link" md5="b30522db2c904986c73938d66d7c7873" size="119" mtime="1642674779"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="756b43081b7b19273447377cca7bdd13" vrev="68" srcmd5="756b43081b7b19273447377cca7bdd13">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="0907be8b2674c011d92041661796fc6c" baserev="0907be8b2674c011d92041661796fc6c" lsrcmd5="5610c6c6e164af37f2321d50dbb8303e"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="1d3597560f82a330b8b187e0ab076d26" size="44" mtime="1643641532"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:00 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:34 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_multibuild
@@ -1004,7 +998,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "<multibuild><flavor>flavor_a</flavor><flavor>flavor_b</flavor></multibuild>"
-  recorded_at: Thu, 20 Jan 2022 10:33:00 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:34 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -1030,22 +1024,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="62" vrev="62" srcmd5="76733dd88c97d6866355f40f56ad7f04">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="c90426f4f77aab1d9616b140c656ad9d" baserev="c90426f4f77aab1d9616b140c656ad9d" xsrcmd5="c50f630d703e587b66ad21a27e7b9b23" lsrcmd5="76733dd88c97d6866355f40f56ad7f04"/>
-          <serviceinfo code="succeeded" xsrcmd5="79961c3ba9ba876655a690d12bd98881"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="42a3abd604781814e37e30345b87326e" size="74" mtime="1642674779"/>
-          <entry name="_link" md5="b30522db2c904986c73938d66d7c7873" size="119" mtime="1642674779"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="34" vrev="34" srcmd5="5610c6c6e164af37f2321d50dbb8303e">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="0907be8b2674c011d92041661796fc6c" baserev="0907be8b2674c011d92041661796fc6c" xsrcmd5="756b43081b7b19273447377cca7bdd13" lsrcmd5="5610c6c6e164af37f2321d50dbb8303e"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="1d3597560f82a330b8b187e0ab076d26" size="44" mtime="1643641532"/>
+          <entry name="_link" md5="e2a98ec941fa509ed1649c8f92c153d3" size="119" mtime="1643641533"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:00 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:34 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1068,19 +1061,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '629'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="62" vrev="62" srcmd5="76733dd88c97d6866355f40f56ad7f04">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="c90426f4f77aab1d9616b140c656ad9d" baserev="c90426f4f77aab1d9616b140c656ad9d" xsrcmd5="c50f630d703e587b66ad21a27e7b9b23" lsrcmd5="76733dd88c97d6866355f40f56ad7f04"/>
-          <serviceinfo code="succeeded" xsrcmd5="79961c3ba9ba876655a690d12bd98881"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="42a3abd604781814e37e30345b87326e" size="74" mtime="1642674779"/>
-          <entry name="_link" md5="b30522db2c904986c73938d66d7c7873" size="119" mtime="1642674779"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="756b43081b7b19273447377cca7bdd13" vrev="68" srcmd5="756b43081b7b19273447377cca7bdd13">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="0907be8b2674c011d92041661796fc6c" baserev="0907be8b2674c011d92041661796fc6c" lsrcmd5="5610c6c6e164af37f2321d50dbb8303e"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="1d3597560f82a330b8b187e0ab076d26" size="44" mtime="1643641532"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:00 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:34 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_multibuild
@@ -1110,7 +1101,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "<multibuild><flavor>flavor_a</flavor><flavor>flavor_b</flavor></multibuild>"
-  recorded_at: Thu, 20 Jan 2022 10:33:00 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:34 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -1136,22 +1127,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="62" vrev="62" srcmd5="76733dd88c97d6866355f40f56ad7f04">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="c90426f4f77aab1d9616b140c656ad9d" baserev="c90426f4f77aab1d9616b140c656ad9d" xsrcmd5="c50f630d703e587b66ad21a27e7b9b23" lsrcmd5="76733dd88c97d6866355f40f56ad7f04"/>
-          <serviceinfo code="succeeded" xsrcmd5="79961c3ba9ba876655a690d12bd98881"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="42a3abd604781814e37e30345b87326e" size="74" mtime="1642674779"/>
-          <entry name="_link" md5="b30522db2c904986c73938d66d7c7873" size="119" mtime="1642674779"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="34" vrev="34" srcmd5="5610c6c6e164af37f2321d50dbb8303e">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="0907be8b2674c011d92041661796fc6c" baserev="0907be8b2674c011d92041661796fc6c" xsrcmd5="756b43081b7b19273447377cca7bdd13" lsrcmd5="5610c6c6e164af37f2321d50dbb8303e"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="1d3597560f82a330b8b187e0ab076d26" size="44" mtime="1643641532"/>
+          <entry name="_link" md5="e2a98ec941fa509ed1649c8f92c153d3" size="119" mtime="1643641533"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:00 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:34 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1174,19 +1164,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '629'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="62" vrev="62" srcmd5="76733dd88c97d6866355f40f56ad7f04">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="c90426f4f77aab1d9616b140c656ad9d" baserev="c90426f4f77aab1d9616b140c656ad9d" xsrcmd5="c50f630d703e587b66ad21a27e7b9b23" lsrcmd5="76733dd88c97d6866355f40f56ad7f04"/>
-          <serviceinfo code="succeeded" xsrcmd5="79961c3ba9ba876655a690d12bd98881"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="42a3abd604781814e37e30345b87326e" size="74" mtime="1642674779"/>
-          <entry name="_link" md5="b30522db2c904986c73938d66d7c7873" size="119" mtime="1642674779"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="756b43081b7b19273447377cca7bdd13" vrev="68" srcmd5="756b43081b7b19273447377cca7bdd13">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="0907be8b2674c011d92041661796fc6c" baserev="0907be8b2674c011d92041661796fc6c" lsrcmd5="5610c6c6e164af37f2321d50dbb8303e"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="1d3597560f82a330b8b187e0ab076d26" size="44" mtime="1643641532"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:00 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:34 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_multibuild
@@ -1216,7 +1204,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "<multibuild><flavor>flavor_a</flavor><flavor>flavor_b</flavor></multibuild>"
-  recorded_at: Thu, 20 Jan 2022 10:33:00 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:34 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -1242,22 +1230,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="62" vrev="62" srcmd5="76733dd88c97d6866355f40f56ad7f04">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="c90426f4f77aab1d9616b140c656ad9d" baserev="c90426f4f77aab1d9616b140c656ad9d" xsrcmd5="c50f630d703e587b66ad21a27e7b9b23" lsrcmd5="76733dd88c97d6866355f40f56ad7f04"/>
-          <serviceinfo code="succeeded" xsrcmd5="79961c3ba9ba876655a690d12bd98881"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="42a3abd604781814e37e30345b87326e" size="74" mtime="1642674779"/>
-          <entry name="_link" md5="b30522db2c904986c73938d66d7c7873" size="119" mtime="1642674779"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="34" vrev="34" srcmd5="5610c6c6e164af37f2321d50dbb8303e">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="0907be8b2674c011d92041661796fc6c" baserev="0907be8b2674c011d92041661796fc6c" xsrcmd5="756b43081b7b19273447377cca7bdd13" lsrcmd5="5610c6c6e164af37f2321d50dbb8303e"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="1d3597560f82a330b8b187e0ab076d26" size="44" mtime="1643641532"/>
+          <entry name="_link" md5="e2a98ec941fa509ed1649c8f92c153d3" size="119" mtime="1643641533"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:00 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:34 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1280,19 +1267,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '629'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="62" vrev="62" srcmd5="76733dd88c97d6866355f40f56ad7f04">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="c90426f4f77aab1d9616b140c656ad9d" baserev="c90426f4f77aab1d9616b140c656ad9d" xsrcmd5="c50f630d703e587b66ad21a27e7b9b23" lsrcmd5="76733dd88c97d6866355f40f56ad7f04"/>
-          <serviceinfo code="succeeded" xsrcmd5="79961c3ba9ba876655a690d12bd98881"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="42a3abd604781814e37e30345b87326e" size="74" mtime="1642674779"/>
-          <entry name="_link" md5="b30522db2c904986c73938d66d7c7873" size="119" mtime="1642674779"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="756b43081b7b19273447377cca7bdd13" vrev="68" srcmd5="756b43081b7b19273447377cca7bdd13">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="0907be8b2674c011d92041661796fc6c" baserev="0907be8b2674c011d92041661796fc6c" lsrcmd5="5610c6c6e164af37f2321d50dbb8303e"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="1d3597560f82a330b8b187e0ab076d26" size="44" mtime="1643641532"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:00 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:34 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_multibuild
@@ -1322,7 +1307,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "<multibuild><flavor>flavor_a</flavor><flavor>flavor_b</flavor></multibuild>"
-  recorded_at: Thu, 20 Jan 2022 10:33:00 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:34 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -1348,22 +1333,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="62" vrev="62" srcmd5="76733dd88c97d6866355f40f56ad7f04">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="c90426f4f77aab1d9616b140c656ad9d" baserev="c90426f4f77aab1d9616b140c656ad9d" xsrcmd5="c50f630d703e587b66ad21a27e7b9b23" lsrcmd5="76733dd88c97d6866355f40f56ad7f04"/>
-          <serviceinfo code="succeeded" xsrcmd5="79961c3ba9ba876655a690d12bd98881"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="42a3abd604781814e37e30345b87326e" size="74" mtime="1642674779"/>
-          <entry name="_link" md5="b30522db2c904986c73938d66d7c7873" size="119" mtime="1642674779"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="34" vrev="34" srcmd5="5610c6c6e164af37f2321d50dbb8303e">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="0907be8b2674c011d92041661796fc6c" baserev="0907be8b2674c011d92041661796fc6c" xsrcmd5="756b43081b7b19273447377cca7bdd13" lsrcmd5="5610c6c6e164af37f2321d50dbb8303e"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="1d3597560f82a330b8b187e0ab076d26" size="44" mtime="1643641532"/>
+          <entry name="_link" md5="e2a98ec941fa509ed1649c8f92c153d3" size="119" mtime="1643641533"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:00 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:34 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1386,19 +1370,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '629'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="62" vrev="62" srcmd5="76733dd88c97d6866355f40f56ad7f04">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="c90426f4f77aab1d9616b140c656ad9d" baserev="c90426f4f77aab1d9616b140c656ad9d" xsrcmd5="c50f630d703e587b66ad21a27e7b9b23" lsrcmd5="76733dd88c97d6866355f40f56ad7f04"/>
-          <serviceinfo code="succeeded" xsrcmd5="79961c3ba9ba876655a690d12bd98881"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="42a3abd604781814e37e30345b87326e" size="74" mtime="1642674779"/>
-          <entry name="_link" md5="b30522db2c904986c73938d66d7c7873" size="119" mtime="1642674779"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="756b43081b7b19273447377cca7bdd13" vrev="68" srcmd5="756b43081b7b19273447377cca7bdd13">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="0907be8b2674c011d92041661796fc6c" baserev="0907be8b2674c011d92041661796fc6c" lsrcmd5="5610c6c6e164af37f2321d50dbb8303e"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="1d3597560f82a330b8b187e0ab076d26" size="44" mtime="1643641532"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:00 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:34 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_multibuild
@@ -1428,7 +1410,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "<multibuild><flavor>flavor_a</flavor><flavor>flavor_b</flavor></multibuild>"
-  recorded_at: Thu, 20 Jan 2022 10:33:00 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:34 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_branch_request
@@ -1458,5 +1440,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"action":"opened","pull_request":{"head":{"repo":{"full_name":"reponame"},"sha":"123456789"}}}'
-  recorded_at: Thu, 20 Jan 2022 10:33:00 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:34 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_a_multibuild_package/1_1_1_4_4.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_a_multibuild_package/1_1_1_4_4.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:03 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:29 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_320
+    uri: http://backend:5352/source/foo_project/_meta?user=user_31
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Blue Remembered Earth</title>
+          <title>Cabbages and Kings</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '153'
+      - '150'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Blue Remembered Earth</title>
+          <title>Cabbages and Kings</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:03 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:29 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/multibuild_package/_meta?user=user_321
+    uri: http://backend:5352/source/foo_project/multibuild_package/_meta?user=user_32
     body:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="foo_project">
-          <title>The Wealth of Nations</title>
-          <description>Ut voluptatem consequatur reiciendis.</description>
+          <title>Blue Remembered Earth</title>
+          <description>Ea sint recusandae sapiente.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '175'
+      - '166'
     body:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="foo_project">
-          <title>The Wealth of Nations</title>
-          <description>Ut voluptatem consequatur reiciendis.</description>
+          <title>Blue Remembered Earth</title>
+          <description>Ea sint recusandae sapiente.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:03 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:29 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/multibuild_package/_config
     body:
       encoding: UTF-8
-      string: In earum et. Non autem sed. Ut et debitis.
+      string: Est officiis maxime. Veniam hic accusantium. Id ipsa sed.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -147,15 +147,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="53" vrev="53">
-          <srcmd5>2669ce0b1e21f806ce13d2a02ecf2c24</srcmd5>
+        <revision rev="29" vrev="29">
+          <srcmd5>fd063229a56b788a0be867b507527017</srcmd5>
           <version>unknown</version>
-          <time>1642674783</time>
+          <time>1643641529</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:03 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:29 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/multibuild_package/_multibuild
@@ -185,15 +185,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="54" vrev="54">
-          <srcmd5>2669ce0b1e21f806ce13d2a02ecf2c24</srcmd5>
+        <revision rev="30" vrev="30">
+          <srcmd5>fd063229a56b788a0be867b507527017</srcmd5>
           <version>unknown</version>
-          <time>1642674783</time>
+          <time>1643641529</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:03 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:29 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22multibuild_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -227,7 +227,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:33:03 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:29 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -267,7 +267,7 @@ http_interactions:
           <description>This project was created for package multibuild_package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:03 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:29 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_meta?user=Iggy
@@ -275,8 +275,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Wealth of Nations</title>
-          <description>Ut voluptatem consequatur reiciendis.</description>
+          <title>Blue Remembered Earth</title>
+          <description>Ea sint recusandae sapiente.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -297,15 +297,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '206'
+      - '197'
     body:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Wealth of Nations</title>
-          <description>Ut voluptatem consequatur reiciendis.</description>
+          <title>Blue Remembered Earth</title>
+          <description>Ea sint recusandae sapiente.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:03 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:29 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?cmd=branch&noservice=1&opackage=multibuild_package&oproject=foo_project&user=Iggy
@@ -337,15 +337,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="67" vrev="67">
-          <srcmd5>21f57415b9389adadc2bfe2a823d474c</srcmd5>
+        <revision rev="29" vrev="29">
+          <srcmd5>64139ca64bdf717999f4a02024431781</srcmd5>
           <version>unknown</version>
-          <time>1642674783</time>
+          <time>1643641529</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:03 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:29 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_meta?user=Iggy
@@ -353,8 +353,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Wealth of Nations</title>
-          <description>Ut voluptatem consequatur reiciendis.</description>
+          <title>Blue Remembered Earth</title>
+          <description>Ea sint recusandae sapiente.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -375,15 +375,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '206'
+      - '197'
     body:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Wealth of Nations</title>
-          <description>Ut voluptatem consequatur reiciendis.</description>
+          <title>Blue Remembered Earth</title>
+          <description>Ea sint recusandae sapiente.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:03 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:29 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -413,13 +413,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="67" vrev="67" srcmd5="21f57415b9389adadc2bfe2a823d474c">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="2669ce0b1e21f806ce13d2a02ecf2c24" baserev="2669ce0b1e21f806ce13d2a02ecf2c24" xsrcmd5="99b84e9b9f1f7e6654c979f4ab24b119" lsrcmd5="21f57415b9389adadc2bfe2a823d474c"/>
-          <entry name="_config" md5="5f70d5f4ae556bd655866ffb13bee980" size="42" mtime="1642674783"/>
-          <entry name="_link" md5="2fae4b6a5da5a93b1f12303ce278ea00" size="119" mtime="1642674783"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="29" vrev="29" srcmd5="64139ca64bdf717999f4a02024431781">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="fd063229a56b788a0be867b507527017" baserev="fd063229a56b788a0be867b507527017" xsrcmd5="b01f7c8344cd3137abd2fff244bfc306" lsrcmd5="64139ca64bdf717999f4a02024431781"/>
+          <entry name="_config" md5="12500ab341447b611b4e8ea353732d33" size="57" mtime="1643641529"/>
+          <entry name="_link" md5="e3cc3863306ace4463efee3f455ad62f" size="119" mtime="1643641529"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:03 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:29 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?view=info
@@ -445,15 +445,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '345'
+      - '344'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="multibuild_package" rev="67" vrev="121" srcmd5="99b84e9b9f1f7e6654c979f4ab24b119" lsrcmd5="21f57415b9389adadc2bfe2a823d474c" verifymd5="2669ce0b1e21f806ce13d2a02ecf2c24">
+        <sourceinfo package="multibuild_package" rev="29" vrev="59" srcmd5="b01f7c8344cd3137abd2fff244bfc306" lsrcmd5="64139ca64bdf717999f4a02024431781" verifymd5="fd063229a56b788a0be867b507527017">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="multibuild_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:03 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:29 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -483,13 +483,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="67" vrev="67" srcmd5="21f57415b9389adadc2bfe2a823d474c">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="2669ce0b1e21f806ce13d2a02ecf2c24" baserev="2669ce0b1e21f806ce13d2a02ecf2c24" xsrcmd5="99b84e9b9f1f7e6654c979f4ab24b119" lsrcmd5="21f57415b9389adadc2bfe2a823d474c"/>
-          <entry name="_config" md5="5f70d5f4ae556bd655866ffb13bee980" size="42" mtime="1642674783"/>
-          <entry name="_link" md5="2fae4b6a5da5a93b1f12303ce278ea00" size="119" mtime="1642674783"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="29" vrev="29" srcmd5="64139ca64bdf717999f4a02024431781">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="fd063229a56b788a0be867b507527017" baserev="fd063229a56b788a0be867b507527017" xsrcmd5="b01f7c8344cd3137abd2fff244bfc306" lsrcmd5="64139ca64bdf717999f4a02024431781"/>
+          <entry name="_config" md5="12500ab341447b611b4e8ea353732d33" size="57" mtime="1643641529"/>
+          <entry name="_link" md5="e3cc3863306ace4463efee3f455ad62f" size="119" mtime="1643641529"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:03 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:29 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -521,14 +521,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="fbddd15d27bc271e6b8ce4316d1dd234">
+        <sourcediff key="045cbeab23f72e83df1b079b58fa0cf3">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="67" srcmd5="21f57415b9389adadc2bfe2a823d474c"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="29" srcmd5="64139ca64bdf717999f4a02024431781"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:03 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:29 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -560,12 +560,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="e38db76d2ae6300145a3848e55d530a9">
-          <old project="foo_project" package="multibuild_package" rev="2669ce0b1e21f806ce13d2a02ecf2c24" srcmd5="2669ce0b1e21f806ce13d2a02ecf2c24"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="99b84e9b9f1f7e6654c979f4ab24b119" srcmd5="99b84e9b9f1f7e6654c979f4ab24b119"/>
+        <sourcediff key="56ff3ca35bf75fcb80ab3365f9f5486e">
+          <old project="foo_project" package="multibuild_package" rev="fd063229a56b788a0be867b507527017" srcmd5="fd063229a56b788a0be867b507527017"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="b01f7c8344cd3137abd2fff244bfc306" srcmd5="b01f7c8344cd3137abd2fff244bfc306"/>
           <files/>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:03 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:29 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -633,7 +633,7 @@ http_interactions:
             <arch>aarch64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:04 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:30 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_branch_request?user=Iggy
@@ -663,15 +663,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="68" vrev="68">
-          <srcmd5>722360971d5aefc84f08ea756de28287</srcmd5>
+        <revision rev="30" vrev="30">
+          <srcmd5>dd034d0334eadc86566c0bf4e71d36b5</srcmd5>
           <version>unknown</version>
-          <time>1642674784</time>
+          <time>1643641530</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:04 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:30 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_meta?user=Iggy
@@ -679,8 +679,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Wealth of Nations</title>
-          <description>Ut voluptatem consequatur reiciendis.</description>
+          <title>Blue Remembered Earth</title>
+          <description>Ea sint recusandae sapiente.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -701,15 +701,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '206'
+      - '197'
     body:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Wealth of Nations</title>
-          <description>Ut voluptatem consequatur reiciendis.</description>
+          <title>Blue Remembered Earth</title>
+          <description>Ea sint recusandae sapiente.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:04 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:30 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -735,19 +735,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="68" vrev="68" srcmd5="722360971d5aefc84f08ea756de28287">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="2669ce0b1e21f806ce13d2a02ecf2c24" baserev="2669ce0b1e21f806ce13d2a02ecf2c24" xsrcmd5="4748baa0989eb9916324b0842d148811" lsrcmd5="722360971d5aefc84f08ea756de28287"/>
-          <serviceinfo code="succeeded" xsrcmd5="245f2db8ec9e268810c740284fd0e401"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="5f70d5f4ae556bd655866ffb13bee980" size="42" mtime="1642674783"/>
-          <entry name="_link" md5="2fae4b6a5da5a93b1f12303ce278ea00" size="119" mtime="1642674783"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="30" vrev="30" srcmd5="dd034d0334eadc86566c0bf4e71d36b5">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="fd063229a56b788a0be867b507527017" baserev="fd063229a56b788a0be867b507527017" xsrcmd5="4ffb04233ce517103a5963b2f9143149" lsrcmd5="dd034d0334eadc86566c0bf4e71d36b5"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="12500ab341447b611b4e8ea353732d33" size="57" mtime="1643641529"/>
+          <entry name="_link" md5="e3cc3863306ace4463efee3f455ad62f" size="119" mtime="1643641529"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:04 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:30 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?view=info
@@ -773,15 +772,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '345'
+      - '344'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="multibuild_package" rev="68" vrev="122" srcmd5="c5d11488f2f066072bad122978562fd6" lsrcmd5="245f2db8ec9e268810c740284fd0e401" verifymd5="c713602490c54486eff5e2b5b8f73347">
+        <sourceinfo package="multibuild_package" rev="30" vrev="60" srcmd5="4ffb04233ce517103a5963b2f9143149" lsrcmd5="dd034d0334eadc86566c0bf4e71d36b5" verifymd5="5904f10399c3fc467c9f27bc8b861ea6">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="multibuild_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:04 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:30 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -807,19 +806,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="68" vrev="68" srcmd5="722360971d5aefc84f08ea756de28287">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="2669ce0b1e21f806ce13d2a02ecf2c24" baserev="2669ce0b1e21f806ce13d2a02ecf2c24" xsrcmd5="4748baa0989eb9916324b0842d148811" lsrcmd5="722360971d5aefc84f08ea756de28287"/>
-          <serviceinfo code="succeeded" xsrcmd5="245f2db8ec9e268810c740284fd0e401"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="5f70d5f4ae556bd655866ffb13bee980" size="42" mtime="1642674783"/>
-          <entry name="_link" md5="2fae4b6a5da5a93b1f12303ce278ea00" size="119" mtime="1642674783"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="30" vrev="30" srcmd5="dd034d0334eadc86566c0bf4e71d36b5">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="fd063229a56b788a0be867b507527017" baserev="fd063229a56b788a0be867b507527017" xsrcmd5="4ffb04233ce517103a5963b2f9143149" lsrcmd5="dd034d0334eadc86566c0bf4e71d36b5"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="12500ab341447b611b4e8ea353732d33" size="57" mtime="1643641529"/>
+          <entry name="_link" md5="e3cc3863306ace4463efee3f455ad62f" size="119" mtime="1643641529"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:04 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:30 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -851,14 +849,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="5713eef1b10a1851d3a6ac0386ccd585">
+        <sourcediff key="031e259c2ea2ed81f5aa7bad2ad943a9">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="68" srcmd5="722360971d5aefc84f08ea756de28287"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="30" srcmd5="dd034d0334eadc86566c0bf4e71d36b5"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:04 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:30 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -890,14 +888,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="be6657eac2491627b29366f6559aa114">
-          <old project="foo_project" package="multibuild_package" rev="2669ce0b1e21f806ce13d2a02ecf2c24" srcmd5="2669ce0b1e21f806ce13d2a02ecf2c24"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="c5d11488f2f066072bad122978562fd6" srcmd5="c5d11488f2f066072bad122978562fd6"/>
+        <sourcediff key="931c773d33a2d8c7af68c38eed7023d4">
+          <old project="foo_project" package="multibuild_package" rev="fd063229a56b788a0be867b507527017" srcmd5="fd063229a56b788a0be867b507527017"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="4ffb04233ce517103a5963b2f9143149" srcmd5="4ffb04233ce517103a5963b2f9143149"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:04 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:30 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -923,22 +921,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="68" vrev="68" srcmd5="722360971d5aefc84f08ea756de28287">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="2669ce0b1e21f806ce13d2a02ecf2c24" baserev="2669ce0b1e21f806ce13d2a02ecf2c24" xsrcmd5="4748baa0989eb9916324b0842d148811" lsrcmd5="722360971d5aefc84f08ea756de28287"/>
-          <serviceinfo code="succeeded" xsrcmd5="245f2db8ec9e268810c740284fd0e401"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="5f70d5f4ae556bd655866ffb13bee980" size="42" mtime="1642674783"/>
-          <entry name="_link" md5="2fae4b6a5da5a93b1f12303ce278ea00" size="119" mtime="1642674783"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="30" vrev="30" srcmd5="dd034d0334eadc86566c0bf4e71d36b5">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="fd063229a56b788a0be867b507527017" baserev="fd063229a56b788a0be867b507527017" xsrcmd5="4ffb04233ce517103a5963b2f9143149" lsrcmd5="dd034d0334eadc86566c0bf4e71d36b5"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="12500ab341447b611b4e8ea353732d33" size="57" mtime="1643641529"/>
+          <entry name="_link" md5="e3cc3863306ace4463efee3f455ad62f" size="119" mtime="1643641529"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:04 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:30 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -961,19 +958,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '629'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="68" vrev="68" srcmd5="722360971d5aefc84f08ea756de28287">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="2669ce0b1e21f806ce13d2a02ecf2c24" baserev="2669ce0b1e21f806ce13d2a02ecf2c24" xsrcmd5="4748baa0989eb9916324b0842d148811" lsrcmd5="722360971d5aefc84f08ea756de28287"/>
-          <serviceinfo code="succeeded" xsrcmd5="245f2db8ec9e268810c740284fd0e401"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="5f70d5f4ae556bd655866ffb13bee980" size="42" mtime="1642674783"/>
-          <entry name="_link" md5="2fae4b6a5da5a93b1f12303ce278ea00" size="119" mtime="1642674783"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="4ffb04233ce517103a5963b2f9143149" vrev="60" srcmd5="4ffb04233ce517103a5963b2f9143149">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="fd063229a56b788a0be867b507527017" baserev="fd063229a56b788a0be867b507527017" lsrcmd5="dd034d0334eadc86566c0bf4e71d36b5"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="12500ab341447b611b4e8ea353732d33" size="57" mtime="1643641529"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:04 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:30 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_multibuild
@@ -1003,7 +998,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "<multibuild><flavor>flavor_a</flavor><flavor>flavor_b</flavor></multibuild>"
-  recorded_at: Thu, 20 Jan 2022 10:33:04 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:30 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -1029,22 +1024,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="68" vrev="68" srcmd5="722360971d5aefc84f08ea756de28287">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="2669ce0b1e21f806ce13d2a02ecf2c24" baserev="2669ce0b1e21f806ce13d2a02ecf2c24" xsrcmd5="4748baa0989eb9916324b0842d148811" lsrcmd5="722360971d5aefc84f08ea756de28287"/>
-          <serviceinfo code="succeeded" xsrcmd5="245f2db8ec9e268810c740284fd0e401"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="5f70d5f4ae556bd655866ffb13bee980" size="42" mtime="1642674783"/>
-          <entry name="_link" md5="2fae4b6a5da5a93b1f12303ce278ea00" size="119" mtime="1642674783"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="30" vrev="30" srcmd5="dd034d0334eadc86566c0bf4e71d36b5">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="fd063229a56b788a0be867b507527017" baserev="fd063229a56b788a0be867b507527017" xsrcmd5="4ffb04233ce517103a5963b2f9143149" lsrcmd5="dd034d0334eadc86566c0bf4e71d36b5"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="12500ab341447b611b4e8ea353732d33" size="57" mtime="1643641529"/>
+          <entry name="_link" md5="e3cc3863306ace4463efee3f455ad62f" size="119" mtime="1643641529"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:04 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:30 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1067,19 +1061,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '629'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="68" vrev="68" srcmd5="722360971d5aefc84f08ea756de28287">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="2669ce0b1e21f806ce13d2a02ecf2c24" baserev="2669ce0b1e21f806ce13d2a02ecf2c24" xsrcmd5="4748baa0989eb9916324b0842d148811" lsrcmd5="722360971d5aefc84f08ea756de28287"/>
-          <serviceinfo code="succeeded" xsrcmd5="245f2db8ec9e268810c740284fd0e401"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="5f70d5f4ae556bd655866ffb13bee980" size="42" mtime="1642674783"/>
-          <entry name="_link" md5="2fae4b6a5da5a93b1f12303ce278ea00" size="119" mtime="1642674783"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="4ffb04233ce517103a5963b2f9143149" vrev="60" srcmd5="4ffb04233ce517103a5963b2f9143149">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="fd063229a56b788a0be867b507527017" baserev="fd063229a56b788a0be867b507527017" lsrcmd5="dd034d0334eadc86566c0bf4e71d36b5"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="12500ab341447b611b4e8ea353732d33" size="57" mtime="1643641529"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:04 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:30 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_multibuild
@@ -1109,7 +1101,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "<multibuild><flavor>flavor_a</flavor><flavor>flavor_b</flavor></multibuild>"
-  recorded_at: Thu, 20 Jan 2022 10:33:04 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:30 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -1135,22 +1127,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="68" vrev="68" srcmd5="722360971d5aefc84f08ea756de28287">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="2669ce0b1e21f806ce13d2a02ecf2c24" baserev="2669ce0b1e21f806ce13d2a02ecf2c24" xsrcmd5="4748baa0989eb9916324b0842d148811" lsrcmd5="722360971d5aefc84f08ea756de28287"/>
-          <serviceinfo code="succeeded" xsrcmd5="245f2db8ec9e268810c740284fd0e401"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="5f70d5f4ae556bd655866ffb13bee980" size="42" mtime="1642674783"/>
-          <entry name="_link" md5="2fae4b6a5da5a93b1f12303ce278ea00" size="119" mtime="1642674783"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="30" vrev="30" srcmd5="dd034d0334eadc86566c0bf4e71d36b5">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="fd063229a56b788a0be867b507527017" baserev="fd063229a56b788a0be867b507527017" xsrcmd5="4ffb04233ce517103a5963b2f9143149" lsrcmd5="dd034d0334eadc86566c0bf4e71d36b5"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="12500ab341447b611b4e8ea353732d33" size="57" mtime="1643641529"/>
+          <entry name="_link" md5="e3cc3863306ace4463efee3f455ad62f" size="119" mtime="1643641529"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:04 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:30 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1173,19 +1164,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '629'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="68" vrev="68" srcmd5="722360971d5aefc84f08ea756de28287">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="2669ce0b1e21f806ce13d2a02ecf2c24" baserev="2669ce0b1e21f806ce13d2a02ecf2c24" xsrcmd5="4748baa0989eb9916324b0842d148811" lsrcmd5="722360971d5aefc84f08ea756de28287"/>
-          <serviceinfo code="succeeded" xsrcmd5="245f2db8ec9e268810c740284fd0e401"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="5f70d5f4ae556bd655866ffb13bee980" size="42" mtime="1642674783"/>
-          <entry name="_link" md5="2fae4b6a5da5a93b1f12303ce278ea00" size="119" mtime="1642674783"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="4ffb04233ce517103a5963b2f9143149" vrev="60" srcmd5="4ffb04233ce517103a5963b2f9143149">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="fd063229a56b788a0be867b507527017" baserev="fd063229a56b788a0be867b507527017" lsrcmd5="dd034d0334eadc86566c0bf4e71d36b5"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="12500ab341447b611b4e8ea353732d33" size="57" mtime="1643641529"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:04 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:30 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_multibuild
@@ -1215,7 +1204,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "<multibuild><flavor>flavor_a</flavor><flavor>flavor_b</flavor></multibuild>"
-  recorded_at: Thu, 20 Jan 2022 10:33:04 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:30 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -1241,22 +1230,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="68" vrev="68" srcmd5="722360971d5aefc84f08ea756de28287">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="2669ce0b1e21f806ce13d2a02ecf2c24" baserev="2669ce0b1e21f806ce13d2a02ecf2c24" xsrcmd5="4748baa0989eb9916324b0842d148811" lsrcmd5="722360971d5aefc84f08ea756de28287"/>
-          <serviceinfo code="succeeded" xsrcmd5="245f2db8ec9e268810c740284fd0e401"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="5f70d5f4ae556bd655866ffb13bee980" size="42" mtime="1642674783"/>
-          <entry name="_link" md5="2fae4b6a5da5a93b1f12303ce278ea00" size="119" mtime="1642674783"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="30" vrev="30" srcmd5="dd034d0334eadc86566c0bf4e71d36b5">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="fd063229a56b788a0be867b507527017" baserev="fd063229a56b788a0be867b507527017" xsrcmd5="4ffb04233ce517103a5963b2f9143149" lsrcmd5="dd034d0334eadc86566c0bf4e71d36b5"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="12500ab341447b611b4e8ea353732d33" size="57" mtime="1643641529"/>
+          <entry name="_link" md5="e3cc3863306ace4463efee3f455ad62f" size="119" mtime="1643641529"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:04 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:30 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1279,19 +1267,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '629'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="68" vrev="68" srcmd5="722360971d5aefc84f08ea756de28287">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="2669ce0b1e21f806ce13d2a02ecf2c24" baserev="2669ce0b1e21f806ce13d2a02ecf2c24" xsrcmd5="4748baa0989eb9916324b0842d148811" lsrcmd5="722360971d5aefc84f08ea756de28287"/>
-          <serviceinfo code="succeeded" xsrcmd5="245f2db8ec9e268810c740284fd0e401"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="5f70d5f4ae556bd655866ffb13bee980" size="42" mtime="1642674783"/>
-          <entry name="_link" md5="2fae4b6a5da5a93b1f12303ce278ea00" size="119" mtime="1642674783"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="4ffb04233ce517103a5963b2f9143149" vrev="60" srcmd5="4ffb04233ce517103a5963b2f9143149">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="fd063229a56b788a0be867b507527017" baserev="fd063229a56b788a0be867b507527017" lsrcmd5="dd034d0334eadc86566c0bf4e71d36b5"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="12500ab341447b611b4e8ea353732d33" size="57" mtime="1643641529"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:04 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:30 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_multibuild
@@ -1321,7 +1307,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "<multibuild><flavor>flavor_a</flavor><flavor>flavor_b</flavor></multibuild>"
-  recorded_at: Thu, 20 Jan 2022 10:33:04 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:30 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -1347,22 +1333,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="68" vrev="68" srcmd5="722360971d5aefc84f08ea756de28287">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="2669ce0b1e21f806ce13d2a02ecf2c24" baserev="2669ce0b1e21f806ce13d2a02ecf2c24" xsrcmd5="4748baa0989eb9916324b0842d148811" lsrcmd5="722360971d5aefc84f08ea756de28287"/>
-          <serviceinfo code="succeeded" xsrcmd5="245f2db8ec9e268810c740284fd0e401"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="5f70d5f4ae556bd655866ffb13bee980" size="42" mtime="1642674783"/>
-          <entry name="_link" md5="2fae4b6a5da5a93b1f12303ce278ea00" size="119" mtime="1642674783"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="30" vrev="30" srcmd5="dd034d0334eadc86566c0bf4e71d36b5">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="fd063229a56b788a0be867b507527017" baserev="fd063229a56b788a0be867b507527017" xsrcmd5="4ffb04233ce517103a5963b2f9143149" lsrcmd5="dd034d0334eadc86566c0bf4e71d36b5"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="12500ab341447b611b4e8ea353732d33" size="57" mtime="1643641529"/>
+          <entry name="_link" md5="e3cc3863306ace4463efee3f455ad62f" size="119" mtime="1643641529"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:04 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:30 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1385,19 +1370,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '629'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="68" vrev="68" srcmd5="722360971d5aefc84f08ea756de28287">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="2669ce0b1e21f806ce13d2a02ecf2c24" baserev="2669ce0b1e21f806ce13d2a02ecf2c24" xsrcmd5="4748baa0989eb9916324b0842d148811" lsrcmd5="722360971d5aefc84f08ea756de28287"/>
-          <serviceinfo code="succeeded" xsrcmd5="245f2db8ec9e268810c740284fd0e401"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="5f70d5f4ae556bd655866ffb13bee980" size="42" mtime="1642674783"/>
-          <entry name="_link" md5="2fae4b6a5da5a93b1f12303ce278ea00" size="119" mtime="1642674783"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="4ffb04233ce517103a5963b2f9143149" vrev="60" srcmd5="4ffb04233ce517103a5963b2f9143149">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="fd063229a56b788a0be867b507527017" baserev="fd063229a56b788a0be867b507527017" lsrcmd5="dd034d0334eadc86566c0bf4e71d36b5"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="12500ab341447b611b4e8ea353732d33" size="57" mtime="1643641529"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:04 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:30 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_multibuild
@@ -1427,7 +1410,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "<multibuild><flavor>flavor_a</flavor><flavor>flavor_b</flavor></multibuild>"
-  recorded_at: Thu, 20 Jan 2022 10:33:04 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:30 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_branch_request
@@ -1457,5 +1440,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"action":"opened","pull_request":{"head":{"repo":{"full_name":"reponame"},"sha":"123456789"}}}'
-  recorded_at: Thu, 20 Jan 2022 10:33:04 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:30 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_a_multibuild_package/1_1_1_4_5.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_a_multibuild_package/1_1_1_4_5.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:01 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:25 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_318
+    uri: http://backend:5352/source/foo_project/_meta?user=user_27
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Surprised by Joy</title>
+          <title>I Will Fear No Evil</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '148'
+      - '151'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Surprised by Joy</title>
+          <title>I Will Fear No Evil</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:02 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:25 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/multibuild_package/_meta?user=user_319
+    uri: http://backend:5352/source/foo_project/multibuild_package/_meta?user=user_28
     body:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="foo_project">
-          <title>Great Work of Time</title>
-          <description>Rerum aliquam iusto laborum.</description>
+          <title>Carrion Comfort</title>
+          <description>Doloremque velit quis neque.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '163'
+      - '160'
     body:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="foo_project">
-          <title>Great Work of Time</title>
-          <description>Rerum aliquam iusto laborum.</description>
+          <title>Carrion Comfort</title>
+          <description>Doloremque velit quis neque.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:02 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:25 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/multibuild_package/_config
     body:
       encoding: UTF-8
-      string: Et doloremque aperiam. Id eaque ratione. Ipsam et officiis.
+      string: Est non et. Qui illo sed. Voluptates aspernatur officia.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -147,15 +147,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="51" vrev="51">
-          <srcmd5>cb861a3817b879ee7ee1d5f3ad6eb54c</srcmd5>
+        <revision rev="25" vrev="25">
+          <srcmd5>d97534c885f38e399a37537e5fd11629</srcmd5>
           <version>unknown</version>
-          <time>1642674782</time>
+          <time>1643641525</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:02 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:25 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/multibuild_package/_multibuild
@@ -185,15 +185,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="52" vrev="52">
-          <srcmd5>cb861a3817b879ee7ee1d5f3ad6eb54c</srcmd5>
+        <revision rev="26" vrev="26">
+          <srcmd5>d97534c885f38e399a37537e5fd11629</srcmd5>
           <version>unknown</version>
-          <time>1642674782</time>
+          <time>1643641525</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:02 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:25 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22multibuild_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -227,7 +227,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:33:02 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:25 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -267,7 +267,7 @@ http_interactions:
           <description>This project was created for package multibuild_package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:02 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:26 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_meta?user=Iggy
@@ -275,8 +275,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Great Work of Time</title>
-          <description>Rerum aliquam iusto laborum.</description>
+          <title>Carrion Comfort</title>
+          <description>Doloremque velit quis neque.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -297,15 +297,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '194'
+      - '191'
     body:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Great Work of Time</title>
-          <description>Rerum aliquam iusto laborum.</description>
+          <title>Carrion Comfort</title>
+          <description>Doloremque velit quis neque.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:02 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:26 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?cmd=branch&noservice=1&opackage=multibuild_package&oproject=foo_project&user=Iggy
@@ -337,15 +337,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="65" vrev="65">
-          <srcmd5>4cb56831c1ba148259e122e7c77aa4c7</srcmd5>
+        <revision rev="25" vrev="25">
+          <srcmd5>99861505ae966a5e5b0a65b2d907b511</srcmd5>
           <version>unknown</version>
-          <time>1642674782</time>
+          <time>1643641526</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:02 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:26 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_meta?user=Iggy
@@ -353,8 +353,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Great Work of Time</title>
-          <description>Rerum aliquam iusto laborum.</description>
+          <title>Carrion Comfort</title>
+          <description>Doloremque velit quis neque.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -375,15 +375,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '194'
+      - '191'
     body:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Great Work of Time</title>
-          <description>Rerum aliquam iusto laborum.</description>
+          <title>Carrion Comfort</title>
+          <description>Doloremque velit quis neque.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:02 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:26 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -413,13 +413,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="65" vrev="65" srcmd5="4cb56831c1ba148259e122e7c77aa4c7">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="cb861a3817b879ee7ee1d5f3ad6eb54c" baserev="cb861a3817b879ee7ee1d5f3ad6eb54c" xsrcmd5="1cae31b22184d477490457aae743eedd" lsrcmd5="4cb56831c1ba148259e122e7c77aa4c7"/>
-          <entry name="_config" md5="23a5d452fba42038bdefb7c238d1d960" size="59" mtime="1642674782"/>
-          <entry name="_link" md5="2ce4b8d2db597b10be9ae9ec1a004775" size="119" mtime="1642674782"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="25" vrev="25" srcmd5="99861505ae966a5e5b0a65b2d907b511">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="d97534c885f38e399a37537e5fd11629" baserev="d97534c885f38e399a37537e5fd11629" xsrcmd5="6994235f818b6418dbdcf03db155c2f2" lsrcmd5="99861505ae966a5e5b0a65b2d907b511"/>
+          <entry name="_config" md5="fa9d5a42bb7d00753dc4f207385a8834" size="56" mtime="1643641525"/>
+          <entry name="_link" md5="582a9c5d1f47c074f5a99a0e561f278b" size="119" mtime="1643641526"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:02 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:26 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?view=info
@@ -445,15 +445,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '345'
+      - '344'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="multibuild_package" rev="65" vrev="117" srcmd5="1cae31b22184d477490457aae743eedd" lsrcmd5="4cb56831c1ba148259e122e7c77aa4c7" verifymd5="cb861a3817b879ee7ee1d5f3ad6eb54c">
+        <sourceinfo package="multibuild_package" rev="25" vrev="51" srcmd5="6994235f818b6418dbdcf03db155c2f2" lsrcmd5="99861505ae966a5e5b0a65b2d907b511" verifymd5="d97534c885f38e399a37537e5fd11629">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="multibuild_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:02 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:26 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -483,13 +483,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="65" vrev="65" srcmd5="4cb56831c1ba148259e122e7c77aa4c7">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="cb861a3817b879ee7ee1d5f3ad6eb54c" baserev="cb861a3817b879ee7ee1d5f3ad6eb54c" xsrcmd5="1cae31b22184d477490457aae743eedd" lsrcmd5="4cb56831c1ba148259e122e7c77aa4c7"/>
-          <entry name="_config" md5="23a5d452fba42038bdefb7c238d1d960" size="59" mtime="1642674782"/>
-          <entry name="_link" md5="2ce4b8d2db597b10be9ae9ec1a004775" size="119" mtime="1642674782"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="25" vrev="25" srcmd5="99861505ae966a5e5b0a65b2d907b511">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="d97534c885f38e399a37537e5fd11629" baserev="d97534c885f38e399a37537e5fd11629" xsrcmd5="6994235f818b6418dbdcf03db155c2f2" lsrcmd5="99861505ae966a5e5b0a65b2d907b511"/>
+          <entry name="_config" md5="fa9d5a42bb7d00753dc4f207385a8834" size="56" mtime="1643641525"/>
+          <entry name="_link" md5="582a9c5d1f47c074f5a99a0e561f278b" size="119" mtime="1643641526"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:02 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:26 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -521,14 +521,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="224deaf31770c976229617f399c938da">
+        <sourcediff key="209cfce933f64aa0177a36deb2174fbf">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="65" srcmd5="4cb56831c1ba148259e122e7c77aa4c7"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="25" srcmd5="99861505ae966a5e5b0a65b2d907b511"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:02 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:26 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -560,12 +560,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="7bac04d9ff26e97f3fb2ba45f745771d">
-          <old project="foo_project" package="multibuild_package" rev="cb861a3817b879ee7ee1d5f3ad6eb54c" srcmd5="cb861a3817b879ee7ee1d5f3ad6eb54c"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="1cae31b22184d477490457aae743eedd" srcmd5="1cae31b22184d477490457aae743eedd"/>
+        <sourcediff key="ff0549da6c3a2c707df2234b33a82f59">
+          <old project="foo_project" package="multibuild_package" rev="d97534c885f38e399a37537e5fd11629" srcmd5="d97534c885f38e399a37537e5fd11629"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="6994235f818b6418dbdcf03db155c2f2" srcmd5="6994235f818b6418dbdcf03db155c2f2"/>
           <files/>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:02 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:26 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -633,7 +633,7 @@ http_interactions:
             <arch>aarch64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:02 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:26 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_branch_request?user=Iggy
@@ -663,15 +663,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="66" vrev="66">
-          <srcmd5>2e8191541d46cc67e6cfc9dc26e4b1eb</srcmd5>
+        <revision rev="26" vrev="26">
+          <srcmd5>3ff785bf8ecdf0f8f950e496adfa01ae</srcmd5>
           <version>unknown</version>
-          <time>1642674782</time>
+          <time>1643641526</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:02 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:26 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_meta?user=Iggy
@@ -679,8 +679,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Great Work of Time</title>
-          <description>Rerum aliquam iusto laborum.</description>
+          <title>Carrion Comfort</title>
+          <description>Doloremque velit quis neque.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -701,15 +701,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '194'
+      - '191'
     body:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Great Work of Time</title>
-          <description>Rerum aliquam iusto laborum.</description>
+          <title>Carrion Comfort</title>
+          <description>Doloremque velit quis neque.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:02 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:26 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -735,19 +735,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="66" vrev="66" srcmd5="2e8191541d46cc67e6cfc9dc26e4b1eb">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="cb861a3817b879ee7ee1d5f3ad6eb54c" baserev="cb861a3817b879ee7ee1d5f3ad6eb54c" xsrcmd5="09cf3f896d18715eae36d68b4359592c" lsrcmd5="2e8191541d46cc67e6cfc9dc26e4b1eb"/>
-          <serviceinfo code="succeeded" xsrcmd5="c15e9427a99624a821ebe9809a865378"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="23a5d452fba42038bdefb7c238d1d960" size="59" mtime="1642674782"/>
-          <entry name="_link" md5="2ce4b8d2db597b10be9ae9ec1a004775" size="119" mtime="1642674782"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="26" vrev="26" srcmd5="3ff785bf8ecdf0f8f950e496adfa01ae">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="d97534c885f38e399a37537e5fd11629" baserev="d97534c885f38e399a37537e5fd11629" xsrcmd5="463f2e71f392f929db1e71add0b0c107" lsrcmd5="3ff785bf8ecdf0f8f950e496adfa01ae"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="fa9d5a42bb7d00753dc4f207385a8834" size="56" mtime="1643641525"/>
+          <entry name="_link" md5="582a9c5d1f47c074f5a99a0e561f278b" size="119" mtime="1643641526"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:02 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:26 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?view=info
@@ -773,15 +772,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '345'
+      - '344'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="multibuild_package" rev="66" vrev="118" srcmd5="4700174f5aad512d6340e822876c3f78" lsrcmd5="c15e9427a99624a821ebe9809a865378" verifymd5="b0115dcbdda1dedabd5efd2b9bfcf2e2">
+        <sourceinfo package="multibuild_package" rev="26" vrev="52" srcmd5="463f2e71f392f929db1e71add0b0c107" lsrcmd5="3ff785bf8ecdf0f8f950e496adfa01ae" verifymd5="baa625fb984ddb187c4dd1c3c933441d">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="multibuild_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:02 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:26 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -807,19 +806,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="66" vrev="66" srcmd5="2e8191541d46cc67e6cfc9dc26e4b1eb">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="cb861a3817b879ee7ee1d5f3ad6eb54c" baserev="cb861a3817b879ee7ee1d5f3ad6eb54c" xsrcmd5="09cf3f896d18715eae36d68b4359592c" lsrcmd5="2e8191541d46cc67e6cfc9dc26e4b1eb"/>
-          <serviceinfo code="succeeded" xsrcmd5="c15e9427a99624a821ebe9809a865378"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="23a5d452fba42038bdefb7c238d1d960" size="59" mtime="1642674782"/>
-          <entry name="_link" md5="2ce4b8d2db597b10be9ae9ec1a004775" size="119" mtime="1642674782"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="26" vrev="26" srcmd5="3ff785bf8ecdf0f8f950e496adfa01ae">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="d97534c885f38e399a37537e5fd11629" baserev="d97534c885f38e399a37537e5fd11629" xsrcmd5="463f2e71f392f929db1e71add0b0c107" lsrcmd5="3ff785bf8ecdf0f8f950e496adfa01ae"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="fa9d5a42bb7d00753dc4f207385a8834" size="56" mtime="1643641525"/>
+          <entry name="_link" md5="582a9c5d1f47c074f5a99a0e561f278b" size="119" mtime="1643641526"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:02 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:26 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -851,14 +849,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="53cc46bbc94b73a97ee4725047f7a0f9">
+        <sourcediff key="3e65e3e5fb3c0c4a3d41ffc3e4b9ffb4">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="66" srcmd5="2e8191541d46cc67e6cfc9dc26e4b1eb"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="26" srcmd5="3ff785bf8ecdf0f8f950e496adfa01ae"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:02 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:26 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -890,14 +888,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="20862ea9e665a22e1fd5562bf4af291b">
-          <old project="foo_project" package="multibuild_package" rev="cb861a3817b879ee7ee1d5f3ad6eb54c" srcmd5="cb861a3817b879ee7ee1d5f3ad6eb54c"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="4700174f5aad512d6340e822876c3f78" srcmd5="4700174f5aad512d6340e822876c3f78"/>
+        <sourcediff key="eb38709c669b9b4f1692939278382696">
+          <old project="foo_project" package="multibuild_package" rev="d97534c885f38e399a37537e5fd11629" srcmd5="d97534c885f38e399a37537e5fd11629"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="463f2e71f392f929db1e71add0b0c107" srcmd5="463f2e71f392f929db1e71add0b0c107"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:02 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:26 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -923,22 +921,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="66" vrev="66" srcmd5="2e8191541d46cc67e6cfc9dc26e4b1eb">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="cb861a3817b879ee7ee1d5f3ad6eb54c" baserev="cb861a3817b879ee7ee1d5f3ad6eb54c" xsrcmd5="09cf3f896d18715eae36d68b4359592c" lsrcmd5="2e8191541d46cc67e6cfc9dc26e4b1eb"/>
-          <serviceinfo code="succeeded" xsrcmd5="c15e9427a99624a821ebe9809a865378"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="23a5d452fba42038bdefb7c238d1d960" size="59" mtime="1642674782"/>
-          <entry name="_link" md5="2ce4b8d2db597b10be9ae9ec1a004775" size="119" mtime="1642674782"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="26" vrev="26" srcmd5="3ff785bf8ecdf0f8f950e496adfa01ae">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="d97534c885f38e399a37537e5fd11629" baserev="d97534c885f38e399a37537e5fd11629" xsrcmd5="463f2e71f392f929db1e71add0b0c107" lsrcmd5="3ff785bf8ecdf0f8f950e496adfa01ae"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="fa9d5a42bb7d00753dc4f207385a8834" size="56" mtime="1643641525"/>
+          <entry name="_link" md5="582a9c5d1f47c074f5a99a0e561f278b" size="119" mtime="1643641526"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:03 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:27 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -961,19 +958,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '629'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="66" vrev="66" srcmd5="2e8191541d46cc67e6cfc9dc26e4b1eb">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="cb861a3817b879ee7ee1d5f3ad6eb54c" baserev="cb861a3817b879ee7ee1d5f3ad6eb54c" xsrcmd5="09cf3f896d18715eae36d68b4359592c" lsrcmd5="2e8191541d46cc67e6cfc9dc26e4b1eb"/>
-          <serviceinfo code="succeeded" xsrcmd5="c15e9427a99624a821ebe9809a865378"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="23a5d452fba42038bdefb7c238d1d960" size="59" mtime="1642674782"/>
-          <entry name="_link" md5="2ce4b8d2db597b10be9ae9ec1a004775" size="119" mtime="1642674782"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="463f2e71f392f929db1e71add0b0c107" vrev="52" srcmd5="463f2e71f392f929db1e71add0b0c107">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="d97534c885f38e399a37537e5fd11629" baserev="d97534c885f38e399a37537e5fd11629" lsrcmd5="3ff785bf8ecdf0f8f950e496adfa01ae"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="fa9d5a42bb7d00753dc4f207385a8834" size="56" mtime="1643641525"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:03 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:27 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_multibuild
@@ -1003,7 +998,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "<multibuild><flavor>flavor_a</flavor><flavor>flavor_b</flavor></multibuild>"
-  recorded_at: Thu, 20 Jan 2022 10:33:03 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:27 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -1029,22 +1024,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="66" vrev="66" srcmd5="2e8191541d46cc67e6cfc9dc26e4b1eb">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="cb861a3817b879ee7ee1d5f3ad6eb54c" baserev="cb861a3817b879ee7ee1d5f3ad6eb54c" xsrcmd5="09cf3f896d18715eae36d68b4359592c" lsrcmd5="2e8191541d46cc67e6cfc9dc26e4b1eb"/>
-          <serviceinfo code="succeeded" xsrcmd5="c15e9427a99624a821ebe9809a865378"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="23a5d452fba42038bdefb7c238d1d960" size="59" mtime="1642674782"/>
-          <entry name="_link" md5="2ce4b8d2db597b10be9ae9ec1a004775" size="119" mtime="1642674782"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="26" vrev="26" srcmd5="3ff785bf8ecdf0f8f950e496adfa01ae">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="d97534c885f38e399a37537e5fd11629" baserev="d97534c885f38e399a37537e5fd11629" xsrcmd5="463f2e71f392f929db1e71add0b0c107" lsrcmd5="3ff785bf8ecdf0f8f950e496adfa01ae"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="fa9d5a42bb7d00753dc4f207385a8834" size="56" mtime="1643641525"/>
+          <entry name="_link" md5="582a9c5d1f47c074f5a99a0e561f278b" size="119" mtime="1643641526"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:03 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:27 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1067,19 +1061,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '629'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="66" vrev="66" srcmd5="2e8191541d46cc67e6cfc9dc26e4b1eb">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="cb861a3817b879ee7ee1d5f3ad6eb54c" baserev="cb861a3817b879ee7ee1d5f3ad6eb54c" xsrcmd5="09cf3f896d18715eae36d68b4359592c" lsrcmd5="2e8191541d46cc67e6cfc9dc26e4b1eb"/>
-          <serviceinfo code="succeeded" xsrcmd5="c15e9427a99624a821ebe9809a865378"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="23a5d452fba42038bdefb7c238d1d960" size="59" mtime="1642674782"/>
-          <entry name="_link" md5="2ce4b8d2db597b10be9ae9ec1a004775" size="119" mtime="1642674782"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="463f2e71f392f929db1e71add0b0c107" vrev="52" srcmd5="463f2e71f392f929db1e71add0b0c107">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="d97534c885f38e399a37537e5fd11629" baserev="d97534c885f38e399a37537e5fd11629" lsrcmd5="3ff785bf8ecdf0f8f950e496adfa01ae"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="fa9d5a42bb7d00753dc4f207385a8834" size="56" mtime="1643641525"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:03 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:27 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_multibuild
@@ -1109,7 +1101,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "<multibuild><flavor>flavor_a</flavor><flavor>flavor_b</flavor></multibuild>"
-  recorded_at: Thu, 20 Jan 2022 10:33:03 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:27 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -1135,22 +1127,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="66" vrev="66" srcmd5="2e8191541d46cc67e6cfc9dc26e4b1eb">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="cb861a3817b879ee7ee1d5f3ad6eb54c" baserev="cb861a3817b879ee7ee1d5f3ad6eb54c" xsrcmd5="09cf3f896d18715eae36d68b4359592c" lsrcmd5="2e8191541d46cc67e6cfc9dc26e4b1eb"/>
-          <serviceinfo code="succeeded" xsrcmd5="c15e9427a99624a821ebe9809a865378"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="23a5d452fba42038bdefb7c238d1d960" size="59" mtime="1642674782"/>
-          <entry name="_link" md5="2ce4b8d2db597b10be9ae9ec1a004775" size="119" mtime="1642674782"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="26" vrev="26" srcmd5="3ff785bf8ecdf0f8f950e496adfa01ae">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="d97534c885f38e399a37537e5fd11629" baserev="d97534c885f38e399a37537e5fd11629" xsrcmd5="463f2e71f392f929db1e71add0b0c107" lsrcmd5="3ff785bf8ecdf0f8f950e496adfa01ae"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="fa9d5a42bb7d00753dc4f207385a8834" size="56" mtime="1643641525"/>
+          <entry name="_link" md5="582a9c5d1f47c074f5a99a0e561f278b" size="119" mtime="1643641526"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:03 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:27 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1173,19 +1164,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '629'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="66" vrev="66" srcmd5="2e8191541d46cc67e6cfc9dc26e4b1eb">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="cb861a3817b879ee7ee1d5f3ad6eb54c" baserev="cb861a3817b879ee7ee1d5f3ad6eb54c" xsrcmd5="09cf3f896d18715eae36d68b4359592c" lsrcmd5="2e8191541d46cc67e6cfc9dc26e4b1eb"/>
-          <serviceinfo code="succeeded" xsrcmd5="c15e9427a99624a821ebe9809a865378"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="23a5d452fba42038bdefb7c238d1d960" size="59" mtime="1642674782"/>
-          <entry name="_link" md5="2ce4b8d2db597b10be9ae9ec1a004775" size="119" mtime="1642674782"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="463f2e71f392f929db1e71add0b0c107" vrev="52" srcmd5="463f2e71f392f929db1e71add0b0c107">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="d97534c885f38e399a37537e5fd11629" baserev="d97534c885f38e399a37537e5fd11629" lsrcmd5="3ff785bf8ecdf0f8f950e496adfa01ae"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="fa9d5a42bb7d00753dc4f207385a8834" size="56" mtime="1643641525"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:03 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:27 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_multibuild
@@ -1215,7 +1204,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "<multibuild><flavor>flavor_a</flavor><flavor>flavor_b</flavor></multibuild>"
-  recorded_at: Thu, 20 Jan 2022 10:33:03 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:27 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -1241,22 +1230,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="66" vrev="66" srcmd5="2e8191541d46cc67e6cfc9dc26e4b1eb">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="cb861a3817b879ee7ee1d5f3ad6eb54c" baserev="cb861a3817b879ee7ee1d5f3ad6eb54c" xsrcmd5="09cf3f896d18715eae36d68b4359592c" lsrcmd5="2e8191541d46cc67e6cfc9dc26e4b1eb"/>
-          <serviceinfo code="succeeded" xsrcmd5="c15e9427a99624a821ebe9809a865378"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="23a5d452fba42038bdefb7c238d1d960" size="59" mtime="1642674782"/>
-          <entry name="_link" md5="2ce4b8d2db597b10be9ae9ec1a004775" size="119" mtime="1642674782"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="26" vrev="26" srcmd5="3ff785bf8ecdf0f8f950e496adfa01ae">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="d97534c885f38e399a37537e5fd11629" baserev="d97534c885f38e399a37537e5fd11629" xsrcmd5="463f2e71f392f929db1e71add0b0c107" lsrcmd5="3ff785bf8ecdf0f8f950e496adfa01ae"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="fa9d5a42bb7d00753dc4f207385a8834" size="56" mtime="1643641525"/>
+          <entry name="_link" md5="582a9c5d1f47c074f5a99a0e561f278b" size="119" mtime="1643641526"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:03 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:27 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1279,19 +1267,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '629'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="66" vrev="66" srcmd5="2e8191541d46cc67e6cfc9dc26e4b1eb">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="cb861a3817b879ee7ee1d5f3ad6eb54c" baserev="cb861a3817b879ee7ee1d5f3ad6eb54c" xsrcmd5="09cf3f896d18715eae36d68b4359592c" lsrcmd5="2e8191541d46cc67e6cfc9dc26e4b1eb"/>
-          <serviceinfo code="succeeded" xsrcmd5="c15e9427a99624a821ebe9809a865378"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="23a5d452fba42038bdefb7c238d1d960" size="59" mtime="1642674782"/>
-          <entry name="_link" md5="2ce4b8d2db597b10be9ae9ec1a004775" size="119" mtime="1642674782"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="463f2e71f392f929db1e71add0b0c107" vrev="52" srcmd5="463f2e71f392f929db1e71add0b0c107">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="d97534c885f38e399a37537e5fd11629" baserev="d97534c885f38e399a37537e5fd11629" lsrcmd5="3ff785bf8ecdf0f8f950e496adfa01ae"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="fa9d5a42bb7d00753dc4f207385a8834" size="56" mtime="1643641525"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:03 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:27 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_multibuild
@@ -1321,7 +1307,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "<multibuild><flavor>flavor_a</flavor><flavor>flavor_b</flavor></multibuild>"
-  recorded_at: Thu, 20 Jan 2022 10:33:03 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:27 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -1347,22 +1333,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="66" vrev="66" srcmd5="2e8191541d46cc67e6cfc9dc26e4b1eb">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="cb861a3817b879ee7ee1d5f3ad6eb54c" baserev="cb861a3817b879ee7ee1d5f3ad6eb54c" xsrcmd5="09cf3f896d18715eae36d68b4359592c" lsrcmd5="2e8191541d46cc67e6cfc9dc26e4b1eb"/>
-          <serviceinfo code="succeeded" xsrcmd5="c15e9427a99624a821ebe9809a865378"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="23a5d452fba42038bdefb7c238d1d960" size="59" mtime="1642674782"/>
-          <entry name="_link" md5="2ce4b8d2db597b10be9ae9ec1a004775" size="119" mtime="1642674782"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="26" vrev="26" srcmd5="3ff785bf8ecdf0f8f950e496adfa01ae">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="d97534c885f38e399a37537e5fd11629" baserev="d97534c885f38e399a37537e5fd11629" xsrcmd5="463f2e71f392f929db1e71add0b0c107" lsrcmd5="3ff785bf8ecdf0f8f950e496adfa01ae"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="fa9d5a42bb7d00753dc4f207385a8834" size="56" mtime="1643641525"/>
+          <entry name="_link" md5="582a9c5d1f47c074f5a99a0e561f278b" size="119" mtime="1643641526"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:03 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:27 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1385,19 +1370,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '629'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="66" vrev="66" srcmd5="2e8191541d46cc67e6cfc9dc26e4b1eb">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="cb861a3817b879ee7ee1d5f3ad6eb54c" baserev="cb861a3817b879ee7ee1d5f3ad6eb54c" xsrcmd5="09cf3f896d18715eae36d68b4359592c" lsrcmd5="2e8191541d46cc67e6cfc9dc26e4b1eb"/>
-          <serviceinfo code="succeeded" xsrcmd5="c15e9427a99624a821ebe9809a865378"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="23a5d452fba42038bdefb7c238d1d960" size="59" mtime="1642674782"/>
-          <entry name="_link" md5="2ce4b8d2db597b10be9ae9ec1a004775" size="119" mtime="1642674782"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="463f2e71f392f929db1e71add0b0c107" vrev="52" srcmd5="463f2e71f392f929db1e71add0b0c107">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="d97534c885f38e399a37537e5fd11629" baserev="d97534c885f38e399a37537e5fd11629" lsrcmd5="3ff785bf8ecdf0f8f950e496adfa01ae"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="fa9d5a42bb7d00753dc4f207385a8834" size="56" mtime="1643641525"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:03 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:27 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_multibuild
@@ -1427,5 +1410,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "<multibuild><flavor>flavor_a</flavor><flavor>flavor_b</flavor></multibuild>"
-  recorded_at: Thu, 20 Jan 2022 10:33:03 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:27 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_a_multibuild_package/1_1_1_4_6.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_a_multibuild_package/1_1_1_4_6.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:04 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:21 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_322
+    uri: http://backend:5352/source/foo_project/_meta?user=user_23
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>The Millstone</title>
+          <title>The Last Enemy</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '145'
+      - '146'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>The Millstone</title>
+          <title>The Last Enemy</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:04 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:21 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/multibuild_package/_meta?user=user_323
+    uri: http://backend:5352/source/foo_project/multibuild_package/_meta?user=user_24
     body:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="foo_project">
-          <title>The Monkey's Raincoat</title>
-          <description>Velit dolorum atque accusamus.</description>
+          <title>Moab Is My Washpot</title>
+          <description>Aut eveniet suscipit et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,22 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '168'
+      - '159'
     body:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="foo_project">
-          <title>The Monkey's Raincoat</title>
-          <description>Velit dolorum atque accusamus.</description>
+          <title>Moab Is My Washpot</title>
+          <description>Aut eveniet suscipit et.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:05 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:21 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/multibuild_package/_config
     body:
       encoding: UTF-8
-      string: Nesciunt cupiditate impedit. Porro ullam voluptates. Distinctio odio
-        amet.
+      string: Enim ut vel. Beatae unde rem. Recusandae dicta aliquid.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -148,15 +147,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="55" vrev="55">
-          <srcmd5>6cb95173e2eb500e5e87febdeb2499e9</srcmd5>
+        <revision rev="21" vrev="21">
+          <srcmd5>28f9e79ce8e316ae6dba8b70d3dc5068</srcmd5>
           <version>unknown</version>
-          <time>1642674785</time>
+          <time>1643641521</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:05 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:21 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/multibuild_package/_multibuild
@@ -186,15 +185,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="56" vrev="56">
-          <srcmd5>6cb95173e2eb500e5e87febdeb2499e9</srcmd5>
+        <revision rev="22" vrev="22">
+          <srcmd5>28f9e79ce8e316ae6dba8b70d3dc5068</srcmd5>
           <version>unknown</version>
-          <time>1642674785</time>
+          <time>1643641521</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:05 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:22 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22multibuild_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -228,7 +227,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:33:05 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:22 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -268,7 +267,7 @@ http_interactions:
           <description>This project was created for package multibuild_package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:05 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:22 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_meta?user=Iggy
@@ -276,8 +275,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Monkey's Raincoat</title>
-          <description>Velit dolorum atque accusamus.</description>
+          <title>Moab Is My Washpot</title>
+          <description>Aut eveniet suscipit et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -298,15 +297,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '199'
+      - '190'
     body:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Monkey's Raincoat</title>
-          <description>Velit dolorum atque accusamus.</description>
+          <title>Moab Is My Washpot</title>
+          <description>Aut eveniet suscipit et.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:05 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:22 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?cmd=branch&noservice=1&opackage=multibuild_package&oproject=foo_project&user=Iggy
@@ -338,15 +337,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="69" vrev="69">
-          <srcmd5>973a5f0cafb7bdb14ddaaf7041843fcc</srcmd5>
+        <revision rev="21" vrev="21">
+          <srcmd5>a911b133143c5d4c5438a4c748124c59</srcmd5>
           <version>unknown</version>
-          <time>1642674785</time>
+          <time>1643641522</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:05 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:22 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_meta?user=Iggy
@@ -354,8 +353,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Monkey's Raincoat</title>
-          <description>Velit dolorum atque accusamus.</description>
+          <title>Moab Is My Washpot</title>
+          <description>Aut eveniet suscipit et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -376,15 +375,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '199'
+      - '190'
     body:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Monkey's Raincoat</title>
-          <description>Velit dolorum atque accusamus.</description>
+          <title>Moab Is My Washpot</title>
+          <description>Aut eveniet suscipit et.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:05 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:22 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -414,13 +413,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="69" vrev="69" srcmd5="973a5f0cafb7bdb14ddaaf7041843fcc">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="6cb95173e2eb500e5e87febdeb2499e9" baserev="6cb95173e2eb500e5e87febdeb2499e9" xsrcmd5="dbffe26338ce451235b56123c7df1dfb" lsrcmd5="973a5f0cafb7bdb14ddaaf7041843fcc"/>
-          <entry name="_config" md5="d8471caf71b1d81454328ac27ec6c8d1" size="74" mtime="1642674785"/>
-          <entry name="_link" md5="46ba5755e96d690029486cb3525032fa" size="119" mtime="1642674785"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="21" vrev="21" srcmd5="a911b133143c5d4c5438a4c748124c59">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="28f9e79ce8e316ae6dba8b70d3dc5068" baserev="28f9e79ce8e316ae6dba8b70d3dc5068" xsrcmd5="ac51fc2722244504d12e4db600cf52c5" lsrcmd5="a911b133143c5d4c5438a4c748124c59"/>
+          <entry name="_config" md5="15564cdf23bbe774a5769601199cb9be" size="55" mtime="1643641521"/>
+          <entry name="_link" md5="890a630d6951fd31f084deddea7dca2e" size="119" mtime="1643641522"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:05 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:22 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?view=info
@@ -446,15 +445,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '345'
+      - '344'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="multibuild_package" rev="69" vrev="125" srcmd5="dbffe26338ce451235b56123c7df1dfb" lsrcmd5="973a5f0cafb7bdb14ddaaf7041843fcc" verifymd5="6cb95173e2eb500e5e87febdeb2499e9">
+        <sourceinfo package="multibuild_package" rev="21" vrev="43" srcmd5="ac51fc2722244504d12e4db600cf52c5" lsrcmd5="a911b133143c5d4c5438a4c748124c59" verifymd5="28f9e79ce8e316ae6dba8b70d3dc5068">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="multibuild_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:05 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:22 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -484,13 +483,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="69" vrev="69" srcmd5="973a5f0cafb7bdb14ddaaf7041843fcc">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="6cb95173e2eb500e5e87febdeb2499e9" baserev="6cb95173e2eb500e5e87febdeb2499e9" xsrcmd5="dbffe26338ce451235b56123c7df1dfb" lsrcmd5="973a5f0cafb7bdb14ddaaf7041843fcc"/>
-          <entry name="_config" md5="d8471caf71b1d81454328ac27ec6c8d1" size="74" mtime="1642674785"/>
-          <entry name="_link" md5="46ba5755e96d690029486cb3525032fa" size="119" mtime="1642674785"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="21" vrev="21" srcmd5="a911b133143c5d4c5438a4c748124c59">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="28f9e79ce8e316ae6dba8b70d3dc5068" baserev="28f9e79ce8e316ae6dba8b70d3dc5068" xsrcmd5="ac51fc2722244504d12e4db600cf52c5" lsrcmd5="a911b133143c5d4c5438a4c748124c59"/>
+          <entry name="_config" md5="15564cdf23bbe774a5769601199cb9be" size="55" mtime="1643641521"/>
+          <entry name="_link" md5="890a630d6951fd31f084deddea7dca2e" size="119" mtime="1643641522"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:05 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:22 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -522,14 +521,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="a8c2140fc50969f13d7d21f8161fff83">
+        <sourcediff key="d57dc864efde50760415144576890061">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="69" srcmd5="973a5f0cafb7bdb14ddaaf7041843fcc"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="21" srcmd5="a911b133143c5d4c5438a4c748124c59"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:05 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:22 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -561,12 +560,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="f54e5028dc2f2a034a75bea2e866a2c2">
-          <old project="foo_project" package="multibuild_package" rev="6cb95173e2eb500e5e87febdeb2499e9" srcmd5="6cb95173e2eb500e5e87febdeb2499e9"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="dbffe26338ce451235b56123c7df1dfb" srcmd5="dbffe26338ce451235b56123c7df1dfb"/>
+        <sourcediff key="508b4192c254915e08e1341d43d6f70b">
+          <old project="foo_project" package="multibuild_package" rev="28f9e79ce8e316ae6dba8b70d3dc5068" srcmd5="28f9e79ce8e316ae6dba8b70d3dc5068"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="ac51fc2722244504d12e4db600cf52c5" srcmd5="ac51fc2722244504d12e4db600cf52c5"/>
           <files/>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:05 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:22 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -634,7 +633,7 @@ http_interactions:
             <arch>aarch64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:05 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:22 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_branch_request?user=Iggy
@@ -664,15 +663,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="70" vrev="70">
-          <srcmd5>6f9da61586f94001095bbe513e5b579e</srcmd5>
+        <revision rev="22" vrev="22">
+          <srcmd5>ef9805b6efb0f0341aa10627ba40cd51</srcmd5>
           <version>unknown</version>
-          <time>1642674785</time>
+          <time>1643641522</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:05 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:22 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_meta?user=Iggy
@@ -680,8 +679,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Monkey's Raincoat</title>
-          <description>Velit dolorum atque accusamus.</description>
+          <title>Moab Is My Washpot</title>
+          <description>Aut eveniet suscipit et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -702,15 +701,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '199'
+      - '190'
     body:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Monkey's Raincoat</title>
-          <description>Velit dolorum atque accusamus.</description>
+          <title>Moab Is My Washpot</title>
+          <description>Aut eveniet suscipit et.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:05 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:22 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -736,19 +735,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="70" vrev="70" srcmd5="6f9da61586f94001095bbe513e5b579e">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="6cb95173e2eb500e5e87febdeb2499e9" baserev="6cb95173e2eb500e5e87febdeb2499e9" xsrcmd5="ff01f2f299a1b70442047bb9f4ae1a19" lsrcmd5="6f9da61586f94001095bbe513e5b579e"/>
-          <serviceinfo code="succeeded" xsrcmd5="402a2147e5963c0c88a05dedfd60b06d"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="d8471caf71b1d81454328ac27ec6c8d1" size="74" mtime="1642674785"/>
-          <entry name="_link" md5="46ba5755e96d690029486cb3525032fa" size="119" mtime="1642674785"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="22" vrev="22" srcmd5="ef9805b6efb0f0341aa10627ba40cd51">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="28f9e79ce8e316ae6dba8b70d3dc5068" baserev="28f9e79ce8e316ae6dba8b70d3dc5068" xsrcmd5="c8da20a744b24103a66e8176cc08d2cb" lsrcmd5="ef9805b6efb0f0341aa10627ba40cd51"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="15564cdf23bbe774a5769601199cb9be" size="55" mtime="1643641521"/>
+          <entry name="_link" md5="890a630d6951fd31f084deddea7dca2e" size="119" mtime="1643641522"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:05 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:22 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?view=info
@@ -774,15 +772,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '345'
+      - '344'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="multibuild_package" rev="70" vrev="126" srcmd5="70e0ab960bd2e7a6f201309be568a02a" lsrcmd5="402a2147e5963c0c88a05dedfd60b06d" verifymd5="765ef9ab2a25b657b6099bae97cbb4a7">
+        <sourceinfo package="multibuild_package" rev="22" vrev="44" srcmd5="c8da20a744b24103a66e8176cc08d2cb" lsrcmd5="ef9805b6efb0f0341aa10627ba40cd51" verifymd5="1d4c37022937625debc35d1f447bf0f4">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="multibuild_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:05 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:22 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -808,19 +806,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="70" vrev="70" srcmd5="6f9da61586f94001095bbe513e5b579e">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="6cb95173e2eb500e5e87febdeb2499e9" baserev="6cb95173e2eb500e5e87febdeb2499e9" xsrcmd5="ff01f2f299a1b70442047bb9f4ae1a19" lsrcmd5="6f9da61586f94001095bbe513e5b579e"/>
-          <serviceinfo code="succeeded" xsrcmd5="402a2147e5963c0c88a05dedfd60b06d"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="d8471caf71b1d81454328ac27ec6c8d1" size="74" mtime="1642674785"/>
-          <entry name="_link" md5="46ba5755e96d690029486cb3525032fa" size="119" mtime="1642674785"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="22" vrev="22" srcmd5="ef9805b6efb0f0341aa10627ba40cd51">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="28f9e79ce8e316ae6dba8b70d3dc5068" baserev="28f9e79ce8e316ae6dba8b70d3dc5068" xsrcmd5="c8da20a744b24103a66e8176cc08d2cb" lsrcmd5="ef9805b6efb0f0341aa10627ba40cd51"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="15564cdf23bbe774a5769601199cb9be" size="55" mtime="1643641521"/>
+          <entry name="_link" md5="890a630d6951fd31f084deddea7dca2e" size="119" mtime="1643641522"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:05 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:22 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -852,14 +849,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="c58a990ceea45c486cfd016276111840">
+        <sourcediff key="02c59f9d361c9a47b103a965eba263ac">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="70" srcmd5="6f9da61586f94001095bbe513e5b579e"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="22" srcmd5="ef9805b6efb0f0341aa10627ba40cd51"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:06 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:23 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -891,14 +888,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="4de34285ba5b099c7547ffd962ca497d">
-          <old project="foo_project" package="multibuild_package" rev="6cb95173e2eb500e5e87febdeb2499e9" srcmd5="6cb95173e2eb500e5e87febdeb2499e9"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="70e0ab960bd2e7a6f201309be568a02a" srcmd5="70e0ab960bd2e7a6f201309be568a02a"/>
+        <sourcediff key="2f0c3b4d3428b7d4b0a66e10aa62adc0">
+          <old project="foo_project" package="multibuild_package" rev="28f9e79ce8e316ae6dba8b70d3dc5068" srcmd5="28f9e79ce8e316ae6dba8b70d3dc5068"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="c8da20a744b24103a66e8176cc08d2cb" srcmd5="c8da20a744b24103a66e8176cc08d2cb"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:06 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:23 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -924,22 +921,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="70" vrev="70" srcmd5="6f9da61586f94001095bbe513e5b579e">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="6cb95173e2eb500e5e87febdeb2499e9" baserev="6cb95173e2eb500e5e87febdeb2499e9" xsrcmd5="ff01f2f299a1b70442047bb9f4ae1a19" lsrcmd5="6f9da61586f94001095bbe513e5b579e"/>
-          <serviceinfo code="succeeded" xsrcmd5="402a2147e5963c0c88a05dedfd60b06d"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="d8471caf71b1d81454328ac27ec6c8d1" size="74" mtime="1642674785"/>
-          <entry name="_link" md5="46ba5755e96d690029486cb3525032fa" size="119" mtime="1642674785"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="22" vrev="22" srcmd5="ef9805b6efb0f0341aa10627ba40cd51">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="28f9e79ce8e316ae6dba8b70d3dc5068" baserev="28f9e79ce8e316ae6dba8b70d3dc5068" xsrcmd5="c8da20a744b24103a66e8176cc08d2cb" lsrcmd5="ef9805b6efb0f0341aa10627ba40cd51"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="15564cdf23bbe774a5769601199cb9be" size="55" mtime="1643641521"/>
+          <entry name="_link" md5="890a630d6951fd31f084deddea7dca2e" size="119" mtime="1643641522"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:06 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:23 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -962,19 +958,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '629'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="70" vrev="70" srcmd5="6f9da61586f94001095bbe513e5b579e">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="6cb95173e2eb500e5e87febdeb2499e9" baserev="6cb95173e2eb500e5e87febdeb2499e9" xsrcmd5="ff01f2f299a1b70442047bb9f4ae1a19" lsrcmd5="6f9da61586f94001095bbe513e5b579e"/>
-          <serviceinfo code="succeeded" xsrcmd5="402a2147e5963c0c88a05dedfd60b06d"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="d8471caf71b1d81454328ac27ec6c8d1" size="74" mtime="1642674785"/>
-          <entry name="_link" md5="46ba5755e96d690029486cb3525032fa" size="119" mtime="1642674785"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="c8da20a744b24103a66e8176cc08d2cb" vrev="44" srcmd5="c8da20a744b24103a66e8176cc08d2cb">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="28f9e79ce8e316ae6dba8b70d3dc5068" baserev="28f9e79ce8e316ae6dba8b70d3dc5068" lsrcmd5="ef9805b6efb0f0341aa10627ba40cd51"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="15564cdf23bbe774a5769601199cb9be" size="55" mtime="1643641521"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:06 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:23 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_multibuild
@@ -1004,7 +998,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "<multibuild><flavor>flavor_a</flavor><flavor>flavor_b</flavor></multibuild>"
-  recorded_at: Thu, 20 Jan 2022 10:33:06 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:23 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -1030,22 +1024,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="70" vrev="70" srcmd5="6f9da61586f94001095bbe513e5b579e">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="6cb95173e2eb500e5e87febdeb2499e9" baserev="6cb95173e2eb500e5e87febdeb2499e9" xsrcmd5="ff01f2f299a1b70442047bb9f4ae1a19" lsrcmd5="6f9da61586f94001095bbe513e5b579e"/>
-          <serviceinfo code="succeeded" xsrcmd5="402a2147e5963c0c88a05dedfd60b06d"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="d8471caf71b1d81454328ac27ec6c8d1" size="74" mtime="1642674785"/>
-          <entry name="_link" md5="46ba5755e96d690029486cb3525032fa" size="119" mtime="1642674785"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="22" vrev="22" srcmd5="ef9805b6efb0f0341aa10627ba40cd51">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="28f9e79ce8e316ae6dba8b70d3dc5068" baserev="28f9e79ce8e316ae6dba8b70d3dc5068" xsrcmd5="c8da20a744b24103a66e8176cc08d2cb" lsrcmd5="ef9805b6efb0f0341aa10627ba40cd51"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="15564cdf23bbe774a5769601199cb9be" size="55" mtime="1643641521"/>
+          <entry name="_link" md5="890a630d6951fd31f084deddea7dca2e" size="119" mtime="1643641522"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:06 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:23 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1068,19 +1061,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '629'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="70" vrev="70" srcmd5="6f9da61586f94001095bbe513e5b579e">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="6cb95173e2eb500e5e87febdeb2499e9" baserev="6cb95173e2eb500e5e87febdeb2499e9" xsrcmd5="ff01f2f299a1b70442047bb9f4ae1a19" lsrcmd5="6f9da61586f94001095bbe513e5b579e"/>
-          <serviceinfo code="succeeded" xsrcmd5="402a2147e5963c0c88a05dedfd60b06d"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="d8471caf71b1d81454328ac27ec6c8d1" size="74" mtime="1642674785"/>
-          <entry name="_link" md5="46ba5755e96d690029486cb3525032fa" size="119" mtime="1642674785"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="c8da20a744b24103a66e8176cc08d2cb" vrev="44" srcmd5="c8da20a744b24103a66e8176cc08d2cb">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="28f9e79ce8e316ae6dba8b70d3dc5068" baserev="28f9e79ce8e316ae6dba8b70d3dc5068" lsrcmd5="ef9805b6efb0f0341aa10627ba40cd51"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="15564cdf23bbe774a5769601199cb9be" size="55" mtime="1643641521"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:06 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:23 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_multibuild
@@ -1110,7 +1101,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "<multibuild><flavor>flavor_a</flavor><flavor>flavor_b</flavor></multibuild>"
-  recorded_at: Thu, 20 Jan 2022 10:33:06 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:23 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -1136,22 +1127,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="70" vrev="70" srcmd5="6f9da61586f94001095bbe513e5b579e">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="6cb95173e2eb500e5e87febdeb2499e9" baserev="6cb95173e2eb500e5e87febdeb2499e9" xsrcmd5="ff01f2f299a1b70442047bb9f4ae1a19" lsrcmd5="6f9da61586f94001095bbe513e5b579e"/>
-          <serviceinfo code="succeeded" xsrcmd5="402a2147e5963c0c88a05dedfd60b06d"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="d8471caf71b1d81454328ac27ec6c8d1" size="74" mtime="1642674785"/>
-          <entry name="_link" md5="46ba5755e96d690029486cb3525032fa" size="119" mtime="1642674785"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="22" vrev="22" srcmd5="ef9805b6efb0f0341aa10627ba40cd51">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="28f9e79ce8e316ae6dba8b70d3dc5068" baserev="28f9e79ce8e316ae6dba8b70d3dc5068" xsrcmd5="c8da20a744b24103a66e8176cc08d2cb" lsrcmd5="ef9805b6efb0f0341aa10627ba40cd51"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="15564cdf23bbe774a5769601199cb9be" size="55" mtime="1643641521"/>
+          <entry name="_link" md5="890a630d6951fd31f084deddea7dca2e" size="119" mtime="1643641522"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:06 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:23 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1174,19 +1164,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '629'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="70" vrev="70" srcmd5="6f9da61586f94001095bbe513e5b579e">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="6cb95173e2eb500e5e87febdeb2499e9" baserev="6cb95173e2eb500e5e87febdeb2499e9" xsrcmd5="ff01f2f299a1b70442047bb9f4ae1a19" lsrcmd5="6f9da61586f94001095bbe513e5b579e"/>
-          <serviceinfo code="succeeded" xsrcmd5="402a2147e5963c0c88a05dedfd60b06d"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="d8471caf71b1d81454328ac27ec6c8d1" size="74" mtime="1642674785"/>
-          <entry name="_link" md5="46ba5755e96d690029486cb3525032fa" size="119" mtime="1642674785"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="c8da20a744b24103a66e8176cc08d2cb" vrev="44" srcmd5="c8da20a744b24103a66e8176cc08d2cb">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="28f9e79ce8e316ae6dba8b70d3dc5068" baserev="28f9e79ce8e316ae6dba8b70d3dc5068" lsrcmd5="ef9805b6efb0f0341aa10627ba40cd51"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="15564cdf23bbe774a5769601199cb9be" size="55" mtime="1643641521"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:06 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:23 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_multibuild
@@ -1216,7 +1204,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "<multibuild><flavor>flavor_a</flavor><flavor>flavor_b</flavor></multibuild>"
-  recorded_at: Thu, 20 Jan 2022 10:33:06 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:23 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -1242,22 +1230,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="70" vrev="70" srcmd5="6f9da61586f94001095bbe513e5b579e">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="6cb95173e2eb500e5e87febdeb2499e9" baserev="6cb95173e2eb500e5e87febdeb2499e9" xsrcmd5="ff01f2f299a1b70442047bb9f4ae1a19" lsrcmd5="6f9da61586f94001095bbe513e5b579e"/>
-          <serviceinfo code="succeeded" xsrcmd5="402a2147e5963c0c88a05dedfd60b06d"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="d8471caf71b1d81454328ac27ec6c8d1" size="74" mtime="1642674785"/>
-          <entry name="_link" md5="46ba5755e96d690029486cb3525032fa" size="119" mtime="1642674785"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="22" vrev="22" srcmd5="ef9805b6efb0f0341aa10627ba40cd51">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="28f9e79ce8e316ae6dba8b70d3dc5068" baserev="28f9e79ce8e316ae6dba8b70d3dc5068" xsrcmd5="c8da20a744b24103a66e8176cc08d2cb" lsrcmd5="ef9805b6efb0f0341aa10627ba40cd51"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="15564cdf23bbe774a5769601199cb9be" size="55" mtime="1643641521"/>
+          <entry name="_link" md5="890a630d6951fd31f084deddea7dca2e" size="119" mtime="1643641522"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:06 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:23 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1280,19 +1267,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '629'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="70" vrev="70" srcmd5="6f9da61586f94001095bbe513e5b579e">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="6cb95173e2eb500e5e87febdeb2499e9" baserev="6cb95173e2eb500e5e87febdeb2499e9" xsrcmd5="ff01f2f299a1b70442047bb9f4ae1a19" lsrcmd5="6f9da61586f94001095bbe513e5b579e"/>
-          <serviceinfo code="succeeded" xsrcmd5="402a2147e5963c0c88a05dedfd60b06d"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="d8471caf71b1d81454328ac27ec6c8d1" size="74" mtime="1642674785"/>
-          <entry name="_link" md5="46ba5755e96d690029486cb3525032fa" size="119" mtime="1642674785"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="c8da20a744b24103a66e8176cc08d2cb" vrev="44" srcmd5="c8da20a744b24103a66e8176cc08d2cb">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="28f9e79ce8e316ae6dba8b70d3dc5068" baserev="28f9e79ce8e316ae6dba8b70d3dc5068" lsrcmd5="ef9805b6efb0f0341aa10627ba40cd51"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="15564cdf23bbe774a5769601199cb9be" size="55" mtime="1643641521"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:06 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:23 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_multibuild
@@ -1322,7 +1307,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "<multibuild><flavor>flavor_a</flavor><flavor>flavor_b</flavor></multibuild>"
-  recorded_at: Thu, 20 Jan 2022 10:33:06 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:23 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -1348,22 +1333,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="70" vrev="70" srcmd5="6f9da61586f94001095bbe513e5b579e">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="6cb95173e2eb500e5e87febdeb2499e9" baserev="6cb95173e2eb500e5e87febdeb2499e9" xsrcmd5="ff01f2f299a1b70442047bb9f4ae1a19" lsrcmd5="6f9da61586f94001095bbe513e5b579e"/>
-          <serviceinfo code="succeeded" xsrcmd5="402a2147e5963c0c88a05dedfd60b06d"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="d8471caf71b1d81454328ac27ec6c8d1" size="74" mtime="1642674785"/>
-          <entry name="_link" md5="46ba5755e96d690029486cb3525032fa" size="119" mtime="1642674785"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="22" vrev="22" srcmd5="ef9805b6efb0f0341aa10627ba40cd51">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="28f9e79ce8e316ae6dba8b70d3dc5068" baserev="28f9e79ce8e316ae6dba8b70d3dc5068" xsrcmd5="c8da20a744b24103a66e8176cc08d2cb" lsrcmd5="ef9805b6efb0f0341aa10627ba40cd51"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="15564cdf23bbe774a5769601199cb9be" size="55" mtime="1643641521"/>
+          <entry name="_link" md5="890a630d6951fd31f084deddea7dca2e" size="119" mtime="1643641522"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:06 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:23 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1386,19 +1370,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '629'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="70" vrev="70" srcmd5="6f9da61586f94001095bbe513e5b579e">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="6cb95173e2eb500e5e87febdeb2499e9" baserev="6cb95173e2eb500e5e87febdeb2499e9" xsrcmd5="ff01f2f299a1b70442047bb9f4ae1a19" lsrcmd5="6f9da61586f94001095bbe513e5b579e"/>
-          <serviceinfo code="succeeded" xsrcmd5="402a2147e5963c0c88a05dedfd60b06d"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="d8471caf71b1d81454328ac27ec6c8d1" size="74" mtime="1642674785"/>
-          <entry name="_link" md5="46ba5755e96d690029486cb3525032fa" size="119" mtime="1642674785"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="c8da20a744b24103a66e8176cc08d2cb" vrev="44" srcmd5="c8da20a744b24103a66e8176cc08d2cb">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="28f9e79ce8e316ae6dba8b70d3dc5068" baserev="28f9e79ce8e316ae6dba8b70d3dc5068" lsrcmd5="ef9805b6efb0f0341aa10627ba40cd51"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="15564cdf23bbe774a5769601199cb9be" size="55" mtime="1643641521"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:06 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:23 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_multibuild
@@ -1428,5 +1410,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "<multibuild><flavor>flavor_a</flavor><flavor>flavor_b</flavor></multibuild>"
-  recorded_at: Thu, 20 Jan 2022 10:33:06 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:23 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_a_multibuild_package/only_reports_for_repositories_and_architectures_matching_the_filters.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_a_multibuild_package/only_reports_for_repositories_and_architectures_matching_the_filters.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:57 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:31 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_312
+    uri: http://backend:5352/source/foo_project/_meta?user=user_33
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Gone with the Wind</title>
+          <title>Behold the Man</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '150'
+      - '146'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Gone with the Wind</title>
+          <title>Behold the Man</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:57 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:31 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/multibuild_package/_meta?user=user_313
+    uri: http://backend:5352/source/foo_project/multibuild_package/_meta?user=user_34
     body:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="foo_project">
-          <title>Mother Night</title>
-          <description>Aperiam a asperiores hic.</description>
+          <title>Dulce et Decorum Est</title>
+          <description>Facere doloremque libero nemo.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,22 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '154'
+      - '167'
     body:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="foo_project">
-          <title>Mother Night</title>
-          <description>Aperiam a asperiores hic.</description>
+          <title>Dulce et Decorum Est</title>
+          <description>Facere doloremque libero nemo.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:57 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:31 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/multibuild_package/_config
     body:
       encoding: UTF-8
-      string: Dicta repellendus necessitatibus. Non asperiores ut. Occaecati sint
-        voluptatem.
+      string: Sint dolorum cumque. Voluptates corporis et. Debitis voluptas pariatur.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -148,15 +147,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="45" vrev="45">
-          <srcmd5>b42439bb9ec75cc8d4ad2becf695b1b4</srcmd5>
+        <revision rev="31" vrev="31">
+          <srcmd5>d488de9b76b5e89371f106776f9d7f94</srcmd5>
           <version>unknown</version>
-          <time>1642674777</time>
+          <time>1643641531</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:57 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:31 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/multibuild_package/_multibuild
@@ -186,15 +185,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="46" vrev="46">
-          <srcmd5>b42439bb9ec75cc8d4ad2becf695b1b4</srcmd5>
+        <revision rev="32" vrev="32">
+          <srcmd5>d488de9b76b5e89371f106776f9d7f94</srcmd5>
           <version>unknown</version>
-          <time>1642674777</time>
+          <time>1643641531</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:57 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:31 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22multibuild_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -228,7 +227,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:32:57 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:31 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -268,7 +267,7 @@ http_interactions:
           <description>This project was created for package multibuild_package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:57 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:31 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_meta?user=Iggy
@@ -276,8 +275,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Mother Night</title>
-          <description>Aperiam a asperiores hic.</description>
+          <title>Dulce et Decorum Est</title>
+          <description>Facere doloremque libero nemo.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -298,15 +297,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '185'
+      - '198'
     body:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Mother Night</title>
-          <description>Aperiam a asperiores hic.</description>
+          <title>Dulce et Decorum Est</title>
+          <description>Facere doloremque libero nemo.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:57 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:31 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?cmd=branch&noservice=1&opackage=multibuild_package&oproject=foo_project&user=Iggy
@@ -338,15 +337,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="59" vrev="59">
-          <srcmd5>ec3ce05ece14d9113bb4fca4e50b992c</srcmd5>
+        <revision rev="31" vrev="31">
+          <srcmd5>3c75f893f1a60efbc89e6232fd413070</srcmd5>
           <version>unknown</version>
-          <time>1642674777</time>
+          <time>1643641531</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:57 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:31 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_meta?user=Iggy
@@ -354,8 +353,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Mother Night</title>
-          <description>Aperiam a asperiores hic.</description>
+          <title>Dulce et Decorum Est</title>
+          <description>Facere doloremque libero nemo.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -376,15 +375,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '185'
+      - '198'
     body:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Mother Night</title>
-          <description>Aperiam a asperiores hic.</description>
+          <title>Dulce et Decorum Est</title>
+          <description>Facere doloremque libero nemo.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:57 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:31 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -414,13 +413,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="59" vrev="59" srcmd5="ec3ce05ece14d9113bb4fca4e50b992c">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="b42439bb9ec75cc8d4ad2becf695b1b4" baserev="b42439bb9ec75cc8d4ad2becf695b1b4" xsrcmd5="3fa02541ceda97cf1771fcbd352c0aa7" lsrcmd5="ec3ce05ece14d9113bb4fca4e50b992c"/>
-          <entry name="_config" md5="6afcd8dc75ec01fc11572b2b067ec169" size="79" mtime="1642674777"/>
-          <entry name="_link" md5="d0a0b01605ce6004e57719f1fa1e08d5" size="119" mtime="1642674777"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="31" vrev="31" srcmd5="3c75f893f1a60efbc89e6232fd413070">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="d488de9b76b5e89371f106776f9d7f94" baserev="d488de9b76b5e89371f106776f9d7f94" xsrcmd5="1806b9979fd255e8eda14b01b9d7d156" lsrcmd5="3c75f893f1a60efbc89e6232fd413070"/>
+          <entry name="_config" md5="13e39062831c9f61ab72cdcd93855dfb" size="71" mtime="1643641531"/>
+          <entry name="_link" md5="c0076f33636beae06f265ce9560cb59c" size="119" mtime="1643641531"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:57 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:31 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?view=info
@@ -446,15 +445,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '345'
+      - '344'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="multibuild_package" rev="59" vrev="105" srcmd5="3fa02541ceda97cf1771fcbd352c0aa7" lsrcmd5="ec3ce05ece14d9113bb4fca4e50b992c" verifymd5="b42439bb9ec75cc8d4ad2becf695b1b4">
+        <sourceinfo package="multibuild_package" rev="31" vrev="63" srcmd5="1806b9979fd255e8eda14b01b9d7d156" lsrcmd5="3c75f893f1a60efbc89e6232fd413070" verifymd5="d488de9b76b5e89371f106776f9d7f94">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="multibuild_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:57 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:31 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -484,13 +483,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="59" vrev="59" srcmd5="ec3ce05ece14d9113bb4fca4e50b992c">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="b42439bb9ec75cc8d4ad2becf695b1b4" baserev="b42439bb9ec75cc8d4ad2becf695b1b4" xsrcmd5="3fa02541ceda97cf1771fcbd352c0aa7" lsrcmd5="ec3ce05ece14d9113bb4fca4e50b992c"/>
-          <entry name="_config" md5="6afcd8dc75ec01fc11572b2b067ec169" size="79" mtime="1642674777"/>
-          <entry name="_link" md5="d0a0b01605ce6004e57719f1fa1e08d5" size="119" mtime="1642674777"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="31" vrev="31" srcmd5="3c75f893f1a60efbc89e6232fd413070">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="d488de9b76b5e89371f106776f9d7f94" baserev="d488de9b76b5e89371f106776f9d7f94" xsrcmd5="1806b9979fd255e8eda14b01b9d7d156" lsrcmd5="3c75f893f1a60efbc89e6232fd413070"/>
+          <entry name="_config" md5="13e39062831c9f61ab72cdcd93855dfb" size="71" mtime="1643641531"/>
+          <entry name="_link" md5="c0076f33636beae06f265ce9560cb59c" size="119" mtime="1643641531"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:57 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:31 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -522,14 +521,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="a0b48d5703eeeff10a1b3b9a23fdee11">
+        <sourcediff key="6246ed51151917aa51b06e2a28edf539">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="59" srcmd5="ec3ce05ece14d9113bb4fca4e50b992c"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="31" srcmd5="3c75f893f1a60efbc89e6232fd413070"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:57 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:31 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -561,12 +560,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="f87419ac44350f6e5618cf6cbbcd984b">
-          <old project="foo_project" package="multibuild_package" rev="b42439bb9ec75cc8d4ad2becf695b1b4" srcmd5="b42439bb9ec75cc8d4ad2becf695b1b4"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="3fa02541ceda97cf1771fcbd352c0aa7" srcmd5="3fa02541ceda97cf1771fcbd352c0aa7"/>
+        <sourcediff key="cd56a53f4eaa9aacebe5326e366b5401">
+          <old project="foo_project" package="multibuild_package" rev="d488de9b76b5e89371f106776f9d7f94" srcmd5="d488de9b76b5e89371f106776f9d7f94"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="1806b9979fd255e8eda14b01b9d7d156" srcmd5="1806b9979fd255e8eda14b01b9d7d156"/>
           <files/>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:57 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:31 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -634,7 +633,7 @@ http_interactions:
             <arch>aarch64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:58 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:32 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_branch_request?user=Iggy
@@ -664,15 +663,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="60" vrev="60">
-          <srcmd5>1e7a5be335297d62df065a1cd58138a7</srcmd5>
+        <revision rev="32" vrev="32">
+          <srcmd5>83aa151115c8b141abc0a835b3636d47</srcmd5>
           <version>unknown</version>
-          <time>1642674778</time>
+          <time>1643641532</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:58 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:32 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_meta?user=Iggy
@@ -680,8 +679,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Mother Night</title>
-          <description>Aperiam a asperiores hic.</description>
+          <title>Dulce et Decorum Est</title>
+          <description>Facere doloremque libero nemo.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -702,15 +701,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '185'
+      - '198'
     body:
       encoding: UTF-8
       string: |
         <package name="multibuild_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Mother Night</title>
-          <description>Aperiam a asperiores hic.</description>
+          <title>Dulce et Decorum Est</title>
+          <description>Facere doloremque libero nemo.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:58 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:32 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -736,19 +735,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="60" vrev="60" srcmd5="1e7a5be335297d62df065a1cd58138a7">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="b42439bb9ec75cc8d4ad2becf695b1b4" baserev="b42439bb9ec75cc8d4ad2becf695b1b4" xsrcmd5="889e249a28690e0cbd3ab7858a880633" lsrcmd5="1e7a5be335297d62df065a1cd58138a7"/>
-          <serviceinfo code="succeeded" xsrcmd5="e1deaa6e3e826cbfba5d2da35812e7e9"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="6afcd8dc75ec01fc11572b2b067ec169" size="79" mtime="1642674777"/>
-          <entry name="_link" md5="d0a0b01605ce6004e57719f1fa1e08d5" size="119" mtime="1642674777"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="32" vrev="32" srcmd5="83aa151115c8b141abc0a835b3636d47">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="d488de9b76b5e89371f106776f9d7f94" baserev="d488de9b76b5e89371f106776f9d7f94" xsrcmd5="ccb66bebaf3be6fb31633f14c64c7f4e" lsrcmd5="83aa151115c8b141abc0a835b3636d47"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="13e39062831c9f61ab72cdcd93855dfb" size="71" mtime="1643641531"/>
+          <entry name="_link" md5="c0076f33636beae06f265ce9560cb59c" size="119" mtime="1643641531"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:58 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:32 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?view=info
@@ -774,15 +772,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '345'
+      - '344'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="multibuild_package" rev="60" vrev="106" srcmd5="191dec52eab67f70c0e7febc5bd4e600" lsrcmd5="e1deaa6e3e826cbfba5d2da35812e7e9" verifymd5="0655540c6fdc4c870381b45a9c11ce53">
+        <sourceinfo package="multibuild_package" rev="32" vrev="64" srcmd5="ccb66bebaf3be6fb31633f14c64c7f4e" lsrcmd5="83aa151115c8b141abc0a835b3636d47" verifymd5="9ea68b3ca22bf21484264758bf8dbe14">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="multibuild_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:58 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:32 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -808,19 +806,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="60" vrev="60" srcmd5="1e7a5be335297d62df065a1cd58138a7">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="b42439bb9ec75cc8d4ad2becf695b1b4" baserev="b42439bb9ec75cc8d4ad2becf695b1b4" xsrcmd5="889e249a28690e0cbd3ab7858a880633" lsrcmd5="1e7a5be335297d62df065a1cd58138a7"/>
-          <serviceinfo code="succeeded" xsrcmd5="e1deaa6e3e826cbfba5d2da35812e7e9"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="6afcd8dc75ec01fc11572b2b067ec169" size="79" mtime="1642674777"/>
-          <entry name="_link" md5="d0a0b01605ce6004e57719f1fa1e08d5" size="119" mtime="1642674777"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="32" vrev="32" srcmd5="83aa151115c8b141abc0a835b3636d47">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="d488de9b76b5e89371f106776f9d7f94" baserev="d488de9b76b5e89371f106776f9d7f94" xsrcmd5="ccb66bebaf3be6fb31633f14c64c7f4e" lsrcmd5="83aa151115c8b141abc0a835b3636d47"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="13e39062831c9f61ab72cdcd93855dfb" size="71" mtime="1643641531"/>
+          <entry name="_link" md5="c0076f33636beae06f265ce9560cb59c" size="119" mtime="1643641531"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:58 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:32 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -852,14 +849,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="adff68491859446d4b078d392136d28f">
+        <sourcediff key="64057805ec46a741cb83549f4dec4055">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="60" srcmd5="1e7a5be335297d62df065a1cd58138a7"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="32" srcmd5="83aa151115c8b141abc0a835b3636d47"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:58 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:32 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -891,14 +888,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="68b737491e32e5b7b077d9a7f5d74e8e">
-          <old project="foo_project" package="multibuild_package" rev="b42439bb9ec75cc8d4ad2becf695b1b4" srcmd5="b42439bb9ec75cc8d4ad2becf695b1b4"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="191dec52eab67f70c0e7febc5bd4e600" srcmd5="191dec52eab67f70c0e7febc5bd4e600"/>
+        <sourcediff key="133f657ed666f9ea489c64080589004c">
+          <old project="foo_project" package="multibuild_package" rev="d488de9b76b5e89371f106776f9d7f94" srcmd5="d488de9b76b5e89371f106776f9d7f94"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="multibuild_package" rev="ccb66bebaf3be6fb31633f14c64c7f4e" srcmd5="ccb66bebaf3be6fb31633f14c64c7f4e"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:58 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:32 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -924,22 +921,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="60" vrev="60" srcmd5="1e7a5be335297d62df065a1cd58138a7">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="b42439bb9ec75cc8d4ad2becf695b1b4" baserev="b42439bb9ec75cc8d4ad2becf695b1b4" xsrcmd5="889e249a28690e0cbd3ab7858a880633" lsrcmd5="1e7a5be335297d62df065a1cd58138a7"/>
-          <serviceinfo code="succeeded" xsrcmd5="e1deaa6e3e826cbfba5d2da35812e7e9"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="6afcd8dc75ec01fc11572b2b067ec169" size="79" mtime="1642674777"/>
-          <entry name="_link" md5="d0a0b01605ce6004e57719f1fa1e08d5" size="119" mtime="1642674777"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="32" vrev="32" srcmd5="83aa151115c8b141abc0a835b3636d47">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="d488de9b76b5e89371f106776f9d7f94" baserev="d488de9b76b5e89371f106776f9d7f94" xsrcmd5="ccb66bebaf3be6fb31633f14c64c7f4e" lsrcmd5="83aa151115c8b141abc0a835b3636d47"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="13e39062831c9f61ab72cdcd93855dfb" size="71" mtime="1643641531"/>
+          <entry name="_link" md5="c0076f33636beae06f265ce9560cb59c" size="119" mtime="1643641531"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:58 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:32 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -962,19 +958,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '629'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="60" vrev="60" srcmd5="1e7a5be335297d62df065a1cd58138a7">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="b42439bb9ec75cc8d4ad2becf695b1b4" baserev="b42439bb9ec75cc8d4ad2becf695b1b4" xsrcmd5="889e249a28690e0cbd3ab7858a880633" lsrcmd5="1e7a5be335297d62df065a1cd58138a7"/>
-          <serviceinfo code="succeeded" xsrcmd5="e1deaa6e3e826cbfba5d2da35812e7e9"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="6afcd8dc75ec01fc11572b2b067ec169" size="79" mtime="1642674777"/>
-          <entry name="_link" md5="d0a0b01605ce6004e57719f1fa1e08d5" size="119" mtime="1642674777"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="ccb66bebaf3be6fb31633f14c64c7f4e" vrev="64" srcmd5="ccb66bebaf3be6fb31633f14c64c7f4e">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="d488de9b76b5e89371f106776f9d7f94" baserev="d488de9b76b5e89371f106776f9d7f94" lsrcmd5="83aa151115c8b141abc0a835b3636d47"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="13e39062831c9f61ab72cdcd93855dfb" size="71" mtime="1643641531"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:58 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:32 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_multibuild
@@ -1004,7 +998,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "<multibuild><flavor>flavor_a</flavor><flavor>flavor_b</flavor></multibuild>"
-  recorded_at: Thu, 20 Jan 2022 10:32:58 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:32 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
@@ -1030,22 +1024,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="60" vrev="60" srcmd5="1e7a5be335297d62df065a1cd58138a7">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="b42439bb9ec75cc8d4ad2becf695b1b4" baserev="b42439bb9ec75cc8d4ad2becf695b1b4" xsrcmd5="889e249a28690e0cbd3ab7858a880633" lsrcmd5="1e7a5be335297d62df065a1cd58138a7"/>
-          <serviceinfo code="succeeded" xsrcmd5="e1deaa6e3e826cbfba5d2da35812e7e9"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="6afcd8dc75ec01fc11572b2b067ec169" size="79" mtime="1642674777"/>
-          <entry name="_link" md5="d0a0b01605ce6004e57719f1fa1e08d5" size="119" mtime="1642674777"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="32" vrev="32" srcmd5="83aa151115c8b141abc0a835b3636d47">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="d488de9b76b5e89371f106776f9d7f94" baserev="d488de9b76b5e89371f106776f9d7f94" xsrcmd5="ccb66bebaf3be6fb31633f14c64c7f4e" lsrcmd5="83aa151115c8b141abc0a835b3636d47"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="13e39062831c9f61ab72cdcd93855dfb" size="71" mtime="1643641531"/>
+          <entry name="_link" md5="c0076f33636beae06f265ce9560cb59c" size="119" mtime="1643641531"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:58 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:32 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1068,19 +1061,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '629'
     body:
       encoding: UTF-8
       string: |
-        <directory name="multibuild_package" rev="60" vrev="60" srcmd5="1e7a5be335297d62df065a1cd58138a7">
-          <linkinfo project="foo_project" package="multibuild_package" srcmd5="b42439bb9ec75cc8d4ad2becf695b1b4" baserev="b42439bb9ec75cc8d4ad2becf695b1b4" xsrcmd5="889e249a28690e0cbd3ab7858a880633" lsrcmd5="1e7a5be335297d62df065a1cd58138a7"/>
-          <serviceinfo code="succeeded" xsrcmd5="e1deaa6e3e826cbfba5d2da35812e7e9"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642597665"/>
-          <entry name="_config" md5="6afcd8dc75ec01fc11572b2b067ec169" size="79" mtime="1642674777"/>
-          <entry name="_link" md5="d0a0b01605ce6004e57719f1fa1e08d5" size="119" mtime="1642674777"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1642597665"/>
+        <directory name="multibuild_package" rev="ccb66bebaf3be6fb31633f14c64c7f4e" vrev="64" srcmd5="ccb66bebaf3be6fb31633f14c64c7f4e">
+          <linkinfo project="foo_project" package="multibuild_package" srcmd5="d488de9b76b5e89371f106776f9d7f94" baserev="d488de9b76b5e89371f106776f9d7f94" lsrcmd5="83aa151115c8b141abc0a835b3636d47"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632572"/>
+          <entry name="_config" md5="13e39062831c9f61ab72cdcd93855dfb" size="71" mtime="1643641531"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643632570"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:58 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:32 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/multibuild_package/_multibuild
@@ -1110,5 +1101,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "<multibuild><flavor>flavor_a</flavor><flavor>flavor_b</flavor></multibuild>"
-  recorded_at: Thu, 20 Jan 2022 10:32:58 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:32 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_a_new_PR_event/behaves_like_failed_when_source_package_does_not_exist/1_1_1_3_2_1.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_a_new_PR_event/behaves_like_failed_when_source_package_does_not_exist/1_1_1_3_2_1.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:16 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:07 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_340
+    uri: http://backend:5352/source/foo_project/_meta?user=user_5
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>The Line of Beauty</title>
+          <title>Of Mice and Men</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '150'
+      - '147'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>The Line of Beauty</title>
+          <title>Of Mice and Men</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:16 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:08 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_341
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_6
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Those Barren Leaves, Thrones, Dominations</title>
-          <description>Libero fuga voluptatem vitae.</description>
+          <title>Let Us Now Praise Famous Men</title>
+          <description>Sint sit impedit quas.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '180'
+      - '160'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Those Barren Leaves, Thrones, Dominations</title>
-          <description>Libero fuga voluptatem vitae.</description>
+          <title>Let Us Now Praise Famous Men</title>
+          <description>Sint sit impedit quas.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:16 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:08 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Illum aut tenetur. Quia voluptates illo. Explicabo labore harum.
+      string: Itaque eum accusamus. Atque accusamus animi. Qui voluptas ut.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1713" vrev="1713">
-          <srcmd5>57e1654c00bcf591a0cc08b1c465f49d</srcmd5>
+        <revision rev="21" vrev="21">
+          <srcmd5>5319b48c797b35ce643d219fd0630f76</srcmd5>
           <version>unknown</version>
-          <time>1642674796</time>
+          <time>1643641508</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:16 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:08 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Non velit fuga. Est quidem et. Debitis sed optio.
+      string: Tenetur est sunt. Et qui placeat. Sit sequi quam.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,17 +181,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1714" vrev="1714">
-          <srcmd5>d7e4c6233e13af0da86fa8e19dd6b75b</srcmd5>
+        <revision rev="22" vrev="22">
+          <srcmd5>9adf8dc313a7dfe1a79d1dfcab9d1feb</srcmd5>
           <version>unknown</version>
-          <time>1642674796</time>
+          <time>1643641508</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:16 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:08 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_a_new_PR_event/behaves_like_failed_without_branch_permissions/1_1_1_3_3_1.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_a_new_PR_event/behaves_like_failed_without_branch_permissions/1_1_1_3_3_1.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:16 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:08 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_342
+    uri: http://backend:5352/source/foo_project/_meta?user=user_7
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>An Instant In The Wind</title>
+          <title>The Wings of the Dove</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '154'
+      - '153'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>An Instant In The Wind</title>
+          <title>The Wings of the Dove</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:16 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:08 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_343
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_8
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Golden Apples of the Sun</title>
-          <description>Id omnis aliquid accusantium.</description>
+          <title>Let Us Now Praise Famous Men</title>
+          <description>Voluptas eum neque recusandae.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,22 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '168'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Golden Apples of the Sun</title>
-          <description>Id omnis aliquid accusantium.</description>
+          <title>Let Us Now Praise Famous Men</title>
+          <description>Voluptas eum neque recusandae.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:16 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:08 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Magni aliquam nihil. Recusandae quaerat et. Ut rerum amet.
+      string: Consequatur officiis dolor. Dolorum occaecati alias. Rerum cupiditate
+        possimus.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +144,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1715" vrev="1715">
-          <srcmd5>481e7da8e1768cba0bbae48fb5179c4a</srcmd5>
+        <revision rev="23" vrev="23">
+          <srcmd5>9acf66fcd49d06b07316aab5b11f9410</srcmd5>
           <version>unknown</version>
-          <time>1642674796</time>
+          <time>1643641508</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:16 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:08 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Omnis enim facilis. Dolorem officiis perferendis. Dolor odio omnis.
+      string: Id qui provident. Eveniet et debitis. Ad qui maxime.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,17 +182,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1716" vrev="1716">
-          <srcmd5>0dfb8259aa99d75488153e4911de040a</srcmd5>
+        <revision rev="24" vrev="24">
+          <srcmd5>e8351b49b29b7484698b13a28d4c9427</srcmd5>
           <version>unknown</version>
-          <time>1642674796</time>
+          <time>1643641508</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:16 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:09 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_a_new_PR_event/behaves_like_fails_with_insufficient_write_permission_on_target_project/1_1_1_3_4_1.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_a_new_PR_event/behaves_like_fails_with_insufficient_write_permission_on_target_project/1_1_1_3_4_1.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:15 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:07 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_338
+    uri: http://backend:5352/source/foo_project/_meta?user=user_3
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Have His Carcase</title>
+          <title>The Line of Beauty</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '148'
+      - '150'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Have His Carcase</title>
+          <title>The Line of Beauty</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:16 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:07 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_339
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_4
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Parliament of Man</title>
-          <description>Qui illo voluptas rem.</description>
+          <title>The Moving Finger</title>
+          <description>Similique eum architecto et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '153'
+      - '155'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Parliament of Man</title>
-          <description>Qui illo voluptas rem.</description>
+          <title>The Moving Finger</title>
+          <description>Similique eum architecto et.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:16 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:07 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Magnam ut fugiat. Repudiandae vel quod. Ducimus adipisci ab.
+      string: Ratione numquam enim. Qui consectetur debitis. Dolor beatae placeat.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1711" vrev="1711">
-          <srcmd5>efe97b922ebd917eead98827013d862c</srcmd5>
+        <revision rev="19" vrev="19">
+          <srcmd5>386455ce087ad6e305b5d9a2d6b59877</srcmd5>
           <version>unknown</version>
-          <time>1642674796</time>
+          <time>1643641507</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:16 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:07 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Aspernatur ut iure. Natus eligendi sed. Id et illo.
+      string: Aut autem error. Neque voluptates nulla. Molestiae cum mollitia.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +181,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1712" vrev="1712">
-          <srcmd5>8db536cd07aa30ebb210550526d84804</srcmd5>
+        <revision rev="20" vrev="20">
+          <srcmd5>4ed1c4f2bc1aa18d5e659033dc17da28</srcmd5>
           <version>unknown</version>
-          <time>1642674796</time>
+          <time>1643641507</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:16 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:07 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_without_maintainer_rights/_meta?user=Iggy
@@ -201,7 +201,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="project_without_maintainer_rights">
-          <title>Paths of Glory</title>
+          <title>The Lathe of Heaven</title>
           <description/>
         </project>
     headers:
@@ -223,15 +223,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '124'
+      - '129'
     body:
       encoding: UTF-8
       string: |
         <project name="project_without_maintainer_rights">
-          <title>Paths of Glory</title>
+          <title>The Lathe of Heaven</title>
           <description></description>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:16 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:07 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -265,5 +265,5 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:33:16 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:07 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_a_new_PR_event/behaves_like_successful_new_PR_or_MR_event/1_1_1_3_1_1.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_a_new_PR_event/behaves_like_successful_new_PR_or_MR_event/1_1_1_3_1_1.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:10 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:17 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_330
+    uri: http://backend:5352/source/foo_project/_meta?user=user_19
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>No Highway</title>
+          <title>The World, the Flesh and the Devil</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '142'
+      - '166'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>No Highway</title>
+          <title>The World, the Flesh and the Devil</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:10 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:17 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_331
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_20
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Skull Beneath the Skin</title>
-          <description>Ea nam eum nihil.</description>
+          <title>If I Forget Thee Jerusalem</title>
+          <description>Qui quia veritatis qui.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '153'
+      - '159'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Skull Beneath the Skin</title>
-          <description>Ea nam eum nihil.</description>
+          <title>If I Forget Thee Jerusalem</title>
+          <description>Qui quia veritatis qui.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:10 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:17 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Consectetur nihil saepe. In sint illum. Ut ut voluptatem.
+      string: Autem et repellendus. Quasi officiis iure. Rem dolor iure.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1703" vrev="1703">
-          <srcmd5>1c31e671d3c0a21404ddcf2986278517</srcmd5>
+        <revision rev="35" vrev="35">
+          <srcmd5>4d87db11b380c334587d8c4cedab83a4</srcmd5>
           <version>unknown</version>
-          <time>1642674790</time>
+          <time>1643641517</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:10 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:17 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Non maxime est. Est asperiores autem. Voluptatum maiores iusto.
+      string: Cumque eos sapiente. Voluptatem aspernatur ab. Suscipit et reprehenderit.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +181,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1704" vrev="1704">
-          <srcmd5>9dc54462c3e3b8ed7f05a7f02f14249d</srcmd5>
+        <revision rev="36" vrev="36">
+          <srcmd5>d3c60d7e997ea0b8fa1cb425a0091a10</srcmd5>
           <version>unknown</version>
-          <time>1642674790</time>
+          <time>1643641517</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:10 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:18 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -227,7 +227,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:33:11 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:18 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -267,7 +267,7 @@ http_interactions:
           <description>This project was created for package bar_package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:11 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:18 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -275,8 +275,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Skull Beneath the Skin</title>
-          <description>Ea nam eum nihil.</description>
+          <title>If I Forget Thee Jerusalem</title>
+          <description>Qui quia veritatis qui.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -297,15 +297,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '184'
+      - '190'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Skull Beneath the Skin</title>
-          <description>Ea nam eum nihil.</description>
+          <title>If I Forget Thee Jerusalem</title>
+          <description>Qui quia veritatis qui.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:11 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:18 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=branch&noservice=1&opackage=bar_package&oproject=foo_project&user=Iggy
@@ -333,19 +333,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="574" vrev="574">
-          <srcmd5>290e57c5e80fe486976251ae76abde3f</srcmd5>
+        <revision rev="13" vrev="13">
+          <srcmd5>fa68b927f680a4989e8cb6d857e88ffe</srcmd5>
           <version>unknown</version>
-          <time>1642674791</time>
+          <time>1643641518</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:11 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:18 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -353,8 +353,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Skull Beneath the Skin</title>
-          <description>Ea nam eum nihil.</description>
+          <title>If I Forget Thee Jerusalem</title>
+          <description>Qui quia veritatis qui.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -375,15 +375,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '184'
+      - '190'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Skull Beneath the Skin</title>
-          <description>Ea nam eum nihil.</description>
+          <title>If I Forget Thee Jerusalem</title>
+          <description>Qui quia veritatis qui.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:11 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:18 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -409,18 +409,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '725'
+      - '620'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="574" vrev="574" srcmd5="290e57c5e80fe486976251ae76abde3f">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="9dc54462c3e3b8ed7f05a7f02f14249d" baserev="9dc54462c3e3b8ed7f05a7f02f14249d" xsrcmd5="b6830e2b166e4f123d5576316d17831b" lsrcmd5="290e57c5e80fe486976251ae76abde3f"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="5e1f67920c1c8246e33ba0ffe5ed569b" size="57" mtime="1642674790"/>
-          <entry name="_link" md5="306673db0c90b4d28b0f1e2ac9414fe9" size="119" mtime="1642674791"/>
-          <entry name="somefile.txt" md5="3aa9ec6ddcc32da37847e711842dd259" size="63" mtime="1642674790"/>
+        <directory name="bar_package" rev="13" vrev="13" srcmd5="fa68b927f680a4989e8cb6d857e88ffe">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="d3c60d7e997ea0b8fa1cb425a0091a10" baserev="d3c60d7e997ea0b8fa1cb425a0091a10" xsrcmd5="429f627c6c614170b5b20902ce2c5e06" lsrcmd5="fa68b927f680a4989e8cb6d857e88ffe"/>
+          <entry name="_config" md5="d1f39e9c23f8f8f9943146d792305937" size="58" mtime="1643641517"/>
+          <entry name="_link" md5="0b8bbc60144eb4bf47cd07b5c99dc12a" size="119" mtime="1643641518"/>
+          <entry name="somefile.txt" md5="97e1f8c4ab5f246083384159d0538f39" size="73" mtime="1643641517"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:11 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:18 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?view=info
@@ -446,15 +445,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '333'
+      - '330'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="574" vrev="2278" srcmd5="b6830e2b166e4f123d5576316d17831b" lsrcmd5="290e57c5e80fe486976251ae76abde3f" verifymd5="9dc54462c3e3b8ed7f05a7f02f14249d">
+        <sourceinfo package="bar_package" rev="13" vrev="49" srcmd5="429f627c6c614170b5b20902ce2c5e06" lsrcmd5="fa68b927f680a4989e8cb6d857e88ffe" verifymd5="d3c60d7e997ea0b8fa1cb425a0091a10">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:11 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:18 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -480,18 +479,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '725'
+      - '620'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="574" vrev="574" srcmd5="290e57c5e80fe486976251ae76abde3f">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="9dc54462c3e3b8ed7f05a7f02f14249d" baserev="9dc54462c3e3b8ed7f05a7f02f14249d" xsrcmd5="b6830e2b166e4f123d5576316d17831b" lsrcmd5="290e57c5e80fe486976251ae76abde3f"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="5e1f67920c1c8246e33ba0ffe5ed569b" size="57" mtime="1642674790"/>
-          <entry name="_link" md5="306673db0c90b4d28b0f1e2ac9414fe9" size="119" mtime="1642674791"/>
-          <entry name="somefile.txt" md5="3aa9ec6ddcc32da37847e711842dd259" size="63" mtime="1642674790"/>
+        <directory name="bar_package" rev="13" vrev="13" srcmd5="fa68b927f680a4989e8cb6d857e88ffe">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="d3c60d7e997ea0b8fa1cb425a0091a10" baserev="d3c60d7e997ea0b8fa1cb425a0091a10" xsrcmd5="429f627c6c614170b5b20902ce2c5e06" lsrcmd5="fa68b927f680a4989e8cb6d857e88ffe"/>
+          <entry name="_config" md5="d1f39e9c23f8f8f9943146d792305937" size="58" mtime="1643641517"/>
+          <entry name="_link" md5="0b8bbc60144eb4bf47cd07b5c99dc12a" size="119" mtime="1643641518"/>
+          <entry name="somefile.txt" md5="97e1f8c4ab5f246083384159d0538f39" size="73" mtime="1643641517"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:11 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:18 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -519,18 +517,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '370'
+      - '369'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="b0cbc4218c228e6ad022d5a4838fbc0a">
+        <sourcediff key="31b78f6bad5390a5ecfd9f653332f7ac">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="574" srcmd5="290e57c5e80fe486976251ae76abde3f"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="13" srcmd5="fa68b927f680a4989e8cb6d857e88ffe"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:11 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:18 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -562,12 +560,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="fc9971068ae84dda6a1600d26e878ece">
-          <old project="foo_project" package="bar_package" rev="9dc54462c3e3b8ed7f05a7f02f14249d" srcmd5="9dc54462c3e3b8ed7f05a7f02f14249d"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="b6830e2b166e4f123d5576316d17831b" srcmd5="b6830e2b166e4f123d5576316d17831b"/>
+        <sourcediff key="d7b2a0bc3942cc5feddb9d4fd68c1d8e">
+          <old project="foo_project" package="bar_package" rev="d3c60d7e997ea0b8fa1cb425a0091a10" srcmd5="d3c60d7e997ea0b8fa1cb425a0091a10"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="429f627c6c614170b5b20902ce2c5e06" srcmd5="429f627c6c614170b5b20902ce2c5e06"/>
           <files/>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:11 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:18 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -635,7 +633,7 @@ http_interactions:
             <arch>aarch64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:11 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:18 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_branch_request?user=Iggy
@@ -661,19 +659,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="575" vrev="575">
-          <srcmd5>1eb4f1b47bcc4ae62b99e5d46e043389</srcmd5>
+        <revision rev="14" vrev="14">
+          <srcmd5>659295b76a24f5316e72e2024c7805d6</srcmd5>
           <version>unknown</version>
-          <time>1642674791</time>
+          <time>1643641518</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:11 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:18 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -681,8 +679,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Skull Beneath the Skin</title>
-          <description>Ea nam eum nihil.</description>
+          <title>If I Forget Thee Jerusalem</title>
+          <description>Qui quia veritatis qui.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -703,15 +701,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '184'
+      - '190'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Skull Beneath the Skin</title>
-          <description>Ea nam eum nihil.</description>
+          <title>If I Forget Thee Jerusalem</title>
+          <description>Qui quia veritatis qui.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:11 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:18 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -737,19 +735,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '722'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="575" vrev="575" srcmd5="1eb4f1b47bcc4ae62b99e5d46e043389">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="9dc54462c3e3b8ed7f05a7f02f14249d" baserev="9dc54462c3e3b8ed7f05a7f02f14249d" xsrcmd5="a532404dfe47ea945266eed7f0cfbf1a" lsrcmd5="1eb4f1b47bcc4ae62b99e5d46e043389"/>
-          <serviceinfo code="succeeded" xsrcmd5="20d8df10369bd5fe435067efecf68ea7"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="5e1f67920c1c8246e33ba0ffe5ed569b" size="57" mtime="1642674790"/>
-          <entry name="_link" md5="306673db0c90b4d28b0f1e2ac9414fe9" size="119" mtime="1642674791"/>
-          <entry name="somefile.txt" md5="3aa9ec6ddcc32da37847e711842dd259" size="63" mtime="1642674790"/>
+        <directory name="bar_package" rev="14" vrev="14" srcmd5="659295b76a24f5316e72e2024c7805d6">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="d3c60d7e997ea0b8fa1cb425a0091a10" baserev="d3c60d7e997ea0b8fa1cb425a0091a10" xsrcmd5="7e14cfbc73d16b1ca1b26684e052aa35" lsrcmd5="659295b76a24f5316e72e2024c7805d6"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="d1f39e9c23f8f8f9943146d792305937" size="58" mtime="1643641517"/>
+          <entry name="_link" md5="0b8bbc60144eb4bf47cd07b5c99dc12a" size="119" mtime="1643641518"/>
+          <entry name="somefile.txt" md5="97e1f8c4ab5f246083384159d0538f39" size="73" mtime="1643641517"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:11 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:18 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?view=info
@@ -775,15 +772,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '333'
+      - '330'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="575" vrev="2279" srcmd5="ec0ecec8eabe1b92d31f8f3731cf8061" lsrcmd5="20d8df10369bd5fe435067efecf68ea7" verifymd5="b473898128a554e51f2dcbdf180afd24">
+        <sourceinfo package="bar_package" rev="14" vrev="50" srcmd5="7e14cfbc73d16b1ca1b26684e052aa35" lsrcmd5="659295b76a24f5316e72e2024c7805d6" verifymd5="0e3180c9a574a517e1e02ef5be57a1b6">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:11 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:18 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -809,19 +806,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '722'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="575" vrev="575" srcmd5="1eb4f1b47bcc4ae62b99e5d46e043389">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="9dc54462c3e3b8ed7f05a7f02f14249d" baserev="9dc54462c3e3b8ed7f05a7f02f14249d" xsrcmd5="a532404dfe47ea945266eed7f0cfbf1a" lsrcmd5="1eb4f1b47bcc4ae62b99e5d46e043389"/>
-          <serviceinfo code="succeeded" xsrcmd5="20d8df10369bd5fe435067efecf68ea7"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="5e1f67920c1c8246e33ba0ffe5ed569b" size="57" mtime="1642674790"/>
-          <entry name="_link" md5="306673db0c90b4d28b0f1e2ac9414fe9" size="119" mtime="1642674791"/>
-          <entry name="somefile.txt" md5="3aa9ec6ddcc32da37847e711842dd259" size="63" mtime="1642674790"/>
+        <directory name="bar_package" rev="14" vrev="14" srcmd5="659295b76a24f5316e72e2024c7805d6">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="d3c60d7e997ea0b8fa1cb425a0091a10" baserev="d3c60d7e997ea0b8fa1cb425a0091a10" xsrcmd5="7e14cfbc73d16b1ca1b26684e052aa35" lsrcmd5="659295b76a24f5316e72e2024c7805d6"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="d1f39e9c23f8f8f9943146d792305937" size="58" mtime="1643641517"/>
+          <entry name="_link" md5="0b8bbc60144eb4bf47cd07b5c99dc12a" size="119" mtime="1643641518"/>
+          <entry name="somefile.txt" md5="97e1f8c4ab5f246083384159d0538f39" size="73" mtime="1643641517"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:11 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:18 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -849,18 +845,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '370'
+      - '369'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="fcb6e368de44b15b6c6845c72d59518c">
+        <sourcediff key="3fd217171537d18b72bf2c2048a23b74">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="575" srcmd5="1eb4f1b47bcc4ae62b99e5d46e043389"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="14" srcmd5="659295b76a24f5316e72e2024c7805d6"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:11 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:18 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -892,14 +888,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="2a856e1127d73e569e8ce0fc499ccd44">
-          <old project="foo_project" package="bar_package" rev="9dc54462c3e3b8ed7f05a7f02f14249d" srcmd5="9dc54462c3e3b8ed7f05a7f02f14249d"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="ec0ecec8eabe1b92d31f8f3731cf8061" srcmd5="ec0ecec8eabe1b92d31f8f3731cf8061"/>
+        <sourcediff key="083d909d9675a7c76a6917e5d59ae65b">
+          <old project="foo_project" package="bar_package" rev="d3c60d7e997ea0b8fa1cb425a0091a10" srcmd5="d3c60d7e997ea0b8fa1cb425a0091a10"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="7e14cfbc73d16b1ca1b26684e052aa35" srcmd5="7e14cfbc73d16b1ca1b26684e052aa35"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:11 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:18 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -925,19 +921,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '722'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="575" vrev="575" srcmd5="1eb4f1b47bcc4ae62b99e5d46e043389">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="9dc54462c3e3b8ed7f05a7f02f14249d" baserev="9dc54462c3e3b8ed7f05a7f02f14249d" xsrcmd5="a532404dfe47ea945266eed7f0cfbf1a" lsrcmd5="1eb4f1b47bcc4ae62b99e5d46e043389"/>
-          <serviceinfo code="succeeded" xsrcmd5="20d8df10369bd5fe435067efecf68ea7"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="5e1f67920c1c8246e33ba0ffe5ed569b" size="57" mtime="1642674790"/>
-          <entry name="_link" md5="306673db0c90b4d28b0f1e2ac9414fe9" size="119" mtime="1642674791"/>
-          <entry name="somefile.txt" md5="3aa9ec6ddcc32da37847e711842dd259" size="63" mtime="1642674790"/>
+        <directory name="bar_package" rev="14" vrev="14" srcmd5="659295b76a24f5316e72e2024c7805d6">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="d3c60d7e997ea0b8fa1cb425a0091a10" baserev="d3c60d7e997ea0b8fa1cb425a0091a10" xsrcmd5="7e14cfbc73d16b1ca1b26684e052aa35" lsrcmd5="659295b76a24f5316e72e2024c7805d6"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="d1f39e9c23f8f8f9943146d792305937" size="58" mtime="1643641517"/>
+          <entry name="_link" md5="0b8bbc60144eb4bf47cd07b5c99dc12a" size="119" mtime="1643641518"/>
+          <entry name="somefile.txt" md5="97e1f8c4ab5f246083384159d0538f39" size="73" mtime="1643641517"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:11 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:18 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '616'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="7e14cfbc73d16b1ca1b26684e052aa35" vrev="50" srcmd5="7e14cfbc73d16b1ca1b26684e052aa35">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="d3c60d7e997ea0b8fa1cb425a0091a10" baserev="d3c60d7e997ea0b8fa1cb425a0091a10" lsrcmd5="659295b76a24f5316e72e2024c7805d6"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="d1f39e9c23f8f8f9943146d792305937" size="58" mtime="1643641517"/>
+          <entry name="somefile.txt" md5="97e1f8c4ab5f246083384159d0538f39" size="73" mtime="1643641517"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:05:18 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -963,19 +994,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '722'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="575" vrev="575" srcmd5="1eb4f1b47bcc4ae62b99e5d46e043389">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="9dc54462c3e3b8ed7f05a7f02f14249d" baserev="9dc54462c3e3b8ed7f05a7f02f14249d" xsrcmd5="a532404dfe47ea945266eed7f0cfbf1a" lsrcmd5="1eb4f1b47bcc4ae62b99e5d46e043389"/>
-          <serviceinfo code="succeeded" xsrcmd5="20d8df10369bd5fe435067efecf68ea7"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="5e1f67920c1c8246e33ba0ffe5ed569b" size="57" mtime="1642674790"/>
-          <entry name="_link" md5="306673db0c90b4d28b0f1e2ac9414fe9" size="119" mtime="1642674791"/>
-          <entry name="somefile.txt" md5="3aa9ec6ddcc32da37847e711842dd259" size="63" mtime="1642674790"/>
+        <directory name="bar_package" rev="14" vrev="14" srcmd5="659295b76a24f5316e72e2024c7805d6">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="d3c60d7e997ea0b8fa1cb425a0091a10" baserev="d3c60d7e997ea0b8fa1cb425a0091a10" xsrcmd5="7e14cfbc73d16b1ca1b26684e052aa35" lsrcmd5="659295b76a24f5316e72e2024c7805d6"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="d1f39e9c23f8f8f9943146d792305937" size="58" mtime="1643641517"/>
+          <entry name="_link" md5="0b8bbc60144eb4bf47cd07b5c99dc12a" size="119" mtime="1643641518"/>
+          <entry name="somefile.txt" md5="97e1f8c4ab5f246083384159d0538f39" size="73" mtime="1643641517"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:11 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:19 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '616'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="7e14cfbc73d16b1ca1b26684e052aa35" vrev="50" srcmd5="7e14cfbc73d16b1ca1b26684e052aa35">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="d3c60d7e997ea0b8fa1cb425a0091a10" baserev="d3c60d7e997ea0b8fa1cb425a0091a10" lsrcmd5="659295b76a24f5316e72e2024c7805d6"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="d1f39e9c23f8f8f9943146d792305937" size="58" mtime="1643641517"/>
+          <entry name="somefile.txt" md5="97e1f8c4ab5f246083384159d0538f39" size="73" mtime="1643641517"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:05:19 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -1001,19 +1067,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '722'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="575" vrev="575" srcmd5="1eb4f1b47bcc4ae62b99e5d46e043389">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="9dc54462c3e3b8ed7f05a7f02f14249d" baserev="9dc54462c3e3b8ed7f05a7f02f14249d" xsrcmd5="a532404dfe47ea945266eed7f0cfbf1a" lsrcmd5="1eb4f1b47bcc4ae62b99e5d46e043389"/>
-          <serviceinfo code="succeeded" xsrcmd5="20d8df10369bd5fe435067efecf68ea7"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="5e1f67920c1c8246e33ba0ffe5ed569b" size="57" mtime="1642674790"/>
-          <entry name="_link" md5="306673db0c90b4d28b0f1e2ac9414fe9" size="119" mtime="1642674791"/>
-          <entry name="somefile.txt" md5="3aa9ec6ddcc32da37847e711842dd259" size="63" mtime="1642674790"/>
+        <directory name="bar_package" rev="14" vrev="14" srcmd5="659295b76a24f5316e72e2024c7805d6">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="d3c60d7e997ea0b8fa1cb425a0091a10" baserev="d3c60d7e997ea0b8fa1cb425a0091a10" xsrcmd5="7e14cfbc73d16b1ca1b26684e052aa35" lsrcmd5="659295b76a24f5316e72e2024c7805d6"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="d1f39e9c23f8f8f9943146d792305937" size="58" mtime="1643641517"/>
+          <entry name="_link" md5="0b8bbc60144eb4bf47cd07b5c99dc12a" size="119" mtime="1643641518"/>
+          <entry name="somefile.txt" md5="97e1f8c4ab5f246083384159d0538f39" size="73" mtime="1643641517"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:11 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:19 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '616'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="7e14cfbc73d16b1ca1b26684e052aa35" vrev="50" srcmd5="7e14cfbc73d16b1ca1b26684e052aa35">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="d3c60d7e997ea0b8fa1cb425a0091a10" baserev="d3c60d7e997ea0b8fa1cb425a0091a10" lsrcmd5="659295b76a24f5316e72e2024c7805d6"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="d1f39e9c23f8f8f9943146d792305937" size="58" mtime="1643641517"/>
+          <entry name="somefile.txt" md5="97e1f8c4ab5f246083384159d0538f39" size="73" mtime="1643641517"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:05:19 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -1039,19 +1140,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '722'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="575" vrev="575" srcmd5="1eb4f1b47bcc4ae62b99e5d46e043389">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="9dc54462c3e3b8ed7f05a7f02f14249d" baserev="9dc54462c3e3b8ed7f05a7f02f14249d" xsrcmd5="a532404dfe47ea945266eed7f0cfbf1a" lsrcmd5="1eb4f1b47bcc4ae62b99e5d46e043389"/>
-          <serviceinfo code="succeeded" xsrcmd5="20d8df10369bd5fe435067efecf68ea7"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="5e1f67920c1c8246e33ba0ffe5ed569b" size="57" mtime="1642674790"/>
-          <entry name="_link" md5="306673db0c90b4d28b0f1e2ac9414fe9" size="119" mtime="1642674791"/>
-          <entry name="somefile.txt" md5="3aa9ec6ddcc32da37847e711842dd259" size="63" mtime="1642674790"/>
+        <directory name="bar_package" rev="14" vrev="14" srcmd5="659295b76a24f5316e72e2024c7805d6">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="d3c60d7e997ea0b8fa1cb425a0091a10" baserev="d3c60d7e997ea0b8fa1cb425a0091a10" xsrcmd5="7e14cfbc73d16b1ca1b26684e052aa35" lsrcmd5="659295b76a24f5316e72e2024c7805d6"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="d1f39e9c23f8f8f9943146d792305937" size="58" mtime="1643641517"/>
+          <entry name="_link" md5="0b8bbc60144eb4bf47cd07b5c99dc12a" size="119" mtime="1643641518"/>
+          <entry name="somefile.txt" md5="97e1f8c4ab5f246083384159d0538f39" size="73" mtime="1643641517"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:11 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:19 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '616'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="7e14cfbc73d16b1ca1b26684e052aa35" vrev="50" srcmd5="7e14cfbc73d16b1ca1b26684e052aa35">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="d3c60d7e997ea0b8fa1cb425a0091a10" baserev="d3c60d7e997ea0b8fa1cb425a0091a10" lsrcmd5="659295b76a24f5316e72e2024c7805d6"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="d1f39e9c23f8f8f9943146d792305937" size="58" mtime="1643641517"/>
+          <entry name="somefile.txt" md5="97e1f8c4ab5f246083384159d0538f39" size="73" mtime="1643641517"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:05:19 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -1077,22 +1213,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '722'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="575" vrev="575" srcmd5="1eb4f1b47bcc4ae62b99e5d46e043389">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="9dc54462c3e3b8ed7f05a7f02f14249d" baserev="9dc54462c3e3b8ed7f05a7f02f14249d" xsrcmd5="a532404dfe47ea945266eed7f0cfbf1a" lsrcmd5="1eb4f1b47bcc4ae62b99e5d46e043389"/>
-          <serviceinfo code="succeeded" xsrcmd5="20d8df10369bd5fe435067efecf68ea7"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="5e1f67920c1c8246e33ba0ffe5ed569b" size="57" mtime="1642674790"/>
-          <entry name="_link" md5="306673db0c90b4d28b0f1e2ac9414fe9" size="119" mtime="1642674791"/>
-          <entry name="somefile.txt" md5="3aa9ec6ddcc32da37847e711842dd259" size="63" mtime="1642674790"/>
+        <directory name="bar_package" rev="14" vrev="14" srcmd5="659295b76a24f5316e72e2024c7805d6">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="d3c60d7e997ea0b8fa1cb425a0091a10" baserev="d3c60d7e997ea0b8fa1cb425a0091a10" xsrcmd5="7e14cfbc73d16b1ca1b26684e052aa35" lsrcmd5="659295b76a24f5316e72e2024c7805d6"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="d1f39e9c23f8f8f9943146d792305937" size="58" mtime="1643641517"/>
+          <entry name="_link" md5="0b8bbc60144eb4bf47cd07b5c99dc12a" size="119" mtime="1643641518"/>
+          <entry name="somefile.txt" md5="97e1f8c4ab5f246083384159d0538f39" size="73" mtime="1643641517"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:11 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:19 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1115,169 +1250,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '616'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="575" vrev="575" srcmd5="1eb4f1b47bcc4ae62b99e5d46e043389">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="9dc54462c3e3b8ed7f05a7f02f14249d" baserev="9dc54462c3e3b8ed7f05a7f02f14249d" xsrcmd5="a532404dfe47ea945266eed7f0cfbf1a" lsrcmd5="1eb4f1b47bcc4ae62b99e5d46e043389"/>
-          <serviceinfo code="succeeded" xsrcmd5="20d8df10369bd5fe435067efecf68ea7"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="5e1f67920c1c8246e33ba0ffe5ed569b" size="57" mtime="1642674790"/>
-          <entry name="_link" md5="306673db0c90b4d28b0f1e2ac9414fe9" size="119" mtime="1642674791"/>
-          <entry name="somefile.txt" md5="3aa9ec6ddcc32da37847e711842dd259" size="63" mtime="1642674790"/>
+        <directory name="bar_package" rev="7e14cfbc73d16b1ca1b26684e052aa35" vrev="50" srcmd5="7e14cfbc73d16b1ca1b26684e052aa35">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="d3c60d7e997ea0b8fa1cb425a0091a10" baserev="d3c60d7e997ea0b8fa1cb425a0091a10" lsrcmd5="659295b76a24f5316e72e2024c7805d6"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="d1f39e9c23f8f8f9943146d792305937" size="58" mtime="1643641517"/>
+          <entry name="somefile.txt" md5="97e1f8c4ab5f246083384159d0538f39" size="73" mtime="1643641517"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:11 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '801'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="575" vrev="575" srcmd5="1eb4f1b47bcc4ae62b99e5d46e043389">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="9dc54462c3e3b8ed7f05a7f02f14249d" baserev="9dc54462c3e3b8ed7f05a7f02f14249d" xsrcmd5="a532404dfe47ea945266eed7f0cfbf1a" lsrcmd5="1eb4f1b47bcc4ae62b99e5d46e043389"/>
-          <serviceinfo code="succeeded" xsrcmd5="20d8df10369bd5fe435067efecf68ea7"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="5e1f67920c1c8246e33ba0ffe5ed569b" size="57" mtime="1642674790"/>
-          <entry name="_link" md5="306673db0c90b4d28b0f1e2ac9414fe9" size="119" mtime="1642674791"/>
-          <entry name="somefile.txt" md5="3aa9ec6ddcc32da37847e711842dd259" size="63" mtime="1642674790"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:11 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '801'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="575" vrev="575" srcmd5="1eb4f1b47bcc4ae62b99e5d46e043389">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="9dc54462c3e3b8ed7f05a7f02f14249d" baserev="9dc54462c3e3b8ed7f05a7f02f14249d" xsrcmd5="a532404dfe47ea945266eed7f0cfbf1a" lsrcmd5="1eb4f1b47bcc4ae62b99e5d46e043389"/>
-          <serviceinfo code="succeeded" xsrcmd5="20d8df10369bd5fe435067efecf68ea7"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="5e1f67920c1c8246e33ba0ffe5ed569b" size="57" mtime="1642674790"/>
-          <entry name="_link" md5="306673db0c90b4d28b0f1e2ac9414fe9" size="119" mtime="1642674791"/>
-          <entry name="somefile.txt" md5="3aa9ec6ddcc32da37847e711842dd259" size="63" mtime="1642674790"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:11 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '801'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="575" vrev="575" srcmd5="1eb4f1b47bcc4ae62b99e5d46e043389">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="9dc54462c3e3b8ed7f05a7f02f14249d" baserev="9dc54462c3e3b8ed7f05a7f02f14249d" xsrcmd5="a532404dfe47ea945266eed7f0cfbf1a" lsrcmd5="1eb4f1b47bcc4ae62b99e5d46e043389"/>
-          <serviceinfo code="succeeded" xsrcmd5="20d8df10369bd5fe435067efecf68ea7"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="5e1f67920c1c8246e33ba0ffe5ed569b" size="57" mtime="1642674790"/>
-          <entry name="_link" md5="306673db0c90b4d28b0f1e2ac9414fe9" size="119" mtime="1642674791"/>
-          <entry name="somefile.txt" md5="3aa9ec6ddcc32da37847e711842dd259" size="63" mtime="1642674790"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:11 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '801'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="575" vrev="575" srcmd5="1eb4f1b47bcc4ae62b99e5d46e043389">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="9dc54462c3e3b8ed7f05a7f02f14249d" baserev="9dc54462c3e3b8ed7f05a7f02f14249d" xsrcmd5="a532404dfe47ea945266eed7f0cfbf1a" lsrcmd5="1eb4f1b47bcc4ae62b99e5d46e043389"/>
-          <serviceinfo code="succeeded" xsrcmd5="20d8df10369bd5fe435067efecf68ea7"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="5e1f67920c1c8246e33ba0ffe5ed569b" size="57" mtime="1642674790"/>
-          <entry name="_link" md5="306673db0c90b4d28b0f1e2ac9414fe9" size="119" mtime="1642674791"/>
-          <entry name="somefile.txt" md5="3aa9ec6ddcc32da37847e711842dd259" size="63" mtime="1642674790"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:11 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:19 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_a_new_PR_event/behaves_like_successful_new_PR_or_MR_event/1_1_1_3_1_2.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_a_new_PR_event/behaves_like_successful_new_PR_or_MR_event/1_1_1_3_1_2.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:13 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:14 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_334
+    uri: http://backend:5352/source/foo_project/_meta?user=user_15
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>In a Glass Darkly</title>
+          <title>The Way of All Flesh</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '149'
+      - '152'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>In a Glass Darkly</title>
+          <title>The Way of All Flesh</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:13 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:14 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_335
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_16
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Jacob Have I Loved</title>
-          <description>Veniam dignissimos suscipit tempore.</description>
+          <title>The Millstone</title>
+          <description>Quasi sit ut facilis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '164'
+      - '144'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Jacob Have I Loved</title>
-          <description>Veniam dignissimos suscipit tempore.</description>
+          <title>The Millstone</title>
+          <description>Quasi sit ut facilis.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:13 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:14 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Quibusdam a sint. Atque excepturi provident. Ratione et corporis.
+      string: Quas a enim. Quia ut voluptatem. Fuga fugit explicabo.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1707" vrev="1707">
-          <srcmd5>05bb8f8ccf33c4e0fb0806aa6d888459</srcmd5>
+        <revision rev="31" vrev="31">
+          <srcmd5>0c6a159be53d33cf0ff99a1b933a73ac</srcmd5>
           <version>unknown</version>
-          <time>1642674793</time>
+          <time>1643641514</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:13 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:14 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Eum exercitationem rem. Tenetur neque quod. Voluptatum et nisi.
+      string: Quia quibusdam nulla. Recusandae voluptates in. Ratione corporis est.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +181,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1708" vrev="1708">
-          <srcmd5>784549c730376263b54c3d8d0693c2c7</srcmd5>
+        <revision rev="32" vrev="32">
+          <srcmd5>38a28c3d6956b1887b80f3614c2a7f06</srcmd5>
           <version>unknown</version>
-          <time>1642674793</time>
+          <time>1643641514</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:13 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:14 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -227,7 +227,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:33:13 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:14 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -267,7 +267,7 @@ http_interactions:
           <description>This project was created for package bar_package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:13 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:14 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -275,8 +275,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Jacob Have I Loved</title>
-          <description>Veniam dignissimos suscipit tempore.</description>
+          <title>The Millstone</title>
+          <description>Quasi sit ut facilis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -297,15 +297,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '195'
+      - '175'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Jacob Have I Loved</title>
-          <description>Veniam dignissimos suscipit tempore.</description>
+          <title>The Millstone</title>
+          <description>Quasi sit ut facilis.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:13 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:14 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=branch&noservice=1&opackage=bar_package&oproject=foo_project&user=Iggy
@@ -333,19 +333,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '204'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="578" vrev="578">
-          <srcmd5>73b977cc59ebdd6969e1e12c5275f5b0</srcmd5>
+        <revision rev="9" vrev="9">
+          <srcmd5>4588f93a3cfed1a2868244d63025f0f0</srcmd5>
           <version>unknown</version>
-          <time>1642674793</time>
+          <time>1643641514</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:13 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:14 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -353,8 +353,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Jacob Have I Loved</title>
-          <description>Veniam dignissimos suscipit tempore.</description>
+          <title>The Millstone</title>
+          <description>Quasi sit ut facilis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -375,15 +375,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '195'
+      - '175'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Jacob Have I Loved</title>
-          <description>Veniam dignissimos suscipit tempore.</description>
+          <title>The Millstone</title>
+          <description>Quasi sit ut facilis.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:13 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:14 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -409,18 +409,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '725'
+      - '618'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="578" vrev="578" srcmd5="73b977cc59ebdd6969e1e12c5275f5b0">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="784549c730376263b54c3d8d0693c2c7" baserev="784549c730376263b54c3d8d0693c2c7" xsrcmd5="95faccebd363873f96c695ae62e38bbc" lsrcmd5="73b977cc59ebdd6969e1e12c5275f5b0"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="e2ade92f99cd551b9931a41f8363b626" size="65" mtime="1642674793"/>
-          <entry name="_link" md5="3bdea221bda1b90ffed2a983437264d6" size="119" mtime="1642674793"/>
-          <entry name="somefile.txt" md5="d27db4ad1c93debe436e6f13e47fa808" size="63" mtime="1642674793"/>
+        <directory name="bar_package" rev="9" vrev="9" srcmd5="4588f93a3cfed1a2868244d63025f0f0">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="38a28c3d6956b1887b80f3614c2a7f06" baserev="38a28c3d6956b1887b80f3614c2a7f06" xsrcmd5="6ce1450cae9b3bbabd84fe499acb55e6" lsrcmd5="4588f93a3cfed1a2868244d63025f0f0"/>
+          <entry name="_config" md5="dc2d49f8159f6492db69b6124d24deeb" size="54" mtime="1643641514"/>
+          <entry name="_link" md5="b77ebfa8dd91ea46e877cadcab688051" size="119" mtime="1643641514"/>
+          <entry name="somefile.txt" md5="3047249b78d9d456f856c41bb6d9c4eb" size="69" mtime="1643641514"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:13 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:14 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?view=info
@@ -446,15 +445,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '333'
+      - '329'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="578" vrev="2286" srcmd5="95faccebd363873f96c695ae62e38bbc" lsrcmd5="73b977cc59ebdd6969e1e12c5275f5b0" verifymd5="784549c730376263b54c3d8d0693c2c7">
+        <sourceinfo package="bar_package" rev="9" vrev="41" srcmd5="6ce1450cae9b3bbabd84fe499acb55e6" lsrcmd5="4588f93a3cfed1a2868244d63025f0f0" verifymd5="38a28c3d6956b1887b80f3614c2a7f06">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:13 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:14 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -480,18 +479,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '725'
+      - '618'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="578" vrev="578" srcmd5="73b977cc59ebdd6969e1e12c5275f5b0">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="784549c730376263b54c3d8d0693c2c7" baserev="784549c730376263b54c3d8d0693c2c7" xsrcmd5="95faccebd363873f96c695ae62e38bbc" lsrcmd5="73b977cc59ebdd6969e1e12c5275f5b0"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="e2ade92f99cd551b9931a41f8363b626" size="65" mtime="1642674793"/>
-          <entry name="_link" md5="3bdea221bda1b90ffed2a983437264d6" size="119" mtime="1642674793"/>
-          <entry name="somefile.txt" md5="d27db4ad1c93debe436e6f13e47fa808" size="63" mtime="1642674793"/>
+        <directory name="bar_package" rev="9" vrev="9" srcmd5="4588f93a3cfed1a2868244d63025f0f0">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="38a28c3d6956b1887b80f3614c2a7f06" baserev="38a28c3d6956b1887b80f3614c2a7f06" xsrcmd5="6ce1450cae9b3bbabd84fe499acb55e6" lsrcmd5="4588f93a3cfed1a2868244d63025f0f0"/>
+          <entry name="_config" md5="dc2d49f8159f6492db69b6124d24deeb" size="54" mtime="1643641514"/>
+          <entry name="_link" md5="b77ebfa8dd91ea46e877cadcab688051" size="119" mtime="1643641514"/>
+          <entry name="somefile.txt" md5="3047249b78d9d456f856c41bb6d9c4eb" size="69" mtime="1643641514"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:13 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:14 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -519,18 +517,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '370'
+      - '368'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="70a6d795559c21bad9e4f85b94f24187">
+        <sourcediff key="f3726e9036e766bae7d74c4603dd940e">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="578" srcmd5="73b977cc59ebdd6969e1e12c5275f5b0"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="9" srcmd5="4588f93a3cfed1a2868244d63025f0f0"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:13 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:15 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -562,12 +560,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="9edbd5cb248b8e69e4a830d57ca847a7">
-          <old project="foo_project" package="bar_package" rev="784549c730376263b54c3d8d0693c2c7" srcmd5="784549c730376263b54c3d8d0693c2c7"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="95faccebd363873f96c695ae62e38bbc" srcmd5="95faccebd363873f96c695ae62e38bbc"/>
+        <sourcediff key="ac6d403560ecb5af578721c4dc6ae5d1">
+          <old project="foo_project" package="bar_package" rev="38a28c3d6956b1887b80f3614c2a7f06" srcmd5="38a28c3d6956b1887b80f3614c2a7f06"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="6ce1450cae9b3bbabd84fe499acb55e6" srcmd5="6ce1450cae9b3bbabd84fe499acb55e6"/>
           <files/>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:13 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:15 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -635,7 +633,7 @@ http_interactions:
             <arch>aarch64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:14 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:15 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_branch_request?user=Iggy
@@ -661,19 +659,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="579" vrev="579">
-          <srcmd5>a9c20ed59907ba980e8531c9184e8595</srcmd5>
+        <revision rev="10" vrev="10">
+          <srcmd5>2183f70a146577dea58ab021a8959677</srcmd5>
           <version>unknown</version>
-          <time>1642674794</time>
+          <time>1643641515</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:14 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:15 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -681,8 +679,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Jacob Have I Loved</title>
-          <description>Veniam dignissimos suscipit tempore.</description>
+          <title>The Millstone</title>
+          <description>Quasi sit ut facilis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -703,15 +701,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '195'
+      - '175'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Jacob Have I Loved</title>
-          <description>Veniam dignissimos suscipit tempore.</description>
+          <title>The Millstone</title>
+          <description>Quasi sit ut facilis.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:14 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:15 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -737,19 +735,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '722'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="579" vrev="579" srcmd5="a9c20ed59907ba980e8531c9184e8595">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="784549c730376263b54c3d8d0693c2c7" baserev="784549c730376263b54c3d8d0693c2c7" xsrcmd5="39bb634107614e1573257014602bb618" lsrcmd5="a9c20ed59907ba980e8531c9184e8595"/>
-          <serviceinfo code="succeeded" xsrcmd5="9dbf4f0e5f8058b850c904e9c0091e52"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="e2ade92f99cd551b9931a41f8363b626" size="65" mtime="1642674793"/>
-          <entry name="_link" md5="3bdea221bda1b90ffed2a983437264d6" size="119" mtime="1642674793"/>
-          <entry name="somefile.txt" md5="d27db4ad1c93debe436e6f13e47fa808" size="63" mtime="1642674793"/>
+        <directory name="bar_package" rev="10" vrev="10" srcmd5="2183f70a146577dea58ab021a8959677">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="38a28c3d6956b1887b80f3614c2a7f06" baserev="38a28c3d6956b1887b80f3614c2a7f06" xsrcmd5="c48bb0791f2a6f585d5267ba388e5c5a" lsrcmd5="2183f70a146577dea58ab021a8959677"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="dc2d49f8159f6492db69b6124d24deeb" size="54" mtime="1643641514"/>
+          <entry name="_link" md5="b77ebfa8dd91ea46e877cadcab688051" size="119" mtime="1643641514"/>
+          <entry name="somefile.txt" md5="3047249b78d9d456f856c41bb6d9c4eb" size="69" mtime="1643641514"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:14 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:15 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?view=info
@@ -775,15 +772,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '333'
+      - '330'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="579" vrev="2287" srcmd5="debd04a81015b22c3e3839575c2d9f15" lsrcmd5="9dbf4f0e5f8058b850c904e9c0091e52" verifymd5="b69c35be19606261ec49ee7f0de703f8">
+        <sourceinfo package="bar_package" rev="10" vrev="42" srcmd5="c48bb0791f2a6f585d5267ba388e5c5a" lsrcmd5="2183f70a146577dea58ab021a8959677" verifymd5="ddb69c2b1953c15b7e520867e284df3d">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:14 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:15 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -809,19 +806,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '722'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="579" vrev="579" srcmd5="a9c20ed59907ba980e8531c9184e8595">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="784549c730376263b54c3d8d0693c2c7" baserev="784549c730376263b54c3d8d0693c2c7" xsrcmd5="39bb634107614e1573257014602bb618" lsrcmd5="a9c20ed59907ba980e8531c9184e8595"/>
-          <serviceinfo code="succeeded" xsrcmd5="9dbf4f0e5f8058b850c904e9c0091e52"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="e2ade92f99cd551b9931a41f8363b626" size="65" mtime="1642674793"/>
-          <entry name="_link" md5="3bdea221bda1b90ffed2a983437264d6" size="119" mtime="1642674793"/>
-          <entry name="somefile.txt" md5="d27db4ad1c93debe436e6f13e47fa808" size="63" mtime="1642674793"/>
+        <directory name="bar_package" rev="10" vrev="10" srcmd5="2183f70a146577dea58ab021a8959677">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="38a28c3d6956b1887b80f3614c2a7f06" baserev="38a28c3d6956b1887b80f3614c2a7f06" xsrcmd5="c48bb0791f2a6f585d5267ba388e5c5a" lsrcmd5="2183f70a146577dea58ab021a8959677"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="dc2d49f8159f6492db69b6124d24deeb" size="54" mtime="1643641514"/>
+          <entry name="_link" md5="b77ebfa8dd91ea46e877cadcab688051" size="119" mtime="1643641514"/>
+          <entry name="somefile.txt" md5="3047249b78d9d456f856c41bb6d9c4eb" size="69" mtime="1643641514"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:14 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:15 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -849,18 +845,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '370'
+      - '369'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="cc1ec6e09f7462407239b70aa45d7c8d">
+        <sourcediff key="31637ba543e92a160d8a589dc06a8724">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="579" srcmd5="a9c20ed59907ba980e8531c9184e8595"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="10" srcmd5="2183f70a146577dea58ab021a8959677"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:14 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:15 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -892,14 +888,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="b17c0e0a117572ddf68c2dbbcb132747">
-          <old project="foo_project" package="bar_package" rev="784549c730376263b54c3d8d0693c2c7" srcmd5="784549c730376263b54c3d8d0693c2c7"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="debd04a81015b22c3e3839575c2d9f15" srcmd5="debd04a81015b22c3e3839575c2d9f15"/>
+        <sourcediff key="641a085643ee4c392180f8f714f4a6b3">
+          <old project="foo_project" package="bar_package" rev="38a28c3d6956b1887b80f3614c2a7f06" srcmd5="38a28c3d6956b1887b80f3614c2a7f06"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="c48bb0791f2a6f585d5267ba388e5c5a" srcmd5="c48bb0791f2a6f585d5267ba388e5c5a"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:14 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:15 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -925,19 +921,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '722'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="579" vrev="579" srcmd5="a9c20ed59907ba980e8531c9184e8595">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="784549c730376263b54c3d8d0693c2c7" baserev="784549c730376263b54c3d8d0693c2c7" xsrcmd5="39bb634107614e1573257014602bb618" lsrcmd5="a9c20ed59907ba980e8531c9184e8595"/>
-          <serviceinfo code="succeeded" xsrcmd5="9dbf4f0e5f8058b850c904e9c0091e52"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="e2ade92f99cd551b9931a41f8363b626" size="65" mtime="1642674793"/>
-          <entry name="_link" md5="3bdea221bda1b90ffed2a983437264d6" size="119" mtime="1642674793"/>
-          <entry name="somefile.txt" md5="d27db4ad1c93debe436e6f13e47fa808" size="63" mtime="1642674793"/>
+        <directory name="bar_package" rev="10" vrev="10" srcmd5="2183f70a146577dea58ab021a8959677">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="38a28c3d6956b1887b80f3614c2a7f06" baserev="38a28c3d6956b1887b80f3614c2a7f06" xsrcmd5="c48bb0791f2a6f585d5267ba388e5c5a" lsrcmd5="2183f70a146577dea58ab021a8959677"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="dc2d49f8159f6492db69b6124d24deeb" size="54" mtime="1643641514"/>
+          <entry name="_link" md5="b77ebfa8dd91ea46e877cadcab688051" size="119" mtime="1643641514"/>
+          <entry name="somefile.txt" md5="3047249b78d9d456f856c41bb6d9c4eb" size="69" mtime="1643641514"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:14 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:15 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '616'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="c48bb0791f2a6f585d5267ba388e5c5a" vrev="42" srcmd5="c48bb0791f2a6f585d5267ba388e5c5a">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="38a28c3d6956b1887b80f3614c2a7f06" baserev="38a28c3d6956b1887b80f3614c2a7f06" lsrcmd5="2183f70a146577dea58ab021a8959677"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="dc2d49f8159f6492db69b6124d24deeb" size="54" mtime="1643641514"/>
+          <entry name="somefile.txt" md5="3047249b78d9d456f856c41bb6d9c4eb" size="69" mtime="1643641514"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:05:15 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -963,19 +994,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '722'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="579" vrev="579" srcmd5="a9c20ed59907ba980e8531c9184e8595">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="784549c730376263b54c3d8d0693c2c7" baserev="784549c730376263b54c3d8d0693c2c7" xsrcmd5="39bb634107614e1573257014602bb618" lsrcmd5="a9c20ed59907ba980e8531c9184e8595"/>
-          <serviceinfo code="succeeded" xsrcmd5="9dbf4f0e5f8058b850c904e9c0091e52"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="e2ade92f99cd551b9931a41f8363b626" size="65" mtime="1642674793"/>
-          <entry name="_link" md5="3bdea221bda1b90ffed2a983437264d6" size="119" mtime="1642674793"/>
-          <entry name="somefile.txt" md5="d27db4ad1c93debe436e6f13e47fa808" size="63" mtime="1642674793"/>
+        <directory name="bar_package" rev="10" vrev="10" srcmd5="2183f70a146577dea58ab021a8959677">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="38a28c3d6956b1887b80f3614c2a7f06" baserev="38a28c3d6956b1887b80f3614c2a7f06" xsrcmd5="c48bb0791f2a6f585d5267ba388e5c5a" lsrcmd5="2183f70a146577dea58ab021a8959677"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="dc2d49f8159f6492db69b6124d24deeb" size="54" mtime="1643641514"/>
+          <entry name="_link" md5="b77ebfa8dd91ea46e877cadcab688051" size="119" mtime="1643641514"/>
+          <entry name="somefile.txt" md5="3047249b78d9d456f856c41bb6d9c4eb" size="69" mtime="1643641514"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:14 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:15 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '616'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="c48bb0791f2a6f585d5267ba388e5c5a" vrev="42" srcmd5="c48bb0791f2a6f585d5267ba388e5c5a">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="38a28c3d6956b1887b80f3614c2a7f06" baserev="38a28c3d6956b1887b80f3614c2a7f06" lsrcmd5="2183f70a146577dea58ab021a8959677"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="dc2d49f8159f6492db69b6124d24deeb" size="54" mtime="1643641514"/>
+          <entry name="somefile.txt" md5="3047249b78d9d456f856c41bb6d9c4eb" size="69" mtime="1643641514"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:05:15 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -1001,19 +1067,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '722'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="579" vrev="579" srcmd5="a9c20ed59907ba980e8531c9184e8595">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="784549c730376263b54c3d8d0693c2c7" baserev="784549c730376263b54c3d8d0693c2c7" xsrcmd5="39bb634107614e1573257014602bb618" lsrcmd5="a9c20ed59907ba980e8531c9184e8595"/>
-          <serviceinfo code="succeeded" xsrcmd5="9dbf4f0e5f8058b850c904e9c0091e52"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="e2ade92f99cd551b9931a41f8363b626" size="65" mtime="1642674793"/>
-          <entry name="_link" md5="3bdea221bda1b90ffed2a983437264d6" size="119" mtime="1642674793"/>
-          <entry name="somefile.txt" md5="d27db4ad1c93debe436e6f13e47fa808" size="63" mtime="1642674793"/>
+        <directory name="bar_package" rev="10" vrev="10" srcmd5="2183f70a146577dea58ab021a8959677">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="38a28c3d6956b1887b80f3614c2a7f06" baserev="38a28c3d6956b1887b80f3614c2a7f06" xsrcmd5="c48bb0791f2a6f585d5267ba388e5c5a" lsrcmd5="2183f70a146577dea58ab021a8959677"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="dc2d49f8159f6492db69b6124d24deeb" size="54" mtime="1643641514"/>
+          <entry name="_link" md5="b77ebfa8dd91ea46e877cadcab688051" size="119" mtime="1643641514"/>
+          <entry name="somefile.txt" md5="3047249b78d9d456f856c41bb6d9c4eb" size="69" mtime="1643641514"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:14 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:15 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '616'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="c48bb0791f2a6f585d5267ba388e5c5a" vrev="42" srcmd5="c48bb0791f2a6f585d5267ba388e5c5a">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="38a28c3d6956b1887b80f3614c2a7f06" baserev="38a28c3d6956b1887b80f3614c2a7f06" lsrcmd5="2183f70a146577dea58ab021a8959677"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="dc2d49f8159f6492db69b6124d24deeb" size="54" mtime="1643641514"/>
+          <entry name="somefile.txt" md5="3047249b78d9d456f856c41bb6d9c4eb" size="69" mtime="1643641514"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:05:15 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -1039,19 +1140,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '722'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="579" vrev="579" srcmd5="a9c20ed59907ba980e8531c9184e8595">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="784549c730376263b54c3d8d0693c2c7" baserev="784549c730376263b54c3d8d0693c2c7" xsrcmd5="39bb634107614e1573257014602bb618" lsrcmd5="a9c20ed59907ba980e8531c9184e8595"/>
-          <serviceinfo code="succeeded" xsrcmd5="9dbf4f0e5f8058b850c904e9c0091e52"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="e2ade92f99cd551b9931a41f8363b626" size="65" mtime="1642674793"/>
-          <entry name="_link" md5="3bdea221bda1b90ffed2a983437264d6" size="119" mtime="1642674793"/>
-          <entry name="somefile.txt" md5="d27db4ad1c93debe436e6f13e47fa808" size="63" mtime="1642674793"/>
+        <directory name="bar_package" rev="10" vrev="10" srcmd5="2183f70a146577dea58ab021a8959677">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="38a28c3d6956b1887b80f3614c2a7f06" baserev="38a28c3d6956b1887b80f3614c2a7f06" xsrcmd5="c48bb0791f2a6f585d5267ba388e5c5a" lsrcmd5="2183f70a146577dea58ab021a8959677"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="dc2d49f8159f6492db69b6124d24deeb" size="54" mtime="1643641514"/>
+          <entry name="_link" md5="b77ebfa8dd91ea46e877cadcab688051" size="119" mtime="1643641514"/>
+          <entry name="somefile.txt" md5="3047249b78d9d456f856c41bb6d9c4eb" size="69" mtime="1643641514"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:14 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:15 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '616'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="c48bb0791f2a6f585d5267ba388e5c5a" vrev="42" srcmd5="c48bb0791f2a6f585d5267ba388e5c5a">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="38a28c3d6956b1887b80f3614c2a7f06" baserev="38a28c3d6956b1887b80f3614c2a7f06" lsrcmd5="2183f70a146577dea58ab021a8959677"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="dc2d49f8159f6492db69b6124d24deeb" size="54" mtime="1643641514"/>
+          <entry name="somefile.txt" md5="3047249b78d9d456f856c41bb6d9c4eb" size="69" mtime="1643641514"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:05:15 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -1077,22 +1213,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '722'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="579" vrev="579" srcmd5="a9c20ed59907ba980e8531c9184e8595">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="784549c730376263b54c3d8d0693c2c7" baserev="784549c730376263b54c3d8d0693c2c7" xsrcmd5="39bb634107614e1573257014602bb618" lsrcmd5="a9c20ed59907ba980e8531c9184e8595"/>
-          <serviceinfo code="succeeded" xsrcmd5="9dbf4f0e5f8058b850c904e9c0091e52"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="e2ade92f99cd551b9931a41f8363b626" size="65" mtime="1642674793"/>
-          <entry name="_link" md5="3bdea221bda1b90ffed2a983437264d6" size="119" mtime="1642674793"/>
-          <entry name="somefile.txt" md5="d27db4ad1c93debe436e6f13e47fa808" size="63" mtime="1642674793"/>
+        <directory name="bar_package" rev="10" vrev="10" srcmd5="2183f70a146577dea58ab021a8959677">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="38a28c3d6956b1887b80f3614c2a7f06" baserev="38a28c3d6956b1887b80f3614c2a7f06" xsrcmd5="c48bb0791f2a6f585d5267ba388e5c5a" lsrcmd5="2183f70a146577dea58ab021a8959677"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="dc2d49f8159f6492db69b6124d24deeb" size="54" mtime="1643641514"/>
+          <entry name="_link" md5="b77ebfa8dd91ea46e877cadcab688051" size="119" mtime="1643641514"/>
+          <entry name="somefile.txt" md5="3047249b78d9d456f856c41bb6d9c4eb" size="69" mtime="1643641514"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:14 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:15 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1115,169 +1250,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '616'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="579" vrev="579" srcmd5="a9c20ed59907ba980e8531c9184e8595">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="784549c730376263b54c3d8d0693c2c7" baserev="784549c730376263b54c3d8d0693c2c7" xsrcmd5="39bb634107614e1573257014602bb618" lsrcmd5="a9c20ed59907ba980e8531c9184e8595"/>
-          <serviceinfo code="succeeded" xsrcmd5="9dbf4f0e5f8058b850c904e9c0091e52"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="e2ade92f99cd551b9931a41f8363b626" size="65" mtime="1642674793"/>
-          <entry name="_link" md5="3bdea221bda1b90ffed2a983437264d6" size="119" mtime="1642674793"/>
-          <entry name="somefile.txt" md5="d27db4ad1c93debe436e6f13e47fa808" size="63" mtime="1642674793"/>
+        <directory name="bar_package" rev="c48bb0791f2a6f585d5267ba388e5c5a" vrev="42" srcmd5="c48bb0791f2a6f585d5267ba388e5c5a">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="38a28c3d6956b1887b80f3614c2a7f06" baserev="38a28c3d6956b1887b80f3614c2a7f06" lsrcmd5="2183f70a146577dea58ab021a8959677"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="dc2d49f8159f6492db69b6124d24deeb" size="54" mtime="1643641514"/>
+          <entry name="somefile.txt" md5="3047249b78d9d456f856c41bb6d9c4eb" size="69" mtime="1643641514"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:14 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '801'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="579" vrev="579" srcmd5="a9c20ed59907ba980e8531c9184e8595">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="784549c730376263b54c3d8d0693c2c7" baserev="784549c730376263b54c3d8d0693c2c7" xsrcmd5="39bb634107614e1573257014602bb618" lsrcmd5="a9c20ed59907ba980e8531c9184e8595"/>
-          <serviceinfo code="succeeded" xsrcmd5="9dbf4f0e5f8058b850c904e9c0091e52"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="e2ade92f99cd551b9931a41f8363b626" size="65" mtime="1642674793"/>
-          <entry name="_link" md5="3bdea221bda1b90ffed2a983437264d6" size="119" mtime="1642674793"/>
-          <entry name="somefile.txt" md5="d27db4ad1c93debe436e6f13e47fa808" size="63" mtime="1642674793"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:14 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '801'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="579" vrev="579" srcmd5="a9c20ed59907ba980e8531c9184e8595">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="784549c730376263b54c3d8d0693c2c7" baserev="784549c730376263b54c3d8d0693c2c7" xsrcmd5="39bb634107614e1573257014602bb618" lsrcmd5="a9c20ed59907ba980e8531c9184e8595"/>
-          <serviceinfo code="succeeded" xsrcmd5="9dbf4f0e5f8058b850c904e9c0091e52"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="e2ade92f99cd551b9931a41f8363b626" size="65" mtime="1642674793"/>
-          <entry name="_link" md5="3bdea221bda1b90ffed2a983437264d6" size="119" mtime="1642674793"/>
-          <entry name="somefile.txt" md5="d27db4ad1c93debe436e6f13e47fa808" size="63" mtime="1642674793"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:14 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '801'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="579" vrev="579" srcmd5="a9c20ed59907ba980e8531c9184e8595">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="784549c730376263b54c3d8d0693c2c7" baserev="784549c730376263b54c3d8d0693c2c7" xsrcmd5="39bb634107614e1573257014602bb618" lsrcmd5="a9c20ed59907ba980e8531c9184e8595"/>
-          <serviceinfo code="succeeded" xsrcmd5="9dbf4f0e5f8058b850c904e9c0091e52"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="e2ade92f99cd551b9931a41f8363b626" size="65" mtime="1642674793"/>
-          <entry name="_link" md5="3bdea221bda1b90ffed2a983437264d6" size="119" mtime="1642674793"/>
-          <entry name="somefile.txt" md5="d27db4ad1c93debe436e6f13e47fa808" size="63" mtime="1642674793"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:14 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '801'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="579" vrev="579" srcmd5="a9c20ed59907ba980e8531c9184e8595">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="784549c730376263b54c3d8d0693c2c7" baserev="784549c730376263b54c3d8d0693c2c7" xsrcmd5="39bb634107614e1573257014602bb618" lsrcmd5="a9c20ed59907ba980e8531c9184e8595"/>
-          <serviceinfo code="succeeded" xsrcmd5="9dbf4f0e5f8058b850c904e9c0091e52"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="e2ade92f99cd551b9931a41f8363b626" size="65" mtime="1642674793"/>
-          <entry name="_link" md5="3bdea221bda1b90ffed2a983437264d6" size="119" mtime="1642674793"/>
-          <entry name="somefile.txt" md5="d27db4ad1c93debe436e6f13e47fa808" size="63" mtime="1642674793"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:14 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:15 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_a_new_PR_event/behaves_like_successful_new_PR_or_MR_event/1_1_1_3_1_3.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_a_new_PR_event/behaves_like_successful_new_PR_or_MR_event/1_1_1_3_1_3.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:06 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:15 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_324
+    uri: http://backend:5352/source/foo_project/_meta?user=user_17
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Clouds of Witness</title>
+          <title>Blood's a Rover</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '149'
+      - '147'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Clouds of Witness</title>
+          <title>Blood's a Rover</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:06 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:16 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_325
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_18
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Quo Vadis</title>
-          <description>Dolor sed velit provident.</description>
+          <title>The Sun Also Rises</title>
+          <description>Maxime ipsum modi quia.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '145'
+      - '151'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Quo Vadis</title>
-          <description>Dolor sed velit provident.</description>
+          <title>The Sun Also Rises</title>
+          <description>Maxime ipsum modi quia.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:06 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:16 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Molestias autem praesentium. Accusamus omnis nemo. Repellat est eos.
+      string: Dolor ea illo. Ut suscipit aut. Id non quod.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,26 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1697" vrev="1697">
-          <srcmd5>47424b394d0db5638f3fe60c1342428a</srcmd5>
+        <revision rev="33" vrev="33">
+          <srcmd5>78a3b72378e1dfb91845a309fb00dc3a</srcmd5>
           <version>unknown</version>
-          <time>1642674786</time>
+          <time>1643641516</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:06 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:16 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Omnis sed voluptatem. Cum iste similique. Voluptate neque id.
+      string: Officiis cumque voluptatum. Molestias voluptatem dolorem. Velit dolores
+        architecto.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +182,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1698" vrev="1698">
-          <srcmd5>b47f94981afd142fa3aa290dac31876b</srcmd5>
+        <revision rev="34" vrev="34">
+          <srcmd5>075d70798e9891b0698a2b3d2c94737f</srcmd5>
           <version>unknown</version>
-          <time>1642674786</time>
+          <time>1643641516</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:06 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:16 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -227,7 +228,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:33:06 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:16 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -267,7 +268,7 @@ http_interactions:
           <description>This project was created for package bar_package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:06 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:16 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -275,8 +276,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Quo Vadis</title>
-          <description>Dolor sed velit provident.</description>
+          <title>The Sun Also Rises</title>
+          <description>Maxime ipsum modi quia.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -297,15 +298,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '176'
+      - '182'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Quo Vadis</title>
-          <description>Dolor sed velit provident.</description>
+          <title>The Sun Also Rises</title>
+          <description>Maxime ipsum modi quia.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:07 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:16 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=branch&noservice=1&opackage=bar_package&oproject=foo_project&user=Iggy
@@ -333,19 +334,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="568" vrev="568">
-          <srcmd5>877250ddc341a85456f7bda6258a1555</srcmd5>
+        <revision rev="11" vrev="11">
+          <srcmd5>09713736a67a8e4a33601934e0fb686b</srcmd5>
           <version>unknown</version>
-          <time>1642674787</time>
+          <time>1643641516</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:07 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:16 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -353,8 +354,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Quo Vadis</title>
-          <description>Dolor sed velit provident.</description>
+          <title>The Sun Also Rises</title>
+          <description>Maxime ipsum modi quia.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -375,15 +376,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '176'
+      - '182'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Quo Vadis</title>
-          <description>Dolor sed velit provident.</description>
+          <title>The Sun Also Rises</title>
+          <description>Maxime ipsum modi quia.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:07 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:16 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -409,18 +410,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '725'
+      - '620'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="568" vrev="568" srcmd5="877250ddc341a85456f7bda6258a1555">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="b47f94981afd142fa3aa290dac31876b" baserev="b47f94981afd142fa3aa290dac31876b" xsrcmd5="b0d3e3af7ec85934f4afbf97c0e7daf9" lsrcmd5="877250ddc341a85456f7bda6258a1555"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="4032107f7d05d213e3502a3ba6fa616e" size="68" mtime="1642674786"/>
-          <entry name="_link" md5="b774b3685acbfff3a1f83a2580f8bba1" size="119" mtime="1642674787"/>
-          <entry name="somefile.txt" md5="ae67b6b2ff37081d2dae8dd866e05d30" size="61" mtime="1642674786"/>
+        <directory name="bar_package" rev="11" vrev="11" srcmd5="09713736a67a8e4a33601934e0fb686b">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="075d70798e9891b0698a2b3d2c94737f" baserev="075d70798e9891b0698a2b3d2c94737f" xsrcmd5="70e1091b19f0389194800b165f042a7c" lsrcmd5="09713736a67a8e4a33601934e0fb686b"/>
+          <entry name="_config" md5="75a8f50338e3967e1a4328bddd45b7a3" size="44" mtime="1643641516"/>
+          <entry name="_link" md5="6f3c044db3224360ea5d5bc1970c8eea" size="119" mtime="1643641516"/>
+          <entry name="somefile.txt" md5="60c291d7a251c07f605dee0a8c943225" size="83" mtime="1643641516"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:07 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:16 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?view=info
@@ -446,15 +446,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '333'
+      - '330'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="568" vrev="2266" srcmd5="b0d3e3af7ec85934f4afbf97c0e7daf9" lsrcmd5="877250ddc341a85456f7bda6258a1555" verifymd5="b47f94981afd142fa3aa290dac31876b">
+        <sourceinfo package="bar_package" rev="11" vrev="45" srcmd5="70e1091b19f0389194800b165f042a7c" lsrcmd5="09713736a67a8e4a33601934e0fb686b" verifymd5="075d70798e9891b0698a2b3d2c94737f">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:07 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:16 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -480,18 +480,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '725'
+      - '620'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="568" vrev="568" srcmd5="877250ddc341a85456f7bda6258a1555">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="b47f94981afd142fa3aa290dac31876b" baserev="b47f94981afd142fa3aa290dac31876b" xsrcmd5="b0d3e3af7ec85934f4afbf97c0e7daf9" lsrcmd5="877250ddc341a85456f7bda6258a1555"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="4032107f7d05d213e3502a3ba6fa616e" size="68" mtime="1642674786"/>
-          <entry name="_link" md5="b774b3685acbfff3a1f83a2580f8bba1" size="119" mtime="1642674787"/>
-          <entry name="somefile.txt" md5="ae67b6b2ff37081d2dae8dd866e05d30" size="61" mtime="1642674786"/>
+        <directory name="bar_package" rev="11" vrev="11" srcmd5="09713736a67a8e4a33601934e0fb686b">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="075d70798e9891b0698a2b3d2c94737f" baserev="075d70798e9891b0698a2b3d2c94737f" xsrcmd5="70e1091b19f0389194800b165f042a7c" lsrcmd5="09713736a67a8e4a33601934e0fb686b"/>
+          <entry name="_config" md5="75a8f50338e3967e1a4328bddd45b7a3" size="44" mtime="1643641516"/>
+          <entry name="_link" md5="6f3c044db3224360ea5d5bc1970c8eea" size="119" mtime="1643641516"/>
+          <entry name="somefile.txt" md5="60c291d7a251c07f605dee0a8c943225" size="83" mtime="1643641516"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:07 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:16 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -519,18 +518,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '370'
+      - '369'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="9363c1041edcc188eeb9f758f10eb11c">
+        <sourcediff key="7fea099d6d4624fc2722c19ccdf8523f">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="568" srcmd5="877250ddc341a85456f7bda6258a1555"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="11" srcmd5="09713736a67a8e4a33601934e0fb686b"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:07 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:16 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -562,12 +561,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="e542314ca1fe4d494c2ca29ad38170d5">
-          <old project="foo_project" package="bar_package" rev="b47f94981afd142fa3aa290dac31876b" srcmd5="b47f94981afd142fa3aa290dac31876b"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="b0d3e3af7ec85934f4afbf97c0e7daf9" srcmd5="b0d3e3af7ec85934f4afbf97c0e7daf9"/>
+        <sourcediff key="b55817620f2817caf09eb61a63224e08">
+          <old project="foo_project" package="bar_package" rev="075d70798e9891b0698a2b3d2c94737f" srcmd5="075d70798e9891b0698a2b3d2c94737f"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="70e1091b19f0389194800b165f042a7c" srcmd5="70e1091b19f0389194800b165f042a7c"/>
           <files/>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:07 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:16 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -635,7 +634,7 @@ http_interactions:
             <arch>aarch64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:07 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:17 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_branch_request?user=Iggy
@@ -661,19 +660,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="569" vrev="569">
-          <srcmd5>446fb537d786a161c14ff28f7ffed1ce</srcmd5>
+        <revision rev="12" vrev="12">
+          <srcmd5>0de2a75a80f5a0716ca2cc0f5441ecb5</srcmd5>
           <version>unknown</version>
-          <time>1642674787</time>
+          <time>1643641517</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:07 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:17 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -681,8 +680,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Quo Vadis</title>
-          <description>Dolor sed velit provident.</description>
+          <title>The Sun Also Rises</title>
+          <description>Maxime ipsum modi quia.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -703,15 +702,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '176'
+      - '182'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Quo Vadis</title>
-          <description>Dolor sed velit provident.</description>
+          <title>The Sun Also Rises</title>
+          <description>Maxime ipsum modi quia.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:07 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:17 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -737,19 +736,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '722'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="569" vrev="569" srcmd5="446fb537d786a161c14ff28f7ffed1ce">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="b47f94981afd142fa3aa290dac31876b" baserev="b47f94981afd142fa3aa290dac31876b" xsrcmd5="df9937f68be072afb77caee553255b7e" lsrcmd5="446fb537d786a161c14ff28f7ffed1ce"/>
-          <serviceinfo code="succeeded" xsrcmd5="1f8af1a133022e17a199a69a8d4bf071"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="4032107f7d05d213e3502a3ba6fa616e" size="68" mtime="1642674786"/>
-          <entry name="_link" md5="b774b3685acbfff3a1f83a2580f8bba1" size="119" mtime="1642674787"/>
-          <entry name="somefile.txt" md5="ae67b6b2ff37081d2dae8dd866e05d30" size="61" mtime="1642674786"/>
+        <directory name="bar_package" rev="12" vrev="12" srcmd5="0de2a75a80f5a0716ca2cc0f5441ecb5">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="075d70798e9891b0698a2b3d2c94737f" baserev="075d70798e9891b0698a2b3d2c94737f" xsrcmd5="c07a5b15b8155287b80d89fbd1869684" lsrcmd5="0de2a75a80f5a0716ca2cc0f5441ecb5"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="75a8f50338e3967e1a4328bddd45b7a3" size="44" mtime="1643641516"/>
+          <entry name="_link" md5="6f3c044db3224360ea5d5bc1970c8eea" size="119" mtime="1643641516"/>
+          <entry name="somefile.txt" md5="60c291d7a251c07f605dee0a8c943225" size="83" mtime="1643641516"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:07 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:17 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?view=info
@@ -775,15 +773,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '333'
+      - '330'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="569" vrev="2267" srcmd5="db0101f138b6d6594442866b1623c8aa" lsrcmd5="1f8af1a133022e17a199a69a8d4bf071" verifymd5="dd81238b1ae0b336774fc9780a256ae6">
+        <sourceinfo package="bar_package" rev="12" vrev="46" srcmd5="c07a5b15b8155287b80d89fbd1869684" lsrcmd5="0de2a75a80f5a0716ca2cc0f5441ecb5" verifymd5="76862da71a01c314c45382f52406d696">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:07 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:17 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -809,19 +807,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '722'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="569" vrev="569" srcmd5="446fb537d786a161c14ff28f7ffed1ce">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="b47f94981afd142fa3aa290dac31876b" baserev="b47f94981afd142fa3aa290dac31876b" xsrcmd5="df9937f68be072afb77caee553255b7e" lsrcmd5="446fb537d786a161c14ff28f7ffed1ce"/>
-          <serviceinfo code="succeeded" xsrcmd5="1f8af1a133022e17a199a69a8d4bf071"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="4032107f7d05d213e3502a3ba6fa616e" size="68" mtime="1642674786"/>
-          <entry name="_link" md5="b774b3685acbfff3a1f83a2580f8bba1" size="119" mtime="1642674787"/>
-          <entry name="somefile.txt" md5="ae67b6b2ff37081d2dae8dd866e05d30" size="61" mtime="1642674786"/>
+        <directory name="bar_package" rev="12" vrev="12" srcmd5="0de2a75a80f5a0716ca2cc0f5441ecb5">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="075d70798e9891b0698a2b3d2c94737f" baserev="075d70798e9891b0698a2b3d2c94737f" xsrcmd5="c07a5b15b8155287b80d89fbd1869684" lsrcmd5="0de2a75a80f5a0716ca2cc0f5441ecb5"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="75a8f50338e3967e1a4328bddd45b7a3" size="44" mtime="1643641516"/>
+          <entry name="_link" md5="6f3c044db3224360ea5d5bc1970c8eea" size="119" mtime="1643641516"/>
+          <entry name="somefile.txt" md5="60c291d7a251c07f605dee0a8c943225" size="83" mtime="1643641516"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:07 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:17 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -849,18 +846,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '370'
+      - '369'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="49b15d8d3685afaff185690ebd460ed6">
+        <sourcediff key="c07a92bd5229687996fc8e956c2ff82a">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="569" srcmd5="446fb537d786a161c14ff28f7ffed1ce"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="12" srcmd5="0de2a75a80f5a0716ca2cc0f5441ecb5"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:07 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:17 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -892,14 +889,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="144bb936103b410198dc74ae3fcc9c14">
-          <old project="foo_project" package="bar_package" rev="b47f94981afd142fa3aa290dac31876b" srcmd5="b47f94981afd142fa3aa290dac31876b"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="db0101f138b6d6594442866b1623c8aa" srcmd5="db0101f138b6d6594442866b1623c8aa"/>
+        <sourcediff key="3889abb32d0fe38cda587da26a4dfb1b">
+          <old project="foo_project" package="bar_package" rev="075d70798e9891b0698a2b3d2c94737f" srcmd5="075d70798e9891b0698a2b3d2c94737f"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="c07a5b15b8155287b80d89fbd1869684" srcmd5="c07a5b15b8155287b80d89fbd1869684"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:07 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:17 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -925,19 +922,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '722'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="569" vrev="569" srcmd5="446fb537d786a161c14ff28f7ffed1ce">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="b47f94981afd142fa3aa290dac31876b" baserev="b47f94981afd142fa3aa290dac31876b" xsrcmd5="df9937f68be072afb77caee553255b7e" lsrcmd5="446fb537d786a161c14ff28f7ffed1ce"/>
-          <serviceinfo code="succeeded" xsrcmd5="1f8af1a133022e17a199a69a8d4bf071"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="4032107f7d05d213e3502a3ba6fa616e" size="68" mtime="1642674786"/>
-          <entry name="_link" md5="b774b3685acbfff3a1f83a2580f8bba1" size="119" mtime="1642674787"/>
-          <entry name="somefile.txt" md5="ae67b6b2ff37081d2dae8dd866e05d30" size="61" mtime="1642674786"/>
+        <directory name="bar_package" rev="12" vrev="12" srcmd5="0de2a75a80f5a0716ca2cc0f5441ecb5">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="075d70798e9891b0698a2b3d2c94737f" baserev="075d70798e9891b0698a2b3d2c94737f" xsrcmd5="c07a5b15b8155287b80d89fbd1869684" lsrcmd5="0de2a75a80f5a0716ca2cc0f5441ecb5"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="75a8f50338e3967e1a4328bddd45b7a3" size="44" mtime="1643641516"/>
+          <entry name="_link" md5="6f3c044db3224360ea5d5bc1970c8eea" size="119" mtime="1643641516"/>
+          <entry name="somefile.txt" md5="60c291d7a251c07f605dee0a8c943225" size="83" mtime="1643641516"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:07 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:17 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '616'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="c07a5b15b8155287b80d89fbd1869684" vrev="46" srcmd5="c07a5b15b8155287b80d89fbd1869684">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="075d70798e9891b0698a2b3d2c94737f" baserev="075d70798e9891b0698a2b3d2c94737f" lsrcmd5="0de2a75a80f5a0716ca2cc0f5441ecb5"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="75a8f50338e3967e1a4328bddd45b7a3" size="44" mtime="1643641516"/>
+          <entry name="somefile.txt" md5="60c291d7a251c07f605dee0a8c943225" size="83" mtime="1643641516"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:05:17 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -963,19 +995,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '722'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="569" vrev="569" srcmd5="446fb537d786a161c14ff28f7ffed1ce">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="b47f94981afd142fa3aa290dac31876b" baserev="b47f94981afd142fa3aa290dac31876b" xsrcmd5="df9937f68be072afb77caee553255b7e" lsrcmd5="446fb537d786a161c14ff28f7ffed1ce"/>
-          <serviceinfo code="succeeded" xsrcmd5="1f8af1a133022e17a199a69a8d4bf071"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="4032107f7d05d213e3502a3ba6fa616e" size="68" mtime="1642674786"/>
-          <entry name="_link" md5="b774b3685acbfff3a1f83a2580f8bba1" size="119" mtime="1642674787"/>
-          <entry name="somefile.txt" md5="ae67b6b2ff37081d2dae8dd866e05d30" size="61" mtime="1642674786"/>
+        <directory name="bar_package" rev="12" vrev="12" srcmd5="0de2a75a80f5a0716ca2cc0f5441ecb5">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="075d70798e9891b0698a2b3d2c94737f" baserev="075d70798e9891b0698a2b3d2c94737f" xsrcmd5="c07a5b15b8155287b80d89fbd1869684" lsrcmd5="0de2a75a80f5a0716ca2cc0f5441ecb5"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="75a8f50338e3967e1a4328bddd45b7a3" size="44" mtime="1643641516"/>
+          <entry name="_link" md5="6f3c044db3224360ea5d5bc1970c8eea" size="119" mtime="1643641516"/>
+          <entry name="somefile.txt" md5="60c291d7a251c07f605dee0a8c943225" size="83" mtime="1643641516"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:07 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:17 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '616'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="c07a5b15b8155287b80d89fbd1869684" vrev="46" srcmd5="c07a5b15b8155287b80d89fbd1869684">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="075d70798e9891b0698a2b3d2c94737f" baserev="075d70798e9891b0698a2b3d2c94737f" lsrcmd5="0de2a75a80f5a0716ca2cc0f5441ecb5"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="75a8f50338e3967e1a4328bddd45b7a3" size="44" mtime="1643641516"/>
+          <entry name="somefile.txt" md5="60c291d7a251c07f605dee0a8c943225" size="83" mtime="1643641516"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:05:17 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -1001,19 +1068,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '722'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="569" vrev="569" srcmd5="446fb537d786a161c14ff28f7ffed1ce">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="b47f94981afd142fa3aa290dac31876b" baserev="b47f94981afd142fa3aa290dac31876b" xsrcmd5="df9937f68be072afb77caee553255b7e" lsrcmd5="446fb537d786a161c14ff28f7ffed1ce"/>
-          <serviceinfo code="succeeded" xsrcmd5="1f8af1a133022e17a199a69a8d4bf071"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="4032107f7d05d213e3502a3ba6fa616e" size="68" mtime="1642674786"/>
-          <entry name="_link" md5="b774b3685acbfff3a1f83a2580f8bba1" size="119" mtime="1642674787"/>
-          <entry name="somefile.txt" md5="ae67b6b2ff37081d2dae8dd866e05d30" size="61" mtime="1642674786"/>
+        <directory name="bar_package" rev="12" vrev="12" srcmd5="0de2a75a80f5a0716ca2cc0f5441ecb5">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="075d70798e9891b0698a2b3d2c94737f" baserev="075d70798e9891b0698a2b3d2c94737f" xsrcmd5="c07a5b15b8155287b80d89fbd1869684" lsrcmd5="0de2a75a80f5a0716ca2cc0f5441ecb5"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="75a8f50338e3967e1a4328bddd45b7a3" size="44" mtime="1643641516"/>
+          <entry name="_link" md5="6f3c044db3224360ea5d5bc1970c8eea" size="119" mtime="1643641516"/>
+          <entry name="somefile.txt" md5="60c291d7a251c07f605dee0a8c943225" size="83" mtime="1643641516"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:07 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:17 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '616'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="c07a5b15b8155287b80d89fbd1869684" vrev="46" srcmd5="c07a5b15b8155287b80d89fbd1869684">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="075d70798e9891b0698a2b3d2c94737f" baserev="075d70798e9891b0698a2b3d2c94737f" lsrcmd5="0de2a75a80f5a0716ca2cc0f5441ecb5"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="75a8f50338e3967e1a4328bddd45b7a3" size="44" mtime="1643641516"/>
+          <entry name="somefile.txt" md5="60c291d7a251c07f605dee0a8c943225" size="83" mtime="1643641516"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:05:17 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -1039,19 +1141,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '722'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="569" vrev="569" srcmd5="446fb537d786a161c14ff28f7ffed1ce">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="b47f94981afd142fa3aa290dac31876b" baserev="b47f94981afd142fa3aa290dac31876b" xsrcmd5="df9937f68be072afb77caee553255b7e" lsrcmd5="446fb537d786a161c14ff28f7ffed1ce"/>
-          <serviceinfo code="succeeded" xsrcmd5="1f8af1a133022e17a199a69a8d4bf071"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="4032107f7d05d213e3502a3ba6fa616e" size="68" mtime="1642674786"/>
-          <entry name="_link" md5="b774b3685acbfff3a1f83a2580f8bba1" size="119" mtime="1642674787"/>
-          <entry name="somefile.txt" md5="ae67b6b2ff37081d2dae8dd866e05d30" size="61" mtime="1642674786"/>
+        <directory name="bar_package" rev="12" vrev="12" srcmd5="0de2a75a80f5a0716ca2cc0f5441ecb5">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="075d70798e9891b0698a2b3d2c94737f" baserev="075d70798e9891b0698a2b3d2c94737f" xsrcmd5="c07a5b15b8155287b80d89fbd1869684" lsrcmd5="0de2a75a80f5a0716ca2cc0f5441ecb5"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="75a8f50338e3967e1a4328bddd45b7a3" size="44" mtime="1643641516"/>
+          <entry name="_link" md5="6f3c044db3224360ea5d5bc1970c8eea" size="119" mtime="1643641516"/>
+          <entry name="somefile.txt" md5="60c291d7a251c07f605dee0a8c943225" size="83" mtime="1643641516"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:07 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:17 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '616'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="c07a5b15b8155287b80d89fbd1869684" vrev="46" srcmd5="c07a5b15b8155287b80d89fbd1869684">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="075d70798e9891b0698a2b3d2c94737f" baserev="075d70798e9891b0698a2b3d2c94737f" lsrcmd5="0de2a75a80f5a0716ca2cc0f5441ecb5"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="75a8f50338e3967e1a4328bddd45b7a3" size="44" mtime="1643641516"/>
+          <entry name="somefile.txt" md5="60c291d7a251c07f605dee0a8c943225" size="83" mtime="1643641516"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:05:17 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -1077,22 +1214,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '722'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="569" vrev="569" srcmd5="446fb537d786a161c14ff28f7ffed1ce">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="b47f94981afd142fa3aa290dac31876b" baserev="b47f94981afd142fa3aa290dac31876b" xsrcmd5="df9937f68be072afb77caee553255b7e" lsrcmd5="446fb537d786a161c14ff28f7ffed1ce"/>
-          <serviceinfo code="succeeded" xsrcmd5="1f8af1a133022e17a199a69a8d4bf071"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="4032107f7d05d213e3502a3ba6fa616e" size="68" mtime="1642674786"/>
-          <entry name="_link" md5="b774b3685acbfff3a1f83a2580f8bba1" size="119" mtime="1642674787"/>
-          <entry name="somefile.txt" md5="ae67b6b2ff37081d2dae8dd866e05d30" size="61" mtime="1642674786"/>
+        <directory name="bar_package" rev="12" vrev="12" srcmd5="0de2a75a80f5a0716ca2cc0f5441ecb5">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="075d70798e9891b0698a2b3d2c94737f" baserev="075d70798e9891b0698a2b3d2c94737f" xsrcmd5="c07a5b15b8155287b80d89fbd1869684" lsrcmd5="0de2a75a80f5a0716ca2cc0f5441ecb5"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="75a8f50338e3967e1a4328bddd45b7a3" size="44" mtime="1643641516"/>
+          <entry name="_link" md5="6f3c044db3224360ea5d5bc1970c8eea" size="119" mtime="1643641516"/>
+          <entry name="somefile.txt" md5="60c291d7a251c07f605dee0a8c943225" size="83" mtime="1643641516"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:07 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:17 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1115,171 +1251,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '616'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="569" vrev="569" srcmd5="446fb537d786a161c14ff28f7ffed1ce">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="b47f94981afd142fa3aa290dac31876b" baserev="b47f94981afd142fa3aa290dac31876b" xsrcmd5="df9937f68be072afb77caee553255b7e" lsrcmd5="446fb537d786a161c14ff28f7ffed1ce"/>
-          <serviceinfo code="succeeded" xsrcmd5="1f8af1a133022e17a199a69a8d4bf071"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="4032107f7d05d213e3502a3ba6fa616e" size="68" mtime="1642674786"/>
-          <entry name="_link" md5="b774b3685acbfff3a1f83a2580f8bba1" size="119" mtime="1642674787"/>
-          <entry name="somefile.txt" md5="ae67b6b2ff37081d2dae8dd866e05d30" size="61" mtime="1642674786"/>
+        <directory name="bar_package" rev="c07a5b15b8155287b80d89fbd1869684" vrev="46" srcmd5="c07a5b15b8155287b80d89fbd1869684">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="075d70798e9891b0698a2b3d2c94737f" baserev="075d70798e9891b0698a2b3d2c94737f" lsrcmd5="0de2a75a80f5a0716ca2cc0f5441ecb5"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="75a8f50338e3967e1a4328bddd45b7a3" size="44" mtime="1643641516"/>
+          <entry name="somefile.txt" md5="60c291d7a251c07f605dee0a8c943225" size="83" mtime="1643641516"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:07 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '801'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="569" vrev="569" srcmd5="446fb537d786a161c14ff28f7ffed1ce">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="b47f94981afd142fa3aa290dac31876b" baserev="b47f94981afd142fa3aa290dac31876b" xsrcmd5="df9937f68be072afb77caee553255b7e" lsrcmd5="446fb537d786a161c14ff28f7ffed1ce"/>
-          <serviceinfo code="succeeded" xsrcmd5="1f8af1a133022e17a199a69a8d4bf071"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="4032107f7d05d213e3502a3ba6fa616e" size="68" mtime="1642674786"/>
-          <entry name="_link" md5="b774b3685acbfff3a1f83a2580f8bba1" size="119" mtime="1642674787"/>
-          <entry name="somefile.txt" md5="ae67b6b2ff37081d2dae8dd866e05d30" size="61" mtime="1642674786"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:07 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '801'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="569" vrev="569" srcmd5="446fb537d786a161c14ff28f7ffed1ce">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="b47f94981afd142fa3aa290dac31876b" baserev="b47f94981afd142fa3aa290dac31876b" xsrcmd5="df9937f68be072afb77caee553255b7e" lsrcmd5="446fb537d786a161c14ff28f7ffed1ce"/>
-          <serviceinfo code="succeeded" xsrcmd5="1f8af1a133022e17a199a69a8d4bf071"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="4032107f7d05d213e3502a3ba6fa616e" size="68" mtime="1642674786"/>
-          <entry name="_link" md5="b774b3685acbfff3a1f83a2580f8bba1" size="119" mtime="1642674787"/>
-          <entry name="somefile.txt" md5="ae67b6b2ff37081d2dae8dd866e05d30" size="61" mtime="1642674786"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:07 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '801'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="569" vrev="569" srcmd5="446fb537d786a161c14ff28f7ffed1ce">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="b47f94981afd142fa3aa290dac31876b" baserev="b47f94981afd142fa3aa290dac31876b" xsrcmd5="df9937f68be072afb77caee553255b7e" lsrcmd5="446fb537d786a161c14ff28f7ffed1ce"/>
-          <serviceinfo code="succeeded" xsrcmd5="1f8af1a133022e17a199a69a8d4bf071"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="4032107f7d05d213e3502a3ba6fa616e" size="68" mtime="1642674786"/>
-          <entry name="_link" md5="b774b3685acbfff3a1f83a2580f8bba1" size="119" mtime="1642674787"/>
-          <entry name="somefile.txt" md5="ae67b6b2ff37081d2dae8dd866e05d30" size="61" mtime="1642674786"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:07 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '801'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="569" vrev="569" srcmd5="446fb537d786a161c14ff28f7ffed1ce">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="b47f94981afd142fa3aa290dac31876b" baserev="b47f94981afd142fa3aa290dac31876b" xsrcmd5="df9937f68be072afb77caee553255b7e" lsrcmd5="446fb537d786a161c14ff28f7ffed1ce"/>
-          <serviceinfo code="succeeded" xsrcmd5="1f8af1a133022e17a199a69a8d4bf071"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="4032107f7d05d213e3502a3ba6fa616e" size="68" mtime="1642674786"/>
-          <entry name="_link" md5="b774b3685acbfff3a1f83a2580f8bba1" size="119" mtime="1642674787"/>
-          <entry name="somefile.txt" md5="ae67b6b2ff37081d2dae8dd866e05d30" size="61" mtime="1642674786"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:07 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:17 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_branch_request
@@ -1309,5 +1291,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"action":"opened","pull_request":{"head":{"repo":{"full_name":"reponame"},"sha":"123456789"}}}'
-  recorded_at: Thu, 20 Jan 2022 10:33:07 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:17 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_a_new_PR_event/behaves_like_successful_new_PR_or_MR_event/1_1_1_3_1_4.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_a_new_PR_event/behaves_like_successful_new_PR_or_MR_event/1_1_1_3_1_4.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:09 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:12 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_328
+    uri: http://backend:5352/source/foo_project/_meta?user=user_13
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>The Grapes of Wrath</title>
+          <title>Consider the Lilies</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -75,20 +75,20 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>The Grapes of Wrath</title>
+          <title>Consider the Lilies</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:09 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:13 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_329
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_14
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Proper Study</title>
-          <description>Rem expedita doloremque possimus.</description>
+          <title>A Monstrous Regiment of Women</title>
+          <description>Numquam vitae rerum repellat.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '159'
+      - '168'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Proper Study</title>
-          <description>Rem expedita doloremque possimus.</description>
+          <title>A Monstrous Regiment of Women</title>
+          <description>Numquam vitae rerum repellat.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:09 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:13 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Est laboriosam odit. Doloribus et est. Eligendi quo aperiam.
+      string: Et non minus. Commodi perferendis provident. Voluptates ipsum sed.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,26 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1701" vrev="1701">
-          <srcmd5>22dabeb987aabb6f71c34226e1164057</srcmd5>
+        <revision rev="29" vrev="29">
+          <srcmd5>f9fa9874fee82063309d69dd0b846ea2</srcmd5>
           <version>unknown</version>
-          <time>1642674789</time>
+          <time>1643641513</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:09 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:13 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Reprehenderit doloribus delectus. Earum quisquam dignissimos. Nemo rerum
-        quis.
+      string: Magnam fugit porro. Ullam et ex. Placeat in est.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -182,19 +181,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1702" vrev="1702">
-          <srcmd5>bb0d9bb54a6f42f67d4ced25b4c198f9</srcmd5>
+        <revision rev="30" vrev="30">
+          <srcmd5>9c2d78fb4cdf91999058e5e10276a9f3</srcmd5>
           <version>unknown</version>
-          <time>1642674789</time>
+          <time>1643641513</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:09 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:13 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -228,7 +227,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:33:09 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:13 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -268,7 +267,7 @@ http_interactions:
           <description>This project was created for package bar_package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:09 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:13 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -276,8 +275,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Proper Study</title>
-          <description>Rem expedita doloremque possimus.</description>
+          <title>A Monstrous Regiment of Women</title>
+          <description>Numquam vitae rerum repellat.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -298,15 +297,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '190'
+      - '199'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Proper Study</title>
-          <description>Rem expedita doloremque possimus.</description>
+          <title>A Monstrous Regiment of Women</title>
+          <description>Numquam vitae rerum repellat.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:09 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:13 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=branch&noservice=1&opackage=bar_package&oproject=foo_project&user=Iggy
@@ -334,19 +333,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '204'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="572" vrev="572">
-          <srcmd5>b8ea0676b2d33ff20c78180ab5d76ca6</srcmd5>
+        <revision rev="7" vrev="7">
+          <srcmd5>90fbcd334df13cfc2846a50bdd5f5a27</srcmd5>
           <version>unknown</version>
-          <time>1642674789</time>
+          <time>1643641513</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:09 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:13 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -354,8 +353,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Proper Study</title>
-          <description>Rem expedita doloremque possimus.</description>
+          <title>A Monstrous Regiment of Women</title>
+          <description>Numquam vitae rerum repellat.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -376,15 +375,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '190'
+      - '199'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Proper Study</title>
-          <description>Rem expedita doloremque possimus.</description>
+          <title>A Monstrous Regiment of Women</title>
+          <description>Numquam vitae rerum repellat.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:09 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:13 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -410,18 +409,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '725'
+      - '618'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="572" vrev="572" srcmd5="b8ea0676b2d33ff20c78180ab5d76ca6">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="bb0d9bb54a6f42f67d4ced25b4c198f9" baserev="bb0d9bb54a6f42f67d4ced25b4c198f9" xsrcmd5="38cc30a60e4c259ffc60e1547783acc8" lsrcmd5="b8ea0676b2d33ff20c78180ab5d76ca6"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="787dff501828cf283e870ee3c92df036" size="60" mtime="1642674789"/>
-          <entry name="_link" md5="36a3e842c0e3eba0d46b6633c5b4983e" size="119" mtime="1642674789"/>
-          <entry name="somefile.txt" md5="e08cf1cc86c4e85cd707cf8b0040efb7" size="78" mtime="1642674789"/>
+        <directory name="bar_package" rev="7" vrev="7" srcmd5="90fbcd334df13cfc2846a50bdd5f5a27">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="9c2d78fb4cdf91999058e5e10276a9f3" baserev="9c2d78fb4cdf91999058e5e10276a9f3" xsrcmd5="8c96054bd76bc276c9036101660db1ab" lsrcmd5="90fbcd334df13cfc2846a50bdd5f5a27"/>
+          <entry name="_config" md5="d06936c8551093bc4dde1f1ebba7ce78" size="66" mtime="1643641513"/>
+          <entry name="_link" md5="419c1ff25d7c4c75f4223702feaa8122" size="119" mtime="1643641513"/>
+          <entry name="somefile.txt" md5="88469f753affadf50d7f5f0023fc5927" size="48" mtime="1643641513"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:09 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:13 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?view=info
@@ -447,15 +445,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '333'
+      - '329'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="572" vrev="2274" srcmd5="38cc30a60e4c259ffc60e1547783acc8" lsrcmd5="b8ea0676b2d33ff20c78180ab5d76ca6" verifymd5="bb0d9bb54a6f42f67d4ced25b4c198f9">
+        <sourceinfo package="bar_package" rev="7" vrev="37" srcmd5="8c96054bd76bc276c9036101660db1ab" lsrcmd5="90fbcd334df13cfc2846a50bdd5f5a27" verifymd5="9c2d78fb4cdf91999058e5e10276a9f3">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:09 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:13 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -481,18 +479,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '725'
+      - '618'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="572" vrev="572" srcmd5="b8ea0676b2d33ff20c78180ab5d76ca6">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="bb0d9bb54a6f42f67d4ced25b4c198f9" baserev="bb0d9bb54a6f42f67d4ced25b4c198f9" xsrcmd5="38cc30a60e4c259ffc60e1547783acc8" lsrcmd5="b8ea0676b2d33ff20c78180ab5d76ca6"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="787dff501828cf283e870ee3c92df036" size="60" mtime="1642674789"/>
-          <entry name="_link" md5="36a3e842c0e3eba0d46b6633c5b4983e" size="119" mtime="1642674789"/>
-          <entry name="somefile.txt" md5="e08cf1cc86c4e85cd707cf8b0040efb7" size="78" mtime="1642674789"/>
+        <directory name="bar_package" rev="7" vrev="7" srcmd5="90fbcd334df13cfc2846a50bdd5f5a27">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="9c2d78fb4cdf91999058e5e10276a9f3" baserev="9c2d78fb4cdf91999058e5e10276a9f3" xsrcmd5="8c96054bd76bc276c9036101660db1ab" lsrcmd5="90fbcd334df13cfc2846a50bdd5f5a27"/>
+          <entry name="_config" md5="d06936c8551093bc4dde1f1ebba7ce78" size="66" mtime="1643641513"/>
+          <entry name="_link" md5="419c1ff25d7c4c75f4223702feaa8122" size="119" mtime="1643641513"/>
+          <entry name="somefile.txt" md5="88469f753affadf50d7f5f0023fc5927" size="48" mtime="1643641513"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:09 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:13 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -520,18 +517,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '370'
+      - '368'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="6bdf2eddeca63b5afda4896d0ffa98aa">
+        <sourcediff key="552b4cb437577e531c0df1be8ccdb451">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="572" srcmd5="b8ea0676b2d33ff20c78180ab5d76ca6"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="7" srcmd5="90fbcd334df13cfc2846a50bdd5f5a27"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:09 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:13 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -563,12 +560,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="41735acf8d090bb3c8f3de6a93d4d143">
-          <old project="foo_project" package="bar_package" rev="bb0d9bb54a6f42f67d4ced25b4c198f9" srcmd5="bb0d9bb54a6f42f67d4ced25b4c198f9"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="38cc30a60e4c259ffc60e1547783acc8" srcmd5="38cc30a60e4c259ffc60e1547783acc8"/>
+        <sourcediff key="82660e0e4cac16da7df8f32dedc662be">
+          <old project="foo_project" package="bar_package" rev="9c2d78fb4cdf91999058e5e10276a9f3" srcmd5="9c2d78fb4cdf91999058e5e10276a9f3"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="8c96054bd76bc276c9036101660db1ab" srcmd5="8c96054bd76bc276c9036101660db1ab"/>
           <files/>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:09 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:13 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -636,7 +633,7 @@ http_interactions:
             <arch>aarch64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:10 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:13 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_branch_request?user=Iggy
@@ -662,19 +659,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '204'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="573" vrev="573">
-          <srcmd5>5d31b9bd08f659d32f332a69cf331913</srcmd5>
+        <revision rev="8" vrev="8">
+          <srcmd5>44ad98fec6311491c3611c69fa72c569</srcmd5>
           <version>unknown</version>
-          <time>1642674790</time>
+          <time>1643641513</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:10 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:13 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -682,8 +679,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Proper Study</title>
-          <description>Rem expedita doloremque possimus.</description>
+          <title>A Monstrous Regiment of Women</title>
+          <description>Numquam vitae rerum repellat.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -704,15 +701,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '190'
+      - '199'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Proper Study</title>
-          <description>Rem expedita doloremque possimus.</description>
+          <title>A Monstrous Regiment of Women</title>
+          <description>Numquam vitae rerum repellat.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:10 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:13 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -738,19 +735,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '720'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="573" vrev="573" srcmd5="5d31b9bd08f659d32f332a69cf331913">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="bb0d9bb54a6f42f67d4ced25b4c198f9" baserev="bb0d9bb54a6f42f67d4ced25b4c198f9" xsrcmd5="ad31224d066569dfacead3e51a4852f4" lsrcmd5="5d31b9bd08f659d32f332a69cf331913"/>
-          <serviceinfo code="succeeded" xsrcmd5="36b3a884b9381115e0495acdb97fc69b"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="787dff501828cf283e870ee3c92df036" size="60" mtime="1642674789"/>
-          <entry name="_link" md5="36a3e842c0e3eba0d46b6633c5b4983e" size="119" mtime="1642674789"/>
-          <entry name="somefile.txt" md5="e08cf1cc86c4e85cd707cf8b0040efb7" size="78" mtime="1642674789"/>
+        <directory name="bar_package" rev="8" vrev="8" srcmd5="44ad98fec6311491c3611c69fa72c569">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="9c2d78fb4cdf91999058e5e10276a9f3" baserev="9c2d78fb4cdf91999058e5e10276a9f3" xsrcmd5="5f1555cbdcca83ca3fee685ba5c90b6c" lsrcmd5="44ad98fec6311491c3611c69fa72c569"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="d06936c8551093bc4dde1f1ebba7ce78" size="66" mtime="1643641513"/>
+          <entry name="_link" md5="419c1ff25d7c4c75f4223702feaa8122" size="119" mtime="1643641513"/>
+          <entry name="somefile.txt" md5="88469f753affadf50d7f5f0023fc5927" size="48" mtime="1643641513"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:10 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:13 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?view=info
@@ -776,15 +772,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '333'
+      - '329'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="573" vrev="2275" srcmd5="d318b5fae8313f1167c34a0b834b80f4" lsrcmd5="36b3a884b9381115e0495acdb97fc69b" verifymd5="0db3447cf4eac0992f7f491b5a298730">
+        <sourceinfo package="bar_package" rev="8" vrev="38" srcmd5="5f1555cbdcca83ca3fee685ba5c90b6c" lsrcmd5="44ad98fec6311491c3611c69fa72c569" verifymd5="d4d933c0020970d2623e97b1e382ea36">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:10 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:13 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -810,19 +806,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '720'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="573" vrev="573" srcmd5="5d31b9bd08f659d32f332a69cf331913">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="bb0d9bb54a6f42f67d4ced25b4c198f9" baserev="bb0d9bb54a6f42f67d4ced25b4c198f9" xsrcmd5="ad31224d066569dfacead3e51a4852f4" lsrcmd5="5d31b9bd08f659d32f332a69cf331913"/>
-          <serviceinfo code="succeeded" xsrcmd5="36b3a884b9381115e0495acdb97fc69b"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="787dff501828cf283e870ee3c92df036" size="60" mtime="1642674789"/>
-          <entry name="_link" md5="36a3e842c0e3eba0d46b6633c5b4983e" size="119" mtime="1642674789"/>
-          <entry name="somefile.txt" md5="e08cf1cc86c4e85cd707cf8b0040efb7" size="78" mtime="1642674789"/>
+        <directory name="bar_package" rev="8" vrev="8" srcmd5="44ad98fec6311491c3611c69fa72c569">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="9c2d78fb4cdf91999058e5e10276a9f3" baserev="9c2d78fb4cdf91999058e5e10276a9f3" xsrcmd5="5f1555cbdcca83ca3fee685ba5c90b6c" lsrcmd5="44ad98fec6311491c3611c69fa72c569"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="d06936c8551093bc4dde1f1ebba7ce78" size="66" mtime="1643641513"/>
+          <entry name="_link" md5="419c1ff25d7c4c75f4223702feaa8122" size="119" mtime="1643641513"/>
+          <entry name="somefile.txt" md5="88469f753affadf50d7f5f0023fc5927" size="48" mtime="1643641513"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:10 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:13 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -850,18 +845,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '370'
+      - '368'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="f53729836ecdcbcc0be62c9886b7f10a">
+        <sourcediff key="5208282281a9774d4c20b69ccd013ace">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="573" srcmd5="5d31b9bd08f659d32f332a69cf331913"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="8" srcmd5="44ad98fec6311491c3611c69fa72c569"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:10 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:13 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -893,14 +888,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="795631e3e591847b6d810b6b9654d27b">
-          <old project="foo_project" package="bar_package" rev="bb0d9bb54a6f42f67d4ced25b4c198f9" srcmd5="bb0d9bb54a6f42f67d4ced25b4c198f9"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="d318b5fae8313f1167c34a0b834b80f4" srcmd5="d318b5fae8313f1167c34a0b834b80f4"/>
+        <sourcediff key="045caa87e542f21b24cfd81c79931d88">
+          <old project="foo_project" package="bar_package" rev="9c2d78fb4cdf91999058e5e10276a9f3" srcmd5="9c2d78fb4cdf91999058e5e10276a9f3"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="5f1555cbdcca83ca3fee685ba5c90b6c" srcmd5="5f1555cbdcca83ca3fee685ba5c90b6c"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:10 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:13 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -926,19 +921,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '720'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="573" vrev="573" srcmd5="5d31b9bd08f659d32f332a69cf331913">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="bb0d9bb54a6f42f67d4ced25b4c198f9" baserev="bb0d9bb54a6f42f67d4ced25b4c198f9" xsrcmd5="ad31224d066569dfacead3e51a4852f4" lsrcmd5="5d31b9bd08f659d32f332a69cf331913"/>
-          <serviceinfo code="succeeded" xsrcmd5="36b3a884b9381115e0495acdb97fc69b"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="787dff501828cf283e870ee3c92df036" size="60" mtime="1642674789"/>
-          <entry name="_link" md5="36a3e842c0e3eba0d46b6633c5b4983e" size="119" mtime="1642674789"/>
-          <entry name="somefile.txt" md5="e08cf1cc86c4e85cd707cf8b0040efb7" size="78" mtime="1642674789"/>
+        <directory name="bar_package" rev="8" vrev="8" srcmd5="44ad98fec6311491c3611c69fa72c569">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="9c2d78fb4cdf91999058e5e10276a9f3" baserev="9c2d78fb4cdf91999058e5e10276a9f3" xsrcmd5="5f1555cbdcca83ca3fee685ba5c90b6c" lsrcmd5="44ad98fec6311491c3611c69fa72c569"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="d06936c8551093bc4dde1f1ebba7ce78" size="66" mtime="1643641513"/>
+          <entry name="_link" md5="419c1ff25d7c4c75f4223702feaa8122" size="119" mtime="1643641513"/>
+          <entry name="somefile.txt" md5="88469f753affadf50d7f5f0023fc5927" size="48" mtime="1643641513"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:10 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:14 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '616'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="5f1555cbdcca83ca3fee685ba5c90b6c" vrev="38" srcmd5="5f1555cbdcca83ca3fee685ba5c90b6c">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="9c2d78fb4cdf91999058e5e10276a9f3" baserev="9c2d78fb4cdf91999058e5e10276a9f3" lsrcmd5="44ad98fec6311491c3611c69fa72c569"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="d06936c8551093bc4dde1f1ebba7ce78" size="66" mtime="1643641513"/>
+          <entry name="somefile.txt" md5="88469f753affadf50d7f5f0023fc5927" size="48" mtime="1643641513"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:05:14 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -964,19 +994,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '720'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="573" vrev="573" srcmd5="5d31b9bd08f659d32f332a69cf331913">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="bb0d9bb54a6f42f67d4ced25b4c198f9" baserev="bb0d9bb54a6f42f67d4ced25b4c198f9" xsrcmd5="ad31224d066569dfacead3e51a4852f4" lsrcmd5="5d31b9bd08f659d32f332a69cf331913"/>
-          <serviceinfo code="succeeded" xsrcmd5="36b3a884b9381115e0495acdb97fc69b"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="787dff501828cf283e870ee3c92df036" size="60" mtime="1642674789"/>
-          <entry name="_link" md5="36a3e842c0e3eba0d46b6633c5b4983e" size="119" mtime="1642674789"/>
-          <entry name="somefile.txt" md5="e08cf1cc86c4e85cd707cf8b0040efb7" size="78" mtime="1642674789"/>
+        <directory name="bar_package" rev="8" vrev="8" srcmd5="44ad98fec6311491c3611c69fa72c569">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="9c2d78fb4cdf91999058e5e10276a9f3" baserev="9c2d78fb4cdf91999058e5e10276a9f3" xsrcmd5="5f1555cbdcca83ca3fee685ba5c90b6c" lsrcmd5="44ad98fec6311491c3611c69fa72c569"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="d06936c8551093bc4dde1f1ebba7ce78" size="66" mtime="1643641513"/>
+          <entry name="_link" md5="419c1ff25d7c4c75f4223702feaa8122" size="119" mtime="1643641513"/>
+          <entry name="somefile.txt" md5="88469f753affadf50d7f5f0023fc5927" size="48" mtime="1643641513"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:10 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:14 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '616'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="5f1555cbdcca83ca3fee685ba5c90b6c" vrev="38" srcmd5="5f1555cbdcca83ca3fee685ba5c90b6c">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="9c2d78fb4cdf91999058e5e10276a9f3" baserev="9c2d78fb4cdf91999058e5e10276a9f3" lsrcmd5="44ad98fec6311491c3611c69fa72c569"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="d06936c8551093bc4dde1f1ebba7ce78" size="66" mtime="1643641513"/>
+          <entry name="somefile.txt" md5="88469f753affadf50d7f5f0023fc5927" size="48" mtime="1643641513"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:05:14 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -1002,19 +1067,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '720'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="573" vrev="573" srcmd5="5d31b9bd08f659d32f332a69cf331913">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="bb0d9bb54a6f42f67d4ced25b4c198f9" baserev="bb0d9bb54a6f42f67d4ced25b4c198f9" xsrcmd5="ad31224d066569dfacead3e51a4852f4" lsrcmd5="5d31b9bd08f659d32f332a69cf331913"/>
-          <serviceinfo code="succeeded" xsrcmd5="36b3a884b9381115e0495acdb97fc69b"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="787dff501828cf283e870ee3c92df036" size="60" mtime="1642674789"/>
-          <entry name="_link" md5="36a3e842c0e3eba0d46b6633c5b4983e" size="119" mtime="1642674789"/>
-          <entry name="somefile.txt" md5="e08cf1cc86c4e85cd707cf8b0040efb7" size="78" mtime="1642674789"/>
+        <directory name="bar_package" rev="8" vrev="8" srcmd5="44ad98fec6311491c3611c69fa72c569">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="9c2d78fb4cdf91999058e5e10276a9f3" baserev="9c2d78fb4cdf91999058e5e10276a9f3" xsrcmd5="5f1555cbdcca83ca3fee685ba5c90b6c" lsrcmd5="44ad98fec6311491c3611c69fa72c569"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="d06936c8551093bc4dde1f1ebba7ce78" size="66" mtime="1643641513"/>
+          <entry name="_link" md5="419c1ff25d7c4c75f4223702feaa8122" size="119" mtime="1643641513"/>
+          <entry name="somefile.txt" md5="88469f753affadf50d7f5f0023fc5927" size="48" mtime="1643641513"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:10 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:14 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '616'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="5f1555cbdcca83ca3fee685ba5c90b6c" vrev="38" srcmd5="5f1555cbdcca83ca3fee685ba5c90b6c">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="9c2d78fb4cdf91999058e5e10276a9f3" baserev="9c2d78fb4cdf91999058e5e10276a9f3" lsrcmd5="44ad98fec6311491c3611c69fa72c569"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="d06936c8551093bc4dde1f1ebba7ce78" size="66" mtime="1643641513"/>
+          <entry name="somefile.txt" md5="88469f753affadf50d7f5f0023fc5927" size="48" mtime="1643641513"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:05:14 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -1040,19 +1140,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '720'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="573" vrev="573" srcmd5="5d31b9bd08f659d32f332a69cf331913">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="bb0d9bb54a6f42f67d4ced25b4c198f9" baserev="bb0d9bb54a6f42f67d4ced25b4c198f9" xsrcmd5="ad31224d066569dfacead3e51a4852f4" lsrcmd5="5d31b9bd08f659d32f332a69cf331913"/>
-          <serviceinfo code="succeeded" xsrcmd5="36b3a884b9381115e0495acdb97fc69b"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="787dff501828cf283e870ee3c92df036" size="60" mtime="1642674789"/>
-          <entry name="_link" md5="36a3e842c0e3eba0d46b6633c5b4983e" size="119" mtime="1642674789"/>
-          <entry name="somefile.txt" md5="e08cf1cc86c4e85cd707cf8b0040efb7" size="78" mtime="1642674789"/>
+        <directory name="bar_package" rev="8" vrev="8" srcmd5="44ad98fec6311491c3611c69fa72c569">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="9c2d78fb4cdf91999058e5e10276a9f3" baserev="9c2d78fb4cdf91999058e5e10276a9f3" xsrcmd5="5f1555cbdcca83ca3fee685ba5c90b6c" lsrcmd5="44ad98fec6311491c3611c69fa72c569"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="d06936c8551093bc4dde1f1ebba7ce78" size="66" mtime="1643641513"/>
+          <entry name="_link" md5="419c1ff25d7c4c75f4223702feaa8122" size="119" mtime="1643641513"/>
+          <entry name="somefile.txt" md5="88469f753affadf50d7f5f0023fc5927" size="48" mtime="1643641513"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:10 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:14 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '616'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="5f1555cbdcca83ca3fee685ba5c90b6c" vrev="38" srcmd5="5f1555cbdcca83ca3fee685ba5c90b6c">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="9c2d78fb4cdf91999058e5e10276a9f3" baserev="9c2d78fb4cdf91999058e5e10276a9f3" lsrcmd5="44ad98fec6311491c3611c69fa72c569"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="d06936c8551093bc4dde1f1ebba7ce78" size="66" mtime="1643641513"/>
+          <entry name="somefile.txt" md5="88469f753affadf50d7f5f0023fc5927" size="48" mtime="1643641513"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:05:14 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -1078,22 +1213,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '720'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="573" vrev="573" srcmd5="5d31b9bd08f659d32f332a69cf331913">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="bb0d9bb54a6f42f67d4ced25b4c198f9" baserev="bb0d9bb54a6f42f67d4ced25b4c198f9" xsrcmd5="ad31224d066569dfacead3e51a4852f4" lsrcmd5="5d31b9bd08f659d32f332a69cf331913"/>
-          <serviceinfo code="succeeded" xsrcmd5="36b3a884b9381115e0495acdb97fc69b"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="787dff501828cf283e870ee3c92df036" size="60" mtime="1642674789"/>
-          <entry name="_link" md5="36a3e842c0e3eba0d46b6633c5b4983e" size="119" mtime="1642674789"/>
-          <entry name="somefile.txt" md5="e08cf1cc86c4e85cd707cf8b0040efb7" size="78" mtime="1642674789"/>
+        <directory name="bar_package" rev="8" vrev="8" srcmd5="44ad98fec6311491c3611c69fa72c569">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="9c2d78fb4cdf91999058e5e10276a9f3" baserev="9c2d78fb4cdf91999058e5e10276a9f3" xsrcmd5="5f1555cbdcca83ca3fee685ba5c90b6c" lsrcmd5="44ad98fec6311491c3611c69fa72c569"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="d06936c8551093bc4dde1f1ebba7ce78" size="66" mtime="1643641513"/>
+          <entry name="_link" md5="419c1ff25d7c4c75f4223702feaa8122" size="119" mtime="1643641513"/>
+          <entry name="somefile.txt" md5="88469f753affadf50d7f5f0023fc5927" size="48" mtime="1643641513"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:10 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:14 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1116,171 +1250,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '616'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="573" vrev="573" srcmd5="5d31b9bd08f659d32f332a69cf331913">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="bb0d9bb54a6f42f67d4ced25b4c198f9" baserev="bb0d9bb54a6f42f67d4ced25b4c198f9" xsrcmd5="ad31224d066569dfacead3e51a4852f4" lsrcmd5="5d31b9bd08f659d32f332a69cf331913"/>
-          <serviceinfo code="succeeded" xsrcmd5="36b3a884b9381115e0495acdb97fc69b"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="787dff501828cf283e870ee3c92df036" size="60" mtime="1642674789"/>
-          <entry name="_link" md5="36a3e842c0e3eba0d46b6633c5b4983e" size="119" mtime="1642674789"/>
-          <entry name="somefile.txt" md5="e08cf1cc86c4e85cd707cf8b0040efb7" size="78" mtime="1642674789"/>
+        <directory name="bar_package" rev="5f1555cbdcca83ca3fee685ba5c90b6c" vrev="38" srcmd5="5f1555cbdcca83ca3fee685ba5c90b6c">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="9c2d78fb4cdf91999058e5e10276a9f3" baserev="9c2d78fb4cdf91999058e5e10276a9f3" lsrcmd5="44ad98fec6311491c3611c69fa72c569"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="d06936c8551093bc4dde1f1ebba7ce78" size="66" mtime="1643641513"/>
+          <entry name="somefile.txt" md5="88469f753affadf50d7f5f0023fc5927" size="48" mtime="1643641513"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:10 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '801'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="573" vrev="573" srcmd5="5d31b9bd08f659d32f332a69cf331913">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="bb0d9bb54a6f42f67d4ced25b4c198f9" baserev="bb0d9bb54a6f42f67d4ced25b4c198f9" xsrcmd5="ad31224d066569dfacead3e51a4852f4" lsrcmd5="5d31b9bd08f659d32f332a69cf331913"/>
-          <serviceinfo code="succeeded" xsrcmd5="36b3a884b9381115e0495acdb97fc69b"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="787dff501828cf283e870ee3c92df036" size="60" mtime="1642674789"/>
-          <entry name="_link" md5="36a3e842c0e3eba0d46b6633c5b4983e" size="119" mtime="1642674789"/>
-          <entry name="somefile.txt" md5="e08cf1cc86c4e85cd707cf8b0040efb7" size="78" mtime="1642674789"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:10 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '801'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="573" vrev="573" srcmd5="5d31b9bd08f659d32f332a69cf331913">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="bb0d9bb54a6f42f67d4ced25b4c198f9" baserev="bb0d9bb54a6f42f67d4ced25b4c198f9" xsrcmd5="ad31224d066569dfacead3e51a4852f4" lsrcmd5="5d31b9bd08f659d32f332a69cf331913"/>
-          <serviceinfo code="succeeded" xsrcmd5="36b3a884b9381115e0495acdb97fc69b"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="787dff501828cf283e870ee3c92df036" size="60" mtime="1642674789"/>
-          <entry name="_link" md5="36a3e842c0e3eba0d46b6633c5b4983e" size="119" mtime="1642674789"/>
-          <entry name="somefile.txt" md5="e08cf1cc86c4e85cd707cf8b0040efb7" size="78" mtime="1642674789"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:10 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '801'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="573" vrev="573" srcmd5="5d31b9bd08f659d32f332a69cf331913">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="bb0d9bb54a6f42f67d4ced25b4c198f9" baserev="bb0d9bb54a6f42f67d4ced25b4c198f9" xsrcmd5="ad31224d066569dfacead3e51a4852f4" lsrcmd5="5d31b9bd08f659d32f332a69cf331913"/>
-          <serviceinfo code="succeeded" xsrcmd5="36b3a884b9381115e0495acdb97fc69b"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="787dff501828cf283e870ee3c92df036" size="60" mtime="1642674789"/>
-          <entry name="_link" md5="36a3e842c0e3eba0d46b6633c5b4983e" size="119" mtime="1642674789"/>
-          <entry name="somefile.txt" md5="e08cf1cc86c4e85cd707cf8b0040efb7" size="78" mtime="1642674789"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:10 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '801'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="573" vrev="573" srcmd5="5d31b9bd08f659d32f332a69cf331913">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="bb0d9bb54a6f42f67d4ced25b4c198f9" baserev="bb0d9bb54a6f42f67d4ced25b4c198f9" xsrcmd5="ad31224d066569dfacead3e51a4852f4" lsrcmd5="5d31b9bd08f659d32f332a69cf331913"/>
-          <serviceinfo code="succeeded" xsrcmd5="36b3a884b9381115e0495acdb97fc69b"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="787dff501828cf283e870ee3c92df036" size="60" mtime="1642674789"/>
-          <entry name="_link" md5="36a3e842c0e3eba0d46b6633c5b4983e" size="119" mtime="1642674789"/>
-          <entry name="somefile.txt" md5="e08cf1cc86c4e85cd707cf8b0040efb7" size="78" mtime="1642674789"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:10 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:14 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_branch_request
@@ -1310,5 +1290,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"action":"opened","pull_request":{"head":{"repo":{"full_name":"reponame"},"sha":"123456789"}}}'
-  recorded_at: Thu, 20 Jan 2022 10:33:10 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:14 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_a_new_PR_event/behaves_like_successful_new_PR_or_MR_event/1_1_1_3_1_5.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_a_new_PR_event/behaves_like_successful_new_PR_or_MR_event/1_1_1_3_1_5.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:14 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:11 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_336
+    uri: http://backend:5352/source/foo_project/_meta?user=user_11
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>The Wind's Twelve Quarters</title>
+          <title>East of Eden</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '158'
+      - '144'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>The Wind's Twelve Quarters</title>
+          <title>East of Eden</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:14 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:11 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_337
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_12
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Look to Windward</title>
-          <description>Est et laborum quaerat.</description>
+          <title>Surprised by Joy</title>
+          <description>Id natus aspernatur ad.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -114,16 +114,16 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Look to Windward</title>
-          <description>Est et laborum quaerat.</description>
+          <title>Surprised by Joy</title>
+          <description>Id natus aspernatur ad.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:14 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:11 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Non vero quas. Illo deserunt ex. Unde sunt quasi.
+      string: Soluta esse amet. Molestiae omnis sit. Incidunt numquam rem.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1709" vrev="1709">
-          <srcmd5>1bd117ada9e2ecb42c0a17aff907d474</srcmd5>
+        <revision rev="27" vrev="27">
+          <srcmd5>d63ec86139a7627f5f1c7fc553befa0d</srcmd5>
           <version>unknown</version>
-          <time>1642674794</time>
+          <time>1643641511</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:14 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:11 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Minima est ullam. Ducimus adipisci quia. Praesentium perferendis est.
+      string: Est dolor doloribus. Iure fugiat mollitia. Natus quis accusamus.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +181,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1710" vrev="1710">
-          <srcmd5>4db6702909d9d4b88ea57cfcfd6eae77</srcmd5>
+        <revision rev="28" vrev="28">
+          <srcmd5>b0f9575b3797ae0399864710eefe36ee</srcmd5>
           <version>unknown</version>
-          <time>1642674794</time>
+          <time>1643641511</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:14 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:11 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -227,7 +227,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:33:14 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:11 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -267,7 +267,7 @@ http_interactions:
           <description>This project was created for package bar_package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:15 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:11 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -275,8 +275,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Look to Windward</title>
-          <description>Est et laborum quaerat.</description>
+          <title>Surprised by Joy</title>
+          <description>Id natus aspernatur ad.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -302,10 +302,10 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Look to Windward</title>
-          <description>Est et laborum quaerat.</description>
+          <title>Surprised by Joy</title>
+          <description>Id natus aspernatur ad.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:15 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:11 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=branch&noservice=1&opackage=bar_package&oproject=foo_project&user=Iggy
@@ -333,19 +333,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '204'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="580" vrev="580">
-          <srcmd5>1e028e387d485637973551aad89b3c64</srcmd5>
+        <revision rev="5" vrev="5">
+          <srcmd5>0a9fd50d9455425c54635dd174916cd2</srcmd5>
           <version>unknown</version>
-          <time>1642674795</time>
+          <time>1643641511</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:15 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:11 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -353,8 +353,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Look to Windward</title>
-          <description>Est et laborum quaerat.</description>
+          <title>Surprised by Joy</title>
+          <description>Id natus aspernatur ad.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -380,10 +380,10 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Look to Windward</title>
-          <description>Est et laborum quaerat.</description>
+          <title>Surprised by Joy</title>
+          <description>Id natus aspernatur ad.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:15 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:11 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -409,18 +409,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '725'
+      - '618'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="580" vrev="580" srcmd5="1e028e387d485637973551aad89b3c64">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="4db6702909d9d4b88ea57cfcfd6eae77" baserev="4db6702909d9d4b88ea57cfcfd6eae77" xsrcmd5="377c394873b733da4f767f39d7d3bcbe" lsrcmd5="1e028e387d485637973551aad89b3c64"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="80a92451d773ddc1e5c672d90d539d57" size="49" mtime="1642674794"/>
-          <entry name="_link" md5="86d891195b349a0a081834322bf62764" size="119" mtime="1642674795"/>
-          <entry name="somefile.txt" md5="e10557a2822e969f81866e86b39d47b9" size="69" mtime="1642674794"/>
+        <directory name="bar_package" rev="5" vrev="5" srcmd5="0a9fd50d9455425c54635dd174916cd2">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="b0f9575b3797ae0399864710eefe36ee" baserev="b0f9575b3797ae0399864710eefe36ee" xsrcmd5="dc0634b05255c110732e1e52850b75b6" lsrcmd5="0a9fd50d9455425c54635dd174916cd2"/>
+          <entry name="_config" md5="46726d7919d6f816dc3cc49cc604e646" size="60" mtime="1643641511"/>
+          <entry name="_link" md5="3f361b05ca96d11415683afe700cf378" size="119" mtime="1643641511"/>
+          <entry name="somefile.txt" md5="9b215dd825180d2e53489366c790f182" size="64" mtime="1643641511"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:15 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:11 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?view=info
@@ -446,15 +445,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '333'
+      - '329'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="580" vrev="2290" srcmd5="377c394873b733da4f767f39d7d3bcbe" lsrcmd5="1e028e387d485637973551aad89b3c64" verifymd5="4db6702909d9d4b88ea57cfcfd6eae77">
+        <sourceinfo package="bar_package" rev="5" vrev="33" srcmd5="dc0634b05255c110732e1e52850b75b6" lsrcmd5="0a9fd50d9455425c54635dd174916cd2" verifymd5="b0f9575b3797ae0399864710eefe36ee">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:15 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:11 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -480,18 +479,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '725'
+      - '618'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="580" vrev="580" srcmd5="1e028e387d485637973551aad89b3c64">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="4db6702909d9d4b88ea57cfcfd6eae77" baserev="4db6702909d9d4b88ea57cfcfd6eae77" xsrcmd5="377c394873b733da4f767f39d7d3bcbe" lsrcmd5="1e028e387d485637973551aad89b3c64"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="80a92451d773ddc1e5c672d90d539d57" size="49" mtime="1642674794"/>
-          <entry name="_link" md5="86d891195b349a0a081834322bf62764" size="119" mtime="1642674795"/>
-          <entry name="somefile.txt" md5="e10557a2822e969f81866e86b39d47b9" size="69" mtime="1642674794"/>
+        <directory name="bar_package" rev="5" vrev="5" srcmd5="0a9fd50d9455425c54635dd174916cd2">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="b0f9575b3797ae0399864710eefe36ee" baserev="b0f9575b3797ae0399864710eefe36ee" xsrcmd5="dc0634b05255c110732e1e52850b75b6" lsrcmd5="0a9fd50d9455425c54635dd174916cd2"/>
+          <entry name="_config" md5="46726d7919d6f816dc3cc49cc604e646" size="60" mtime="1643641511"/>
+          <entry name="_link" md5="3f361b05ca96d11415683afe700cf378" size="119" mtime="1643641511"/>
+          <entry name="somefile.txt" md5="9b215dd825180d2e53489366c790f182" size="64" mtime="1643641511"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:15 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:11 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -519,18 +517,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '370'
+      - '368'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="be661f21f24252bcbc4d53a077b21fe1">
+        <sourcediff key="d0ed442a8ff4b81785e609bdfea70c0c">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="580" srcmd5="1e028e387d485637973551aad89b3c64"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="5" srcmd5="0a9fd50d9455425c54635dd174916cd2"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:15 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:12 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -562,12 +560,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="e3003eda906577af9b94135e06c4f20c">
-          <old project="foo_project" package="bar_package" rev="4db6702909d9d4b88ea57cfcfd6eae77" srcmd5="4db6702909d9d4b88ea57cfcfd6eae77"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="377c394873b733da4f767f39d7d3bcbe" srcmd5="377c394873b733da4f767f39d7d3bcbe"/>
+        <sourcediff key="e2cb9cabfe8a5759ca64a90408262f6a">
+          <old project="foo_project" package="bar_package" rev="b0f9575b3797ae0399864710eefe36ee" srcmd5="b0f9575b3797ae0399864710eefe36ee"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="dc0634b05255c110732e1e52850b75b6" srcmd5="dc0634b05255c110732e1e52850b75b6"/>
           <files/>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:15 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:12 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -635,7 +633,7 @@ http_interactions:
             <arch>aarch64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:15 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:12 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_branch_request?user=Iggy
@@ -661,19 +659,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '204'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="581" vrev="581">
-          <srcmd5>d9a2792199d5ed50ae7a7b79ab380dec</srcmd5>
+        <revision rev="6" vrev="6">
+          <srcmd5>9c56b2c3cb88a7e71e32ea72c8b3c60c</srcmd5>
           <version>unknown</version>
-          <time>1642674795</time>
+          <time>1643641512</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:15 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:12 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -681,8 +679,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Look to Windward</title>
-          <description>Est et laborum quaerat.</description>
+          <title>Surprised by Joy</title>
+          <description>Id natus aspernatur ad.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -708,10 +706,10 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Look to Windward</title>
-          <description>Est et laborum quaerat.</description>
+          <title>Surprised by Joy</title>
+          <description>Id natus aspernatur ad.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:15 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:12 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -737,19 +735,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '720'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="581" vrev="581" srcmd5="d9a2792199d5ed50ae7a7b79ab380dec">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="4db6702909d9d4b88ea57cfcfd6eae77" baserev="4db6702909d9d4b88ea57cfcfd6eae77" xsrcmd5="1a8acf00c09e245e156236dce2f546ed" lsrcmd5="d9a2792199d5ed50ae7a7b79ab380dec"/>
-          <serviceinfo code="succeeded" xsrcmd5="f89f6b5b8db7d891b0b867a7d494e09a"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="80a92451d773ddc1e5c672d90d539d57" size="49" mtime="1642674794"/>
-          <entry name="_link" md5="86d891195b349a0a081834322bf62764" size="119" mtime="1642674795"/>
-          <entry name="somefile.txt" md5="e10557a2822e969f81866e86b39d47b9" size="69" mtime="1642674794"/>
+        <directory name="bar_package" rev="6" vrev="6" srcmd5="9c56b2c3cb88a7e71e32ea72c8b3c60c">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="b0f9575b3797ae0399864710eefe36ee" baserev="b0f9575b3797ae0399864710eefe36ee" xsrcmd5="2b51b01954a3d30a16038575606c0986" lsrcmd5="9c56b2c3cb88a7e71e32ea72c8b3c60c"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="46726d7919d6f816dc3cc49cc604e646" size="60" mtime="1643641511"/>
+          <entry name="_link" md5="3f361b05ca96d11415683afe700cf378" size="119" mtime="1643641511"/>
+          <entry name="somefile.txt" md5="9b215dd825180d2e53489366c790f182" size="64" mtime="1643641511"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:15 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:12 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?view=info
@@ -775,15 +772,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '333'
+      - '329'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="581" vrev="2291" srcmd5="bcfb2731796ccde4c4cece2fd17bcfc2" lsrcmd5="f89f6b5b8db7d891b0b867a7d494e09a" verifymd5="d12aef661535b554411a7dbe4f9f48ea">
+        <sourceinfo package="bar_package" rev="6" vrev="34" srcmd5="2b51b01954a3d30a16038575606c0986" lsrcmd5="9c56b2c3cb88a7e71e32ea72c8b3c60c" verifymd5="5081aeeee155c59ecbfd110947d073cf">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:15 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:12 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -809,19 +806,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '720'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="581" vrev="581" srcmd5="d9a2792199d5ed50ae7a7b79ab380dec">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="4db6702909d9d4b88ea57cfcfd6eae77" baserev="4db6702909d9d4b88ea57cfcfd6eae77" xsrcmd5="1a8acf00c09e245e156236dce2f546ed" lsrcmd5="d9a2792199d5ed50ae7a7b79ab380dec"/>
-          <serviceinfo code="succeeded" xsrcmd5="f89f6b5b8db7d891b0b867a7d494e09a"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="80a92451d773ddc1e5c672d90d539d57" size="49" mtime="1642674794"/>
-          <entry name="_link" md5="86d891195b349a0a081834322bf62764" size="119" mtime="1642674795"/>
-          <entry name="somefile.txt" md5="e10557a2822e969f81866e86b39d47b9" size="69" mtime="1642674794"/>
+        <directory name="bar_package" rev="6" vrev="6" srcmd5="9c56b2c3cb88a7e71e32ea72c8b3c60c">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="b0f9575b3797ae0399864710eefe36ee" baserev="b0f9575b3797ae0399864710eefe36ee" xsrcmd5="2b51b01954a3d30a16038575606c0986" lsrcmd5="9c56b2c3cb88a7e71e32ea72c8b3c60c"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="46726d7919d6f816dc3cc49cc604e646" size="60" mtime="1643641511"/>
+          <entry name="_link" md5="3f361b05ca96d11415683afe700cf378" size="119" mtime="1643641511"/>
+          <entry name="somefile.txt" md5="9b215dd825180d2e53489366c790f182" size="64" mtime="1643641511"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:15 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:12 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -849,18 +845,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '370'
+      - '368'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="f62c8fe27000047d97a62165244cd174">
+        <sourcediff key="56aac47bddd5edac720840a27949089c">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="581" srcmd5="d9a2792199d5ed50ae7a7b79ab380dec"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="6" srcmd5="9c56b2c3cb88a7e71e32ea72c8b3c60c"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:15 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:12 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -892,14 +888,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="1832823b5808c10720c5d690bd04b59f">
-          <old project="foo_project" package="bar_package" rev="4db6702909d9d4b88ea57cfcfd6eae77" srcmd5="4db6702909d9d4b88ea57cfcfd6eae77"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="bcfb2731796ccde4c4cece2fd17bcfc2" srcmd5="bcfb2731796ccde4c4cece2fd17bcfc2"/>
+        <sourcediff key="e60253bcc60e08882a0bd7a465327839">
+          <old project="foo_project" package="bar_package" rev="b0f9575b3797ae0399864710eefe36ee" srcmd5="b0f9575b3797ae0399864710eefe36ee"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="2b51b01954a3d30a16038575606c0986" srcmd5="2b51b01954a3d30a16038575606c0986"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:15 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:12 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -925,19 +921,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '720'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="581" vrev="581" srcmd5="d9a2792199d5ed50ae7a7b79ab380dec">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="4db6702909d9d4b88ea57cfcfd6eae77" baserev="4db6702909d9d4b88ea57cfcfd6eae77" xsrcmd5="1a8acf00c09e245e156236dce2f546ed" lsrcmd5="d9a2792199d5ed50ae7a7b79ab380dec"/>
-          <serviceinfo code="succeeded" xsrcmd5="f89f6b5b8db7d891b0b867a7d494e09a"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="80a92451d773ddc1e5c672d90d539d57" size="49" mtime="1642674794"/>
-          <entry name="_link" md5="86d891195b349a0a081834322bf62764" size="119" mtime="1642674795"/>
-          <entry name="somefile.txt" md5="e10557a2822e969f81866e86b39d47b9" size="69" mtime="1642674794"/>
+        <directory name="bar_package" rev="6" vrev="6" srcmd5="9c56b2c3cb88a7e71e32ea72c8b3c60c">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="b0f9575b3797ae0399864710eefe36ee" baserev="b0f9575b3797ae0399864710eefe36ee" xsrcmd5="2b51b01954a3d30a16038575606c0986" lsrcmd5="9c56b2c3cb88a7e71e32ea72c8b3c60c"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="46726d7919d6f816dc3cc49cc604e646" size="60" mtime="1643641511"/>
+          <entry name="_link" md5="3f361b05ca96d11415683afe700cf378" size="119" mtime="1643641511"/>
+          <entry name="somefile.txt" md5="9b215dd825180d2e53489366c790f182" size="64" mtime="1643641511"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:15 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:12 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '616'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="2b51b01954a3d30a16038575606c0986" vrev="34" srcmd5="2b51b01954a3d30a16038575606c0986">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="b0f9575b3797ae0399864710eefe36ee" baserev="b0f9575b3797ae0399864710eefe36ee" lsrcmd5="9c56b2c3cb88a7e71e32ea72c8b3c60c"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="46726d7919d6f816dc3cc49cc604e646" size="60" mtime="1643641511"/>
+          <entry name="somefile.txt" md5="9b215dd825180d2e53489366c790f182" size="64" mtime="1643641511"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:05:12 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -963,19 +994,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '720'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="581" vrev="581" srcmd5="d9a2792199d5ed50ae7a7b79ab380dec">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="4db6702909d9d4b88ea57cfcfd6eae77" baserev="4db6702909d9d4b88ea57cfcfd6eae77" xsrcmd5="1a8acf00c09e245e156236dce2f546ed" lsrcmd5="d9a2792199d5ed50ae7a7b79ab380dec"/>
-          <serviceinfo code="succeeded" xsrcmd5="f89f6b5b8db7d891b0b867a7d494e09a"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="80a92451d773ddc1e5c672d90d539d57" size="49" mtime="1642674794"/>
-          <entry name="_link" md5="86d891195b349a0a081834322bf62764" size="119" mtime="1642674795"/>
-          <entry name="somefile.txt" md5="e10557a2822e969f81866e86b39d47b9" size="69" mtime="1642674794"/>
+        <directory name="bar_package" rev="6" vrev="6" srcmd5="9c56b2c3cb88a7e71e32ea72c8b3c60c">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="b0f9575b3797ae0399864710eefe36ee" baserev="b0f9575b3797ae0399864710eefe36ee" xsrcmd5="2b51b01954a3d30a16038575606c0986" lsrcmd5="9c56b2c3cb88a7e71e32ea72c8b3c60c"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="46726d7919d6f816dc3cc49cc604e646" size="60" mtime="1643641511"/>
+          <entry name="_link" md5="3f361b05ca96d11415683afe700cf378" size="119" mtime="1643641511"/>
+          <entry name="somefile.txt" md5="9b215dd825180d2e53489366c790f182" size="64" mtime="1643641511"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:15 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:12 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '616'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="2b51b01954a3d30a16038575606c0986" vrev="34" srcmd5="2b51b01954a3d30a16038575606c0986">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="b0f9575b3797ae0399864710eefe36ee" baserev="b0f9575b3797ae0399864710eefe36ee" lsrcmd5="9c56b2c3cb88a7e71e32ea72c8b3c60c"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="46726d7919d6f816dc3cc49cc604e646" size="60" mtime="1643641511"/>
+          <entry name="somefile.txt" md5="9b215dd825180d2e53489366c790f182" size="64" mtime="1643641511"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:05:12 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -1001,19 +1067,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '720'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="581" vrev="581" srcmd5="d9a2792199d5ed50ae7a7b79ab380dec">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="4db6702909d9d4b88ea57cfcfd6eae77" baserev="4db6702909d9d4b88ea57cfcfd6eae77" xsrcmd5="1a8acf00c09e245e156236dce2f546ed" lsrcmd5="d9a2792199d5ed50ae7a7b79ab380dec"/>
-          <serviceinfo code="succeeded" xsrcmd5="f89f6b5b8db7d891b0b867a7d494e09a"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="80a92451d773ddc1e5c672d90d539d57" size="49" mtime="1642674794"/>
-          <entry name="_link" md5="86d891195b349a0a081834322bf62764" size="119" mtime="1642674795"/>
-          <entry name="somefile.txt" md5="e10557a2822e969f81866e86b39d47b9" size="69" mtime="1642674794"/>
+        <directory name="bar_package" rev="6" vrev="6" srcmd5="9c56b2c3cb88a7e71e32ea72c8b3c60c">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="b0f9575b3797ae0399864710eefe36ee" baserev="b0f9575b3797ae0399864710eefe36ee" xsrcmd5="2b51b01954a3d30a16038575606c0986" lsrcmd5="9c56b2c3cb88a7e71e32ea72c8b3c60c"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="46726d7919d6f816dc3cc49cc604e646" size="60" mtime="1643641511"/>
+          <entry name="_link" md5="3f361b05ca96d11415683afe700cf378" size="119" mtime="1643641511"/>
+          <entry name="somefile.txt" md5="9b215dd825180d2e53489366c790f182" size="64" mtime="1643641511"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:15 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:12 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '616'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="2b51b01954a3d30a16038575606c0986" vrev="34" srcmd5="2b51b01954a3d30a16038575606c0986">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="b0f9575b3797ae0399864710eefe36ee" baserev="b0f9575b3797ae0399864710eefe36ee" lsrcmd5="9c56b2c3cb88a7e71e32ea72c8b3c60c"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="46726d7919d6f816dc3cc49cc604e646" size="60" mtime="1643641511"/>
+          <entry name="somefile.txt" md5="9b215dd825180d2e53489366c790f182" size="64" mtime="1643641511"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:05:12 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -1039,19 +1140,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '720'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="581" vrev="581" srcmd5="d9a2792199d5ed50ae7a7b79ab380dec">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="4db6702909d9d4b88ea57cfcfd6eae77" baserev="4db6702909d9d4b88ea57cfcfd6eae77" xsrcmd5="1a8acf00c09e245e156236dce2f546ed" lsrcmd5="d9a2792199d5ed50ae7a7b79ab380dec"/>
-          <serviceinfo code="succeeded" xsrcmd5="f89f6b5b8db7d891b0b867a7d494e09a"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="80a92451d773ddc1e5c672d90d539d57" size="49" mtime="1642674794"/>
-          <entry name="_link" md5="86d891195b349a0a081834322bf62764" size="119" mtime="1642674795"/>
-          <entry name="somefile.txt" md5="e10557a2822e969f81866e86b39d47b9" size="69" mtime="1642674794"/>
+        <directory name="bar_package" rev="6" vrev="6" srcmd5="9c56b2c3cb88a7e71e32ea72c8b3c60c">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="b0f9575b3797ae0399864710eefe36ee" baserev="b0f9575b3797ae0399864710eefe36ee" xsrcmd5="2b51b01954a3d30a16038575606c0986" lsrcmd5="9c56b2c3cb88a7e71e32ea72c8b3c60c"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="46726d7919d6f816dc3cc49cc604e646" size="60" mtime="1643641511"/>
+          <entry name="_link" md5="3f361b05ca96d11415683afe700cf378" size="119" mtime="1643641511"/>
+          <entry name="somefile.txt" md5="9b215dd825180d2e53489366c790f182" size="64" mtime="1643641511"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:15 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:12 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '616'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="2b51b01954a3d30a16038575606c0986" vrev="34" srcmd5="2b51b01954a3d30a16038575606c0986">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="b0f9575b3797ae0399864710eefe36ee" baserev="b0f9575b3797ae0399864710eefe36ee" lsrcmd5="9c56b2c3cb88a7e71e32ea72c8b3c60c"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="46726d7919d6f816dc3cc49cc604e646" size="60" mtime="1643641511"/>
+          <entry name="somefile.txt" md5="9b215dd825180d2e53489366c790f182" size="64" mtime="1643641511"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:05:12 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -1077,22 +1213,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '720'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="581" vrev="581" srcmd5="d9a2792199d5ed50ae7a7b79ab380dec">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="4db6702909d9d4b88ea57cfcfd6eae77" baserev="4db6702909d9d4b88ea57cfcfd6eae77" xsrcmd5="1a8acf00c09e245e156236dce2f546ed" lsrcmd5="d9a2792199d5ed50ae7a7b79ab380dec"/>
-          <serviceinfo code="succeeded" xsrcmd5="f89f6b5b8db7d891b0b867a7d494e09a"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="80a92451d773ddc1e5c672d90d539d57" size="49" mtime="1642674794"/>
-          <entry name="_link" md5="86d891195b349a0a081834322bf62764" size="119" mtime="1642674795"/>
-          <entry name="somefile.txt" md5="e10557a2822e969f81866e86b39d47b9" size="69" mtime="1642674794"/>
+        <directory name="bar_package" rev="6" vrev="6" srcmd5="9c56b2c3cb88a7e71e32ea72c8b3c60c">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="b0f9575b3797ae0399864710eefe36ee" baserev="b0f9575b3797ae0399864710eefe36ee" xsrcmd5="2b51b01954a3d30a16038575606c0986" lsrcmd5="9c56b2c3cb88a7e71e32ea72c8b3c60c"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="46726d7919d6f816dc3cc49cc604e646" size="60" mtime="1643641511"/>
+          <entry name="_link" md5="3f361b05ca96d11415683afe700cf378" size="119" mtime="1643641511"/>
+          <entry name="somefile.txt" md5="9b215dd825180d2e53489366c790f182" size="64" mtime="1643641511"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:15 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:12 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1115,169 +1250,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '616'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="581" vrev="581" srcmd5="d9a2792199d5ed50ae7a7b79ab380dec">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="4db6702909d9d4b88ea57cfcfd6eae77" baserev="4db6702909d9d4b88ea57cfcfd6eae77" xsrcmd5="1a8acf00c09e245e156236dce2f546ed" lsrcmd5="d9a2792199d5ed50ae7a7b79ab380dec"/>
-          <serviceinfo code="succeeded" xsrcmd5="f89f6b5b8db7d891b0b867a7d494e09a"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="80a92451d773ddc1e5c672d90d539d57" size="49" mtime="1642674794"/>
-          <entry name="_link" md5="86d891195b349a0a081834322bf62764" size="119" mtime="1642674795"/>
-          <entry name="somefile.txt" md5="e10557a2822e969f81866e86b39d47b9" size="69" mtime="1642674794"/>
+        <directory name="bar_package" rev="2b51b01954a3d30a16038575606c0986" vrev="34" srcmd5="2b51b01954a3d30a16038575606c0986">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="b0f9575b3797ae0399864710eefe36ee" baserev="b0f9575b3797ae0399864710eefe36ee" lsrcmd5="9c56b2c3cb88a7e71e32ea72c8b3c60c"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="46726d7919d6f816dc3cc49cc604e646" size="60" mtime="1643641511"/>
+          <entry name="somefile.txt" md5="9b215dd825180d2e53489366c790f182" size="64" mtime="1643641511"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:15 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '801'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="581" vrev="581" srcmd5="d9a2792199d5ed50ae7a7b79ab380dec">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="4db6702909d9d4b88ea57cfcfd6eae77" baserev="4db6702909d9d4b88ea57cfcfd6eae77" xsrcmd5="1a8acf00c09e245e156236dce2f546ed" lsrcmd5="d9a2792199d5ed50ae7a7b79ab380dec"/>
-          <serviceinfo code="succeeded" xsrcmd5="f89f6b5b8db7d891b0b867a7d494e09a"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="80a92451d773ddc1e5c672d90d539d57" size="49" mtime="1642674794"/>
-          <entry name="_link" md5="86d891195b349a0a081834322bf62764" size="119" mtime="1642674795"/>
-          <entry name="somefile.txt" md5="e10557a2822e969f81866e86b39d47b9" size="69" mtime="1642674794"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:15 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '801'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="581" vrev="581" srcmd5="d9a2792199d5ed50ae7a7b79ab380dec">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="4db6702909d9d4b88ea57cfcfd6eae77" baserev="4db6702909d9d4b88ea57cfcfd6eae77" xsrcmd5="1a8acf00c09e245e156236dce2f546ed" lsrcmd5="d9a2792199d5ed50ae7a7b79ab380dec"/>
-          <serviceinfo code="succeeded" xsrcmd5="f89f6b5b8db7d891b0b867a7d494e09a"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="80a92451d773ddc1e5c672d90d539d57" size="49" mtime="1642674794"/>
-          <entry name="_link" md5="86d891195b349a0a081834322bf62764" size="119" mtime="1642674795"/>
-          <entry name="somefile.txt" md5="e10557a2822e969f81866e86b39d47b9" size="69" mtime="1642674794"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:15 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '801'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="581" vrev="581" srcmd5="d9a2792199d5ed50ae7a7b79ab380dec">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="4db6702909d9d4b88ea57cfcfd6eae77" baserev="4db6702909d9d4b88ea57cfcfd6eae77" xsrcmd5="1a8acf00c09e245e156236dce2f546ed" lsrcmd5="d9a2792199d5ed50ae7a7b79ab380dec"/>
-          <serviceinfo code="succeeded" xsrcmd5="f89f6b5b8db7d891b0b867a7d494e09a"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="80a92451d773ddc1e5c672d90d539d57" size="49" mtime="1642674794"/>
-          <entry name="_link" md5="86d891195b349a0a081834322bf62764" size="119" mtime="1642674795"/>
-          <entry name="somefile.txt" md5="e10557a2822e969f81866e86b39d47b9" size="69" mtime="1642674794"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:15 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '801'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="581" vrev="581" srcmd5="d9a2792199d5ed50ae7a7b79ab380dec">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="4db6702909d9d4b88ea57cfcfd6eae77" baserev="4db6702909d9d4b88ea57cfcfd6eae77" xsrcmd5="1a8acf00c09e245e156236dce2f546ed" lsrcmd5="d9a2792199d5ed50ae7a7b79ab380dec"/>
-          <serviceinfo code="succeeded" xsrcmd5="f89f6b5b8db7d891b0b867a7d494e09a"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="80a92451d773ddc1e5c672d90d539d57" size="49" mtime="1642674794"/>
-          <entry name="_link" md5="86d891195b349a0a081834322bf62764" size="119" mtime="1642674795"/>
-          <entry name="somefile.txt" md5="e10557a2822e969f81866e86b39d47b9" size="69" mtime="1642674794"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:15 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:12 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_a_new_PR_event/behaves_like_successful_new_PR_or_MR_event/1_1_1_3_1_6.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_a_new_PR_event/behaves_like_successful_new_PR_or_MR_event/1_1_1_3_1_6.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:08 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:19 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_326
+    uri: http://backend:5352/source/foo_project/_meta?user=user_21
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>The World, the Flesh and the Devil</title>
+          <title>Françoise Sagan</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '166'
+      - '148'
     body:
-      encoding: UTF-8
-      string: |
-        <project name="foo_project">
-          <title>The World, the Flesh and the Devil</title>
-          <description></description>
-          <person userid="Iggy" role="maintainer"/>
-        </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:08 GMT
+      encoding: ASCII-8BIT
+      string: !binary |-
+        PHByb2plY3QgbmFtZT0iZm9vX3Byb2plY3QiPgogIDx0aXRsZT5GcmFuw6dvaXNlIFNhZ2FuPC90aXRsZT4KICA8ZGVzY3JpcHRpb24+PC9kZXNjcmlwdGlvbj4KICA8cGVyc29uIHVzZXJpZD0iSWdneSIgcm9sZT0ibWFpbnRhaW5lciIvPgo8L3Byb2plY3Q+Cg==
+  recorded_at: Mon, 31 Jan 2022 15:05:19 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_327
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_22
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Way of All Flesh</title>
-          <description>Ut distinctio iste quibusdam.</description>
+          <title>Beyond the Mexique Bay</title>
+          <description>Ducimus unde et at.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +105,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '159'
+      - '151'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Way of All Flesh</title>
-          <description>Ut distinctio iste quibusdam.</description>
+          <title>Beyond the Mexique Bay</title>
+          <description>Ducimus unde et at.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:08 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:19 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Nobis qui quisquam. Cum ipsum odit. Omnis nesciunt ex.
+      string: Totam voluptatum esse. Omnis similique enim. Distinctio ut eos.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,26 +139,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1699" vrev="1699">
-          <srcmd5>3e1a48f2d4dadc7c4040a65a0c43d22b</srcmd5>
+        <revision rev="37" vrev="37">
+          <srcmd5>e871a4b680060e474430bd90e1231cbc</srcmd5>
           <version>unknown</version>
-          <time>1642674788</time>
+          <time>1643641519</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:08 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:19 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Consequatur similique voluptate. Mollitia nobis excepturi. Excepturi
-        qui et.
+      string: Aut suscipit itaque. Et repellat incidunt. Voluptatem doloremque aspernatur.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -182,19 +177,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1700" vrev="1700">
-          <srcmd5>3c48d89233cde16c2a104f31d876894e</srcmd5>
+        <revision rev="38" vrev="38">
+          <srcmd5>ef80c124535c0012c25a302dbaa3732c</srcmd5>
           <version>unknown</version>
-          <time>1642674788</time>
+          <time>1643641519</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:08 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:19 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -228,7 +223,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:33:08 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:19 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -268,7 +263,7 @@ http_interactions:
           <description>This project was created for package bar_package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:08 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:20 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -276,8 +271,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Way of All Flesh</title>
-          <description>Ut distinctio iste quibusdam.</description>
+          <title>Beyond the Mexique Bay</title>
+          <description>Ducimus unde et at.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -298,15 +293,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '190'
+      - '182'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Way of All Flesh</title>
-          <description>Ut distinctio iste quibusdam.</description>
+          <title>Beyond the Mexique Bay</title>
+          <description>Ducimus unde et at.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:08 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:20 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=branch&noservice=1&opackage=bar_package&oproject=foo_project&user=Iggy
@@ -334,19 +329,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="570" vrev="570">
-          <srcmd5>f6e50d275aa95c9ff6469093ce346df0</srcmd5>
+        <revision rev="15" vrev="15">
+          <srcmd5>25d4ebf8d6f887a4dc964e921edf381c</srcmd5>
           <version>unknown</version>
-          <time>1642674788</time>
+          <time>1643641520</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:08 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:20 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -354,8 +349,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Way of All Flesh</title>
-          <description>Ut distinctio iste quibusdam.</description>
+          <title>Beyond the Mexique Bay</title>
+          <description>Ducimus unde et at.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -376,15 +371,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '190'
+      - '182'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Way of All Flesh</title>
-          <description>Ut distinctio iste quibusdam.</description>
+          <title>Beyond the Mexique Bay</title>
+          <description>Ducimus unde et at.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:08 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:20 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -410,18 +405,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '725'
+      - '620'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="570" vrev="570" srcmd5="f6e50d275aa95c9ff6469093ce346df0">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3c48d89233cde16c2a104f31d876894e" baserev="3c48d89233cde16c2a104f31d876894e" xsrcmd5="670626ea9b0079e400fb85286a1965c5" lsrcmd5="f6e50d275aa95c9ff6469093ce346df0"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="dd7f4261ff4f5f1036c9b1dbaca56913" size="54" mtime="1642674788"/>
-          <entry name="_link" md5="337c171a192c7a75a9d6d3b3906251ed" size="119" mtime="1642674788"/>
-          <entry name="somefile.txt" md5="c02e00309372b60710fa54ff546bf3a7" size="76" mtime="1642674788"/>
+        <directory name="bar_package" rev="15" vrev="15" srcmd5="25d4ebf8d6f887a4dc964e921edf381c">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="ef80c124535c0012c25a302dbaa3732c" baserev="ef80c124535c0012c25a302dbaa3732c" xsrcmd5="ea98789440ad3cf1a37b0b85c62f18f2" lsrcmd5="25d4ebf8d6f887a4dc964e921edf381c"/>
+          <entry name="_config" md5="0848103dc75849f6054a63ed7cb93e4d" size="63" mtime="1643641519"/>
+          <entry name="_link" md5="8897a5cbc411aba7d197e7dbaeb5f3f5" size="119" mtime="1643641520"/>
+          <entry name="somefile.txt" md5="763e2cc9c8eeb9ba4181bec61f3e145d" size="76" mtime="1643641519"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:08 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:20 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?view=info
@@ -447,15 +441,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '333'
+      - '330'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="570" vrev="2270" srcmd5="670626ea9b0079e400fb85286a1965c5" lsrcmd5="f6e50d275aa95c9ff6469093ce346df0" verifymd5="3c48d89233cde16c2a104f31d876894e">
+        <sourceinfo package="bar_package" rev="15" vrev="53" srcmd5="ea98789440ad3cf1a37b0b85c62f18f2" lsrcmd5="25d4ebf8d6f887a4dc964e921edf381c" verifymd5="ef80c124535c0012c25a302dbaa3732c">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:08 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:20 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -481,18 +475,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '725'
+      - '620'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="570" vrev="570" srcmd5="f6e50d275aa95c9ff6469093ce346df0">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3c48d89233cde16c2a104f31d876894e" baserev="3c48d89233cde16c2a104f31d876894e" xsrcmd5="670626ea9b0079e400fb85286a1965c5" lsrcmd5="f6e50d275aa95c9ff6469093ce346df0"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="dd7f4261ff4f5f1036c9b1dbaca56913" size="54" mtime="1642674788"/>
-          <entry name="_link" md5="337c171a192c7a75a9d6d3b3906251ed" size="119" mtime="1642674788"/>
-          <entry name="somefile.txt" md5="c02e00309372b60710fa54ff546bf3a7" size="76" mtime="1642674788"/>
+        <directory name="bar_package" rev="15" vrev="15" srcmd5="25d4ebf8d6f887a4dc964e921edf381c">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="ef80c124535c0012c25a302dbaa3732c" baserev="ef80c124535c0012c25a302dbaa3732c" xsrcmd5="ea98789440ad3cf1a37b0b85c62f18f2" lsrcmd5="25d4ebf8d6f887a4dc964e921edf381c"/>
+          <entry name="_config" md5="0848103dc75849f6054a63ed7cb93e4d" size="63" mtime="1643641519"/>
+          <entry name="_link" md5="8897a5cbc411aba7d197e7dbaeb5f3f5" size="119" mtime="1643641520"/>
+          <entry name="somefile.txt" md5="763e2cc9c8eeb9ba4181bec61f3e145d" size="76" mtime="1643641519"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:08 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:20 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -520,18 +513,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '370'
+      - '369'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="965f2c538fc89f99144885ef36e2978d">
+        <sourcediff key="378a4205188bb6c9c675ae646ac4a195">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="570" srcmd5="f6e50d275aa95c9ff6469093ce346df0"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="15" srcmd5="25d4ebf8d6f887a4dc964e921edf381c"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:08 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:20 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -563,12 +556,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="bf9a3c9b88e8496eef39dd7501e52ffc">
-          <old project="foo_project" package="bar_package" rev="3c48d89233cde16c2a104f31d876894e" srcmd5="3c48d89233cde16c2a104f31d876894e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="670626ea9b0079e400fb85286a1965c5" srcmd5="670626ea9b0079e400fb85286a1965c5"/>
+        <sourcediff key="2f1d7e2bf5b91ab4a3f27b368aa5ba6d">
+          <old project="foo_project" package="bar_package" rev="ef80c124535c0012c25a302dbaa3732c" srcmd5="ef80c124535c0012c25a302dbaa3732c"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="ea98789440ad3cf1a37b0b85c62f18f2" srcmd5="ea98789440ad3cf1a37b0b85c62f18f2"/>
           <files/>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:08 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:20 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -636,7 +629,7 @@ http_interactions:
             <arch>aarch64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:08 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:20 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_branch_request?user=Iggy
@@ -662,19 +655,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="571" vrev="571">
-          <srcmd5>15808a5e47aaf1f4cd20b49868e881a7</srcmd5>
+        <revision rev="16" vrev="16">
+          <srcmd5>0df8c1026d0cfb94dffe014ea9a5fdc6</srcmd5>
           <version>unknown</version>
-          <time>1642674788</time>
+          <time>1643641520</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:08 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:20 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -682,8 +675,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Way of All Flesh</title>
-          <description>Ut distinctio iste quibusdam.</description>
+          <title>Beyond the Mexique Bay</title>
+          <description>Ducimus unde et at.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -704,15 +697,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '190'
+      - '182'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Way of All Flesh</title>
-          <description>Ut distinctio iste quibusdam.</description>
+          <title>Beyond the Mexique Bay</title>
+          <description>Ducimus unde et at.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:09 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:21 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -738,19 +731,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '722'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="571" vrev="571" srcmd5="15808a5e47aaf1f4cd20b49868e881a7">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3c48d89233cde16c2a104f31d876894e" baserev="3c48d89233cde16c2a104f31d876894e" xsrcmd5="234ea9e85c4086f7ea318559a3ebdba9" lsrcmd5="15808a5e47aaf1f4cd20b49868e881a7"/>
-          <serviceinfo code="succeeded" xsrcmd5="eefd6c95d991aa44f26c8df7dece342a"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="dd7f4261ff4f5f1036c9b1dbaca56913" size="54" mtime="1642674788"/>
-          <entry name="_link" md5="337c171a192c7a75a9d6d3b3906251ed" size="119" mtime="1642674788"/>
-          <entry name="somefile.txt" md5="c02e00309372b60710fa54ff546bf3a7" size="76" mtime="1642674788"/>
+        <directory name="bar_package" rev="16" vrev="16" srcmd5="0df8c1026d0cfb94dffe014ea9a5fdc6">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="ef80c124535c0012c25a302dbaa3732c" baserev="ef80c124535c0012c25a302dbaa3732c" xsrcmd5="f67b8b506a83648538bb5d854dead19e" lsrcmd5="0df8c1026d0cfb94dffe014ea9a5fdc6"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="0848103dc75849f6054a63ed7cb93e4d" size="63" mtime="1643641519"/>
+          <entry name="_link" md5="8897a5cbc411aba7d197e7dbaeb5f3f5" size="119" mtime="1643641520"/>
+          <entry name="somefile.txt" md5="763e2cc9c8eeb9ba4181bec61f3e145d" size="76" mtime="1643641519"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:09 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:21 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?view=info
@@ -776,15 +768,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '333'
+      - '330'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="571" vrev="2271" srcmd5="52e3af778af61302c80a3c683ea60cef" lsrcmd5="eefd6c95d991aa44f26c8df7dece342a" verifymd5="0478acdfc5333e1966d0b1c598994809">
+        <sourceinfo package="bar_package" rev="16" vrev="54" srcmd5="f67b8b506a83648538bb5d854dead19e" lsrcmd5="0df8c1026d0cfb94dffe014ea9a5fdc6" verifymd5="aa7eb30a58cd576d2173d77f0cc56dc0">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:09 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:21 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -810,19 +802,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '722'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="571" vrev="571" srcmd5="15808a5e47aaf1f4cd20b49868e881a7">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3c48d89233cde16c2a104f31d876894e" baserev="3c48d89233cde16c2a104f31d876894e" xsrcmd5="234ea9e85c4086f7ea318559a3ebdba9" lsrcmd5="15808a5e47aaf1f4cd20b49868e881a7"/>
-          <serviceinfo code="succeeded" xsrcmd5="eefd6c95d991aa44f26c8df7dece342a"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="dd7f4261ff4f5f1036c9b1dbaca56913" size="54" mtime="1642674788"/>
-          <entry name="_link" md5="337c171a192c7a75a9d6d3b3906251ed" size="119" mtime="1642674788"/>
-          <entry name="somefile.txt" md5="c02e00309372b60710fa54ff546bf3a7" size="76" mtime="1642674788"/>
+        <directory name="bar_package" rev="16" vrev="16" srcmd5="0df8c1026d0cfb94dffe014ea9a5fdc6">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="ef80c124535c0012c25a302dbaa3732c" baserev="ef80c124535c0012c25a302dbaa3732c" xsrcmd5="f67b8b506a83648538bb5d854dead19e" lsrcmd5="0df8c1026d0cfb94dffe014ea9a5fdc6"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="0848103dc75849f6054a63ed7cb93e4d" size="63" mtime="1643641519"/>
+          <entry name="_link" md5="8897a5cbc411aba7d197e7dbaeb5f3f5" size="119" mtime="1643641520"/>
+          <entry name="somefile.txt" md5="763e2cc9c8eeb9ba4181bec61f3e145d" size="76" mtime="1643641519"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:09 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:21 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -850,18 +841,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '370'
+      - '369'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="ee6ebcb94ceee1231be6529299ecdf99">
+        <sourcediff key="cf39298c2877dbe936bef4e8c40a5b05">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="571" srcmd5="15808a5e47aaf1f4cd20b49868e881a7"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="16" srcmd5="0df8c1026d0cfb94dffe014ea9a5fdc6"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:09 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:21 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -893,14 +884,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="253ce45c0fcbfa4a53e869154af1b1f0">
-          <old project="foo_project" package="bar_package" rev="3c48d89233cde16c2a104f31d876894e" srcmd5="3c48d89233cde16c2a104f31d876894e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="52e3af778af61302c80a3c683ea60cef" srcmd5="52e3af778af61302c80a3c683ea60cef"/>
+        <sourcediff key="51b4df966cb1c9b61afdbe15f5e927d9">
+          <old project="foo_project" package="bar_package" rev="ef80c124535c0012c25a302dbaa3732c" srcmd5="ef80c124535c0012c25a302dbaa3732c"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="f67b8b506a83648538bb5d854dead19e" srcmd5="f67b8b506a83648538bb5d854dead19e"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:09 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:21 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -926,19 +917,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '722'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="571" vrev="571" srcmd5="15808a5e47aaf1f4cd20b49868e881a7">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3c48d89233cde16c2a104f31d876894e" baserev="3c48d89233cde16c2a104f31d876894e" xsrcmd5="234ea9e85c4086f7ea318559a3ebdba9" lsrcmd5="15808a5e47aaf1f4cd20b49868e881a7"/>
-          <serviceinfo code="succeeded" xsrcmd5="eefd6c95d991aa44f26c8df7dece342a"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="dd7f4261ff4f5f1036c9b1dbaca56913" size="54" mtime="1642674788"/>
-          <entry name="_link" md5="337c171a192c7a75a9d6d3b3906251ed" size="119" mtime="1642674788"/>
-          <entry name="somefile.txt" md5="c02e00309372b60710fa54ff546bf3a7" size="76" mtime="1642674788"/>
+        <directory name="bar_package" rev="16" vrev="16" srcmd5="0df8c1026d0cfb94dffe014ea9a5fdc6">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="ef80c124535c0012c25a302dbaa3732c" baserev="ef80c124535c0012c25a302dbaa3732c" xsrcmd5="f67b8b506a83648538bb5d854dead19e" lsrcmd5="0df8c1026d0cfb94dffe014ea9a5fdc6"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="0848103dc75849f6054a63ed7cb93e4d" size="63" mtime="1643641519"/>
+          <entry name="_link" md5="8897a5cbc411aba7d197e7dbaeb5f3f5" size="119" mtime="1643641520"/>
+          <entry name="somefile.txt" md5="763e2cc9c8eeb9ba4181bec61f3e145d" size="76" mtime="1643641519"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:09 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:21 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '616'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="f67b8b506a83648538bb5d854dead19e" vrev="54" srcmd5="f67b8b506a83648538bb5d854dead19e">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="ef80c124535c0012c25a302dbaa3732c" baserev="ef80c124535c0012c25a302dbaa3732c" lsrcmd5="0df8c1026d0cfb94dffe014ea9a5fdc6"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="0848103dc75849f6054a63ed7cb93e4d" size="63" mtime="1643641519"/>
+          <entry name="somefile.txt" md5="763e2cc9c8eeb9ba4181bec61f3e145d" size="76" mtime="1643641519"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:05:21 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -964,19 +990,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '722'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="571" vrev="571" srcmd5="15808a5e47aaf1f4cd20b49868e881a7">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3c48d89233cde16c2a104f31d876894e" baserev="3c48d89233cde16c2a104f31d876894e" xsrcmd5="234ea9e85c4086f7ea318559a3ebdba9" lsrcmd5="15808a5e47aaf1f4cd20b49868e881a7"/>
-          <serviceinfo code="succeeded" xsrcmd5="eefd6c95d991aa44f26c8df7dece342a"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="dd7f4261ff4f5f1036c9b1dbaca56913" size="54" mtime="1642674788"/>
-          <entry name="_link" md5="337c171a192c7a75a9d6d3b3906251ed" size="119" mtime="1642674788"/>
-          <entry name="somefile.txt" md5="c02e00309372b60710fa54ff546bf3a7" size="76" mtime="1642674788"/>
+        <directory name="bar_package" rev="16" vrev="16" srcmd5="0df8c1026d0cfb94dffe014ea9a5fdc6">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="ef80c124535c0012c25a302dbaa3732c" baserev="ef80c124535c0012c25a302dbaa3732c" xsrcmd5="f67b8b506a83648538bb5d854dead19e" lsrcmd5="0df8c1026d0cfb94dffe014ea9a5fdc6"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="0848103dc75849f6054a63ed7cb93e4d" size="63" mtime="1643641519"/>
+          <entry name="_link" md5="8897a5cbc411aba7d197e7dbaeb5f3f5" size="119" mtime="1643641520"/>
+          <entry name="somefile.txt" md5="763e2cc9c8eeb9ba4181bec61f3e145d" size="76" mtime="1643641519"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:09 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:21 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '616'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="f67b8b506a83648538bb5d854dead19e" vrev="54" srcmd5="f67b8b506a83648538bb5d854dead19e">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="ef80c124535c0012c25a302dbaa3732c" baserev="ef80c124535c0012c25a302dbaa3732c" lsrcmd5="0df8c1026d0cfb94dffe014ea9a5fdc6"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="0848103dc75849f6054a63ed7cb93e4d" size="63" mtime="1643641519"/>
+          <entry name="somefile.txt" md5="763e2cc9c8eeb9ba4181bec61f3e145d" size="76" mtime="1643641519"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:05:21 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -1002,19 +1063,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '722'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="571" vrev="571" srcmd5="15808a5e47aaf1f4cd20b49868e881a7">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3c48d89233cde16c2a104f31d876894e" baserev="3c48d89233cde16c2a104f31d876894e" xsrcmd5="234ea9e85c4086f7ea318559a3ebdba9" lsrcmd5="15808a5e47aaf1f4cd20b49868e881a7"/>
-          <serviceinfo code="succeeded" xsrcmd5="eefd6c95d991aa44f26c8df7dece342a"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="dd7f4261ff4f5f1036c9b1dbaca56913" size="54" mtime="1642674788"/>
-          <entry name="_link" md5="337c171a192c7a75a9d6d3b3906251ed" size="119" mtime="1642674788"/>
-          <entry name="somefile.txt" md5="c02e00309372b60710fa54ff546bf3a7" size="76" mtime="1642674788"/>
+        <directory name="bar_package" rev="16" vrev="16" srcmd5="0df8c1026d0cfb94dffe014ea9a5fdc6">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="ef80c124535c0012c25a302dbaa3732c" baserev="ef80c124535c0012c25a302dbaa3732c" xsrcmd5="f67b8b506a83648538bb5d854dead19e" lsrcmd5="0df8c1026d0cfb94dffe014ea9a5fdc6"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="0848103dc75849f6054a63ed7cb93e4d" size="63" mtime="1643641519"/>
+          <entry name="_link" md5="8897a5cbc411aba7d197e7dbaeb5f3f5" size="119" mtime="1643641520"/>
+          <entry name="somefile.txt" md5="763e2cc9c8eeb9ba4181bec61f3e145d" size="76" mtime="1643641519"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:09 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:21 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '616'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="f67b8b506a83648538bb5d854dead19e" vrev="54" srcmd5="f67b8b506a83648538bb5d854dead19e">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="ef80c124535c0012c25a302dbaa3732c" baserev="ef80c124535c0012c25a302dbaa3732c" lsrcmd5="0df8c1026d0cfb94dffe014ea9a5fdc6"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="0848103dc75849f6054a63ed7cb93e4d" size="63" mtime="1643641519"/>
+          <entry name="somefile.txt" md5="763e2cc9c8eeb9ba4181bec61f3e145d" size="76" mtime="1643641519"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:05:21 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -1040,19 +1136,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '722'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="571" vrev="571" srcmd5="15808a5e47aaf1f4cd20b49868e881a7">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3c48d89233cde16c2a104f31d876894e" baserev="3c48d89233cde16c2a104f31d876894e" xsrcmd5="234ea9e85c4086f7ea318559a3ebdba9" lsrcmd5="15808a5e47aaf1f4cd20b49868e881a7"/>
-          <serviceinfo code="succeeded" xsrcmd5="eefd6c95d991aa44f26c8df7dece342a"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="dd7f4261ff4f5f1036c9b1dbaca56913" size="54" mtime="1642674788"/>
-          <entry name="_link" md5="337c171a192c7a75a9d6d3b3906251ed" size="119" mtime="1642674788"/>
-          <entry name="somefile.txt" md5="c02e00309372b60710fa54ff546bf3a7" size="76" mtime="1642674788"/>
+        <directory name="bar_package" rev="16" vrev="16" srcmd5="0df8c1026d0cfb94dffe014ea9a5fdc6">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="ef80c124535c0012c25a302dbaa3732c" baserev="ef80c124535c0012c25a302dbaa3732c" xsrcmd5="f67b8b506a83648538bb5d854dead19e" lsrcmd5="0df8c1026d0cfb94dffe014ea9a5fdc6"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="0848103dc75849f6054a63ed7cb93e4d" size="63" mtime="1643641519"/>
+          <entry name="_link" md5="8897a5cbc411aba7d197e7dbaeb5f3f5" size="119" mtime="1643641520"/>
+          <entry name="somefile.txt" md5="763e2cc9c8eeb9ba4181bec61f3e145d" size="76" mtime="1643641519"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:09 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:21 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '616'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="f67b8b506a83648538bb5d854dead19e" vrev="54" srcmd5="f67b8b506a83648538bb5d854dead19e">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="ef80c124535c0012c25a302dbaa3732c" baserev="ef80c124535c0012c25a302dbaa3732c" lsrcmd5="0df8c1026d0cfb94dffe014ea9a5fdc6"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="0848103dc75849f6054a63ed7cb93e4d" size="63" mtime="1643641519"/>
+          <entry name="somefile.txt" md5="763e2cc9c8eeb9ba4181bec61f3e145d" size="76" mtime="1643641519"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:05:21 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -1078,22 +1209,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '722'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="571" vrev="571" srcmd5="15808a5e47aaf1f4cd20b49868e881a7">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3c48d89233cde16c2a104f31d876894e" baserev="3c48d89233cde16c2a104f31d876894e" xsrcmd5="234ea9e85c4086f7ea318559a3ebdba9" lsrcmd5="15808a5e47aaf1f4cd20b49868e881a7"/>
-          <serviceinfo code="succeeded" xsrcmd5="eefd6c95d991aa44f26c8df7dece342a"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="dd7f4261ff4f5f1036c9b1dbaca56913" size="54" mtime="1642674788"/>
-          <entry name="_link" md5="337c171a192c7a75a9d6d3b3906251ed" size="119" mtime="1642674788"/>
-          <entry name="somefile.txt" md5="c02e00309372b60710fa54ff546bf3a7" size="76" mtime="1642674788"/>
+        <directory name="bar_package" rev="16" vrev="16" srcmd5="0df8c1026d0cfb94dffe014ea9a5fdc6">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="ef80c124535c0012c25a302dbaa3732c" baserev="ef80c124535c0012c25a302dbaa3732c" xsrcmd5="f67b8b506a83648538bb5d854dead19e" lsrcmd5="0df8c1026d0cfb94dffe014ea9a5fdc6"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="0848103dc75849f6054a63ed7cb93e4d" size="63" mtime="1643641519"/>
+          <entry name="_link" md5="8897a5cbc411aba7d197e7dbaeb5f3f5" size="119" mtime="1643641520"/>
+          <entry name="somefile.txt" md5="763e2cc9c8eeb9ba4181bec61f3e145d" size="76" mtime="1643641519"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:09 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:21 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1116,169 +1246,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '616'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="571" vrev="571" srcmd5="15808a5e47aaf1f4cd20b49868e881a7">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3c48d89233cde16c2a104f31d876894e" baserev="3c48d89233cde16c2a104f31d876894e" xsrcmd5="234ea9e85c4086f7ea318559a3ebdba9" lsrcmd5="15808a5e47aaf1f4cd20b49868e881a7"/>
-          <serviceinfo code="succeeded" xsrcmd5="eefd6c95d991aa44f26c8df7dece342a"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="dd7f4261ff4f5f1036c9b1dbaca56913" size="54" mtime="1642674788"/>
-          <entry name="_link" md5="337c171a192c7a75a9d6d3b3906251ed" size="119" mtime="1642674788"/>
-          <entry name="somefile.txt" md5="c02e00309372b60710fa54ff546bf3a7" size="76" mtime="1642674788"/>
+        <directory name="bar_package" rev="f67b8b506a83648538bb5d854dead19e" vrev="54" srcmd5="f67b8b506a83648538bb5d854dead19e">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="ef80c124535c0012c25a302dbaa3732c" baserev="ef80c124535c0012c25a302dbaa3732c" lsrcmd5="0df8c1026d0cfb94dffe014ea9a5fdc6"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="0848103dc75849f6054a63ed7cb93e4d" size="63" mtime="1643641519"/>
+          <entry name="somefile.txt" md5="763e2cc9c8eeb9ba4181bec61f3e145d" size="76" mtime="1643641519"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:09 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '801'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="571" vrev="571" srcmd5="15808a5e47aaf1f4cd20b49868e881a7">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3c48d89233cde16c2a104f31d876894e" baserev="3c48d89233cde16c2a104f31d876894e" xsrcmd5="234ea9e85c4086f7ea318559a3ebdba9" lsrcmd5="15808a5e47aaf1f4cd20b49868e881a7"/>
-          <serviceinfo code="succeeded" xsrcmd5="eefd6c95d991aa44f26c8df7dece342a"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="dd7f4261ff4f5f1036c9b1dbaca56913" size="54" mtime="1642674788"/>
-          <entry name="_link" md5="337c171a192c7a75a9d6d3b3906251ed" size="119" mtime="1642674788"/>
-          <entry name="somefile.txt" md5="c02e00309372b60710fa54ff546bf3a7" size="76" mtime="1642674788"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:09 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '801'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="571" vrev="571" srcmd5="15808a5e47aaf1f4cd20b49868e881a7">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3c48d89233cde16c2a104f31d876894e" baserev="3c48d89233cde16c2a104f31d876894e" xsrcmd5="234ea9e85c4086f7ea318559a3ebdba9" lsrcmd5="15808a5e47aaf1f4cd20b49868e881a7"/>
-          <serviceinfo code="succeeded" xsrcmd5="eefd6c95d991aa44f26c8df7dece342a"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="dd7f4261ff4f5f1036c9b1dbaca56913" size="54" mtime="1642674788"/>
-          <entry name="_link" md5="337c171a192c7a75a9d6d3b3906251ed" size="119" mtime="1642674788"/>
-          <entry name="somefile.txt" md5="c02e00309372b60710fa54ff546bf3a7" size="76" mtime="1642674788"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:09 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '801'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="571" vrev="571" srcmd5="15808a5e47aaf1f4cd20b49868e881a7">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3c48d89233cde16c2a104f31d876894e" baserev="3c48d89233cde16c2a104f31d876894e" xsrcmd5="234ea9e85c4086f7ea318559a3ebdba9" lsrcmd5="15808a5e47aaf1f4cd20b49868e881a7"/>
-          <serviceinfo code="succeeded" xsrcmd5="eefd6c95d991aa44f26c8df7dece342a"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="dd7f4261ff4f5f1036c9b1dbaca56913" size="54" mtime="1642674788"/>
-          <entry name="_link" md5="337c171a192c7a75a9d6d3b3906251ed" size="119" mtime="1642674788"/>
-          <entry name="somefile.txt" md5="c02e00309372b60710fa54ff546bf3a7" size="76" mtime="1642674788"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:09 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '801'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="571" vrev="571" srcmd5="15808a5e47aaf1f4cd20b49868e881a7">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3c48d89233cde16c2a104f31d876894e" baserev="3c48d89233cde16c2a104f31d876894e" xsrcmd5="234ea9e85c4086f7ea318559a3ebdba9" lsrcmd5="15808a5e47aaf1f4cd20b49868e881a7"/>
-          <serviceinfo code="succeeded" xsrcmd5="eefd6c95d991aa44f26c8df7dece342a"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="dd7f4261ff4f5f1036c9b1dbaca56913" size="54" mtime="1642674788"/>
-          <entry name="_link" md5="337c171a192c7a75a9d6d3b3906251ed" size="119" mtime="1642674788"/>
-          <entry name="somefile.txt" md5="c02e00309372b60710fa54ff546bf3a7" size="76" mtime="1642674788"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:09 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:21 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_a_new_PR_event/behaves_like_successful_new_PR_or_MR_event/only_reports_for_repositories_and_architectures_matching_the_filters.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_a_new_PR_event/behaves_like_successful_new_PR_or_MR_event/only_reports_for_repositories_and_architectures_matching_the_filters.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:12 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:09 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_332
+    uri: http://backend:5352/source/foo_project/_meta?user=user_9
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Bury My Heart at Wounded Knee</title>
+          <title>The Glory and the Dream</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '161'
+      - '155'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Bury My Heart at Wounded Knee</title>
+          <title>The Glory and the Dream</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:12 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:09 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_333
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_10
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Have His Carcase</title>
-          <description>Et in quod occaecati.</description>
+          <title>The Moving Finger</title>
+          <description>Officia laborum qui aspernatur.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '147'
+      - '158'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Have His Carcase</title>
-          <description>Et in quod occaecati.</description>
+          <title>The Moving Finger</title>
+          <description>Officia laborum qui aspernatur.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:12 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:09 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Quae quidem est. Aut et natus. Ad architecto exercitationem.
+      string: Est ipsum minima. Voluptatum occaecati sed. Ad aut voluptatem.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1705" vrev="1705">
-          <srcmd5>785432da576fb48f2ce939e70070c8d1</srcmd5>
+        <revision rev="25" vrev="25">
+          <srcmd5>066b9300c79f42dde16efb91100c1389</srcmd5>
           <version>unknown</version>
-          <time>1642674792</time>
+          <time>1643641509</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:12 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:09 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Et dolorem ut. Est rerum aspernatur. Delectus nesciunt illo.
+      string: Quo architecto aut. Blanditiis totam architecto. Ullam deleniti ex.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +181,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1706" vrev="1706">
-          <srcmd5>98e4b6312cb23af7dc1f83e4e3847fa9</srcmd5>
+        <revision rev="26" vrev="26">
+          <srcmd5>1ba0ae6e2239d05cf63d6a924e1cdff8</srcmd5>
           <version>unknown</version>
-          <time>1642674792</time>
+          <time>1643641509</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:12 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:09 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -227,7 +227,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:33:12 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:09 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -267,7 +267,7 @@ http_interactions:
           <description>This project was created for package bar_package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:12 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:10 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -275,8 +275,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Have His Carcase</title>
-          <description>Et in quod occaecati.</description>
+          <title>The Moving Finger</title>
+          <description>Officia laborum qui aspernatur.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -297,15 +297,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '178'
+      - '189'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Have His Carcase</title>
-          <description>Et in quod occaecati.</description>
+          <title>The Moving Finger</title>
+          <description>Officia laborum qui aspernatur.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:12 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:10 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=branch&noservice=1&opackage=bar_package&oproject=foo_project&user=Iggy
@@ -333,19 +333,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '204'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="576" vrev="576">
-          <srcmd5>5d33396faa9b206dec6ab9a41b6a77fa</srcmd5>
+        <revision rev="3" vrev="3">
+          <srcmd5>805d7aa5633209fa26c8a3e59a70a8a0</srcmd5>
           <version>unknown</version>
-          <time>1642674792</time>
+          <time>1643641510</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:12 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:10 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -353,8 +353,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Have His Carcase</title>
-          <description>Et in quod occaecati.</description>
+          <title>The Moving Finger</title>
+          <description>Officia laborum qui aspernatur.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -375,15 +375,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '178'
+      - '189'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Have His Carcase</title>
-          <description>Et in quod occaecati.</description>
+          <title>The Moving Finger</title>
+          <description>Officia laborum qui aspernatur.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:12 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:10 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -409,18 +409,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '725'
+      - '618'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="576" vrev="576" srcmd5="5d33396faa9b206dec6ab9a41b6a77fa">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="98e4b6312cb23af7dc1f83e4e3847fa9" baserev="98e4b6312cb23af7dc1f83e4e3847fa9" xsrcmd5="ee84c1bb995549ab3fc53bdf83118802" lsrcmd5="5d33396faa9b206dec6ab9a41b6a77fa"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="7a942ca70c8f695d8e8b88a4b261126d" size="60" mtime="1642674792"/>
-          <entry name="_link" md5="7a059fbc4105a72736cc09787771320d" size="119" mtime="1642674792"/>
-          <entry name="somefile.txt" md5="d2bf3076612e9b506be02493f0ec2650" size="60" mtime="1642674792"/>
+        <directory name="bar_package" rev="3" vrev="3" srcmd5="805d7aa5633209fa26c8a3e59a70a8a0">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="1ba0ae6e2239d05cf63d6a924e1cdff8" baserev="1ba0ae6e2239d05cf63d6a924e1cdff8" xsrcmd5="8731e5b4c100fa808f807aeccd23b642" lsrcmd5="805d7aa5633209fa26c8a3e59a70a8a0"/>
+          <entry name="_config" md5="38cdb2f65eee9db0e811165f8eceebed" size="62" mtime="1643641509"/>
+          <entry name="_link" md5="9e5b3396fefb192e7121dbba9c4282b4" size="119" mtime="1643641510"/>
+          <entry name="somefile.txt" md5="2fac50f06172bf76bfda9fb795e49eab" size="67" mtime="1643641509"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:12 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:10 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?view=info
@@ -446,15 +445,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '333'
+      - '329'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="576" vrev="2282" srcmd5="ee84c1bb995549ab3fc53bdf83118802" lsrcmd5="5d33396faa9b206dec6ab9a41b6a77fa" verifymd5="98e4b6312cb23af7dc1f83e4e3847fa9">
+        <sourceinfo package="bar_package" rev="3" vrev="29" srcmd5="8731e5b4c100fa808f807aeccd23b642" lsrcmd5="805d7aa5633209fa26c8a3e59a70a8a0" verifymd5="1ba0ae6e2239d05cf63d6a924e1cdff8">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:12 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:10 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -480,18 +479,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '725'
+      - '618'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="576" vrev="576" srcmd5="5d33396faa9b206dec6ab9a41b6a77fa">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="98e4b6312cb23af7dc1f83e4e3847fa9" baserev="98e4b6312cb23af7dc1f83e4e3847fa9" xsrcmd5="ee84c1bb995549ab3fc53bdf83118802" lsrcmd5="5d33396faa9b206dec6ab9a41b6a77fa"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="7a942ca70c8f695d8e8b88a4b261126d" size="60" mtime="1642674792"/>
-          <entry name="_link" md5="7a059fbc4105a72736cc09787771320d" size="119" mtime="1642674792"/>
-          <entry name="somefile.txt" md5="d2bf3076612e9b506be02493f0ec2650" size="60" mtime="1642674792"/>
+        <directory name="bar_package" rev="3" vrev="3" srcmd5="805d7aa5633209fa26c8a3e59a70a8a0">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="1ba0ae6e2239d05cf63d6a924e1cdff8" baserev="1ba0ae6e2239d05cf63d6a924e1cdff8" xsrcmd5="8731e5b4c100fa808f807aeccd23b642" lsrcmd5="805d7aa5633209fa26c8a3e59a70a8a0"/>
+          <entry name="_config" md5="38cdb2f65eee9db0e811165f8eceebed" size="62" mtime="1643641509"/>
+          <entry name="_link" md5="9e5b3396fefb192e7121dbba9c4282b4" size="119" mtime="1643641510"/>
+          <entry name="somefile.txt" md5="2fac50f06172bf76bfda9fb795e49eab" size="67" mtime="1643641509"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:12 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:10 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -519,18 +517,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '370'
+      - '368'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="d3f07578dc771f1e2d4b7382a79833a2">
+        <sourcediff key="a3c817e10943d880dbe167dcf9b085be">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="576" srcmd5="5d33396faa9b206dec6ab9a41b6a77fa"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="3" srcmd5="805d7aa5633209fa26c8a3e59a70a8a0"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:12 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:10 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -562,12 +560,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="aa62a7ab00e3a69ace5fb4c91ee08b54">
-          <old project="foo_project" package="bar_package" rev="98e4b6312cb23af7dc1f83e4e3847fa9" srcmd5="98e4b6312cb23af7dc1f83e4e3847fa9"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="ee84c1bb995549ab3fc53bdf83118802" srcmd5="ee84c1bb995549ab3fc53bdf83118802"/>
+        <sourcediff key="26b81e31ef3a16634732ddbb5d03c991">
+          <old project="foo_project" package="bar_package" rev="1ba0ae6e2239d05cf63d6a924e1cdff8" srcmd5="1ba0ae6e2239d05cf63d6a924e1cdff8"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="8731e5b4c100fa808f807aeccd23b642" srcmd5="8731e5b4c100fa808f807aeccd23b642"/>
           <files/>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:12 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:10 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -635,7 +633,7 @@ http_interactions:
             <arch>aarch64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:12 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:10 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_branch_request?user=Iggy
@@ -661,19 +659,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '204'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="577" vrev="577">
-          <srcmd5>f19738b15d4de53e33101e8d60fcaa7f</srcmd5>
+        <revision rev="4" vrev="4">
+          <srcmd5>c942abd2c79aba043b62d7673a58aea1</srcmd5>
           <version>unknown</version>
-          <time>1642674792</time>
+          <time>1643641510</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:12 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:10 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -681,8 +679,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Have His Carcase</title>
-          <description>Et in quod occaecati.</description>
+          <title>The Moving Finger</title>
+          <description>Officia laborum qui aspernatur.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -703,15 +701,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '178'
+      - '189'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Have His Carcase</title>
-          <description>Et in quod occaecati.</description>
+          <title>The Moving Finger</title>
+          <description>Officia laborum qui aspernatur.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:12 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:10 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -737,19 +735,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '720'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="577" vrev="577" srcmd5="f19738b15d4de53e33101e8d60fcaa7f">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="98e4b6312cb23af7dc1f83e4e3847fa9" baserev="98e4b6312cb23af7dc1f83e4e3847fa9" xsrcmd5="02d597b8327bad83b075788d741e26ae" lsrcmd5="f19738b15d4de53e33101e8d60fcaa7f"/>
-          <serviceinfo code="succeeded" xsrcmd5="a7a718131645b221a725806961f0d9b0"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="7a942ca70c8f695d8e8b88a4b261126d" size="60" mtime="1642674792"/>
-          <entry name="_link" md5="7a059fbc4105a72736cc09787771320d" size="119" mtime="1642674792"/>
-          <entry name="somefile.txt" md5="d2bf3076612e9b506be02493f0ec2650" size="60" mtime="1642674792"/>
+        <directory name="bar_package" rev="4" vrev="4" srcmd5="c942abd2c79aba043b62d7673a58aea1">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="1ba0ae6e2239d05cf63d6a924e1cdff8" baserev="1ba0ae6e2239d05cf63d6a924e1cdff8" xsrcmd5="4612752361979d1e341fb4101ae76a35" lsrcmd5="c942abd2c79aba043b62d7673a58aea1"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="38cdb2f65eee9db0e811165f8eceebed" size="62" mtime="1643641509"/>
+          <entry name="_link" md5="9e5b3396fefb192e7121dbba9c4282b4" size="119" mtime="1643641510"/>
+          <entry name="somefile.txt" md5="2fac50f06172bf76bfda9fb795e49eab" size="67" mtime="1643641509"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:12 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:10 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?view=info
@@ -775,15 +772,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '333'
+      - '329'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="577" vrev="2283" srcmd5="b09417ec0f7fd9467dc8fe285094007c" lsrcmd5="a7a718131645b221a725806961f0d9b0" verifymd5="774f81aca198c59f69eb858cb9d42d86">
+        <sourceinfo package="bar_package" rev="4" vrev="30" srcmd5="4612752361979d1e341fb4101ae76a35" lsrcmd5="c942abd2c79aba043b62d7673a58aea1" verifymd5="6c0064c37e89960fd0359757a890f7c0">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:12 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:10 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -809,19 +806,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '720'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="577" vrev="577" srcmd5="f19738b15d4de53e33101e8d60fcaa7f">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="98e4b6312cb23af7dc1f83e4e3847fa9" baserev="98e4b6312cb23af7dc1f83e4e3847fa9" xsrcmd5="02d597b8327bad83b075788d741e26ae" lsrcmd5="f19738b15d4de53e33101e8d60fcaa7f"/>
-          <serviceinfo code="succeeded" xsrcmd5="a7a718131645b221a725806961f0d9b0"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="7a942ca70c8f695d8e8b88a4b261126d" size="60" mtime="1642674792"/>
-          <entry name="_link" md5="7a059fbc4105a72736cc09787771320d" size="119" mtime="1642674792"/>
-          <entry name="somefile.txt" md5="d2bf3076612e9b506be02493f0ec2650" size="60" mtime="1642674792"/>
+        <directory name="bar_package" rev="4" vrev="4" srcmd5="c942abd2c79aba043b62d7673a58aea1">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="1ba0ae6e2239d05cf63d6a924e1cdff8" baserev="1ba0ae6e2239d05cf63d6a924e1cdff8" xsrcmd5="4612752361979d1e341fb4101ae76a35" lsrcmd5="c942abd2c79aba043b62d7673a58aea1"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="38cdb2f65eee9db0e811165f8eceebed" size="62" mtime="1643641509"/>
+          <entry name="_link" md5="9e5b3396fefb192e7121dbba9c4282b4" size="119" mtime="1643641510"/>
+          <entry name="somefile.txt" md5="2fac50f06172bf76bfda9fb795e49eab" size="67" mtime="1643641509"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:12 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:10 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -849,18 +845,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '370'
+      - '368'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="1c1f0d6f1830e5bd593666141359d8d2">
+        <sourcediff key="f9822c13180be3610d85a8fbde32de6a">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="577" srcmd5="f19738b15d4de53e33101e8d60fcaa7f"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="4" srcmd5="c942abd2c79aba043b62d7673a58aea1"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:12 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:11 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -892,14 +888,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="eccd4315c2788f20dcfd83b943599fcb">
-          <old project="foo_project" package="bar_package" rev="98e4b6312cb23af7dc1f83e4e3847fa9" srcmd5="98e4b6312cb23af7dc1f83e4e3847fa9"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="b09417ec0f7fd9467dc8fe285094007c" srcmd5="b09417ec0f7fd9467dc8fe285094007c"/>
+        <sourcediff key="2e8106f89ab1ec6dcd3f499aebf4b058">
+          <old project="foo_project" package="bar_package" rev="1ba0ae6e2239d05cf63d6a924e1cdff8" srcmd5="1ba0ae6e2239d05cf63d6a924e1cdff8"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="4612752361979d1e341fb4101ae76a35" srcmd5="4612752361979d1e341fb4101ae76a35"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:12 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:11 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -925,19 +921,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '720'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="577" vrev="577" srcmd5="f19738b15d4de53e33101e8d60fcaa7f">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="98e4b6312cb23af7dc1f83e4e3847fa9" baserev="98e4b6312cb23af7dc1f83e4e3847fa9" xsrcmd5="02d597b8327bad83b075788d741e26ae" lsrcmd5="f19738b15d4de53e33101e8d60fcaa7f"/>
-          <serviceinfo code="succeeded" xsrcmd5="a7a718131645b221a725806961f0d9b0"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="7a942ca70c8f695d8e8b88a4b261126d" size="60" mtime="1642674792"/>
-          <entry name="_link" md5="7a059fbc4105a72736cc09787771320d" size="119" mtime="1642674792"/>
-          <entry name="somefile.txt" md5="d2bf3076612e9b506be02493f0ec2650" size="60" mtime="1642674792"/>
+        <directory name="bar_package" rev="4" vrev="4" srcmd5="c942abd2c79aba043b62d7673a58aea1">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="1ba0ae6e2239d05cf63d6a924e1cdff8" baserev="1ba0ae6e2239d05cf63d6a924e1cdff8" xsrcmd5="4612752361979d1e341fb4101ae76a35" lsrcmd5="c942abd2c79aba043b62d7673a58aea1"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="38cdb2f65eee9db0e811165f8eceebed" size="62" mtime="1643641509"/>
+          <entry name="_link" md5="9e5b3396fefb192e7121dbba9c4282b4" size="119" mtime="1643641510"/>
+          <entry name="somefile.txt" md5="2fac50f06172bf76bfda9fb795e49eab" size="67" mtime="1643641509"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:13 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:11 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '616'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="4612752361979d1e341fb4101ae76a35" vrev="30" srcmd5="4612752361979d1e341fb4101ae76a35">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="1ba0ae6e2239d05cf63d6a924e1cdff8" baserev="1ba0ae6e2239d05cf63d6a924e1cdff8" lsrcmd5="c942abd2c79aba043b62d7673a58aea1"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="38cdb2f65eee9db0e811165f8eceebed" size="62" mtime="1643641509"/>
+          <entry name="somefile.txt" md5="2fac50f06172bf76bfda9fb795e49eab" size="67" mtime="1643641509"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:05:11 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -963,22 +994,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '720'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="577" vrev="577" srcmd5="f19738b15d4de53e33101e8d60fcaa7f">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="98e4b6312cb23af7dc1f83e4e3847fa9" baserev="98e4b6312cb23af7dc1f83e4e3847fa9" xsrcmd5="02d597b8327bad83b075788d741e26ae" lsrcmd5="f19738b15d4de53e33101e8d60fcaa7f"/>
-          <serviceinfo code="succeeded" xsrcmd5="a7a718131645b221a725806961f0d9b0"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="7a942ca70c8f695d8e8b88a4b261126d" size="60" mtime="1642674792"/>
-          <entry name="_link" md5="7a059fbc4105a72736cc09787771320d" size="119" mtime="1642674792"/>
-          <entry name="somefile.txt" md5="d2bf3076612e9b506be02493f0ec2650" size="60" mtime="1642674792"/>
+        <directory name="bar_package" rev="4" vrev="4" srcmd5="c942abd2c79aba043b62d7673a58aea1">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="1ba0ae6e2239d05cf63d6a924e1cdff8" baserev="1ba0ae6e2239d05cf63d6a924e1cdff8" xsrcmd5="4612752361979d1e341fb4101ae76a35" lsrcmd5="c942abd2c79aba043b62d7673a58aea1"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="38cdb2f65eee9db0e811165f8eceebed" size="62" mtime="1643641509"/>
+          <entry name="_link" md5="9e5b3396fefb192e7121dbba9c4282b4" size="119" mtime="1643641510"/>
+          <entry name="somefile.txt" md5="2fac50f06172bf76bfda9fb795e49eab" size="67" mtime="1643641509"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:13 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:11 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1001,55 +1031,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '616'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="577" vrev="577" srcmd5="f19738b15d4de53e33101e8d60fcaa7f">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="98e4b6312cb23af7dc1f83e4e3847fa9" baserev="98e4b6312cb23af7dc1f83e4e3847fa9" xsrcmd5="02d597b8327bad83b075788d741e26ae" lsrcmd5="f19738b15d4de53e33101e8d60fcaa7f"/>
-          <serviceinfo code="succeeded" xsrcmd5="a7a718131645b221a725806961f0d9b0"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="7a942ca70c8f695d8e8b88a4b261126d" size="60" mtime="1642674792"/>
-          <entry name="_link" md5="7a059fbc4105a72736cc09787771320d" size="119" mtime="1642674792"/>
-          <entry name="somefile.txt" md5="d2bf3076612e9b506be02493f0ec2650" size="60" mtime="1642674792"/>
+        <directory name="bar_package" rev="4612752361979d1e341fb4101ae76a35" vrev="30" srcmd5="4612752361979d1e341fb4101ae76a35">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="1ba0ae6e2239d05cf63d6a924e1cdff8" baserev="1ba0ae6e2239d05cf63d6a924e1cdff8" lsrcmd5="c942abd2c79aba043b62d7673a58aea1"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="38cdb2f65eee9db0e811165f8eceebed" size="62" mtime="1643641509"/>
+          <entry name="somefile.txt" md5="2fac50f06172bf76bfda9fb795e49eab" size="67" mtime="1643641509"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:13 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '801'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="577" vrev="577" srcmd5="f19738b15d4de53e33101e8d60fcaa7f">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="98e4b6312cb23af7dc1f83e4e3847fa9" baserev="98e4b6312cb23af7dc1f83e4e3847fa9" xsrcmd5="02d597b8327bad83b075788d741e26ae" lsrcmd5="f19738b15d4de53e33101e8d60fcaa7f"/>
-          <serviceinfo code="succeeded" xsrcmd5="a7a718131645b221a725806961f0d9b0"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="7a942ca70c8f695d8e8b88a4b261126d" size="60" mtime="1642674792"/>
-          <entry name="_link" md5="7a059fbc4105a72736cc09787771320d" size="119" mtime="1642674792"/>
-          <entry name="somefile.txt" md5="d2bf3076612e9b506be02493f0ec2650" size="60" mtime="1642674792"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:13 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:11 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_an_updated_PR_event/when_the_branched_package_already_existed/behaves_like_successful_update_event_when_the_branch_package_already_exists/1_1_1_5_1_1_1.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_an_updated_PR_event/when_the_branched_package_already_existed/behaves_like_successful_update_event_when_the_branch_package_already_exists/1_1_1_5_1_1_1.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:18 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:37 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_348
+    uri: http://backend:5352/source/foo_project/_meta?user=user_41
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Brandy of the Damned</title>
+          <title>The Moving Finger</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '152'
+      - '149'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Brandy of the Damned</title>
+          <title>The Moving Finger</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:18 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:37 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_349
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_42
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Cabbages and Kings</title>
-          <description>Nulla et ipsum doloremque.</description>
+          <title>The Glory and the Dream</title>
+          <description>Aliquid et et cumque.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -114,16 +114,16 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Cabbages and Kings</title>
-          <description>Nulla et ipsum doloremque.</description>
+          <title>The Glory and the Dream</title>
+          <description>Aliquid et et cumque.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:18 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:37 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Iusto iure eos. Nemo quia omnis. Omnis sint nemo.
+      string: Molestias nisi est. Sunt omnis perferendis. Veniam quia eius.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1723" vrev="1723">
-          <srcmd5>878b13ec5466820fc30d5ca871514300</srcmd5>
+        <revision rev="43" vrev="43">
+          <srcmd5>d81999ce35ff090590461c9cd9d62e46</srcmd5>
           <version>unknown</version>
-          <time>1642674798</time>
+          <time>1643641537</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:18 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:37 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Repellat similique veritatis. Et quas error. Consequuntur voluptas necessitatibus.
+      string: Sint ut accusantium. Ea quod illo. Non maxime placeat.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +181,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1724" vrev="1724">
-          <srcmd5>48386d66a9b1612b7b90ebf1b54c8197</srcmd5>
+        <revision rev="44" vrev="44">
+          <srcmd5>775b706552ce3784b92eb0638444a496</srcmd5>
           <version>unknown</version>
-          <time>1642674798</time>
+          <time>1643641537</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:19 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:37 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -201,7 +201,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>A Handful of Dust</title>
+          <title>All Passion Spent</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -229,11 +229,11 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>A Handful of Dust</title>
+          <title>All Passion Spent</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:19 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:37 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -241,8 +241,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Jesting Pilate</title>
-          <description>Impedit facilis aut nulla.</description>
+          <title>Blood's a Rover</title>
+          <description>Dicta exercitationem et temporibus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -263,21 +263,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '181'
+      - '191'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Jesting Pilate</title>
-          <description>Impedit facilis aut nulla.</description>
+          <title>Blood's a Rover</title>
+          <description>Dicta exercitationem et temporibus.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:19 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:37 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_config
     body:
       encoding: UTF-8
-      string: Quasi quibusdam est. Quis voluptatum ullam. Aut libero molestiae.
+      string: Iusto minima sint. Et quasi nihil. Quos delectus natus.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -297,25 +297,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="588" vrev="588">
-          <srcmd5>a82213359cc9d85a74a973116bb5808b</srcmd5>
+        <revision rev="21" vrev="21">
+          <srcmd5>65478561bd11e1d7628a5a00293278bc</srcmd5>
           <version>unknown</version>
-          <time>1642674799</time>
+          <time>1643641537</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:19 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:37 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Similique et beatae. Facilis voluptatem dolor. Dolor maiores blanditiis.
+      string: Reprehenderit aliquid sit. Ut est doloremque. Dolores officia quae.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -335,19 +335,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="589" vrev="589">
-          <srcmd5>48b2f994a83fa012bad1081b0936678c</srcmd5>
+        <revision rev="22" vrev="22">
+          <srcmd5>b865cc7248d1985b2e504db8785e93cb</srcmd5>
           <version>unknown</version>
-          <time>1642674799</time>
+          <time>1643641537</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:19 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:37 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_branch_request?user=Iggy
@@ -373,28 +373,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '210'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1725" vrev="1725">
-          <srcmd5>48386d66a9b1612b7b90ebf1b54c8197</srcmd5>
+        <revision rev="45" vrev="45">
+          <srcmd5>c8428b0102526f87e5f10735c4f02617</srcmd5>
           <version>unknown</version>
-          <time>1642674799</time>
+          <time>1643641537</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:19 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:37 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_349
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_42
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Cabbages and Kings</title>
-          <description>Nulla et ipsum doloremque.</description>
+          <title>The Glory and the Dream</title>
+          <description>Aliquid et et cumque.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -420,10 +420,10 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Cabbages and Kings</title>
-          <description>Nulla et ipsum doloremque.</description>
+          <title>The Glory and the Dream</title>
+          <description>Aliquid et et cumque.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:19 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:37 GMT
 - request:
     method: get
     uri: http://backend:5352/source/foo_project/bar_package
@@ -449,16 +449,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '405'
+      - '401'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="1725" vrev="1725" srcmd5="48386d66a9b1612b7b90ebf1b54c8197">
-          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1642591329"/>
-          <entry name="_config" md5="373ffa6cda3692d910d033e48052a68e" size="49" mtime="1642674798"/>
-          <entry name="somefile.txt" md5="59cadbdbcdd4dc537390d59ef8a527ad" size="82" mtime="1642674798"/>
+        <directory name="bar_package" rev="45" vrev="45" srcmd5="c8428b0102526f87e5f10735c4f02617">
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="be237da485b18f209fa51fba594afce6" size="61" mtime="1643641537"/>
+          <entry name="somefile.txt" md5="a3c82c7dac24ea6bc530dd5288bc0a34" size="54" mtime="1643641537"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:19 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:37 GMT
 - request:
     method: get
     uri: http://backend:5352/source/foo_project/bar_package?view=info
@@ -484,14 +484,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '235'
+      - '231'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="1725" vrev="1725" srcmd5="48386d66a9b1612b7b90ebf1b54c8197" verifymd5="48386d66a9b1612b7b90ebf1b54c8197">
+        <sourceinfo package="bar_package" rev="45" vrev="45" srcmd5="c8428b0102526f87e5f10735c4f02617" verifymd5="c8428b0102526f87e5f10735c4f02617">
           <error>bad build configuration, no build type defined or detected</error>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:19 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:37 GMT
 - request:
     method: get
     uri: http://backend:5352/source/foo_project/bar_package
@@ -517,16 +517,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '405'
+      - '401'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="1725" vrev="1725" srcmd5="48386d66a9b1612b7b90ebf1b54c8197">
-          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1642591329"/>
-          <entry name="_config" md5="373ffa6cda3692d910d033e48052a68e" size="49" mtime="1642674798"/>
-          <entry name="somefile.txt" md5="59cadbdbcdd4dc537390d59ef8a527ad" size="82" mtime="1642674798"/>
+        <directory name="bar_package" rev="45" vrev="45" srcmd5="c8428b0102526f87e5f10735c4f02617">
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="be237da485b18f209fa51fba594afce6" size="61" mtime="1643641537"/>
+          <entry name="somefile.txt" md5="a3c82c7dac24ea6bc530dd5288bc0a34" size="54" mtime="1643641537"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:19 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:37 GMT
 - request:
     method: post
     uri: http://backend:5352/source/foo_project/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -554,18 +554,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '309'
+      - '307'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="6abbe13c57c7d201b4104d22e8b0641e">
+        <sourcediff key="8a6b511aed69a63a230c0a523f03895e">
           <old project="foo_project" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="foo_project" package="bar_package" rev="1725" srcmd5="48386d66a9b1612b7b90ebf1b54c8197"/>
+          <new project="foo_project" package="bar_package" rev="45" srcmd5="c8428b0102526f87e5f10735c4f02617"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:19 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:37 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_branch_request?user=Iggy
@@ -591,19 +591,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="590" vrev="590">
-          <srcmd5>716c48df6e6805bcc55ce64912e10afc</srcmd5>
+        <revision rev="23" vrev="23">
+          <srcmd5>b865cc7248d1985b2e504db8785e93cb</srcmd5>
           <version>unknown</version>
-          <time>1642674799</time>
+          <time>1643641537</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:19 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:38 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -611,8 +611,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Jesting Pilate</title>
-          <description>Impedit facilis aut nulla.</description>
+          <title>Blood's a Rover</title>
+          <description>Dicta exercitationem et temporibus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -633,15 +633,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '181'
+      - '191'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Jesting Pilate</title>
-          <description>Impedit facilis aut nulla.</description>
+          <title>Blood's a Rover</title>
+          <description>Dicta exercitationem et temporibus.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:19 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:38 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -667,21 +667,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '831'
+      - '670'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="590" vrev="590" srcmd5="716c48df6e6805bcc55ce64912e10afc">
-          <linkinfo project="foo_project" package="bar_package" baserev="4db6702909d9d4b88ea57cfcfd6eae77" xsrcmd5="41ced3f30d70453209780bc00a7e2f6d" error="conflict in file _config"/>
-          <serviceinfo code="failed" xsrcmd5="835e60ee299d9f1e6dd4aaf55f8235bc">
-            <error>service error: bad link: conflict in file _config</error>
-          </serviceinfo>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="fbf17fc6d8408b932ddcce2dab090b01" size="65" mtime="1642674799"/>
-          <entry name="_link" md5="86d891195b349a0a081834322bf62764" size="119" mtime="1642674795"/>
-          <entry name="somefile.txt" md5="2f9a0b4e0d6ade0f4636ae6f699ca737" size="72" mtime="1642674799"/>
+        <directory name="bar_package" rev="23" vrev="23" srcmd5="b865cc7248d1985b2e504db8785e93cb">
+          <linkinfo project="foo_project" package="bar_package" baserev="7e3a8ddb7d7c6013d4d98f6f202e3508" xsrcmd5="7f46bb3b633f093a46fc26d7b5b77c5d" error="conflict in file _config"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="e6e2b6e21f037c4d4448309ed5670d45" size="55" mtime="1643641537"/>
+          <entry name="_link" md5="ff3d9dc8a65ce527370348e821fae4b8" size="119" mtime="1643641536"/>
+          <entry name="somefile.txt" md5="dae432a6b172364f52b4f48317a69811" size="67" mtime="1643641537"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:19 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:38 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?view=info
@@ -707,14 +704,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '179'
+      - '253'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="590" vrev="590" srcmd5="716c48df6e6805bcc55ce64912e10afc">
-          <error>service error: bad link: conflict in file _config</error>
+        <sourceinfo package="bar_package" rev="23" vrev="68" srcmd5="b865cc7248d1985b2e504db8785e93cb" verifymd5="b865cc7248d1985b2e504db8785e93cb">
+          <error>conflict in file _config</error>
+          <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:19 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:38 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -740,21 +738,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '831'
+      - '670'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="590" vrev="590" srcmd5="716c48df6e6805bcc55ce64912e10afc">
-          <linkinfo project="foo_project" package="bar_package" baserev="4db6702909d9d4b88ea57cfcfd6eae77" xsrcmd5="41ced3f30d70453209780bc00a7e2f6d" error="conflict in file _config"/>
-          <serviceinfo code="failed" xsrcmd5="835e60ee299d9f1e6dd4aaf55f8235bc">
-            <error>service error: bad link: conflict in file _config</error>
-          </serviceinfo>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="fbf17fc6d8408b932ddcce2dab090b01" size="65" mtime="1642674799"/>
-          <entry name="_link" md5="86d891195b349a0a081834322bf62764" size="119" mtime="1642674795"/>
-          <entry name="somefile.txt" md5="2f9a0b4e0d6ade0f4636ae6f699ca737" size="72" mtime="1642674799"/>
+        <directory name="bar_package" rev="23" vrev="23" srcmd5="b865cc7248d1985b2e504db8785e93cb">
+          <linkinfo project="foo_project" package="bar_package" baserev="7e3a8ddb7d7c6013d4d98f6f202e3508" xsrcmd5="7f46bb3b633f093a46fc26d7b5b77c5d" error="conflict in file _config"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="e6e2b6e21f037c4d4448309ed5670d45" size="55" mtime="1643641537"/>
+          <entry name="_link" md5="ff3d9dc8a65ce527370348e821fae4b8" size="119" mtime="1643641536"/>
+          <entry name="somefile.txt" md5="dae432a6b172364f52b4f48317a69811" size="67" mtime="1643641537"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:19 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:38 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -782,18 +777,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '370'
+      - '369'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="49e908751175f867a161cd820e9ce64f">
+        <sourcediff key="9a97165d18d5546bb5aec461bc92ad21">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="590" srcmd5="716c48df6e6805bcc55ce64912e10afc"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="23" srcmd5="b865cc7248d1985b2e504db8785e93cb"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:19 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:38 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -811,8 +806,8 @@ http_interactions:
       - Ruby
   response:
     status:
-      code: 400
-      message: service error  bad link  conflict in file _config
+      code: 200
+      message: OK
     headers:
       Content-Type:
       - text/xml
@@ -821,12 +816,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '101'
+      - '399'
     body:
       encoding: UTF-8
       string: |
-        <status code="400">
-          <summary>service error: bad link: conflict in file _config</summary>
-        </status>
-  recorded_at: Thu, 20 Jan 2022 10:33:19 GMT
+        <sourcediff key="741a958f9666d2904c7f3dce3ffe6541">
+          <old project="foo_project" package="bar_package" rev="7e3a8ddb7d7c6013d4d98f6f202e3508" srcmd5="7e3a8ddb7d7c6013d4d98f6f202e3508"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="b17697dd6b14cebbd6d790e49a53401e" srcmd5="b17697dd6b14cebbd6d790e49a53401e"/>
+          <files/>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Mon, 31 Jan 2022 15:05:38 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_an_updated_PR_event/when_the_branched_package_already_existed/behaves_like_successful_update_event_when_the_branch_package_already_exists/1_1_1_5_1_1_2.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_an_updated_PR_event/when_the_branched_package_already_existed/behaves_like_successful_update_event_when_the_branch_package_already_exists/1_1_1_5_1_1_2.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:39 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_354
+    uri: http://backend:5352/source/foo_project/_meta?user=user_45
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Some Buried Caesar</title>
+          <title>Far From the Madding Crowd</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '150'
+      - '158'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Some Buried Caesar</title>
+          <title>Far From the Madding Crowd</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:39 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_355
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_46
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Wives of Bath</title>
-          <description>Amet dolorem assumenda at.</description>
+          <title>The Green Bay Tree</title>
+          <description>Eaque molestiae quod voluptates.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '153'
+      - '160'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Wives of Bath</title>
-          <description>Amet dolorem assumenda at.</description>
+          <title>The Green Bay Tree</title>
+          <description>Eaque molestiae quod voluptates.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:39 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Occaecati harum nobis. Quis pariatur dolorem. Qui sit vel.
+      string: Beatae iure molestiae. Deleniti maiores et. Necessitatibus ea hic.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1732" vrev="1732">
-          <srcmd5>fd0b481384a72e4ab6517a077893e227</srcmd5>
+        <revision rev="49" vrev="49">
+          <srcmd5>668f6305159b5dbe23e4d44ac64724a6</srcmd5>
           <version>unknown</version>
-          <time>1642674801</time>
+          <time>1643641539</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:39 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Reiciendis non autem. Eligendi recusandae ipsam. Quia animi est.
+      string: Error exercitationem aut. Maxime aspernatur dicta. Vel similique numquam.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +181,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1733" vrev="1733">
-          <srcmd5>ec6c166cf4ffd448701f0a91e453c0c0</srcmd5>
+        <revision rev="50" vrev="50">
+          <srcmd5>1cc0ba93527824151248405be2a99ccf</srcmd5>
           <version>unknown</version>
-          <time>1642674801</time>
+          <time>1643641539</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:39 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -201,7 +201,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Mermaids Singing</title>
+          <title>Time of our Darkness</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -229,11 +229,11 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Mermaids Singing</title>
+          <title>Time of our Darkness</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:39 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -241,8 +241,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Those Barren Leaves, Thrones, Dominations</title>
-          <description>Perspiciatis sint at numquam.</description>
+          <title>In Dubious Battle</title>
+          <description>Debitis quia neque ducimus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -263,21 +263,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '185'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Those Barren Leaves, Thrones, Dominations</title>
-          <description>Perspiciatis sint at numquam.</description>
+          <title>In Dubious Battle</title>
+          <description>Debitis quia neque ducimus.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:39 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_config
     body:
       encoding: UTF-8
-      string: Dolores atque tempora. Voluptates nihil et. Vel molestiae sint.
+      string: Eligendi esse ut. Qui esse distinctio. Autem ratione et.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -297,25 +297,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="597" vrev="597">
-          <srcmd5>856f97d8a1cfcdb4c0d3a95fd186ed23</srcmd5>
+        <revision rev="27" vrev="27">
+          <srcmd5>4b03b7235827a7d9f1412cf3b39ad1bb</srcmd5>
           <version>unknown</version>
-          <time>1642674801</time>
+          <time>1643641539</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:39 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Placeat aspernatur illum. Modi voluptas enim. Cum sit laboriosam.
+      string: Quod sit repellendus. Quo sunt repellat. Non qui dignissimos.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -335,19 +335,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="598" vrev="598">
-          <srcmd5>a835a156886bca019483a449f15764d8</srcmd5>
+        <revision rev="28" vrev="28">
+          <srcmd5>f29d82c9ca6a7f6878987e5615a41dfa</srcmd5>
           <version>unknown</version>
-          <time>1642674801</time>
+          <time>1643641539</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:39 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_branch_request?user=Iggy
@@ -373,28 +373,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '210'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1734" vrev="1734">
-          <srcmd5>ec6c166cf4ffd448701f0a91e453c0c0</srcmd5>
+        <revision rev="51" vrev="51">
+          <srcmd5>1cc0ba93527824151248405be2a99ccf</srcmd5>
           <version>unknown</version>
-          <time>1642674801</time>
+          <time>1643641539</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:39 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_355
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_46
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Wives of Bath</title>
-          <description>Amet dolorem assumenda at.</description>
+          <title>The Green Bay Tree</title>
+          <description>Eaque molestiae quod voluptates.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -415,15 +415,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '153'
+      - '160'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Wives of Bath</title>
-          <description>Amet dolorem assumenda at.</description>
+          <title>The Green Bay Tree</title>
+          <description>Eaque molestiae quod voluptates.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:39 GMT
 - request:
     method: get
     uri: http://backend:5352/source/foo_project/bar_package
@@ -449,16 +449,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '405'
+      - '401'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="1734" vrev="1734" srcmd5="ec6c166cf4ffd448701f0a91e453c0c0">
-          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1642591329"/>
-          <entry name="_config" md5="d6fb85372e567bfdfab196f4448c222b" size="58" mtime="1642674801"/>
-          <entry name="somefile.txt" md5="3882f269c8c7474f9eaeeb26cff696d0" size="64" mtime="1642674801"/>
+        <directory name="bar_package" rev="51" vrev="51" srcmd5="1cc0ba93527824151248405be2a99ccf">
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="6051ff53e4dce7ff419138f9ec7baebb" size="66" mtime="1643641539"/>
+          <entry name="somefile.txt" md5="3d987ddf73c43deca5ced2ceed4abb7a" size="73" mtime="1643641539"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:39 GMT
 - request:
     method: get
     uri: http://backend:5352/source/foo_project/bar_package?view=info
@@ -484,14 +484,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '235'
+      - '231'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="1734" vrev="1734" srcmd5="ec6c166cf4ffd448701f0a91e453c0c0" verifymd5="ec6c166cf4ffd448701f0a91e453c0c0">
+        <sourceinfo package="bar_package" rev="51" vrev="51" srcmd5="1cc0ba93527824151248405be2a99ccf" verifymd5="1cc0ba93527824151248405be2a99ccf">
           <error>bad build configuration, no build type defined or detected</error>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:40 GMT
 - request:
     method: get
     uri: http://backend:5352/source/foo_project/bar_package
@@ -517,16 +517,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '405'
+      - '401'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="1734" vrev="1734" srcmd5="ec6c166cf4ffd448701f0a91e453c0c0">
-          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1642591329"/>
-          <entry name="_config" md5="d6fb85372e567bfdfab196f4448c222b" size="58" mtime="1642674801"/>
-          <entry name="somefile.txt" md5="3882f269c8c7474f9eaeeb26cff696d0" size="64" mtime="1642674801"/>
+        <directory name="bar_package" rev="51" vrev="51" srcmd5="1cc0ba93527824151248405be2a99ccf">
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="6051ff53e4dce7ff419138f9ec7baebb" size="66" mtime="1643641539"/>
+          <entry name="somefile.txt" md5="3d987ddf73c43deca5ced2ceed4abb7a" size="73" mtime="1643641539"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:40 GMT
 - request:
     method: post
     uri: http://backend:5352/source/foo_project/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -554,18 +554,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '309'
+      - '307'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="a7bb4b65c8642a2e22048076724795b1">
+        <sourcediff key="4e42904627f3ee9483a732247ca62b14">
           <old project="foo_project" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="foo_project" package="bar_package" rev="1734" srcmd5="ec6c166cf4ffd448701f0a91e453c0c0"/>
+          <new project="foo_project" package="bar_package" rev="51" srcmd5="1cc0ba93527824151248405be2a99ccf"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:40 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_branch_request?user=Iggy
@@ -591,19 +591,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="599" vrev="599">
-          <srcmd5>73cf78f62d4fcc85077e1db2a5c3dde2</srcmd5>
+        <revision rev="29" vrev="29">
+          <srcmd5>f29d82c9ca6a7f6878987e5615a41dfa</srcmd5>
           <version>unknown</version>
-          <time>1642674802</time>
+          <time>1643641540</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:40 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -611,8 +611,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Those Barren Leaves, Thrones, Dominations</title>
-          <description>Perspiciatis sint at numquam.</description>
+          <title>In Dubious Battle</title>
+          <description>Debitis quia neque ducimus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -633,15 +633,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '185'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Those Barren Leaves, Thrones, Dominations</title>
-          <description>Perspiciatis sint at numquam.</description>
+          <title>In Dubious Battle</title>
+          <description>Debitis quia neque ducimus.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:40 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -667,21 +667,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '831'
+      - '670'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="599" vrev="599" srcmd5="73cf78f62d4fcc85077e1db2a5c3dde2">
-          <linkinfo project="foo_project" package="bar_package" baserev="4db6702909d9d4b88ea57cfcfd6eae77" xsrcmd5="925b88a5cbbf4b8a3212f6b4268a3daa" error="conflict in file _config"/>
-          <serviceinfo code="failed" xsrcmd5="9336a00f3082e678c3a19f5696a17fd4">
-            <error>service error: bad link: conflict in file _config</error>
-          </serviceinfo>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="cc49f86169492495d6f73755b618c15e" size="63" mtime="1642674801"/>
-          <entry name="_link" md5="86d891195b349a0a081834322bf62764" size="119" mtime="1642674795"/>
-          <entry name="somefile.txt" md5="812873a66229ee59ccc995466791e3c8" size="65" mtime="1642674801"/>
+        <directory name="bar_package" rev="29" vrev="29" srcmd5="f29d82c9ca6a7f6878987e5615a41dfa">
+          <linkinfo project="foo_project" package="bar_package" baserev="7e3a8ddb7d7c6013d4d98f6f202e3508" xsrcmd5="0f0881652262d2c63f530046636ba732" error="conflict in file _config"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="8d6295c8fe5e7142feaadbbef5d89116" size="56" mtime="1643641539"/>
+          <entry name="_link" md5="ff3d9dc8a65ce527370348e821fae4b8" size="119" mtime="1643641536"/>
+          <entry name="somefile.txt" md5="9d4841ef47eb5aa591ea2bddf1e5ac9d" size="61" mtime="1643641539"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:40 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?view=info
@@ -707,14 +704,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '179'
+      - '253'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="599" vrev="599" srcmd5="73cf78f62d4fcc85077e1db2a5c3dde2">
-          <error>service error: bad link: conflict in file _config</error>
+        <sourceinfo package="bar_package" rev="29" vrev="80" srcmd5="f29d82c9ca6a7f6878987e5615a41dfa" verifymd5="f29d82c9ca6a7f6878987e5615a41dfa">
+          <error>conflict in file _config</error>
+          <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:40 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -740,21 +738,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '831'
+      - '670'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="599" vrev="599" srcmd5="73cf78f62d4fcc85077e1db2a5c3dde2">
-          <linkinfo project="foo_project" package="bar_package" baserev="4db6702909d9d4b88ea57cfcfd6eae77" xsrcmd5="925b88a5cbbf4b8a3212f6b4268a3daa" error="conflict in file _config"/>
-          <serviceinfo code="failed" xsrcmd5="9336a00f3082e678c3a19f5696a17fd4">
-            <error>service error: bad link: conflict in file _config</error>
-          </serviceinfo>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="cc49f86169492495d6f73755b618c15e" size="63" mtime="1642674801"/>
-          <entry name="_link" md5="86d891195b349a0a081834322bf62764" size="119" mtime="1642674795"/>
-          <entry name="somefile.txt" md5="812873a66229ee59ccc995466791e3c8" size="65" mtime="1642674801"/>
+        <directory name="bar_package" rev="29" vrev="29" srcmd5="f29d82c9ca6a7f6878987e5615a41dfa">
+          <linkinfo project="foo_project" package="bar_package" baserev="7e3a8ddb7d7c6013d4d98f6f202e3508" xsrcmd5="0f0881652262d2c63f530046636ba732" error="conflict in file _config"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="8d6295c8fe5e7142feaadbbef5d89116" size="56" mtime="1643641539"/>
+          <entry name="_link" md5="ff3d9dc8a65ce527370348e821fae4b8" size="119" mtime="1643641536"/>
+          <entry name="somefile.txt" md5="9d4841ef47eb5aa591ea2bddf1e5ac9d" size="61" mtime="1643641539"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:40 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -782,18 +777,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '370'
+      - '369'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="b2ce695347f1f2b3becc39e940445cc0">
+        <sourcediff key="8b7515d9b414e7556ea5a8d252d5ef18">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="599" srcmd5="73cf78f62d4fcc85077e1db2a5c3dde2"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="29" srcmd5="f29d82c9ca6a7f6878987e5615a41dfa"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:40 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -811,8 +806,8 @@ http_interactions:
       - Ruby
   response:
     status:
-      code: 400
-      message: service error  bad link  conflict in file _config
+      code: 200
+      message: OK
     headers:
       Content-Type:
       - text/xml
@@ -821,14 +816,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '101'
+      - '399'
     body:
       encoding: UTF-8
       string: |
-        <status code="400">
-          <summary>service error: bad link: conflict in file _config</summary>
-        </status>
-  recorded_at: Thu, 20 Jan 2022 10:33:22 GMT
+        <sourcediff key="2f71c97a3118bd9ae77d41a12055a2b1">
+          <old project="foo_project" package="bar_package" rev="7e3a8ddb7d7c6013d4d98f6f202e3508" srcmd5="7e3a8ddb7d7c6013d4d98f6f202e3508"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="8ca180c59376d6e7b0919518cba979bc" srcmd5="8ca180c59376d6e7b0919518cba979bc"/>
+          <files/>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Mon, 31 Jan 2022 15:05:40 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_branch_request
@@ -858,5 +857,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"action":"opened","pull_request":{"head":{"repo":{"full_name":"reponame"},"sha":"123456789"}}}'
-  recorded_at: Thu, 20 Jan 2022 10:33:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:40 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_an_updated_PR_event/when_the_branched_package_already_existed/behaves_like_successful_update_event_when_the_branch_package_already_exists/1_1_1_5_1_1_4.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_an_updated_PR_event/when_the_branched_package_already_existed/behaves_like_successful_update_event_when_the_branch_package_already_exists/1_1_1_5_1_1_4.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:17 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:38 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_344
+    uri: http://backend:5352/source/foo_project/_meta?user=user_43
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>His Dark Materials</title>
+          <title>The Skull Beneath the Skin</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '150'
+      - '158'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>His Dark Materials</title>
+          <title>The Skull Beneath the Skin</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:17 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:38 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_345
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_44
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Moving Toyshop</title>
-          <description>Alias sint in ex.</description>
+          <title>The Mirror Crack'd from Side to Side</title>
+          <description>Est tenetur incidunt quo.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '145'
+      - '171'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Moving Toyshop</title>
-          <description>Alias sint in ex.</description>
+          <title>The Mirror Crack'd from Side to Side</title>
+          <description>Est tenetur incidunt quo.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:17 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:38 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Esse nulla corrupti. Eaque nesciunt molestiae. Nostrum cupiditate dolores.
+      string: Pariatur qui neque. Dolorum velit occaecati. Ullam quod dolorum.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1717" vrev="1717">
-          <srcmd5>40f4d2387755e6eed78fdd0a0bf10637</srcmd5>
+        <revision rev="46" vrev="46">
+          <srcmd5>53600e60db45f8744b0aaa8436e2f48b</srcmd5>
           <version>unknown</version>
-          <time>1642674797</time>
+          <time>1643641538</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:17 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:38 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Magnam omnis quisquam. Ut sed impedit. Consequatur eos voluptas.
+      string: Fuga laudantium modi. Autem eum assumenda. Culpa autem ut.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +181,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1718" vrev="1718">
-          <srcmd5>7ab6cc7aabd5dbcd344777a564093c28</srcmd5>
+        <revision rev="47" vrev="47">
+          <srcmd5>3ce67b20382a9902b946b0a02c0c2f7e</srcmd5>
           <version>unknown</version>
-          <time>1642674797</time>
+          <time>1643641538</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:17 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:38 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -201,7 +201,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Specimen Days</title>
+          <title>The Way Through the Woods</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -224,16 +224,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '176'
+      - '188'
     body:
       encoding: UTF-8
       string: |
         <project name="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Specimen Days</title>
+          <title>The Way Through the Woods</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:17 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:38 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -241,8 +241,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Things Fall Apart</title>
-          <description>Est unde soluta a.</description>
+          <title>I Know Why the Caged Bird Sings</title>
+          <description>Officia et illo at.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -263,21 +263,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '176'
+      - '191'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Things Fall Apart</title>
-          <description>Est unde soluta a.</description>
+          <title>I Know Why the Caged Bird Sings</title>
+          <description>Officia et illo at.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:17 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:38 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_config
     body:
       encoding: UTF-8
-      string: Aut maxime cumque. Voluptates distinctio quia. Reprehenderit sed et.
+      string: Consectetur sunt vero. A temporibus explicabo. Et voluptatem possimus.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -297,25 +297,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="582" vrev="582">
-          <srcmd5>1640105022f371377e4dbba986650dc0</srcmd5>
+        <revision rev="24" vrev="24">
+          <srcmd5>51cbfee6b97fac2da91249831539cf3c</srcmd5>
           <version>unknown</version>
-          <time>1642674797</time>
+          <time>1643641538</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:17 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:38 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Aut quis aspernatur. Est aut ut. Illum porro vero.
+      string: Dolores doloremque facere. Consequatur numquam minus. Quidem unde cupiditate.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -335,19 +335,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="583" vrev="583">
-          <srcmd5>52aae9a6549665149868d8810bbe3f96</srcmd5>
+        <revision rev="25" vrev="25">
+          <srcmd5>71794f443da8d579528a778cb1668e2e</srcmd5>
           <version>unknown</version>
-          <time>1642674797</time>
+          <time>1643641538</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:17 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:38 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_branch_request?user=Iggy
@@ -373,28 +373,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '210'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1719" vrev="1719">
-          <srcmd5>67046860f39e77600aa9c232598900f4</srcmd5>
+        <revision rev="48" vrev="48">
+          <srcmd5>3ce67b20382a9902b946b0a02c0c2f7e</srcmd5>
           <version>unknown</version>
-          <time>1642674797</time>
+          <time>1643641538</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:17 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:38 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_345
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_44
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Moving Toyshop</title>
-          <description>Alias sint in ex.</description>
+          <title>The Mirror Crack'd from Side to Side</title>
+          <description>Est tenetur incidunt quo.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -415,15 +415,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '145'
+      - '171'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Moving Toyshop</title>
-          <description>Alias sint in ex.</description>
+          <title>The Mirror Crack'd from Side to Side</title>
+          <description>Est tenetur incidunt quo.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:17 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:38 GMT
 - request:
     method: get
     uri: http://backend:5352/source/foo_project/bar_package
@@ -449,16 +449,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '405'
+      - '401'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="1719" vrev="1719" srcmd5="67046860f39e77600aa9c232598900f4">
-          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1642591329"/>
-          <entry name="_config" md5="f659a7cfa1053d543f3fc113ffa0d127" size="74" mtime="1642674797"/>
-          <entry name="somefile.txt" md5="e4496356701e1e204ed5aa9369e2c54c" size="64" mtime="1642674797"/>
+        <directory name="bar_package" rev="48" vrev="48" srcmd5="3ce67b20382a9902b946b0a02c0c2f7e">
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="5115fd35632ac0c98733cf989ab3a8ba" size="64" mtime="1643641538"/>
+          <entry name="somefile.txt" md5="ec8aa3c584fe0fd0bc002ad377b61e12" size="58" mtime="1643641538"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:17 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:38 GMT
 - request:
     method: get
     uri: http://backend:5352/source/foo_project/bar_package?view=info
@@ -484,14 +484,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '235'
+      - '231'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="1719" vrev="1719" srcmd5="67046860f39e77600aa9c232598900f4" verifymd5="67046860f39e77600aa9c232598900f4">
+        <sourceinfo package="bar_package" rev="48" vrev="48" srcmd5="3ce67b20382a9902b946b0a02c0c2f7e" verifymd5="3ce67b20382a9902b946b0a02c0c2f7e">
           <error>bad build configuration, no build type defined or detected</error>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:17 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:38 GMT
 - request:
     method: get
     uri: http://backend:5352/source/foo_project/bar_package
@@ -517,16 +517,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '405'
+      - '401'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="1719" vrev="1719" srcmd5="67046860f39e77600aa9c232598900f4">
-          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1642591329"/>
-          <entry name="_config" md5="f659a7cfa1053d543f3fc113ffa0d127" size="74" mtime="1642674797"/>
-          <entry name="somefile.txt" md5="e4496356701e1e204ed5aa9369e2c54c" size="64" mtime="1642674797"/>
+        <directory name="bar_package" rev="48" vrev="48" srcmd5="3ce67b20382a9902b946b0a02c0c2f7e">
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="5115fd35632ac0c98733cf989ab3a8ba" size="64" mtime="1643641538"/>
+          <entry name="somefile.txt" md5="ec8aa3c584fe0fd0bc002ad377b61e12" size="58" mtime="1643641538"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:17 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:38 GMT
 - request:
     method: post
     uri: http://backend:5352/source/foo_project/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -554,18 +554,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '309'
+      - '307'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="66bad1586dba9c4b88a44428e4cb3fc0">
+        <sourcediff key="cbcfe4b2e25d465bef29f3154b331525">
           <old project="foo_project" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="foo_project" package="bar_package" rev="1719" srcmd5="67046860f39e77600aa9c232598900f4"/>
+          <new project="foo_project" package="bar_package" rev="48" srcmd5="3ce67b20382a9902b946b0a02c0c2f7e"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:17 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:39 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_branch_request?user=Iggy
@@ -591,19 +591,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="584" vrev="584">
-          <srcmd5>98fe3e29edfeccc577995d83148ccf65</srcmd5>
+        <revision rev="26" vrev="26">
+          <srcmd5>71794f443da8d579528a778cb1668e2e</srcmd5>
           <version>unknown</version>
-          <time>1642674797</time>
+          <time>1643641539</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:17 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:39 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -611,8 +611,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Things Fall Apart</title>
-          <description>Est unde soluta a.</description>
+          <title>I Know Why the Caged Bird Sings</title>
+          <description>Officia et illo at.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -633,15 +633,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '176'
+      - '191'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Things Fall Apart</title>
-          <description>Est unde soluta a.</description>
+          <title>I Know Why the Caged Bird Sings</title>
+          <description>Officia et illo at.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:17 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:39 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -667,21 +667,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '831'
+      - '670'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="584" vrev="584" srcmd5="98fe3e29edfeccc577995d83148ccf65">
-          <linkinfo project="foo_project" package="bar_package" baserev="4db6702909d9d4b88ea57cfcfd6eae77" xsrcmd5="ab5a195b3709d002038dae0f8e010a54" error="conflict in file _config"/>
-          <serviceinfo code="failed" xsrcmd5="62c22ae8435fbe197a044daf9b0fd266">
-            <error>service error: bad link: conflict in file _config</error>
-          </serviceinfo>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="4bfb7a82cb00df3e81713496810bea73" size="68" mtime="1642674797"/>
-          <entry name="_link" md5="86d891195b349a0a081834322bf62764" size="119" mtime="1642674795"/>
-          <entry name="somefile.txt" md5="eab1973593c3470c842a73ea0c2d8118" size="50" mtime="1642674797"/>
+        <directory name="bar_package" rev="26" vrev="26" srcmd5="71794f443da8d579528a778cb1668e2e">
+          <linkinfo project="foo_project" package="bar_package" baserev="7e3a8ddb7d7c6013d4d98f6f202e3508" xsrcmd5="5fea59361d18fb19fd8ea3ee192b8bce" error="conflict in file _config"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="dcd1ccb11873a0d02bf15f5c4939946d" size="70" mtime="1643641538"/>
+          <entry name="_link" md5="ff3d9dc8a65ce527370348e821fae4b8" size="119" mtime="1643641536"/>
+          <entry name="somefile.txt" md5="1f0e289a41700cccc00634fd16cda149" size="77" mtime="1643641538"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:17 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:39 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?view=info
@@ -707,14 +704,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '179'
+      - '253'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="584" vrev="584" srcmd5="98fe3e29edfeccc577995d83148ccf65">
-          <error>service error: bad link: conflict in file _config</error>
+        <sourceinfo package="bar_package" rev="26" vrev="74" srcmd5="71794f443da8d579528a778cb1668e2e" verifymd5="71794f443da8d579528a778cb1668e2e">
+          <error>conflict in file _config</error>
+          <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:17 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:39 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -740,21 +738,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '831'
+      - '670'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="584" vrev="584" srcmd5="98fe3e29edfeccc577995d83148ccf65">
-          <linkinfo project="foo_project" package="bar_package" baserev="4db6702909d9d4b88ea57cfcfd6eae77" xsrcmd5="ab5a195b3709d002038dae0f8e010a54" error="conflict in file _config"/>
-          <serviceinfo code="failed" xsrcmd5="62c22ae8435fbe197a044daf9b0fd266">
-            <error>service error: bad link: conflict in file _config</error>
-          </serviceinfo>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="4bfb7a82cb00df3e81713496810bea73" size="68" mtime="1642674797"/>
-          <entry name="_link" md5="86d891195b349a0a081834322bf62764" size="119" mtime="1642674795"/>
-          <entry name="somefile.txt" md5="eab1973593c3470c842a73ea0c2d8118" size="50" mtime="1642674797"/>
+        <directory name="bar_package" rev="26" vrev="26" srcmd5="71794f443da8d579528a778cb1668e2e">
+          <linkinfo project="foo_project" package="bar_package" baserev="7e3a8ddb7d7c6013d4d98f6f202e3508" xsrcmd5="5fea59361d18fb19fd8ea3ee192b8bce" error="conflict in file _config"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="dcd1ccb11873a0d02bf15f5c4939946d" size="70" mtime="1643641538"/>
+          <entry name="_link" md5="ff3d9dc8a65ce527370348e821fae4b8" size="119" mtime="1643641536"/>
+          <entry name="somefile.txt" md5="1f0e289a41700cccc00634fd16cda149" size="77" mtime="1643641538"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:17 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:39 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -782,18 +777,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '370'
+      - '369'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="be3330e2aecd65959623fde619f24c01">
+        <sourcediff key="58eb1d4b64eb640ad76f26d760c734de">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="584" srcmd5="98fe3e29edfeccc577995d83148ccf65"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="26" srcmd5="71794f443da8d579528a778cb1668e2e"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:17 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:39 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -811,8 +806,8 @@ http_interactions:
       - Ruby
   response:
     status:
-      code: 400
-      message: service error  bad link  conflict in file _config
+      code: 200
+      message: OK
     headers:
       Content-Type:
       - text/xml
@@ -821,12 +816,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '101'
+      - '399'
     body:
       encoding: UTF-8
       string: |
-        <status code="400">
-          <summary>service error: bad link: conflict in file _config</summary>
-        </status>
-  recorded_at: Thu, 20 Jan 2022 10:33:17 GMT
+        <sourcediff key="4c7d879cf155cbd2bea50989b52c0472">
+          <old project="foo_project" package="bar_package" rev="7e3a8ddb7d7c6013d4d98f6f202e3508" srcmd5="7e3a8ddb7d7c6013d4d98f6f202e3508"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="e0490bd1daeac3a7bb8bb77d6701c9cf" srcmd5="e0490bd1daeac3a7bb8bb77d6701c9cf"/>
+          <files/>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Mon, 31 Jan 2022 15:05:39 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_an_updated_PR_event/when_the_branched_package_already_existed/behaves_like_successful_update_event_when_the_branch_package_already_exists/1_1_1_5_1_1_5.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_an_updated_PR_event/when_the_branched_package_already_existed/behaves_like_successful_update_event_when_the_branch_package_already_exists/1_1_1_5_1_1_5.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:19 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:42 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_350
+    uri: http://backend:5352/source/foo_project/_meta?user=user_51
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>The Far-Distant Oxus</title>
+          <title>This Side of Paradise</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '152'
+      - '153'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>The Far-Distant Oxus</title>
+          <title>This Side of Paradise</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:19 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:43 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_351
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_52
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>O Jerusalem!</title>
-          <description>Qui unde consequatur ea.</description>
+          <title>A Many-Splendoured Thing</title>
+          <description>Qui repudiandae optio reprehenderit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '146'
+      - '170'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>O Jerusalem!</title>
-          <description>Qui unde consequatur ea.</description>
+          <title>A Many-Splendoured Thing</title>
+          <description>Qui repudiandae optio reprehenderit.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:19 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:43 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Hic voluptas voluptatem. Sit nesciunt quam. Blanditiis debitis tempore.
+      string: Magni nesciunt possimus. Voluptatibus facilis qui. Velit dolor enim.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1726" vrev="1726">
-          <srcmd5>b77c21ab613fde6a3882ee9ce48e734f</srcmd5>
+        <revision rev="58" vrev="58">
+          <srcmd5>e7c39ba91db1b6e04564ef69b4d9a374</srcmd5>
           <version>unknown</version>
-          <time>1642674799</time>
+          <time>1643641543</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:19 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:43 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Rem nobis ut. Rem qui rerum. Voluptatem ab possimus.
+      string: Repellat nulla eum. Similique tempora voluptates. Et reiciendis molestiae.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +181,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1727" vrev="1727">
-          <srcmd5>22b027406bf5bbd4d7cb780971f0be31</srcmd5>
+        <revision rev="59" vrev="59">
+          <srcmd5>0c24ce58ce5bc8e000b4b42df3c60c95</srcmd5>
           <version>unknown</version>
-          <time>1642674799</time>
+          <time>1643641543</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:19 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:43 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -201,7 +201,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Tirra Lirra by the River</title>
+          <title>The Needle's Eye</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -224,16 +224,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '187'
+      - '179'
     body:
       encoding: UTF-8
       string: |
         <project name="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Tirra Lirra by the River</title>
+          <title>The Needle's Eye</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:19 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:43 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -241,8 +241,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Precious Bane</title>
-          <description>Et dolores et sit.</description>
+          <title>Ego Dominus Tuus</title>
+          <description>Est saepe eligendi vero.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -263,21 +263,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '172'
+      - '181'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Precious Bane</title>
-          <description>Et dolores et sit.</description>
+          <title>Ego Dominus Tuus</title>
+          <description>Est saepe eligendi vero.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:19 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:43 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_config
     body:
       encoding: UTF-8
-      string: Totam omnis rem. Voluptatum libero porro. Error quis tempore.
+      string: Non impedit ipsa. Ad quia quisquam. Quod sed id.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -297,25 +297,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="591" vrev="591">
-          <srcmd5>005835721e360ab3d4e618d7235112ac</srcmd5>
+        <revision rev="36" vrev="36">
+          <srcmd5>6f23d31170479a76acc558a06d67e458</srcmd5>
           <version>unknown</version>
-          <time>1642674799</time>
+          <time>1643641543</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:20 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:43 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Voluptate nobis ipsam. Id ut qui. Consequatur reprehenderit et.
+      string: Quo tempora harum. Illum vel est. Nemo tenetur incidunt.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -335,19 +335,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="592" vrev="592">
-          <srcmd5>64b15e8923f4ac88112d23a07ccf5317</srcmd5>
+        <revision rev="37" vrev="37">
+          <srcmd5>9862ad877bbb470693c86b88a1caf20b</srcmd5>
           <version>unknown</version>
-          <time>1642674800</time>
+          <time>1643641543</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:20 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:43 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_branch_request?user=Iggy
@@ -373,28 +373,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '210'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1728" vrev="1728">
-          <srcmd5>22b027406bf5bbd4d7cb780971f0be31</srcmd5>
+        <revision rev="60" vrev="60">
+          <srcmd5>0c24ce58ce5bc8e000b4b42df3c60c95</srcmd5>
           <version>unknown</version>
-          <time>1642674800</time>
+          <time>1643641543</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:20 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:43 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_351
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_52
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>O Jerusalem!</title>
-          <description>Qui unde consequatur ea.</description>
+          <title>A Many-Splendoured Thing</title>
+          <description>Qui repudiandae optio reprehenderit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -415,15 +415,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '146'
+      - '170'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>O Jerusalem!</title>
-          <description>Qui unde consequatur ea.</description>
+          <title>A Many-Splendoured Thing</title>
+          <description>Qui repudiandae optio reprehenderit.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:20 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:43 GMT
 - request:
     method: get
     uri: http://backend:5352/source/foo_project/bar_package
@@ -449,16 +449,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '405'
+      - '401'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="1728" vrev="1728" srcmd5="22b027406bf5bbd4d7cb780971f0be31">
-          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1642591329"/>
-          <entry name="_config" md5="58d9e5a1881e759ee06972c54206268b" size="71" mtime="1642674799"/>
-          <entry name="somefile.txt" md5="dc98b6a49d926f899f97edb57a7a836f" size="52" mtime="1642674799"/>
+        <directory name="bar_package" rev="60" vrev="60" srcmd5="0c24ce58ce5bc8e000b4b42df3c60c95">
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="921e6f22c61775e853a945f7faa51865" size="68" mtime="1643641543"/>
+          <entry name="somefile.txt" md5="ebef9f089f0c16e3cc47d4ac08b49685" size="74" mtime="1643641543"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:20 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:43 GMT
 - request:
     method: get
     uri: http://backend:5352/source/foo_project/bar_package?view=info
@@ -484,14 +484,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '235'
+      - '231'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="1728" vrev="1728" srcmd5="22b027406bf5bbd4d7cb780971f0be31" verifymd5="22b027406bf5bbd4d7cb780971f0be31">
+        <sourceinfo package="bar_package" rev="60" vrev="60" srcmd5="0c24ce58ce5bc8e000b4b42df3c60c95" verifymd5="0c24ce58ce5bc8e000b4b42df3c60c95">
           <error>bad build configuration, no build type defined or detected</error>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:20 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:43 GMT
 - request:
     method: get
     uri: http://backend:5352/source/foo_project/bar_package
@@ -517,16 +517,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '405'
+      - '401'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="1728" vrev="1728" srcmd5="22b027406bf5bbd4d7cb780971f0be31">
-          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1642591329"/>
-          <entry name="_config" md5="58d9e5a1881e759ee06972c54206268b" size="71" mtime="1642674799"/>
-          <entry name="somefile.txt" md5="dc98b6a49d926f899f97edb57a7a836f" size="52" mtime="1642674799"/>
+        <directory name="bar_package" rev="60" vrev="60" srcmd5="0c24ce58ce5bc8e000b4b42df3c60c95">
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="921e6f22c61775e853a945f7faa51865" size="68" mtime="1643641543"/>
+          <entry name="somefile.txt" md5="ebef9f089f0c16e3cc47d4ac08b49685" size="74" mtime="1643641543"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:20 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:43 GMT
 - request:
     method: post
     uri: http://backend:5352/source/foo_project/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -554,18 +554,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '309'
+      - '307'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="a11ce2ab4476834dd0f48a47b141d15b">
+        <sourcediff key="144b592f75679efca0765dbd2c46bd0a">
           <old project="foo_project" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="foo_project" package="bar_package" rev="1728" srcmd5="22b027406bf5bbd4d7cb780971f0be31"/>
+          <new project="foo_project" package="bar_package" rev="60" srcmd5="0c24ce58ce5bc8e000b4b42df3c60c95"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:20 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:43 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_branch_request?user=Iggy
@@ -591,19 +591,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="593" vrev="593">
-          <srcmd5>1d54a79551631970f73af5bec245826c</srcmd5>
+        <revision rev="38" vrev="38">
+          <srcmd5>9862ad877bbb470693c86b88a1caf20b</srcmd5>
           <version>unknown</version>
-          <time>1642674800</time>
+          <time>1643641543</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:20 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:43 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -611,8 +611,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Precious Bane</title>
-          <description>Et dolores et sit.</description>
+          <title>Ego Dominus Tuus</title>
+          <description>Est saepe eligendi vero.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -633,15 +633,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '172'
+      - '181'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Precious Bane</title>
-          <description>Et dolores et sit.</description>
+          <title>Ego Dominus Tuus</title>
+          <description>Est saepe eligendi vero.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:20 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:43 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -667,21 +667,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '831'
+      - '670'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="593" vrev="593" srcmd5="1d54a79551631970f73af5bec245826c">
-          <linkinfo project="foo_project" package="bar_package" baserev="4db6702909d9d4b88ea57cfcfd6eae77" xsrcmd5="999643b85a6c6ce296f68c0df9fb4d93" error="conflict in file _config"/>
-          <serviceinfo code="failed" xsrcmd5="0543f6c1e47358f49583ca75c7a08178">
-            <error>service error: bad link: conflict in file _config</error>
-          </serviceinfo>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="128c25331005c86302cfcb3fcb8d88f8" size="61" mtime="1642674799"/>
-          <entry name="_link" md5="86d891195b349a0a081834322bf62764" size="119" mtime="1642674795"/>
-          <entry name="somefile.txt" md5="3a89c40f2ac516e8c2b5dc8c852c16cb" size="63" mtime="1642674800"/>
+        <directory name="bar_package" rev="38" vrev="38" srcmd5="9862ad877bbb470693c86b88a1caf20b">
+          <linkinfo project="foo_project" package="bar_package" baserev="7e3a8ddb7d7c6013d4d98f6f202e3508" xsrcmd5="4fadba3b644d130e663f838f312afb30" error="conflict in file _config"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="687c6647da8f512279635e8d090c192b" size="48" mtime="1643641543"/>
+          <entry name="_link" md5="ff3d9dc8a65ce527370348e821fae4b8" size="119" mtime="1643641536"/>
+          <entry name="somefile.txt" md5="e6f3f4a37d53d2000b79e5c2f3491e72" size="56" mtime="1643641543"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:20 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:43 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?view=info
@@ -707,14 +704,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '179'
+      - '253'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="593" vrev="593" srcmd5="1d54a79551631970f73af5bec245826c">
-          <error>service error: bad link: conflict in file _config</error>
+        <sourceinfo package="bar_package" rev="38" vrev="98" srcmd5="9862ad877bbb470693c86b88a1caf20b" verifymd5="9862ad877bbb470693c86b88a1caf20b">
+          <error>conflict in file _config</error>
+          <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:20 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:43 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -740,21 +738,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '831'
+      - '670'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="593" vrev="593" srcmd5="1d54a79551631970f73af5bec245826c">
-          <linkinfo project="foo_project" package="bar_package" baserev="4db6702909d9d4b88ea57cfcfd6eae77" xsrcmd5="999643b85a6c6ce296f68c0df9fb4d93" error="conflict in file _config"/>
-          <serviceinfo code="failed" xsrcmd5="0543f6c1e47358f49583ca75c7a08178">
-            <error>service error: bad link: conflict in file _config</error>
-          </serviceinfo>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="128c25331005c86302cfcb3fcb8d88f8" size="61" mtime="1642674799"/>
-          <entry name="_link" md5="86d891195b349a0a081834322bf62764" size="119" mtime="1642674795"/>
-          <entry name="somefile.txt" md5="3a89c40f2ac516e8c2b5dc8c852c16cb" size="63" mtime="1642674800"/>
+        <directory name="bar_package" rev="38" vrev="38" srcmd5="9862ad877bbb470693c86b88a1caf20b">
+          <linkinfo project="foo_project" package="bar_package" baserev="7e3a8ddb7d7c6013d4d98f6f202e3508" xsrcmd5="4fadba3b644d130e663f838f312afb30" error="conflict in file _config"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="687c6647da8f512279635e8d090c192b" size="48" mtime="1643641543"/>
+          <entry name="_link" md5="ff3d9dc8a65ce527370348e821fae4b8" size="119" mtime="1643641536"/>
+          <entry name="somefile.txt" md5="e6f3f4a37d53d2000b79e5c2f3491e72" size="56" mtime="1643641543"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:20 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:43 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -782,18 +777,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '370'
+      - '369'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="14b25619cb94cc2821cfb68877a94e0a">
+        <sourcediff key="4955181c52928806cfa508361eaf3616">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="593" srcmd5="1d54a79551631970f73af5bec245826c"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="38" srcmd5="9862ad877bbb470693c86b88a1caf20b"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:20 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:43 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -811,8 +806,8 @@ http_interactions:
       - Ruby
   response:
     status:
-      code: 400
-      message: service error  bad link  conflict in file _config
+      code: 200
+      message: OK
     headers:
       Content-Type:
       - text/xml
@@ -821,12 +816,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '101'
+      - '399'
     body:
       encoding: UTF-8
       string: |
-        <status code="400">
-          <summary>service error: bad link: conflict in file _config</summary>
-        </status>
-  recorded_at: Thu, 20 Jan 2022 10:33:20 GMT
+        <sourcediff key="e70d07ae2f8c5c2a939f710786195911">
+          <old project="foo_project" package="bar_package" rev="7e3a8ddb7d7c6013d4d98f6f202e3508" srcmd5="7e3a8ddb7d7c6013d4d98f6f202e3508"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="3ee0d6c67af8edb1ea05353283662c45" srcmd5="3ee0d6c67af8edb1ea05353283662c45"/>
+          <files/>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Mon, 31 Jan 2022 15:05:43 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_an_updated_PR_event/when_the_branched_package_already_existed/behaves_like_successful_update_event_when_the_branch_package_already_exists/1_1_1_5_1_1_6.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_an_updated_PR_event/when_the_branched_package_already_existed/behaves_like_successful_update_event_when_the_branch_package_already_exists/1_1_1_5_1_1_6.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:20 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:40 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_352
+    uri: http://backend:5352/source/foo_project/_meta?user=user_47
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Such, Such Were the Joys</title>
+          <title>Death Be Not Proud</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '156'
+      - '150'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Such, Such Were the Joys</title>
+          <title>Death Be Not Proud</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:20 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:40 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_353
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_48
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Moving Finger</title>
-          <description>Amet error nulla dolores.</description>
+          <title>The Moon by Night</title>
+          <description>Et qui qui nisi.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '152'
+      - '143'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Moving Finger</title>
-          <description>Amet error nulla dolores.</description>
+          <title>The Moon by Night</title>
+          <description>Et qui qui nisi.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:20 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:40 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Omnis doloribus accusantium. Occaecati sed quasi. Officiis veniam repellat.
+      string: Magni sapiente dolores. Fugit sed aut. Blanditiis quasi dolorum.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,26 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1729" vrev="1729">
-          <srcmd5>09a4cd6259cc11ce72722b4f53713a8d</srcmd5>
+        <revision rev="52" vrev="52">
+          <srcmd5>1ccddf3c6ce6af6c2eae7b891672e3ce</srcmd5>
           <version>unknown</version>
-          <time>1642674800</time>
+          <time>1643641540</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:20 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:40 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Veritatis maxime doloribus. Repudiandae totam odio. Qui consequatur
-        enim.
+      string: Vel ut itaque. Cupiditate non accusamus. Nulla quaerat ducimus.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -182,19 +181,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1730" vrev="1730">
-          <srcmd5>7d748e87c7b28109ecccf0ae271b111c</srcmd5>
+        <revision rev="53" vrev="53">
+          <srcmd5>6a23c2c2dde86e0b757f6615b47f1bfa</srcmd5>
           <version>unknown</version>
-          <time>1642674800</time>
+          <time>1643641540</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:20 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:40 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -202,7 +201,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Everything is Illuminated</title>
+          <title>The Line of Beauty</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -225,16 +224,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '188'
+      - '181'
     body:
       encoding: UTF-8
       string: |
         <project name="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Everything is Illuminated</title>
+          <title>The Line of Beauty</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:20 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:40 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -242,8 +241,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>If Not Now, When?</title>
-          <description>Cum praesentium aut quasi.</description>
+          <title>The Yellow Meads of Asphodel</title>
+          <description>Ut sit a adipisci.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -264,21 +263,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '184'
+      - '187'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>If Not Now, When?</title>
-          <description>Cum praesentium aut quasi.</description>
+          <title>The Yellow Meads of Asphodel</title>
+          <description>Ut sit a adipisci.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:20 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:40 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_config
     body:
       encoding: UTF-8
-      string: Totam ea quia. Inventore mollitia et. Eligendi nesciunt error.
+      string: Qui dolore id. Aperiam facere veritatis. Tenetur neque eum.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -298,25 +297,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="594" vrev="594">
-          <srcmd5>0d4035f0fc987fb165265a115f31ea06</srcmd5>
+        <revision rev="30" vrev="30">
+          <srcmd5>de486b741d39303cb6f652d7773a6289</srcmd5>
           <version>unknown</version>
-          <time>1642674800</time>
+          <time>1643641540</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:20 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:40 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Vel non possimus. Doloribus quo aliquam. Aliquam fugit atque.
+      string: Eos ullam vel. Quae voluptatum numquam. Iste dolorem sed.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -336,19 +335,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="595" vrev="595">
-          <srcmd5>372a3d596735a480a4ae36058749896b</srcmd5>
+        <revision rev="31" vrev="31">
+          <srcmd5>21b670c9f03afd279c7ef6de8a93ee3a</srcmd5>
           <version>unknown</version>
-          <time>1642674800</time>
+          <time>1643641540</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:20 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:40 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_branch_request?user=Iggy
@@ -374,28 +373,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '210'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1731" vrev="1731">
-          <srcmd5>7d748e87c7b28109ecccf0ae271b111c</srcmd5>
+        <revision rev="54" vrev="54">
+          <srcmd5>6a23c2c2dde86e0b757f6615b47f1bfa</srcmd5>
           <version>unknown</version>
-          <time>1642674801</time>
+          <time>1643641540</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:41 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_353
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_48
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Moving Finger</title>
-          <description>Amet error nulla dolores.</description>
+          <title>The Moon by Night</title>
+          <description>Et qui qui nisi.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -416,15 +415,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '152'
+      - '143'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Moving Finger</title>
-          <description>Amet error nulla dolores.</description>
+          <title>The Moon by Night</title>
+          <description>Et qui qui nisi.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:41 GMT
 - request:
     method: get
     uri: http://backend:5352/source/foo_project/bar_package
@@ -450,16 +449,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '405'
+      - '401'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="1731" vrev="1731" srcmd5="7d748e87c7b28109ecccf0ae271b111c">
-          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1642591329"/>
-          <entry name="_config" md5="3170b33ddcc867aca847c74d516c4794" size="75" mtime="1642674800"/>
-          <entry name="somefile.txt" md5="ad204c945002bd964fc688331e262385" size="73" mtime="1642674800"/>
+        <directory name="bar_package" rev="54" vrev="54" srcmd5="6a23c2c2dde86e0b757f6615b47f1bfa">
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="0ee52e4d9ada46c4b48a8e094a1a7e7b" size="64" mtime="1643641540"/>
+          <entry name="somefile.txt" md5="81ef112435c84ad3834f3454150a01ee" size="63" mtime="1643641540"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:41 GMT
 - request:
     method: get
     uri: http://backend:5352/source/foo_project/bar_package?view=info
@@ -485,14 +484,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '235'
+      - '231'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="1731" vrev="1731" srcmd5="7d748e87c7b28109ecccf0ae271b111c" verifymd5="7d748e87c7b28109ecccf0ae271b111c">
+        <sourceinfo package="bar_package" rev="54" vrev="54" srcmd5="6a23c2c2dde86e0b757f6615b47f1bfa" verifymd5="6a23c2c2dde86e0b757f6615b47f1bfa">
           <error>bad build configuration, no build type defined or detected</error>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:41 GMT
 - request:
     method: get
     uri: http://backend:5352/source/foo_project/bar_package
@@ -518,16 +517,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '405'
+      - '401'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="1731" vrev="1731" srcmd5="7d748e87c7b28109ecccf0ae271b111c">
-          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1642591329"/>
-          <entry name="_config" md5="3170b33ddcc867aca847c74d516c4794" size="75" mtime="1642674800"/>
-          <entry name="somefile.txt" md5="ad204c945002bd964fc688331e262385" size="73" mtime="1642674800"/>
+        <directory name="bar_package" rev="54" vrev="54" srcmd5="6a23c2c2dde86e0b757f6615b47f1bfa">
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="0ee52e4d9ada46c4b48a8e094a1a7e7b" size="64" mtime="1643641540"/>
+          <entry name="somefile.txt" md5="81ef112435c84ad3834f3454150a01ee" size="63" mtime="1643641540"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:41 GMT
 - request:
     method: post
     uri: http://backend:5352/source/foo_project/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -555,18 +554,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '309'
+      - '307'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="6d8fc503db4145a653269f2401c9671c">
+        <sourcediff key="317fe544b67a241e2ab0ee709478c4ae">
           <old project="foo_project" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="foo_project" package="bar_package" rev="1731" srcmd5="7d748e87c7b28109ecccf0ae271b111c"/>
+          <new project="foo_project" package="bar_package" rev="54" srcmd5="6a23c2c2dde86e0b757f6615b47f1bfa"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:41 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_branch_request?user=Iggy
@@ -592,19 +591,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="596" vrev="596">
-          <srcmd5>2f6ee1e0921eef621b8775521c5b99ec</srcmd5>
+        <revision rev="32" vrev="32">
+          <srcmd5>21b670c9f03afd279c7ef6de8a93ee3a</srcmd5>
           <version>unknown</version>
-          <time>1642674801</time>
+          <time>1643641541</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:41 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -612,8 +611,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>If Not Now, When?</title>
-          <description>Cum praesentium aut quasi.</description>
+          <title>The Yellow Meads of Asphodel</title>
+          <description>Ut sit a adipisci.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -634,15 +633,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '184'
+      - '187'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>If Not Now, When?</title>
-          <description>Cum praesentium aut quasi.</description>
+          <title>The Yellow Meads of Asphodel</title>
+          <description>Ut sit a adipisci.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:41 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -668,21 +667,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '831'
+      - '670'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="596" vrev="596" srcmd5="2f6ee1e0921eef621b8775521c5b99ec">
-          <linkinfo project="foo_project" package="bar_package" baserev="4db6702909d9d4b88ea57cfcfd6eae77" xsrcmd5="900685ab20392eb29cf9b6476d1053d1" error="conflict in file _config"/>
-          <serviceinfo code="failed" xsrcmd5="d8f091429fd1459ec60a6da5cde10ada">
-            <error>service error: bad link: conflict in file _config</error>
-          </serviceinfo>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="910b99ed90cf46ba5be0cf1179987486" size="62" mtime="1642674800"/>
-          <entry name="_link" md5="86d891195b349a0a081834322bf62764" size="119" mtime="1642674795"/>
-          <entry name="somefile.txt" md5="994b76958d3abee3f287df457ffc226f" size="61" mtime="1642674800"/>
+        <directory name="bar_package" rev="32" vrev="32" srcmd5="21b670c9f03afd279c7ef6de8a93ee3a">
+          <linkinfo project="foo_project" package="bar_package" baserev="7e3a8ddb7d7c6013d4d98f6f202e3508" xsrcmd5="33ceb906a9ad4f49ae4e714641ff9dd4" error="conflict in file _config"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="7322e63794aba5d3cd616cd3bcb841ca" size="59" mtime="1643641540"/>
+          <entry name="_link" md5="ff3d9dc8a65ce527370348e821fae4b8" size="119" mtime="1643641536"/>
+          <entry name="somefile.txt" md5="f0582b0aa51c457900c7471863e3d219" size="57" mtime="1643641540"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:41 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?view=info
@@ -708,14 +704,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '179'
+      - '253'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="596" vrev="596" srcmd5="2f6ee1e0921eef621b8775521c5b99ec">
-          <error>service error: bad link: conflict in file _config</error>
+        <sourceinfo package="bar_package" rev="32" vrev="86" srcmd5="21b670c9f03afd279c7ef6de8a93ee3a" verifymd5="21b670c9f03afd279c7ef6de8a93ee3a">
+          <error>conflict in file _config</error>
+          <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:41 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -741,21 +738,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '831'
+      - '670'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="596" vrev="596" srcmd5="2f6ee1e0921eef621b8775521c5b99ec">
-          <linkinfo project="foo_project" package="bar_package" baserev="4db6702909d9d4b88ea57cfcfd6eae77" xsrcmd5="900685ab20392eb29cf9b6476d1053d1" error="conflict in file _config"/>
-          <serviceinfo code="failed" xsrcmd5="d8f091429fd1459ec60a6da5cde10ada">
-            <error>service error: bad link: conflict in file _config</error>
-          </serviceinfo>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="910b99ed90cf46ba5be0cf1179987486" size="62" mtime="1642674800"/>
-          <entry name="_link" md5="86d891195b349a0a081834322bf62764" size="119" mtime="1642674795"/>
-          <entry name="somefile.txt" md5="994b76958d3abee3f287df457ffc226f" size="61" mtime="1642674800"/>
+        <directory name="bar_package" rev="32" vrev="32" srcmd5="21b670c9f03afd279c7ef6de8a93ee3a">
+          <linkinfo project="foo_project" package="bar_package" baserev="7e3a8ddb7d7c6013d4d98f6f202e3508" xsrcmd5="33ceb906a9ad4f49ae4e714641ff9dd4" error="conflict in file _config"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="7322e63794aba5d3cd616cd3bcb841ca" size="59" mtime="1643641540"/>
+          <entry name="_link" md5="ff3d9dc8a65ce527370348e821fae4b8" size="119" mtime="1643641536"/>
+          <entry name="somefile.txt" md5="f0582b0aa51c457900c7471863e3d219" size="57" mtime="1643641540"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:41 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -783,18 +777,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '370'
+      - '369'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="5ab3e66616a56121b2848a3e73daa798">
+        <sourcediff key="670bde40c8a00c1b07094c9b12a5e298">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="596" srcmd5="2f6ee1e0921eef621b8775521c5b99ec"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="32" srcmd5="21b670c9f03afd279c7ef6de8a93ee3a"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:41 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -812,8 +806,8 @@ http_interactions:
       - Ruby
   response:
     status:
-      code: 400
-      message: service error  bad link  conflict in file _config
+      code: 200
+      message: OK
     headers:
       Content-Type:
       - text/xml
@@ -822,12 +816,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '101'
+      - '399'
     body:
       encoding: UTF-8
       string: |
-        <status code="400">
-          <summary>service error: bad link: conflict in file _config</summary>
-        </status>
-  recorded_at: Thu, 20 Jan 2022 10:33:21 GMT
+        <sourcediff key="0c5c85fa7e4a542ef4cb49d46e72f385">
+          <old project="foo_project" package="bar_package" rev="7e3a8ddb7d7c6013d4d98f6f202e3508" srcmd5="7e3a8ddb7d7c6013d4d98f6f202e3508"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="1004c45a4ff33d9c1bceb44bd974e040" srcmd5="1004c45a4ff33d9c1bceb44bd974e040"/>
+          <files/>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Mon, 31 Jan 2022 15:05:41 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_an_updated_PR_event/when_the_branched_package_already_existed/behaves_like_successful_update_event_when_the_branch_package_already_exists/updates__branch_request_file_including_new_commit_sha.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_an_updated_PR_event/when_the_branched_package_already_existed/behaves_like_successful_update_event_when_the_branch_package_already_exists/updates__branch_request_file_including_new_commit_sha.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:17 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:41 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_346
+    uri: http://backend:5352/source/foo_project/_meta?user=user_49
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Dulce et Decorum Est</title>
+          <title>I Sing the Body Electric</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '152'
+      - '156'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Dulce et Decorum Est</title>
+          <title>I Sing the Body Electric</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:18 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:41 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_347
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_50
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Oh! To be in England</title>
-          <description>Aut ipsum sit non.</description>
+          <title>Ah, Wilderness!</title>
+          <description>Nesciunt accusamus numquam eos.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '148'
+      - '156'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Oh! To be in England</title>
-          <description>Aut ipsum sit non.</description>
+          <title>Ah, Wilderness!</title>
+          <description>Nesciunt accusamus numquam eos.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:18 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:41 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Soluta repellat odio. Fugiat assumenda sed. Praesentium eius est.
+      string: Labore et delectus. Excepturi ut aut. Ullam soluta officia.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1720" vrev="1720">
-          <srcmd5>11dfbbe3a231e8d0b2e880c6c656077e</srcmd5>
+        <revision rev="55" vrev="55">
+          <srcmd5>11ad9589b7781551bac27a4dd24a08f5</srcmd5>
           <version>unknown</version>
-          <time>1642674798</time>
+          <time>1643641541</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:18 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:42 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Sit eos expedita. Possimus atque nisi. Omnis a sed.
+      string: Repellat aperiam nam. Nihil odit eligendi. Qui accusantium ut.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +181,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1721" vrev="1721">
-          <srcmd5>45ac75aff37f539277983e332241ea5f</srcmd5>
+        <revision rev="56" vrev="56">
+          <srcmd5>27bf9b044983588c8ac00f0bf7cb747b</srcmd5>
           <version>unknown</version>
-          <time>1642674798</time>
+          <time>1643641542</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:18 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:42 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -201,7 +201,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>O Pioneers!</title>
+          <title>Unweaving the Rainbow</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -224,16 +224,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '174'
+      - '184'
     body:
       encoding: UTF-8
       string: |
         <project name="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>O Pioneers!</title>
+          <title>Unweaving the Rainbow</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:18 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:42 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -241,8 +241,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Fame Is the Spur</title>
-          <description>Harum et doloremque reprehenderit.</description>
+          <title>Jesting Pilate</title>
+          <description>Veniam ea molestias perspiciatis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -263,21 +263,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '191'
+      - '188'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Fame Is the Spur</title>
-          <description>Harum et doloremque reprehenderit.</description>
+          <title>Jesting Pilate</title>
+          <description>Veniam ea molestias perspiciatis.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:18 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:42 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_config
     body:
       encoding: UTF-8
-      string: Nulla perferendis et. Dolor repudiandae error. Voluptas rerum consequatur.
+      string: Accusamus est quaerat. A numquam facere. Ut quibusdam adipisci.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -297,25 +297,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="585" vrev="585">
-          <srcmd5>04aa0f34dd80d2c55a617742a5acc5be</srcmd5>
+        <revision rev="33" vrev="33">
+          <srcmd5>4c3a9a754f3c4a19df09bcbc58913035</srcmd5>
           <version>unknown</version>
-          <time>1642674798</time>
+          <time>1643641542</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:18 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:42 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Tenetur sit qui. Omnis dolorum dolore. Dolor facilis quis.
+      string: Architecto vel quas. Voluptatem amet consectetur. Aliquam hic quod.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -335,19 +335,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="586" vrev="586">
-          <srcmd5>069eb273794bd6345280b59fd0dccaa1</srcmd5>
+        <revision rev="34" vrev="34">
+          <srcmd5>863d61c9a01ca5a29f4bfdf0efdc8a25</srcmd5>
           <version>unknown</version>
-          <time>1642674798</time>
+          <time>1643641542</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:18 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:42 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_branch_request?user=Iggy
@@ -373,28 +373,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '210'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1722" vrev="1722">
-          <srcmd5>45ac75aff37f539277983e332241ea5f</srcmd5>
+        <revision rev="57" vrev="57">
+          <srcmd5>27bf9b044983588c8ac00f0bf7cb747b</srcmd5>
           <version>unknown</version>
-          <time>1642674798</time>
+          <time>1643641542</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:18 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:42 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_347
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_50
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Oh! To be in England</title>
-          <description>Aut ipsum sit non.</description>
+          <title>Ah, Wilderness!</title>
+          <description>Nesciunt accusamus numquam eos.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -415,15 +415,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '148'
+      - '156'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Oh! To be in England</title>
-          <description>Aut ipsum sit non.</description>
+          <title>Ah, Wilderness!</title>
+          <description>Nesciunt accusamus numquam eos.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:18 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:42 GMT
 - request:
     method: get
     uri: http://backend:5352/source/foo_project/bar_package
@@ -449,16 +449,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '405'
+      - '401'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="1722" vrev="1722" srcmd5="45ac75aff37f539277983e332241ea5f">
-          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1642591329"/>
-          <entry name="_config" md5="d397b532a1ee7d47dbb6dea8dcb19342" size="65" mtime="1642674798"/>
-          <entry name="somefile.txt" md5="7e54bb613d9ee64e438d87f6016c53b1" size="51" mtime="1642674798"/>
+        <directory name="bar_package" rev="57" vrev="57" srcmd5="27bf9b044983588c8ac00f0bf7cb747b">
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="78fe2c87f2156829db0c1718e48beea3" size="59" mtime="1643641541"/>
+          <entry name="somefile.txt" md5="ac1cb1d996830b0f54a83be76ab75455" size="62" mtime="1643641542"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:18 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:42 GMT
 - request:
     method: get
     uri: http://backend:5352/source/foo_project/bar_package?view=info
@@ -484,14 +484,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '235'
+      - '231'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="1722" vrev="1722" srcmd5="45ac75aff37f539277983e332241ea5f" verifymd5="45ac75aff37f539277983e332241ea5f">
+        <sourceinfo package="bar_package" rev="57" vrev="57" srcmd5="27bf9b044983588c8ac00f0bf7cb747b" verifymd5="27bf9b044983588c8ac00f0bf7cb747b">
           <error>bad build configuration, no build type defined or detected</error>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:18 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:42 GMT
 - request:
     method: get
     uri: http://backend:5352/source/foo_project/bar_package
@@ -517,16 +517,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '405'
+      - '401'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="1722" vrev="1722" srcmd5="45ac75aff37f539277983e332241ea5f">
-          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1642591329"/>
-          <entry name="_config" md5="d397b532a1ee7d47dbb6dea8dcb19342" size="65" mtime="1642674798"/>
-          <entry name="somefile.txt" md5="7e54bb613d9ee64e438d87f6016c53b1" size="51" mtime="1642674798"/>
+        <directory name="bar_package" rev="57" vrev="57" srcmd5="27bf9b044983588c8ac00f0bf7cb747b">
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="78fe2c87f2156829db0c1718e48beea3" size="59" mtime="1643641541"/>
+          <entry name="somefile.txt" md5="ac1cb1d996830b0f54a83be76ab75455" size="62" mtime="1643641542"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:18 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:42 GMT
 - request:
     method: post
     uri: http://backend:5352/source/foo_project/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -554,18 +554,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '309'
+      - '307'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="9672fa1539d272a8ee41d945d6a9233e">
+        <sourcediff key="4040cf2d279ccf3b4d7462a580e7e381">
           <old project="foo_project" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="foo_project" package="bar_package" rev="1722" srcmd5="45ac75aff37f539277983e332241ea5f"/>
+          <new project="foo_project" package="bar_package" rev="57" srcmd5="27bf9b044983588c8ac00f0bf7cb747b"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:18 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:42 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_branch_request?user=Iggy
@@ -591,19 +591,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="587" vrev="587">
-          <srcmd5>b82a9590384bfc5d4c5483a81db9ad8d</srcmd5>
+        <revision rev="35" vrev="35">
+          <srcmd5>863d61c9a01ca5a29f4bfdf0efdc8a25</srcmd5>
           <version>unknown</version>
-          <time>1642674798</time>
+          <time>1643641542</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:18 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:42 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -611,8 +611,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Fame Is the Spur</title>
-          <description>Harum et doloremque reprehenderit.</description>
+          <title>Jesting Pilate</title>
+          <description>Veniam ea molestias perspiciatis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -633,15 +633,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '191'
+      - '188'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Fame Is the Spur</title>
-          <description>Harum et doloremque reprehenderit.</description>
+          <title>Jesting Pilate</title>
+          <description>Veniam ea molestias perspiciatis.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:18 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:42 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -667,21 +667,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '831'
+      - '670'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="587" vrev="587" srcmd5="b82a9590384bfc5d4c5483a81db9ad8d">
-          <linkinfo project="foo_project" package="bar_package" baserev="4db6702909d9d4b88ea57cfcfd6eae77" xsrcmd5="84d9d1fa4b85c098db321fdea9e936c7" error="conflict in file _config"/>
-          <serviceinfo code="failed" xsrcmd5="6ffced41acc0ceeb848683517d008c84">
-            <error>service error: bad link: conflict in file _config</error>
-          </serviceinfo>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="4dbb24be05460ac30dc8b1e91e823f91" size="74" mtime="1642674798"/>
-          <entry name="_link" md5="86d891195b349a0a081834322bf62764" size="119" mtime="1642674795"/>
-          <entry name="somefile.txt" md5="5072e3c3701a10ca79bee6f46c8828ca" size="58" mtime="1642674798"/>
+        <directory name="bar_package" rev="35" vrev="35" srcmd5="863d61c9a01ca5a29f4bfdf0efdc8a25">
+          <linkinfo project="foo_project" package="bar_package" baserev="7e3a8ddb7d7c6013d4d98f6f202e3508" xsrcmd5="182b9518f0834902b77650183a2e9003" error="conflict in file _config"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="8ff32546444d2086f29eb1ceb1906238" size="63" mtime="1643641542"/>
+          <entry name="_link" md5="ff3d9dc8a65ce527370348e821fae4b8" size="119" mtime="1643641536"/>
+          <entry name="somefile.txt" md5="ea17911322dff377cf7dc842aff2f43f" size="67" mtime="1643641542"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:18 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:42 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?view=info
@@ -707,14 +704,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '179'
+      - '253'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="587" vrev="587" srcmd5="b82a9590384bfc5d4c5483a81db9ad8d">
-          <error>service error: bad link: conflict in file _config</error>
+        <sourceinfo package="bar_package" rev="35" vrev="92" srcmd5="863d61c9a01ca5a29f4bfdf0efdc8a25" verifymd5="863d61c9a01ca5a29f4bfdf0efdc8a25">
+          <error>conflict in file _config</error>
+          <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:18 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:42 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -740,21 +738,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '831'
+      - '670'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="587" vrev="587" srcmd5="b82a9590384bfc5d4c5483a81db9ad8d">
-          <linkinfo project="foo_project" package="bar_package" baserev="4db6702909d9d4b88ea57cfcfd6eae77" xsrcmd5="84d9d1fa4b85c098db321fdea9e936c7" error="conflict in file _config"/>
-          <serviceinfo code="failed" xsrcmd5="6ffced41acc0ceeb848683517d008c84">
-            <error>service error: bad link: conflict in file _config</error>
-          </serviceinfo>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="4dbb24be05460ac30dc8b1e91e823f91" size="74" mtime="1642674798"/>
-          <entry name="_link" md5="86d891195b349a0a081834322bf62764" size="119" mtime="1642674795"/>
-          <entry name="somefile.txt" md5="5072e3c3701a10ca79bee6f46c8828ca" size="58" mtime="1642674798"/>
+        <directory name="bar_package" rev="35" vrev="35" srcmd5="863d61c9a01ca5a29f4bfdf0efdc8a25">
+          <linkinfo project="foo_project" package="bar_package" baserev="7e3a8ddb7d7c6013d4d98f6f202e3508" xsrcmd5="182b9518f0834902b77650183a2e9003" error="conflict in file _config"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="8ff32546444d2086f29eb1ceb1906238" size="63" mtime="1643641542"/>
+          <entry name="_link" md5="ff3d9dc8a65ce527370348e821fae4b8" size="119" mtime="1643641536"/>
+          <entry name="somefile.txt" md5="ea17911322dff377cf7dc842aff2f43f" size="67" mtime="1643641542"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:18 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:42 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -782,18 +777,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '370'
+      - '369'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="bc1bdcac1f97852bf4982246e6c0734b">
+        <sourcediff key="b2ce9de70fcc3c2e1e47c3e2038418c4">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="587" srcmd5="b82a9590384bfc5d4c5483a81db9ad8d"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="35" srcmd5="863d61c9a01ca5a29f4bfdf0efdc8a25"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:18 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:42 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -811,8 +806,8 @@ http_interactions:
       - Ruby
   response:
     status:
-      code: 400
-      message: service error  bad link  conflict in file _config
+      code: 200
+      message: OK
     headers:
       Content-Type:
       - text/xml
@@ -821,14 +816,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '101'
+      - '399'
     body:
       encoding: UTF-8
       string: |
-        <status code="400">
-          <summary>service error: bad link: conflict in file _config</summary>
-        </status>
-  recorded_at: Thu, 20 Jan 2022 10:33:18 GMT
+        <sourcediff key="2def38de61abcc858287a73f5ea704e1">
+          <old project="foo_project" package="bar_package" rev="7e3a8ddb7d7c6013d4d98f6f202e3508" srcmd5="7e3a8ddb7d7c6013d4d98f6f202e3508"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="8d55083d5abbc103b66bae71b152da64" srcmd5="8d55083d5abbc103b66bae71b152da64"/>
+          <files/>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Mon, 31 Jan 2022 15:05:42 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_branch_request
@@ -858,5 +857,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"action":"opened","pull_request":{"head":{"repo":{"full_name":"reponame"},"sha":"123456789"}}}'
-  recorded_at: Thu, 20 Jan 2022 10:33:18 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:42 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_an_updated_PR_event/when_the_branched_package_did_not_exist/behaves_like_non-existent_branched_package/1_1_1_5_2_1_1.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_an_updated_PR_event/when_the_branched_package_did_not_exist/behaves_like_non-existent_branched_package/1_1_1_5_2_1_1.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:36 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_358
+    uri: http://backend:5352/source/foo_project/_meta?user=user_39
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>To Sail Beyond the Sunset</title>
+          <title>Fear and Trembling</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '157'
+      - '150'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>To Sail Beyond the Sunset</title>
+          <title>Fear and Trembling</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:36 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_359
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_40
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Parliament of Man</title>
-          <description>Ipsa cumque temporibus odit.</description>
+          <title>An Instant In The Wind</title>
+          <description>Amet sequi rerum enim.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '159'
+      - '154'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Parliament of Man</title>
-          <description>Ipsa cumque temporibus odit.</description>
+          <title>An Instant In The Wind</title>
+          <description>Amet sequi rerum enim.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:36 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Rerum et minima. Laborum excepturi dolor. Similique voluptatem et.
+      string: Blanditiis odit nihil. Magnam aliquam est. Et odio quidem.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1737" vrev="1737">
-          <srcmd5>20869c24f61056f99f2d73016eeb445d</srcmd5>
+        <revision rev="41" vrev="41">
+          <srcmd5>d5bb5ed2e62b0c1f5b8aee75c195999d</srcmd5>
           <version>unknown</version>
-          <time>1642674803</time>
+          <time>1643641536</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:36 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Quia inventore atque. Sapiente autem est. Quae suscipit iure.
+      string: Ratione delectus suscipit. Suscipit quam ut. Unde nam sit.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +181,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1738" vrev="1738">
-          <srcmd5>28f7cd6dd151a6f3129b92356e59915d</srcmd5>
+        <revision rev="42" vrev="42">
+          <srcmd5>7e3a8ddb7d7c6013d4d98f6f202e3508</srcmd5>
           <version>unknown</version>
-          <time>1642674803</time>
+          <time>1643641536</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:36 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -227,7 +227,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:33:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:36 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -267,7 +267,7 @@ http_interactions:
           <description>This project was created for package bar_package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:36 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -275,8 +275,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Parliament of Man</title>
-          <description>Ipsa cumque temporibus odit.</description>
+          <title>An Instant In The Wind</title>
+          <description>Amet sequi rerum enim.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -297,15 +297,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '190'
+      - '185'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Parliament of Man</title>
-          <description>Ipsa cumque temporibus odit.</description>
+          <title>An Instant In The Wind</title>
+          <description>Amet sequi rerum enim.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:36 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=branch&noservice=1&opackage=bar_package&oproject=foo_project&user=Iggy
@@ -333,19 +333,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="602" vrev="602">
-          <srcmd5>72a21357cf4932eb885be6bb4c13f8df</srcmd5>
+        <revision rev="19" vrev="19">
+          <srcmd5>974d15ae5e1049c264a9d35577358e87</srcmd5>
           <version>unknown</version>
-          <time>1642674803</time>
+          <time>1643641536</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:36 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -353,8 +353,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Parliament of Man</title>
-          <description>Ipsa cumque temporibus odit.</description>
+          <title>An Instant In The Wind</title>
+          <description>Amet sequi rerum enim.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -375,15 +375,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '190'
+      - '185'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Parliament of Man</title>
-          <description>Ipsa cumque temporibus odit.</description>
+          <title>An Instant In The Wind</title>
+          <description>Amet sequi rerum enim.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:36 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -409,18 +409,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '725'
+      - '620'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="602" vrev="602" srcmd5="72a21357cf4932eb885be6bb4c13f8df">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="28f7cd6dd151a6f3129b92356e59915d" baserev="28f7cd6dd151a6f3129b92356e59915d" xsrcmd5="f2e70bfdb719df6aaa63d6dd216ec72e" lsrcmd5="72a21357cf4932eb885be6bb4c13f8df"/>
-          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1642591329"/>
-          <entry name="_config" md5="3ecdc5b2c6ef3a0c3be63847bc263e8e" size="66" mtime="1642674803"/>
-          <entry name="_link" md5="7877f9fcb838b875f0c506a89bc0b9a9" size="119" mtime="1642674803"/>
-          <entry name="somefile.txt" md5="043d57853bdaab775622ca07e525b168" size="61" mtime="1642674803"/>
+        <directory name="bar_package" rev="19" vrev="19" srcmd5="974d15ae5e1049c264a9d35577358e87">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="7e3a8ddb7d7c6013d4d98f6f202e3508" baserev="7e3a8ddb7d7c6013d4d98f6f202e3508" xsrcmd5="79ca1dfbf156462f5b724d1d73f72c60" lsrcmd5="974d15ae5e1049c264a9d35577358e87"/>
+          <entry name="_config" md5="5b81b7485c7ef73da27b9540043985f6" size="58" mtime="1643641536"/>
+          <entry name="_link" md5="ff3d9dc8a65ce527370348e821fae4b8" size="119" mtime="1643641536"/>
+          <entry name="somefile.txt" md5="1cd7094613007b106b65cc2439330dad" size="58" mtime="1643641536"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:36 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?view=info
@@ -446,15 +445,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '333'
+      - '330'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="602" vrev="2340" srcmd5="f2e70bfdb719df6aaa63d6dd216ec72e" lsrcmd5="72a21357cf4932eb885be6bb4c13f8df" verifymd5="28f7cd6dd151a6f3129b92356e59915d">
+        <sourceinfo package="bar_package" rev="19" vrev="61" srcmd5="79ca1dfbf156462f5b724d1d73f72c60" lsrcmd5="974d15ae5e1049c264a9d35577358e87" verifymd5="7e3a8ddb7d7c6013d4d98f6f202e3508">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:36 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -480,18 +479,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '725'
+      - '620'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="602" vrev="602" srcmd5="72a21357cf4932eb885be6bb4c13f8df">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="28f7cd6dd151a6f3129b92356e59915d" baserev="28f7cd6dd151a6f3129b92356e59915d" xsrcmd5="f2e70bfdb719df6aaa63d6dd216ec72e" lsrcmd5="72a21357cf4932eb885be6bb4c13f8df"/>
-          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1642591329"/>
-          <entry name="_config" md5="3ecdc5b2c6ef3a0c3be63847bc263e8e" size="66" mtime="1642674803"/>
-          <entry name="_link" md5="7877f9fcb838b875f0c506a89bc0b9a9" size="119" mtime="1642674803"/>
-          <entry name="somefile.txt" md5="043d57853bdaab775622ca07e525b168" size="61" mtime="1642674803"/>
+        <directory name="bar_package" rev="19" vrev="19" srcmd5="974d15ae5e1049c264a9d35577358e87">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="7e3a8ddb7d7c6013d4d98f6f202e3508" baserev="7e3a8ddb7d7c6013d4d98f6f202e3508" xsrcmd5="79ca1dfbf156462f5b724d1d73f72c60" lsrcmd5="974d15ae5e1049c264a9d35577358e87"/>
+          <entry name="_config" md5="5b81b7485c7ef73da27b9540043985f6" size="58" mtime="1643641536"/>
+          <entry name="_link" md5="ff3d9dc8a65ce527370348e821fae4b8" size="119" mtime="1643641536"/>
+          <entry name="somefile.txt" md5="1cd7094613007b106b65cc2439330dad" size="58" mtime="1643641536"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:36 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -519,18 +517,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '370'
+      - '369'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="38fcf46df30b2121e8b0c802a25fb95c">
+        <sourcediff key="4d0a7ed467fe0e01045422aeee037b2a">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="602" srcmd5="72a21357cf4932eb885be6bb4c13f8df"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="19" srcmd5="974d15ae5e1049c264a9d35577358e87"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:36 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -562,12 +560,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="1cfd9ecbfbd99df2fc9b4f40ae018990">
-          <old project="foo_project" package="bar_package" rev="28f7cd6dd151a6f3129b92356e59915d" srcmd5="28f7cd6dd151a6f3129b92356e59915d"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="f2e70bfdb719df6aaa63d6dd216ec72e" srcmd5="f2e70bfdb719df6aaa63d6dd216ec72e"/>
+        <sourcediff key="c614c76f3542f4d4de9f64377325b253">
+          <old project="foo_project" package="bar_package" rev="7e3a8ddb7d7c6013d4d98f6f202e3508" srcmd5="7e3a8ddb7d7c6013d4d98f6f202e3508"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="79ca1dfbf156462f5b724d1d73f72c60" srcmd5="79ca1dfbf156462f5b724d1d73f72c60"/>
           <files/>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:36 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -613,7 +611,7 @@ http_interactions:
             <disable/>
           </publish>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:36 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_branch_request?user=Iggy
@@ -639,19 +637,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="603" vrev="603">
-          <srcmd5>43c86b65f6bdcfe0b673d9d8fc990a47</srcmd5>
+        <revision rev="20" vrev="20">
+          <srcmd5>ac897a61a452f9a9ccb185d9cf897d20</srcmd5>
           <version>unknown</version>
-          <time>1642674804</time>
+          <time>1643641536</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:36 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -659,8 +657,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Parliament of Man</title>
-          <description>Ipsa cumque temporibus odit.</description>
+          <title>An Instant In The Wind</title>
+          <description>Amet sequi rerum enim.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -681,15 +679,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '190'
+      - '185'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Parliament of Man</title>
-          <description>Ipsa cumque temporibus odit.</description>
+          <title>An Instant In The Wind</title>
+          <description>Amet sequi rerum enim.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:36 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -715,19 +713,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '722'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="603" vrev="603" srcmd5="43c86b65f6bdcfe0b673d9d8fc990a47">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="28f7cd6dd151a6f3129b92356e59915d" baserev="28f7cd6dd151a6f3129b92356e59915d" xsrcmd5="d4e67c3daaee0e6d559a1cf484593924" lsrcmd5="43c86b65f6bdcfe0b673d9d8fc990a47"/>
-          <serviceinfo code="succeeded" xsrcmd5="f0f3b8d8062014c99bd57bda52bb3cb4"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="3ecdc5b2c6ef3a0c3be63847bc263e8e" size="66" mtime="1642674803"/>
-          <entry name="_link" md5="7877f9fcb838b875f0c506a89bc0b9a9" size="119" mtime="1642674803"/>
-          <entry name="somefile.txt" md5="043d57853bdaab775622ca07e525b168" size="61" mtime="1642674803"/>
+        <directory name="bar_package" rev="20" vrev="20" srcmd5="ac897a61a452f9a9ccb185d9cf897d20">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="7e3a8ddb7d7c6013d4d98f6f202e3508" baserev="7e3a8ddb7d7c6013d4d98f6f202e3508" xsrcmd5="916d44373100252ad5732f82658cf89c" lsrcmd5="ac897a61a452f9a9ccb185d9cf897d20"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="5b81b7485c7ef73da27b9540043985f6" size="58" mtime="1643641536"/>
+          <entry name="_link" md5="ff3d9dc8a65ce527370348e821fae4b8" size="119" mtime="1643641536"/>
+          <entry name="somefile.txt" md5="1cd7094613007b106b65cc2439330dad" size="58" mtime="1643641536"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:36 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?view=info
@@ -753,15 +750,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '333'
+      - '330'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="603" vrev="2341" srcmd5="49d4d1bab0e04f299de07ede055d5553" lsrcmd5="f0f3b8d8062014c99bd57bda52bb3cb4" verifymd5="459e331be104058dd00100be2b145bdc">
+        <sourceinfo package="bar_package" rev="20" vrev="62" srcmd5="916d44373100252ad5732f82658cf89c" lsrcmd5="ac897a61a452f9a9ccb185d9cf897d20" verifymd5="753de28c974edfe547afe0d4a882bbc2">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:37 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -787,19 +784,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '722'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="603" vrev="603" srcmd5="43c86b65f6bdcfe0b673d9d8fc990a47">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="28f7cd6dd151a6f3129b92356e59915d" baserev="28f7cd6dd151a6f3129b92356e59915d" xsrcmd5="d4e67c3daaee0e6d559a1cf484593924" lsrcmd5="43c86b65f6bdcfe0b673d9d8fc990a47"/>
-          <serviceinfo code="succeeded" xsrcmd5="f0f3b8d8062014c99bd57bda52bb3cb4"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="3ecdc5b2c6ef3a0c3be63847bc263e8e" size="66" mtime="1642674803"/>
-          <entry name="_link" md5="7877f9fcb838b875f0c506a89bc0b9a9" size="119" mtime="1642674803"/>
-          <entry name="somefile.txt" md5="043d57853bdaab775622ca07e525b168" size="61" mtime="1642674803"/>
+        <directory name="bar_package" rev="20" vrev="20" srcmd5="ac897a61a452f9a9ccb185d9cf897d20">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="7e3a8ddb7d7c6013d4d98f6f202e3508" baserev="7e3a8ddb7d7c6013d4d98f6f202e3508" xsrcmd5="916d44373100252ad5732f82658cf89c" lsrcmd5="ac897a61a452f9a9ccb185d9cf897d20"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="5b81b7485c7ef73da27b9540043985f6" size="58" mtime="1643641536"/>
+          <entry name="_link" md5="ff3d9dc8a65ce527370348e821fae4b8" size="119" mtime="1643641536"/>
+          <entry name="somefile.txt" md5="1cd7094613007b106b65cc2439330dad" size="58" mtime="1643641536"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:37 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -827,18 +823,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '370'
+      - '369'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="9006d6fc05e9557653bc77f591542b21">
+        <sourcediff key="e4f0173ac3897dd06ba4da99a52a9159">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="603" srcmd5="43c86b65f6bdcfe0b673d9d8fc990a47"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="20" srcmd5="ac897a61a452f9a9ccb185d9cf897d20"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:37 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -870,12 +866,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="b3e67557ad4d38e27d14b7999f88e6c2">
-          <old project="foo_project" package="bar_package" rev="28f7cd6dd151a6f3129b92356e59915d" srcmd5="28f7cd6dd151a6f3129b92356e59915d"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="49d4d1bab0e04f299de07ede055d5553" srcmd5="49d4d1bab0e04f299de07ede055d5553"/>
+        <sourcediff key="20c5c4273d56021f398cceb0e5283a55">
+          <old project="foo_project" package="bar_package" rev="7e3a8ddb7d7c6013d4d98f6f202e3508" srcmd5="7e3a8ddb7d7c6013d4d98f6f202e3508"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="916d44373100252ad5732f82658cf89c" srcmd5="916d44373100252ad5732f82658cf89c"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:37 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_an_updated_PR_event/when_the_branched_package_did_not_exist/behaves_like_non-existent_branched_package/1_1_1_5_2_1_2.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/for_an_updated_PR_event/when_the_branched_package_did_not_exist/behaves_like_non-existent_branched_package/1_1_1_5_2_1_2.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:34 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_356
+    uri: http://backend:5352/source/foo_project/_meta?user=user_37
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Cover Her Face</title>
+          <title>No Longer at Ease</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '146'
+      - '149'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Cover Her Face</title>
+          <title>No Longer at Ease</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:34 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_357
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_38
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>I Sing the Body Electric</title>
-          <description>Explicabo ad illum earum.</description>
+          <title>Behold the Man</title>
+          <description>Autem ipsam debitis et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '159'
+      - '147'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>I Sing the Body Electric</title>
-          <description>Explicabo ad illum earum.</description>
+          <title>Behold the Man</title>
+          <description>Autem ipsam debitis et.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:34 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Omnis consectetur porro. Quia quos neque. Sit vel qui.
+      string: Non vel hic. Distinctio voluptatibus est. Debitis dolorem nobis.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1735" vrev="1735">
-          <srcmd5>932ef2073287de5a97c96d3d6ee014ab</srcmd5>
+        <revision rev="39" vrev="39">
+          <srcmd5>a3537077cefc050b057c89c4918bbc96</srcmd5>
           <version>unknown</version>
-          <time>1642674802</time>
+          <time>1643641534</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:34 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Harum quis quo. Reprehenderit et optio. Enim asperiores dolorem.
+      string: Voluptatem aut ea. Nobis modi qui. Hic quis molestiae.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +181,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1736" vrev="1736">
-          <srcmd5>a490773dd80e4db66aabbb8f9b79f087</srcmd5>
+        <revision rev="40" vrev="40">
+          <srcmd5>502a40e4eae7c19b1f9841fbc392c1f3</srcmd5>
           <version>unknown</version>
-          <time>1642674802</time>
+          <time>1643641534</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:34 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -227,7 +227,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:33:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:35 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -267,7 +267,7 @@ http_interactions:
           <description>This project was created for package bar_package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:35 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -275,8 +275,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>I Sing the Body Electric</title>
-          <description>Explicabo ad illum earum.</description>
+          <title>Behold the Man</title>
+          <description>Autem ipsam debitis et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -297,15 +297,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '190'
+      - '178'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>I Sing the Body Electric</title>
-          <description>Explicabo ad illum earum.</description>
+          <title>Behold the Man</title>
+          <description>Autem ipsam debitis et.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:35 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=branch&noservice=1&opackage=bar_package&oproject=foo_project&user=Iggy
@@ -333,19 +333,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="600" vrev="600">
-          <srcmd5>5cd19a3e8089b0f33e9d9435d88f2025</srcmd5>
+        <revision rev="17" vrev="17">
+          <srcmd5>b1e54ce239eb2c19d21b9897ebf2dd8d</srcmd5>
           <version>unknown</version>
-          <time>1642674802</time>
+          <time>1643641535</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:35 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -353,8 +353,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>I Sing the Body Electric</title>
-          <description>Explicabo ad illum earum.</description>
+          <title>Behold the Man</title>
+          <description>Autem ipsam debitis et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -375,15 +375,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '190'
+      - '178'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>I Sing the Body Electric</title>
-          <description>Explicabo ad illum earum.</description>
+          <title>Behold the Man</title>
+          <description>Autem ipsam debitis et.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:35 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -409,18 +409,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '725'
+      - '620'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="600" vrev="600" srcmd5="5cd19a3e8089b0f33e9d9435d88f2025">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="a490773dd80e4db66aabbb8f9b79f087" baserev="a490773dd80e4db66aabbb8f9b79f087" xsrcmd5="5d0d57080c129cb2ef6559099e8c58bd" lsrcmd5="5cd19a3e8089b0f33e9d9435d88f2025"/>
-          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1642591329"/>
-          <entry name="_config" md5="10bf4c263e5002629a03e8a4a1e01e14" size="54" mtime="1642674802"/>
-          <entry name="_link" md5="1a06cfef25f9cd0a2b1ba4a5cc5b79f1" size="119" mtime="1642674802"/>
-          <entry name="somefile.txt" md5="679b9a7d6916cc95a58e4140caf1162e" size="64" mtime="1642674802"/>
+        <directory name="bar_package" rev="17" vrev="17" srcmd5="b1e54ce239eb2c19d21b9897ebf2dd8d">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="502a40e4eae7c19b1f9841fbc392c1f3" baserev="502a40e4eae7c19b1f9841fbc392c1f3" xsrcmd5="c462666524b228ecf28c64a817bf365d" lsrcmd5="b1e54ce239eb2c19d21b9897ebf2dd8d"/>
+          <entry name="_config" md5="7597f585d36065ee5d4b1d55795d9d0e" size="64" mtime="1643641534"/>
+          <entry name="_link" md5="65710299a55a8f8d8a6c9617156d16b6" size="119" mtime="1643641535"/>
+          <entry name="somefile.txt" md5="e7e5d8612ce903f84b5fef7a198fbab9" size="54" mtime="1643641534"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:35 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?view=info
@@ -446,15 +445,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '333'
+      - '330'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="600" vrev="2336" srcmd5="5d0d57080c129cb2ef6559099e8c58bd" lsrcmd5="5cd19a3e8089b0f33e9d9435d88f2025" verifymd5="a490773dd80e4db66aabbb8f9b79f087">
+        <sourceinfo package="bar_package" rev="17" vrev="57" srcmd5="c462666524b228ecf28c64a817bf365d" lsrcmd5="b1e54ce239eb2c19d21b9897ebf2dd8d" verifymd5="502a40e4eae7c19b1f9841fbc392c1f3">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:35 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -480,18 +479,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '725'
+      - '620'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="600" vrev="600" srcmd5="5cd19a3e8089b0f33e9d9435d88f2025">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="a490773dd80e4db66aabbb8f9b79f087" baserev="a490773dd80e4db66aabbb8f9b79f087" xsrcmd5="5d0d57080c129cb2ef6559099e8c58bd" lsrcmd5="5cd19a3e8089b0f33e9d9435d88f2025"/>
-          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1642591329"/>
-          <entry name="_config" md5="10bf4c263e5002629a03e8a4a1e01e14" size="54" mtime="1642674802"/>
-          <entry name="_link" md5="1a06cfef25f9cd0a2b1ba4a5cc5b79f1" size="119" mtime="1642674802"/>
-          <entry name="somefile.txt" md5="679b9a7d6916cc95a58e4140caf1162e" size="64" mtime="1642674802"/>
+        <directory name="bar_package" rev="17" vrev="17" srcmd5="b1e54ce239eb2c19d21b9897ebf2dd8d">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="502a40e4eae7c19b1f9841fbc392c1f3" baserev="502a40e4eae7c19b1f9841fbc392c1f3" xsrcmd5="c462666524b228ecf28c64a817bf365d" lsrcmd5="b1e54ce239eb2c19d21b9897ebf2dd8d"/>
+          <entry name="_config" md5="7597f585d36065ee5d4b1d55795d9d0e" size="64" mtime="1643641534"/>
+          <entry name="_link" md5="65710299a55a8f8d8a6c9617156d16b6" size="119" mtime="1643641535"/>
+          <entry name="somefile.txt" md5="e7e5d8612ce903f84b5fef7a198fbab9" size="54" mtime="1643641534"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:35 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -519,18 +517,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '370'
+      - '369'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="85f1ccffe1acb4ba7391d132d7e759f8">
+        <sourcediff key="934ee859bf9324f6a9986065cc3459a0">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="600" srcmd5="5cd19a3e8089b0f33e9d9435d88f2025"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="17" srcmd5="b1e54ce239eb2c19d21b9897ebf2dd8d"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:35 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -562,12 +560,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="51f3cda5a51984a3e4b4d5cd2aca1572">
-          <old project="foo_project" package="bar_package" rev="a490773dd80e4db66aabbb8f9b79f087" srcmd5="a490773dd80e4db66aabbb8f9b79f087"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="5d0d57080c129cb2ef6559099e8c58bd" srcmd5="5d0d57080c129cb2ef6559099e8c58bd"/>
+        <sourcediff key="a6b1735101e744cbb862cc2df05797c0">
+          <old project="foo_project" package="bar_package" rev="502a40e4eae7c19b1f9841fbc392c1f3" srcmd5="502a40e4eae7c19b1f9841fbc392c1f3"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="c462666524b228ecf28c64a817bf365d" srcmd5="c462666524b228ecf28c64a817bf365d"/>
           <files/>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:35 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -613,7 +611,7 @@ http_interactions:
             <disable/>
           </publish>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:35 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_branch_request?user=Iggy
@@ -639,19 +637,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="601" vrev="601">
-          <srcmd5>2320f64bead33e8026e05a71de774b30</srcmd5>
+        <revision rev="18" vrev="18">
+          <srcmd5>3b745571b8833b307a39ca0f7ad522a3</srcmd5>
           <version>unknown</version>
-          <time>1642674803</time>
+          <time>1643641535</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:35 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -659,8 +657,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>I Sing the Body Electric</title>
-          <description>Explicabo ad illum earum.</description>
+          <title>Behold the Man</title>
+          <description>Autem ipsam debitis et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -681,15 +679,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '190'
+      - '178'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>I Sing the Body Electric</title>
-          <description>Explicabo ad illum earum.</description>
+          <title>Behold the Man</title>
+          <description>Autem ipsam debitis et.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:35 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -715,19 +713,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '722'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="601" vrev="601" srcmd5="2320f64bead33e8026e05a71de774b30">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="a490773dd80e4db66aabbb8f9b79f087" baserev="a490773dd80e4db66aabbb8f9b79f087" xsrcmd5="d8ef520160c0c3ebcdce8b494ebeb319" lsrcmd5="2320f64bead33e8026e05a71de774b30"/>
-          <serviceinfo code="succeeded" xsrcmd5="148793e46d75cee7489e0e9f1584bdc1"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="10bf4c263e5002629a03e8a4a1e01e14" size="54" mtime="1642674802"/>
-          <entry name="_link" md5="1a06cfef25f9cd0a2b1ba4a5cc5b79f1" size="119" mtime="1642674802"/>
-          <entry name="somefile.txt" md5="679b9a7d6916cc95a58e4140caf1162e" size="64" mtime="1642674802"/>
+        <directory name="bar_package" rev="18" vrev="18" srcmd5="3b745571b8833b307a39ca0f7ad522a3">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="502a40e4eae7c19b1f9841fbc392c1f3" baserev="502a40e4eae7c19b1f9841fbc392c1f3" xsrcmd5="f9a8ee38f807e72d8186fb902ca5a59e" lsrcmd5="3b745571b8833b307a39ca0f7ad522a3"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="7597f585d36065ee5d4b1d55795d9d0e" size="64" mtime="1643641534"/>
+          <entry name="_link" md5="65710299a55a8f8d8a6c9617156d16b6" size="119" mtime="1643641535"/>
+          <entry name="somefile.txt" md5="e7e5d8612ce903f84b5fef7a198fbab9" size="54" mtime="1643641534"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:35 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?view=info
@@ -753,15 +750,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '333'
+      - '330'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="601" vrev="2337" srcmd5="ae595d633ca947d637b6fb5673171961" lsrcmd5="148793e46d75cee7489e0e9f1584bdc1" verifymd5="9095da35ba7dc91bd24397d5cdfd929d">
+        <sourceinfo package="bar_package" rev="18" vrev="58" srcmd5="f9a8ee38f807e72d8186fb902ca5a59e" lsrcmd5="3b745571b8833b307a39ca0f7ad522a3" verifymd5="76227b7a6643b4950c7f79ecf33e85a1">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:35 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -787,19 +784,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '722'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="601" vrev="601" srcmd5="2320f64bead33e8026e05a71de774b30">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="a490773dd80e4db66aabbb8f9b79f087" baserev="a490773dd80e4db66aabbb8f9b79f087" xsrcmd5="d8ef520160c0c3ebcdce8b494ebeb319" lsrcmd5="2320f64bead33e8026e05a71de774b30"/>
-          <serviceinfo code="succeeded" xsrcmd5="148793e46d75cee7489e0e9f1584bdc1"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596964"/>
-          <entry name="_config" md5="10bf4c263e5002629a03e8a4a1e01e14" size="54" mtime="1642674802"/>
-          <entry name="_link" md5="1a06cfef25f9cd0a2b1ba4a5cc5b79f1" size="119" mtime="1642674802"/>
-          <entry name="somefile.txt" md5="679b9a7d6916cc95a58e4140caf1162e" size="64" mtime="1642674802"/>
+        <directory name="bar_package" rev="18" vrev="18" srcmd5="3b745571b8833b307a39ca0f7ad522a3">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="502a40e4eae7c19b1f9841fbc392c1f3" baserev="502a40e4eae7c19b1f9841fbc392c1f3" xsrcmd5="f9a8ee38f807e72d8186fb902ca5a59e" lsrcmd5="3b745571b8833b307a39ca0f7ad522a3"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632505"/>
+          <entry name="_config" md5="7597f585d36065ee5d4b1d55795d9d0e" size="64" mtime="1643641534"/>
+          <entry name="_link" md5="65710299a55a8f8d8a6c9617156d16b6" size="119" mtime="1643641535"/>
+          <entry name="somefile.txt" md5="e7e5d8612ce903f84b5fef7a198fbab9" size="54" mtime="1643641534"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:35 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -827,18 +823,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '370'
+      - '369'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="2158a09c739397fe05fc73e09d7b5d81">
+        <sourcediff key="062cb9e5f843d0bac07fd0f7600642c5">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="601" srcmd5="2320f64bead33e8026e05a71de774b30"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="18" srcmd5="3b745571b8833b307a39ca0f7ad522a3"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:35 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -870,12 +866,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="f308bbdd39a0d97ee42812ccac9c5147">
-          <old project="foo_project" package="bar_package" rev="a490773dd80e4db66aabbb8f9b79f087" srcmd5="a490773dd80e4db66aabbb8f9b79f087"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="ae595d633ca947d637b6fb5673171961" srcmd5="ae595d633ca947d637b6fb5673171961"/>
+        <sourcediff key="4f0dde824de3e7635bc1006088ce7a59">
+          <old project="foo_project" package="bar_package" rev="502a40e4eae7c19b1f9841fbc392c1f3" srcmd5="502a40e4eae7c19b1f9841fbc392c1f3"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="f9a8ee38f807e72d8186fb902ca5a59e" srcmd5="f9a8ee38f807e72d8186fb902ca5a59e"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:35 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/with_a_push_event_for_a_commit/behaves_like_failed_when_source_package_does_not_exist/1_1_1_6_2_1.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/with_a_push_event_for_a_commit/behaves_like_failed_when_source_package_does_not_exist/1_1_1_6_2_1.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:54 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:54 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_306
+    uri: http://backend:5352/source/foo_project/_meta?user=user_75
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Those Barren Leaves, Thrones, Dominations</title>
+          <title>The Moving Finger</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '173'
+      - '149'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Those Barren Leaves, Thrones, Dominations</title>
+          <title>The Moving Finger</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:55 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:54 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_307
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_76
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>A Farewell to Arms</title>
-          <description>Unde iure quo aut.</description>
+          <title>Specimen Days</title>
+          <description>Esse culpa voluptatem ipsa.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '146'
+      - '150'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>A Farewell to Arms</title>
-          <description>Unde iure quo aut.</description>
+          <title>Specimen Days</title>
+          <description>Esse culpa voluptatem ipsa.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:55 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:54 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Id quia alias. Dolorem repellat quod. Quis ut aliquam.
+      string: Quis odio rem. Qui aperiam amet. Dicta quod dolorem.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1693" vrev="1693">
-          <srcmd5>24e0212aa99836911777e60f0648b54f</srcmd5>
+        <revision rev="83" vrev="83">
+          <srcmd5>ee35d7ac9c2de8b69400742b34ba5938</srcmd5>
           <version>unknown</version>
-          <time>1642674775</time>
+          <time>1643641554</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:55 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:54 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Vel iste voluptas. Nostrum asperiores quis. Aut soluta quod.
+      string: Quo aut fugit. Commodi veritatis est. Unde aut voluptatibus.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,17 +181,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1694" vrev="1694">
-          <srcmd5>87085393f5923d2ef62272be0e8d554c</srcmd5>
+        <revision rev="84" vrev="84">
+          <srcmd5>ea452f10d82f077d0aa4e097537173c1</srcmd5>
           <version>unknown</version>
-          <time>1642674775</time>
+          <time>1643641554</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:55 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:54 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/with_a_push_event_for_a_commit/behaves_like_failed_without_branch_permissions/1_1_1_6_3_1.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/with_a_push_event_for_a_commit/behaves_like_failed_without_branch_permissions/1_1_1_6_3_1.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:47 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:05 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_290
+    uri: http://backend:5352/source/foo_project/_meta?user=user_93
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>The Grapes of Wrath</title>
+          <title>That Good Night</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '151'
+      - '147'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>The Grapes of Wrath</title>
+          <title>That Good Night</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:47 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:05 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_291
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_94
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Look to Windward</title>
-          <description>Dolore repellendus commodi hic.</description>
+          <title>Recalled to Life</title>
+          <description>Dolores qui aut est.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '157'
+      - '146'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Look to Windward</title>
-          <description>Dolore repellendus commodi hic.</description>
+          <title>Recalled to Life</title>
+          <description>Dolores qui aut est.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:47 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:05 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Illo voluptatem ex. Quia corrupti ea. Et quam odit.
+      string: Magnam non dolor. Ex dolor ullam. Veniam temporibus nesciunt.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1677" vrev="1677">
-          <srcmd5>5f25a03aeec02a0ac1396b159b833c47</srcmd5>
+        <revision rev="101" vrev="101">
+          <srcmd5>38906cf129c4ec13641209f5d7f38af8</srcmd5>
           <version>unknown</version>
-          <time>1642674767</time>
+          <time>1643641565</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:47 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:05 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: In a commodi. Autem qui nam. Porro dolores ut.
+      string: Facere aliquam enim. Enim accusamus officiis. Aliquid eligendi sunt.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,17 +181,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1678" vrev="1678">
-          <srcmd5>7543368a9c9a11f43c27e0fcb8cb7194</srcmd5>
+        <revision rev="102" vrev="102">
+          <srcmd5>c638008195e1cb2ded215af6eab260f9</srcmd5>
           <version>unknown</version>
-          <time>1642674767</time>
+          <time>1643641565</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:47 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:05 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/with_a_push_event_for_a_commit/behaves_like_fails_with_insufficient_write_permission_on_target_project/1_1_1_6_4_1.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/with_a_push_event_for_a_commit/behaves_like_fails_with_insufficient_write_permission_on_target_project/1_1_1_6_4_1.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:55 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:04 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_308
+    uri: http://backend:5352/source/foo_project/_meta?user=user_91
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Number the Stars</title>
+          <title>The Lathe of Heaven</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '148'
+      - '151'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Number the Stars</title>
+          <title>The Lathe of Heaven</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:55 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:04 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_309
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_92
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Last Temptation</title>
-          <description>Assumenda excepturi aut expedita.</description>
+          <title>An Acceptable Time</title>
+          <description>Ducimus at eligendi repellendus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '162'
+      - '160'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Last Temptation</title>
-          <description>Assumenda excepturi aut expedita.</description>
+          <title>An Acceptable Time</title>
+          <description>Ducimus at eligendi repellendus.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:55 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:04 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Ab maxime a. Qui quis porro. Nesciunt rerum ea.
+      string: Officiis dolore ipsum. Et id id. Perspiciatis rerum eos.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1695" vrev="1695">
-          <srcmd5>88a54830c3254159d21f3a039ba9d0df</srcmd5>
+        <revision rev="99" vrev="99">
+          <srcmd5>d2e69834c11476f8e946e8ab2734abf0</srcmd5>
           <version>unknown</version>
-          <time>1642674775</time>
+          <time>1643641564</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:55 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:04 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Corrupti cupiditate labore. Veritatis perferendis vel. Quia quam consequatur.
+      string: Veritatis est repellat. Soluta qui et. Iure dolores voluptas.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +181,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1696" vrev="1696">
-          <srcmd5>7583443d23c7dcddb4d195a3bf4921a2</srcmd5>
+        <revision rev="100" vrev="100">
+          <srcmd5>0a83ce3de84d8d816ee772d0e2828cb6</srcmd5>
           <version>unknown</version>
-          <time>1642674775</time>
+          <time>1643641564</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:55 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:04 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_without_maintainer_rights/_meta?user=Iggy
@@ -201,7 +201,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="project_without_maintainer_rights">
-          <title>Stranger in a Strange Land</title>
+          <title>Mr Standfast</title>
           <description/>
         </project>
     headers:
@@ -223,15 +223,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '136'
+      - '122'
     body:
       encoding: UTF-8
       string: |
         <project name="project_without_maintainer_rights">
-          <title>Stranger in a Strange Land</title>
+          <title>Mr Standfast</title>
           <description></description>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:55 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:04 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -265,5 +265,5 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:32:55 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:04 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/with_a_push_event_for_a_commit/behaves_like_successful_new_PR_or_MR_event/1_1_1_6_1_1.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/with_a_push_event_for_a_commit/behaves_like_successful_new_PR_or_MR_event/1_1_1_6_1_1.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:48 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:56 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_294
+    uri: http://backend:5352/source/foo_project/_meta?user=user_79
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Look Homeward, Angel</title>
+          <title>A Passage to India</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '152'
+      - '150'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Look Homeward, Angel</title>
+          <title>A Passage to India</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:48 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:56 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_295
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_80
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Golden Apples of the Sun</title>
-          <description>Perferendis aut eius eos.</description>
+          <title>Tender Is the Night</title>
+          <description>Enim et quas omnis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '163'
+      - '148'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Golden Apples of the Sun</title>
-          <description>Perferendis aut eius eos.</description>
+          <title>Tender Is the Night</title>
+          <description>Enim et quas omnis.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:48 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:56 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Totam odio reiciendis. Delectus omnis excepturi. Quos ut optio.
+      string: Ut nam aut. Repudiandae exercitationem accusantium. Vel deserunt et.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1681" vrev="1681">
-          <srcmd5>c962771c4f9ccf9822c480f2e9c1d58a</srcmd5>
+        <revision rev="87" vrev="87">
+          <srcmd5>ee3d73426b7bb66003c4b5e202ca31c8</srcmd5>
           <version>unknown</version>
-          <time>1642674768</time>
+          <time>1643641556</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:48 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:56 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Ullam dolores quia. Itaque ad et. Rerum vero praesentium.
+      string: Assumenda laborum asperiores. In aut ratione. Qui et accusamus.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +181,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1682" vrev="1682">
-          <srcmd5>770b57df5c7d0482c493b6ea931fbbaa</srcmd5>
+        <revision rev="88" vrev="88">
+          <srcmd5>5125b8f8753f5d7283cfb3c2a9d522cc</srcmd5>
           <version>unknown</version>
-          <time>1642674768</time>
+          <time>1643641556</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:48 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:56 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -227,7 +227,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:32:48 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:56 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_meta?user=Iggy
@@ -235,8 +235,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>The Golden Apples of the Sun</title>
-          <description>Perferendis aut eius eos.</description>
+          <title>Tender Is the Night</title>
+          <description>Enim et quas omnis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -257,15 +257,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '156'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>The Golden Apples of the Sun</title>
-          <description>Perferendis aut eius eos.</description>
+          <title>Tender Is the Night</title>
+          <description>Enim et quas omnis.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:48 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:56 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=branch&noservice=1&opackage=bar_package&oproject=foo_project&user=Iggy
@@ -293,19 +293,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="113" vrev="113">
-          <srcmd5>a4ac8b17e8aa13dd9cee223276fc828d</srcmd5>
+        <revision rev="17" vrev="17">
+          <srcmd5>233dfb4c7353943f1c3426e2784f509b</srcmd5>
           <version>unknown</version>
-          <time>1642674768</time>
+          <time>1643641556</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:48 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:56 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_meta?user=Iggy
@@ -313,8 +313,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>The Golden Apples of the Sun</title>
-          <description>Perferendis aut eius eos.</description>
+          <title>Tender Is the Night</title>
+          <description>Enim et quas omnis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -335,15 +335,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '156'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>The Golden Apples of the Sun</title>
-          <description>Perferendis aut eius eos.</description>
+          <title>Tender Is the Night</title>
+          <description>Enim et quas omnis.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:48 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:56 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -369,18 +369,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '735'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="113" vrev="113" srcmd5="a4ac8b17e8aa13dd9cee223276fc828d">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="770b57df5c7d0482c493b6ea931fbbaa" baserev="770b57df5c7d0482c493b6ea931fbbaa" xsrcmd5="877e01dcb6e09dd2655a47cb1fd0d300" lsrcmd5="a4ac8b17e8aa13dd9cee223276fc828d"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="357235f23591e75697a4bca26783b3e7" size="63" mtime="1642674768"/>
-          <entry name="_link" md5="73e255b360d9a5d5da9a1c5b600fa709" size="141" mtime="1642674768"/>
-          <entry name="somefile.txt" md5="b79e516dfd08127a50d01fa540f1b88a" size="57" mtime="1642674768"/>
+        <directory name="bar_package-123456789" rev="17" vrev="17" srcmd5="233dfb4c7353943f1c3426e2784f509b">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="5125b8f8753f5d7283cfb3c2a9d522cc" baserev="5125b8f8753f5d7283cfb3c2a9d522cc" xsrcmd5="ba2e98b9808d945621064dbff67262c1" lsrcmd5="233dfb4c7353943f1c3426e2784f509b"/>
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="4fa73dbc4ed96db8e653c8308fdbd054" size="68" mtime="1643641556"/>
+          <entry name="_link" md5="9dae0b8c95e13b12675e4fd97f3774da" size="141" mtime="1643641556"/>
+          <entry name="somefile.txt" md5="a0a86f542b241ce857cc53944a92745d" size="63" mtime="1643641556"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:48 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:56 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?view=info
@@ -406,15 +406,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '343'
+      - '341'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package-123456789" rev="113" vrev="1795" srcmd5="877e01dcb6e09dd2655a47cb1fd0d300" lsrcmd5="a4ac8b17e8aa13dd9cee223276fc828d" verifymd5="770b57df5c7d0482c493b6ea931fbbaa">
+        <sourceinfo package="bar_package-123456789" rev="17" vrev="105" srcmd5="ba2e98b9808d945621064dbff67262c1" lsrcmd5="233dfb4c7353943f1c3426e2784f509b" verifymd5="5125b8f8753f5d7283cfb3c2a9d522cc">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:48 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:56 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -440,18 +440,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '735'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="113" vrev="113" srcmd5="a4ac8b17e8aa13dd9cee223276fc828d">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="770b57df5c7d0482c493b6ea931fbbaa" baserev="770b57df5c7d0482c493b6ea931fbbaa" xsrcmd5="877e01dcb6e09dd2655a47cb1fd0d300" lsrcmd5="a4ac8b17e8aa13dd9cee223276fc828d"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="357235f23591e75697a4bca26783b3e7" size="63" mtime="1642674768"/>
-          <entry name="_link" md5="73e255b360d9a5d5da9a1c5b600fa709" size="141" mtime="1642674768"/>
-          <entry name="somefile.txt" md5="b79e516dfd08127a50d01fa540f1b88a" size="57" mtime="1642674768"/>
+        <directory name="bar_package-123456789" rev="17" vrev="17" srcmd5="233dfb4c7353943f1c3426e2784f509b">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="5125b8f8753f5d7283cfb3c2a9d522cc" baserev="5125b8f8753f5d7283cfb3c2a9d522cc" xsrcmd5="ba2e98b9808d945621064dbff67262c1" lsrcmd5="233dfb4c7353943f1c3426e2784f509b"/>
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="4fa73dbc4ed96db8e653c8308fdbd054" size="68" mtime="1643641556"/>
+          <entry name="_link" md5="9dae0b8c95e13b12675e4fd97f3774da" size="141" mtime="1643641556"/>
+          <entry name="somefile.txt" md5="a0a86f542b241ce857cc53944a92745d" size="63" mtime="1643641556"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:48 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:56 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -479,18 +479,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '324'
+      - '323'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="73bc1c86a37a96041c5ea1e9426df197">
+        <sourcediff key="f3de2483a9dbd7630de506a5506be5f7">
           <old project="home:Iggy" package="bar_package-123456789" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="113" srcmd5="a4ac8b17e8aa13dd9cee223276fc828d"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="17" srcmd5="233dfb4c7353943f1c3426e2784f509b"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:48 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:56 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -522,14 +522,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="a57b493d75f8ccba602b0b7696e44a47">
-          <old project="foo_project" package="bar_package" rev="770b57df5c7d0482c493b6ea931fbbaa" srcmd5="770b57df5c7d0482c493b6ea931fbbaa"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="877e01dcb6e09dd2655a47cb1fd0d300" srcmd5="877e01dcb6e09dd2655a47cb1fd0d300"/>
+        <sourcediff key="2b33cf76fe912f2c28ef69f88d3edc8e">
+          <old project="foo_project" package="bar_package" rev="5125b8f8753f5d7283cfb3c2a9d522cc" srcmd5="5125b8f8753f5d7283cfb3c2a9d522cc"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="ba2e98b9808d945621064dbff67262c1" srcmd5="ba2e98b9808d945621064dbff67262c1"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:48 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:56 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/_meta?user=Iggy
@@ -587,7 +587,7 @@ http_interactions:
             <arch>aarch64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:49 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:56 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_branch_request?user=Iggy
@@ -613,19 +613,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="114" vrev="114">
-          <srcmd5>0ea5eb2218bed90eedffe495bcc8bfdf</srcmd5>
+        <revision rev="18" vrev="18">
+          <srcmd5>41174312578be1710923ff8067d4f829</srcmd5>
           <version>unknown</version>
-          <time>1642674769</time>
+          <time>1643641557</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:49 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:57 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_meta?user=Iggy
@@ -633,8 +633,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>The Golden Apples of the Sun</title>
-          <description>Perferendis aut eius eos.</description>
+          <title>Tender Is the Night</title>
+          <description>Enim et quas omnis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -655,15 +655,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '156'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>The Golden Apples of the Sun</title>
-          <description>Perferendis aut eius eos.</description>
+          <title>Tender Is the Night</title>
+          <description>Enim et quas omnis.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:49 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:57 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -689,19 +689,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="114" vrev="114" srcmd5="0ea5eb2218bed90eedffe495bcc8bfdf">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="770b57df5c7d0482c493b6ea931fbbaa" baserev="770b57df5c7d0482c493b6ea931fbbaa" xsrcmd5="c5b6c2aa46a49504cc92d21cb8776eab" lsrcmd5="0ea5eb2218bed90eedffe495bcc8bfdf"/>
-          <serviceinfo code="succeeded" xsrcmd5="b500de2829b87b848a19a0ab110e8ca0"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="357235f23591e75697a4bca26783b3e7" size="63" mtime="1642674768"/>
-          <entry name="_link" md5="73e255b360d9a5d5da9a1c5b600fa709" size="141" mtime="1642674768"/>
-          <entry name="somefile.txt" md5="b79e516dfd08127a50d01fa540f1b88a" size="57" mtime="1642674768"/>
+        <directory name="bar_package-123456789" rev="18" vrev="18" srcmd5="41174312578be1710923ff8067d4f829">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="5125b8f8753f5d7283cfb3c2a9d522cc" baserev="5125b8f8753f5d7283cfb3c2a9d522cc" xsrcmd5="e6cf2e168f988504d56ed4cecec02714" lsrcmd5="41174312578be1710923ff8067d4f829"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="4fa73dbc4ed96db8e653c8308fdbd054" size="68" mtime="1643641556"/>
+          <entry name="_link" md5="9dae0b8c95e13b12675e4fd97f3774da" size="141" mtime="1643641556"/>
+          <entry name="somefile.txt" md5="a0a86f542b241ce857cc53944a92745d" size="63" mtime="1643641556"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:49 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:57 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?view=info
@@ -727,15 +726,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '343'
+      - '341'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package-123456789" rev="114" vrev="1796" srcmd5="4183dba36e6e7830f5eb5fecebe3e083" lsrcmd5="b500de2829b87b848a19a0ab110e8ca0" verifymd5="6e5d0dbe711b05ba1a11e19c3794a0b9">
+        <sourceinfo package="bar_package-123456789" rev="18" vrev="106" srcmd5="e6cf2e168f988504d56ed4cecec02714" lsrcmd5="41174312578be1710923ff8067d4f829" verifymd5="269f0faaddcdfca91b0d161a9cb65b78">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:49 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:57 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -761,19 +760,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="114" vrev="114" srcmd5="0ea5eb2218bed90eedffe495bcc8bfdf">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="770b57df5c7d0482c493b6ea931fbbaa" baserev="770b57df5c7d0482c493b6ea931fbbaa" xsrcmd5="c5b6c2aa46a49504cc92d21cb8776eab" lsrcmd5="0ea5eb2218bed90eedffe495bcc8bfdf"/>
-          <serviceinfo code="succeeded" xsrcmd5="b500de2829b87b848a19a0ab110e8ca0"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="357235f23591e75697a4bca26783b3e7" size="63" mtime="1642674768"/>
-          <entry name="_link" md5="73e255b360d9a5d5da9a1c5b600fa709" size="141" mtime="1642674768"/>
-          <entry name="somefile.txt" md5="b79e516dfd08127a50d01fa540f1b88a" size="57" mtime="1642674768"/>
+        <directory name="bar_package-123456789" rev="18" vrev="18" srcmd5="41174312578be1710923ff8067d4f829">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="5125b8f8753f5d7283cfb3c2a9d522cc" baserev="5125b8f8753f5d7283cfb3c2a9d522cc" xsrcmd5="e6cf2e168f988504d56ed4cecec02714" lsrcmd5="41174312578be1710923ff8067d4f829"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="4fa73dbc4ed96db8e653c8308fdbd054" size="68" mtime="1643641556"/>
+          <entry name="_link" md5="9dae0b8c95e13b12675e4fd97f3774da" size="141" mtime="1643641556"/>
+          <entry name="somefile.txt" md5="a0a86f542b241ce857cc53944a92745d" size="63" mtime="1643641556"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:49 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:57 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -801,18 +799,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '324'
+      - '323'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="c0fd534ef70d40eddda14b75db0c1f6c">
+        <sourcediff key="192ea6a6674f1da392188f6cb53eda8f">
           <old project="home:Iggy" package="bar_package-123456789" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="114" srcmd5="0ea5eb2218bed90eedffe495bcc8bfdf"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="18" srcmd5="41174312578be1710923ff8067d4f829"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:49 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:57 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -844,14 +842,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="66aef90178a124635013f5064b6dd064">
-          <old project="foo_project" package="bar_package" rev="770b57df5c7d0482c493b6ea931fbbaa" srcmd5="770b57df5c7d0482c493b6ea931fbbaa"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="4183dba36e6e7830f5eb5fecebe3e083" srcmd5="4183dba36e6e7830f5eb5fecebe3e083"/>
+        <sourcediff key="edb23b55c46bfd7a52c0ab4ba29256d3">
+          <old project="foo_project" package="bar_package" rev="5125b8f8753f5d7283cfb3c2a9d522cc" srcmd5="5125b8f8753f5d7283cfb3c2a9d522cc"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="e6cf2e168f988504d56ed4cecec02714" srcmd5="e6cf2e168f988504d56ed4cecec02714"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:49 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:57 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -877,19 +875,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="114" vrev="114" srcmd5="0ea5eb2218bed90eedffe495bcc8bfdf">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="770b57df5c7d0482c493b6ea931fbbaa" baserev="770b57df5c7d0482c493b6ea931fbbaa" xsrcmd5="c5b6c2aa46a49504cc92d21cb8776eab" lsrcmd5="0ea5eb2218bed90eedffe495bcc8bfdf"/>
-          <serviceinfo code="succeeded" xsrcmd5="b500de2829b87b848a19a0ab110e8ca0"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="357235f23591e75697a4bca26783b3e7" size="63" mtime="1642674768"/>
-          <entry name="_link" md5="73e255b360d9a5d5da9a1c5b600fa709" size="141" mtime="1642674768"/>
-          <entry name="somefile.txt" md5="b79e516dfd08127a50d01fa540f1b88a" size="57" mtime="1642674768"/>
+        <directory name="bar_package-123456789" rev="18" vrev="18" srcmd5="41174312578be1710923ff8067d4f829">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="5125b8f8753f5d7283cfb3c2a9d522cc" baserev="5125b8f8753f5d7283cfb3c2a9d522cc" xsrcmd5="e6cf2e168f988504d56ed4cecec02714" lsrcmd5="41174312578be1710923ff8067d4f829"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="4fa73dbc4ed96db8e653c8308fdbd054" size="68" mtime="1643641556"/>
+          <entry name="_link" md5="9dae0b8c95e13b12675e4fd97f3774da" size="141" mtime="1643641556"/>
+          <entry name="somefile.txt" md5="a0a86f542b241ce857cc53944a92745d" size="63" mtime="1643641556"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:49 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:57 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '627'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="e6cf2e168f988504d56ed4cecec02714" vrev="106" srcmd5="e6cf2e168f988504d56ed4cecec02714">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="5125b8f8753f5d7283cfb3c2a9d522cc" baserev="5125b8f8753f5d7283cfb3c2a9d522cc" lsrcmd5="41174312578be1710923ff8067d4f829"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="4fa73dbc4ed96db8e653c8308fdbd054" size="68" mtime="1643641556"/>
+          <entry name="somefile.txt" md5="a0a86f542b241ce857cc53944a92745d" size="63" mtime="1643641556"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:05:57 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -915,19 +948,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="114" vrev="114" srcmd5="0ea5eb2218bed90eedffe495bcc8bfdf">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="770b57df5c7d0482c493b6ea931fbbaa" baserev="770b57df5c7d0482c493b6ea931fbbaa" xsrcmd5="c5b6c2aa46a49504cc92d21cb8776eab" lsrcmd5="0ea5eb2218bed90eedffe495bcc8bfdf"/>
-          <serviceinfo code="succeeded" xsrcmd5="b500de2829b87b848a19a0ab110e8ca0"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="357235f23591e75697a4bca26783b3e7" size="63" mtime="1642674768"/>
-          <entry name="_link" md5="73e255b360d9a5d5da9a1c5b600fa709" size="141" mtime="1642674768"/>
-          <entry name="somefile.txt" md5="b79e516dfd08127a50d01fa540f1b88a" size="57" mtime="1642674768"/>
+        <directory name="bar_package-123456789" rev="18" vrev="18" srcmd5="41174312578be1710923ff8067d4f829">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="5125b8f8753f5d7283cfb3c2a9d522cc" baserev="5125b8f8753f5d7283cfb3c2a9d522cc" xsrcmd5="e6cf2e168f988504d56ed4cecec02714" lsrcmd5="41174312578be1710923ff8067d4f829"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="4fa73dbc4ed96db8e653c8308fdbd054" size="68" mtime="1643641556"/>
+          <entry name="_link" md5="9dae0b8c95e13b12675e4fd97f3774da" size="141" mtime="1643641556"/>
+          <entry name="somefile.txt" md5="a0a86f542b241ce857cc53944a92745d" size="63" mtime="1643641556"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:49 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:57 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '627'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="e6cf2e168f988504d56ed4cecec02714" vrev="106" srcmd5="e6cf2e168f988504d56ed4cecec02714">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="5125b8f8753f5d7283cfb3c2a9d522cc" baserev="5125b8f8753f5d7283cfb3c2a9d522cc" lsrcmd5="41174312578be1710923ff8067d4f829"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="4fa73dbc4ed96db8e653c8308fdbd054" size="68" mtime="1643641556"/>
+          <entry name="somefile.txt" md5="a0a86f542b241ce857cc53944a92745d" size="63" mtime="1643641556"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:05:57 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -953,19 +1021,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="114" vrev="114" srcmd5="0ea5eb2218bed90eedffe495bcc8bfdf">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="770b57df5c7d0482c493b6ea931fbbaa" baserev="770b57df5c7d0482c493b6ea931fbbaa" xsrcmd5="c5b6c2aa46a49504cc92d21cb8776eab" lsrcmd5="0ea5eb2218bed90eedffe495bcc8bfdf"/>
-          <serviceinfo code="succeeded" xsrcmd5="b500de2829b87b848a19a0ab110e8ca0"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="357235f23591e75697a4bca26783b3e7" size="63" mtime="1642674768"/>
-          <entry name="_link" md5="73e255b360d9a5d5da9a1c5b600fa709" size="141" mtime="1642674768"/>
-          <entry name="somefile.txt" md5="b79e516dfd08127a50d01fa540f1b88a" size="57" mtime="1642674768"/>
+        <directory name="bar_package-123456789" rev="18" vrev="18" srcmd5="41174312578be1710923ff8067d4f829">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="5125b8f8753f5d7283cfb3c2a9d522cc" baserev="5125b8f8753f5d7283cfb3c2a9d522cc" xsrcmd5="e6cf2e168f988504d56ed4cecec02714" lsrcmd5="41174312578be1710923ff8067d4f829"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="4fa73dbc4ed96db8e653c8308fdbd054" size="68" mtime="1643641556"/>
+          <entry name="_link" md5="9dae0b8c95e13b12675e4fd97f3774da" size="141" mtime="1643641556"/>
+          <entry name="somefile.txt" md5="a0a86f542b241ce857cc53944a92745d" size="63" mtime="1643641556"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:49 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:57 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '627'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="e6cf2e168f988504d56ed4cecec02714" vrev="106" srcmd5="e6cf2e168f988504d56ed4cecec02714">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="5125b8f8753f5d7283cfb3c2a9d522cc" baserev="5125b8f8753f5d7283cfb3c2a9d522cc" lsrcmd5="41174312578be1710923ff8067d4f829"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="4fa73dbc4ed96db8e653c8308fdbd054" size="68" mtime="1643641556"/>
+          <entry name="somefile.txt" md5="a0a86f542b241ce857cc53944a92745d" size="63" mtime="1643641556"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:05:57 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -991,19 +1094,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="114" vrev="114" srcmd5="0ea5eb2218bed90eedffe495bcc8bfdf">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="770b57df5c7d0482c493b6ea931fbbaa" baserev="770b57df5c7d0482c493b6ea931fbbaa" xsrcmd5="c5b6c2aa46a49504cc92d21cb8776eab" lsrcmd5="0ea5eb2218bed90eedffe495bcc8bfdf"/>
-          <serviceinfo code="succeeded" xsrcmd5="b500de2829b87b848a19a0ab110e8ca0"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="357235f23591e75697a4bca26783b3e7" size="63" mtime="1642674768"/>
-          <entry name="_link" md5="73e255b360d9a5d5da9a1c5b600fa709" size="141" mtime="1642674768"/>
-          <entry name="somefile.txt" md5="b79e516dfd08127a50d01fa540f1b88a" size="57" mtime="1642674768"/>
+        <directory name="bar_package-123456789" rev="18" vrev="18" srcmd5="41174312578be1710923ff8067d4f829">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="5125b8f8753f5d7283cfb3c2a9d522cc" baserev="5125b8f8753f5d7283cfb3c2a9d522cc" xsrcmd5="e6cf2e168f988504d56ed4cecec02714" lsrcmd5="41174312578be1710923ff8067d4f829"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="4fa73dbc4ed96db8e653c8308fdbd054" size="68" mtime="1643641556"/>
+          <entry name="_link" md5="9dae0b8c95e13b12675e4fd97f3774da" size="141" mtime="1643641556"/>
+          <entry name="somefile.txt" md5="a0a86f542b241ce857cc53944a92745d" size="63" mtime="1643641556"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:49 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:57 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '627'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="e6cf2e168f988504d56ed4cecec02714" vrev="106" srcmd5="e6cf2e168f988504d56ed4cecec02714">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="5125b8f8753f5d7283cfb3c2a9d522cc" baserev="5125b8f8753f5d7283cfb3c2a9d522cc" lsrcmd5="41174312578be1710923ff8067d4f829"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="4fa73dbc4ed96db8e653c8308fdbd054" size="68" mtime="1643641556"/>
+          <entry name="somefile.txt" md5="a0a86f542b241ce857cc53944a92745d" size="63" mtime="1643641556"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:05:57 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -1029,22 +1167,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="114" vrev="114" srcmd5="0ea5eb2218bed90eedffe495bcc8bfdf">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="770b57df5c7d0482c493b6ea931fbbaa" baserev="770b57df5c7d0482c493b6ea931fbbaa" xsrcmd5="c5b6c2aa46a49504cc92d21cb8776eab" lsrcmd5="0ea5eb2218bed90eedffe495bcc8bfdf"/>
-          <serviceinfo code="succeeded" xsrcmd5="b500de2829b87b848a19a0ab110e8ca0"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="357235f23591e75697a4bca26783b3e7" size="63" mtime="1642674768"/>
-          <entry name="_link" md5="73e255b360d9a5d5da9a1c5b600fa709" size="141" mtime="1642674768"/>
-          <entry name="somefile.txt" md5="b79e516dfd08127a50d01fa540f1b88a" size="57" mtime="1642674768"/>
+        <directory name="bar_package-123456789" rev="18" vrev="18" srcmd5="41174312578be1710923ff8067d4f829">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="5125b8f8753f5d7283cfb3c2a9d522cc" baserev="5125b8f8753f5d7283cfb3c2a9d522cc" xsrcmd5="e6cf2e168f988504d56ed4cecec02714" lsrcmd5="41174312578be1710923ff8067d4f829"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="4fa73dbc4ed96db8e653c8308fdbd054" size="68" mtime="1643641556"/>
+          <entry name="_link" md5="9dae0b8c95e13b12675e4fd97f3774da" size="141" mtime="1643641556"/>
+          <entry name="somefile.txt" md5="a0a86f542b241ce857cc53944a92745d" size="63" mtime="1643641556"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:49 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:57 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1067,169 +1204,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '627'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="114" vrev="114" srcmd5="0ea5eb2218bed90eedffe495bcc8bfdf">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="770b57df5c7d0482c493b6ea931fbbaa" baserev="770b57df5c7d0482c493b6ea931fbbaa" xsrcmd5="c5b6c2aa46a49504cc92d21cb8776eab" lsrcmd5="0ea5eb2218bed90eedffe495bcc8bfdf"/>
-          <serviceinfo code="succeeded" xsrcmd5="b500de2829b87b848a19a0ab110e8ca0"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="357235f23591e75697a4bca26783b3e7" size="63" mtime="1642674768"/>
-          <entry name="_link" md5="73e255b360d9a5d5da9a1c5b600fa709" size="141" mtime="1642674768"/>
-          <entry name="somefile.txt" md5="b79e516dfd08127a50d01fa540f1b88a" size="57" mtime="1642674768"/>
+        <directory name="bar_package-123456789" rev="e6cf2e168f988504d56ed4cecec02714" vrev="106" srcmd5="e6cf2e168f988504d56ed4cecec02714">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="5125b8f8753f5d7283cfb3c2a9d522cc" baserev="5125b8f8753f5d7283cfb3c2a9d522cc" lsrcmd5="41174312578be1710923ff8067d4f829"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="4fa73dbc4ed96db8e653c8308fdbd054" size="68" mtime="1643641556"/>
+          <entry name="somefile.txt" md5="a0a86f542b241ce857cc53944a92745d" size="63" mtime="1643641556"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:49 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '811'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="114" vrev="114" srcmd5="0ea5eb2218bed90eedffe495bcc8bfdf">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="770b57df5c7d0482c493b6ea931fbbaa" baserev="770b57df5c7d0482c493b6ea931fbbaa" xsrcmd5="c5b6c2aa46a49504cc92d21cb8776eab" lsrcmd5="0ea5eb2218bed90eedffe495bcc8bfdf"/>
-          <serviceinfo code="succeeded" xsrcmd5="b500de2829b87b848a19a0ab110e8ca0"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="357235f23591e75697a4bca26783b3e7" size="63" mtime="1642674768"/>
-          <entry name="_link" md5="73e255b360d9a5d5da9a1c5b600fa709" size="141" mtime="1642674768"/>
-          <entry name="somefile.txt" md5="b79e516dfd08127a50d01fa540f1b88a" size="57" mtime="1642674768"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:49 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '811'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="114" vrev="114" srcmd5="0ea5eb2218bed90eedffe495bcc8bfdf">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="770b57df5c7d0482c493b6ea931fbbaa" baserev="770b57df5c7d0482c493b6ea931fbbaa" xsrcmd5="c5b6c2aa46a49504cc92d21cb8776eab" lsrcmd5="0ea5eb2218bed90eedffe495bcc8bfdf"/>
-          <serviceinfo code="succeeded" xsrcmd5="b500de2829b87b848a19a0ab110e8ca0"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="357235f23591e75697a4bca26783b3e7" size="63" mtime="1642674768"/>
-          <entry name="_link" md5="73e255b360d9a5d5da9a1c5b600fa709" size="141" mtime="1642674768"/>
-          <entry name="somefile.txt" md5="b79e516dfd08127a50d01fa540f1b88a" size="57" mtime="1642674768"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:49 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '811'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="114" vrev="114" srcmd5="0ea5eb2218bed90eedffe495bcc8bfdf">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="770b57df5c7d0482c493b6ea931fbbaa" baserev="770b57df5c7d0482c493b6ea931fbbaa" xsrcmd5="c5b6c2aa46a49504cc92d21cb8776eab" lsrcmd5="0ea5eb2218bed90eedffe495bcc8bfdf"/>
-          <serviceinfo code="succeeded" xsrcmd5="b500de2829b87b848a19a0ab110e8ca0"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="357235f23591e75697a4bca26783b3e7" size="63" mtime="1642674768"/>
-          <entry name="_link" md5="73e255b360d9a5d5da9a1c5b600fa709" size="141" mtime="1642674768"/>
-          <entry name="somefile.txt" md5="b79e516dfd08127a50d01fa540f1b88a" size="57" mtime="1642674768"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:49 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '811'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="114" vrev="114" srcmd5="0ea5eb2218bed90eedffe495bcc8bfdf">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="770b57df5c7d0482c493b6ea931fbbaa" baserev="770b57df5c7d0482c493b6ea931fbbaa" xsrcmd5="c5b6c2aa46a49504cc92d21cb8776eab" lsrcmd5="0ea5eb2218bed90eedffe495bcc8bfdf"/>
-          <serviceinfo code="succeeded" xsrcmd5="b500de2829b87b848a19a0ab110e8ca0"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="357235f23591e75697a4bca26783b3e7" size="63" mtime="1642674768"/>
-          <entry name="_link" md5="73e255b360d9a5d5da9a1c5b600fa709" size="141" mtime="1642674768"/>
-          <entry name="somefile.txt" md5="b79e516dfd08127a50d01fa540f1b88a" size="57" mtime="1642674768"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:49 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:57 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/with_a_push_event_for_a_commit/behaves_like_successful_new_PR_or_MR_event/1_1_1_6_1_2.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/with_a_push_event_for_a_commit/behaves_like_successful_new_PR_or_MR_event/1_1_1_6_1_2.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:49 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:59 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_296
+    uri: http://backend:5352/source/foo_project/_meta?user=user_83
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Terrible Swift Sword</title>
+          <title>To Your Scattered Bodies Go</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '152'
+      - '159'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Terrible Swift Sword</title>
+          <title>To Your Scattered Bodies Go</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:49 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:59 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_297
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_84
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Infinite Jest</title>
-          <description>Aut totam asperiores quia.</description>
+          <title>Precious Bane</title>
+          <description>Ullam ut labore tempora.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '149'
+      - '147'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Infinite Jest</title>
-          <description>Aut totam asperiores quia.</description>
+          <title>Precious Bane</title>
+          <description>Ullam ut labore tempora.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:49 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:59 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Eaque quos ipsa. Incidunt veritatis alias. Ipsam reprehenderit et.
+      string: Sunt soluta voluptatem. Ut labore dignissimos. Neque dolores nobis.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1683" vrev="1683">
-          <srcmd5>ee48fc025cd36e2462ba52be7ae276c2</srcmd5>
+        <revision rev="91" vrev="91">
+          <srcmd5>eb89b74ff1f6da319ed1203b17623465</srcmd5>
           <version>unknown</version>
-          <time>1642674769</time>
+          <time>1643641559</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:49 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:59 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Corrupti modi quas. Quo magni qui. Ad eligendi hic.
+      string: Eos accusamus rem. Esse nobis rerum. Nulla ratione eos.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +181,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1684" vrev="1684">
-          <srcmd5>a15809dc418999eebe3a033dade917dc</srcmd5>
+        <revision rev="92" vrev="92">
+          <srcmd5>3d9c65fdb5e9e41f9963b3cb68026c29</srcmd5>
           <version>unknown</version>
-          <time>1642674769</time>
+          <time>1643641559</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:49 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:59 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -227,7 +227,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:32:49 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:59 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_meta?user=Iggy
@@ -235,8 +235,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>Infinite Jest</title>
-          <description>Aut totam asperiores quia.</description>
+          <title>Precious Bane</title>
+          <description>Ullam ut labore tempora.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -257,15 +257,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '157'
+      - '155'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>Infinite Jest</title>
-          <description>Aut totam asperiores quia.</description>
+          <title>Precious Bane</title>
+          <description>Ullam ut labore tempora.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:49 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:59 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=branch&noservice=1&opackage=bar_package&oproject=foo_project&user=Iggy
@@ -293,19 +293,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="115" vrev="115">
-          <srcmd5>407a636c2e3dc12f01df329afaaf291d</srcmd5>
+        <revision rev="21" vrev="21">
+          <srcmd5>1577db14fa2614a8b36585900934217f</srcmd5>
           <version>unknown</version>
-          <time>1642674769</time>
+          <time>1643641559</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:49 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:59 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_meta?user=Iggy
@@ -313,8 +313,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>Infinite Jest</title>
-          <description>Aut totam asperiores quia.</description>
+          <title>Precious Bane</title>
+          <description>Ullam ut labore tempora.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -335,15 +335,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '157'
+      - '155'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>Infinite Jest</title>
-          <description>Aut totam asperiores quia.</description>
+          <title>Precious Bane</title>
+          <description>Ullam ut labore tempora.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:49 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:59 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -369,18 +369,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '735'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="115" vrev="115" srcmd5="407a636c2e3dc12f01df329afaaf291d">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="a15809dc418999eebe3a033dade917dc" baserev="a15809dc418999eebe3a033dade917dc" xsrcmd5="e366eaafbb452055fc43faf85046cfdd" lsrcmd5="407a636c2e3dc12f01df329afaaf291d"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="ba9737b9ca9b52b0fd326e975c49d7c9" size="66" mtime="1642674769"/>
-          <entry name="_link" md5="e74d0362de7535993ff2ddd390acdee4" size="141" mtime="1642674769"/>
-          <entry name="somefile.txt" md5="97b299a35dfe151a1571a91551d2c484" size="51" mtime="1642674769"/>
+        <directory name="bar_package-123456789" rev="21" vrev="21" srcmd5="1577db14fa2614a8b36585900934217f">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="3d9c65fdb5e9e41f9963b3cb68026c29" baserev="3d9c65fdb5e9e41f9963b3cb68026c29" xsrcmd5="3076cadd800a8c58a0eb51c11c2ea099" lsrcmd5="1577db14fa2614a8b36585900934217f"/>
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="c34c5d5e1810d64546d9673a9fbce58d" size="67" mtime="1643641559"/>
+          <entry name="_link" md5="a3f0666cfdfd4816f82cedf1f30ed1bf" size="141" mtime="1643641559"/>
+          <entry name="somefile.txt" md5="0bf85c0fbb0538a5c48b740544d20b69" size="55" mtime="1643641559"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:49 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:59 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?view=info
@@ -406,15 +406,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '343'
+      - '341'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package-123456789" rev="115" vrev="1799" srcmd5="e366eaafbb452055fc43faf85046cfdd" lsrcmd5="407a636c2e3dc12f01df329afaaf291d" verifymd5="a15809dc418999eebe3a033dade917dc">
+        <sourceinfo package="bar_package-123456789" rev="21" vrev="113" srcmd5="3076cadd800a8c58a0eb51c11c2ea099" lsrcmd5="1577db14fa2614a8b36585900934217f" verifymd5="3d9c65fdb5e9e41f9963b3cb68026c29">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:49 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:59 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -440,18 +440,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '735'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="115" vrev="115" srcmd5="407a636c2e3dc12f01df329afaaf291d">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="a15809dc418999eebe3a033dade917dc" baserev="a15809dc418999eebe3a033dade917dc" xsrcmd5="e366eaafbb452055fc43faf85046cfdd" lsrcmd5="407a636c2e3dc12f01df329afaaf291d"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="ba9737b9ca9b52b0fd326e975c49d7c9" size="66" mtime="1642674769"/>
-          <entry name="_link" md5="e74d0362de7535993ff2ddd390acdee4" size="141" mtime="1642674769"/>
-          <entry name="somefile.txt" md5="97b299a35dfe151a1571a91551d2c484" size="51" mtime="1642674769"/>
+        <directory name="bar_package-123456789" rev="21" vrev="21" srcmd5="1577db14fa2614a8b36585900934217f">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="3d9c65fdb5e9e41f9963b3cb68026c29" baserev="3d9c65fdb5e9e41f9963b3cb68026c29" xsrcmd5="3076cadd800a8c58a0eb51c11c2ea099" lsrcmd5="1577db14fa2614a8b36585900934217f"/>
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="c34c5d5e1810d64546d9673a9fbce58d" size="67" mtime="1643641559"/>
+          <entry name="_link" md5="a3f0666cfdfd4816f82cedf1f30ed1bf" size="141" mtime="1643641559"/>
+          <entry name="somefile.txt" md5="0bf85c0fbb0538a5c48b740544d20b69" size="55" mtime="1643641559"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:49 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:59 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -479,18 +479,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '324'
+      - '323'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="d582797706fb2517449bf4dc803ef760">
+        <sourcediff key="d6cf817a54e5c4eeb66f35d10141827e">
           <old project="home:Iggy" package="bar_package-123456789" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="115" srcmd5="407a636c2e3dc12f01df329afaaf291d"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="21" srcmd5="1577db14fa2614a8b36585900934217f"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:49 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:59 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -522,14 +522,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="ee6bbf1e6bce3e767f38ae096ddb37d6">
-          <old project="foo_project" package="bar_package" rev="a15809dc418999eebe3a033dade917dc" srcmd5="a15809dc418999eebe3a033dade917dc"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="e366eaafbb452055fc43faf85046cfdd" srcmd5="e366eaafbb452055fc43faf85046cfdd"/>
+        <sourcediff key="a1302e2125354a7e4a9358c72328f6a5">
+          <old project="foo_project" package="bar_package" rev="3d9c65fdb5e9e41f9963b3cb68026c29" srcmd5="3d9c65fdb5e9e41f9963b3cb68026c29"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="3076cadd800a8c58a0eb51c11c2ea099" srcmd5="3076cadd800a8c58a0eb51c11c2ea099"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:50 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:59 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/_meta?user=Iggy
@@ -587,7 +587,7 @@ http_interactions:
             <arch>aarch64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:50 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:59 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_branch_request?user=Iggy
@@ -613,19 +613,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="116" vrev="116">
-          <srcmd5>c01528be1f650b917d8b68cac4e77b53</srcmd5>
+        <revision rev="22" vrev="22">
+          <srcmd5>b9b0bc55fe8653c1c66ca70aaed48b2e</srcmd5>
           <version>unknown</version>
-          <time>1642674770</time>
+          <time>1643641559</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:50 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:59 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_meta?user=Iggy
@@ -633,8 +633,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>Infinite Jest</title>
-          <description>Aut totam asperiores quia.</description>
+          <title>Precious Bane</title>
+          <description>Ullam ut labore tempora.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -655,15 +655,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '157'
+      - '155'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>Infinite Jest</title>
-          <description>Aut totam asperiores quia.</description>
+          <title>Precious Bane</title>
+          <description>Ullam ut labore tempora.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:50 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:59 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -689,19 +689,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="116" vrev="116" srcmd5="c01528be1f650b917d8b68cac4e77b53">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="a15809dc418999eebe3a033dade917dc" baserev="a15809dc418999eebe3a033dade917dc" xsrcmd5="f4ff3e6ee85e3a91117100ec3b222964" lsrcmd5="c01528be1f650b917d8b68cac4e77b53"/>
-          <serviceinfo code="succeeded" xsrcmd5="8e9189131cc337dd5837d3a0443f3b21"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="ba9737b9ca9b52b0fd326e975c49d7c9" size="66" mtime="1642674769"/>
-          <entry name="_link" md5="e74d0362de7535993ff2ddd390acdee4" size="141" mtime="1642674769"/>
-          <entry name="somefile.txt" md5="97b299a35dfe151a1571a91551d2c484" size="51" mtime="1642674769"/>
+        <directory name="bar_package-123456789" rev="22" vrev="22" srcmd5="b9b0bc55fe8653c1c66ca70aaed48b2e">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="3d9c65fdb5e9e41f9963b3cb68026c29" baserev="3d9c65fdb5e9e41f9963b3cb68026c29" xsrcmd5="05bb50c3c6e394c3c99353aade5b71ce" lsrcmd5="b9b0bc55fe8653c1c66ca70aaed48b2e"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="c34c5d5e1810d64546d9673a9fbce58d" size="67" mtime="1643641559"/>
+          <entry name="_link" md5="a3f0666cfdfd4816f82cedf1f30ed1bf" size="141" mtime="1643641559"/>
+          <entry name="somefile.txt" md5="0bf85c0fbb0538a5c48b740544d20b69" size="55" mtime="1643641559"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:50 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:59 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?view=info
@@ -727,15 +726,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '343'
+      - '341'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package-123456789" rev="116" vrev="1800" srcmd5="84440de59ea40fb5d9d106c616254fb2" lsrcmd5="8e9189131cc337dd5837d3a0443f3b21" verifymd5="bd84322aa3724c02910ed147e5cca8c8">
+        <sourceinfo package="bar_package-123456789" rev="22" vrev="114" srcmd5="05bb50c3c6e394c3c99353aade5b71ce" lsrcmd5="b9b0bc55fe8653c1c66ca70aaed48b2e" verifymd5="a92334dcb6ffd384d53222c6eafb2516">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:50 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:59 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -761,19 +760,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="116" vrev="116" srcmd5="c01528be1f650b917d8b68cac4e77b53">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="a15809dc418999eebe3a033dade917dc" baserev="a15809dc418999eebe3a033dade917dc" xsrcmd5="f4ff3e6ee85e3a91117100ec3b222964" lsrcmd5="c01528be1f650b917d8b68cac4e77b53"/>
-          <serviceinfo code="succeeded" xsrcmd5="8e9189131cc337dd5837d3a0443f3b21"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="ba9737b9ca9b52b0fd326e975c49d7c9" size="66" mtime="1642674769"/>
-          <entry name="_link" md5="e74d0362de7535993ff2ddd390acdee4" size="141" mtime="1642674769"/>
-          <entry name="somefile.txt" md5="97b299a35dfe151a1571a91551d2c484" size="51" mtime="1642674769"/>
+        <directory name="bar_package-123456789" rev="22" vrev="22" srcmd5="b9b0bc55fe8653c1c66ca70aaed48b2e">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="3d9c65fdb5e9e41f9963b3cb68026c29" baserev="3d9c65fdb5e9e41f9963b3cb68026c29" xsrcmd5="05bb50c3c6e394c3c99353aade5b71ce" lsrcmd5="b9b0bc55fe8653c1c66ca70aaed48b2e"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="c34c5d5e1810d64546d9673a9fbce58d" size="67" mtime="1643641559"/>
+          <entry name="_link" md5="a3f0666cfdfd4816f82cedf1f30ed1bf" size="141" mtime="1643641559"/>
+          <entry name="somefile.txt" md5="0bf85c0fbb0538a5c48b740544d20b69" size="55" mtime="1643641559"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:50 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:59 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -801,18 +799,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '324'
+      - '323'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="55b4c1044196b84785874f3e7c6cc097">
+        <sourcediff key="4515f0ad35a543718eeaee152949d4c5">
           <old project="home:Iggy" package="bar_package-123456789" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="116" srcmd5="c01528be1f650b917d8b68cac4e77b53"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="22" srcmd5="b9b0bc55fe8653c1c66ca70aaed48b2e"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:50 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:59 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -844,14 +842,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="19869a0c4e029619fede2a0b969df4a9">
-          <old project="foo_project" package="bar_package" rev="a15809dc418999eebe3a033dade917dc" srcmd5="a15809dc418999eebe3a033dade917dc"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="84440de59ea40fb5d9d106c616254fb2" srcmd5="84440de59ea40fb5d9d106c616254fb2"/>
+        <sourcediff key="3d7358d3a4ac90e44265eef8e346c264">
+          <old project="foo_project" package="bar_package" rev="3d9c65fdb5e9e41f9963b3cb68026c29" srcmd5="3d9c65fdb5e9e41f9963b3cb68026c29"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="05bb50c3c6e394c3c99353aade5b71ce" srcmd5="05bb50c3c6e394c3c99353aade5b71ce"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:50 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:59 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -877,19 +875,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="116" vrev="116" srcmd5="c01528be1f650b917d8b68cac4e77b53">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="a15809dc418999eebe3a033dade917dc" baserev="a15809dc418999eebe3a033dade917dc" xsrcmd5="f4ff3e6ee85e3a91117100ec3b222964" lsrcmd5="c01528be1f650b917d8b68cac4e77b53"/>
-          <serviceinfo code="succeeded" xsrcmd5="8e9189131cc337dd5837d3a0443f3b21"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="ba9737b9ca9b52b0fd326e975c49d7c9" size="66" mtime="1642674769"/>
-          <entry name="_link" md5="e74d0362de7535993ff2ddd390acdee4" size="141" mtime="1642674769"/>
-          <entry name="somefile.txt" md5="97b299a35dfe151a1571a91551d2c484" size="51" mtime="1642674769"/>
+        <directory name="bar_package-123456789" rev="22" vrev="22" srcmd5="b9b0bc55fe8653c1c66ca70aaed48b2e">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="3d9c65fdb5e9e41f9963b3cb68026c29" baserev="3d9c65fdb5e9e41f9963b3cb68026c29" xsrcmd5="05bb50c3c6e394c3c99353aade5b71ce" lsrcmd5="b9b0bc55fe8653c1c66ca70aaed48b2e"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="c34c5d5e1810d64546d9673a9fbce58d" size="67" mtime="1643641559"/>
+          <entry name="_link" md5="a3f0666cfdfd4816f82cedf1f30ed1bf" size="141" mtime="1643641559"/>
+          <entry name="somefile.txt" md5="0bf85c0fbb0538a5c48b740544d20b69" size="55" mtime="1643641559"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:50 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:59 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '627'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="05bb50c3c6e394c3c99353aade5b71ce" vrev="114" srcmd5="05bb50c3c6e394c3c99353aade5b71ce">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="3d9c65fdb5e9e41f9963b3cb68026c29" baserev="3d9c65fdb5e9e41f9963b3cb68026c29" lsrcmd5="b9b0bc55fe8653c1c66ca70aaed48b2e"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="c34c5d5e1810d64546d9673a9fbce58d" size="67" mtime="1643641559"/>
+          <entry name="somefile.txt" md5="0bf85c0fbb0538a5c48b740544d20b69" size="55" mtime="1643641559"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:06:00 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -915,19 +948,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="116" vrev="116" srcmd5="c01528be1f650b917d8b68cac4e77b53">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="a15809dc418999eebe3a033dade917dc" baserev="a15809dc418999eebe3a033dade917dc" xsrcmd5="f4ff3e6ee85e3a91117100ec3b222964" lsrcmd5="c01528be1f650b917d8b68cac4e77b53"/>
-          <serviceinfo code="succeeded" xsrcmd5="8e9189131cc337dd5837d3a0443f3b21"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="ba9737b9ca9b52b0fd326e975c49d7c9" size="66" mtime="1642674769"/>
-          <entry name="_link" md5="e74d0362de7535993ff2ddd390acdee4" size="141" mtime="1642674769"/>
-          <entry name="somefile.txt" md5="97b299a35dfe151a1571a91551d2c484" size="51" mtime="1642674769"/>
+        <directory name="bar_package-123456789" rev="22" vrev="22" srcmd5="b9b0bc55fe8653c1c66ca70aaed48b2e">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="3d9c65fdb5e9e41f9963b3cb68026c29" baserev="3d9c65fdb5e9e41f9963b3cb68026c29" xsrcmd5="05bb50c3c6e394c3c99353aade5b71ce" lsrcmd5="b9b0bc55fe8653c1c66ca70aaed48b2e"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="c34c5d5e1810d64546d9673a9fbce58d" size="67" mtime="1643641559"/>
+          <entry name="_link" md5="a3f0666cfdfd4816f82cedf1f30ed1bf" size="141" mtime="1643641559"/>
+          <entry name="somefile.txt" md5="0bf85c0fbb0538a5c48b740544d20b69" size="55" mtime="1643641559"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:50 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:00 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '627'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="05bb50c3c6e394c3c99353aade5b71ce" vrev="114" srcmd5="05bb50c3c6e394c3c99353aade5b71ce">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="3d9c65fdb5e9e41f9963b3cb68026c29" baserev="3d9c65fdb5e9e41f9963b3cb68026c29" lsrcmd5="b9b0bc55fe8653c1c66ca70aaed48b2e"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="c34c5d5e1810d64546d9673a9fbce58d" size="67" mtime="1643641559"/>
+          <entry name="somefile.txt" md5="0bf85c0fbb0538a5c48b740544d20b69" size="55" mtime="1643641559"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:06:00 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -953,19 +1021,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="116" vrev="116" srcmd5="c01528be1f650b917d8b68cac4e77b53">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="a15809dc418999eebe3a033dade917dc" baserev="a15809dc418999eebe3a033dade917dc" xsrcmd5="f4ff3e6ee85e3a91117100ec3b222964" lsrcmd5="c01528be1f650b917d8b68cac4e77b53"/>
-          <serviceinfo code="succeeded" xsrcmd5="8e9189131cc337dd5837d3a0443f3b21"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="ba9737b9ca9b52b0fd326e975c49d7c9" size="66" mtime="1642674769"/>
-          <entry name="_link" md5="e74d0362de7535993ff2ddd390acdee4" size="141" mtime="1642674769"/>
-          <entry name="somefile.txt" md5="97b299a35dfe151a1571a91551d2c484" size="51" mtime="1642674769"/>
+        <directory name="bar_package-123456789" rev="22" vrev="22" srcmd5="b9b0bc55fe8653c1c66ca70aaed48b2e">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="3d9c65fdb5e9e41f9963b3cb68026c29" baserev="3d9c65fdb5e9e41f9963b3cb68026c29" xsrcmd5="05bb50c3c6e394c3c99353aade5b71ce" lsrcmd5="b9b0bc55fe8653c1c66ca70aaed48b2e"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="c34c5d5e1810d64546d9673a9fbce58d" size="67" mtime="1643641559"/>
+          <entry name="_link" md5="a3f0666cfdfd4816f82cedf1f30ed1bf" size="141" mtime="1643641559"/>
+          <entry name="somefile.txt" md5="0bf85c0fbb0538a5c48b740544d20b69" size="55" mtime="1643641559"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:50 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:00 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '627'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="05bb50c3c6e394c3c99353aade5b71ce" vrev="114" srcmd5="05bb50c3c6e394c3c99353aade5b71ce">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="3d9c65fdb5e9e41f9963b3cb68026c29" baserev="3d9c65fdb5e9e41f9963b3cb68026c29" lsrcmd5="b9b0bc55fe8653c1c66ca70aaed48b2e"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="c34c5d5e1810d64546d9673a9fbce58d" size="67" mtime="1643641559"/>
+          <entry name="somefile.txt" md5="0bf85c0fbb0538a5c48b740544d20b69" size="55" mtime="1643641559"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:06:00 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -991,19 +1094,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="116" vrev="116" srcmd5="c01528be1f650b917d8b68cac4e77b53">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="a15809dc418999eebe3a033dade917dc" baserev="a15809dc418999eebe3a033dade917dc" xsrcmd5="f4ff3e6ee85e3a91117100ec3b222964" lsrcmd5="c01528be1f650b917d8b68cac4e77b53"/>
-          <serviceinfo code="succeeded" xsrcmd5="8e9189131cc337dd5837d3a0443f3b21"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="ba9737b9ca9b52b0fd326e975c49d7c9" size="66" mtime="1642674769"/>
-          <entry name="_link" md5="e74d0362de7535993ff2ddd390acdee4" size="141" mtime="1642674769"/>
-          <entry name="somefile.txt" md5="97b299a35dfe151a1571a91551d2c484" size="51" mtime="1642674769"/>
+        <directory name="bar_package-123456789" rev="22" vrev="22" srcmd5="b9b0bc55fe8653c1c66ca70aaed48b2e">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="3d9c65fdb5e9e41f9963b3cb68026c29" baserev="3d9c65fdb5e9e41f9963b3cb68026c29" xsrcmd5="05bb50c3c6e394c3c99353aade5b71ce" lsrcmd5="b9b0bc55fe8653c1c66ca70aaed48b2e"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="c34c5d5e1810d64546d9673a9fbce58d" size="67" mtime="1643641559"/>
+          <entry name="_link" md5="a3f0666cfdfd4816f82cedf1f30ed1bf" size="141" mtime="1643641559"/>
+          <entry name="somefile.txt" md5="0bf85c0fbb0538a5c48b740544d20b69" size="55" mtime="1643641559"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:50 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:00 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '627'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="05bb50c3c6e394c3c99353aade5b71ce" vrev="114" srcmd5="05bb50c3c6e394c3c99353aade5b71ce">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="3d9c65fdb5e9e41f9963b3cb68026c29" baserev="3d9c65fdb5e9e41f9963b3cb68026c29" lsrcmd5="b9b0bc55fe8653c1c66ca70aaed48b2e"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="c34c5d5e1810d64546d9673a9fbce58d" size="67" mtime="1643641559"/>
+          <entry name="somefile.txt" md5="0bf85c0fbb0538a5c48b740544d20b69" size="55" mtime="1643641559"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:06:00 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -1029,22 +1167,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="116" vrev="116" srcmd5="c01528be1f650b917d8b68cac4e77b53">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="a15809dc418999eebe3a033dade917dc" baserev="a15809dc418999eebe3a033dade917dc" xsrcmd5="f4ff3e6ee85e3a91117100ec3b222964" lsrcmd5="c01528be1f650b917d8b68cac4e77b53"/>
-          <serviceinfo code="succeeded" xsrcmd5="8e9189131cc337dd5837d3a0443f3b21"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="ba9737b9ca9b52b0fd326e975c49d7c9" size="66" mtime="1642674769"/>
-          <entry name="_link" md5="e74d0362de7535993ff2ddd390acdee4" size="141" mtime="1642674769"/>
-          <entry name="somefile.txt" md5="97b299a35dfe151a1571a91551d2c484" size="51" mtime="1642674769"/>
+        <directory name="bar_package-123456789" rev="22" vrev="22" srcmd5="b9b0bc55fe8653c1c66ca70aaed48b2e">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="3d9c65fdb5e9e41f9963b3cb68026c29" baserev="3d9c65fdb5e9e41f9963b3cb68026c29" xsrcmd5="05bb50c3c6e394c3c99353aade5b71ce" lsrcmd5="b9b0bc55fe8653c1c66ca70aaed48b2e"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="c34c5d5e1810d64546d9673a9fbce58d" size="67" mtime="1643641559"/>
+          <entry name="_link" md5="a3f0666cfdfd4816f82cedf1f30ed1bf" size="141" mtime="1643641559"/>
+          <entry name="somefile.txt" md5="0bf85c0fbb0538a5c48b740544d20b69" size="55" mtime="1643641559"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:50 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:00 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1067,169 +1204,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '627'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="116" vrev="116" srcmd5="c01528be1f650b917d8b68cac4e77b53">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="a15809dc418999eebe3a033dade917dc" baserev="a15809dc418999eebe3a033dade917dc" xsrcmd5="f4ff3e6ee85e3a91117100ec3b222964" lsrcmd5="c01528be1f650b917d8b68cac4e77b53"/>
-          <serviceinfo code="succeeded" xsrcmd5="8e9189131cc337dd5837d3a0443f3b21"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="ba9737b9ca9b52b0fd326e975c49d7c9" size="66" mtime="1642674769"/>
-          <entry name="_link" md5="e74d0362de7535993ff2ddd390acdee4" size="141" mtime="1642674769"/>
-          <entry name="somefile.txt" md5="97b299a35dfe151a1571a91551d2c484" size="51" mtime="1642674769"/>
+        <directory name="bar_package-123456789" rev="05bb50c3c6e394c3c99353aade5b71ce" vrev="114" srcmd5="05bb50c3c6e394c3c99353aade5b71ce">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="3d9c65fdb5e9e41f9963b3cb68026c29" baserev="3d9c65fdb5e9e41f9963b3cb68026c29" lsrcmd5="b9b0bc55fe8653c1c66ca70aaed48b2e"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="c34c5d5e1810d64546d9673a9fbce58d" size="67" mtime="1643641559"/>
+          <entry name="somefile.txt" md5="0bf85c0fbb0538a5c48b740544d20b69" size="55" mtime="1643641559"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:50 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '811'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="116" vrev="116" srcmd5="c01528be1f650b917d8b68cac4e77b53">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="a15809dc418999eebe3a033dade917dc" baserev="a15809dc418999eebe3a033dade917dc" xsrcmd5="f4ff3e6ee85e3a91117100ec3b222964" lsrcmd5="c01528be1f650b917d8b68cac4e77b53"/>
-          <serviceinfo code="succeeded" xsrcmd5="8e9189131cc337dd5837d3a0443f3b21"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="ba9737b9ca9b52b0fd326e975c49d7c9" size="66" mtime="1642674769"/>
-          <entry name="_link" md5="e74d0362de7535993ff2ddd390acdee4" size="141" mtime="1642674769"/>
-          <entry name="somefile.txt" md5="97b299a35dfe151a1571a91551d2c484" size="51" mtime="1642674769"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:50 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '811'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="116" vrev="116" srcmd5="c01528be1f650b917d8b68cac4e77b53">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="a15809dc418999eebe3a033dade917dc" baserev="a15809dc418999eebe3a033dade917dc" xsrcmd5="f4ff3e6ee85e3a91117100ec3b222964" lsrcmd5="c01528be1f650b917d8b68cac4e77b53"/>
-          <serviceinfo code="succeeded" xsrcmd5="8e9189131cc337dd5837d3a0443f3b21"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="ba9737b9ca9b52b0fd326e975c49d7c9" size="66" mtime="1642674769"/>
-          <entry name="_link" md5="e74d0362de7535993ff2ddd390acdee4" size="141" mtime="1642674769"/>
-          <entry name="somefile.txt" md5="97b299a35dfe151a1571a91551d2c484" size="51" mtime="1642674769"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:50 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '811'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="116" vrev="116" srcmd5="c01528be1f650b917d8b68cac4e77b53">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="a15809dc418999eebe3a033dade917dc" baserev="a15809dc418999eebe3a033dade917dc" xsrcmd5="f4ff3e6ee85e3a91117100ec3b222964" lsrcmd5="c01528be1f650b917d8b68cac4e77b53"/>
-          <serviceinfo code="succeeded" xsrcmd5="8e9189131cc337dd5837d3a0443f3b21"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="ba9737b9ca9b52b0fd326e975c49d7c9" size="66" mtime="1642674769"/>
-          <entry name="_link" md5="e74d0362de7535993ff2ddd390acdee4" size="141" mtime="1642674769"/>
-          <entry name="somefile.txt" md5="97b299a35dfe151a1571a91551d2c484" size="51" mtime="1642674769"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:50 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '811'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="116" vrev="116" srcmd5="c01528be1f650b917d8b68cac4e77b53">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="a15809dc418999eebe3a033dade917dc" baserev="a15809dc418999eebe3a033dade917dc" xsrcmd5="f4ff3e6ee85e3a91117100ec3b222964" lsrcmd5="c01528be1f650b917d8b68cac4e77b53"/>
-          <serviceinfo code="succeeded" xsrcmd5="8e9189131cc337dd5837d3a0443f3b21"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="ba9737b9ca9b52b0fd326e975c49d7c9" size="66" mtime="1642674769"/>
-          <entry name="_link" md5="e74d0362de7535993ff2ddd390acdee4" size="141" mtime="1642674769"/>
-          <entry name="somefile.txt" md5="97b299a35dfe151a1571a91551d2c484" size="51" mtime="1642674769"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:50 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:00 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/with_a_push_event_for_a_commit/behaves_like_successful_new_PR_or_MR_event/1_1_1_6_1_3.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/with_a_push_event_for_a_commit/behaves_like_successful_new_PR_or_MR_event/1_1_1_6_1_3.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:50 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:00 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_298
+    uri: http://backend:5352/source/foo_project/_meta?user=user_85
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Blithe Spirit</title>
+          <title>Precious Bane</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -75,20 +75,20 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Blithe Spirit</title>
+          <title>Precious Bane</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:50 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:00 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_299
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_86
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Cricket on the Hearth</title>
-          <description>Et mollitia et voluptatem.</description>
+          <title>Mr Standfast</title>
+          <description>Reprehenderit quo animi qui.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '161'
+      - '150'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Cricket on the Hearth</title>
-          <description>Et mollitia et voluptatem.</description>
+          <title>Mr Standfast</title>
+          <description>Reprehenderit quo animi qui.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:50 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:00 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Corporis aspernatur cum. Dolorem aliquid harum. Ea quae et.
+      string: Incidunt dolorem qui. Harum voluptatum voluptates. Iste et earum.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1685" vrev="1685">
-          <srcmd5>01e1821a3d7ba64dff32b7cfb36a0f01</srcmd5>
+        <revision rev="93" vrev="93">
+          <srcmd5>5a4758167397536dc630a3d9fa6b85dd</srcmd5>
           <version>unknown</version>
-          <time>1642674770</time>
+          <time>1643641560</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:50 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:00 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Magnam velit enim. Et vero nobis. Sequi rem sit.
+      string: Fugit nihil consectetur. Porro ea sit. Ipsum expedita sed.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +181,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1686" vrev="1686">
-          <srcmd5>3fbf6327d132f3f6d82c1180b0a158c3</srcmd5>
+        <revision rev="94" vrev="94">
+          <srcmd5>ce460f02f52f8546a51bf0d9f2195d55</srcmd5>
           <version>unknown</version>
-          <time>1642674770</time>
+          <time>1643641560</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:50 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:00 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -227,7 +227,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:32:50 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:00 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_meta?user=Iggy
@@ -235,8 +235,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>The Cricket on the Hearth</title>
-          <description>Et mollitia et voluptatem.</description>
+          <title>Mr Standfast</title>
+          <description>Reprehenderit quo animi qui.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -257,15 +257,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '169'
+      - '158'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>The Cricket on the Hearth</title>
-          <description>Et mollitia et voluptatem.</description>
+          <title>Mr Standfast</title>
+          <description>Reprehenderit quo animi qui.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:50 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:00 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=branch&noservice=1&opackage=bar_package&oproject=foo_project&user=Iggy
@@ -293,19 +293,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="117" vrev="117">
-          <srcmd5>94e177fa8d80153245b981e78f511817</srcmd5>
+        <revision rev="23" vrev="23">
+          <srcmd5>16f82f10650a4509d322a471a8c42b42</srcmd5>
           <version>unknown</version>
-          <time>1642674770</time>
+          <time>1643641560</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:50 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:00 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_meta?user=Iggy
@@ -313,8 +313,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>The Cricket on the Hearth</title>
-          <description>Et mollitia et voluptatem.</description>
+          <title>Mr Standfast</title>
+          <description>Reprehenderit quo animi qui.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -335,15 +335,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '169'
+      - '158'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>The Cricket on the Hearth</title>
-          <description>Et mollitia et voluptatem.</description>
+          <title>Mr Standfast</title>
+          <description>Reprehenderit quo animi qui.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:50 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:00 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -369,18 +369,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '735'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="117" vrev="117" srcmd5="94e177fa8d80153245b981e78f511817">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3fbf6327d132f3f6d82c1180b0a158c3" baserev="3fbf6327d132f3f6d82c1180b0a158c3" xsrcmd5="abce0458a716527d86d43c6978ab80e9" lsrcmd5="94e177fa8d80153245b981e78f511817"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="2296c244c8ce457c66222300f4415b59" size="59" mtime="1642674770"/>
-          <entry name="_link" md5="8a42bc9f110bfeb585300510c19b7346" size="141" mtime="1642674770"/>
-          <entry name="somefile.txt" md5="aa5c7a5c2a0f61b4718fa6fae5d66303" size="48" mtime="1642674770"/>
+        <directory name="bar_package-123456789" rev="23" vrev="23" srcmd5="16f82f10650a4509d322a471a8c42b42">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="ce460f02f52f8546a51bf0d9f2195d55" baserev="ce460f02f52f8546a51bf0d9f2195d55" xsrcmd5="d203e50f4f99a9e6097450118f4eb1d6" lsrcmd5="16f82f10650a4509d322a471a8c42b42"/>
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="47fbdce3b05832bd46373248a810017b" size="65" mtime="1643641560"/>
+          <entry name="_link" md5="12ee49e6fd3e9e8f50dc7448ef7a22e2" size="141" mtime="1643641560"/>
+          <entry name="somefile.txt" md5="fadb4526ed5cf9cba7debe2f979899c4" size="58" mtime="1643641560"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:51 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:00 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?view=info
@@ -406,15 +406,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '343'
+      - '341'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package-123456789" rev="117" vrev="1803" srcmd5="abce0458a716527d86d43c6978ab80e9" lsrcmd5="94e177fa8d80153245b981e78f511817" verifymd5="3fbf6327d132f3f6d82c1180b0a158c3">
+        <sourceinfo package="bar_package-123456789" rev="23" vrev="117" srcmd5="d203e50f4f99a9e6097450118f4eb1d6" lsrcmd5="16f82f10650a4509d322a471a8c42b42" verifymd5="ce460f02f52f8546a51bf0d9f2195d55">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:51 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:00 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -440,18 +440,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '735'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="117" vrev="117" srcmd5="94e177fa8d80153245b981e78f511817">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3fbf6327d132f3f6d82c1180b0a158c3" baserev="3fbf6327d132f3f6d82c1180b0a158c3" xsrcmd5="abce0458a716527d86d43c6978ab80e9" lsrcmd5="94e177fa8d80153245b981e78f511817"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="2296c244c8ce457c66222300f4415b59" size="59" mtime="1642674770"/>
-          <entry name="_link" md5="8a42bc9f110bfeb585300510c19b7346" size="141" mtime="1642674770"/>
-          <entry name="somefile.txt" md5="aa5c7a5c2a0f61b4718fa6fae5d66303" size="48" mtime="1642674770"/>
+        <directory name="bar_package-123456789" rev="23" vrev="23" srcmd5="16f82f10650a4509d322a471a8c42b42">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="ce460f02f52f8546a51bf0d9f2195d55" baserev="ce460f02f52f8546a51bf0d9f2195d55" xsrcmd5="d203e50f4f99a9e6097450118f4eb1d6" lsrcmd5="16f82f10650a4509d322a471a8c42b42"/>
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="47fbdce3b05832bd46373248a810017b" size="65" mtime="1643641560"/>
+          <entry name="_link" md5="12ee49e6fd3e9e8f50dc7448ef7a22e2" size="141" mtime="1643641560"/>
+          <entry name="somefile.txt" md5="fadb4526ed5cf9cba7debe2f979899c4" size="58" mtime="1643641560"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:51 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:00 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -479,18 +479,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '324'
+      - '323'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="4b8690418795c188854bcd60827c572f">
+        <sourcediff key="8948a9bc39d109aa79aedc53db6e3da0">
           <old project="home:Iggy" package="bar_package-123456789" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="117" srcmd5="94e177fa8d80153245b981e78f511817"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="23" srcmd5="16f82f10650a4509d322a471a8c42b42"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:51 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:01 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -522,14 +522,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="9d2856d5fe9c75a02a314b5f8abdc1dd">
-          <old project="foo_project" package="bar_package" rev="3fbf6327d132f3f6d82c1180b0a158c3" srcmd5="3fbf6327d132f3f6d82c1180b0a158c3"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="abce0458a716527d86d43c6978ab80e9" srcmd5="abce0458a716527d86d43c6978ab80e9"/>
+        <sourcediff key="e076f0b28dcc1406ebf0d19bcacadbc5">
+          <old project="foo_project" package="bar_package" rev="ce460f02f52f8546a51bf0d9f2195d55" srcmd5="ce460f02f52f8546a51bf0d9f2195d55"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="d203e50f4f99a9e6097450118f4eb1d6" srcmd5="d203e50f4f99a9e6097450118f4eb1d6"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:51 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:01 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/_meta?user=Iggy
@@ -587,7 +587,7 @@ http_interactions:
             <arch>aarch64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:51 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:01 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_branch_request?user=Iggy
@@ -613,19 +613,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="118" vrev="118">
-          <srcmd5>846980b78ff943ac18504334d92851dc</srcmd5>
+        <revision rev="24" vrev="24">
+          <srcmd5>c697592b5df09b28d58266451af1da7e</srcmd5>
           <version>unknown</version>
-          <time>1642674771</time>
+          <time>1643641561</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:51 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:01 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_meta?user=Iggy
@@ -633,8 +633,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>The Cricket on the Hearth</title>
-          <description>Et mollitia et voluptatem.</description>
+          <title>Mr Standfast</title>
+          <description>Reprehenderit quo animi qui.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -655,15 +655,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '169'
+      - '158'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>The Cricket on the Hearth</title>
-          <description>Et mollitia et voluptatem.</description>
+          <title>Mr Standfast</title>
+          <description>Reprehenderit quo animi qui.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:51 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:01 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -689,19 +689,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="118" vrev="118" srcmd5="846980b78ff943ac18504334d92851dc">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3fbf6327d132f3f6d82c1180b0a158c3" baserev="3fbf6327d132f3f6d82c1180b0a158c3" xsrcmd5="6d5bb5b7602960d8605af84b60ffcaf8" lsrcmd5="846980b78ff943ac18504334d92851dc"/>
-          <serviceinfo code="succeeded" xsrcmd5="55ed88b4b5f4bd8bdf0c994e77967573"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="2296c244c8ce457c66222300f4415b59" size="59" mtime="1642674770"/>
-          <entry name="_link" md5="8a42bc9f110bfeb585300510c19b7346" size="141" mtime="1642674770"/>
-          <entry name="somefile.txt" md5="aa5c7a5c2a0f61b4718fa6fae5d66303" size="48" mtime="1642674770"/>
+        <directory name="bar_package-123456789" rev="24" vrev="24" srcmd5="c697592b5df09b28d58266451af1da7e">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="ce460f02f52f8546a51bf0d9f2195d55" baserev="ce460f02f52f8546a51bf0d9f2195d55" xsrcmd5="ea0af5b06c5e48370fbbaa9a2a3422ba" lsrcmd5="c697592b5df09b28d58266451af1da7e"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="47fbdce3b05832bd46373248a810017b" size="65" mtime="1643641560"/>
+          <entry name="_link" md5="12ee49e6fd3e9e8f50dc7448ef7a22e2" size="141" mtime="1643641560"/>
+          <entry name="somefile.txt" md5="fadb4526ed5cf9cba7debe2f979899c4" size="58" mtime="1643641560"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:51 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:01 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?view=info
@@ -727,15 +726,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '343'
+      - '341'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package-123456789" rev="118" vrev="1804" srcmd5="1d5d83559b0236614145428b7558e4d2" lsrcmd5="55ed88b4b5f4bd8bdf0c994e77967573" verifymd5="2d2d9210bb7605a58487572046099666">
+        <sourceinfo package="bar_package-123456789" rev="24" vrev="118" srcmd5="ea0af5b06c5e48370fbbaa9a2a3422ba" lsrcmd5="c697592b5df09b28d58266451af1da7e" verifymd5="3c7b5d79fb3c78b40cf4b2cb51825747">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:51 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:01 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -761,19 +760,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="118" vrev="118" srcmd5="846980b78ff943ac18504334d92851dc">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3fbf6327d132f3f6d82c1180b0a158c3" baserev="3fbf6327d132f3f6d82c1180b0a158c3" xsrcmd5="6d5bb5b7602960d8605af84b60ffcaf8" lsrcmd5="846980b78ff943ac18504334d92851dc"/>
-          <serviceinfo code="succeeded" xsrcmd5="55ed88b4b5f4bd8bdf0c994e77967573"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="2296c244c8ce457c66222300f4415b59" size="59" mtime="1642674770"/>
-          <entry name="_link" md5="8a42bc9f110bfeb585300510c19b7346" size="141" mtime="1642674770"/>
-          <entry name="somefile.txt" md5="aa5c7a5c2a0f61b4718fa6fae5d66303" size="48" mtime="1642674770"/>
+        <directory name="bar_package-123456789" rev="24" vrev="24" srcmd5="c697592b5df09b28d58266451af1da7e">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="ce460f02f52f8546a51bf0d9f2195d55" baserev="ce460f02f52f8546a51bf0d9f2195d55" xsrcmd5="ea0af5b06c5e48370fbbaa9a2a3422ba" lsrcmd5="c697592b5df09b28d58266451af1da7e"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="47fbdce3b05832bd46373248a810017b" size="65" mtime="1643641560"/>
+          <entry name="_link" md5="12ee49e6fd3e9e8f50dc7448ef7a22e2" size="141" mtime="1643641560"/>
+          <entry name="somefile.txt" md5="fadb4526ed5cf9cba7debe2f979899c4" size="58" mtime="1643641560"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:51 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:01 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -801,18 +799,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '324'
+      - '323'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="9b2090e640949ae45daa1d60c33d1c14">
+        <sourcediff key="c0b363479204e174c2d2d0f061090f8c">
           <old project="home:Iggy" package="bar_package-123456789" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="118" srcmd5="846980b78ff943ac18504334d92851dc"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="24" srcmd5="c697592b5df09b28d58266451af1da7e"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:51 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:01 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -844,14 +842,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="bff3d3e1e97ca627b8b1db8cfd162e24">
-          <old project="foo_project" package="bar_package" rev="3fbf6327d132f3f6d82c1180b0a158c3" srcmd5="3fbf6327d132f3f6d82c1180b0a158c3"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="1d5d83559b0236614145428b7558e4d2" srcmd5="1d5d83559b0236614145428b7558e4d2"/>
+        <sourcediff key="2b2784ef2bb692f3e65b0cb6d1046a96">
+          <old project="foo_project" package="bar_package" rev="ce460f02f52f8546a51bf0d9f2195d55" srcmd5="ce460f02f52f8546a51bf0d9f2195d55"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="ea0af5b06c5e48370fbbaa9a2a3422ba" srcmd5="ea0af5b06c5e48370fbbaa9a2a3422ba"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:51 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:01 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -877,19 +875,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="118" vrev="118" srcmd5="846980b78ff943ac18504334d92851dc">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3fbf6327d132f3f6d82c1180b0a158c3" baserev="3fbf6327d132f3f6d82c1180b0a158c3" xsrcmd5="6d5bb5b7602960d8605af84b60ffcaf8" lsrcmd5="846980b78ff943ac18504334d92851dc"/>
-          <serviceinfo code="succeeded" xsrcmd5="55ed88b4b5f4bd8bdf0c994e77967573"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="2296c244c8ce457c66222300f4415b59" size="59" mtime="1642674770"/>
-          <entry name="_link" md5="8a42bc9f110bfeb585300510c19b7346" size="141" mtime="1642674770"/>
-          <entry name="somefile.txt" md5="aa5c7a5c2a0f61b4718fa6fae5d66303" size="48" mtime="1642674770"/>
+        <directory name="bar_package-123456789" rev="24" vrev="24" srcmd5="c697592b5df09b28d58266451af1da7e">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="ce460f02f52f8546a51bf0d9f2195d55" baserev="ce460f02f52f8546a51bf0d9f2195d55" xsrcmd5="ea0af5b06c5e48370fbbaa9a2a3422ba" lsrcmd5="c697592b5df09b28d58266451af1da7e"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="47fbdce3b05832bd46373248a810017b" size="65" mtime="1643641560"/>
+          <entry name="_link" md5="12ee49e6fd3e9e8f50dc7448ef7a22e2" size="141" mtime="1643641560"/>
+          <entry name="somefile.txt" md5="fadb4526ed5cf9cba7debe2f979899c4" size="58" mtime="1643641560"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:51 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:01 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '627'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="ea0af5b06c5e48370fbbaa9a2a3422ba" vrev="118" srcmd5="ea0af5b06c5e48370fbbaa9a2a3422ba">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="ce460f02f52f8546a51bf0d9f2195d55" baserev="ce460f02f52f8546a51bf0d9f2195d55" lsrcmd5="c697592b5df09b28d58266451af1da7e"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="47fbdce3b05832bd46373248a810017b" size="65" mtime="1643641560"/>
+          <entry name="somefile.txt" md5="fadb4526ed5cf9cba7debe2f979899c4" size="58" mtime="1643641560"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:06:01 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -915,19 +948,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="118" vrev="118" srcmd5="846980b78ff943ac18504334d92851dc">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3fbf6327d132f3f6d82c1180b0a158c3" baserev="3fbf6327d132f3f6d82c1180b0a158c3" xsrcmd5="6d5bb5b7602960d8605af84b60ffcaf8" lsrcmd5="846980b78ff943ac18504334d92851dc"/>
-          <serviceinfo code="succeeded" xsrcmd5="55ed88b4b5f4bd8bdf0c994e77967573"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="2296c244c8ce457c66222300f4415b59" size="59" mtime="1642674770"/>
-          <entry name="_link" md5="8a42bc9f110bfeb585300510c19b7346" size="141" mtime="1642674770"/>
-          <entry name="somefile.txt" md5="aa5c7a5c2a0f61b4718fa6fae5d66303" size="48" mtime="1642674770"/>
+        <directory name="bar_package-123456789" rev="24" vrev="24" srcmd5="c697592b5df09b28d58266451af1da7e">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="ce460f02f52f8546a51bf0d9f2195d55" baserev="ce460f02f52f8546a51bf0d9f2195d55" xsrcmd5="ea0af5b06c5e48370fbbaa9a2a3422ba" lsrcmd5="c697592b5df09b28d58266451af1da7e"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="47fbdce3b05832bd46373248a810017b" size="65" mtime="1643641560"/>
+          <entry name="_link" md5="12ee49e6fd3e9e8f50dc7448ef7a22e2" size="141" mtime="1643641560"/>
+          <entry name="somefile.txt" md5="fadb4526ed5cf9cba7debe2f979899c4" size="58" mtime="1643641560"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:51 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:01 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '627'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="ea0af5b06c5e48370fbbaa9a2a3422ba" vrev="118" srcmd5="ea0af5b06c5e48370fbbaa9a2a3422ba">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="ce460f02f52f8546a51bf0d9f2195d55" baserev="ce460f02f52f8546a51bf0d9f2195d55" lsrcmd5="c697592b5df09b28d58266451af1da7e"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="47fbdce3b05832bd46373248a810017b" size="65" mtime="1643641560"/>
+          <entry name="somefile.txt" md5="fadb4526ed5cf9cba7debe2f979899c4" size="58" mtime="1643641560"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:06:01 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -953,19 +1021,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="118" vrev="118" srcmd5="846980b78ff943ac18504334d92851dc">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3fbf6327d132f3f6d82c1180b0a158c3" baserev="3fbf6327d132f3f6d82c1180b0a158c3" xsrcmd5="6d5bb5b7602960d8605af84b60ffcaf8" lsrcmd5="846980b78ff943ac18504334d92851dc"/>
-          <serviceinfo code="succeeded" xsrcmd5="55ed88b4b5f4bd8bdf0c994e77967573"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="2296c244c8ce457c66222300f4415b59" size="59" mtime="1642674770"/>
-          <entry name="_link" md5="8a42bc9f110bfeb585300510c19b7346" size="141" mtime="1642674770"/>
-          <entry name="somefile.txt" md5="aa5c7a5c2a0f61b4718fa6fae5d66303" size="48" mtime="1642674770"/>
+        <directory name="bar_package-123456789" rev="24" vrev="24" srcmd5="c697592b5df09b28d58266451af1da7e">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="ce460f02f52f8546a51bf0d9f2195d55" baserev="ce460f02f52f8546a51bf0d9f2195d55" xsrcmd5="ea0af5b06c5e48370fbbaa9a2a3422ba" lsrcmd5="c697592b5df09b28d58266451af1da7e"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="47fbdce3b05832bd46373248a810017b" size="65" mtime="1643641560"/>
+          <entry name="_link" md5="12ee49e6fd3e9e8f50dc7448ef7a22e2" size="141" mtime="1643641560"/>
+          <entry name="somefile.txt" md5="fadb4526ed5cf9cba7debe2f979899c4" size="58" mtime="1643641560"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:51 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:01 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '627'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="ea0af5b06c5e48370fbbaa9a2a3422ba" vrev="118" srcmd5="ea0af5b06c5e48370fbbaa9a2a3422ba">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="ce460f02f52f8546a51bf0d9f2195d55" baserev="ce460f02f52f8546a51bf0d9f2195d55" lsrcmd5="c697592b5df09b28d58266451af1da7e"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="47fbdce3b05832bd46373248a810017b" size="65" mtime="1643641560"/>
+          <entry name="somefile.txt" md5="fadb4526ed5cf9cba7debe2f979899c4" size="58" mtime="1643641560"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:06:01 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -991,19 +1094,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="118" vrev="118" srcmd5="846980b78ff943ac18504334d92851dc">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3fbf6327d132f3f6d82c1180b0a158c3" baserev="3fbf6327d132f3f6d82c1180b0a158c3" xsrcmd5="6d5bb5b7602960d8605af84b60ffcaf8" lsrcmd5="846980b78ff943ac18504334d92851dc"/>
-          <serviceinfo code="succeeded" xsrcmd5="55ed88b4b5f4bd8bdf0c994e77967573"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="2296c244c8ce457c66222300f4415b59" size="59" mtime="1642674770"/>
-          <entry name="_link" md5="8a42bc9f110bfeb585300510c19b7346" size="141" mtime="1642674770"/>
-          <entry name="somefile.txt" md5="aa5c7a5c2a0f61b4718fa6fae5d66303" size="48" mtime="1642674770"/>
+        <directory name="bar_package-123456789" rev="24" vrev="24" srcmd5="c697592b5df09b28d58266451af1da7e">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="ce460f02f52f8546a51bf0d9f2195d55" baserev="ce460f02f52f8546a51bf0d9f2195d55" xsrcmd5="ea0af5b06c5e48370fbbaa9a2a3422ba" lsrcmd5="c697592b5df09b28d58266451af1da7e"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="47fbdce3b05832bd46373248a810017b" size="65" mtime="1643641560"/>
+          <entry name="_link" md5="12ee49e6fd3e9e8f50dc7448ef7a22e2" size="141" mtime="1643641560"/>
+          <entry name="somefile.txt" md5="fadb4526ed5cf9cba7debe2f979899c4" size="58" mtime="1643641560"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:51 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:01 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '627'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="ea0af5b06c5e48370fbbaa9a2a3422ba" vrev="118" srcmd5="ea0af5b06c5e48370fbbaa9a2a3422ba">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="ce460f02f52f8546a51bf0d9f2195d55" baserev="ce460f02f52f8546a51bf0d9f2195d55" lsrcmd5="c697592b5df09b28d58266451af1da7e"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="47fbdce3b05832bd46373248a810017b" size="65" mtime="1643641560"/>
+          <entry name="somefile.txt" md5="fadb4526ed5cf9cba7debe2f979899c4" size="58" mtime="1643641560"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:06:01 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -1029,22 +1167,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="118" vrev="118" srcmd5="846980b78ff943ac18504334d92851dc">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3fbf6327d132f3f6d82c1180b0a158c3" baserev="3fbf6327d132f3f6d82c1180b0a158c3" xsrcmd5="6d5bb5b7602960d8605af84b60ffcaf8" lsrcmd5="846980b78ff943ac18504334d92851dc"/>
-          <serviceinfo code="succeeded" xsrcmd5="55ed88b4b5f4bd8bdf0c994e77967573"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="2296c244c8ce457c66222300f4415b59" size="59" mtime="1642674770"/>
-          <entry name="_link" md5="8a42bc9f110bfeb585300510c19b7346" size="141" mtime="1642674770"/>
-          <entry name="somefile.txt" md5="aa5c7a5c2a0f61b4718fa6fae5d66303" size="48" mtime="1642674770"/>
+        <directory name="bar_package-123456789" rev="24" vrev="24" srcmd5="c697592b5df09b28d58266451af1da7e">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="ce460f02f52f8546a51bf0d9f2195d55" baserev="ce460f02f52f8546a51bf0d9f2195d55" xsrcmd5="ea0af5b06c5e48370fbbaa9a2a3422ba" lsrcmd5="c697592b5df09b28d58266451af1da7e"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="47fbdce3b05832bd46373248a810017b" size="65" mtime="1643641560"/>
+          <entry name="_link" md5="12ee49e6fd3e9e8f50dc7448ef7a22e2" size="141" mtime="1643641560"/>
+          <entry name="somefile.txt" md5="fadb4526ed5cf9cba7debe2f979899c4" size="58" mtime="1643641560"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:51 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:01 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1067,171 +1204,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '627'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="118" vrev="118" srcmd5="846980b78ff943ac18504334d92851dc">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3fbf6327d132f3f6d82c1180b0a158c3" baserev="3fbf6327d132f3f6d82c1180b0a158c3" xsrcmd5="6d5bb5b7602960d8605af84b60ffcaf8" lsrcmd5="846980b78ff943ac18504334d92851dc"/>
-          <serviceinfo code="succeeded" xsrcmd5="55ed88b4b5f4bd8bdf0c994e77967573"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="2296c244c8ce457c66222300f4415b59" size="59" mtime="1642674770"/>
-          <entry name="_link" md5="8a42bc9f110bfeb585300510c19b7346" size="141" mtime="1642674770"/>
-          <entry name="somefile.txt" md5="aa5c7a5c2a0f61b4718fa6fae5d66303" size="48" mtime="1642674770"/>
+        <directory name="bar_package-123456789" rev="ea0af5b06c5e48370fbbaa9a2a3422ba" vrev="118" srcmd5="ea0af5b06c5e48370fbbaa9a2a3422ba">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="ce460f02f52f8546a51bf0d9f2195d55" baserev="ce460f02f52f8546a51bf0d9f2195d55" lsrcmd5="c697592b5df09b28d58266451af1da7e"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="47fbdce3b05832bd46373248a810017b" size="65" mtime="1643641560"/>
+          <entry name="somefile.txt" md5="fadb4526ed5cf9cba7debe2f979899c4" size="58" mtime="1643641560"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:51 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '811'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="118" vrev="118" srcmd5="846980b78ff943ac18504334d92851dc">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3fbf6327d132f3f6d82c1180b0a158c3" baserev="3fbf6327d132f3f6d82c1180b0a158c3" xsrcmd5="6d5bb5b7602960d8605af84b60ffcaf8" lsrcmd5="846980b78ff943ac18504334d92851dc"/>
-          <serviceinfo code="succeeded" xsrcmd5="55ed88b4b5f4bd8bdf0c994e77967573"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="2296c244c8ce457c66222300f4415b59" size="59" mtime="1642674770"/>
-          <entry name="_link" md5="8a42bc9f110bfeb585300510c19b7346" size="141" mtime="1642674770"/>
-          <entry name="somefile.txt" md5="aa5c7a5c2a0f61b4718fa6fae5d66303" size="48" mtime="1642674770"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:51 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '811'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="118" vrev="118" srcmd5="846980b78ff943ac18504334d92851dc">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3fbf6327d132f3f6d82c1180b0a158c3" baserev="3fbf6327d132f3f6d82c1180b0a158c3" xsrcmd5="6d5bb5b7602960d8605af84b60ffcaf8" lsrcmd5="846980b78ff943ac18504334d92851dc"/>
-          <serviceinfo code="succeeded" xsrcmd5="55ed88b4b5f4bd8bdf0c994e77967573"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="2296c244c8ce457c66222300f4415b59" size="59" mtime="1642674770"/>
-          <entry name="_link" md5="8a42bc9f110bfeb585300510c19b7346" size="141" mtime="1642674770"/>
-          <entry name="somefile.txt" md5="aa5c7a5c2a0f61b4718fa6fae5d66303" size="48" mtime="1642674770"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:51 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '811'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="118" vrev="118" srcmd5="846980b78ff943ac18504334d92851dc">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3fbf6327d132f3f6d82c1180b0a158c3" baserev="3fbf6327d132f3f6d82c1180b0a158c3" xsrcmd5="6d5bb5b7602960d8605af84b60ffcaf8" lsrcmd5="846980b78ff943ac18504334d92851dc"/>
-          <serviceinfo code="succeeded" xsrcmd5="55ed88b4b5f4bd8bdf0c994e77967573"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="2296c244c8ce457c66222300f4415b59" size="59" mtime="1642674770"/>
-          <entry name="_link" md5="8a42bc9f110bfeb585300510c19b7346" size="141" mtime="1642674770"/>
-          <entry name="somefile.txt" md5="aa5c7a5c2a0f61b4718fa6fae5d66303" size="48" mtime="1642674770"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:51 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '811'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="118" vrev="118" srcmd5="846980b78ff943ac18504334d92851dc">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3fbf6327d132f3f6d82c1180b0a158c3" baserev="3fbf6327d132f3f6d82c1180b0a158c3" xsrcmd5="6d5bb5b7602960d8605af84b60ffcaf8" lsrcmd5="846980b78ff943ac18504334d92851dc"/>
-          <serviceinfo code="succeeded" xsrcmd5="55ed88b4b5f4bd8bdf0c994e77967573"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="2296c244c8ce457c66222300f4415b59" size="59" mtime="1642674770"/>
-          <entry name="_link" md5="8a42bc9f110bfeb585300510c19b7346" size="141" mtime="1642674770"/>
-          <entry name="somefile.txt" md5="aa5c7a5c2a0f61b4718fa6fae5d66303" size="48" mtime="1642674770"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:51 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:01 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_branch_request
@@ -1261,5 +1244,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"action":"opened","pull_request":{"head":{"repo":{"full_name":"reponame"},"sha":"123456789"}}}'
-  recorded_at: Thu, 20 Jan 2022 10:32:51 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:01 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/with_a_push_event_for_a_commit/behaves_like_successful_new_PR_or_MR_event/1_1_1_6_1_4.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/with_a_push_event_for_a_commit/behaves_like_successful_new_PR_or_MR_event/1_1_1_6_1_4.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:47 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:57 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_292
+    uri: http://backend:5352/source/foo_project/_meta?user=user_81
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>An Acceptable Time</title>
+          <title>The Painted Veil</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '150'
+      - '148'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>An Acceptable Time</title>
+          <title>The Painted Veil</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:47 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:57 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_293
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_82
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Behold the Man</title>
-          <description>Non ut eveniet omnis.</description>
+          <title>Dulce et Decorum Est</title>
+          <description>Minus quia nobis quidem.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '145'
+      - '154'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Behold the Man</title>
-          <description>Non ut eveniet omnis.</description>
+          <title>Dulce et Decorum Est</title>
+          <description>Minus quia nobis quidem.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:47 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:57 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Id beatae aperiam. Est sunt distinctio. Vitae reprehenderit quibusdam.
+      string: Animi laborum exercitationem. Ipsam sapiente et. Minus alias excepturi.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1679" vrev="1679">
-          <srcmd5>4f3d32e2d4fa1dbfa5a06171064a1a5e</srcmd5>
+        <revision rev="89" vrev="89">
+          <srcmd5>4f513dba257750f604e2fb999588f0af</srcmd5>
           <version>unknown</version>
-          <time>1642674767</time>
+          <time>1643641557</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:47 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:57 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Exercitationem eius sed. Aliquam quos qui. Veniam dolorem qui.
+      string: Provident ex ea. Eum veniam officia. Sunt qui eum.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +181,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1680" vrev="1680">
-          <srcmd5>45719e25acd10e8432226971b16eff09</srcmd5>
+        <revision rev="90" vrev="90">
+          <srcmd5>a1588369a3b2271d76be1a4a50ab53d6</srcmd5>
           <version>unknown</version>
-          <time>1642674767</time>
+          <time>1643641557</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:47 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:57 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -227,7 +227,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:32:47 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:58 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_meta?user=Iggy
@@ -235,8 +235,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>Behold the Man</title>
-          <description>Non ut eveniet omnis.</description>
+          <title>Dulce et Decorum Est</title>
+          <description>Minus quia nobis quidem.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -257,15 +257,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '153'
+      - '162'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>Behold the Man</title>
-          <description>Non ut eveniet omnis.</description>
+          <title>Dulce et Decorum Est</title>
+          <description>Minus quia nobis quidem.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:47 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:58 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=branch&noservice=1&opackage=bar_package&oproject=foo_project&user=Iggy
@@ -293,19 +293,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="111" vrev="111">
-          <srcmd5>dfc4885b31b064ff1bdb4f356769b4b4</srcmd5>
+        <revision rev="19" vrev="19">
+          <srcmd5>fc1b0172eb3ce3f4a31e61ba763f4cc6</srcmd5>
           <version>unknown</version>
-          <time>1642674767</time>
+          <time>1643641558</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:47 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:58 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_meta?user=Iggy
@@ -313,8 +313,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>Behold the Man</title>
-          <description>Non ut eveniet omnis.</description>
+          <title>Dulce et Decorum Est</title>
+          <description>Minus quia nobis quidem.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -335,15 +335,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '153'
+      - '162'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>Behold the Man</title>
-          <description>Non ut eveniet omnis.</description>
+          <title>Dulce et Decorum Est</title>
+          <description>Minus quia nobis quidem.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:47 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:58 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -369,18 +369,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '735'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="111" vrev="111" srcmd5="dfc4885b31b064ff1bdb4f356769b4b4">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="45719e25acd10e8432226971b16eff09" baserev="45719e25acd10e8432226971b16eff09" xsrcmd5="12926d2ef7e930f33253032b7b27d7aa" lsrcmd5="dfc4885b31b064ff1bdb4f356769b4b4"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="590f86a72623c054371d9a885cc40a94" size="70" mtime="1642674767"/>
-          <entry name="_link" md5="9e4834436549068499458a8614249ab5" size="141" mtime="1642674767"/>
-          <entry name="somefile.txt" md5="06682d28c4b1ab31a0f24268c5d03f46" size="62" mtime="1642674767"/>
+        <directory name="bar_package-123456789" rev="19" vrev="19" srcmd5="fc1b0172eb3ce3f4a31e61ba763f4cc6">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="a1588369a3b2271d76be1a4a50ab53d6" baserev="a1588369a3b2271d76be1a4a50ab53d6" xsrcmd5="c7ced3670cb04a03f0d32025836baa81" lsrcmd5="fc1b0172eb3ce3f4a31e61ba763f4cc6"/>
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="d419a907fd5f15676c97af8de754d1c3" size="71" mtime="1643641557"/>
+          <entry name="_link" md5="23d404da83d83658686f73d15353d78e" size="141" mtime="1643641558"/>
+          <entry name="somefile.txt" md5="4c07dfaa41adfe37c823efbb14961ff1" size="50" mtime="1643641557"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:47 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:58 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?view=info
@@ -406,15 +406,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '343'
+      - '341'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package-123456789" rev="111" vrev="1791" srcmd5="12926d2ef7e930f33253032b7b27d7aa" lsrcmd5="dfc4885b31b064ff1bdb4f356769b4b4" verifymd5="45719e25acd10e8432226971b16eff09">
+        <sourceinfo package="bar_package-123456789" rev="19" vrev="109" srcmd5="c7ced3670cb04a03f0d32025836baa81" lsrcmd5="fc1b0172eb3ce3f4a31e61ba763f4cc6" verifymd5="a1588369a3b2271d76be1a4a50ab53d6">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:47 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:58 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -440,18 +440,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '735'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="111" vrev="111" srcmd5="dfc4885b31b064ff1bdb4f356769b4b4">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="45719e25acd10e8432226971b16eff09" baserev="45719e25acd10e8432226971b16eff09" xsrcmd5="12926d2ef7e930f33253032b7b27d7aa" lsrcmd5="dfc4885b31b064ff1bdb4f356769b4b4"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="590f86a72623c054371d9a885cc40a94" size="70" mtime="1642674767"/>
-          <entry name="_link" md5="9e4834436549068499458a8614249ab5" size="141" mtime="1642674767"/>
-          <entry name="somefile.txt" md5="06682d28c4b1ab31a0f24268c5d03f46" size="62" mtime="1642674767"/>
+        <directory name="bar_package-123456789" rev="19" vrev="19" srcmd5="fc1b0172eb3ce3f4a31e61ba763f4cc6">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="a1588369a3b2271d76be1a4a50ab53d6" baserev="a1588369a3b2271d76be1a4a50ab53d6" xsrcmd5="c7ced3670cb04a03f0d32025836baa81" lsrcmd5="fc1b0172eb3ce3f4a31e61ba763f4cc6"/>
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="d419a907fd5f15676c97af8de754d1c3" size="71" mtime="1643641557"/>
+          <entry name="_link" md5="23d404da83d83658686f73d15353d78e" size="141" mtime="1643641558"/>
+          <entry name="somefile.txt" md5="4c07dfaa41adfe37c823efbb14961ff1" size="50" mtime="1643641557"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:47 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:58 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -479,18 +479,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '324'
+      - '323'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="33afc1eada34e9a31578ae55579deb99">
+        <sourcediff key="641b376186b2320318c2032f798378fe">
           <old project="home:Iggy" package="bar_package-123456789" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="111" srcmd5="dfc4885b31b064ff1bdb4f356769b4b4"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="19" srcmd5="fc1b0172eb3ce3f4a31e61ba763f4cc6"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:47 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:58 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -522,14 +522,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="8288f5010d75e1b2c278d02da98cea98">
-          <old project="foo_project" package="bar_package" rev="45719e25acd10e8432226971b16eff09" srcmd5="45719e25acd10e8432226971b16eff09"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="12926d2ef7e930f33253032b7b27d7aa" srcmd5="12926d2ef7e930f33253032b7b27d7aa"/>
+        <sourcediff key="f2c439b01ba7f2dbcfab393faa2e203e">
+          <old project="foo_project" package="bar_package" rev="a1588369a3b2271d76be1a4a50ab53d6" srcmd5="a1588369a3b2271d76be1a4a50ab53d6"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="c7ced3670cb04a03f0d32025836baa81" srcmd5="c7ced3670cb04a03f0d32025836baa81"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:47 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:58 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/_meta?user=Iggy
@@ -587,7 +587,7 @@ http_interactions:
             <arch>aarch64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:47 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:58 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_branch_request?user=Iggy
@@ -613,19 +613,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="112" vrev="112">
-          <srcmd5>12e6175e517d1c8895af9a0c8f5c14f2</srcmd5>
+        <revision rev="20" vrev="20">
+          <srcmd5>f4f1d703dd1a9015df95b723fcfced76</srcmd5>
           <version>unknown</version>
-          <time>1642674767</time>
+          <time>1643641558</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:48 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:58 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_meta?user=Iggy
@@ -633,8 +633,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>Behold the Man</title>
-          <description>Non ut eveniet omnis.</description>
+          <title>Dulce et Decorum Est</title>
+          <description>Minus quia nobis quidem.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -655,15 +655,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '153'
+      - '162'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>Behold the Man</title>
-          <description>Non ut eveniet omnis.</description>
+          <title>Dulce et Decorum Est</title>
+          <description>Minus quia nobis quidem.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:48 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:58 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -689,19 +689,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="112" vrev="112" srcmd5="12e6175e517d1c8895af9a0c8f5c14f2">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="45719e25acd10e8432226971b16eff09" baserev="45719e25acd10e8432226971b16eff09" xsrcmd5="f60bc27cb6ce989e22401f8c555b8e1e" lsrcmd5="12e6175e517d1c8895af9a0c8f5c14f2"/>
-          <serviceinfo code="succeeded" xsrcmd5="906903c573d5f4f8c5e7086a053a0576"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="590f86a72623c054371d9a885cc40a94" size="70" mtime="1642674767"/>
-          <entry name="_link" md5="9e4834436549068499458a8614249ab5" size="141" mtime="1642674767"/>
-          <entry name="somefile.txt" md5="06682d28c4b1ab31a0f24268c5d03f46" size="62" mtime="1642674767"/>
+        <directory name="bar_package-123456789" rev="20" vrev="20" srcmd5="f4f1d703dd1a9015df95b723fcfced76">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="a1588369a3b2271d76be1a4a50ab53d6" baserev="a1588369a3b2271d76be1a4a50ab53d6" xsrcmd5="31c3649f1abc652efde7b03daa93258c" lsrcmd5="f4f1d703dd1a9015df95b723fcfced76"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="d419a907fd5f15676c97af8de754d1c3" size="71" mtime="1643641557"/>
+          <entry name="_link" md5="23d404da83d83658686f73d15353d78e" size="141" mtime="1643641558"/>
+          <entry name="somefile.txt" md5="4c07dfaa41adfe37c823efbb14961ff1" size="50" mtime="1643641557"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:48 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:58 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?view=info
@@ -727,15 +726,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '343'
+      - '341'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package-123456789" rev="112" vrev="1792" srcmd5="653dd426e58f94b13c8300d1dbb50acb" lsrcmd5="906903c573d5f4f8c5e7086a053a0576" verifymd5="09ca183671efb82b829efab614a8ee48">
+        <sourceinfo package="bar_package-123456789" rev="20" vrev="110" srcmd5="31c3649f1abc652efde7b03daa93258c" lsrcmd5="f4f1d703dd1a9015df95b723fcfced76" verifymd5="b79f9e78f4056258de824d253d3a6ea1">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:48 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:58 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -761,19 +760,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="112" vrev="112" srcmd5="12e6175e517d1c8895af9a0c8f5c14f2">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="45719e25acd10e8432226971b16eff09" baserev="45719e25acd10e8432226971b16eff09" xsrcmd5="f60bc27cb6ce989e22401f8c555b8e1e" lsrcmd5="12e6175e517d1c8895af9a0c8f5c14f2"/>
-          <serviceinfo code="succeeded" xsrcmd5="906903c573d5f4f8c5e7086a053a0576"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="590f86a72623c054371d9a885cc40a94" size="70" mtime="1642674767"/>
-          <entry name="_link" md5="9e4834436549068499458a8614249ab5" size="141" mtime="1642674767"/>
-          <entry name="somefile.txt" md5="06682d28c4b1ab31a0f24268c5d03f46" size="62" mtime="1642674767"/>
+        <directory name="bar_package-123456789" rev="20" vrev="20" srcmd5="f4f1d703dd1a9015df95b723fcfced76">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="a1588369a3b2271d76be1a4a50ab53d6" baserev="a1588369a3b2271d76be1a4a50ab53d6" xsrcmd5="31c3649f1abc652efde7b03daa93258c" lsrcmd5="f4f1d703dd1a9015df95b723fcfced76"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="d419a907fd5f15676c97af8de754d1c3" size="71" mtime="1643641557"/>
+          <entry name="_link" md5="23d404da83d83658686f73d15353d78e" size="141" mtime="1643641558"/>
+          <entry name="somefile.txt" md5="4c07dfaa41adfe37c823efbb14961ff1" size="50" mtime="1643641557"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:48 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:58 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -801,18 +799,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '324'
+      - '323'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="07d83bbe6bef649f3581ae3cce1372cc">
+        <sourcediff key="7f1dc91ebdd9934c05cd190a864f4843">
           <old project="home:Iggy" package="bar_package-123456789" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="112" srcmd5="12e6175e517d1c8895af9a0c8f5c14f2"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="20" srcmd5="f4f1d703dd1a9015df95b723fcfced76"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:48 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:58 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -844,14 +842,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="d29cd1b0cd4d592b033834fda5c30ea9">
-          <old project="foo_project" package="bar_package" rev="45719e25acd10e8432226971b16eff09" srcmd5="45719e25acd10e8432226971b16eff09"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="653dd426e58f94b13c8300d1dbb50acb" srcmd5="653dd426e58f94b13c8300d1dbb50acb"/>
+        <sourcediff key="65d39866bb1db11995db7c785b5f6966">
+          <old project="foo_project" package="bar_package" rev="a1588369a3b2271d76be1a4a50ab53d6" srcmd5="a1588369a3b2271d76be1a4a50ab53d6"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="31c3649f1abc652efde7b03daa93258c" srcmd5="31c3649f1abc652efde7b03daa93258c"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:48 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:58 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -877,19 +875,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="112" vrev="112" srcmd5="12e6175e517d1c8895af9a0c8f5c14f2">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="45719e25acd10e8432226971b16eff09" baserev="45719e25acd10e8432226971b16eff09" xsrcmd5="f60bc27cb6ce989e22401f8c555b8e1e" lsrcmd5="12e6175e517d1c8895af9a0c8f5c14f2"/>
-          <serviceinfo code="succeeded" xsrcmd5="906903c573d5f4f8c5e7086a053a0576"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="590f86a72623c054371d9a885cc40a94" size="70" mtime="1642674767"/>
-          <entry name="_link" md5="9e4834436549068499458a8614249ab5" size="141" mtime="1642674767"/>
-          <entry name="somefile.txt" md5="06682d28c4b1ab31a0f24268c5d03f46" size="62" mtime="1642674767"/>
+        <directory name="bar_package-123456789" rev="20" vrev="20" srcmd5="f4f1d703dd1a9015df95b723fcfced76">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="a1588369a3b2271d76be1a4a50ab53d6" baserev="a1588369a3b2271d76be1a4a50ab53d6" xsrcmd5="31c3649f1abc652efde7b03daa93258c" lsrcmd5="f4f1d703dd1a9015df95b723fcfced76"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="d419a907fd5f15676c97af8de754d1c3" size="71" mtime="1643641557"/>
+          <entry name="_link" md5="23d404da83d83658686f73d15353d78e" size="141" mtime="1643641558"/>
+          <entry name="somefile.txt" md5="4c07dfaa41adfe37c823efbb14961ff1" size="50" mtime="1643641557"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:48 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:58 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '627'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="31c3649f1abc652efde7b03daa93258c" vrev="110" srcmd5="31c3649f1abc652efde7b03daa93258c">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="a1588369a3b2271d76be1a4a50ab53d6" baserev="a1588369a3b2271d76be1a4a50ab53d6" lsrcmd5="f4f1d703dd1a9015df95b723fcfced76"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="d419a907fd5f15676c97af8de754d1c3" size="71" mtime="1643641557"/>
+          <entry name="somefile.txt" md5="4c07dfaa41adfe37c823efbb14961ff1" size="50" mtime="1643641557"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:05:58 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -915,19 +948,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="112" vrev="112" srcmd5="12e6175e517d1c8895af9a0c8f5c14f2">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="45719e25acd10e8432226971b16eff09" baserev="45719e25acd10e8432226971b16eff09" xsrcmd5="f60bc27cb6ce989e22401f8c555b8e1e" lsrcmd5="12e6175e517d1c8895af9a0c8f5c14f2"/>
-          <serviceinfo code="succeeded" xsrcmd5="906903c573d5f4f8c5e7086a053a0576"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="590f86a72623c054371d9a885cc40a94" size="70" mtime="1642674767"/>
-          <entry name="_link" md5="9e4834436549068499458a8614249ab5" size="141" mtime="1642674767"/>
-          <entry name="somefile.txt" md5="06682d28c4b1ab31a0f24268c5d03f46" size="62" mtime="1642674767"/>
+        <directory name="bar_package-123456789" rev="20" vrev="20" srcmd5="f4f1d703dd1a9015df95b723fcfced76">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="a1588369a3b2271d76be1a4a50ab53d6" baserev="a1588369a3b2271d76be1a4a50ab53d6" xsrcmd5="31c3649f1abc652efde7b03daa93258c" lsrcmd5="f4f1d703dd1a9015df95b723fcfced76"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="d419a907fd5f15676c97af8de754d1c3" size="71" mtime="1643641557"/>
+          <entry name="_link" md5="23d404da83d83658686f73d15353d78e" size="141" mtime="1643641558"/>
+          <entry name="somefile.txt" md5="4c07dfaa41adfe37c823efbb14961ff1" size="50" mtime="1643641557"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:48 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:58 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '627'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="31c3649f1abc652efde7b03daa93258c" vrev="110" srcmd5="31c3649f1abc652efde7b03daa93258c">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="a1588369a3b2271d76be1a4a50ab53d6" baserev="a1588369a3b2271d76be1a4a50ab53d6" lsrcmd5="f4f1d703dd1a9015df95b723fcfced76"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="d419a907fd5f15676c97af8de754d1c3" size="71" mtime="1643641557"/>
+          <entry name="somefile.txt" md5="4c07dfaa41adfe37c823efbb14961ff1" size="50" mtime="1643641557"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:05:58 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -953,19 +1021,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="112" vrev="112" srcmd5="12e6175e517d1c8895af9a0c8f5c14f2">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="45719e25acd10e8432226971b16eff09" baserev="45719e25acd10e8432226971b16eff09" xsrcmd5="f60bc27cb6ce989e22401f8c555b8e1e" lsrcmd5="12e6175e517d1c8895af9a0c8f5c14f2"/>
-          <serviceinfo code="succeeded" xsrcmd5="906903c573d5f4f8c5e7086a053a0576"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="590f86a72623c054371d9a885cc40a94" size="70" mtime="1642674767"/>
-          <entry name="_link" md5="9e4834436549068499458a8614249ab5" size="141" mtime="1642674767"/>
-          <entry name="somefile.txt" md5="06682d28c4b1ab31a0f24268c5d03f46" size="62" mtime="1642674767"/>
+        <directory name="bar_package-123456789" rev="20" vrev="20" srcmd5="f4f1d703dd1a9015df95b723fcfced76">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="a1588369a3b2271d76be1a4a50ab53d6" baserev="a1588369a3b2271d76be1a4a50ab53d6" xsrcmd5="31c3649f1abc652efde7b03daa93258c" lsrcmd5="f4f1d703dd1a9015df95b723fcfced76"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="d419a907fd5f15676c97af8de754d1c3" size="71" mtime="1643641557"/>
+          <entry name="_link" md5="23d404da83d83658686f73d15353d78e" size="141" mtime="1643641558"/>
+          <entry name="somefile.txt" md5="4c07dfaa41adfe37c823efbb14961ff1" size="50" mtime="1643641557"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:48 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:58 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '627'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="31c3649f1abc652efde7b03daa93258c" vrev="110" srcmd5="31c3649f1abc652efde7b03daa93258c">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="a1588369a3b2271d76be1a4a50ab53d6" baserev="a1588369a3b2271d76be1a4a50ab53d6" lsrcmd5="f4f1d703dd1a9015df95b723fcfced76"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="d419a907fd5f15676c97af8de754d1c3" size="71" mtime="1643641557"/>
+          <entry name="somefile.txt" md5="4c07dfaa41adfe37c823efbb14961ff1" size="50" mtime="1643641557"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:05:58 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -991,19 +1094,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="112" vrev="112" srcmd5="12e6175e517d1c8895af9a0c8f5c14f2">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="45719e25acd10e8432226971b16eff09" baserev="45719e25acd10e8432226971b16eff09" xsrcmd5="f60bc27cb6ce989e22401f8c555b8e1e" lsrcmd5="12e6175e517d1c8895af9a0c8f5c14f2"/>
-          <serviceinfo code="succeeded" xsrcmd5="906903c573d5f4f8c5e7086a053a0576"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="590f86a72623c054371d9a885cc40a94" size="70" mtime="1642674767"/>
-          <entry name="_link" md5="9e4834436549068499458a8614249ab5" size="141" mtime="1642674767"/>
-          <entry name="somefile.txt" md5="06682d28c4b1ab31a0f24268c5d03f46" size="62" mtime="1642674767"/>
+        <directory name="bar_package-123456789" rev="20" vrev="20" srcmd5="f4f1d703dd1a9015df95b723fcfced76">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="a1588369a3b2271d76be1a4a50ab53d6" baserev="a1588369a3b2271d76be1a4a50ab53d6" xsrcmd5="31c3649f1abc652efde7b03daa93258c" lsrcmd5="f4f1d703dd1a9015df95b723fcfced76"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="d419a907fd5f15676c97af8de754d1c3" size="71" mtime="1643641557"/>
+          <entry name="_link" md5="23d404da83d83658686f73d15353d78e" size="141" mtime="1643641558"/>
+          <entry name="somefile.txt" md5="4c07dfaa41adfe37c823efbb14961ff1" size="50" mtime="1643641557"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:48 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:58 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '627'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="31c3649f1abc652efde7b03daa93258c" vrev="110" srcmd5="31c3649f1abc652efde7b03daa93258c">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="a1588369a3b2271d76be1a4a50ab53d6" baserev="a1588369a3b2271d76be1a4a50ab53d6" lsrcmd5="f4f1d703dd1a9015df95b723fcfced76"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="d419a907fd5f15676c97af8de754d1c3" size="71" mtime="1643641557"/>
+          <entry name="somefile.txt" md5="4c07dfaa41adfe37c823efbb14961ff1" size="50" mtime="1643641557"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:05:58 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -1029,22 +1167,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="112" vrev="112" srcmd5="12e6175e517d1c8895af9a0c8f5c14f2">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="45719e25acd10e8432226971b16eff09" baserev="45719e25acd10e8432226971b16eff09" xsrcmd5="f60bc27cb6ce989e22401f8c555b8e1e" lsrcmd5="12e6175e517d1c8895af9a0c8f5c14f2"/>
-          <serviceinfo code="succeeded" xsrcmd5="906903c573d5f4f8c5e7086a053a0576"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="590f86a72623c054371d9a885cc40a94" size="70" mtime="1642674767"/>
-          <entry name="_link" md5="9e4834436549068499458a8614249ab5" size="141" mtime="1642674767"/>
-          <entry name="somefile.txt" md5="06682d28c4b1ab31a0f24268c5d03f46" size="62" mtime="1642674767"/>
+        <directory name="bar_package-123456789" rev="20" vrev="20" srcmd5="f4f1d703dd1a9015df95b723fcfced76">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="a1588369a3b2271d76be1a4a50ab53d6" baserev="a1588369a3b2271d76be1a4a50ab53d6" xsrcmd5="31c3649f1abc652efde7b03daa93258c" lsrcmd5="f4f1d703dd1a9015df95b723fcfced76"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="d419a907fd5f15676c97af8de754d1c3" size="71" mtime="1643641557"/>
+          <entry name="_link" md5="23d404da83d83658686f73d15353d78e" size="141" mtime="1643641558"/>
+          <entry name="somefile.txt" md5="4c07dfaa41adfe37c823efbb14961ff1" size="50" mtime="1643641557"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:48 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:58 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1067,171 +1204,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '627'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="112" vrev="112" srcmd5="12e6175e517d1c8895af9a0c8f5c14f2">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="45719e25acd10e8432226971b16eff09" baserev="45719e25acd10e8432226971b16eff09" xsrcmd5="f60bc27cb6ce989e22401f8c555b8e1e" lsrcmd5="12e6175e517d1c8895af9a0c8f5c14f2"/>
-          <serviceinfo code="succeeded" xsrcmd5="906903c573d5f4f8c5e7086a053a0576"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="590f86a72623c054371d9a885cc40a94" size="70" mtime="1642674767"/>
-          <entry name="_link" md5="9e4834436549068499458a8614249ab5" size="141" mtime="1642674767"/>
-          <entry name="somefile.txt" md5="06682d28c4b1ab31a0f24268c5d03f46" size="62" mtime="1642674767"/>
+        <directory name="bar_package-123456789" rev="31c3649f1abc652efde7b03daa93258c" vrev="110" srcmd5="31c3649f1abc652efde7b03daa93258c">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="a1588369a3b2271d76be1a4a50ab53d6" baserev="a1588369a3b2271d76be1a4a50ab53d6" lsrcmd5="f4f1d703dd1a9015df95b723fcfced76"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="d419a907fd5f15676c97af8de754d1c3" size="71" mtime="1643641557"/>
+          <entry name="somefile.txt" md5="4c07dfaa41adfe37c823efbb14961ff1" size="50" mtime="1643641557"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:48 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '811'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="112" vrev="112" srcmd5="12e6175e517d1c8895af9a0c8f5c14f2">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="45719e25acd10e8432226971b16eff09" baserev="45719e25acd10e8432226971b16eff09" xsrcmd5="f60bc27cb6ce989e22401f8c555b8e1e" lsrcmd5="12e6175e517d1c8895af9a0c8f5c14f2"/>
-          <serviceinfo code="succeeded" xsrcmd5="906903c573d5f4f8c5e7086a053a0576"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="590f86a72623c054371d9a885cc40a94" size="70" mtime="1642674767"/>
-          <entry name="_link" md5="9e4834436549068499458a8614249ab5" size="141" mtime="1642674767"/>
-          <entry name="somefile.txt" md5="06682d28c4b1ab31a0f24268c5d03f46" size="62" mtime="1642674767"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:48 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '811'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="112" vrev="112" srcmd5="12e6175e517d1c8895af9a0c8f5c14f2">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="45719e25acd10e8432226971b16eff09" baserev="45719e25acd10e8432226971b16eff09" xsrcmd5="f60bc27cb6ce989e22401f8c555b8e1e" lsrcmd5="12e6175e517d1c8895af9a0c8f5c14f2"/>
-          <serviceinfo code="succeeded" xsrcmd5="906903c573d5f4f8c5e7086a053a0576"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="590f86a72623c054371d9a885cc40a94" size="70" mtime="1642674767"/>
-          <entry name="_link" md5="9e4834436549068499458a8614249ab5" size="141" mtime="1642674767"/>
-          <entry name="somefile.txt" md5="06682d28c4b1ab31a0f24268c5d03f46" size="62" mtime="1642674767"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:48 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '811'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="112" vrev="112" srcmd5="12e6175e517d1c8895af9a0c8f5c14f2">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="45719e25acd10e8432226971b16eff09" baserev="45719e25acd10e8432226971b16eff09" xsrcmd5="f60bc27cb6ce989e22401f8c555b8e1e" lsrcmd5="12e6175e517d1c8895af9a0c8f5c14f2"/>
-          <serviceinfo code="succeeded" xsrcmd5="906903c573d5f4f8c5e7086a053a0576"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="590f86a72623c054371d9a885cc40a94" size="70" mtime="1642674767"/>
-          <entry name="_link" md5="9e4834436549068499458a8614249ab5" size="141" mtime="1642674767"/>
-          <entry name="somefile.txt" md5="06682d28c4b1ab31a0f24268c5d03f46" size="62" mtime="1642674767"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:48 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '811'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="112" vrev="112" srcmd5="12e6175e517d1c8895af9a0c8f5c14f2">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="45719e25acd10e8432226971b16eff09" baserev="45719e25acd10e8432226971b16eff09" xsrcmd5="f60bc27cb6ce989e22401f8c555b8e1e" lsrcmd5="12e6175e517d1c8895af9a0c8f5c14f2"/>
-          <serviceinfo code="succeeded" xsrcmd5="906903c573d5f4f8c5e7086a053a0576"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="590f86a72623c054371d9a885cc40a94" size="70" mtime="1642674767"/>
-          <entry name="_link" md5="9e4834436549068499458a8614249ab5" size="141" mtime="1642674767"/>
-          <entry name="somefile.txt" md5="06682d28c4b1ab31a0f24268c5d03f46" size="62" mtime="1642674767"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:48 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:58 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_branch_request
@@ -1261,5 +1244,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"action":"opened","pull_request":{"head":{"repo":{"full_name":"reponame"},"sha":"123456789"}}}'
-  recorded_at: Thu, 20 Jan 2022 10:32:48 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:58 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/with_a_push_event_for_a_commit/behaves_like_successful_new_PR_or_MR_event/1_1_1_6_1_5.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/with_a_push_event_for_a_commit/behaves_like_successful_new_PR_or_MR_event/1_1_1_6_1_5.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:52 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:01 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_302
+    uri: http://backend:5352/source/foo_project/_meta?user=user_87
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>In Death Ground</title>
+          <title>If I Forget Thee Jerusalem</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '147'
+      - '158'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>In Death Ground</title>
+          <title>If I Forget Thee Jerusalem</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:52 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:01 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_303
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_88
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Moving Toyshop</title>
-          <description>Aut dolores dolores voluptas.</description>
+          <title>Ring of Bright Water</title>
+          <description>Sit qui eligendi amet.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '157'
+      - '152'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Moving Toyshop</title>
-          <description>Aut dolores dolores voluptas.</description>
+          <title>Ring of Bright Water</title>
+          <description>Sit qui eligendi amet.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:52 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:01 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Ipsam voluptas omnis. Libero quibusdam a. Corrupti tempora non.
+      string: Quibusdam optio tempore. Rem recusandae rerum. Eum et mollitia.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1689" vrev="1689">
-          <srcmd5>fd112d5b176c980934b923a15745be67</srcmd5>
+        <revision rev="95" vrev="95">
+          <srcmd5>1fd7a2ac9ff904ba01cd6b969ead529d</srcmd5>
           <version>unknown</version>
-          <time>1642674772</time>
+          <time>1643641561</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:52 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:01 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Tenetur laudantium molestiae. Sunt itaque quia. Nihil quaerat quibusdam.
+      string: Temporibus autem aut. Omnis officia praesentium. Nemo et velit.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +181,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1690" vrev="1690">
-          <srcmd5>a1cdb30479d5f96c4fdd3d95db8c9faa</srcmd5>
+        <revision rev="96" vrev="96">
+          <srcmd5>2db5c3deb7eecda63594a7c3d1fbb4d5</srcmd5>
           <version>unknown</version>
-          <time>1642674772</time>
+          <time>1643641561</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:52 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:02 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -227,7 +227,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:32:52 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:02 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_meta?user=Iggy
@@ -235,8 +235,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>The Moving Toyshop</title>
-          <description>Aut dolores dolores voluptas.</description>
+          <title>Ring of Bright Water</title>
+          <description>Sit qui eligendi amet.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -257,15 +257,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '165'
+      - '160'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>The Moving Toyshop</title>
-          <description>Aut dolores dolores voluptas.</description>
+          <title>Ring of Bright Water</title>
+          <description>Sit qui eligendi amet.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:53 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:02 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=branch&noservice=1&opackage=bar_package&oproject=foo_project&user=Iggy
@@ -293,19 +293,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="121" vrev="121">
-          <srcmd5>72471306445a5d0955cb6aa611eb28a6</srcmd5>
+        <revision rev="25" vrev="25">
+          <srcmd5>89c528b7beb27cd93bbd4cda2324a430</srcmd5>
           <version>unknown</version>
-          <time>1642674773</time>
+          <time>1643641562</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:53 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:02 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_meta?user=Iggy
@@ -313,8 +313,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>The Moving Toyshop</title>
-          <description>Aut dolores dolores voluptas.</description>
+          <title>Ring of Bright Water</title>
+          <description>Sit qui eligendi amet.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -335,15 +335,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '165'
+      - '160'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>The Moving Toyshop</title>
-          <description>Aut dolores dolores voluptas.</description>
+          <title>Ring of Bright Water</title>
+          <description>Sit qui eligendi amet.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:53 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:02 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -369,18 +369,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '735'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="121" vrev="121" srcmd5="72471306445a5d0955cb6aa611eb28a6">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="a1cdb30479d5f96c4fdd3d95db8c9faa" baserev="a1cdb30479d5f96c4fdd3d95db8c9faa" xsrcmd5="4594a95709ab5e0b69bfcbae33a3d023" lsrcmd5="72471306445a5d0955cb6aa611eb28a6"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="63b3df0f8536f14a66b3ccc6cbae24c2" size="63" mtime="1642674772"/>
-          <entry name="_link" md5="aae3276d42a4a2f686243e0258542df1" size="141" mtime="1642674773"/>
-          <entry name="somefile.txt" md5="d3f06f7a560f5ff571477aacc1aa179c" size="72" mtime="1642674772"/>
+        <directory name="bar_package-123456789" rev="25" vrev="25" srcmd5="89c528b7beb27cd93bbd4cda2324a430">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="2db5c3deb7eecda63594a7c3d1fbb4d5" baserev="2db5c3deb7eecda63594a7c3d1fbb4d5" xsrcmd5="32add58f5e570466cd765a383a8a4664" lsrcmd5="89c528b7beb27cd93bbd4cda2324a430"/>
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="c6742f0b4f9c7961a583ab3e7bb7bb76" size="63" mtime="1643641561"/>
+          <entry name="_link" md5="85f145ceb0c88ee40cb98fd594d60142" size="141" mtime="1643641562"/>
+          <entry name="somefile.txt" md5="367de265a06b9df5ba181537b4dcfd44" size="63" mtime="1643641561"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:53 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:02 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?view=info
@@ -406,15 +406,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '343'
+      - '341'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package-123456789" rev="121" vrev="1811" srcmd5="4594a95709ab5e0b69bfcbae33a3d023" lsrcmd5="72471306445a5d0955cb6aa611eb28a6" verifymd5="a1cdb30479d5f96c4fdd3d95db8c9faa">
+        <sourceinfo package="bar_package-123456789" rev="25" vrev="121" srcmd5="32add58f5e570466cd765a383a8a4664" lsrcmd5="89c528b7beb27cd93bbd4cda2324a430" verifymd5="2db5c3deb7eecda63594a7c3d1fbb4d5">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:53 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:02 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -440,18 +440,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '735'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="121" vrev="121" srcmd5="72471306445a5d0955cb6aa611eb28a6">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="a1cdb30479d5f96c4fdd3d95db8c9faa" baserev="a1cdb30479d5f96c4fdd3d95db8c9faa" xsrcmd5="4594a95709ab5e0b69bfcbae33a3d023" lsrcmd5="72471306445a5d0955cb6aa611eb28a6"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="63b3df0f8536f14a66b3ccc6cbae24c2" size="63" mtime="1642674772"/>
-          <entry name="_link" md5="aae3276d42a4a2f686243e0258542df1" size="141" mtime="1642674773"/>
-          <entry name="somefile.txt" md5="d3f06f7a560f5ff571477aacc1aa179c" size="72" mtime="1642674772"/>
+        <directory name="bar_package-123456789" rev="25" vrev="25" srcmd5="89c528b7beb27cd93bbd4cda2324a430">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="2db5c3deb7eecda63594a7c3d1fbb4d5" baserev="2db5c3deb7eecda63594a7c3d1fbb4d5" xsrcmd5="32add58f5e570466cd765a383a8a4664" lsrcmd5="89c528b7beb27cd93bbd4cda2324a430"/>
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="c6742f0b4f9c7961a583ab3e7bb7bb76" size="63" mtime="1643641561"/>
+          <entry name="_link" md5="85f145ceb0c88ee40cb98fd594d60142" size="141" mtime="1643641562"/>
+          <entry name="somefile.txt" md5="367de265a06b9df5ba181537b4dcfd44" size="63" mtime="1643641561"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:53 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:02 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -479,18 +479,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '324'
+      - '323'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="39b10b6ade4e0cfab6c833da6a28ca47">
+        <sourcediff key="b2d26c8ce532253313e5c6c45918997f">
           <old project="home:Iggy" package="bar_package-123456789" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="121" srcmd5="72471306445a5d0955cb6aa611eb28a6"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="25" srcmd5="89c528b7beb27cd93bbd4cda2324a430"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:53 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:02 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -522,14 +522,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="0c3c556720f401fffb4a68a909f7edd2">
-          <old project="foo_project" package="bar_package" rev="a1cdb30479d5f96c4fdd3d95db8c9faa" srcmd5="a1cdb30479d5f96c4fdd3d95db8c9faa"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="4594a95709ab5e0b69bfcbae33a3d023" srcmd5="4594a95709ab5e0b69bfcbae33a3d023"/>
+        <sourcediff key="9e86689c6baece1268af6211626ac541">
+          <old project="foo_project" package="bar_package" rev="2db5c3deb7eecda63594a7c3d1fbb4d5" srcmd5="2db5c3deb7eecda63594a7c3d1fbb4d5"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="32add58f5e570466cd765a383a8a4664" srcmd5="32add58f5e570466cd765a383a8a4664"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:53 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:02 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/_meta?user=Iggy
@@ -587,7 +587,7 @@ http_interactions:
             <arch>aarch64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:53 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:02 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_branch_request?user=Iggy
@@ -613,19 +613,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="122" vrev="122">
-          <srcmd5>3309e1bc152dca37008ef887098abf27</srcmd5>
+        <revision rev="26" vrev="26">
+          <srcmd5>f48e1a4372fcb32606585b3be0980a72</srcmd5>
           <version>unknown</version>
-          <time>1642674773</time>
+          <time>1643641562</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:53 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:02 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_meta?user=Iggy
@@ -633,8 +633,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>The Moving Toyshop</title>
-          <description>Aut dolores dolores voluptas.</description>
+          <title>Ring of Bright Water</title>
+          <description>Sit qui eligendi amet.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -655,15 +655,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '165'
+      - '160'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>The Moving Toyshop</title>
-          <description>Aut dolores dolores voluptas.</description>
+          <title>Ring of Bright Water</title>
+          <description>Sit qui eligendi amet.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:53 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:02 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -689,19 +689,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="122" vrev="122" srcmd5="3309e1bc152dca37008ef887098abf27">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="a1cdb30479d5f96c4fdd3d95db8c9faa" baserev="a1cdb30479d5f96c4fdd3d95db8c9faa" xsrcmd5="8e52190c02012c192476f792c21a0f11" lsrcmd5="3309e1bc152dca37008ef887098abf27"/>
-          <serviceinfo code="succeeded" xsrcmd5="9575b5b406a6ae6b34ff29083722ed8a"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="63b3df0f8536f14a66b3ccc6cbae24c2" size="63" mtime="1642674772"/>
-          <entry name="_link" md5="aae3276d42a4a2f686243e0258542df1" size="141" mtime="1642674773"/>
-          <entry name="somefile.txt" md5="d3f06f7a560f5ff571477aacc1aa179c" size="72" mtime="1642674772"/>
+        <directory name="bar_package-123456789" rev="26" vrev="26" srcmd5="f48e1a4372fcb32606585b3be0980a72">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="2db5c3deb7eecda63594a7c3d1fbb4d5" baserev="2db5c3deb7eecda63594a7c3d1fbb4d5" xsrcmd5="e07c02bc5128831d22b4fb52cab6c683" lsrcmd5="f48e1a4372fcb32606585b3be0980a72"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="c6742f0b4f9c7961a583ab3e7bb7bb76" size="63" mtime="1643641561"/>
+          <entry name="_link" md5="85f145ceb0c88ee40cb98fd594d60142" size="141" mtime="1643641562"/>
+          <entry name="somefile.txt" md5="367de265a06b9df5ba181537b4dcfd44" size="63" mtime="1643641561"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:53 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:02 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?view=info
@@ -727,15 +726,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '343'
+      - '341'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package-123456789" rev="122" vrev="1812" srcmd5="df7cfe69d2fd24257437e4610dd935f1" lsrcmd5="9575b5b406a6ae6b34ff29083722ed8a" verifymd5="3ba696b713eb3bd5d524186cfa8548ae">
+        <sourceinfo package="bar_package-123456789" rev="26" vrev="122" srcmd5="e07c02bc5128831d22b4fb52cab6c683" lsrcmd5="f48e1a4372fcb32606585b3be0980a72" verifymd5="3e8d0b52ed377775b902dedd91f1710b">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:53 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:02 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -761,19 +760,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="122" vrev="122" srcmd5="3309e1bc152dca37008ef887098abf27">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="a1cdb30479d5f96c4fdd3d95db8c9faa" baserev="a1cdb30479d5f96c4fdd3d95db8c9faa" xsrcmd5="8e52190c02012c192476f792c21a0f11" lsrcmd5="3309e1bc152dca37008ef887098abf27"/>
-          <serviceinfo code="succeeded" xsrcmd5="9575b5b406a6ae6b34ff29083722ed8a"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="63b3df0f8536f14a66b3ccc6cbae24c2" size="63" mtime="1642674772"/>
-          <entry name="_link" md5="aae3276d42a4a2f686243e0258542df1" size="141" mtime="1642674773"/>
-          <entry name="somefile.txt" md5="d3f06f7a560f5ff571477aacc1aa179c" size="72" mtime="1642674772"/>
+        <directory name="bar_package-123456789" rev="26" vrev="26" srcmd5="f48e1a4372fcb32606585b3be0980a72">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="2db5c3deb7eecda63594a7c3d1fbb4d5" baserev="2db5c3deb7eecda63594a7c3d1fbb4d5" xsrcmd5="e07c02bc5128831d22b4fb52cab6c683" lsrcmd5="f48e1a4372fcb32606585b3be0980a72"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="c6742f0b4f9c7961a583ab3e7bb7bb76" size="63" mtime="1643641561"/>
+          <entry name="_link" md5="85f145ceb0c88ee40cb98fd594d60142" size="141" mtime="1643641562"/>
+          <entry name="somefile.txt" md5="367de265a06b9df5ba181537b4dcfd44" size="63" mtime="1643641561"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:53 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:02 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -801,18 +799,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '324'
+      - '323'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="5f6b998660bddd0224b1357e51b6ced9">
+        <sourcediff key="4d9de8bde4e35e015bec51859f5ad38d">
           <old project="home:Iggy" package="bar_package-123456789" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="122" srcmd5="3309e1bc152dca37008ef887098abf27"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="26" srcmd5="f48e1a4372fcb32606585b3be0980a72"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:53 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:02 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -844,14 +842,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="a570cf98be803b16a95bf48cf8719f51">
-          <old project="foo_project" package="bar_package" rev="a1cdb30479d5f96c4fdd3d95db8c9faa" srcmd5="a1cdb30479d5f96c4fdd3d95db8c9faa"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="df7cfe69d2fd24257437e4610dd935f1" srcmd5="df7cfe69d2fd24257437e4610dd935f1"/>
+        <sourcediff key="b5df5a00ccd2f1ef2630c131d07ae8cd">
+          <old project="foo_project" package="bar_package" rev="2db5c3deb7eecda63594a7c3d1fbb4d5" srcmd5="2db5c3deb7eecda63594a7c3d1fbb4d5"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="e07c02bc5128831d22b4fb52cab6c683" srcmd5="e07c02bc5128831d22b4fb52cab6c683"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:53 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:02 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -877,19 +875,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="122" vrev="122" srcmd5="3309e1bc152dca37008ef887098abf27">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="a1cdb30479d5f96c4fdd3d95db8c9faa" baserev="a1cdb30479d5f96c4fdd3d95db8c9faa" xsrcmd5="8e52190c02012c192476f792c21a0f11" lsrcmd5="3309e1bc152dca37008ef887098abf27"/>
-          <serviceinfo code="succeeded" xsrcmd5="9575b5b406a6ae6b34ff29083722ed8a"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="63b3df0f8536f14a66b3ccc6cbae24c2" size="63" mtime="1642674772"/>
-          <entry name="_link" md5="aae3276d42a4a2f686243e0258542df1" size="141" mtime="1642674773"/>
-          <entry name="somefile.txt" md5="d3f06f7a560f5ff571477aacc1aa179c" size="72" mtime="1642674772"/>
+        <directory name="bar_package-123456789" rev="26" vrev="26" srcmd5="f48e1a4372fcb32606585b3be0980a72">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="2db5c3deb7eecda63594a7c3d1fbb4d5" baserev="2db5c3deb7eecda63594a7c3d1fbb4d5" xsrcmd5="e07c02bc5128831d22b4fb52cab6c683" lsrcmd5="f48e1a4372fcb32606585b3be0980a72"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="c6742f0b4f9c7961a583ab3e7bb7bb76" size="63" mtime="1643641561"/>
+          <entry name="_link" md5="85f145ceb0c88ee40cb98fd594d60142" size="141" mtime="1643641562"/>
+          <entry name="somefile.txt" md5="367de265a06b9df5ba181537b4dcfd44" size="63" mtime="1643641561"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:53 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:02 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '627'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="e07c02bc5128831d22b4fb52cab6c683" vrev="122" srcmd5="e07c02bc5128831d22b4fb52cab6c683">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="2db5c3deb7eecda63594a7c3d1fbb4d5" baserev="2db5c3deb7eecda63594a7c3d1fbb4d5" lsrcmd5="f48e1a4372fcb32606585b3be0980a72"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="c6742f0b4f9c7961a583ab3e7bb7bb76" size="63" mtime="1643641561"/>
+          <entry name="somefile.txt" md5="367de265a06b9df5ba181537b4dcfd44" size="63" mtime="1643641561"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:06:02 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -915,19 +948,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="122" vrev="122" srcmd5="3309e1bc152dca37008ef887098abf27">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="a1cdb30479d5f96c4fdd3d95db8c9faa" baserev="a1cdb30479d5f96c4fdd3d95db8c9faa" xsrcmd5="8e52190c02012c192476f792c21a0f11" lsrcmd5="3309e1bc152dca37008ef887098abf27"/>
-          <serviceinfo code="succeeded" xsrcmd5="9575b5b406a6ae6b34ff29083722ed8a"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="63b3df0f8536f14a66b3ccc6cbae24c2" size="63" mtime="1642674772"/>
-          <entry name="_link" md5="aae3276d42a4a2f686243e0258542df1" size="141" mtime="1642674773"/>
-          <entry name="somefile.txt" md5="d3f06f7a560f5ff571477aacc1aa179c" size="72" mtime="1642674772"/>
+        <directory name="bar_package-123456789" rev="26" vrev="26" srcmd5="f48e1a4372fcb32606585b3be0980a72">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="2db5c3deb7eecda63594a7c3d1fbb4d5" baserev="2db5c3deb7eecda63594a7c3d1fbb4d5" xsrcmd5="e07c02bc5128831d22b4fb52cab6c683" lsrcmd5="f48e1a4372fcb32606585b3be0980a72"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="c6742f0b4f9c7961a583ab3e7bb7bb76" size="63" mtime="1643641561"/>
+          <entry name="_link" md5="85f145ceb0c88ee40cb98fd594d60142" size="141" mtime="1643641562"/>
+          <entry name="somefile.txt" md5="367de265a06b9df5ba181537b4dcfd44" size="63" mtime="1643641561"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:53 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:02 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '627'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="e07c02bc5128831d22b4fb52cab6c683" vrev="122" srcmd5="e07c02bc5128831d22b4fb52cab6c683">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="2db5c3deb7eecda63594a7c3d1fbb4d5" baserev="2db5c3deb7eecda63594a7c3d1fbb4d5" lsrcmd5="f48e1a4372fcb32606585b3be0980a72"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="c6742f0b4f9c7961a583ab3e7bb7bb76" size="63" mtime="1643641561"/>
+          <entry name="somefile.txt" md5="367de265a06b9df5ba181537b4dcfd44" size="63" mtime="1643641561"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:06:02 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -953,19 +1021,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="122" vrev="122" srcmd5="3309e1bc152dca37008ef887098abf27">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="a1cdb30479d5f96c4fdd3d95db8c9faa" baserev="a1cdb30479d5f96c4fdd3d95db8c9faa" xsrcmd5="8e52190c02012c192476f792c21a0f11" lsrcmd5="3309e1bc152dca37008ef887098abf27"/>
-          <serviceinfo code="succeeded" xsrcmd5="9575b5b406a6ae6b34ff29083722ed8a"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="63b3df0f8536f14a66b3ccc6cbae24c2" size="63" mtime="1642674772"/>
-          <entry name="_link" md5="aae3276d42a4a2f686243e0258542df1" size="141" mtime="1642674773"/>
-          <entry name="somefile.txt" md5="d3f06f7a560f5ff571477aacc1aa179c" size="72" mtime="1642674772"/>
+        <directory name="bar_package-123456789" rev="26" vrev="26" srcmd5="f48e1a4372fcb32606585b3be0980a72">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="2db5c3deb7eecda63594a7c3d1fbb4d5" baserev="2db5c3deb7eecda63594a7c3d1fbb4d5" xsrcmd5="e07c02bc5128831d22b4fb52cab6c683" lsrcmd5="f48e1a4372fcb32606585b3be0980a72"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="c6742f0b4f9c7961a583ab3e7bb7bb76" size="63" mtime="1643641561"/>
+          <entry name="_link" md5="85f145ceb0c88ee40cb98fd594d60142" size="141" mtime="1643641562"/>
+          <entry name="somefile.txt" md5="367de265a06b9df5ba181537b4dcfd44" size="63" mtime="1643641561"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:53 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:02 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '627'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="e07c02bc5128831d22b4fb52cab6c683" vrev="122" srcmd5="e07c02bc5128831d22b4fb52cab6c683">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="2db5c3deb7eecda63594a7c3d1fbb4d5" baserev="2db5c3deb7eecda63594a7c3d1fbb4d5" lsrcmd5="f48e1a4372fcb32606585b3be0980a72"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="c6742f0b4f9c7961a583ab3e7bb7bb76" size="63" mtime="1643641561"/>
+          <entry name="somefile.txt" md5="367de265a06b9df5ba181537b4dcfd44" size="63" mtime="1643641561"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:06:02 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -991,19 +1094,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="122" vrev="122" srcmd5="3309e1bc152dca37008ef887098abf27">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="a1cdb30479d5f96c4fdd3d95db8c9faa" baserev="a1cdb30479d5f96c4fdd3d95db8c9faa" xsrcmd5="8e52190c02012c192476f792c21a0f11" lsrcmd5="3309e1bc152dca37008ef887098abf27"/>
-          <serviceinfo code="succeeded" xsrcmd5="9575b5b406a6ae6b34ff29083722ed8a"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="63b3df0f8536f14a66b3ccc6cbae24c2" size="63" mtime="1642674772"/>
-          <entry name="_link" md5="aae3276d42a4a2f686243e0258542df1" size="141" mtime="1642674773"/>
-          <entry name="somefile.txt" md5="d3f06f7a560f5ff571477aacc1aa179c" size="72" mtime="1642674772"/>
+        <directory name="bar_package-123456789" rev="26" vrev="26" srcmd5="f48e1a4372fcb32606585b3be0980a72">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="2db5c3deb7eecda63594a7c3d1fbb4d5" baserev="2db5c3deb7eecda63594a7c3d1fbb4d5" xsrcmd5="e07c02bc5128831d22b4fb52cab6c683" lsrcmd5="f48e1a4372fcb32606585b3be0980a72"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="c6742f0b4f9c7961a583ab3e7bb7bb76" size="63" mtime="1643641561"/>
+          <entry name="_link" md5="85f145ceb0c88ee40cb98fd594d60142" size="141" mtime="1643641562"/>
+          <entry name="somefile.txt" md5="367de265a06b9df5ba181537b4dcfd44" size="63" mtime="1643641561"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:53 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:02 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '627'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="e07c02bc5128831d22b4fb52cab6c683" vrev="122" srcmd5="e07c02bc5128831d22b4fb52cab6c683">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="2db5c3deb7eecda63594a7c3d1fbb4d5" baserev="2db5c3deb7eecda63594a7c3d1fbb4d5" lsrcmd5="f48e1a4372fcb32606585b3be0980a72"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="c6742f0b4f9c7961a583ab3e7bb7bb76" size="63" mtime="1643641561"/>
+          <entry name="somefile.txt" md5="367de265a06b9df5ba181537b4dcfd44" size="63" mtime="1643641561"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:06:02 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -1029,22 +1167,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="122" vrev="122" srcmd5="3309e1bc152dca37008ef887098abf27">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="a1cdb30479d5f96c4fdd3d95db8c9faa" baserev="a1cdb30479d5f96c4fdd3d95db8c9faa" xsrcmd5="8e52190c02012c192476f792c21a0f11" lsrcmd5="3309e1bc152dca37008ef887098abf27"/>
-          <serviceinfo code="succeeded" xsrcmd5="9575b5b406a6ae6b34ff29083722ed8a"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="63b3df0f8536f14a66b3ccc6cbae24c2" size="63" mtime="1642674772"/>
-          <entry name="_link" md5="aae3276d42a4a2f686243e0258542df1" size="141" mtime="1642674773"/>
-          <entry name="somefile.txt" md5="d3f06f7a560f5ff571477aacc1aa179c" size="72" mtime="1642674772"/>
+        <directory name="bar_package-123456789" rev="26" vrev="26" srcmd5="f48e1a4372fcb32606585b3be0980a72">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="2db5c3deb7eecda63594a7c3d1fbb4d5" baserev="2db5c3deb7eecda63594a7c3d1fbb4d5" xsrcmd5="e07c02bc5128831d22b4fb52cab6c683" lsrcmd5="f48e1a4372fcb32606585b3be0980a72"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="c6742f0b4f9c7961a583ab3e7bb7bb76" size="63" mtime="1643641561"/>
+          <entry name="_link" md5="85f145ceb0c88ee40cb98fd594d60142" size="141" mtime="1643641562"/>
+          <entry name="somefile.txt" md5="367de265a06b9df5ba181537b4dcfd44" size="63" mtime="1643641561"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:53 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:02 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1067,169 +1204,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '627'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="122" vrev="122" srcmd5="3309e1bc152dca37008ef887098abf27">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="a1cdb30479d5f96c4fdd3d95db8c9faa" baserev="a1cdb30479d5f96c4fdd3d95db8c9faa" xsrcmd5="8e52190c02012c192476f792c21a0f11" lsrcmd5="3309e1bc152dca37008ef887098abf27"/>
-          <serviceinfo code="succeeded" xsrcmd5="9575b5b406a6ae6b34ff29083722ed8a"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="63b3df0f8536f14a66b3ccc6cbae24c2" size="63" mtime="1642674772"/>
-          <entry name="_link" md5="aae3276d42a4a2f686243e0258542df1" size="141" mtime="1642674773"/>
-          <entry name="somefile.txt" md5="d3f06f7a560f5ff571477aacc1aa179c" size="72" mtime="1642674772"/>
+        <directory name="bar_package-123456789" rev="e07c02bc5128831d22b4fb52cab6c683" vrev="122" srcmd5="e07c02bc5128831d22b4fb52cab6c683">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="2db5c3deb7eecda63594a7c3d1fbb4d5" baserev="2db5c3deb7eecda63594a7c3d1fbb4d5" lsrcmd5="f48e1a4372fcb32606585b3be0980a72"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="c6742f0b4f9c7961a583ab3e7bb7bb76" size="63" mtime="1643641561"/>
+          <entry name="somefile.txt" md5="367de265a06b9df5ba181537b4dcfd44" size="63" mtime="1643641561"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:53 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '811'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="122" vrev="122" srcmd5="3309e1bc152dca37008ef887098abf27">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="a1cdb30479d5f96c4fdd3d95db8c9faa" baserev="a1cdb30479d5f96c4fdd3d95db8c9faa" xsrcmd5="8e52190c02012c192476f792c21a0f11" lsrcmd5="3309e1bc152dca37008ef887098abf27"/>
-          <serviceinfo code="succeeded" xsrcmd5="9575b5b406a6ae6b34ff29083722ed8a"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="63b3df0f8536f14a66b3ccc6cbae24c2" size="63" mtime="1642674772"/>
-          <entry name="_link" md5="aae3276d42a4a2f686243e0258542df1" size="141" mtime="1642674773"/>
-          <entry name="somefile.txt" md5="d3f06f7a560f5ff571477aacc1aa179c" size="72" mtime="1642674772"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:53 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '811'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="122" vrev="122" srcmd5="3309e1bc152dca37008ef887098abf27">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="a1cdb30479d5f96c4fdd3d95db8c9faa" baserev="a1cdb30479d5f96c4fdd3d95db8c9faa" xsrcmd5="8e52190c02012c192476f792c21a0f11" lsrcmd5="3309e1bc152dca37008ef887098abf27"/>
-          <serviceinfo code="succeeded" xsrcmd5="9575b5b406a6ae6b34ff29083722ed8a"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="63b3df0f8536f14a66b3ccc6cbae24c2" size="63" mtime="1642674772"/>
-          <entry name="_link" md5="aae3276d42a4a2f686243e0258542df1" size="141" mtime="1642674773"/>
-          <entry name="somefile.txt" md5="d3f06f7a560f5ff571477aacc1aa179c" size="72" mtime="1642674772"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:53 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '811'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="122" vrev="122" srcmd5="3309e1bc152dca37008ef887098abf27">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="a1cdb30479d5f96c4fdd3d95db8c9faa" baserev="a1cdb30479d5f96c4fdd3d95db8c9faa" xsrcmd5="8e52190c02012c192476f792c21a0f11" lsrcmd5="3309e1bc152dca37008ef887098abf27"/>
-          <serviceinfo code="succeeded" xsrcmd5="9575b5b406a6ae6b34ff29083722ed8a"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="63b3df0f8536f14a66b3ccc6cbae24c2" size="63" mtime="1642674772"/>
-          <entry name="_link" md5="aae3276d42a4a2f686243e0258542df1" size="141" mtime="1642674773"/>
-          <entry name="somefile.txt" md5="d3f06f7a560f5ff571477aacc1aa179c" size="72" mtime="1642674772"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:53 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '811'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="122" vrev="122" srcmd5="3309e1bc152dca37008ef887098abf27">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="a1cdb30479d5f96c4fdd3d95db8c9faa" baserev="a1cdb30479d5f96c4fdd3d95db8c9faa" xsrcmd5="8e52190c02012c192476f792c21a0f11" lsrcmd5="3309e1bc152dca37008ef887098abf27"/>
-          <serviceinfo code="succeeded" xsrcmd5="9575b5b406a6ae6b34ff29083722ed8a"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="63b3df0f8536f14a66b3ccc6cbae24c2" size="63" mtime="1642674772"/>
-          <entry name="_link" md5="aae3276d42a4a2f686243e0258542df1" size="141" mtime="1642674773"/>
-          <entry name="somefile.txt" md5="d3f06f7a560f5ff571477aacc1aa179c" size="72" mtime="1642674772"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:53 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:02 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/with_a_push_event_for_a_commit/behaves_like_successful_new_PR_or_MR_event/1_1_1_6_1_6.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/with_a_push_event_for_a_commit/behaves_like_successful_new_PR_or_MR_event/1_1_1_6_1_6.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:53 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:03 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_304
+    uri: http://backend:5352/source/foo_project/_meta?user=user_89
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Unweaving the Rainbow</title>
+          <title>Absalom, Absalom!</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '153'
+      - '149'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Unweaving the Rainbow</title>
+          <title>Absalom, Absalom!</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:53 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:03 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_305
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_90
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Recalled to Life</title>
-          <description>Ad excepturi nihil vero.</description>
+          <title>This Side of Paradise</title>
+          <description>Error qui enim velit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '150'
+      - '152'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Recalled to Life</title>
-          <description>Ad excepturi nihil vero.</description>
+          <title>This Side of Paradise</title>
+          <description>Error qui enim velit.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:53 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:03 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Est consequuntur enim. Et repellat vel. Qui temporibus officia.
+      string: Suscipit eius in. Delectus unde assumenda. Veritatis nihil tempore.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1691" vrev="1691">
-          <srcmd5>acc438b7caea7936b0b57416457aa390</srcmd5>
+        <revision rev="97" vrev="97">
+          <srcmd5>cef958d4b611bce70566ff80e9ae2b16</srcmd5>
           <version>unknown</version>
-          <time>1642674773</time>
+          <time>1643641563</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:53 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:03 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Quia qui voluptatem. Odio rem error. Dignissimos laboriosam nemo.
+      string: Dolorem ut non. Voluptas dolorem quidem. Adipisci aut reprehenderit.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +181,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1692" vrev="1692">
-          <srcmd5>59dae5d4f40e0b3cac8b063cbdf89096</srcmd5>
+        <revision rev="98" vrev="98">
+          <srcmd5>8a9246290d834a740a5a2fb1cc0523ec</srcmd5>
           <version>unknown</version>
-          <time>1642674773</time>
+          <time>1643641563</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:53 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:03 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -227,7 +227,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:32:54 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:03 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_meta?user=Iggy
@@ -235,8 +235,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>Recalled to Life</title>
-          <description>Ad excepturi nihil vero.</description>
+          <title>This Side of Paradise</title>
+          <description>Error qui enim velit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -257,15 +257,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '158'
+      - '160'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>Recalled to Life</title>
-          <description>Ad excepturi nihil vero.</description>
+          <title>This Side of Paradise</title>
+          <description>Error qui enim velit.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:54 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:03 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=branch&noservice=1&opackage=bar_package&oproject=foo_project&user=Iggy
@@ -293,19 +293,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="123" vrev="123">
-          <srcmd5>940a72687d0b4bfac8292ca19d4c3890</srcmd5>
+        <revision rev="27" vrev="27">
+          <srcmd5>82dea2f8690f3e2e617e6ad8a806617c</srcmd5>
           <version>unknown</version>
-          <time>1642674774</time>
+          <time>1643641563</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:54 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:03 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_meta?user=Iggy
@@ -313,8 +313,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>Recalled to Life</title>
-          <description>Ad excepturi nihil vero.</description>
+          <title>This Side of Paradise</title>
+          <description>Error qui enim velit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -335,15 +335,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '158'
+      - '160'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>Recalled to Life</title>
-          <description>Ad excepturi nihil vero.</description>
+          <title>This Side of Paradise</title>
+          <description>Error qui enim velit.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:54 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:03 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -369,18 +369,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '735'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="123" vrev="123" srcmd5="940a72687d0b4bfac8292ca19d4c3890">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="59dae5d4f40e0b3cac8b063cbdf89096" baserev="59dae5d4f40e0b3cac8b063cbdf89096" xsrcmd5="f53330ef9f32b281fa1d8e8751cea091" lsrcmd5="940a72687d0b4bfac8292ca19d4c3890"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="2091985096c1224fdecf5cbb30c98fe8" size="63" mtime="1642674773"/>
-          <entry name="_link" md5="92d0f6420273f53d1699591054fb0acd" size="141" mtime="1642674774"/>
-          <entry name="somefile.txt" md5="d60ec8ab0a78e5c67358412577e1397d" size="65" mtime="1642674773"/>
+        <directory name="bar_package-123456789" rev="27" vrev="27" srcmd5="82dea2f8690f3e2e617e6ad8a806617c">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="8a9246290d834a740a5a2fb1cc0523ec" baserev="8a9246290d834a740a5a2fb1cc0523ec" xsrcmd5="2625c9dbea52ad77841024926c2258dd" lsrcmd5="82dea2f8690f3e2e617e6ad8a806617c"/>
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="50818b7aabea9d7d8c9303b07aca3ca0" size="67" mtime="1643641563"/>
+          <entry name="_link" md5="89660fcebd91a5b8eab8746237ce1ac7" size="141" mtime="1643641563"/>
+          <entry name="somefile.txt" md5="d0f77cdaa5e7be303fe6bd26d04dd74a" size="68" mtime="1643641563"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:54 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:03 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?view=info
@@ -406,15 +406,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '343'
+      - '341'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package-123456789" rev="123" vrev="1815" srcmd5="f53330ef9f32b281fa1d8e8751cea091" lsrcmd5="940a72687d0b4bfac8292ca19d4c3890" verifymd5="59dae5d4f40e0b3cac8b063cbdf89096">
+        <sourceinfo package="bar_package-123456789" rev="27" vrev="125" srcmd5="2625c9dbea52ad77841024926c2258dd" lsrcmd5="82dea2f8690f3e2e617e6ad8a806617c" verifymd5="8a9246290d834a740a5a2fb1cc0523ec">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:54 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:03 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -440,18 +440,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '735'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="123" vrev="123" srcmd5="940a72687d0b4bfac8292ca19d4c3890">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="59dae5d4f40e0b3cac8b063cbdf89096" baserev="59dae5d4f40e0b3cac8b063cbdf89096" xsrcmd5="f53330ef9f32b281fa1d8e8751cea091" lsrcmd5="940a72687d0b4bfac8292ca19d4c3890"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="2091985096c1224fdecf5cbb30c98fe8" size="63" mtime="1642674773"/>
-          <entry name="_link" md5="92d0f6420273f53d1699591054fb0acd" size="141" mtime="1642674774"/>
-          <entry name="somefile.txt" md5="d60ec8ab0a78e5c67358412577e1397d" size="65" mtime="1642674773"/>
+        <directory name="bar_package-123456789" rev="27" vrev="27" srcmd5="82dea2f8690f3e2e617e6ad8a806617c">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="8a9246290d834a740a5a2fb1cc0523ec" baserev="8a9246290d834a740a5a2fb1cc0523ec" xsrcmd5="2625c9dbea52ad77841024926c2258dd" lsrcmd5="82dea2f8690f3e2e617e6ad8a806617c"/>
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="50818b7aabea9d7d8c9303b07aca3ca0" size="67" mtime="1643641563"/>
+          <entry name="_link" md5="89660fcebd91a5b8eab8746237ce1ac7" size="141" mtime="1643641563"/>
+          <entry name="somefile.txt" md5="d0f77cdaa5e7be303fe6bd26d04dd74a" size="68" mtime="1643641563"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:54 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:03 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -479,18 +479,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '324'
+      - '323'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="c4dcabbbb787bbba073a5aca1359b7ce">
+        <sourcediff key="77ecba67da349319691e798c238c4d47">
           <old project="home:Iggy" package="bar_package-123456789" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="123" srcmd5="940a72687d0b4bfac8292ca19d4c3890"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="27" srcmd5="82dea2f8690f3e2e617e6ad8a806617c"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:54 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:03 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -522,14 +522,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="9e6ccec2716df0def7de801930e9eacd">
-          <old project="foo_project" package="bar_package" rev="59dae5d4f40e0b3cac8b063cbdf89096" srcmd5="59dae5d4f40e0b3cac8b063cbdf89096"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="f53330ef9f32b281fa1d8e8751cea091" srcmd5="f53330ef9f32b281fa1d8e8751cea091"/>
+        <sourcediff key="57f10af5dd5d9535eb0d9d38ffcf6efa">
+          <old project="foo_project" package="bar_package" rev="8a9246290d834a740a5a2fb1cc0523ec" srcmd5="8a9246290d834a740a5a2fb1cc0523ec"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="2625c9dbea52ad77841024926c2258dd" srcmd5="2625c9dbea52ad77841024926c2258dd"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:54 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:03 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/_meta?user=Iggy
@@ -587,7 +587,7 @@ http_interactions:
             <arch>aarch64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:54 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:03 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_branch_request?user=Iggy
@@ -613,19 +613,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="124" vrev="124">
-          <srcmd5>c0b874da3c9b67de9e7d2557963a8794</srcmd5>
+        <revision rev="28" vrev="28">
+          <srcmd5>3c0a4f94c2707188673540a169650eb0</srcmd5>
           <version>unknown</version>
-          <time>1642674774</time>
+          <time>1643641563</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:54 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:03 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_meta?user=Iggy
@@ -633,8 +633,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>Recalled to Life</title>
-          <description>Ad excepturi nihil vero.</description>
+          <title>This Side of Paradise</title>
+          <description>Error qui enim velit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -655,15 +655,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '158'
+      - '160'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>Recalled to Life</title>
-          <description>Ad excepturi nihil vero.</description>
+          <title>This Side of Paradise</title>
+          <description>Error qui enim velit.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:54 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:04 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -689,19 +689,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="124" vrev="124" srcmd5="c0b874da3c9b67de9e7d2557963a8794">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="59dae5d4f40e0b3cac8b063cbdf89096" baserev="59dae5d4f40e0b3cac8b063cbdf89096" xsrcmd5="98ba442bfa5ff16d4366ae74eb0fe943" lsrcmd5="c0b874da3c9b67de9e7d2557963a8794"/>
-          <serviceinfo code="succeeded" xsrcmd5="6dff0965ccbe9c0625de5af822e8f86e"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="2091985096c1224fdecf5cbb30c98fe8" size="63" mtime="1642674773"/>
-          <entry name="_link" md5="92d0f6420273f53d1699591054fb0acd" size="141" mtime="1642674774"/>
-          <entry name="somefile.txt" md5="d60ec8ab0a78e5c67358412577e1397d" size="65" mtime="1642674773"/>
+        <directory name="bar_package-123456789" rev="28" vrev="28" srcmd5="3c0a4f94c2707188673540a169650eb0">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="8a9246290d834a740a5a2fb1cc0523ec" baserev="8a9246290d834a740a5a2fb1cc0523ec" xsrcmd5="eb6c2b21270ee1d587214e58725fae00" lsrcmd5="3c0a4f94c2707188673540a169650eb0"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="50818b7aabea9d7d8c9303b07aca3ca0" size="67" mtime="1643641563"/>
+          <entry name="_link" md5="89660fcebd91a5b8eab8746237ce1ac7" size="141" mtime="1643641563"/>
+          <entry name="somefile.txt" md5="d0f77cdaa5e7be303fe6bd26d04dd74a" size="68" mtime="1643641563"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:54 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:04 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?view=info
@@ -727,15 +726,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '343'
+      - '341'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package-123456789" rev="124" vrev="1816" srcmd5="1deee533e06542357568f5118e044887" lsrcmd5="6dff0965ccbe9c0625de5af822e8f86e" verifymd5="7c22180339f7e6cd0ba728a262d74f01">
+        <sourceinfo package="bar_package-123456789" rev="28" vrev="126" srcmd5="eb6c2b21270ee1d587214e58725fae00" lsrcmd5="3c0a4f94c2707188673540a169650eb0" verifymd5="d6310d7e357887e468219e71761f7681">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:54 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:04 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -761,19 +760,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="124" vrev="124" srcmd5="c0b874da3c9b67de9e7d2557963a8794">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="59dae5d4f40e0b3cac8b063cbdf89096" baserev="59dae5d4f40e0b3cac8b063cbdf89096" xsrcmd5="98ba442bfa5ff16d4366ae74eb0fe943" lsrcmd5="c0b874da3c9b67de9e7d2557963a8794"/>
-          <serviceinfo code="succeeded" xsrcmd5="6dff0965ccbe9c0625de5af822e8f86e"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="2091985096c1224fdecf5cbb30c98fe8" size="63" mtime="1642674773"/>
-          <entry name="_link" md5="92d0f6420273f53d1699591054fb0acd" size="141" mtime="1642674774"/>
-          <entry name="somefile.txt" md5="d60ec8ab0a78e5c67358412577e1397d" size="65" mtime="1642674773"/>
+        <directory name="bar_package-123456789" rev="28" vrev="28" srcmd5="3c0a4f94c2707188673540a169650eb0">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="8a9246290d834a740a5a2fb1cc0523ec" baserev="8a9246290d834a740a5a2fb1cc0523ec" xsrcmd5="eb6c2b21270ee1d587214e58725fae00" lsrcmd5="3c0a4f94c2707188673540a169650eb0"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="50818b7aabea9d7d8c9303b07aca3ca0" size="67" mtime="1643641563"/>
+          <entry name="_link" md5="89660fcebd91a5b8eab8746237ce1ac7" size="141" mtime="1643641563"/>
+          <entry name="somefile.txt" md5="d0f77cdaa5e7be303fe6bd26d04dd74a" size="68" mtime="1643641563"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:54 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:04 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -801,18 +799,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '324'
+      - '323'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="2c942e2e4c2dbfaaa2598bcb5c73cb83">
+        <sourcediff key="64e27a791556acf7ef5002258d849ca8">
           <old project="home:Iggy" package="bar_package-123456789" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="124" srcmd5="c0b874da3c9b67de9e7d2557963a8794"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="28" srcmd5="3c0a4f94c2707188673540a169650eb0"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:54 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:04 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -844,14 +842,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="73a66127572c1c005e47752d4f2fc407">
-          <old project="foo_project" package="bar_package" rev="59dae5d4f40e0b3cac8b063cbdf89096" srcmd5="59dae5d4f40e0b3cac8b063cbdf89096"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="1deee533e06542357568f5118e044887" srcmd5="1deee533e06542357568f5118e044887"/>
+        <sourcediff key="a8a6a8c9f1ada82e03e7e6b655cf8777">
+          <old project="foo_project" package="bar_package" rev="8a9246290d834a740a5a2fb1cc0523ec" srcmd5="8a9246290d834a740a5a2fb1cc0523ec"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="eb6c2b21270ee1d587214e58725fae00" srcmd5="eb6c2b21270ee1d587214e58725fae00"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:54 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:04 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -877,19 +875,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="124" vrev="124" srcmd5="c0b874da3c9b67de9e7d2557963a8794">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="59dae5d4f40e0b3cac8b063cbdf89096" baserev="59dae5d4f40e0b3cac8b063cbdf89096" xsrcmd5="98ba442bfa5ff16d4366ae74eb0fe943" lsrcmd5="c0b874da3c9b67de9e7d2557963a8794"/>
-          <serviceinfo code="succeeded" xsrcmd5="6dff0965ccbe9c0625de5af822e8f86e"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="2091985096c1224fdecf5cbb30c98fe8" size="63" mtime="1642674773"/>
-          <entry name="_link" md5="92d0f6420273f53d1699591054fb0acd" size="141" mtime="1642674774"/>
-          <entry name="somefile.txt" md5="d60ec8ab0a78e5c67358412577e1397d" size="65" mtime="1642674773"/>
+        <directory name="bar_package-123456789" rev="28" vrev="28" srcmd5="3c0a4f94c2707188673540a169650eb0">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="8a9246290d834a740a5a2fb1cc0523ec" baserev="8a9246290d834a740a5a2fb1cc0523ec" xsrcmd5="eb6c2b21270ee1d587214e58725fae00" lsrcmd5="3c0a4f94c2707188673540a169650eb0"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="50818b7aabea9d7d8c9303b07aca3ca0" size="67" mtime="1643641563"/>
+          <entry name="_link" md5="89660fcebd91a5b8eab8746237ce1ac7" size="141" mtime="1643641563"/>
+          <entry name="somefile.txt" md5="d0f77cdaa5e7be303fe6bd26d04dd74a" size="68" mtime="1643641563"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:54 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:04 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '627'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="eb6c2b21270ee1d587214e58725fae00" vrev="126" srcmd5="eb6c2b21270ee1d587214e58725fae00">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="8a9246290d834a740a5a2fb1cc0523ec" baserev="8a9246290d834a740a5a2fb1cc0523ec" lsrcmd5="3c0a4f94c2707188673540a169650eb0"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="50818b7aabea9d7d8c9303b07aca3ca0" size="67" mtime="1643641563"/>
+          <entry name="somefile.txt" md5="d0f77cdaa5e7be303fe6bd26d04dd74a" size="68" mtime="1643641563"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:06:04 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -915,19 +948,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="124" vrev="124" srcmd5="c0b874da3c9b67de9e7d2557963a8794">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="59dae5d4f40e0b3cac8b063cbdf89096" baserev="59dae5d4f40e0b3cac8b063cbdf89096" xsrcmd5="98ba442bfa5ff16d4366ae74eb0fe943" lsrcmd5="c0b874da3c9b67de9e7d2557963a8794"/>
-          <serviceinfo code="succeeded" xsrcmd5="6dff0965ccbe9c0625de5af822e8f86e"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="2091985096c1224fdecf5cbb30c98fe8" size="63" mtime="1642674773"/>
-          <entry name="_link" md5="92d0f6420273f53d1699591054fb0acd" size="141" mtime="1642674774"/>
-          <entry name="somefile.txt" md5="d60ec8ab0a78e5c67358412577e1397d" size="65" mtime="1642674773"/>
+        <directory name="bar_package-123456789" rev="28" vrev="28" srcmd5="3c0a4f94c2707188673540a169650eb0">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="8a9246290d834a740a5a2fb1cc0523ec" baserev="8a9246290d834a740a5a2fb1cc0523ec" xsrcmd5="eb6c2b21270ee1d587214e58725fae00" lsrcmd5="3c0a4f94c2707188673540a169650eb0"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="50818b7aabea9d7d8c9303b07aca3ca0" size="67" mtime="1643641563"/>
+          <entry name="_link" md5="89660fcebd91a5b8eab8746237ce1ac7" size="141" mtime="1643641563"/>
+          <entry name="somefile.txt" md5="d0f77cdaa5e7be303fe6bd26d04dd74a" size="68" mtime="1643641563"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:54 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:04 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '627'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="eb6c2b21270ee1d587214e58725fae00" vrev="126" srcmd5="eb6c2b21270ee1d587214e58725fae00">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="8a9246290d834a740a5a2fb1cc0523ec" baserev="8a9246290d834a740a5a2fb1cc0523ec" lsrcmd5="3c0a4f94c2707188673540a169650eb0"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="50818b7aabea9d7d8c9303b07aca3ca0" size="67" mtime="1643641563"/>
+          <entry name="somefile.txt" md5="d0f77cdaa5e7be303fe6bd26d04dd74a" size="68" mtime="1643641563"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:06:04 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -953,19 +1021,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="124" vrev="124" srcmd5="c0b874da3c9b67de9e7d2557963a8794">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="59dae5d4f40e0b3cac8b063cbdf89096" baserev="59dae5d4f40e0b3cac8b063cbdf89096" xsrcmd5="98ba442bfa5ff16d4366ae74eb0fe943" lsrcmd5="c0b874da3c9b67de9e7d2557963a8794"/>
-          <serviceinfo code="succeeded" xsrcmd5="6dff0965ccbe9c0625de5af822e8f86e"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="2091985096c1224fdecf5cbb30c98fe8" size="63" mtime="1642674773"/>
-          <entry name="_link" md5="92d0f6420273f53d1699591054fb0acd" size="141" mtime="1642674774"/>
-          <entry name="somefile.txt" md5="d60ec8ab0a78e5c67358412577e1397d" size="65" mtime="1642674773"/>
+        <directory name="bar_package-123456789" rev="28" vrev="28" srcmd5="3c0a4f94c2707188673540a169650eb0">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="8a9246290d834a740a5a2fb1cc0523ec" baserev="8a9246290d834a740a5a2fb1cc0523ec" xsrcmd5="eb6c2b21270ee1d587214e58725fae00" lsrcmd5="3c0a4f94c2707188673540a169650eb0"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="50818b7aabea9d7d8c9303b07aca3ca0" size="67" mtime="1643641563"/>
+          <entry name="_link" md5="89660fcebd91a5b8eab8746237ce1ac7" size="141" mtime="1643641563"/>
+          <entry name="somefile.txt" md5="d0f77cdaa5e7be303fe6bd26d04dd74a" size="68" mtime="1643641563"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:54 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:04 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '627'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="eb6c2b21270ee1d587214e58725fae00" vrev="126" srcmd5="eb6c2b21270ee1d587214e58725fae00">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="8a9246290d834a740a5a2fb1cc0523ec" baserev="8a9246290d834a740a5a2fb1cc0523ec" lsrcmd5="3c0a4f94c2707188673540a169650eb0"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="50818b7aabea9d7d8c9303b07aca3ca0" size="67" mtime="1643641563"/>
+          <entry name="somefile.txt" md5="d0f77cdaa5e7be303fe6bd26d04dd74a" size="68" mtime="1643641563"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:06:04 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -991,19 +1094,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="124" vrev="124" srcmd5="c0b874da3c9b67de9e7d2557963a8794">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="59dae5d4f40e0b3cac8b063cbdf89096" baserev="59dae5d4f40e0b3cac8b063cbdf89096" xsrcmd5="98ba442bfa5ff16d4366ae74eb0fe943" lsrcmd5="c0b874da3c9b67de9e7d2557963a8794"/>
-          <serviceinfo code="succeeded" xsrcmd5="6dff0965ccbe9c0625de5af822e8f86e"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="2091985096c1224fdecf5cbb30c98fe8" size="63" mtime="1642674773"/>
-          <entry name="_link" md5="92d0f6420273f53d1699591054fb0acd" size="141" mtime="1642674774"/>
-          <entry name="somefile.txt" md5="d60ec8ab0a78e5c67358412577e1397d" size="65" mtime="1642674773"/>
+        <directory name="bar_package-123456789" rev="28" vrev="28" srcmd5="3c0a4f94c2707188673540a169650eb0">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="8a9246290d834a740a5a2fb1cc0523ec" baserev="8a9246290d834a740a5a2fb1cc0523ec" xsrcmd5="eb6c2b21270ee1d587214e58725fae00" lsrcmd5="3c0a4f94c2707188673540a169650eb0"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="50818b7aabea9d7d8c9303b07aca3ca0" size="67" mtime="1643641563"/>
+          <entry name="_link" md5="89660fcebd91a5b8eab8746237ce1ac7" size="141" mtime="1643641563"/>
+          <entry name="somefile.txt" md5="d0f77cdaa5e7be303fe6bd26d04dd74a" size="68" mtime="1643641563"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:54 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:04 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '627'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="eb6c2b21270ee1d587214e58725fae00" vrev="126" srcmd5="eb6c2b21270ee1d587214e58725fae00">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="8a9246290d834a740a5a2fb1cc0523ec" baserev="8a9246290d834a740a5a2fb1cc0523ec" lsrcmd5="3c0a4f94c2707188673540a169650eb0"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="50818b7aabea9d7d8c9303b07aca3ca0" size="67" mtime="1643641563"/>
+          <entry name="somefile.txt" md5="d0f77cdaa5e7be303fe6bd26d04dd74a" size="68" mtime="1643641563"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:06:04 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -1029,22 +1167,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="124" vrev="124" srcmd5="c0b874da3c9b67de9e7d2557963a8794">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="59dae5d4f40e0b3cac8b063cbdf89096" baserev="59dae5d4f40e0b3cac8b063cbdf89096" xsrcmd5="98ba442bfa5ff16d4366ae74eb0fe943" lsrcmd5="c0b874da3c9b67de9e7d2557963a8794"/>
-          <serviceinfo code="succeeded" xsrcmd5="6dff0965ccbe9c0625de5af822e8f86e"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="2091985096c1224fdecf5cbb30c98fe8" size="63" mtime="1642674773"/>
-          <entry name="_link" md5="92d0f6420273f53d1699591054fb0acd" size="141" mtime="1642674774"/>
-          <entry name="somefile.txt" md5="d60ec8ab0a78e5c67358412577e1397d" size="65" mtime="1642674773"/>
+        <directory name="bar_package-123456789" rev="28" vrev="28" srcmd5="3c0a4f94c2707188673540a169650eb0">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="8a9246290d834a740a5a2fb1cc0523ec" baserev="8a9246290d834a740a5a2fb1cc0523ec" xsrcmd5="eb6c2b21270ee1d587214e58725fae00" lsrcmd5="3c0a4f94c2707188673540a169650eb0"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="50818b7aabea9d7d8c9303b07aca3ca0" size="67" mtime="1643641563"/>
+          <entry name="_link" md5="89660fcebd91a5b8eab8746237ce1ac7" size="141" mtime="1643641563"/>
+          <entry name="somefile.txt" md5="d0f77cdaa5e7be303fe6bd26d04dd74a" size="68" mtime="1643641563"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:54 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:04 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1067,169 +1204,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '627'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="124" vrev="124" srcmd5="c0b874da3c9b67de9e7d2557963a8794">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="59dae5d4f40e0b3cac8b063cbdf89096" baserev="59dae5d4f40e0b3cac8b063cbdf89096" xsrcmd5="98ba442bfa5ff16d4366ae74eb0fe943" lsrcmd5="c0b874da3c9b67de9e7d2557963a8794"/>
-          <serviceinfo code="succeeded" xsrcmd5="6dff0965ccbe9c0625de5af822e8f86e"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="2091985096c1224fdecf5cbb30c98fe8" size="63" mtime="1642674773"/>
-          <entry name="_link" md5="92d0f6420273f53d1699591054fb0acd" size="141" mtime="1642674774"/>
-          <entry name="somefile.txt" md5="d60ec8ab0a78e5c67358412577e1397d" size="65" mtime="1642674773"/>
+        <directory name="bar_package-123456789" rev="eb6c2b21270ee1d587214e58725fae00" vrev="126" srcmd5="eb6c2b21270ee1d587214e58725fae00">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="8a9246290d834a740a5a2fb1cc0523ec" baserev="8a9246290d834a740a5a2fb1cc0523ec" lsrcmd5="3c0a4f94c2707188673540a169650eb0"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="50818b7aabea9d7d8c9303b07aca3ca0" size="67" mtime="1643641563"/>
+          <entry name="somefile.txt" md5="d0f77cdaa5e7be303fe6bd26d04dd74a" size="68" mtime="1643641563"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:54 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '811'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="124" vrev="124" srcmd5="c0b874da3c9b67de9e7d2557963a8794">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="59dae5d4f40e0b3cac8b063cbdf89096" baserev="59dae5d4f40e0b3cac8b063cbdf89096" xsrcmd5="98ba442bfa5ff16d4366ae74eb0fe943" lsrcmd5="c0b874da3c9b67de9e7d2557963a8794"/>
-          <serviceinfo code="succeeded" xsrcmd5="6dff0965ccbe9c0625de5af822e8f86e"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="2091985096c1224fdecf5cbb30c98fe8" size="63" mtime="1642674773"/>
-          <entry name="_link" md5="92d0f6420273f53d1699591054fb0acd" size="141" mtime="1642674774"/>
-          <entry name="somefile.txt" md5="d60ec8ab0a78e5c67358412577e1397d" size="65" mtime="1642674773"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:54 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '811'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="124" vrev="124" srcmd5="c0b874da3c9b67de9e7d2557963a8794">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="59dae5d4f40e0b3cac8b063cbdf89096" baserev="59dae5d4f40e0b3cac8b063cbdf89096" xsrcmd5="98ba442bfa5ff16d4366ae74eb0fe943" lsrcmd5="c0b874da3c9b67de9e7d2557963a8794"/>
-          <serviceinfo code="succeeded" xsrcmd5="6dff0965ccbe9c0625de5af822e8f86e"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="2091985096c1224fdecf5cbb30c98fe8" size="63" mtime="1642674773"/>
-          <entry name="_link" md5="92d0f6420273f53d1699591054fb0acd" size="141" mtime="1642674774"/>
-          <entry name="somefile.txt" md5="d60ec8ab0a78e5c67358412577e1397d" size="65" mtime="1642674773"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:54 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '811'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="124" vrev="124" srcmd5="c0b874da3c9b67de9e7d2557963a8794">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="59dae5d4f40e0b3cac8b063cbdf89096" baserev="59dae5d4f40e0b3cac8b063cbdf89096" xsrcmd5="98ba442bfa5ff16d4366ae74eb0fe943" lsrcmd5="c0b874da3c9b67de9e7d2557963a8794"/>
-          <serviceinfo code="succeeded" xsrcmd5="6dff0965ccbe9c0625de5af822e8f86e"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="2091985096c1224fdecf5cbb30c98fe8" size="63" mtime="1642674773"/>
-          <entry name="_link" md5="92d0f6420273f53d1699591054fb0acd" size="141" mtime="1642674774"/>
-          <entry name="somefile.txt" md5="d60ec8ab0a78e5c67358412577e1397d" size="65" mtime="1642674773"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:54 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '811'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="124" vrev="124" srcmd5="c0b874da3c9b67de9e7d2557963a8794">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="59dae5d4f40e0b3cac8b063cbdf89096" baserev="59dae5d4f40e0b3cac8b063cbdf89096" xsrcmd5="98ba442bfa5ff16d4366ae74eb0fe943" lsrcmd5="c0b874da3c9b67de9e7d2557963a8794"/>
-          <serviceinfo code="succeeded" xsrcmd5="6dff0965ccbe9c0625de5af822e8f86e"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="2091985096c1224fdecf5cbb30c98fe8" size="63" mtime="1642674773"/>
-          <entry name="_link" md5="92d0f6420273f53d1699591054fb0acd" size="141" mtime="1642674774"/>
-          <entry name="somefile.txt" md5="d60ec8ab0a78e5c67358412577e1397d" size="65" mtime="1642674773"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:54 GMT
+  recorded_at: Mon, 31 Jan 2022 15:06:04 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/with_a_push_event_for_a_commit/behaves_like_successful_new_PR_or_MR_event/only_reports_for_repositories_and_architectures_matching_the_filters.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/with_a_push_event_for_a_commit/behaves_like_successful_new_PR_or_MR_event/only_reports_for_repositories_and_architectures_matching_the_filters.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:51 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:55 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_300
+    uri: http://backend:5352/source/foo_project/_meta?user=user_77
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>The Daffodil Sky</title>
+          <title>To Sail Beyond the Sunset</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '148'
+      - '157'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>The Daffodil Sky</title>
+          <title>To Sail Beyond the Sunset</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:51 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:55 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_301
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_78
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Ego Dominus Tuus</title>
-          <description>Ut sed eum totam.</description>
+          <title>An Instant In The Wind</title>
+          <description>Est fuga voluptatem esse.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '143'
+      - '157'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Ego Dominus Tuus</title>
-          <description>Ut sed eum totam.</description>
+          <title>An Instant In The Wind</title>
+          <description>Est fuga voluptatem esse.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:51 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:55 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Ea quia est. Hic aspernatur nam. Iste accusamus nulla.
+      string: Nihil et placeat. Ut aut libero. Velit excepturi provident.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1687" vrev="1687">
-          <srcmd5>ac4ddf85a13be346768ae5113e0597b3</srcmd5>
+        <revision rev="85" vrev="85">
+          <srcmd5>ccbc2041671b0c603575ea1b657f5bae</srcmd5>
           <version>unknown</version>
-          <time>1642674771</time>
+          <time>1643641555</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:51 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:55 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Voluptatem distinctio vero. Nemo neque excepturi. Aut aut incidunt.
+      string: Nobis dolor dolore. Labore voluptatem sit. Voluptatum expedita dolores.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +181,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1688" vrev="1688">
-          <srcmd5>3c21ab3d4f3f978f625614bd0ad95e92</srcmd5>
+        <revision rev="86" vrev="86">
+          <srcmd5>578326bfe1acf7da4163c719fffc33e1</srcmd5>
           <version>unknown</version>
-          <time>1642674771</time>
+          <time>1643641555</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:51 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:55 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -227,7 +227,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:32:51 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:55 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_meta?user=Iggy
@@ -235,8 +235,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>Ego Dominus Tuus</title>
-          <description>Ut sed eum totam.</description>
+          <title>An Instant In The Wind</title>
+          <description>Est fuga voluptatem esse.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -257,15 +257,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '151'
+      - '165'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>Ego Dominus Tuus</title>
-          <description>Ut sed eum totam.</description>
+          <title>An Instant In The Wind</title>
+          <description>Est fuga voluptatem esse.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:52 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:55 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=branch&noservice=1&opackage=bar_package&oproject=foo_project&user=Iggy
@@ -293,19 +293,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="119" vrev="119">
-          <srcmd5>efb6d5461a29c8fb66f25c1e136c2f57</srcmd5>
+        <revision rev="15" vrev="15">
+          <srcmd5>ec13d5f64148296a7d59e5fcf882401f</srcmd5>
           <version>unknown</version>
-          <time>1642674772</time>
+          <time>1643641555</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:52 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:55 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_meta?user=Iggy
@@ -313,8 +313,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>Ego Dominus Tuus</title>
-          <description>Ut sed eum totam.</description>
+          <title>An Instant In The Wind</title>
+          <description>Est fuga voluptatem esse.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -335,15 +335,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '151'
+      - '165'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>Ego Dominus Tuus</title>
-          <description>Ut sed eum totam.</description>
+          <title>An Instant In The Wind</title>
+          <description>Est fuga voluptatem esse.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:52 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:55 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -369,18 +369,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '735'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="119" vrev="119" srcmd5="efb6d5461a29c8fb66f25c1e136c2f57">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3c21ab3d4f3f978f625614bd0ad95e92" baserev="3c21ab3d4f3f978f625614bd0ad95e92" xsrcmd5="b9d4d6b23e0dda773a006aee970f7894" lsrcmd5="efb6d5461a29c8fb66f25c1e136c2f57"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="4bfb228734430ef7e3ad442200bf4995" size="54" mtime="1642674771"/>
-          <entry name="_link" md5="65ff0f6e4b8f4c5ee4dca005f8daab3e" size="141" mtime="1642674772"/>
-          <entry name="somefile.txt" md5="e73201f8a364edde92e51c03f0384a25" size="67" mtime="1642674771"/>
+        <directory name="bar_package-123456789" rev="15" vrev="15" srcmd5="ec13d5f64148296a7d59e5fcf882401f">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="578326bfe1acf7da4163c719fffc33e1" baserev="578326bfe1acf7da4163c719fffc33e1" xsrcmd5="5e7d0226a981630bc113ff7f9df74864" lsrcmd5="ec13d5f64148296a7d59e5fcf882401f"/>
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="445af978e5f6a53d99291363bca47538" size="59" mtime="1643641555"/>
+          <entry name="_link" md5="053a7fd6ce11cfbcb93b8c78ba6a4d3a" size="141" mtime="1643641555"/>
+          <entry name="somefile.txt" md5="da2428832fb59c07abced1d557fe2e95" size="71" mtime="1643641555"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:52 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:55 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?view=info
@@ -406,15 +406,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '343'
+      - '341'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package-123456789" rev="119" vrev="1807" srcmd5="b9d4d6b23e0dda773a006aee970f7894" lsrcmd5="efb6d5461a29c8fb66f25c1e136c2f57" verifymd5="3c21ab3d4f3f978f625614bd0ad95e92">
+        <sourceinfo package="bar_package-123456789" rev="15" vrev="101" srcmd5="5e7d0226a981630bc113ff7f9df74864" lsrcmd5="ec13d5f64148296a7d59e5fcf882401f" verifymd5="578326bfe1acf7da4163c719fffc33e1">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:52 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:55 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -440,18 +440,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '735'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="119" vrev="119" srcmd5="efb6d5461a29c8fb66f25c1e136c2f57">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3c21ab3d4f3f978f625614bd0ad95e92" baserev="3c21ab3d4f3f978f625614bd0ad95e92" xsrcmd5="b9d4d6b23e0dda773a006aee970f7894" lsrcmd5="efb6d5461a29c8fb66f25c1e136c2f57"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="4bfb228734430ef7e3ad442200bf4995" size="54" mtime="1642674771"/>
-          <entry name="_link" md5="65ff0f6e4b8f4c5ee4dca005f8daab3e" size="141" mtime="1642674772"/>
-          <entry name="somefile.txt" md5="e73201f8a364edde92e51c03f0384a25" size="67" mtime="1642674771"/>
+        <directory name="bar_package-123456789" rev="15" vrev="15" srcmd5="ec13d5f64148296a7d59e5fcf882401f">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="578326bfe1acf7da4163c719fffc33e1" baserev="578326bfe1acf7da4163c719fffc33e1" xsrcmd5="5e7d0226a981630bc113ff7f9df74864" lsrcmd5="ec13d5f64148296a7d59e5fcf882401f"/>
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="445af978e5f6a53d99291363bca47538" size="59" mtime="1643641555"/>
+          <entry name="_link" md5="053a7fd6ce11cfbcb93b8c78ba6a4d3a" size="141" mtime="1643641555"/>
+          <entry name="somefile.txt" md5="da2428832fb59c07abced1d557fe2e95" size="71" mtime="1643641555"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:52 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:55 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -479,18 +479,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '324'
+      - '323'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="8d33fe0bb6a77a44a5fa132a0bfeb4c0">
+        <sourcediff key="991afbd848437c4bb2cd330b94964941">
           <old project="home:Iggy" package="bar_package-123456789" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="119" srcmd5="efb6d5461a29c8fb66f25c1e136c2f57"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="15" srcmd5="ec13d5f64148296a7d59e5fcf882401f"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:52 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:55 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -522,14 +522,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="7bd1ddd2153ceff1caa3e5535903ce74">
-          <old project="foo_project" package="bar_package" rev="3c21ab3d4f3f978f625614bd0ad95e92" srcmd5="3c21ab3d4f3f978f625614bd0ad95e92"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="b9d4d6b23e0dda773a006aee970f7894" srcmd5="b9d4d6b23e0dda773a006aee970f7894"/>
+        <sourcediff key="2269a738d23b1f50fb7595da327189ac">
+          <old project="foo_project" package="bar_package" rev="578326bfe1acf7da4163c719fffc33e1" srcmd5="578326bfe1acf7da4163c719fffc33e1"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="5e7d0226a981630bc113ff7f9df74864" srcmd5="5e7d0226a981630bc113ff7f9df74864"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:52 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:55 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/_meta?user=Iggy
@@ -587,7 +587,7 @@ http_interactions:
             <arch>aarch64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:52 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:55 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_branch_request?user=Iggy
@@ -613,19 +613,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="120" vrev="120">
-          <srcmd5>2a082ec0065832c10ac2772b26bd79f7</srcmd5>
+        <revision rev="16" vrev="16">
+          <srcmd5>a3bc02a84992457ccc16f682dcbdf00f</srcmd5>
           <version>unknown</version>
-          <time>1642674772</time>
+          <time>1643641555</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:52 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:55 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_meta?user=Iggy
@@ -633,8 +633,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>Ego Dominus Tuus</title>
-          <description>Ut sed eum totam.</description>
+          <title>An Instant In The Wind</title>
+          <description>Est fuga voluptatem esse.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -655,15 +655,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '151'
+      - '165'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>Ego Dominus Tuus</title>
-          <description>Ut sed eum totam.</description>
+          <title>An Instant In The Wind</title>
+          <description>Est fuga voluptatem esse.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:52 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:55 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -689,19 +689,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="120" vrev="120" srcmd5="2a082ec0065832c10ac2772b26bd79f7">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3c21ab3d4f3f978f625614bd0ad95e92" baserev="3c21ab3d4f3f978f625614bd0ad95e92" xsrcmd5="6055a73f3811391c3142300255d1cee7" lsrcmd5="2a082ec0065832c10ac2772b26bd79f7"/>
-          <serviceinfo code="succeeded" xsrcmd5="37f6c531b492d35dc574940dc18a8595"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="4bfb228734430ef7e3ad442200bf4995" size="54" mtime="1642674771"/>
-          <entry name="_link" md5="65ff0f6e4b8f4c5ee4dca005f8daab3e" size="141" mtime="1642674772"/>
-          <entry name="somefile.txt" md5="e73201f8a364edde92e51c03f0384a25" size="67" mtime="1642674771"/>
+        <directory name="bar_package-123456789" rev="16" vrev="16" srcmd5="a3bc02a84992457ccc16f682dcbdf00f">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="578326bfe1acf7da4163c719fffc33e1" baserev="578326bfe1acf7da4163c719fffc33e1" xsrcmd5="d981d2361744c5c7ad08f5405f18c4ff" lsrcmd5="a3bc02a84992457ccc16f682dcbdf00f"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="445af978e5f6a53d99291363bca47538" size="59" mtime="1643641555"/>
+          <entry name="_link" md5="053a7fd6ce11cfbcb93b8c78ba6a4d3a" size="141" mtime="1643641555"/>
+          <entry name="somefile.txt" md5="da2428832fb59c07abced1d557fe2e95" size="71" mtime="1643641555"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:52 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:55 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?view=info
@@ -727,15 +726,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '343'
+      - '341'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package-123456789" rev="120" vrev="1808" srcmd5="f890eb17e8758fb6788b09bac1160f6e" lsrcmd5="37f6c531b492d35dc574940dc18a8595" verifymd5="4244bf4cc8f3fe55edfd8e96de87f2da">
+        <sourceinfo package="bar_package-123456789" rev="16" vrev="102" srcmd5="d981d2361744c5c7ad08f5405f18c4ff" lsrcmd5="a3bc02a84992457ccc16f682dcbdf00f" verifymd5="be5381b0e445a64665b7a7f8e34516d7">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:52 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:55 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -761,19 +760,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="120" vrev="120" srcmd5="2a082ec0065832c10ac2772b26bd79f7">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3c21ab3d4f3f978f625614bd0ad95e92" baserev="3c21ab3d4f3f978f625614bd0ad95e92" xsrcmd5="6055a73f3811391c3142300255d1cee7" lsrcmd5="2a082ec0065832c10ac2772b26bd79f7"/>
-          <serviceinfo code="succeeded" xsrcmd5="37f6c531b492d35dc574940dc18a8595"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="4bfb228734430ef7e3ad442200bf4995" size="54" mtime="1642674771"/>
-          <entry name="_link" md5="65ff0f6e4b8f4c5ee4dca005f8daab3e" size="141" mtime="1642674772"/>
-          <entry name="somefile.txt" md5="e73201f8a364edde92e51c03f0384a25" size="67" mtime="1642674771"/>
+        <directory name="bar_package-123456789" rev="16" vrev="16" srcmd5="a3bc02a84992457ccc16f682dcbdf00f">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="578326bfe1acf7da4163c719fffc33e1" baserev="578326bfe1acf7da4163c719fffc33e1" xsrcmd5="d981d2361744c5c7ad08f5405f18c4ff" lsrcmd5="a3bc02a84992457ccc16f682dcbdf00f"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="445af978e5f6a53d99291363bca47538" size="59" mtime="1643641555"/>
+          <entry name="_link" md5="053a7fd6ce11cfbcb93b8c78ba6a4d3a" size="141" mtime="1643641555"/>
+          <entry name="somefile.txt" md5="da2428832fb59c07abced1d557fe2e95" size="71" mtime="1643641555"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:52 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:55 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -801,18 +799,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '324'
+      - '323'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="a317fc5000fc3c89569e7732a606e364">
+        <sourcediff key="3d99ec4bcfce1a5228b421f115f49a4a">
           <old project="home:Iggy" package="bar_package-123456789" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="120" srcmd5="2a082ec0065832c10ac2772b26bd79f7"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="16" srcmd5="a3bc02a84992457ccc16f682dcbdf00f"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:52 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:55 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -844,14 +842,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="66cf9dbe0505f145b5dbb56129bf1264">
-          <old project="foo_project" package="bar_package" rev="3c21ab3d4f3f978f625614bd0ad95e92" srcmd5="3c21ab3d4f3f978f625614bd0ad95e92"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="f890eb17e8758fb6788b09bac1160f6e" srcmd5="f890eb17e8758fb6788b09bac1160f6e"/>
+        <sourcediff key="6cf40b9bb4d3025d8aa4da57a484fa35">
+          <old project="foo_project" package="bar_package" rev="578326bfe1acf7da4163c719fffc33e1" srcmd5="578326bfe1acf7da4163c719fffc33e1"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="d981d2361744c5c7ad08f5405f18c4ff" srcmd5="d981d2361744c5c7ad08f5405f18c4ff"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:52 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:55 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -877,19 +875,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="120" vrev="120" srcmd5="2a082ec0065832c10ac2772b26bd79f7">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3c21ab3d4f3f978f625614bd0ad95e92" baserev="3c21ab3d4f3f978f625614bd0ad95e92" xsrcmd5="6055a73f3811391c3142300255d1cee7" lsrcmd5="2a082ec0065832c10ac2772b26bd79f7"/>
-          <serviceinfo code="succeeded" xsrcmd5="37f6c531b492d35dc574940dc18a8595"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="4bfb228734430ef7e3ad442200bf4995" size="54" mtime="1642674771"/>
-          <entry name="_link" md5="65ff0f6e4b8f4c5ee4dca005f8daab3e" size="141" mtime="1642674772"/>
-          <entry name="somefile.txt" md5="e73201f8a364edde92e51c03f0384a25" size="67" mtime="1642674771"/>
+        <directory name="bar_package-123456789" rev="16" vrev="16" srcmd5="a3bc02a84992457ccc16f682dcbdf00f">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="578326bfe1acf7da4163c719fffc33e1" baserev="578326bfe1acf7da4163c719fffc33e1" xsrcmd5="d981d2361744c5c7ad08f5405f18c4ff" lsrcmd5="a3bc02a84992457ccc16f682dcbdf00f"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="445af978e5f6a53d99291363bca47538" size="59" mtime="1643641555"/>
+          <entry name="_link" md5="053a7fd6ce11cfbcb93b8c78ba6a4d3a" size="141" mtime="1643641555"/>
+          <entry name="somefile.txt" md5="da2428832fb59c07abced1d557fe2e95" size="71" mtime="1643641555"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:52 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:56 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '627'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="d981d2361744c5c7ad08f5405f18c4ff" vrev="102" srcmd5="d981d2361744c5c7ad08f5405f18c4ff">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="578326bfe1acf7da4163c719fffc33e1" baserev="578326bfe1acf7da4163c719fffc33e1" lsrcmd5="a3bc02a84992457ccc16f682dcbdf00f"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="445af978e5f6a53d99291363bca47538" size="59" mtime="1643641555"/>
+          <entry name="somefile.txt" md5="da2428832fb59c07abced1d557fe2e95" size="71" mtime="1643641555"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:05:56 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -915,22 +948,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="120" vrev="120" srcmd5="2a082ec0065832c10ac2772b26bd79f7">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3c21ab3d4f3f978f625614bd0ad95e92" baserev="3c21ab3d4f3f978f625614bd0ad95e92" xsrcmd5="6055a73f3811391c3142300255d1cee7" lsrcmd5="2a082ec0065832c10ac2772b26bd79f7"/>
-          <serviceinfo code="succeeded" xsrcmd5="37f6c531b492d35dc574940dc18a8595"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="4bfb228734430ef7e3ad442200bf4995" size="54" mtime="1642674771"/>
-          <entry name="_link" md5="65ff0f6e4b8f4c5ee4dca005f8daab3e" size="141" mtime="1642674772"/>
-          <entry name="somefile.txt" md5="e73201f8a364edde92e51c03f0384a25" size="67" mtime="1642674771"/>
+        <directory name="bar_package-123456789" rev="16" vrev="16" srcmd5="a3bc02a84992457ccc16f682dcbdf00f">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="578326bfe1acf7da4163c719fffc33e1" baserev="578326bfe1acf7da4163c719fffc33e1" xsrcmd5="d981d2361744c5c7ad08f5405f18c4ff" lsrcmd5="a3bc02a84992457ccc16f682dcbdf00f"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="445af978e5f6a53d99291363bca47538" size="59" mtime="1643641555"/>
+          <entry name="_link" md5="053a7fd6ce11cfbcb93b8c78ba6a4d3a" size="141" mtime="1643641555"/>
+          <entry name="somefile.txt" md5="da2428832fb59c07abced1d557fe2e95" size="71" mtime="1643641555"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:52 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:56 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -953,55 +985,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '811'
+      - '627'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="120" vrev="120" srcmd5="2a082ec0065832c10ac2772b26bd79f7">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3c21ab3d4f3f978f625614bd0ad95e92" baserev="3c21ab3d4f3f978f625614bd0ad95e92" xsrcmd5="6055a73f3811391c3142300255d1cee7" lsrcmd5="2a082ec0065832c10ac2772b26bd79f7"/>
-          <serviceinfo code="succeeded" xsrcmd5="37f6c531b492d35dc574940dc18a8595"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="4bfb228734430ef7e3ad442200bf4995" size="54" mtime="1642674771"/>
-          <entry name="_link" md5="65ff0f6e4b8f4c5ee4dca005f8daab3e" size="141" mtime="1642674772"/>
-          <entry name="somefile.txt" md5="e73201f8a364edde92e51c03f0384a25" size="67" mtime="1642674771"/>
+        <directory name="bar_package-123456789" rev="d981d2361744c5c7ad08f5405f18c4ff" vrev="102" srcmd5="d981d2361744c5c7ad08f5405f18c4ff">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="578326bfe1acf7da4163c719fffc33e1" baserev="578326bfe1acf7da4163c719fffc33e1" lsrcmd5="a3bc02a84992457ccc16f682dcbdf00f"/>
+          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1643632108"/>
+          <entry name="_config" md5="445af978e5f6a53d99291363bca47538" size="59" mtime="1643641555"/>
+          <entry name="somefile.txt" md5="da2428832fb59c07abced1d557fe2e95" size="71" mtime="1643641555"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:52 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '811'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="120" vrev="120" srcmd5="2a082ec0065832c10ac2772b26bd79f7">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3c21ab3d4f3f978f625614bd0ad95e92" baserev="3c21ab3d4f3f978f625614bd0ad95e92" xsrcmd5="6055a73f3811391c3142300255d1cee7" lsrcmd5="2a082ec0065832c10ac2772b26bd79f7"/>
-          <serviceinfo code="succeeded" xsrcmd5="37f6c531b492d35dc574940dc18a8595"/>
-          <entry name="_branch_request" md5="a0ae3e8c1598e691c7662a4b258bd481" size="95" mtime="1642596971"/>
-          <entry name="_config" md5="4bfb228734430ef7e3ad442200bf4995" size="54" mtime="1642674771"/>
-          <entry name="_link" md5="65ff0f6e4b8f4c5ee4dca005f8daab3e" size="141" mtime="1642674772"/>
-          <entry name="somefile.txt" md5="e73201f8a364edde92e51c03f0384a25" size="67" mtime="1642674771"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:52 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:56 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/with_a_push_event_for_a_tag/1_1_1_7_1.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/with_a_push_event_for_a_tag/1_1_1_7_1.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:26 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:44 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_366
+    uri: http://backend:5352/source/foo_project/_meta?user=user_55
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Vanity Fair</title>
+          <title>The Wives of Bath</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '143'
+      - '149'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Vanity Fair</title>
+          <title>The Wives of Bath</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:26 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:44 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_367
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_56
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>For Whom the Bell Tolls</title>
-          <description>Expedita est blanditiis vel.</description>
+          <title>The Road Less Traveled</title>
+          <description>Odio veniam quis et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '161'
+      - '152'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>For Whom the Bell Tolls</title>
-          <description>Expedita est blanditiis vel.</description>
+          <title>The Road Less Traveled</title>
+          <description>Odio veniam quis et.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:26 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:44 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Asperiores dolorem culpa. Ratione quia earum. Ut et animi.
+      string: Vel eligendi porro. Tenetur quasi aspernatur. Rerum nemo rem.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,26 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1745" vrev="1745">
-          <srcmd5>a0c8e558e51f0be9288cc5a2c0bf5d47</srcmd5>
+        <revision rev="63" vrev="63">
+          <srcmd5>2ba1b97e539b8365ae175e69ffcb68d5</srcmd5>
           <version>unknown</version>
-          <time>1642674806</time>
+          <time>1643641544</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:26 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:44 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Repellendus earum exercitationem. A earum non. Suscipit et sapiente.
+      string: Optio sit eligendi. Voluptate beatae voluptas. Perspiciatis suscipit
+        rerum.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +182,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1746" vrev="1746">
-          <srcmd5>f38c0e5caae279250209e3b39a28e967</srcmd5>
+        <revision rev="64" vrev="64">
+          <srcmd5>1e88b44e274683ede52307f06de2e137</srcmd5>
           <version>unknown</version>
-          <time>1642674806</time>
+          <time>1643641544</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:26 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:44 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -227,7 +228,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:33:26 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:44 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc/_meta?user=Iggy
@@ -235,8 +236,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-release_abc" project="home:Iggy">
-          <title>For Whom the Bell Tolls</title>
-          <description>Expedita est blanditiis vel.</description>
+          <title>The Road Less Traveled</title>
+          <description>Odio veniam quis et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -257,15 +258,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '162'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-release_abc" project="home:Iggy">
-          <title>For Whom the Bell Tolls</title>
-          <description>Expedita est blanditiis vel.</description>
+          <title>The Road Less Traveled</title>
+          <description>Odio veniam quis et.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:26 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:44 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc?cmd=branch&noservice=1&opackage=bar_package&oproject=foo_project&user=Iggy
@@ -293,19 +294,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '204'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="171" vrev="171">
-          <srcmd5>ea2092b74b638a66d76bb3292007eae5</srcmd5>
+        <revision rev="1" vrev="1">
+          <srcmd5>0103ce36190d98085bd324bfeb426cd8</srcmd5>
           <version>unknown</version>
-          <time>1642674806</time>
+          <time>1643641544</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:26 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:44 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc/_meta?user=Iggy
@@ -313,8 +314,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-release_abc" project="home:Iggy">
-          <title>For Whom the Bell Tolls</title>
-          <description>Expedita est blanditiis vel.</description>
+          <title>The Road Less Traveled</title>
+          <description>Odio veniam quis et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -335,15 +336,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '162'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-release_abc" project="home:Iggy">
-          <title>For Whom the Bell Tolls</title>
-          <description>Expedita est blanditiis vel.</description>
+          <title>The Road Less Traveled</title>
+          <description>Odio veniam quis et.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:26 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:44 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc
@@ -369,18 +370,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '737'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-release_abc" rev="171" vrev="171" srcmd5="ea2092b74b638a66d76bb3292007eae5">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="f38c0e5caae279250209e3b39a28e967" baserev="f38c0e5caae279250209e3b39a28e967" xsrcmd5="8ce937998097fd3bc44b075e75b078cc" lsrcmd5="ea2092b74b638a66d76bb3292007eae5"/>
-          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1642591329"/>
-          <entry name="_config" md5="bf30fb4e74dfea3884d0908cc4d8ad76" size="58" mtime="1642674806"/>
-          <entry name="_link" md5="fcd76a3706f558d059df2053754ae9a1" size="141" mtime="1642674806"/>
-          <entry name="somefile.txt" md5="7f1c5eda66da3e87977169bca861024f" size="68" mtime="1642674806"/>
+        <directory name="bar_package-release_abc" rev="1" vrev="1" srcmd5="0103ce36190d98085bd324bfeb426cd8">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="1e88b44e274683ede52307f06de2e137" baserev="1e88b44e274683ede52307f06de2e137" xsrcmd5="e8fe70e67812ac2f9c708c05dacda002" lsrcmd5="0103ce36190d98085bd324bfeb426cd8"/>
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="5526c00b19a2c95ecc01ef4a3772f15e" size="61" mtime="1643641544"/>
+          <entry name="_link" md5="b8a32b21eb6d3a10faa101f4738a5d1b" size="141" mtime="1643641544"/>
+          <entry name="somefile.txt" md5="16b0ab0f1be901ecc4d6fa8536858aea" size="75" mtime="1643641544"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:26 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:44 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc?view=info
@@ -406,15 +407,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '345'
+      - '341'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package-release_abc" rev="171" vrev="1917" srcmd5="8ce937998097fd3bc44b075e75b078cc" lsrcmd5="ea2092b74b638a66d76bb3292007eae5" verifymd5="f38c0e5caae279250209e3b39a28e967">
+        <sourceinfo package="bar_package-release_abc" rev="1" vrev="65" srcmd5="e8fe70e67812ac2f9c708c05dacda002" lsrcmd5="0103ce36190d98085bd324bfeb426cd8" verifymd5="1e88b44e274683ede52307f06de2e137">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:26 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:44 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc
@@ -440,18 +441,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '737'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-release_abc" rev="171" vrev="171" srcmd5="ea2092b74b638a66d76bb3292007eae5">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="f38c0e5caae279250209e3b39a28e967" baserev="f38c0e5caae279250209e3b39a28e967" xsrcmd5="8ce937998097fd3bc44b075e75b078cc" lsrcmd5="ea2092b74b638a66d76bb3292007eae5"/>
-          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1642591329"/>
-          <entry name="_config" md5="bf30fb4e74dfea3884d0908cc4d8ad76" size="58" mtime="1642674806"/>
-          <entry name="_link" md5="fcd76a3706f558d059df2053754ae9a1" size="141" mtime="1642674806"/>
-          <entry name="somefile.txt" md5="7f1c5eda66da3e87977169bca861024f" size="68" mtime="1642674806"/>
+        <directory name="bar_package-release_abc" rev="1" vrev="1" srcmd5="0103ce36190d98085bd324bfeb426cd8">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="1e88b44e274683ede52307f06de2e137" baserev="1e88b44e274683ede52307f06de2e137" xsrcmd5="e8fe70e67812ac2f9c708c05dacda002" lsrcmd5="0103ce36190d98085bd324bfeb426cd8"/>
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="5526c00b19a2c95ecc01ef4a3772f15e" size="61" mtime="1643641544"/>
+          <entry name="_link" md5="b8a32b21eb6d3a10faa101f4738a5d1b" size="141" mtime="1643641544"/>
+          <entry name="somefile.txt" md5="16b0ab0f1be901ecc4d6fa8536858aea" size="75" mtime="1643641544"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:26 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:45 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -479,18 +480,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '328'
+      - '326'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="993a707d7774b0621d80c7531fe425c9">
+        <sourcediff key="377bef4743a06931f677d10fb467b237">
           <old project="home:Iggy" package="bar_package-release_abc" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy" package="bar_package-release_abc" rev="171" srcmd5="ea2092b74b638a66d76bb3292007eae5"/>
+          <new project="home:Iggy" package="bar_package-release_abc" rev="1" srcmd5="0103ce36190d98085bd324bfeb426cd8"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:27 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:45 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -522,14 +523,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="8fd9775b5e3d9019b60a29208c45531a">
-          <old project="foo_project" package="bar_package" rev="f38c0e5caae279250209e3b39a28e967" srcmd5="f38c0e5caae279250209e3b39a28e967"/>
-          <new project="home:Iggy" package="bar_package-release_abc" rev="8ce937998097fd3bc44b075e75b078cc" srcmd5="8ce937998097fd3bc44b075e75b078cc"/>
+        <sourcediff key="bc70c9c021f307d262ac241e8f98b25b">
+          <old project="foo_project" package="bar_package" rev="1e88b44e274683ede52307f06de2e137" srcmd5="1e88b44e274683ede52307f06de2e137"/>
+          <new project="home:Iggy" package="bar_package-release_abc" rev="e8fe70e67812ac2f9c708c05dacda002" srcmd5="e8fe70e67812ac2f9c708c05dacda002"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:27 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:45 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/_meta?user=Iggy
@@ -587,7 +588,7 @@ http_interactions:
             <arch>aarch64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:27 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:45 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc/_branch_request?user=Iggy
@@ -613,19 +614,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '204'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="172" vrev="172">
-          <srcmd5>981de8689fbaae9e590d64970c3a4a0e</srcmd5>
+        <revision rev="2" vrev="2">
+          <srcmd5>1514a23a94cecb0b6f6ebf0d1681037d</srcmd5>
           <version>unknown</version>
-          <time>1642674807</time>
+          <time>1643641545</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:27 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:45 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc/_meta?user=Iggy
@@ -633,8 +634,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-release_abc" project="home:Iggy">
-          <title>For Whom the Bell Tolls</title>
-          <description>Expedita est blanditiis vel.</description>
+          <title>The Road Less Traveled</title>
+          <description>Odio veniam quis et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -655,15 +656,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '162'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-release_abc" project="home:Iggy">
-          <title>For Whom the Bell Tolls</title>
-          <description>Expedita est blanditiis vel.</description>
+          <title>The Road Less Traveled</title>
+          <description>Odio veniam quis et.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:27 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:45 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc
@@ -689,19 +690,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '814'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-release_abc" rev="172" vrev="172" srcmd5="981de8689fbaae9e590d64970c3a4a0e">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="f38c0e5caae279250209e3b39a28e967" baserev="f38c0e5caae279250209e3b39a28e967" xsrcmd5="d45f38c58d162dfc7e60925289c753e1" lsrcmd5="981de8689fbaae9e590d64970c3a4a0e"/>
-          <serviceinfo code="succeeded" xsrcmd5="01562bc36291dadb0e02ac006f45a016"/>
-          <entry name="_branch_request" md5="8ccc2896b48bb83bb375eaf0b342764a" size="120" mtime="1637576859"/>
-          <entry name="_config" md5="bf30fb4e74dfea3884d0908cc4d8ad76" size="58" mtime="1642674806"/>
-          <entry name="_link" md5="fcd76a3706f558d059df2053754ae9a1" size="141" mtime="1642674806"/>
-          <entry name="somefile.txt" md5="7f1c5eda66da3e87977169bca861024f" size="68" mtime="1642674806"/>
+        <directory name="bar_package-release_abc" rev="2" vrev="2" srcmd5="1514a23a94cecb0b6f6ebf0d1681037d">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="1e88b44e274683ede52307f06de2e137" baserev="1e88b44e274683ede52307f06de2e137" xsrcmd5="4ce5f2ff79b41f417285a75a02d315f4" lsrcmd5="1514a23a94cecb0b6f6ebf0d1681037d"/>
+          <entry name="_branch_request" md5="8ccc2896b48bb83bb375eaf0b342764a" size="120" mtime="1643641545"/>
+          <entry name="_config" md5="5526c00b19a2c95ecc01ef4a3772f15e" size="61" mtime="1643641544"/>
+          <entry name="_link" md5="b8a32b21eb6d3a10faa101f4738a5d1b" size="141" mtime="1643641544"/>
+          <entry name="somefile.txt" md5="16b0ab0f1be901ecc4d6fa8536858aea" size="75" mtime="1643641544"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:27 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:45 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc?view=info
@@ -727,15 +727,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '345'
+      - '341'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package-release_abc" rev="172" vrev="1918" srcmd5="585cc088a51754789b4bada8831248de" lsrcmd5="01562bc36291dadb0e02ac006f45a016" verifymd5="5098a656e07769d0a202e802d59c1de4">
+        <sourceinfo package="bar_package-release_abc" rev="2" vrev="66" srcmd5="4ce5f2ff79b41f417285a75a02d315f4" lsrcmd5="1514a23a94cecb0b6f6ebf0d1681037d" verifymd5="4a83fc85fb9f62a36871bffdcd1a57d9">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:27 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:45 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc
@@ -761,19 +761,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '814'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-release_abc" rev="172" vrev="172" srcmd5="981de8689fbaae9e590d64970c3a4a0e">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="f38c0e5caae279250209e3b39a28e967" baserev="f38c0e5caae279250209e3b39a28e967" xsrcmd5="d45f38c58d162dfc7e60925289c753e1" lsrcmd5="981de8689fbaae9e590d64970c3a4a0e"/>
-          <serviceinfo code="succeeded" xsrcmd5="01562bc36291dadb0e02ac006f45a016"/>
-          <entry name="_branch_request" md5="8ccc2896b48bb83bb375eaf0b342764a" size="120" mtime="1637576859"/>
-          <entry name="_config" md5="bf30fb4e74dfea3884d0908cc4d8ad76" size="58" mtime="1642674806"/>
-          <entry name="_link" md5="fcd76a3706f558d059df2053754ae9a1" size="141" mtime="1642674806"/>
-          <entry name="somefile.txt" md5="7f1c5eda66da3e87977169bca861024f" size="68" mtime="1642674806"/>
+        <directory name="bar_package-release_abc" rev="2" vrev="2" srcmd5="1514a23a94cecb0b6f6ebf0d1681037d">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="1e88b44e274683ede52307f06de2e137" baserev="1e88b44e274683ede52307f06de2e137" xsrcmd5="4ce5f2ff79b41f417285a75a02d315f4" lsrcmd5="1514a23a94cecb0b6f6ebf0d1681037d"/>
+          <entry name="_branch_request" md5="8ccc2896b48bb83bb375eaf0b342764a" size="120" mtime="1643641545"/>
+          <entry name="_config" md5="5526c00b19a2c95ecc01ef4a3772f15e" size="61" mtime="1643641544"/>
+          <entry name="_link" md5="b8a32b21eb6d3a10faa101f4738a5d1b" size="141" mtime="1643641544"/>
+          <entry name="somefile.txt" md5="16b0ab0f1be901ecc4d6fa8536858aea" size="75" mtime="1643641544"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:27 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:45 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -801,18 +800,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '328'
+      - '326'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="77e1cda929939c276737e7c6851cb12e">
+        <sourcediff key="34a694edc71fdc65df8069f6241d7dca">
           <old project="home:Iggy" package="bar_package-release_abc" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy" package="bar_package-release_abc" rev="172" srcmd5="981de8689fbaae9e590d64970c3a4a0e"/>
+          <new project="home:Iggy" package="bar_package-release_abc" rev="2" srcmd5="1514a23a94cecb0b6f6ebf0d1681037d"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:27 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:45 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -844,12 +843,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="b0c72501b5cd3ed3e2531b2b7a895b1e">
-          <old project="foo_project" package="bar_package" rev="f38c0e5caae279250209e3b39a28e967" srcmd5="f38c0e5caae279250209e3b39a28e967"/>
-          <new project="home:Iggy" package="bar_package-release_abc" rev="585cc088a51754789b4bada8831248de" srcmd5="585cc088a51754789b4bada8831248de"/>
+        <sourcediff key="b4c35127f37b0379850d9d2d97875625">
+          <old project="foo_project" package="bar_package" rev="1e88b44e274683ede52307f06de2e137" srcmd5="1e88b44e274683ede52307f06de2e137"/>
+          <new project="home:Iggy" package="bar_package-release_abc" rev="4ce5f2ff79b41f417285a75a02d315f4" srcmd5="4ce5f2ff79b41f417285a75a02d315f4"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:27 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:45 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/with_a_push_event_for_a_tag/1_1_1_7_2.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/with_a_push_event_for_a_tag/1_1_1_7_2.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:51 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_362
+    uri: http://backend:5352/source/foo_project/_meta?user=user_65
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>O Pioneers!</title>
+          <title>A Confederacy of Dunces</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '143'
+      - '155'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>O Pioneers!</title>
+          <title>A Confederacy of Dunces</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:51 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_363
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_66
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Oh! To be in England</title>
-          <description>Autem excepturi dolore aspernatur.</description>
+          <title>Let Us Now Praise Famous Men</title>
+          <description>Et accusamus non vel.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '164'
+      - '159'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Oh! To be in England</title>
-          <description>Autem excepturi dolore aspernatur.</description>
+          <title>Let Us Now Praise Famous Men</title>
+          <description>Et accusamus non vel.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:51 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Nobis aperiam labore. Et id velit. At dolor quos.
+      string: Architecto aut officia. Sed incidunt vel. Non consequatur corporis.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1741" vrev="1741">
-          <srcmd5>e6318abb92734fcfd68511d54db34ae1</srcmd5>
+        <revision rev="73" vrev="73">
+          <srcmd5>881a6ba2b680a7502df9774be1872c30</srcmd5>
           <version>unknown</version>
-          <time>1642674804</time>
+          <time>1643641551</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:51 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Vel enim pariatur. Doloribus ut ut. Neque fuga accusantium.
+      string: Eum aut temporibus. Inventore assumenda modi. Et rem voluptatum.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +181,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1742" vrev="1742">
-          <srcmd5>9ce337a44efd846974e07257268e591b</srcmd5>
+        <revision rev="74" vrev="74">
+          <srcmd5>c50d57d8b25e8b65f624084f1441754d</srcmd5>
           <version>unknown</version>
-          <time>1642674804</time>
+          <time>1643641551</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:51 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -227,7 +227,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:33:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:51 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc/_meta?user=Iggy
@@ -235,8 +235,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-release_abc" project="home:Iggy">
-          <title>Oh! To be in England</title>
-          <description>Autem excepturi dolore aspernatur.</description>
+          <title>Let Us Now Praise Famous Men</title>
+          <description>Et accusamus non vel.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -257,15 +257,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '174'
+      - '169'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-release_abc" project="home:Iggy">
-          <title>Oh! To be in England</title>
-          <description>Autem excepturi dolore aspernatur.</description>
+          <title>Let Us Now Praise Famous Men</title>
+          <description>Et accusamus non vel.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:51 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc?cmd=branch&noservice=1&opackage=bar_package&oproject=foo_project&user=Iggy
@@ -293,19 +293,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="167" vrev="167">
-          <srcmd5>7e20d5d7a56c6668cdff1f5433da6cab</srcmd5>
+        <revision rev="11" vrev="11">
+          <srcmd5>7e810736af43f4a3208af6a52f0dcfcc</srcmd5>
           <version>unknown</version>
-          <time>1642674805</time>
+          <time>1643641551</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:51 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc/_meta?user=Iggy
@@ -313,8 +313,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-release_abc" project="home:Iggy">
-          <title>Oh! To be in England</title>
-          <description>Autem excepturi dolore aspernatur.</description>
+          <title>Let Us Now Praise Famous Men</title>
+          <description>Et accusamus non vel.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -335,15 +335,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '174'
+      - '169'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-release_abc" project="home:Iggy">
-          <title>Oh! To be in England</title>
-          <description>Autem excepturi dolore aspernatur.</description>
+          <title>Let Us Now Praise Famous Men</title>
+          <description>Et accusamus non vel.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:51 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc
@@ -369,18 +369,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '737'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-release_abc" rev="167" vrev="167" srcmd5="7e20d5d7a56c6668cdff1f5433da6cab">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="9ce337a44efd846974e07257268e591b" baserev="9ce337a44efd846974e07257268e591b" xsrcmd5="c778a9f59ac304a4d7bfd2d5ca3f6a6c" lsrcmd5="7e20d5d7a56c6668cdff1f5433da6cab"/>
-          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1642591329"/>
-          <entry name="_config" md5="d5f4cff20d50f39ff5b95ca3e9fd114f" size="49" mtime="1642674804"/>
-          <entry name="_link" md5="c41b320bfbdc0eb7f8cfda2e4624e373" size="141" mtime="1642674805"/>
-          <entry name="somefile.txt" md5="7137503c2101f5d89f3cd5b721d51097" size="59" mtime="1642674804"/>
+        <directory name="bar_package-release_abc" rev="11" vrev="11" srcmd5="7e810736af43f4a3208af6a52f0dcfcc">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="c50d57d8b25e8b65f624084f1441754d" baserev="c50d57d8b25e8b65f624084f1441754d" xsrcmd5="33600966703b5008f3ac6553f46e9c32" lsrcmd5="7e810736af43f4a3208af6a52f0dcfcc"/>
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="3917196ef3c887993a9c481600711292" size="67" mtime="1643641551"/>
+          <entry name="_link" md5="99ae29aad28310347371b2056bf06d9e" size="141" mtime="1643641551"/>
+          <entry name="somefile.txt" md5="2b2259dea9a3b6f4561f7f18789befe5" size="64" mtime="1643641551"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:51 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc?view=info
@@ -406,15 +406,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '345'
+      - '342'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package-release_abc" rev="167" vrev="1909" srcmd5="c778a9f59ac304a4d7bfd2d5ca3f6a6c" lsrcmd5="7e20d5d7a56c6668cdff1f5433da6cab" verifymd5="9ce337a44efd846974e07257268e591b">
+        <sourceinfo package="bar_package-release_abc" rev="11" vrev="85" srcmd5="33600966703b5008f3ac6553f46e9c32" lsrcmd5="7e810736af43f4a3208af6a52f0dcfcc" verifymd5="c50d57d8b25e8b65f624084f1441754d">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:51 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc
@@ -440,18 +440,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '737'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-release_abc" rev="167" vrev="167" srcmd5="7e20d5d7a56c6668cdff1f5433da6cab">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="9ce337a44efd846974e07257268e591b" baserev="9ce337a44efd846974e07257268e591b" xsrcmd5="c778a9f59ac304a4d7bfd2d5ca3f6a6c" lsrcmd5="7e20d5d7a56c6668cdff1f5433da6cab"/>
-          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1642591329"/>
-          <entry name="_config" md5="d5f4cff20d50f39ff5b95ca3e9fd114f" size="49" mtime="1642674804"/>
-          <entry name="_link" md5="c41b320bfbdc0eb7f8cfda2e4624e373" size="141" mtime="1642674805"/>
-          <entry name="somefile.txt" md5="7137503c2101f5d89f3cd5b721d51097" size="59" mtime="1642674804"/>
+        <directory name="bar_package-release_abc" rev="11" vrev="11" srcmd5="7e810736af43f4a3208af6a52f0dcfcc">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="c50d57d8b25e8b65f624084f1441754d" baserev="c50d57d8b25e8b65f624084f1441754d" xsrcmd5="33600966703b5008f3ac6553f46e9c32" lsrcmd5="7e810736af43f4a3208af6a52f0dcfcc"/>
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="3917196ef3c887993a9c481600711292" size="67" mtime="1643641551"/>
+          <entry name="_link" md5="99ae29aad28310347371b2056bf06d9e" size="141" mtime="1643641551"/>
+          <entry name="somefile.txt" md5="2b2259dea9a3b6f4561f7f18789befe5" size="64" mtime="1643641551"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:51 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -479,18 +479,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '328'
+      - '327'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="c772ebe1ad1ca5b94ec86e749e4040f3">
+        <sourcediff key="3effbd631aecc0b449f9baecf5763e6b">
           <old project="home:Iggy" package="bar_package-release_abc" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy" package="bar_package-release_abc" rev="167" srcmd5="7e20d5d7a56c6668cdff1f5433da6cab"/>
+          <new project="home:Iggy" package="bar_package-release_abc" rev="11" srcmd5="7e810736af43f4a3208af6a52f0dcfcc"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:51 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -522,14 +522,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="a5ed99654387ff2ca9139d710d27b395">
-          <old project="foo_project" package="bar_package" rev="9ce337a44efd846974e07257268e591b" srcmd5="9ce337a44efd846974e07257268e591b"/>
-          <new project="home:Iggy" package="bar_package-release_abc" rev="c778a9f59ac304a4d7bfd2d5ca3f6a6c" srcmd5="c778a9f59ac304a4d7bfd2d5ca3f6a6c"/>
+        <sourcediff key="8c5c2f68dad6095a35eb6c7e9c4551d7">
+          <old project="foo_project" package="bar_package" rev="c50d57d8b25e8b65f624084f1441754d" srcmd5="c50d57d8b25e8b65f624084f1441754d"/>
+          <new project="home:Iggy" package="bar_package-release_abc" rev="33600966703b5008f3ac6553f46e9c32" srcmd5="33600966703b5008f3ac6553f46e9c32"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:51 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/_meta?user=Iggy
@@ -587,7 +587,7 @@ http_interactions:
             <arch>aarch64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:51 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc/_branch_request?user=Iggy
@@ -613,19 +613,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="168" vrev="168">
-          <srcmd5>082bd068eb7387e4f2d3ec46f9a3321f</srcmd5>
+        <revision rev="12" vrev="12">
+          <srcmd5>edcc28ba5dc8829d09083b36160af38b</srcmd5>
           <version>unknown</version>
-          <time>1642674805</time>
+          <time>1643641551</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:51 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc/_meta?user=Iggy
@@ -633,8 +633,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-release_abc" project="home:Iggy">
-          <title>Oh! To be in England</title>
-          <description>Autem excepturi dolore aspernatur.</description>
+          <title>Let Us Now Praise Famous Men</title>
+          <description>Et accusamus non vel.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -655,15 +655,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '174'
+      - '169'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-release_abc" project="home:Iggy">
-          <title>Oh! To be in England</title>
-          <description>Autem excepturi dolore aspernatur.</description>
+          <title>Let Us Now Praise Famous Men</title>
+          <description>Et accusamus non vel.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:51 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc
@@ -689,19 +689,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '814'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-release_abc" rev="168" vrev="168" srcmd5="082bd068eb7387e4f2d3ec46f9a3321f">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="9ce337a44efd846974e07257268e591b" baserev="9ce337a44efd846974e07257268e591b" xsrcmd5="d68ea56132776279382ec980c7897b08" lsrcmd5="082bd068eb7387e4f2d3ec46f9a3321f"/>
-          <serviceinfo code="succeeded" xsrcmd5="443c26c05a55434bbb102ae7163e6b3b"/>
-          <entry name="_branch_request" md5="8ccc2896b48bb83bb375eaf0b342764a" size="120" mtime="1637576859"/>
-          <entry name="_config" md5="d5f4cff20d50f39ff5b95ca3e9fd114f" size="49" mtime="1642674804"/>
-          <entry name="_link" md5="c41b320bfbdc0eb7f8cfda2e4624e373" size="141" mtime="1642674805"/>
-          <entry name="somefile.txt" md5="7137503c2101f5d89f3cd5b721d51097" size="59" mtime="1642674804"/>
+        <directory name="bar_package-release_abc" rev="12" vrev="12" srcmd5="edcc28ba5dc8829d09083b36160af38b">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="c50d57d8b25e8b65f624084f1441754d" baserev="c50d57d8b25e8b65f624084f1441754d" xsrcmd5="c378e07abcc0a945c13a1b6826a4c3fc" lsrcmd5="edcc28ba5dc8829d09083b36160af38b"/>
+          <entry name="_branch_request" md5="8ccc2896b48bb83bb375eaf0b342764a" size="120" mtime="1643641545"/>
+          <entry name="_config" md5="3917196ef3c887993a9c481600711292" size="67" mtime="1643641551"/>
+          <entry name="_link" md5="99ae29aad28310347371b2056bf06d9e" size="141" mtime="1643641551"/>
+          <entry name="somefile.txt" md5="2b2259dea9a3b6f4561f7f18789befe5" size="64" mtime="1643641551"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:51 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc?view=info
@@ -727,15 +726,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '345'
+      - '342'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package-release_abc" rev="168" vrev="1910" srcmd5="e4f2df9b02812267fbdca80ade60374b" lsrcmd5="443c26c05a55434bbb102ae7163e6b3b" verifymd5="084521af87bd68b7db08656fa9615008">
+        <sourceinfo package="bar_package-release_abc" rev="12" vrev="86" srcmd5="c378e07abcc0a945c13a1b6826a4c3fc" lsrcmd5="edcc28ba5dc8829d09083b36160af38b" verifymd5="5aa77719250486928ce570042967571e">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:51 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc
@@ -761,19 +760,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '814'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-release_abc" rev="168" vrev="168" srcmd5="082bd068eb7387e4f2d3ec46f9a3321f">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="9ce337a44efd846974e07257268e591b" baserev="9ce337a44efd846974e07257268e591b" xsrcmd5="d68ea56132776279382ec980c7897b08" lsrcmd5="082bd068eb7387e4f2d3ec46f9a3321f"/>
-          <serviceinfo code="succeeded" xsrcmd5="443c26c05a55434bbb102ae7163e6b3b"/>
-          <entry name="_branch_request" md5="8ccc2896b48bb83bb375eaf0b342764a" size="120" mtime="1637576859"/>
-          <entry name="_config" md5="d5f4cff20d50f39ff5b95ca3e9fd114f" size="49" mtime="1642674804"/>
-          <entry name="_link" md5="c41b320bfbdc0eb7f8cfda2e4624e373" size="141" mtime="1642674805"/>
-          <entry name="somefile.txt" md5="7137503c2101f5d89f3cd5b721d51097" size="59" mtime="1642674804"/>
+        <directory name="bar_package-release_abc" rev="12" vrev="12" srcmd5="edcc28ba5dc8829d09083b36160af38b">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="c50d57d8b25e8b65f624084f1441754d" baserev="c50d57d8b25e8b65f624084f1441754d" xsrcmd5="c378e07abcc0a945c13a1b6826a4c3fc" lsrcmd5="edcc28ba5dc8829d09083b36160af38b"/>
+          <entry name="_branch_request" md5="8ccc2896b48bb83bb375eaf0b342764a" size="120" mtime="1643641545"/>
+          <entry name="_config" md5="3917196ef3c887993a9c481600711292" size="67" mtime="1643641551"/>
+          <entry name="_link" md5="99ae29aad28310347371b2056bf06d9e" size="141" mtime="1643641551"/>
+          <entry name="somefile.txt" md5="2b2259dea9a3b6f4561f7f18789befe5" size="64" mtime="1643641551"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:51 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -801,18 +799,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '328'
+      - '327'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="1ca3fc04fae30f645a3e6395786c35e5">
+        <sourcediff key="2b43a1b83a0fad600dccafc0f4465c45">
           <old project="home:Iggy" package="bar_package-release_abc" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy" package="bar_package-release_abc" rev="168" srcmd5="082bd068eb7387e4f2d3ec46f9a3321f"/>
+          <new project="home:Iggy" package="bar_package-release_abc" rev="12" srcmd5="edcc28ba5dc8829d09083b36160af38b"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:51 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -844,12 +842,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="100dc7d72076eb1555ff3eeda833c550">
-          <old project="foo_project" package="bar_package" rev="9ce337a44efd846974e07257268e591b" srcmd5="9ce337a44efd846974e07257268e591b"/>
-          <new project="home:Iggy" package="bar_package-release_abc" rev="e4f2df9b02812267fbdca80ade60374b" srcmd5="e4f2df9b02812267fbdca80ade60374b"/>
+        <sourcediff key="cdf07f5d903e8536294993113e4cf04e">
+          <old project="foo_project" package="bar_package" rev="c50d57d8b25e8b65f624084f1441754d" srcmd5="c50d57d8b25e8b65f624084f1441754d"/>
+          <new project="home:Iggy" package="bar_package-release_abc" rev="c378e07abcc0a945c13a1b6826a4c3fc" srcmd5="c378e07abcc0a945c13a1b6826a4c3fc"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:51 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/with_a_push_event_for_a_tag/1_1_1_7_3.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/with_a_push_event_for_a_tag/1_1_1_7_3.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:30 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:50 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_374
+    uri: http://backend:5352/source/foo_project/_meta?user=user_63
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>If I Forget Thee Jerusalem</title>
+          <title>The Line of Beauty</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '158'
+      - '150'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>If I Forget Thee Jerusalem</title>
+          <title>The Line of Beauty</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:30 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:50 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_375
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_64
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>As I Lay Dying</title>
-          <description>Vel ratione ea modi.</description>
+          <title>No Country for Old Men</title>
+          <description>Quam perspiciatis recusandae natus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '144'
+      - '167'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>As I Lay Dying</title>
-          <description>Vel ratione ea modi.</description>
+          <title>No Country for Old Men</title>
+          <description>Quam perspiciatis recusandae natus.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:30 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:50 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Consequatur ut suscipit. Totam doloribus aspernatur. Enim aut non.
+      string: Repudiandae omnis maxime. Voluptas sapiente hic. Aut error velit.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1753" vrev="1753">
-          <srcmd5>bda24606e2539d305ea596506820d77c</srcmd5>
+        <revision rev="71" vrev="71">
+          <srcmd5>aa93358821cd452ba61d8b64d1362809</srcmd5>
           <version>unknown</version>
-          <time>1642674810</time>
+          <time>1643641550</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:30 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:50 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Omnis modi doloribus. Optio perferendis sit. Dolorum repellat illo.
+      string: Soluta nihil velit. Harum velit id. Sit iste qui.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +181,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1754" vrev="1754">
-          <srcmd5>8ffd847453b98f87e60d3b363afba1e1</srcmd5>
+        <revision rev="72" vrev="72">
+          <srcmd5>bdb5258b715f5b181b14e443016b4930</srcmd5>
           <version>unknown</version>
-          <time>1642674810</time>
+          <time>1643641550</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:30 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:50 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -227,7 +227,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:33:30 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:50 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc/_meta?user=Iggy
@@ -235,8 +235,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-release_abc" project="home:Iggy">
-          <title>As I Lay Dying</title>
-          <description>Vel ratione ea modi.</description>
+          <title>No Country for Old Men</title>
+          <description>Quam perspiciatis recusandae natus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -257,15 +257,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '154'
+      - '177'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-release_abc" project="home:Iggy">
-          <title>As I Lay Dying</title>
-          <description>Vel ratione ea modi.</description>
+          <title>No Country for Old Men</title>
+          <description>Quam perspiciatis recusandae natus.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:30 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:50 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc?cmd=branch&noservice=1&opackage=bar_package&oproject=foo_project&user=Iggy
@@ -293,19 +293,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '204'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="179" vrev="179">
-          <srcmd5>25fcd165378117ebd8d61d1378f19d4e</srcmd5>
+        <revision rev="9" vrev="9">
+          <srcmd5>1e9c3340df7a94efefdbc675ce65d445</srcmd5>
           <version>unknown</version>
-          <time>1642674810</time>
+          <time>1643641550</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:30 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:50 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc/_meta?user=Iggy
@@ -313,8 +313,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-release_abc" project="home:Iggy">
-          <title>As I Lay Dying</title>
-          <description>Vel ratione ea modi.</description>
+          <title>No Country for Old Men</title>
+          <description>Quam perspiciatis recusandae natus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -335,15 +335,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '154'
+      - '177'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-release_abc" project="home:Iggy">
-          <title>As I Lay Dying</title>
-          <description>Vel ratione ea modi.</description>
+          <title>No Country for Old Men</title>
+          <description>Quam perspiciatis recusandae natus.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:30 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:50 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc
@@ -369,18 +369,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '737'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-release_abc" rev="179" vrev="179" srcmd5="25fcd165378117ebd8d61d1378f19d4e">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="8ffd847453b98f87e60d3b363afba1e1" baserev="8ffd847453b98f87e60d3b363afba1e1" xsrcmd5="574559e690d2284dfdd5bbdf88f3ac66" lsrcmd5="25fcd165378117ebd8d61d1378f19d4e"/>
-          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1642591329"/>
-          <entry name="_config" md5="0b5bc9ab0eb1b5af8ba13ebf5060f46d" size="66" mtime="1642674810"/>
-          <entry name="_link" md5="415bcdd9564c5037d60abc874ae43f33" size="141" mtime="1642674810"/>
-          <entry name="somefile.txt" md5="9e6948e5fdfb7a9f145e24710c312ad4" size="67" mtime="1642674810"/>
+        <directory name="bar_package-release_abc" rev="9" vrev="9" srcmd5="1e9c3340df7a94efefdbc675ce65d445">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="bdb5258b715f5b181b14e443016b4930" baserev="bdb5258b715f5b181b14e443016b4930" xsrcmd5="6ee2c26e3786c31c476e6cb9864d46ff" lsrcmd5="1e9c3340df7a94efefdbc675ce65d445"/>
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="b0123b0021d37a84c49975effe10299a" size="65" mtime="1643641550"/>
+          <entry name="_link" md5="9d7e266c17f7e1de851a15f3b1aacfdd" size="141" mtime="1643641550"/>
+          <entry name="somefile.txt" md5="a7e70a0ca7c7bfa26e9d4d606a3ad714" size="49" mtime="1643641550"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:30 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:50 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc?view=info
@@ -406,15 +406,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '345'
+      - '341'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package-release_abc" rev="179" vrev="1933" srcmd5="574559e690d2284dfdd5bbdf88f3ac66" lsrcmd5="25fcd165378117ebd8d61d1378f19d4e" verifymd5="8ffd847453b98f87e60d3b363afba1e1">
+        <sourceinfo package="bar_package-release_abc" rev="9" vrev="81" srcmd5="6ee2c26e3786c31c476e6cb9864d46ff" lsrcmd5="1e9c3340df7a94efefdbc675ce65d445" verifymd5="bdb5258b715f5b181b14e443016b4930">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:30 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:50 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc
@@ -440,18 +440,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '737'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-release_abc" rev="179" vrev="179" srcmd5="25fcd165378117ebd8d61d1378f19d4e">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="8ffd847453b98f87e60d3b363afba1e1" baserev="8ffd847453b98f87e60d3b363afba1e1" xsrcmd5="574559e690d2284dfdd5bbdf88f3ac66" lsrcmd5="25fcd165378117ebd8d61d1378f19d4e"/>
-          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1642591329"/>
-          <entry name="_config" md5="0b5bc9ab0eb1b5af8ba13ebf5060f46d" size="66" mtime="1642674810"/>
-          <entry name="_link" md5="415bcdd9564c5037d60abc874ae43f33" size="141" mtime="1642674810"/>
-          <entry name="somefile.txt" md5="9e6948e5fdfb7a9f145e24710c312ad4" size="67" mtime="1642674810"/>
+        <directory name="bar_package-release_abc" rev="9" vrev="9" srcmd5="1e9c3340df7a94efefdbc675ce65d445">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="bdb5258b715f5b181b14e443016b4930" baserev="bdb5258b715f5b181b14e443016b4930" xsrcmd5="6ee2c26e3786c31c476e6cb9864d46ff" lsrcmd5="1e9c3340df7a94efefdbc675ce65d445"/>
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="b0123b0021d37a84c49975effe10299a" size="65" mtime="1643641550"/>
+          <entry name="_link" md5="9d7e266c17f7e1de851a15f3b1aacfdd" size="141" mtime="1643641550"/>
+          <entry name="somefile.txt" md5="a7e70a0ca7c7bfa26e9d4d606a3ad714" size="49" mtime="1643641550"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:30 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:50 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -479,18 +479,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '328'
+      - '326'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="fb7cba4fbe2699b1c52f15f890ae3cfa">
+        <sourcediff key="cc89ba4e96e6fc5161e97c7a0f2f7a0c">
           <old project="home:Iggy" package="bar_package-release_abc" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy" package="bar_package-release_abc" rev="179" srcmd5="25fcd165378117ebd8d61d1378f19d4e"/>
+          <new project="home:Iggy" package="bar_package-release_abc" rev="9" srcmd5="1e9c3340df7a94efefdbc675ce65d445"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:30 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:50 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -522,14 +522,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="f13674d3445b84f88b68ae07600afa9b">
-          <old project="foo_project" package="bar_package" rev="8ffd847453b98f87e60d3b363afba1e1" srcmd5="8ffd847453b98f87e60d3b363afba1e1"/>
-          <new project="home:Iggy" package="bar_package-release_abc" rev="574559e690d2284dfdd5bbdf88f3ac66" srcmd5="574559e690d2284dfdd5bbdf88f3ac66"/>
+        <sourcediff key="ed6aa8bebca4015b73751fedd0e6b91a">
+          <old project="foo_project" package="bar_package" rev="bdb5258b715f5b181b14e443016b4930" srcmd5="bdb5258b715f5b181b14e443016b4930"/>
+          <new project="home:Iggy" package="bar_package-release_abc" rev="6ee2c26e3786c31c476e6cb9864d46ff" srcmd5="6ee2c26e3786c31c476e6cb9864d46ff"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:30 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:50 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/_meta?user=Iggy
@@ -587,7 +587,7 @@ http_interactions:
             <arch>aarch64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:31 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:50 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc/_branch_request?user=Iggy
@@ -613,19 +613,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="180" vrev="180">
-          <srcmd5>b67d4e4cc0497019a260df2eea32b06e</srcmd5>
+        <revision rev="10" vrev="10">
+          <srcmd5>e67d1286793ebf1c54b33183acc1e57e</srcmd5>
           <version>unknown</version>
-          <time>1642674811</time>
+          <time>1643641550</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:31 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:50 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc/_meta?user=Iggy
@@ -633,8 +633,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-release_abc" project="home:Iggy">
-          <title>As I Lay Dying</title>
-          <description>Vel ratione ea modi.</description>
+          <title>No Country for Old Men</title>
+          <description>Quam perspiciatis recusandae natus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -655,15 +655,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '154'
+      - '177'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-release_abc" project="home:Iggy">
-          <title>As I Lay Dying</title>
-          <description>Vel ratione ea modi.</description>
+          <title>No Country for Old Men</title>
+          <description>Quam perspiciatis recusandae natus.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:31 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:50 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc
@@ -689,19 +689,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '814'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-release_abc" rev="180" vrev="180" srcmd5="b67d4e4cc0497019a260df2eea32b06e">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="8ffd847453b98f87e60d3b363afba1e1" baserev="8ffd847453b98f87e60d3b363afba1e1" xsrcmd5="33cd878b6469b2e5c4a0c4f5f2685d12" lsrcmd5="b67d4e4cc0497019a260df2eea32b06e"/>
-          <serviceinfo code="succeeded" xsrcmd5="dbb71abf8edf54f19ce40f38251bde26"/>
-          <entry name="_branch_request" md5="8ccc2896b48bb83bb375eaf0b342764a" size="120" mtime="1637576859"/>
-          <entry name="_config" md5="0b5bc9ab0eb1b5af8ba13ebf5060f46d" size="66" mtime="1642674810"/>
-          <entry name="_link" md5="415bcdd9564c5037d60abc874ae43f33" size="141" mtime="1642674810"/>
-          <entry name="somefile.txt" md5="9e6948e5fdfb7a9f145e24710c312ad4" size="67" mtime="1642674810"/>
+        <directory name="bar_package-release_abc" rev="10" vrev="10" srcmd5="e67d1286793ebf1c54b33183acc1e57e">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="bdb5258b715f5b181b14e443016b4930" baserev="bdb5258b715f5b181b14e443016b4930" xsrcmd5="dbb97485c6d8a44676102876a685886a" lsrcmd5="e67d1286793ebf1c54b33183acc1e57e"/>
+          <entry name="_branch_request" md5="8ccc2896b48bb83bb375eaf0b342764a" size="120" mtime="1643641545"/>
+          <entry name="_config" md5="b0123b0021d37a84c49975effe10299a" size="65" mtime="1643641550"/>
+          <entry name="_link" md5="9d7e266c17f7e1de851a15f3b1aacfdd" size="141" mtime="1643641550"/>
+          <entry name="somefile.txt" md5="a7e70a0ca7c7bfa26e9d4d606a3ad714" size="49" mtime="1643641550"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:31 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:50 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc?view=info
@@ -727,15 +726,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '345'
+      - '342'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package-release_abc" rev="180" vrev="1934" srcmd5="30ef9f15b3b4df9ae437f1f5e35b837c" lsrcmd5="dbb71abf8edf54f19ce40f38251bde26" verifymd5="f15d6123c0295b85671baa24ddf7e98a">
+        <sourceinfo package="bar_package-release_abc" rev="10" vrev="82" srcmd5="dbb97485c6d8a44676102876a685886a" lsrcmd5="e67d1286793ebf1c54b33183acc1e57e" verifymd5="593b0d39eedb683ff081c8d3f2b2e3e7">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:31 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:50 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc
@@ -761,19 +760,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '814'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-release_abc" rev="180" vrev="180" srcmd5="b67d4e4cc0497019a260df2eea32b06e">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="8ffd847453b98f87e60d3b363afba1e1" baserev="8ffd847453b98f87e60d3b363afba1e1" xsrcmd5="33cd878b6469b2e5c4a0c4f5f2685d12" lsrcmd5="b67d4e4cc0497019a260df2eea32b06e"/>
-          <serviceinfo code="succeeded" xsrcmd5="dbb71abf8edf54f19ce40f38251bde26"/>
-          <entry name="_branch_request" md5="8ccc2896b48bb83bb375eaf0b342764a" size="120" mtime="1637576859"/>
-          <entry name="_config" md5="0b5bc9ab0eb1b5af8ba13ebf5060f46d" size="66" mtime="1642674810"/>
-          <entry name="_link" md5="415bcdd9564c5037d60abc874ae43f33" size="141" mtime="1642674810"/>
-          <entry name="somefile.txt" md5="9e6948e5fdfb7a9f145e24710c312ad4" size="67" mtime="1642674810"/>
+        <directory name="bar_package-release_abc" rev="10" vrev="10" srcmd5="e67d1286793ebf1c54b33183acc1e57e">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="bdb5258b715f5b181b14e443016b4930" baserev="bdb5258b715f5b181b14e443016b4930" xsrcmd5="dbb97485c6d8a44676102876a685886a" lsrcmd5="e67d1286793ebf1c54b33183acc1e57e"/>
+          <entry name="_branch_request" md5="8ccc2896b48bb83bb375eaf0b342764a" size="120" mtime="1643641545"/>
+          <entry name="_config" md5="b0123b0021d37a84c49975effe10299a" size="65" mtime="1643641550"/>
+          <entry name="_link" md5="9d7e266c17f7e1de851a15f3b1aacfdd" size="141" mtime="1643641550"/>
+          <entry name="somefile.txt" md5="a7e70a0ca7c7bfa26e9d4d606a3ad714" size="49" mtime="1643641550"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:31 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:50 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -801,18 +799,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '328'
+      - '327'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="f109c65de6ed64016aa4f1a01193ca6b">
+        <sourcediff key="fba438e98da5822d3112317f36ba0393">
           <old project="home:Iggy" package="bar_package-release_abc" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy" package="bar_package-release_abc" rev="180" srcmd5="b67d4e4cc0497019a260df2eea32b06e"/>
+          <new project="home:Iggy" package="bar_package-release_abc" rev="10" srcmd5="e67d1286793ebf1c54b33183acc1e57e"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:31 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:50 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -844,14 +842,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="a4de53e8300ea014e90e552e3f5638a4">
-          <old project="foo_project" package="bar_package" rev="8ffd847453b98f87e60d3b363afba1e1" srcmd5="8ffd847453b98f87e60d3b363afba1e1"/>
-          <new project="home:Iggy" package="bar_package-release_abc" rev="30ef9f15b3b4df9ae437f1f5e35b837c" srcmd5="30ef9f15b3b4df9ae437f1f5e35b837c"/>
+        <sourcediff key="9ddb4dc0f51af0b79de8c451b1115b83">
+          <old project="foo_project" package="bar_package" rev="bdb5258b715f5b181b14e443016b4930" srcmd5="bdb5258b715f5b181b14e443016b4930"/>
+          <new project="home:Iggy" package="bar_package-release_abc" rev="dbb97485c6d8a44676102876a685886a" srcmd5="dbb97485c6d8a44676102876a685886a"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:31 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:50 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc/_branch_request
@@ -881,5 +879,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"action":"opened","pull_request":{"head":{"repo":{"full_name":"openSUSE/open-build-service"},"sha":"123456789012345"}}}'
-  recorded_at: Thu, 20 Jan 2022 10:33:31 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:50 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/with_a_push_event_for_a_tag/1_1_1_7_4.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/with_a_push_event_for_a_tag/1_1_1_7_4.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:52 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_370
+    uri: http://backend:5352/source/foo_project/_meta?user=user_67
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>The Man Within</title>
+          <title>Recalled to Life</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '146'
+      - '148'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>The Man Within</title>
+          <title>Recalled to Life</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:52 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_371
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_68
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Last Enemy</title>
-          <description>Alias est natus sint.</description>
+          <title>Dulce et Decorum Est</title>
+          <description>Accusantium rerum eveniet eligendi.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '145'
+      - '165'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Last Enemy</title>
-          <description>Alias est natus sint.</description>
+          <title>Dulce et Decorum Est</title>
+          <description>Accusantium rerum eveniet eligendi.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:52 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Aut omnis enim. Nisi dolor delectus. Qui suscipit rerum.
+      string: Minus tempora ad. Dolor cum sed. Nostrum et at.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,26 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1749" vrev="1749">
-          <srcmd5>a83c88c7fc2c56cca36ba8d3b90ce12a</srcmd5>
+        <revision rev="75" vrev="75">
+          <srcmd5>74977d5719dc19a618fb22ef1b43531f</srcmd5>
           <version>unknown</version>
-          <time>1642674808</time>
+          <time>1643641552</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:52 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Adipisci est odio. A quae nisi. Dignissimos voluptas tempore.
+      string: Voluptatem voluptatibus sunt. Sint voluptatibus nihil. Quasi quidem
+        est.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +182,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1750" vrev="1750">
-          <srcmd5>4a5b4822176361c21a511b98b788d0f2</srcmd5>
+        <revision rev="76" vrev="76">
+          <srcmd5>fd075aea23c78971ddfb82dc937e7bf4</srcmd5>
           <version>unknown</version>
-          <time>1642674808</time>
+          <time>1643641552</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:52 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -227,7 +228,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:33:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:52 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc/_meta?user=Iggy
@@ -235,8 +236,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-release_abc" project="home:Iggy">
-          <title>The Last Enemy</title>
-          <description>Alias est natus sint.</description>
+          <title>Dulce et Decorum Est</title>
+          <description>Accusantium rerum eveniet eligendi.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -257,15 +258,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '155'
+      - '175'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-release_abc" project="home:Iggy">
-          <title>The Last Enemy</title>
-          <description>Alias est natus sint.</description>
+          <title>Dulce et Decorum Est</title>
+          <description>Accusantium rerum eveniet eligendi.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:52 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc?cmd=branch&noservice=1&opackage=bar_package&oproject=foo_project&user=Iggy
@@ -293,19 +294,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="175" vrev="175">
-          <srcmd5>b7409758feacab70a2f192cb9c68505e</srcmd5>
+        <revision rev="13" vrev="13">
+          <srcmd5>3cd5942dea6803c5f854ac5eb97aa19c</srcmd5>
           <version>unknown</version>
-          <time>1642674809</time>
+          <time>1643641552</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:52 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc/_meta?user=Iggy
@@ -313,8 +314,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-release_abc" project="home:Iggy">
-          <title>The Last Enemy</title>
-          <description>Alias est natus sint.</description>
+          <title>Dulce et Decorum Est</title>
+          <description>Accusantium rerum eveniet eligendi.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -335,15 +336,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '155'
+      - '175'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-release_abc" project="home:Iggy">
-          <title>The Last Enemy</title>
-          <description>Alias est natus sint.</description>
+          <title>Dulce et Decorum Est</title>
+          <description>Accusantium rerum eveniet eligendi.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:52 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc
@@ -369,18 +370,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '737'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-release_abc" rev="175" vrev="175" srcmd5="b7409758feacab70a2f192cb9c68505e">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="4a5b4822176361c21a511b98b788d0f2" baserev="4a5b4822176361c21a511b98b788d0f2" xsrcmd5="c7668d0ee0367ed33626be14273a6d1f" lsrcmd5="b7409758feacab70a2f192cb9c68505e"/>
-          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1642591329"/>
-          <entry name="_config" md5="d50531ab1d29475811d92eb25611e31d" size="56" mtime="1642674808"/>
-          <entry name="_link" md5="bb1f398187516aca420cb17a5609c39e" size="141" mtime="1642674809"/>
-          <entry name="somefile.txt" md5="26348e03c41be6f3944d7c713aa46110" size="61" mtime="1642674808"/>
+        <directory name="bar_package-release_abc" rev="13" vrev="13" srcmd5="3cd5942dea6803c5f854ac5eb97aa19c">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="fd075aea23c78971ddfb82dc937e7bf4" baserev="fd075aea23c78971ddfb82dc937e7bf4" xsrcmd5="56b0f8cb703eaa77414c03e9fcf4540c" lsrcmd5="3cd5942dea6803c5f854ac5eb97aa19c"/>
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="fd753b0b4326e6944acebbf50eb7ad7b" size="47" mtime="1643641552"/>
+          <entry name="_link" md5="9ca6fd5ea19f0802a272404c6179f53f" size="141" mtime="1643641552"/>
+          <entry name="somefile.txt" md5="80b55a1965a52f1e402532a70c5a91ac" size="72" mtime="1643641552"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:52 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc?view=info
@@ -406,15 +407,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '345'
+      - '342'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package-release_abc" rev="175" vrev="1925" srcmd5="c7668d0ee0367ed33626be14273a6d1f" lsrcmd5="b7409758feacab70a2f192cb9c68505e" verifymd5="4a5b4822176361c21a511b98b788d0f2">
+        <sourceinfo package="bar_package-release_abc" rev="13" vrev="89" srcmd5="56b0f8cb703eaa77414c03e9fcf4540c" lsrcmd5="3cd5942dea6803c5f854ac5eb97aa19c" verifymd5="fd075aea23c78971ddfb82dc937e7bf4">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:52 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc
@@ -440,18 +441,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '737'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-release_abc" rev="175" vrev="175" srcmd5="b7409758feacab70a2f192cb9c68505e">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="4a5b4822176361c21a511b98b788d0f2" baserev="4a5b4822176361c21a511b98b788d0f2" xsrcmd5="c7668d0ee0367ed33626be14273a6d1f" lsrcmd5="b7409758feacab70a2f192cb9c68505e"/>
-          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1642591329"/>
-          <entry name="_config" md5="d50531ab1d29475811d92eb25611e31d" size="56" mtime="1642674808"/>
-          <entry name="_link" md5="bb1f398187516aca420cb17a5609c39e" size="141" mtime="1642674809"/>
-          <entry name="somefile.txt" md5="26348e03c41be6f3944d7c713aa46110" size="61" mtime="1642674808"/>
+        <directory name="bar_package-release_abc" rev="13" vrev="13" srcmd5="3cd5942dea6803c5f854ac5eb97aa19c">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="fd075aea23c78971ddfb82dc937e7bf4" baserev="fd075aea23c78971ddfb82dc937e7bf4" xsrcmd5="56b0f8cb703eaa77414c03e9fcf4540c" lsrcmd5="3cd5942dea6803c5f854ac5eb97aa19c"/>
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="fd753b0b4326e6944acebbf50eb7ad7b" size="47" mtime="1643641552"/>
+          <entry name="_link" md5="9ca6fd5ea19f0802a272404c6179f53f" size="141" mtime="1643641552"/>
+          <entry name="somefile.txt" md5="80b55a1965a52f1e402532a70c5a91ac" size="72" mtime="1643641552"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:52 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -479,18 +480,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '328'
+      - '327'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="aea58ab308bbb493500463efd359b33f">
+        <sourcediff key="cc43f8184c263430b32b6254156db364">
           <old project="home:Iggy" package="bar_package-release_abc" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy" package="bar_package-release_abc" rev="175" srcmd5="b7409758feacab70a2f192cb9c68505e"/>
+          <new project="home:Iggy" package="bar_package-release_abc" rev="13" srcmd5="3cd5942dea6803c5f854ac5eb97aa19c"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:52 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -522,14 +523,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="34da8c142a59d23e5789cf466c7c70d0">
-          <old project="foo_project" package="bar_package" rev="4a5b4822176361c21a511b98b788d0f2" srcmd5="4a5b4822176361c21a511b98b788d0f2"/>
-          <new project="home:Iggy" package="bar_package-release_abc" rev="c7668d0ee0367ed33626be14273a6d1f" srcmd5="c7668d0ee0367ed33626be14273a6d1f"/>
+        <sourcediff key="9bcf0ecfbf0c4032b981990c13096251">
+          <old project="foo_project" package="bar_package" rev="fd075aea23c78971ddfb82dc937e7bf4" srcmd5="fd075aea23c78971ddfb82dc937e7bf4"/>
+          <new project="home:Iggy" package="bar_package-release_abc" rev="56b0f8cb703eaa77414c03e9fcf4540c" srcmd5="56b0f8cb703eaa77414c03e9fcf4540c"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:52 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/_meta?user=Iggy
@@ -587,7 +588,7 @@ http_interactions:
             <arch>aarch64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:52 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc/_branch_request?user=Iggy
@@ -613,19 +614,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="176" vrev="176">
-          <srcmd5>7c455ede2bb3d1bd508d2f55596153c8</srcmd5>
+        <revision rev="14" vrev="14">
+          <srcmd5>f4b03b27b8f6d8033482e0afb57dbba9</srcmd5>
           <version>unknown</version>
-          <time>1642674809</time>
+          <time>1643641552</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:52 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc/_meta?user=Iggy
@@ -633,8 +634,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-release_abc" project="home:Iggy">
-          <title>The Last Enemy</title>
-          <description>Alias est natus sint.</description>
+          <title>Dulce et Decorum Est</title>
+          <description>Accusantium rerum eveniet eligendi.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -655,15 +656,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '155'
+      - '175'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-release_abc" project="home:Iggy">
-          <title>The Last Enemy</title>
-          <description>Alias est natus sint.</description>
+          <title>Dulce et Decorum Est</title>
+          <description>Accusantium rerum eveniet eligendi.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:52 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc
@@ -689,19 +690,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '814'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-release_abc" rev="176" vrev="176" srcmd5="7c455ede2bb3d1bd508d2f55596153c8">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="4a5b4822176361c21a511b98b788d0f2" baserev="4a5b4822176361c21a511b98b788d0f2" xsrcmd5="b88a5ec8a6d4211e199af2c60d2e21a7" lsrcmd5="7c455ede2bb3d1bd508d2f55596153c8"/>
-          <serviceinfo code="succeeded" xsrcmd5="cde54db74963a645ebd697fb3667dd87"/>
-          <entry name="_branch_request" md5="8ccc2896b48bb83bb375eaf0b342764a" size="120" mtime="1637576859"/>
-          <entry name="_config" md5="d50531ab1d29475811d92eb25611e31d" size="56" mtime="1642674808"/>
-          <entry name="_link" md5="bb1f398187516aca420cb17a5609c39e" size="141" mtime="1642674809"/>
-          <entry name="somefile.txt" md5="26348e03c41be6f3944d7c713aa46110" size="61" mtime="1642674808"/>
+        <directory name="bar_package-release_abc" rev="14" vrev="14" srcmd5="f4b03b27b8f6d8033482e0afb57dbba9">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="fd075aea23c78971ddfb82dc937e7bf4" baserev="fd075aea23c78971ddfb82dc937e7bf4" xsrcmd5="eb670a62689671b8be401460d0a12a3e" lsrcmd5="f4b03b27b8f6d8033482e0afb57dbba9"/>
+          <entry name="_branch_request" md5="8ccc2896b48bb83bb375eaf0b342764a" size="120" mtime="1643641545"/>
+          <entry name="_config" md5="fd753b0b4326e6944acebbf50eb7ad7b" size="47" mtime="1643641552"/>
+          <entry name="_link" md5="9ca6fd5ea19f0802a272404c6179f53f" size="141" mtime="1643641552"/>
+          <entry name="somefile.txt" md5="80b55a1965a52f1e402532a70c5a91ac" size="72" mtime="1643641552"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:52 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc?view=info
@@ -727,15 +727,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '345'
+      - '342'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package-release_abc" rev="176" vrev="1926" srcmd5="58aa2ef6159eb25a68ab58fa83bd6ec7" lsrcmd5="cde54db74963a645ebd697fb3667dd87" verifymd5="3f949b12e5f9cbe40d48b1a39a0f82a5">
+        <sourceinfo package="bar_package-release_abc" rev="14" vrev="90" srcmd5="eb670a62689671b8be401460d0a12a3e" lsrcmd5="f4b03b27b8f6d8033482e0afb57dbba9" verifymd5="d9eec21e2cc50aee3407f709818a71cf">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:52 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc
@@ -761,19 +761,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '814'
+      - '735'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-release_abc" rev="176" vrev="176" srcmd5="7c455ede2bb3d1bd508d2f55596153c8">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="4a5b4822176361c21a511b98b788d0f2" baserev="4a5b4822176361c21a511b98b788d0f2" xsrcmd5="b88a5ec8a6d4211e199af2c60d2e21a7" lsrcmd5="7c455ede2bb3d1bd508d2f55596153c8"/>
-          <serviceinfo code="succeeded" xsrcmd5="cde54db74963a645ebd697fb3667dd87"/>
-          <entry name="_branch_request" md5="8ccc2896b48bb83bb375eaf0b342764a" size="120" mtime="1637576859"/>
-          <entry name="_config" md5="d50531ab1d29475811d92eb25611e31d" size="56" mtime="1642674808"/>
-          <entry name="_link" md5="bb1f398187516aca420cb17a5609c39e" size="141" mtime="1642674809"/>
-          <entry name="somefile.txt" md5="26348e03c41be6f3944d7c713aa46110" size="61" mtime="1642674808"/>
+        <directory name="bar_package-release_abc" rev="14" vrev="14" srcmd5="f4b03b27b8f6d8033482e0afb57dbba9">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="fd075aea23c78971ddfb82dc937e7bf4" baserev="fd075aea23c78971ddfb82dc937e7bf4" xsrcmd5="eb670a62689671b8be401460d0a12a3e" lsrcmd5="f4b03b27b8f6d8033482e0afb57dbba9"/>
+          <entry name="_branch_request" md5="8ccc2896b48bb83bb375eaf0b342764a" size="120" mtime="1643641545"/>
+          <entry name="_config" md5="fd753b0b4326e6944acebbf50eb7ad7b" size="47" mtime="1643641552"/>
+          <entry name="_link" md5="9ca6fd5ea19f0802a272404c6179f53f" size="141" mtime="1643641552"/>
+          <entry name="somefile.txt" md5="80b55a1965a52f1e402532a70c5a91ac" size="72" mtime="1643641552"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:52 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -801,18 +800,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '328'
+      - '327'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="4ad9548ab5ed5bfe740a3a6cb0bbbde7">
+        <sourcediff key="696bcf2eae80d6c9ad36ea8970b59020">
           <old project="home:Iggy" package="bar_package-release_abc" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy" package="bar_package-release_abc" rev="176" srcmd5="7c455ede2bb3d1bd508d2f55596153c8"/>
+          <new project="home:Iggy" package="bar_package-release_abc" rev="14" srcmd5="f4b03b27b8f6d8033482e0afb57dbba9"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:52 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -844,14 +843,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="ee4929464719e0d3cdf64a620505fb2a">
-          <old project="foo_project" package="bar_package" rev="4a5b4822176361c21a511b98b788d0f2" srcmd5="4a5b4822176361c21a511b98b788d0f2"/>
-          <new project="home:Iggy" package="bar_package-release_abc" rev="58aa2ef6159eb25a68ab58fa83bd6ec7" srcmd5="58aa2ef6159eb25a68ab58fa83bd6ec7"/>
+        <sourcediff key="689599a189be54db557319f6776e00af">
+          <old project="foo_project" package="bar_package" rev="fd075aea23c78971ddfb82dc937e7bf4" srcmd5="fd075aea23c78971ddfb82dc937e7bf4"/>
+          <new project="home:Iggy" package="bar_package-release_abc" rev="eb670a62689671b8be401460d0a12a3e" srcmd5="eb670a62689671b8be401460d0a12a3e"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:52 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc/_branch_request
@@ -881,5 +880,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"action":"opened","pull_request":{"head":{"repo":{"full_name":"openSUSE/open-build-service"},"sha":"123456789012345"}}}'
-  recorded_at: Thu, 20 Jan 2022 10:33:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:52 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/with_a_push_event_for_a_tag/1_1_1_7_5.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/with_a_push_event_for_a_tag/1_1_1_7_5.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:48 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_372
+    uri: http://backend:5352/source/foo_project/_meta?user=user_61
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Tirra Lirra by the River</title>
+          <title>Beneath the Bleeding</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '156'
+      - '152'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Tirra Lirra by the River</title>
+          <title>Beneath the Bleeding</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:48 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_373
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_62
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Soldier's Art</title>
-          <description>Eaque consequatur aspernatur ut.</description>
+          <title>The Painted Veil</title>
+          <description>Aut qui quis quis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '159'
+      - '144'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Soldier's Art</title>
-          <description>Eaque consequatur aspernatur ut.</description>
+          <title>The Painted Veil</title>
+          <description>Aut qui quis quis.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:48 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Dolorum expedita et. Et inventore natus. Voluptatem magni quo.
+      string: Rerum ipsum occaecati. Qui at natus. Quis optio nisi.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1751" vrev="1751">
-          <srcmd5>00fb588cbf56ea07c480a8dd7d298b4d</srcmd5>
+        <revision rev="69" vrev="69">
+          <srcmd5>cb8ec39e84f02b638e4cf6350cb168e4</srcmd5>
           <version>unknown</version>
-          <time>1642674809</time>
+          <time>1643641548</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:48 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Et exercitationem perferendis. Ea tempore sit. Consequatur nulla totam.
+      string: Non eos velit. Molestiae tenetur consequatur. Voluptatem aut quisquam.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +181,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1752" vrev="1752">
-          <srcmd5>5232a224e5b25f56afa88fca0d2e25c1</srcmd5>
+        <revision rev="70" vrev="70">
+          <srcmd5>5916ec5ffc82915fa10c0bcf252c6886</srcmd5>
           <version>unknown</version>
-          <time>1642674809</time>
+          <time>1643641548</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:49 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -227,7 +227,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:33:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc/_meta?user=Iggy
@@ -235,8 +235,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-release_abc" project="home:Iggy">
-          <title>The Soldier's Art</title>
-          <description>Eaque consequatur aspernatur ut.</description>
+          <title>The Painted Veil</title>
+          <description>Aut qui quis quis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -257,15 +257,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '169'
+      - '154'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-release_abc" project="home:Iggy">
-          <title>The Soldier's Art</title>
-          <description>Eaque consequatur aspernatur ut.</description>
+          <title>The Painted Veil</title>
+          <description>Aut qui quis quis.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:49 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc?cmd=branch&noservice=1&opackage=bar_package&oproject=foo_project&user=Iggy
@@ -293,19 +293,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '204'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="177" vrev="177">
-          <srcmd5>89be12dfd1a7501c0e3f26801ffbd7eb</srcmd5>
+        <revision rev="7" vrev="7">
+          <srcmd5>45c9a196e190f893a7219736efe138c6</srcmd5>
           <version>unknown</version>
-          <time>1642674809</time>
+          <time>1643641549</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc/_meta?user=Iggy
@@ -313,8 +313,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-release_abc" project="home:Iggy">
-          <title>The Soldier's Art</title>
-          <description>Eaque consequatur aspernatur ut.</description>
+          <title>The Painted Veil</title>
+          <description>Aut qui quis quis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -335,15 +335,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '169'
+      - '154'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-release_abc" project="home:Iggy">
-          <title>The Soldier's Art</title>
-          <description>Eaque consequatur aspernatur ut.</description>
+          <title>The Painted Veil</title>
+          <description>Aut qui quis quis.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:49 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc
@@ -369,18 +369,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '737'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-release_abc" rev="177" vrev="177" srcmd5="89be12dfd1a7501c0e3f26801ffbd7eb">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="5232a224e5b25f56afa88fca0d2e25c1" baserev="5232a224e5b25f56afa88fca0d2e25c1" xsrcmd5="326ee13783cd43b20030429d4ed1baf0" lsrcmd5="89be12dfd1a7501c0e3f26801ffbd7eb"/>
-          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1642591329"/>
-          <entry name="_config" md5="28d49d13ba5f8a729278554e7ee47424" size="62" mtime="1642674809"/>
-          <entry name="_link" md5="62f47fbdaebb7c2ee1f9a0b69aa8e80e" size="141" mtime="1642674809"/>
-          <entry name="somefile.txt" md5="db592fc54e8a5e8ea3b28472d5101d18" size="71" mtime="1642674809"/>
+        <directory name="bar_package-release_abc" rev="7" vrev="7" srcmd5="45c9a196e190f893a7219736efe138c6">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="5916ec5ffc82915fa10c0bcf252c6886" baserev="5916ec5ffc82915fa10c0bcf252c6886" xsrcmd5="7b22b2f1fbe06f2b5c44023073e29cf1" lsrcmd5="45c9a196e190f893a7219736efe138c6"/>
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="69fab1f2eb7ff5c19dbf2427a46efad0" size="53" mtime="1643641548"/>
+          <entry name="_link" md5="320ca80b6a4c043277dcd6b2153afd07" size="141" mtime="1643641549"/>
+          <entry name="somefile.txt" md5="e24481dab8b06994fc8e6e23411746ba" size="70" mtime="1643641548"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:49 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc?view=info
@@ -406,15 +406,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '345'
+      - '341'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package-release_abc" rev="177" vrev="1929" srcmd5="326ee13783cd43b20030429d4ed1baf0" lsrcmd5="89be12dfd1a7501c0e3f26801ffbd7eb" verifymd5="5232a224e5b25f56afa88fca0d2e25c1">
+        <sourceinfo package="bar_package-release_abc" rev="7" vrev="77" srcmd5="7b22b2f1fbe06f2b5c44023073e29cf1" lsrcmd5="45c9a196e190f893a7219736efe138c6" verifymd5="5916ec5ffc82915fa10c0bcf252c6886">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:30 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:49 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc
@@ -440,18 +440,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '737'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-release_abc" rev="177" vrev="177" srcmd5="89be12dfd1a7501c0e3f26801ffbd7eb">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="5232a224e5b25f56afa88fca0d2e25c1" baserev="5232a224e5b25f56afa88fca0d2e25c1" xsrcmd5="326ee13783cd43b20030429d4ed1baf0" lsrcmd5="89be12dfd1a7501c0e3f26801ffbd7eb"/>
-          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1642591329"/>
-          <entry name="_config" md5="28d49d13ba5f8a729278554e7ee47424" size="62" mtime="1642674809"/>
-          <entry name="_link" md5="62f47fbdaebb7c2ee1f9a0b69aa8e80e" size="141" mtime="1642674809"/>
-          <entry name="somefile.txt" md5="db592fc54e8a5e8ea3b28472d5101d18" size="71" mtime="1642674809"/>
+        <directory name="bar_package-release_abc" rev="7" vrev="7" srcmd5="45c9a196e190f893a7219736efe138c6">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="5916ec5ffc82915fa10c0bcf252c6886" baserev="5916ec5ffc82915fa10c0bcf252c6886" xsrcmd5="7b22b2f1fbe06f2b5c44023073e29cf1" lsrcmd5="45c9a196e190f893a7219736efe138c6"/>
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="69fab1f2eb7ff5c19dbf2427a46efad0" size="53" mtime="1643641548"/>
+          <entry name="_link" md5="320ca80b6a4c043277dcd6b2153afd07" size="141" mtime="1643641549"/>
+          <entry name="somefile.txt" md5="e24481dab8b06994fc8e6e23411746ba" size="70" mtime="1643641548"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:30 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:49 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -479,18 +479,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '328'
+      - '326'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="ba8b3aba55c32d608e59cfc9ef5367e4">
+        <sourcediff key="41f65bd2d4d8b9844713d8a93ece3526">
           <old project="home:Iggy" package="bar_package-release_abc" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy" package="bar_package-release_abc" rev="177" srcmd5="89be12dfd1a7501c0e3f26801ffbd7eb"/>
+          <new project="home:Iggy" package="bar_package-release_abc" rev="7" srcmd5="45c9a196e190f893a7219736efe138c6"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:30 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:49 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -522,14 +522,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="8525a202f2ad693ed259f1dcacc45b72">
-          <old project="foo_project" package="bar_package" rev="5232a224e5b25f56afa88fca0d2e25c1" srcmd5="5232a224e5b25f56afa88fca0d2e25c1"/>
-          <new project="home:Iggy" package="bar_package-release_abc" rev="326ee13783cd43b20030429d4ed1baf0" srcmd5="326ee13783cd43b20030429d4ed1baf0"/>
+        <sourcediff key="5da56e1bf55d343c3f17e5226fadc815">
+          <old project="foo_project" package="bar_package" rev="5916ec5ffc82915fa10c0bcf252c6886" srcmd5="5916ec5ffc82915fa10c0bcf252c6886"/>
+          <new project="home:Iggy" package="bar_package-release_abc" rev="7b22b2f1fbe06f2b5c44023073e29cf1" srcmd5="7b22b2f1fbe06f2b5c44023073e29cf1"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:30 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/_meta?user=Iggy
@@ -587,7 +587,7 @@ http_interactions:
             <arch>aarch64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:30 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc/_branch_request?user=Iggy
@@ -613,19 +613,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '204'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="178" vrev="178">
-          <srcmd5>ae76013c9f7e3d41c353647f9b80e077</srcmd5>
+        <revision rev="8" vrev="8">
+          <srcmd5>b19422281cbe0f87b78bf8169f3eed4e</srcmd5>
           <version>unknown</version>
-          <time>1642674810</time>
+          <time>1643641549</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:30 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc/_meta?user=Iggy
@@ -633,8 +633,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-release_abc" project="home:Iggy">
-          <title>The Soldier's Art</title>
-          <description>Eaque consequatur aspernatur ut.</description>
+          <title>The Painted Veil</title>
+          <description>Aut qui quis quis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -655,15 +655,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '169'
+      - '154'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-release_abc" project="home:Iggy">
-          <title>The Soldier's Art</title>
-          <description>Eaque consequatur aspernatur ut.</description>
+          <title>The Painted Veil</title>
+          <description>Aut qui quis quis.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:30 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:49 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc
@@ -689,19 +689,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '814'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-release_abc" rev="178" vrev="178" srcmd5="ae76013c9f7e3d41c353647f9b80e077">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="5232a224e5b25f56afa88fca0d2e25c1" baserev="5232a224e5b25f56afa88fca0d2e25c1" xsrcmd5="94fb06e2f49d4c9653f8c59541d54224" lsrcmd5="ae76013c9f7e3d41c353647f9b80e077"/>
-          <serviceinfo code="succeeded" xsrcmd5="167053f58e8244340327541d85ca354b"/>
-          <entry name="_branch_request" md5="8ccc2896b48bb83bb375eaf0b342764a" size="120" mtime="1637576859"/>
-          <entry name="_config" md5="28d49d13ba5f8a729278554e7ee47424" size="62" mtime="1642674809"/>
-          <entry name="_link" md5="62f47fbdaebb7c2ee1f9a0b69aa8e80e" size="141" mtime="1642674809"/>
-          <entry name="somefile.txt" md5="db592fc54e8a5e8ea3b28472d5101d18" size="71" mtime="1642674809"/>
+        <directory name="bar_package-release_abc" rev="8" vrev="8" srcmd5="b19422281cbe0f87b78bf8169f3eed4e">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="5916ec5ffc82915fa10c0bcf252c6886" baserev="5916ec5ffc82915fa10c0bcf252c6886" xsrcmd5="f26d812e4e74fb3dc96809db16d4a308" lsrcmd5="b19422281cbe0f87b78bf8169f3eed4e"/>
+          <entry name="_branch_request" md5="8ccc2896b48bb83bb375eaf0b342764a" size="120" mtime="1643641545"/>
+          <entry name="_config" md5="69fab1f2eb7ff5c19dbf2427a46efad0" size="53" mtime="1643641548"/>
+          <entry name="_link" md5="320ca80b6a4c043277dcd6b2153afd07" size="141" mtime="1643641549"/>
+          <entry name="somefile.txt" md5="e24481dab8b06994fc8e6e23411746ba" size="70" mtime="1643641548"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:30 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:49 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc?view=info
@@ -727,15 +726,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '345'
+      - '341'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package-release_abc" rev="178" vrev="1930" srcmd5="5c03593dab4214dd177ce7204486343f" lsrcmd5="167053f58e8244340327541d85ca354b" verifymd5="51c7deb82dbd36266698c35a03ddb6ea">
+        <sourceinfo package="bar_package-release_abc" rev="8" vrev="78" srcmd5="f26d812e4e74fb3dc96809db16d4a308" lsrcmd5="b19422281cbe0f87b78bf8169f3eed4e" verifymd5="07d145d0891e9d7dbdb43ac31a89282f">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:30 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:49 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc
@@ -761,19 +760,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '814'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-release_abc" rev="178" vrev="178" srcmd5="ae76013c9f7e3d41c353647f9b80e077">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="5232a224e5b25f56afa88fca0d2e25c1" baserev="5232a224e5b25f56afa88fca0d2e25c1" xsrcmd5="94fb06e2f49d4c9653f8c59541d54224" lsrcmd5="ae76013c9f7e3d41c353647f9b80e077"/>
-          <serviceinfo code="succeeded" xsrcmd5="167053f58e8244340327541d85ca354b"/>
-          <entry name="_branch_request" md5="8ccc2896b48bb83bb375eaf0b342764a" size="120" mtime="1637576859"/>
-          <entry name="_config" md5="28d49d13ba5f8a729278554e7ee47424" size="62" mtime="1642674809"/>
-          <entry name="_link" md5="62f47fbdaebb7c2ee1f9a0b69aa8e80e" size="141" mtime="1642674809"/>
-          <entry name="somefile.txt" md5="db592fc54e8a5e8ea3b28472d5101d18" size="71" mtime="1642674809"/>
+        <directory name="bar_package-release_abc" rev="8" vrev="8" srcmd5="b19422281cbe0f87b78bf8169f3eed4e">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="5916ec5ffc82915fa10c0bcf252c6886" baserev="5916ec5ffc82915fa10c0bcf252c6886" xsrcmd5="f26d812e4e74fb3dc96809db16d4a308" lsrcmd5="b19422281cbe0f87b78bf8169f3eed4e"/>
+          <entry name="_branch_request" md5="8ccc2896b48bb83bb375eaf0b342764a" size="120" mtime="1643641545"/>
+          <entry name="_config" md5="69fab1f2eb7ff5c19dbf2427a46efad0" size="53" mtime="1643641548"/>
+          <entry name="_link" md5="320ca80b6a4c043277dcd6b2153afd07" size="141" mtime="1643641549"/>
+          <entry name="somefile.txt" md5="e24481dab8b06994fc8e6e23411746ba" size="70" mtime="1643641548"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:30 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:49 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -801,18 +799,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '328'
+      - '326'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="f868d1510a0db7ff82e4cef4ffc677c3">
+        <sourcediff key="1dab37d06e2e268d6abb287380a19c2c">
           <old project="home:Iggy" package="bar_package-release_abc" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy" package="bar_package-release_abc" rev="178" srcmd5="ae76013c9f7e3d41c353647f9b80e077"/>
+          <new project="home:Iggy" package="bar_package-release_abc" rev="8" srcmd5="b19422281cbe0f87b78bf8169f3eed4e"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:30 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:49 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -844,12 +842,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="44e001564204633cb2c573fca8a2699d">
-          <old project="foo_project" package="bar_package" rev="5232a224e5b25f56afa88fca0d2e25c1" srcmd5="5232a224e5b25f56afa88fca0d2e25c1"/>
-          <new project="home:Iggy" package="bar_package-release_abc" rev="5c03593dab4214dd177ce7204486343f" srcmd5="5c03593dab4214dd177ce7204486343f"/>
+        <sourcediff key="835a48c68f9cecb450d8213ffafd3e8f">
+          <old project="foo_project" package="bar_package" rev="5916ec5ffc82915fa10c0bcf252c6886" srcmd5="5916ec5ffc82915fa10c0bcf252c6886"/>
+          <new project="home:Iggy" package="bar_package-release_abc" rev="f26d812e4e74fb3dc96809db16d4a308" srcmd5="f26d812e4e74fb3dc96809db16d4a308"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:30 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:49 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/with_a_push_event_for_a_tag/1_1_1_7_6.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/with_a_push_event_for_a_tag/1_1_1_7_6.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:27 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:45 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_368
+    uri: http://backend:5352/source/foo_project/_meta?user=user_57
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>The Wealth of Nations</title>
+          <title>Dying of the Light</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '153'
+      - '150'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>The Wealth of Nations</title>
+          <title>Dying of the Light</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:27 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:45 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_369
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_58
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>To a God Unknown</title>
-          <description>Aperiam iste cumque distinctio.</description>
+          <title>Cabbages and Kings</title>
+          <description>Voluptate voluptas perferendis numquam.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '157'
+      - '167'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>To a God Unknown</title>
-          <description>Aperiam iste cumque distinctio.</description>
+          <title>Cabbages and Kings</title>
+          <description>Voluptate voluptas perferendis numquam.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:27 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:45 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Dolorum maiores quia. Dicta quae distinctio. Labore perspiciatis consectetur.
+      string: Rem labore eaque. Nesciunt ad occaecati. Vel sit ipsam.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1747" vrev="1747">
-          <srcmd5>1b013c3a134ddf5a15894d21e5b89bfb</srcmd5>
+        <revision rev="65" vrev="65">
+          <srcmd5>1c5fe82bb33dd77152c676c590bfb40e</srcmd5>
           <version>unknown</version>
-          <time>1642674807</time>
+          <time>1643641545</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:27 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:45 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Dolorum odio occaecati. Eos ut officiis. Provident repellendus sit.
+      string: Eaque quae dolorem. Quibusdam assumenda doloremque. At nihil delectus.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +181,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1748" vrev="1748">
-          <srcmd5>5148a429fb540d9fab162357accea976</srcmd5>
+        <revision rev="66" vrev="66">
+          <srcmd5>a3f968147fa6781facc83f417b099fcb</srcmd5>
           <version>unknown</version>
-          <time>1642674807</time>
+          <time>1643641545</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:27 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:45 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -227,7 +227,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:33:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:45 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc/_meta?user=Iggy
@@ -235,8 +235,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-release_abc" project="home:Iggy">
-          <title>To a God Unknown</title>
-          <description>Aperiam iste cumque distinctio.</description>
+          <title>Cabbages and Kings</title>
+          <description>Voluptate voluptas perferendis numquam.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -257,15 +257,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '177'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-release_abc" project="home:Iggy">
-          <title>To a God Unknown</title>
-          <description>Aperiam iste cumque distinctio.</description>
+          <title>Cabbages and Kings</title>
+          <description>Voluptate voluptas perferendis numquam.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:46 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc?cmd=branch&noservice=1&opackage=bar_package&oproject=foo_project&user=Iggy
@@ -293,19 +293,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '204'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="173" vrev="173">
-          <srcmd5>1e02191b2f62a1e62db70a4530185efb</srcmd5>
+        <revision rev="3" vrev="3">
+          <srcmd5>0efb1ac098d821b28c32fc757a220ee0</srcmd5>
           <version>unknown</version>
-          <time>1642674808</time>
+          <time>1643641546</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc/_meta?user=Iggy
@@ -313,8 +313,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-release_abc" project="home:Iggy">
-          <title>To a God Unknown</title>
-          <description>Aperiam iste cumque distinctio.</description>
+          <title>Cabbages and Kings</title>
+          <description>Voluptate voluptas perferendis numquam.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -335,15 +335,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '177'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-release_abc" project="home:Iggy">
-          <title>To a God Unknown</title>
-          <description>Aperiam iste cumque distinctio.</description>
+          <title>Cabbages and Kings</title>
+          <description>Voluptate voluptas perferendis numquam.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:46 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc
@@ -369,18 +369,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '737'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-release_abc" rev="173" vrev="173" srcmd5="1e02191b2f62a1e62db70a4530185efb">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="5148a429fb540d9fab162357accea976" baserev="5148a429fb540d9fab162357accea976" xsrcmd5="0b230bf6400fc2e0343eb51ae441d2c6" lsrcmd5="1e02191b2f62a1e62db70a4530185efb"/>
-          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1642591329"/>
-          <entry name="_config" md5="efa8dc54bf44db7bce09264ce36bda2a" size="77" mtime="1642674807"/>
-          <entry name="_link" md5="769d248eaeeb4ba5b32087f8624d3156" size="141" mtime="1642674808"/>
-          <entry name="somefile.txt" md5="1813bd955bb551ebad532f4f89a5d9e3" size="67" mtime="1642674807"/>
+        <directory name="bar_package-release_abc" rev="3" vrev="3" srcmd5="0efb1ac098d821b28c32fc757a220ee0">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="a3f968147fa6781facc83f417b099fcb" baserev="a3f968147fa6781facc83f417b099fcb" xsrcmd5="9dee97c30f06eb99022b9f4c47ef3536" lsrcmd5="0efb1ac098d821b28c32fc757a220ee0"/>
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="dc795f616ae422e685f94a863323727f" size="55" mtime="1643641545"/>
+          <entry name="_link" md5="a3108df720a4e66156004d3e4afa9049" size="141" mtime="1643641546"/>
+          <entry name="somefile.txt" md5="f9f5d201d9c3968d667e4ddf1b925ced" size="70" mtime="1643641545"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:46 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc?view=info
@@ -406,15 +406,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '345'
+      - '341'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package-release_abc" rev="173" vrev="1921" srcmd5="0b230bf6400fc2e0343eb51ae441d2c6" lsrcmd5="1e02191b2f62a1e62db70a4530185efb" verifymd5="5148a429fb540d9fab162357accea976">
+        <sourceinfo package="bar_package-release_abc" rev="3" vrev="69" srcmd5="9dee97c30f06eb99022b9f4c47ef3536" lsrcmd5="0efb1ac098d821b28c32fc757a220ee0" verifymd5="a3f968147fa6781facc83f417b099fcb">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:46 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc
@@ -440,18 +440,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '737'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-release_abc" rev="173" vrev="173" srcmd5="1e02191b2f62a1e62db70a4530185efb">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="5148a429fb540d9fab162357accea976" baserev="5148a429fb540d9fab162357accea976" xsrcmd5="0b230bf6400fc2e0343eb51ae441d2c6" lsrcmd5="1e02191b2f62a1e62db70a4530185efb"/>
-          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1642591329"/>
-          <entry name="_config" md5="efa8dc54bf44db7bce09264ce36bda2a" size="77" mtime="1642674807"/>
-          <entry name="_link" md5="769d248eaeeb4ba5b32087f8624d3156" size="141" mtime="1642674808"/>
-          <entry name="somefile.txt" md5="1813bd955bb551ebad532f4f89a5d9e3" size="67" mtime="1642674807"/>
+        <directory name="bar_package-release_abc" rev="3" vrev="3" srcmd5="0efb1ac098d821b28c32fc757a220ee0">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="a3f968147fa6781facc83f417b099fcb" baserev="a3f968147fa6781facc83f417b099fcb" xsrcmd5="9dee97c30f06eb99022b9f4c47ef3536" lsrcmd5="0efb1ac098d821b28c32fc757a220ee0"/>
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="dc795f616ae422e685f94a863323727f" size="55" mtime="1643641545"/>
+          <entry name="_link" md5="a3108df720a4e66156004d3e4afa9049" size="141" mtime="1643641546"/>
+          <entry name="somefile.txt" md5="f9f5d201d9c3968d667e4ddf1b925ced" size="70" mtime="1643641545"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:46 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -479,18 +479,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '328'
+      - '326'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="437be77744ccc0bf3a850eaac77e8338">
+        <sourcediff key="33a18e301a3afdb34a2aec10fd58cc7d">
           <old project="home:Iggy" package="bar_package-release_abc" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy" package="bar_package-release_abc" rev="173" srcmd5="1e02191b2f62a1e62db70a4530185efb"/>
+          <new project="home:Iggy" package="bar_package-release_abc" rev="3" srcmd5="0efb1ac098d821b28c32fc757a220ee0"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:46 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -522,14 +522,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="33f4ba5fe44ef5041d401ad8f9ee5095">
-          <old project="foo_project" package="bar_package" rev="5148a429fb540d9fab162357accea976" srcmd5="5148a429fb540d9fab162357accea976"/>
-          <new project="home:Iggy" package="bar_package-release_abc" rev="0b230bf6400fc2e0343eb51ae441d2c6" srcmd5="0b230bf6400fc2e0343eb51ae441d2c6"/>
+        <sourcediff key="9166792f6d460716011879911423d201">
+          <old project="foo_project" package="bar_package" rev="a3f968147fa6781facc83f417b099fcb" srcmd5="a3f968147fa6781facc83f417b099fcb"/>
+          <new project="home:Iggy" package="bar_package-release_abc" rev="9dee97c30f06eb99022b9f4c47ef3536" srcmd5="9dee97c30f06eb99022b9f4c47ef3536"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/_meta?user=Iggy
@@ -587,7 +587,7 @@ http_interactions:
             <arch>aarch64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc/_branch_request?user=Iggy
@@ -613,19 +613,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '204'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="174" vrev="174">
-          <srcmd5>933c06ba1c3acb16de29f7958a591e74</srcmd5>
+        <revision rev="4" vrev="4">
+          <srcmd5>1d478d4e98c7e30408925b25b5fe2469</srcmd5>
           <version>unknown</version>
-          <time>1642674808</time>
+          <time>1643641546</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc/_meta?user=Iggy
@@ -633,8 +633,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-release_abc" project="home:Iggy">
-          <title>To a God Unknown</title>
-          <description>Aperiam iste cumque distinctio.</description>
+          <title>Cabbages and Kings</title>
+          <description>Voluptate voluptas perferendis numquam.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -655,15 +655,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '177'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-release_abc" project="home:Iggy">
-          <title>To a God Unknown</title>
-          <description>Aperiam iste cumque distinctio.</description>
+          <title>Cabbages and Kings</title>
+          <description>Voluptate voluptas perferendis numquam.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:46 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc
@@ -689,19 +689,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '814'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-release_abc" rev="174" vrev="174" srcmd5="933c06ba1c3acb16de29f7958a591e74">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="5148a429fb540d9fab162357accea976" baserev="5148a429fb540d9fab162357accea976" xsrcmd5="cc3287a0fe5df4655c696b4bc6aff842" lsrcmd5="933c06ba1c3acb16de29f7958a591e74"/>
-          <serviceinfo code="succeeded" xsrcmd5="b4e8f78a1dddf24fdc74e26167df08f3"/>
-          <entry name="_branch_request" md5="8ccc2896b48bb83bb375eaf0b342764a" size="120" mtime="1637576859"/>
-          <entry name="_config" md5="efa8dc54bf44db7bce09264ce36bda2a" size="77" mtime="1642674807"/>
-          <entry name="_link" md5="769d248eaeeb4ba5b32087f8624d3156" size="141" mtime="1642674808"/>
-          <entry name="somefile.txt" md5="1813bd955bb551ebad532f4f89a5d9e3" size="67" mtime="1642674807"/>
+        <directory name="bar_package-release_abc" rev="4" vrev="4" srcmd5="1d478d4e98c7e30408925b25b5fe2469">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="a3f968147fa6781facc83f417b099fcb" baserev="a3f968147fa6781facc83f417b099fcb" xsrcmd5="20cf7df804e41b87facaca211e0ad878" lsrcmd5="1d478d4e98c7e30408925b25b5fe2469"/>
+          <entry name="_branch_request" md5="8ccc2896b48bb83bb375eaf0b342764a" size="120" mtime="1643641545"/>
+          <entry name="_config" md5="dc795f616ae422e685f94a863323727f" size="55" mtime="1643641545"/>
+          <entry name="_link" md5="a3108df720a4e66156004d3e4afa9049" size="141" mtime="1643641546"/>
+          <entry name="somefile.txt" md5="f9f5d201d9c3968d667e4ddf1b925ced" size="70" mtime="1643641545"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:46 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc?view=info
@@ -727,15 +726,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '345'
+      - '341'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package-release_abc" rev="174" vrev="1922" srcmd5="d131d5cce42a39c6ca77f3e8dbf8fc60" lsrcmd5="b4e8f78a1dddf24fdc74e26167df08f3" verifymd5="ff1acdd4c45bb973215641957489eca9">
+        <sourceinfo package="bar_package-release_abc" rev="4" vrev="70" srcmd5="20cf7df804e41b87facaca211e0ad878" lsrcmd5="1d478d4e98c7e30408925b25b5fe2469" verifymd5="46176c92f1c7fa2a4d559af833b408ae">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:46 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc
@@ -761,19 +760,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '814'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-release_abc" rev="174" vrev="174" srcmd5="933c06ba1c3acb16de29f7958a591e74">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="5148a429fb540d9fab162357accea976" baserev="5148a429fb540d9fab162357accea976" xsrcmd5="cc3287a0fe5df4655c696b4bc6aff842" lsrcmd5="933c06ba1c3acb16de29f7958a591e74"/>
-          <serviceinfo code="succeeded" xsrcmd5="b4e8f78a1dddf24fdc74e26167df08f3"/>
-          <entry name="_branch_request" md5="8ccc2896b48bb83bb375eaf0b342764a" size="120" mtime="1637576859"/>
-          <entry name="_config" md5="efa8dc54bf44db7bce09264ce36bda2a" size="77" mtime="1642674807"/>
-          <entry name="_link" md5="769d248eaeeb4ba5b32087f8624d3156" size="141" mtime="1642674808"/>
-          <entry name="somefile.txt" md5="1813bd955bb551ebad532f4f89a5d9e3" size="67" mtime="1642674807"/>
+        <directory name="bar_package-release_abc" rev="4" vrev="4" srcmd5="1d478d4e98c7e30408925b25b5fe2469">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="a3f968147fa6781facc83f417b099fcb" baserev="a3f968147fa6781facc83f417b099fcb" xsrcmd5="20cf7df804e41b87facaca211e0ad878" lsrcmd5="1d478d4e98c7e30408925b25b5fe2469"/>
+          <entry name="_branch_request" md5="8ccc2896b48bb83bb375eaf0b342764a" size="120" mtime="1643641545"/>
+          <entry name="_config" md5="dc795f616ae422e685f94a863323727f" size="55" mtime="1643641545"/>
+          <entry name="_link" md5="a3108df720a4e66156004d3e4afa9049" size="141" mtime="1643641546"/>
+          <entry name="somefile.txt" md5="f9f5d201d9c3968d667e4ddf1b925ced" size="70" mtime="1643641545"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:46 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -801,18 +799,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '328'
+      - '326'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="d8672ac4e79497b46bc9991a9e29e9ac">
+        <sourcediff key="940cd92fcaa029e88862c6e79ba4cca9">
           <old project="home:Iggy" package="bar_package-release_abc" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy" package="bar_package-release_abc" rev="174" srcmd5="933c06ba1c3acb16de29f7958a591e74"/>
+          <new project="home:Iggy" package="bar_package-release_abc" rev="4" srcmd5="1d478d4e98c7e30408925b25b5fe2469"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:46 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -844,12 +842,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="d92c0848e71b17e382ddf8ea11dcde9a">
-          <old project="foo_project" package="bar_package" rev="5148a429fb540d9fab162357accea976" srcmd5="5148a429fb540d9fab162357accea976"/>
-          <new project="home:Iggy" package="bar_package-release_abc" rev="d131d5cce42a39c6ca77f3e8dbf8fc60" srcmd5="d131d5cce42a39c6ca77f3e8dbf8fc60"/>
+        <sourcediff key="34595bb1d96584dfe26a95f35645add3">
+          <old project="foo_project" package="bar_package" rev="a3f968147fa6781facc83f417b099fcb" srcmd5="a3f968147fa6781facc83f417b099fcb"/>
+          <new project="home:Iggy" package="bar_package-release_abc" rev="20cf7df804e41b87facaca211e0ad878" srcmd5="20cf7df804e41b87facaca211e0ad878"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:46 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/with_a_push_event_for_a_tag/behaves_like_failed_when_source_package_does_not_exist/1_1_1_7_8_1.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/with_a_push_event_for_a_tag/behaves_like_failed_when_source_package_does_not_exist/1_1_1_7_8_1.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:32 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:54 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_380
+    uri: http://backend:5352/source/foo_project/_meta?user=user_73
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Dying of the Light</title>
+          <title>Great Work of Time</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -75,20 +75,20 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Dying of the Light</title>
+          <title>Great Work of Time</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:32 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:54 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_381
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_74
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Surprised by Joy</title>
-          <description>Et possimus laborum est.</description>
+          <title>The Grapes of Wrath</title>
+          <description>Dicta optio aperiam quae.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '150'
+      - '154'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Surprised by Joy</title>
-          <description>Et possimus laborum est.</description>
+          <title>The Grapes of Wrath</title>
+          <description>Dicta optio aperiam quae.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:32 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:54 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Non sit sunt. Et excepturi sit. Iusto explicabo rerum.
+      string: Eveniet et non. Molestiae quisquam sapiente. Fugiat repellendus aut.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1759" vrev="1759">
-          <srcmd5>5d6af00df0753572fa406e0335b455ee</srcmd5>
+        <revision rev="81" vrev="81">
+          <srcmd5>c1494a0605bf5afff3c172b19c63b49c</srcmd5>
           <version>unknown</version>
-          <time>1642674812</time>
+          <time>1643641554</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:32 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:54 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Qui alias pariatur. Maxime assumenda et. Iure perspiciatis magni.
+      string: Nesciunt unde illum. Et blanditiis eos. Accusantium et quia.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,17 +181,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1760" vrev="1760">
-          <srcmd5>bbab490ac38534215b73e36af9cb7505</srcmd5>
+        <revision rev="82" vrev="82">
+          <srcmd5>81ab214e89833870e3f6fd30d137c6ab</srcmd5>
           <version>unknown</version>
-          <time>1642674812</time>
+          <time>1643641554</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:32 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:54 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/with_a_push_event_for_a_tag/behaves_like_failed_without_branch_permissions/1_1_1_7_9_1.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/with_a_push_event_for_a_tag/behaves_like_failed_without_branch_permissions/1_1_1_7_9_1.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:31 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:53 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_378
+    uri: http://backend:5352/source/foo_project/_meta?user=user_71
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>No Highway</title>
+          <title>Rosemary Sutcliff</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '142'
+      - '149'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>No Highway</title>
+          <title>Rosemary Sutcliff</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:31 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:53 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_379
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_72
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Alone on a Wide, Wide Sea</title>
-          <description>Voluptate omnis minima delectus.</description>
+          <title>Terrible Swift Sword</title>
+          <description>Earum sint a ut.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '146'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Alone on a Wide, Wide Sea</title>
-          <description>Voluptate omnis minima delectus.</description>
+          <title>Terrible Swift Sword</title>
+          <description>Earum sint a ut.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:31 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Nisi non omnis. Quisquam et qui. Sit maiores quia.
+      string: Tempore quod et. Harum repellendus et. Velit illum veritatis.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,26 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1757" vrev="1757">
-          <srcmd5>4350d72ea1c4903e0d5798e97b9999f1</srcmd5>
+        <revision rev="79" vrev="79">
+          <srcmd5>1d97cf41a83ae2be0dc745801740f61e</srcmd5>
           <version>unknown</version>
-          <time>1642674811</time>
+          <time>1643641553</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:32 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Qui repellat nam. Vero soluta quasi. Quos veniam at.
+      string: Consequatur reprehenderit accusamus. Voluptas accusamus et. Et quas
+        odit.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,17 +182,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1758" vrev="1758">
-          <srcmd5>a8b1c54d4369f8ea67da157d0fa14215</srcmd5>
+        <revision rev="80" vrev="80">
+          <srcmd5>9fbba75b112901ea6f32e6da966b2f4c</srcmd5>
           <version>unknown</version>
-          <time>1642674812</time>
+          <time>1643641553</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:32 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:53 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/with_a_push_event_for_a_tag/behaves_like_fails_with_insufficient_write_permission_on_target_project/1_1_1_7_10_1.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/with_a_push_event_for_a_tag/behaves_like_fails_with_insufficient_write_permission_on_target_project/1_1_1_7_10_1.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:31 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:53 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_376
+    uri: http://backend:5352/source/foo_project/_meta?user=user_69
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Cover Her Face</title>
+          <title>If Not Now, When?</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '146'
+      - '149'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Cover Her Face</title>
+          <title>If Not Now, When?</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:31 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:53 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_377
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_70
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>A Swiftly Tilting Planet</title>
-          <description>Ea est fugit numquam.</description>
+          <title>The Last Enemy</title>
+          <description>Dolorem esse reiciendis placeat.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '155'
+      - '156'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>A Swiftly Tilting Planet</title>
-          <description>Ea est fugit numquam.</description>
+          <title>The Last Enemy</title>
+          <description>Dolorem esse reiciendis placeat.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:31 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Voluptatem veritatis optio. Non deleniti vero. Accusamus voluptas iusto.
+      string: Deserunt modi non. Ut dicta vel. Beatae qui adipisci.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1755" vrev="1755">
-          <srcmd5>414578ef5d7c5201564d5bb9abd57069</srcmd5>
+        <revision rev="77" vrev="77">
+          <srcmd5>f2847791642d947bb84a5443740ef5d5</srcmd5>
           <version>unknown</version>
-          <time>1642674811</time>
+          <time>1643641553</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:31 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Veniam qui facere. Ut aliquam aut. Sunt omnis dicta.
+      string: Ut qui ut. Aliquam quis aut. Cumque suscipit atque.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +181,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1756" vrev="1756">
-          <srcmd5>3be8a62a3b37e8e210e9287f21878714</srcmd5>
+        <revision rev="78" vrev="78">
+          <srcmd5>d99d9c5f075e267340c94469e0b30583</srcmd5>
           <version>unknown</version>
-          <time>1642674811</time>
+          <time>1643641553</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:31 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_without_maintainer_rights/_meta?user=Iggy
@@ -201,7 +201,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="project_without_maintainer_rights">
-          <title>All Passion Spent</title>
+          <title>The Way Through the Woods</title>
           <description/>
         </project>
     headers:
@@ -223,15 +223,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '127'
+      - '135'
     body:
       encoding: UTF-8
       string: |
         <project name="project_without_maintainer_rights">
-          <title>All Passion Spent</title>
+          <title>The Way Through the Woods</title>
           <description></description>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:31 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:53 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -265,5 +265,5 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:33:31 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:53 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/with_a_push_event_for_a_tag/does_not_report_back_to_the_SCM.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitHub/with_a_push_event_for_a_tag/does_not_report_back_to_the_SCM.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:46 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_364
+    uri: http://backend:5352/source/foo_project/_meta?user=user_59
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Unweaving the Rainbow</title>
+          <title>Terrible Swift Sword</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '153'
+      - '152'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Unweaving the Rainbow</title>
+          <title>Terrible Swift Sword</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:46 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_365
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_60
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Have His Carcase</title>
-          <description>Fugit ut sint adipisci.</description>
+          <title>Of Human Bondage</title>
+          <description>Et omnis reiciendis sit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,22 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '149'
+      - '150'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Have His Carcase</title>
-          <description>Fugit ut sint adipisci.</description>
+          <title>Of Human Bondage</title>
+          <description>Et omnis reiciendis sit.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Quaerat inventore rerum. Vel rerum facere. Mollitia deleniti nisi.
+      string: Eum reprehenderit occaecati. Amet sit officia. Exercitationem reiciendis
+        sed.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +144,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1743" vrev="1743">
-          <srcmd5>3c48849c8c273c86cc8b513d4094699f</srcmd5>
+        <revision rev="67" vrev="67">
+          <srcmd5>8da43aebcfb915a3dc5183bb0a93cbdc</srcmd5>
           <version>unknown</version>
-          <time>1642674805</time>
+          <time>1643641546</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Rerum fugit ipsum. Quasi modi quo. Aliquid id necessitatibus.
+      string: Eos vel minus. Eum occaecati impedit. Adipisci quis rerum.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +182,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1744" vrev="1744">
-          <srcmd5>5224145c7593f1037d7e585f9f6a66c1</srcmd5>
+        <revision rev="68" vrev="68">
+          <srcmd5>d9983205a17055acc7cf2858cd9851aa</srcmd5>
           <version>unknown</version>
-          <time>1642674805</time>
+          <time>1643641547</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:47 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -227,7 +228,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:33:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc/_meta?user=Iggy
@@ -235,8 +236,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-release_abc" project="home:Iggy">
-          <title>Have His Carcase</title>
-          <description>Fugit ut sint adipisci.</description>
+          <title>Of Human Bondage</title>
+          <description>Et omnis reiciendis sit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -257,15 +258,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '159'
+      - '160'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-release_abc" project="home:Iggy">
-          <title>Have His Carcase</title>
-          <description>Fugit ut sint adipisci.</description>
+          <title>Of Human Bondage</title>
+          <description>Et omnis reiciendis sit.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:47 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc?cmd=branch&noservice=1&opackage=bar_package&oproject=foo_project&user=Iggy
@@ -293,19 +294,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '204'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="169" vrev="169">
-          <srcmd5>a22f5d0a59ef788b7ca6b4bf9b6132ad</srcmd5>
+        <revision rev="5" vrev="5">
+          <srcmd5>8151d04f284674c41a6202091671c1bb</srcmd5>
           <version>unknown</version>
-          <time>1642674805</time>
+          <time>1643641547</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc/_meta?user=Iggy
@@ -313,8 +314,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-release_abc" project="home:Iggy">
-          <title>Have His Carcase</title>
-          <description>Fugit ut sint adipisci.</description>
+          <title>Of Human Bondage</title>
+          <description>Et omnis reiciendis sit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -335,15 +336,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '159'
+      - '160'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-release_abc" project="home:Iggy">
-          <title>Have His Carcase</title>
-          <description>Fugit ut sint adipisci.</description>
+          <title>Of Human Bondage</title>
+          <description>Et omnis reiciendis sit.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:26 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:47 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc
@@ -369,18 +370,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '737'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-release_abc" rev="169" vrev="169" srcmd5="a22f5d0a59ef788b7ca6b4bf9b6132ad">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="5224145c7593f1037d7e585f9f6a66c1" baserev="5224145c7593f1037d7e585f9f6a66c1" xsrcmd5="526e0e8ceefcf900a9cc95ded600240a" lsrcmd5="a22f5d0a59ef788b7ca6b4bf9b6132ad"/>
-          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1642591329"/>
-          <entry name="_config" md5="cb9d4c3b76326f916eef0daf08a7ea3d" size="66" mtime="1642674805"/>
-          <entry name="_link" md5="c2ec59203aa45446d29e1f547280944b" size="141" mtime="1642674805"/>
-          <entry name="somefile.txt" md5="ca7dfec324b26d6fdfe2e75ea9c98899" size="61" mtime="1642674805"/>
+        <directory name="bar_package-release_abc" rev="5" vrev="5" srcmd5="8151d04f284674c41a6202091671c1bb">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="d9983205a17055acc7cf2858cd9851aa" baserev="d9983205a17055acc7cf2858cd9851aa" xsrcmd5="4f19286b96ab498f70151d9c811f12b1" lsrcmd5="8151d04f284674c41a6202091671c1bb"/>
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="5118cd17e886f9b134e5274a097a0425" size="77" mtime="1643641546"/>
+          <entry name="_link" md5="86c67445005fcdaada073a9b64e6ddd4" size="141" mtime="1643641547"/>
+          <entry name="somefile.txt" md5="9491d8819b4c390b3932a1d32a08944d" size="58" mtime="1643641547"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:26 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:47 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc?view=info
@@ -406,15 +407,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '345'
+      - '341'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package-release_abc" rev="169" vrev="1913" srcmd5="526e0e8ceefcf900a9cc95ded600240a" lsrcmd5="a22f5d0a59ef788b7ca6b4bf9b6132ad" verifymd5="5224145c7593f1037d7e585f9f6a66c1">
+        <sourceinfo package="bar_package-release_abc" rev="5" vrev="73" srcmd5="4f19286b96ab498f70151d9c811f12b1" lsrcmd5="8151d04f284674c41a6202091671c1bb" verifymd5="d9983205a17055acc7cf2858cd9851aa">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:26 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:47 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc
@@ -440,18 +441,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '737'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-release_abc" rev="169" vrev="169" srcmd5="a22f5d0a59ef788b7ca6b4bf9b6132ad">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="5224145c7593f1037d7e585f9f6a66c1" baserev="5224145c7593f1037d7e585f9f6a66c1" xsrcmd5="526e0e8ceefcf900a9cc95ded600240a" lsrcmd5="a22f5d0a59ef788b7ca6b4bf9b6132ad"/>
-          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1642591329"/>
-          <entry name="_config" md5="cb9d4c3b76326f916eef0daf08a7ea3d" size="66" mtime="1642674805"/>
-          <entry name="_link" md5="c2ec59203aa45446d29e1f547280944b" size="141" mtime="1642674805"/>
-          <entry name="somefile.txt" md5="ca7dfec324b26d6fdfe2e75ea9c98899" size="61" mtime="1642674805"/>
+        <directory name="bar_package-release_abc" rev="5" vrev="5" srcmd5="8151d04f284674c41a6202091671c1bb">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="d9983205a17055acc7cf2858cd9851aa" baserev="d9983205a17055acc7cf2858cd9851aa" xsrcmd5="4f19286b96ab498f70151d9c811f12b1" lsrcmd5="8151d04f284674c41a6202091671c1bb"/>
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="5118cd17e886f9b134e5274a097a0425" size="77" mtime="1643641546"/>
+          <entry name="_link" md5="86c67445005fcdaada073a9b64e6ddd4" size="141" mtime="1643641547"/>
+          <entry name="somefile.txt" md5="9491d8819b4c390b3932a1d32a08944d" size="58" mtime="1643641547"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:26 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:47 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -479,18 +480,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '328'
+      - '326'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="4aa8464269cf63f750800b6a1310b8f0">
+        <sourcediff key="7772c48f45a19210c556fc4ebf38bfaf">
           <old project="home:Iggy" package="bar_package-release_abc" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy" package="bar_package-release_abc" rev="169" srcmd5="a22f5d0a59ef788b7ca6b4bf9b6132ad"/>
+          <new project="home:Iggy" package="bar_package-release_abc" rev="5" srcmd5="8151d04f284674c41a6202091671c1bb"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:26 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:47 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -522,14 +523,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="d03913975281d754f2a883ebaa0d8689">
-          <old project="foo_project" package="bar_package" rev="5224145c7593f1037d7e585f9f6a66c1" srcmd5="5224145c7593f1037d7e585f9f6a66c1"/>
-          <new project="home:Iggy" package="bar_package-release_abc" rev="526e0e8ceefcf900a9cc95ded600240a" srcmd5="526e0e8ceefcf900a9cc95ded600240a"/>
+        <sourcediff key="8068b624e37aeeb1a9651ebb65873db2">
+          <old project="foo_project" package="bar_package" rev="d9983205a17055acc7cf2858cd9851aa" srcmd5="d9983205a17055acc7cf2858cd9851aa"/>
+          <new project="home:Iggy" package="bar_package-release_abc" rev="4f19286b96ab498f70151d9c811f12b1" srcmd5="4f19286b96ab498f70151d9c811f12b1"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:26 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/_meta?user=Iggy
@@ -587,7 +588,7 @@ http_interactions:
             <arch>aarch64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:33:26 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc/_branch_request?user=Iggy
@@ -613,19 +614,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '204'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="170" vrev="170">
-          <srcmd5>7693e0ce9fb73c3a381a22b63c3a9bc7</srcmd5>
+        <revision rev="6" vrev="6">
+          <srcmd5>0dd50f3280e6d68bad0811067f31f596</srcmd5>
           <version>unknown</version>
-          <time>1642674806</time>
+          <time>1643641547</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:33:26 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:48 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc/_meta?user=Iggy
@@ -633,8 +634,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-release_abc" project="home:Iggy">
-          <title>Have His Carcase</title>
-          <description>Fugit ut sint adipisci.</description>
+          <title>Of Human Bondage</title>
+          <description>Et omnis reiciendis sit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -655,15 +656,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '159'
+      - '160'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-release_abc" project="home:Iggy">
-          <title>Have His Carcase</title>
-          <description>Fugit ut sint adipisci.</description>
+          <title>Of Human Bondage</title>
+          <description>Et omnis reiciendis sit.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:33:26 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:48 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc
@@ -689,19 +690,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '814'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-release_abc" rev="170" vrev="170" srcmd5="7693e0ce9fb73c3a381a22b63c3a9bc7">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="5224145c7593f1037d7e585f9f6a66c1" baserev="5224145c7593f1037d7e585f9f6a66c1" xsrcmd5="7edd8d7a4bd121c533e4a102d5fa29fc" lsrcmd5="7693e0ce9fb73c3a381a22b63c3a9bc7"/>
-          <serviceinfo code="succeeded" xsrcmd5="a9cf9bd55d9063e38756d680d26da121"/>
-          <entry name="_branch_request" md5="8ccc2896b48bb83bb375eaf0b342764a" size="120" mtime="1637576859"/>
-          <entry name="_config" md5="cb9d4c3b76326f916eef0daf08a7ea3d" size="66" mtime="1642674805"/>
-          <entry name="_link" md5="c2ec59203aa45446d29e1f547280944b" size="141" mtime="1642674805"/>
-          <entry name="somefile.txt" md5="ca7dfec324b26d6fdfe2e75ea9c98899" size="61" mtime="1642674805"/>
+        <directory name="bar_package-release_abc" rev="6" vrev="6" srcmd5="0dd50f3280e6d68bad0811067f31f596">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="d9983205a17055acc7cf2858cd9851aa" baserev="d9983205a17055acc7cf2858cd9851aa" xsrcmd5="5ed8b15e9828186e33134e4d63114cfc" lsrcmd5="0dd50f3280e6d68bad0811067f31f596"/>
+          <entry name="_branch_request" md5="8ccc2896b48bb83bb375eaf0b342764a" size="120" mtime="1643641545"/>
+          <entry name="_config" md5="5118cd17e886f9b134e5274a097a0425" size="77" mtime="1643641546"/>
+          <entry name="_link" md5="86c67445005fcdaada073a9b64e6ddd4" size="141" mtime="1643641547"/>
+          <entry name="somefile.txt" md5="9491d8819b4c390b3932a1d32a08944d" size="58" mtime="1643641547"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:26 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:48 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc?view=info
@@ -727,15 +727,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '345'
+      - '341'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package-release_abc" rev="170" vrev="1914" srcmd5="1b36f34cb1bdc61c4b77dfdaa31ba220" lsrcmd5="a9cf9bd55d9063e38756d680d26da121" verifymd5="5970c0113741acaecfe4160c296b4ffa">
+        <sourceinfo package="bar_package-release_abc" rev="6" vrev="74" srcmd5="5ed8b15e9828186e33134e4d63114cfc" lsrcmd5="0dd50f3280e6d68bad0811067f31f596" verifymd5="1d025b47100ac79ac3aa527be7f61995">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:33:26 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:48 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc
@@ -761,19 +761,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '814'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-release_abc" rev="170" vrev="170" srcmd5="7693e0ce9fb73c3a381a22b63c3a9bc7">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="5224145c7593f1037d7e585f9f6a66c1" baserev="5224145c7593f1037d7e585f9f6a66c1" xsrcmd5="7edd8d7a4bd121c533e4a102d5fa29fc" lsrcmd5="7693e0ce9fb73c3a381a22b63c3a9bc7"/>
-          <serviceinfo code="succeeded" xsrcmd5="a9cf9bd55d9063e38756d680d26da121"/>
-          <entry name="_branch_request" md5="8ccc2896b48bb83bb375eaf0b342764a" size="120" mtime="1637576859"/>
-          <entry name="_config" md5="cb9d4c3b76326f916eef0daf08a7ea3d" size="66" mtime="1642674805"/>
-          <entry name="_link" md5="c2ec59203aa45446d29e1f547280944b" size="141" mtime="1642674805"/>
-          <entry name="somefile.txt" md5="ca7dfec324b26d6fdfe2e75ea9c98899" size="61" mtime="1642674805"/>
+        <directory name="bar_package-release_abc" rev="6" vrev="6" srcmd5="0dd50f3280e6d68bad0811067f31f596">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="d9983205a17055acc7cf2858cd9851aa" baserev="d9983205a17055acc7cf2858cd9851aa" xsrcmd5="5ed8b15e9828186e33134e4d63114cfc" lsrcmd5="0dd50f3280e6d68bad0811067f31f596"/>
+          <entry name="_branch_request" md5="8ccc2896b48bb83bb375eaf0b342764a" size="120" mtime="1643641545"/>
+          <entry name="_config" md5="5118cd17e886f9b134e5274a097a0425" size="77" mtime="1643641546"/>
+          <entry name="_link" md5="86c67445005fcdaada073a9b64e6ddd4" size="141" mtime="1643641547"/>
+          <entry name="somefile.txt" md5="9491d8819b4c390b3932a1d32a08944d" size="58" mtime="1643641547"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:33:26 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:48 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -801,18 +800,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '328'
+      - '326'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="6c28f50ac671103883d68100a52e5117">
+        <sourcediff key="3fcbc05ae4bc9d7d3180642fc3ab6eac">
           <old project="home:Iggy" package="bar_package-release_abc" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy" package="bar_package-release_abc" rev="170" srcmd5="7693e0ce9fb73c3a381a22b63c3a9bc7"/>
+          <new project="home:Iggy" package="bar_package-release_abc" rev="6" srcmd5="0dd50f3280e6d68bad0811067f31f596"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:26 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:48 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-release_abc?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -844,12 +843,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="4add8fad6701f612b1602b9ae141acbb">
-          <old project="foo_project" package="bar_package" rev="5224145c7593f1037d7e585f9f6a66c1" srcmd5="5224145c7593f1037d7e585f9f6a66c1"/>
-          <new project="home:Iggy" package="bar_package-release_abc" rev="1b36f34cb1bdc61c4b77dfdaa31ba220" srcmd5="1b36f34cb1bdc61c4b77dfdaa31ba220"/>
+        <sourcediff key="c408509c8b5ef8cf7fbfdb18c1232818">
+          <old project="foo_project" package="bar_package" rev="d9983205a17055acc7cf2858cd9851aa" srcmd5="d9983205a17055acc7cf2858cd9851aa"/>
+          <new project="home:Iggy" package="bar_package-release_abc" rev="5ed8b15e9828186e33134e4d63114cfc" srcmd5="5ed8b15e9828186e33134e4d63114cfc"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:33:26 GMT
+  recorded_at: Mon, 31 Jan 2022 15:05:48 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/but_we_don_t_provide_a_source_package/behaves_like_source_package_not_provided/1_1_2_2_1_1.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/but_we_don_t_provide_a_source_package/behaves_like_source_package_not_provided/1_1_2_2_1_1.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:19 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:57 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_228
+    uri: http://backend:5352/source/foo_project/_meta?user=user_39
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>The Man Within</title>
+          <title>The Cricket on the Hearth</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '146'
+      - '157'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>The Man Within</title>
+          <title>The Cricket on the Hearth</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:19 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:57 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_229
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_40
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Tiger! Tiger!</title>
-          <description>Provident fugiat error et.</description>
+          <title>Things Fall Apart</title>
+          <description>Consequuntur at maxime quia.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,22 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '149'
+      - '155'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Tiger! Tiger!</title>
-          <description>Provident fugiat error et.</description>
+          <title>Things Fall Apart</title>
+          <description>Consequuntur at maxime quia.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:19 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:57 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Assumenda officiis dolorum. Est quis quibusdam. Odit iusto quis.
+      string: Distinctio quaerat nostrum. Nostrum labore ducimus. Voluptatum cumque
+        dolorum.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +144,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1609" vrev="1609">
-          <srcmd5>28bca8efad72414455f77f2cc805fd50</srcmd5>
+        <revision rev="147" vrev="147">
+          <srcmd5>067a8888fb8dce1c6bd4c4154ec4e573</srcmd5>
           <version>unknown</version>
-          <time>1642674739</time>
+          <time>1643641677</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:19 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:57 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Est nesciunt veniam. Est omnis dolores. Beatae quia sit.
+      string: Sed sit eos. Facere sit quas. Mollitia harum nostrum.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,17 +182,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1610" vrev="1610">
-          <srcmd5>9a74efb4c61fc3f22e5dc78e0ff66a44</srcmd5>
+        <revision rev="148" vrev="148">
+          <srcmd5>1419122ff5002fdd458391c3239061d2</srcmd5>
           <version>unknown</version>
-          <time>1642674739</time>
+          <time>1643641677</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:19 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:57 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/but_we_don_t_provide_source_project/behaves_like_source_project_not_provided/1_1_2_1_1_1.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/but_we_don_t_provide_source_project/behaves_like_source_project_not_provided/1_1_2_1_1_1.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:20 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:57 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_230
+    uri: http://backend:5352/source/foo_project/_meta?user=user_37
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Vanity Fair</title>
+          <title>It's a Battlefield</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '143'
+      - '150'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Vanity Fair</title>
+          <title>It's a Battlefield</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:20 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:57 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_231
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_38
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Mirror Crack'd from Side to Side</title>
-          <description>Est doloremque sint eos.</description>
+          <title>Alone on a Wide, Wide Sea</title>
+          <description>Quam blanditiis impedit non.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,22 +109,22 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '170'
+      - '163'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Mirror Crack'd from Side to Side</title>
-          <description>Est doloremque sint eos.</description>
+          <title>Alone on a Wide, Wide Sea</title>
+          <description>Quam blanditiis impedit non.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:20 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:57 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Exercitationem excepturi facere. Dolore cumque cupiditate. Nemo corrupti
-        quidem.
+      string: Velit ea consectetur. Et perspiciatis voluptatem. Necessitatibus laboriosam
+        voluptatum.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -144,25 +144,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1611" vrev="1611">
-          <srcmd5>74dabe7522ba6a08e9936afc851140aa</srcmd5>
+        <revision rev="145" vrev="145">
+          <srcmd5>291ae2358bdee2c09cd7c9d4bcd12f28</srcmd5>
           <version>unknown</version>
-          <time>1642674740</time>
+          <time>1643641677</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:20 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:57 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Quos cumque ut. Sit quae veritatis. Porro tempora earum.
+      string: Rerum omnis dolor. Qui deserunt laborum. Corporis quia rem.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -182,17 +182,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1612" vrev="1612">
-          <srcmd5>67ad392e7cfe68fd65eb80e381bf2fda</srcmd5>
+        <revision rev="146" vrev="146">
+          <srcmd5>f05e310a6efa62759131cb083239c69a</srcmd5>
           <version>unknown</version>
-          <time>1642674740</time>
+          <time>1643641677</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:20 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:57 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/for_a_new_MR_event/behaves_like_failed_when_source_package_does_not_exist/1_1_2_3_2_1.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/for_a_new_MR_event/behaves_like_failed_when_source_package_does_not_exist/1_1_2_3_2_1.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:39 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:08 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_270
+    uri: http://backend:5352/source/foo_project/_meta?user=user_57
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>No Highway</title>
+          <title>Paths of Glory</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '142'
+      - '146'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>No Highway</title>
+          <title>Paths of Glory</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:39 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:08 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_271
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_58
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Last Temptation</title>
-          <description>Quo sint laboriosam provident.</description>
+          <title>Gone with the Wind</title>
+          <description>Dolores ducimus voluptate alias.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '159'
+      - '160'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Last Temptation</title>
-          <description>Quo sint laboriosam provident.</description>
+          <title>Gone with the Wind</title>
+          <description>Dolores ducimus voluptate alias.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:39 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:08 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Placeat officia occaecati. Aperiam placeat non. Aut est ducimus.
+      string: Consequatur enim labore. Hic ducimus fugiat. Quas deserunt est.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1651" vrev="1651">
-          <srcmd5>f66a6752e04849b47a8c1c9621f1fedd</srcmd5>
+        <revision rev="165" vrev="165">
+          <srcmd5>f5e1993ef7a1ef3f097e5c5e52d7b079</srcmd5>
           <version>unknown</version>
-          <time>1642674759</time>
+          <time>1643641688</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:39 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:08 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Aperiam expedita aliquid. Omnis est corporis. Magnam voluptatem delectus.
+      string: Facere animi ea. Eos nesciunt dicta. Eum quibusdam quis.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,17 +181,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1652" vrev="1652">
-          <srcmd5>c259793a09dd17c9c9c129428a80ebbe</srcmd5>
+        <revision rev="166" vrev="166">
+          <srcmd5>e0a741c9815035d317e676153c3629e2</srcmd5>
           <version>unknown</version>
-          <time>1642674759</time>
+          <time>1643641689</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:39 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:09 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/for_a_new_MR_event/behaves_like_failed_without_branch_permissions/1_1_2_3_3_1.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/for_a_new_MR_event/behaves_like_failed_without_branch_permissions/1_1_2_3_3_1.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:09 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_252
+    uri: http://backend:5352/source/foo_project/_meta?user=user_59
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>From Here to Eternity</title>
+          <title>O Pioneers!</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '153'
+      - '143'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>From Here to Eternity</title>
+          <title>O Pioneers!</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:09 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_253
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_60
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Oh! To be in England</title>
-          <description>Quo alias expedita voluptatibus.</description>
+          <title>Shall not Perish</title>
+          <description>Et accusantium reiciendis eum.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,22 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '162'
+      - '156'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Oh! To be in England</title>
-          <description>Quo alias expedita voluptatibus.</description>
+          <title>Shall not Perish</title>
+          <description>Et accusantium reiciendis eum.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:09 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Facilis sapiente consequatur. Amet culpa perspiciatis. Magni aut voluptas.
+      string: Eligendi molestiae tempora. Accusantium officiis qui. Commodi recusandae
+        officiis.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +144,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1633" vrev="1633">
-          <srcmd5>c2d0e4c9b132ad37895b99bac27126dd</srcmd5>
+        <revision rev="167" vrev="167">
+          <srcmd5>cdde251501b0a5cde5a6d79e92d5bb04</srcmd5>
           <version>unknown</version>
-          <time>1642674749</time>
+          <time>1643641689</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:09 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Earum aliquid quis. Porro molestias corporis. Natus voluptatem est.
+      string: Enim maxime quo. Illo non mollitia. Impedit reprehenderit repudiandae.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,17 +182,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1634" vrev="1634">
-          <srcmd5>fd57f54e22cfa273130c65db96684480</srcmd5>
+        <revision rev="168" vrev="168">
+          <srcmd5>7cb0bb8e0ad1391ab9715bc0a818a430</srcmd5>
           <version>unknown</version>
-          <time>1642674749</time>
+          <time>1643641689</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:09 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/for_a_new_MR_event/behaves_like_fails_with_insufficient_write_permission_on_target_project/1_1_2_3_4_1.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/for_a_new_MR_event/behaves_like_fails_with_insufficient_write_permission_on_target_project/1_1_2_3_4_1.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:30 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:57 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_254
+    uri: http://backend:5352/source/foo_project/_meta?user=user_41
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>The Monkey's Raincoat</title>
+          <title>Dance Dance Dance</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '153'
+      - '149'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>The Monkey's Raincoat</title>
+          <title>Dance Dance Dance</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:30 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:58 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_255
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_42
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Nine Coaches Waiting</title>
-          <description>Et voluptatum et aut.</description>
+          <title>An Acceptable Time</title>
+          <description>Iste et animi earum.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '151'
+      - '148'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Nine Coaches Waiting</title>
-          <description>Et voluptatum et aut.</description>
+          <title>An Acceptable Time</title>
+          <description>Iste et animi earum.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:30 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:58 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Consequuntur maiores facere. Mollitia quia eveniet. Est libero et.
+      string: Alias aliquam quia. Iusto ipsum dolores. Unde sed non.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1635" vrev="1635">
-          <srcmd5>911a41ba9a36dd9e30b1db5b6cdbf2a3</srcmd5>
+        <revision rev="149" vrev="149">
+          <srcmd5>854d7bdbcd81559b05f414933ab782fe</srcmd5>
           <version>unknown</version>
-          <time>1642674750</time>
+          <time>1643641678</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:30 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:58 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Quos nihil natus. Officiis ea est. Eum facere quisquam.
+      string: Suscipit possimus minus. Placeat voluptas et. Eligendi illo excepturi.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +181,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1636" vrev="1636">
-          <srcmd5>c99d97024dd55793428db167a62a20a2</srcmd5>
+        <revision rev="150" vrev="150">
+          <srcmd5>a824fb606cdd6253c225af545526fbd0</srcmd5>
           <version>unknown</version>
-          <time>1642674750</time>
+          <time>1643641678</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:30 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:58 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_without_maintainer_rights/_meta?user=Iggy
@@ -201,7 +201,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="project_without_maintainer_rights">
-          <title>Many Waters</title>
+          <title>Of Mice and Men</title>
           <description/>
         </project>
     headers:
@@ -223,15 +223,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '121'
+      - '125'
     body:
       encoding: UTF-8
       string: |
         <project name="project_without_maintainer_rights">
-          <title>Many Waters</title>
+          <title>Of Mice and Men</title>
           <description></description>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:30 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:58 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -265,5 +265,5 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:32:30 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:58 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/for_a_new_MR_event/behaves_like_successful_new_PR_or_MR_event/1_1_2_3_1_1.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/for_a_new_MR_event/behaves_like_successful_new_PR_or_MR_event/1_1_2_3_1_1.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:30 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:07 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_256
+    uri: http://backend:5352/source/foo_project/_meta?user=user_55
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Many Waters</title>
+          <title>Absalom, Absalom!</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '143'
+      - '149'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Many Waters</title>
+          <title>Absalom, Absalom!</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:30 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:07 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_257
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_56
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Last Enemy</title>
-          <description>Vel repellat expedita quis.</description>
+          <title>The Mirror Crack'd from Side to Side</title>
+          <description>Eos rerum aut autem.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '151'
+      - '166'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Last Enemy</title>
-          <description>Vel repellat expedita quis.</description>
+          <title>The Mirror Crack'd from Side to Side</title>
+          <description>Eos rerum aut autem.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:30 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:07 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Deserunt reiciendis ab. Officia voluptates fuga. Sed veniam est.
+      string: Consectetur voluptatibus ullam. Incidunt at totam. Maiores hic molestiae.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,26 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1637" vrev="1637">
-          <srcmd5>67e6ceaea4525de97cf98b5da885d936</srcmd5>
+        <revision rev="163" vrev="163">
+          <srcmd5>b047b5e5e87cb57416302e860a75559b</srcmd5>
           <version>unknown</version>
-          <time>1642674750</time>
+          <time>1643641687</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:30 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:07 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Est ut vero. Vel iste sapiente. Quia omnis omnis.
+      string: Corporis ipsam debitis. Distinctio molestiae beatae. Eius accusamus
+        atque.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +182,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1638" vrev="1638">
-          <srcmd5>a4a82f9441333431d8728403eef4dc87</srcmd5>
+        <revision rev="164" vrev="164">
+          <srcmd5>d368e58751702be63f1101e3a8b5b48c</srcmd5>
           <version>unknown</version>
-          <time>1642674750</time>
+          <time>1643641687</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:30 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:07 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -227,7 +228,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:32:30 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:07 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -267,7 +268,7 @@ http_interactions:
           <description>This project was created for package bar_package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:30 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:07 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -275,8 +276,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Last Enemy</title>
-          <description>Vel repellat expedita quis.</description>
+          <title>The Mirror Crack'd from Side to Side</title>
+          <description>Eos rerum aut autem.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -297,15 +298,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '182'
+      - '197'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Last Enemy</title>
-          <description>Vel repellat expedita quis.</description>
+          <title>The Mirror Crack'd from Side to Side</title>
+          <description>Eos rerum aut autem.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:30 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:07 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=branch&noservice=1&opackage=bar_package&oproject=foo_project&user=Iggy
@@ -333,19 +334,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="532" vrev="532">
-          <srcmd5>c19ab1eeda556fc149f52ef7b7117186</srcmd5>
+        <revision rev="73" vrev="73">
+          <srcmd5>da4df6d41e50e9a18235fdb61359176c</srcmd5>
           <version>unknown</version>
-          <time>1642674750</time>
+          <time>1643641687</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:30 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:07 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -353,8 +354,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Last Enemy</title>
-          <description>Vel repellat expedita quis.</description>
+          <title>The Mirror Crack'd from Side to Side</title>
+          <description>Eos rerum aut autem.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -375,15 +376,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '182'
+      - '197'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Last Enemy</title>
-          <description>Vel repellat expedita quis.</description>
+          <title>The Mirror Crack'd from Side to Side</title>
+          <description>Eos rerum aut autem.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:30 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:07 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -409,18 +410,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '725'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="532" vrev="532" srcmd5="c19ab1eeda556fc149f52ef7b7117186">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="a4a82f9441333431d8728403eef4dc87" baserev="a4a82f9441333431d8728403eef4dc87" xsrcmd5="d3e2e059670ece53f2ad58aa65757a81" lsrcmd5="c19ab1eeda556fc149f52ef7b7117186"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="8439713fcd147ca4e7365225defab9fc" size="64" mtime="1642674750"/>
-          <entry name="_link" md5="585d931ff93fd8202be04b1a70d50623" size="119" mtime="1642674750"/>
-          <entry name="somefile.txt" md5="e80a93875410646b863b63909912e3ab" size="49" mtime="1642674750"/>
+        <directory name="bar_package" rev="73" vrev="73" srcmd5="da4df6d41e50e9a18235fdb61359176c">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="d368e58751702be63f1101e3a8b5b48c" baserev="d368e58751702be63f1101e3a8b5b48c" xsrcmd5="a07d6b61b975e0885b7138a68a644014" lsrcmd5="da4df6d41e50e9a18235fdb61359176c"/>
+          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1643641671"/>
+          <entry name="_config" md5="b9a4c8680b2e19cc45b42196dbf22421" size="73" mtime="1643641687"/>
+          <entry name="_link" md5="cad1e0595c3069061de02000e04327be" size="119" mtime="1643641687"/>
+          <entry name="somefile.txt" md5="8ae92c6d2564c71e0df0e54fb9a5c0ef" size="74" mtime="1643641687"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:30 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:07 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?view=info
@@ -446,15 +447,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '333'
+      - '331'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="532" vrev="2170" srcmd5="d3e2e059670ece53f2ad58aa65757a81" lsrcmd5="c19ab1eeda556fc149f52ef7b7117186" verifymd5="a4a82f9441333431d8728403eef4dc87">
+        <sourceinfo package="bar_package" rev="73" vrev="237" srcmd5="a07d6b61b975e0885b7138a68a644014" lsrcmd5="da4df6d41e50e9a18235fdb61359176c" verifymd5="d368e58751702be63f1101e3a8b5b48c">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:30 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:07 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -480,18 +481,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '725'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="532" vrev="532" srcmd5="c19ab1eeda556fc149f52ef7b7117186">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="a4a82f9441333431d8728403eef4dc87" baserev="a4a82f9441333431d8728403eef4dc87" xsrcmd5="d3e2e059670ece53f2ad58aa65757a81" lsrcmd5="c19ab1eeda556fc149f52ef7b7117186"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="8439713fcd147ca4e7365225defab9fc" size="64" mtime="1642674750"/>
-          <entry name="_link" md5="585d931ff93fd8202be04b1a70d50623" size="119" mtime="1642674750"/>
-          <entry name="somefile.txt" md5="e80a93875410646b863b63909912e3ab" size="49" mtime="1642674750"/>
+        <directory name="bar_package" rev="73" vrev="73" srcmd5="da4df6d41e50e9a18235fdb61359176c">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="d368e58751702be63f1101e3a8b5b48c" baserev="d368e58751702be63f1101e3a8b5b48c" xsrcmd5="a07d6b61b975e0885b7138a68a644014" lsrcmd5="da4df6d41e50e9a18235fdb61359176c"/>
+          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1643641671"/>
+          <entry name="_config" md5="b9a4c8680b2e19cc45b42196dbf22421" size="73" mtime="1643641687"/>
+          <entry name="_link" md5="cad1e0595c3069061de02000e04327be" size="119" mtime="1643641687"/>
+          <entry name="somefile.txt" md5="8ae92c6d2564c71e0df0e54fb9a5c0ef" size="74" mtime="1643641687"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:30 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:07 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -519,18 +520,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '370'
+      - '369'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="e71a9c177ffd238374e97178482cb881">
+        <sourcediff key="69dd6021deaf9607e079f330808c8e87">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="532" srcmd5="c19ab1eeda556fc149f52ef7b7117186"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="73" srcmd5="da4df6d41e50e9a18235fdb61359176c"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:30 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:07 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -562,12 +563,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="8463ec67de6fbf330865444e36b4f571">
-          <old project="foo_project" package="bar_package" rev="a4a82f9441333431d8728403eef4dc87" srcmd5="a4a82f9441333431d8728403eef4dc87"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="d3e2e059670ece53f2ad58aa65757a81" srcmd5="d3e2e059670ece53f2ad58aa65757a81"/>
+        <sourcediff key="2a17ed445ec3f8a8876d8f07ec07d8de">
+          <old project="foo_project" package="bar_package" rev="d368e58751702be63f1101e3a8b5b48c" srcmd5="d368e58751702be63f1101e3a8b5b48c"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="a07d6b61b975e0885b7138a68a644014" srcmd5="a07d6b61b975e0885b7138a68a644014"/>
           <files/>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:30 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:08 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -635,7 +636,7 @@ http_interactions:
             <arch>aarch64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:31 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:08 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_branch_request?user=Iggy
@@ -661,19 +662,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="533" vrev="533">
-          <srcmd5>61ddae133ab4ad14bfcbe8cae71e1bb4</srcmd5>
+        <revision rev="74" vrev="74">
+          <srcmd5>483628ab8d2479e2f493c2d3b1f894a7</srcmd5>
           <version>unknown</version>
-          <time>1642674751</time>
+          <time>1643641688</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:31 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:08 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -681,8 +682,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Last Enemy</title>
-          <description>Vel repellat expedita quis.</description>
+          <title>The Mirror Crack'd from Side to Side</title>
+          <description>Eos rerum aut autem.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -703,15 +704,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '182'
+      - '197'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Last Enemy</title>
-          <description>Vel repellat expedita quis.</description>
+          <title>The Mirror Crack'd from Side to Side</title>
+          <description>Eos rerum aut autem.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:31 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:08 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -737,19 +738,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="533" vrev="533" srcmd5="61ddae133ab4ad14bfcbe8cae71e1bb4">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="a4a82f9441333431d8728403eef4dc87" baserev="a4a82f9441333431d8728403eef4dc87" xsrcmd5="1affd47786f5fea3136a8a6e8df97f87" lsrcmd5="61ddae133ab4ad14bfcbe8cae71e1bb4"/>
-          <serviceinfo code="succeeded" xsrcmd5="c94ee4c2db24971c48531f634adafac0"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="8439713fcd147ca4e7365225defab9fc" size="64" mtime="1642674750"/>
-          <entry name="_link" md5="585d931ff93fd8202be04b1a70d50623" size="119" mtime="1642674750"/>
-          <entry name="somefile.txt" md5="e80a93875410646b863b63909912e3ab" size="49" mtime="1642674750"/>
+        <directory name="bar_package" rev="74" vrev="74" srcmd5="483628ab8d2479e2f493c2d3b1f894a7">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="d368e58751702be63f1101e3a8b5b48c" baserev="d368e58751702be63f1101e3a8b5b48c" xsrcmd5="17edb7f8b3f2f230eba6dd0719fd1148" lsrcmd5="483628ab8d2479e2f493c2d3b1f894a7"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="b9a4c8680b2e19cc45b42196dbf22421" size="73" mtime="1643641687"/>
+          <entry name="_link" md5="cad1e0595c3069061de02000e04327be" size="119" mtime="1643641687"/>
+          <entry name="somefile.txt" md5="8ae92c6d2564c71e0df0e54fb9a5c0ef" size="74" mtime="1643641687"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:31 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:08 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?view=info
@@ -775,15 +775,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '333'
+      - '331'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="533" vrev="2171" srcmd5="f35e3be4ae334941111c8ee82ca9296d" lsrcmd5="c94ee4c2db24971c48531f634adafac0" verifymd5="7cd985a284b70938587a3d141c56ba08">
+        <sourceinfo package="bar_package" rev="74" vrev="238" srcmd5="17edb7f8b3f2f230eba6dd0719fd1148" lsrcmd5="483628ab8d2479e2f493c2d3b1f894a7" verifymd5="e3b7362879cde1b41980f2f369e3d860">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:31 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:08 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -809,19 +809,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="533" vrev="533" srcmd5="61ddae133ab4ad14bfcbe8cae71e1bb4">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="a4a82f9441333431d8728403eef4dc87" baserev="a4a82f9441333431d8728403eef4dc87" xsrcmd5="1affd47786f5fea3136a8a6e8df97f87" lsrcmd5="61ddae133ab4ad14bfcbe8cae71e1bb4"/>
-          <serviceinfo code="succeeded" xsrcmd5="c94ee4c2db24971c48531f634adafac0"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="8439713fcd147ca4e7365225defab9fc" size="64" mtime="1642674750"/>
-          <entry name="_link" md5="585d931ff93fd8202be04b1a70d50623" size="119" mtime="1642674750"/>
-          <entry name="somefile.txt" md5="e80a93875410646b863b63909912e3ab" size="49" mtime="1642674750"/>
+        <directory name="bar_package" rev="74" vrev="74" srcmd5="483628ab8d2479e2f493c2d3b1f894a7">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="d368e58751702be63f1101e3a8b5b48c" baserev="d368e58751702be63f1101e3a8b5b48c" xsrcmd5="17edb7f8b3f2f230eba6dd0719fd1148" lsrcmd5="483628ab8d2479e2f493c2d3b1f894a7"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="b9a4c8680b2e19cc45b42196dbf22421" size="73" mtime="1643641687"/>
+          <entry name="_link" md5="cad1e0595c3069061de02000e04327be" size="119" mtime="1643641687"/>
+          <entry name="somefile.txt" md5="8ae92c6d2564c71e0df0e54fb9a5c0ef" size="74" mtime="1643641687"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:31 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:08 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -849,18 +848,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '370'
+      - '369'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="6d438f0f3fe29b9ec76f0ed9e0bd9d7b">
+        <sourcediff key="8d011705a6bd9752f95f92b15565ebfa">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="533" srcmd5="61ddae133ab4ad14bfcbe8cae71e1bb4"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="74" srcmd5="483628ab8d2479e2f493c2d3b1f894a7"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:31 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:08 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -892,14 +891,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="0f0c93fc7dbfe28802174e7cb7c90ead">
-          <old project="foo_project" package="bar_package" rev="a4a82f9441333431d8728403eef4dc87" srcmd5="a4a82f9441333431d8728403eef4dc87"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="f35e3be4ae334941111c8ee82ca9296d" srcmd5="f35e3be4ae334941111c8ee82ca9296d"/>
+        <sourcediff key="71700f170ea6a2b46d435d9ce9949d80">
+          <old project="foo_project" package="bar_package" rev="d368e58751702be63f1101e3a8b5b48c" srcmd5="d368e58751702be63f1101e3a8b5b48c"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="17edb7f8b3f2f230eba6dd0719fd1148" srcmd5="17edb7f8b3f2f230eba6dd0719fd1148"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:31 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:08 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -925,19 +924,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="533" vrev="533" srcmd5="61ddae133ab4ad14bfcbe8cae71e1bb4">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="a4a82f9441333431d8728403eef4dc87" baserev="a4a82f9441333431d8728403eef4dc87" xsrcmd5="1affd47786f5fea3136a8a6e8df97f87" lsrcmd5="61ddae133ab4ad14bfcbe8cae71e1bb4"/>
-          <serviceinfo code="succeeded" xsrcmd5="c94ee4c2db24971c48531f634adafac0"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="8439713fcd147ca4e7365225defab9fc" size="64" mtime="1642674750"/>
-          <entry name="_link" md5="585d931ff93fd8202be04b1a70d50623" size="119" mtime="1642674750"/>
-          <entry name="somefile.txt" md5="e80a93875410646b863b63909912e3ab" size="49" mtime="1642674750"/>
+        <directory name="bar_package" rev="74" vrev="74" srcmd5="483628ab8d2479e2f493c2d3b1f894a7">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="d368e58751702be63f1101e3a8b5b48c" baserev="d368e58751702be63f1101e3a8b5b48c" xsrcmd5="17edb7f8b3f2f230eba6dd0719fd1148" lsrcmd5="483628ab8d2479e2f493c2d3b1f894a7"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="b9a4c8680b2e19cc45b42196dbf22421" size="73" mtime="1643641687"/>
+          <entry name="_link" md5="cad1e0595c3069061de02000e04327be" size="119" mtime="1643641687"/>
+          <entry name="somefile.txt" md5="8ae92c6d2564c71e0df0e54fb9a5c0ef" size="74" mtime="1643641687"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:31 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:08 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '618'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="17edb7f8b3f2f230eba6dd0719fd1148" vrev="238" srcmd5="17edb7f8b3f2f230eba6dd0719fd1148">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="d368e58751702be63f1101e3a8b5b48c" baserev="d368e58751702be63f1101e3a8b5b48c" lsrcmd5="483628ab8d2479e2f493c2d3b1f894a7"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="b9a4c8680b2e19cc45b42196dbf22421" size="73" mtime="1643641687"/>
+          <entry name="somefile.txt" md5="8ae92c6d2564c71e0df0e54fb9a5c0ef" size="74" mtime="1643641687"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:08:08 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -963,19 +997,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="533" vrev="533" srcmd5="61ddae133ab4ad14bfcbe8cae71e1bb4">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="a4a82f9441333431d8728403eef4dc87" baserev="a4a82f9441333431d8728403eef4dc87" xsrcmd5="1affd47786f5fea3136a8a6e8df97f87" lsrcmd5="61ddae133ab4ad14bfcbe8cae71e1bb4"/>
-          <serviceinfo code="succeeded" xsrcmd5="c94ee4c2db24971c48531f634adafac0"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="8439713fcd147ca4e7365225defab9fc" size="64" mtime="1642674750"/>
-          <entry name="_link" md5="585d931ff93fd8202be04b1a70d50623" size="119" mtime="1642674750"/>
-          <entry name="somefile.txt" md5="e80a93875410646b863b63909912e3ab" size="49" mtime="1642674750"/>
+        <directory name="bar_package" rev="74" vrev="74" srcmd5="483628ab8d2479e2f493c2d3b1f894a7">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="d368e58751702be63f1101e3a8b5b48c" baserev="d368e58751702be63f1101e3a8b5b48c" xsrcmd5="17edb7f8b3f2f230eba6dd0719fd1148" lsrcmd5="483628ab8d2479e2f493c2d3b1f894a7"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="b9a4c8680b2e19cc45b42196dbf22421" size="73" mtime="1643641687"/>
+          <entry name="_link" md5="cad1e0595c3069061de02000e04327be" size="119" mtime="1643641687"/>
+          <entry name="somefile.txt" md5="8ae92c6d2564c71e0df0e54fb9a5c0ef" size="74" mtime="1643641687"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:31 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:08 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '618'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="17edb7f8b3f2f230eba6dd0719fd1148" vrev="238" srcmd5="17edb7f8b3f2f230eba6dd0719fd1148">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="d368e58751702be63f1101e3a8b5b48c" baserev="d368e58751702be63f1101e3a8b5b48c" lsrcmd5="483628ab8d2479e2f493c2d3b1f894a7"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="b9a4c8680b2e19cc45b42196dbf22421" size="73" mtime="1643641687"/>
+          <entry name="somefile.txt" md5="8ae92c6d2564c71e0df0e54fb9a5c0ef" size="74" mtime="1643641687"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:08:08 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -1001,19 +1070,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="533" vrev="533" srcmd5="61ddae133ab4ad14bfcbe8cae71e1bb4">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="a4a82f9441333431d8728403eef4dc87" baserev="a4a82f9441333431d8728403eef4dc87" xsrcmd5="1affd47786f5fea3136a8a6e8df97f87" lsrcmd5="61ddae133ab4ad14bfcbe8cae71e1bb4"/>
-          <serviceinfo code="succeeded" xsrcmd5="c94ee4c2db24971c48531f634adafac0"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="8439713fcd147ca4e7365225defab9fc" size="64" mtime="1642674750"/>
-          <entry name="_link" md5="585d931ff93fd8202be04b1a70d50623" size="119" mtime="1642674750"/>
-          <entry name="somefile.txt" md5="e80a93875410646b863b63909912e3ab" size="49" mtime="1642674750"/>
+        <directory name="bar_package" rev="74" vrev="74" srcmd5="483628ab8d2479e2f493c2d3b1f894a7">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="d368e58751702be63f1101e3a8b5b48c" baserev="d368e58751702be63f1101e3a8b5b48c" xsrcmd5="17edb7f8b3f2f230eba6dd0719fd1148" lsrcmd5="483628ab8d2479e2f493c2d3b1f894a7"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="b9a4c8680b2e19cc45b42196dbf22421" size="73" mtime="1643641687"/>
+          <entry name="_link" md5="cad1e0595c3069061de02000e04327be" size="119" mtime="1643641687"/>
+          <entry name="somefile.txt" md5="8ae92c6d2564c71e0df0e54fb9a5c0ef" size="74" mtime="1643641687"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:31 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:08 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '618'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="17edb7f8b3f2f230eba6dd0719fd1148" vrev="238" srcmd5="17edb7f8b3f2f230eba6dd0719fd1148">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="d368e58751702be63f1101e3a8b5b48c" baserev="d368e58751702be63f1101e3a8b5b48c" lsrcmd5="483628ab8d2479e2f493c2d3b1f894a7"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="b9a4c8680b2e19cc45b42196dbf22421" size="73" mtime="1643641687"/>
+          <entry name="somefile.txt" md5="8ae92c6d2564c71e0df0e54fb9a5c0ef" size="74" mtime="1643641687"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:08:08 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -1039,19 +1143,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="533" vrev="533" srcmd5="61ddae133ab4ad14bfcbe8cae71e1bb4">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="a4a82f9441333431d8728403eef4dc87" baserev="a4a82f9441333431d8728403eef4dc87" xsrcmd5="1affd47786f5fea3136a8a6e8df97f87" lsrcmd5="61ddae133ab4ad14bfcbe8cae71e1bb4"/>
-          <serviceinfo code="succeeded" xsrcmd5="c94ee4c2db24971c48531f634adafac0"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="8439713fcd147ca4e7365225defab9fc" size="64" mtime="1642674750"/>
-          <entry name="_link" md5="585d931ff93fd8202be04b1a70d50623" size="119" mtime="1642674750"/>
-          <entry name="somefile.txt" md5="e80a93875410646b863b63909912e3ab" size="49" mtime="1642674750"/>
+        <directory name="bar_package" rev="74" vrev="74" srcmd5="483628ab8d2479e2f493c2d3b1f894a7">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="d368e58751702be63f1101e3a8b5b48c" baserev="d368e58751702be63f1101e3a8b5b48c" xsrcmd5="17edb7f8b3f2f230eba6dd0719fd1148" lsrcmd5="483628ab8d2479e2f493c2d3b1f894a7"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="b9a4c8680b2e19cc45b42196dbf22421" size="73" mtime="1643641687"/>
+          <entry name="_link" md5="cad1e0595c3069061de02000e04327be" size="119" mtime="1643641687"/>
+          <entry name="somefile.txt" md5="8ae92c6d2564c71e0df0e54fb9a5c0ef" size="74" mtime="1643641687"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:31 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:08 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '618'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="17edb7f8b3f2f230eba6dd0719fd1148" vrev="238" srcmd5="17edb7f8b3f2f230eba6dd0719fd1148">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="d368e58751702be63f1101e3a8b5b48c" baserev="d368e58751702be63f1101e3a8b5b48c" lsrcmd5="483628ab8d2479e2f493c2d3b1f894a7"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="b9a4c8680b2e19cc45b42196dbf22421" size="73" mtime="1643641687"/>
+          <entry name="somefile.txt" md5="8ae92c6d2564c71e0df0e54fb9a5c0ef" size="74" mtime="1643641687"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:08:08 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -1077,22 +1216,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="533" vrev="533" srcmd5="61ddae133ab4ad14bfcbe8cae71e1bb4">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="a4a82f9441333431d8728403eef4dc87" baserev="a4a82f9441333431d8728403eef4dc87" xsrcmd5="1affd47786f5fea3136a8a6e8df97f87" lsrcmd5="61ddae133ab4ad14bfcbe8cae71e1bb4"/>
-          <serviceinfo code="succeeded" xsrcmd5="c94ee4c2db24971c48531f634adafac0"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="8439713fcd147ca4e7365225defab9fc" size="64" mtime="1642674750"/>
-          <entry name="_link" md5="585d931ff93fd8202be04b1a70d50623" size="119" mtime="1642674750"/>
-          <entry name="somefile.txt" md5="e80a93875410646b863b63909912e3ab" size="49" mtime="1642674750"/>
+        <directory name="bar_package" rev="74" vrev="74" srcmd5="483628ab8d2479e2f493c2d3b1f894a7">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="d368e58751702be63f1101e3a8b5b48c" baserev="d368e58751702be63f1101e3a8b5b48c" xsrcmd5="17edb7f8b3f2f230eba6dd0719fd1148" lsrcmd5="483628ab8d2479e2f493c2d3b1f894a7"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="b9a4c8680b2e19cc45b42196dbf22421" size="73" mtime="1643641687"/>
+          <entry name="_link" md5="cad1e0595c3069061de02000e04327be" size="119" mtime="1643641687"/>
+          <entry name="somefile.txt" md5="8ae92c6d2564c71e0df0e54fb9a5c0ef" size="74" mtime="1643641687"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:31 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:08 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1115,169 +1253,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '618'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="533" vrev="533" srcmd5="61ddae133ab4ad14bfcbe8cae71e1bb4">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="a4a82f9441333431d8728403eef4dc87" baserev="a4a82f9441333431d8728403eef4dc87" xsrcmd5="1affd47786f5fea3136a8a6e8df97f87" lsrcmd5="61ddae133ab4ad14bfcbe8cae71e1bb4"/>
-          <serviceinfo code="succeeded" xsrcmd5="c94ee4c2db24971c48531f634adafac0"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="8439713fcd147ca4e7365225defab9fc" size="64" mtime="1642674750"/>
-          <entry name="_link" md5="585d931ff93fd8202be04b1a70d50623" size="119" mtime="1642674750"/>
-          <entry name="somefile.txt" md5="e80a93875410646b863b63909912e3ab" size="49" mtime="1642674750"/>
+        <directory name="bar_package" rev="17edb7f8b3f2f230eba6dd0719fd1148" vrev="238" srcmd5="17edb7f8b3f2f230eba6dd0719fd1148">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="d368e58751702be63f1101e3a8b5b48c" baserev="d368e58751702be63f1101e3a8b5b48c" lsrcmd5="483628ab8d2479e2f493c2d3b1f894a7"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="b9a4c8680b2e19cc45b42196dbf22421" size="73" mtime="1643641687"/>
+          <entry name="somefile.txt" md5="8ae92c6d2564c71e0df0e54fb9a5c0ef" size="74" mtime="1643641687"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:31 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '802'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="533" vrev="533" srcmd5="61ddae133ab4ad14bfcbe8cae71e1bb4">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="a4a82f9441333431d8728403eef4dc87" baserev="a4a82f9441333431d8728403eef4dc87" xsrcmd5="1affd47786f5fea3136a8a6e8df97f87" lsrcmd5="61ddae133ab4ad14bfcbe8cae71e1bb4"/>
-          <serviceinfo code="succeeded" xsrcmd5="c94ee4c2db24971c48531f634adafac0"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="8439713fcd147ca4e7365225defab9fc" size="64" mtime="1642674750"/>
-          <entry name="_link" md5="585d931ff93fd8202be04b1a70d50623" size="119" mtime="1642674750"/>
-          <entry name="somefile.txt" md5="e80a93875410646b863b63909912e3ab" size="49" mtime="1642674750"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:31 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '802'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="533" vrev="533" srcmd5="61ddae133ab4ad14bfcbe8cae71e1bb4">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="a4a82f9441333431d8728403eef4dc87" baserev="a4a82f9441333431d8728403eef4dc87" xsrcmd5="1affd47786f5fea3136a8a6e8df97f87" lsrcmd5="61ddae133ab4ad14bfcbe8cae71e1bb4"/>
-          <serviceinfo code="succeeded" xsrcmd5="c94ee4c2db24971c48531f634adafac0"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="8439713fcd147ca4e7365225defab9fc" size="64" mtime="1642674750"/>
-          <entry name="_link" md5="585d931ff93fd8202be04b1a70d50623" size="119" mtime="1642674750"/>
-          <entry name="somefile.txt" md5="e80a93875410646b863b63909912e3ab" size="49" mtime="1642674750"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:31 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '802'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="533" vrev="533" srcmd5="61ddae133ab4ad14bfcbe8cae71e1bb4">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="a4a82f9441333431d8728403eef4dc87" baserev="a4a82f9441333431d8728403eef4dc87" xsrcmd5="1affd47786f5fea3136a8a6e8df97f87" lsrcmd5="61ddae133ab4ad14bfcbe8cae71e1bb4"/>
-          <serviceinfo code="succeeded" xsrcmd5="c94ee4c2db24971c48531f634adafac0"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="8439713fcd147ca4e7365225defab9fc" size="64" mtime="1642674750"/>
-          <entry name="_link" md5="585d931ff93fd8202be04b1a70d50623" size="119" mtime="1642674750"/>
-          <entry name="somefile.txt" md5="e80a93875410646b863b63909912e3ab" size="49" mtime="1642674750"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:31 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '802'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="533" vrev="533" srcmd5="61ddae133ab4ad14bfcbe8cae71e1bb4">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="a4a82f9441333431d8728403eef4dc87" baserev="a4a82f9441333431d8728403eef4dc87" xsrcmd5="1affd47786f5fea3136a8a6e8df97f87" lsrcmd5="61ddae133ab4ad14bfcbe8cae71e1bb4"/>
-          <serviceinfo code="succeeded" xsrcmd5="c94ee4c2db24971c48531f634adafac0"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="8439713fcd147ca4e7365225defab9fc" size="64" mtime="1642674750"/>
-          <entry name="_link" md5="585d931ff93fd8202be04b1a70d50623" size="119" mtime="1642674750"/>
-          <entry name="somefile.txt" md5="e80a93875410646b863b63909912e3ab" size="49" mtime="1642674750"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:31 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:08 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/for_a_new_MR_event/behaves_like_successful_new_PR_or_MR_event/1_1_2_3_1_2.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/for_a_new_MR_event/behaves_like_successful_new_PR_or_MR_event/1_1_2_3_1_2.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:33 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:58 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_260
+    uri: http://backend:5352/source/foo_project/_meta?user=user_43
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>The Cricket on the Hearth</title>
+          <title>The Moving Finger</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '157'
+      - '149'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>The Cricket on the Hearth</title>
+          <title>The Moving Finger</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:33 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:58 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_261
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_44
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>A Monstrous Regiment of Women</title>
-          <description>In consequuntur sit ut.</description>
+          <title>The Millstone</title>
+          <description>Accusamus voluptate libero explicabo.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '162'
+      - '160'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>A Monstrous Regiment of Women</title>
-          <description>In consequuntur sit ut.</description>
+          <title>The Millstone</title>
+          <description>Accusamus voluptate libero explicabo.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:33 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:58 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Modi labore est. Recusandae minima et. Quae et error.
+      string: Consequatur rerum soluta. Est corporis vel. Asperiores numquam quia.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1641" vrev="1641">
-          <srcmd5>ae6f60071e4206491d0334b9b29e2eef</srcmd5>
+        <revision rev="151" vrev="151">
+          <srcmd5>dea819db89cf79b566bbeb617a3e2f0b</srcmd5>
           <version>unknown</version>
-          <time>1642674753</time>
+          <time>1643641678</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:33 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:58 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Excepturi magni optio. Voluptatem sunt molestias. Natus ipsum qui.
+      string: Nobis minima saepe. Corporis officia vel. Aperiam neque ad.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +181,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1642" vrev="1642">
-          <srcmd5>c5e290237d1703a5dd6d4b80c7fcd403</srcmd5>
+        <revision rev="152" vrev="152">
+          <srcmd5>4a52ccc3a6679621ba4c4327f4ab867b</srcmd5>
           <version>unknown</version>
-          <time>1642674753</time>
+          <time>1643641678</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:33 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:58 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -227,7 +227,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:32:33 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:58 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -267,7 +267,7 @@ http_interactions:
           <description>This project was created for package bar_package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:33 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:58 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -275,8 +275,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>A Monstrous Regiment of Women</title>
-          <description>In consequuntur sit ut.</description>
+          <title>The Millstone</title>
+          <description>Accusamus voluptate libero explicabo.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -297,15 +297,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '193'
+      - '191'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>A Monstrous Regiment of Women</title>
-          <description>In consequuntur sit ut.</description>
+          <title>The Millstone</title>
+          <description>Accusamus voluptate libero explicabo.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:33 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:58 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=branch&noservice=1&opackage=bar_package&oproject=foo_project&user=Iggy
@@ -333,19 +333,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="536" vrev="536">
-          <srcmd5>331e76f64b98dcd926efd5420d391cdb</srcmd5>
+        <revision rev="61" vrev="61">
+          <srcmd5>101a58ef998d929a13e46f8b46e1159d</srcmd5>
           <version>unknown</version>
-          <time>1642674753</time>
+          <time>1643641678</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:33 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:58 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -353,8 +353,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>A Monstrous Regiment of Women</title>
-          <description>In consequuntur sit ut.</description>
+          <title>The Millstone</title>
+          <description>Accusamus voluptate libero explicabo.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -375,15 +375,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '193'
+      - '191'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>A Monstrous Regiment of Women</title>
-          <description>In consequuntur sit ut.</description>
+          <title>The Millstone</title>
+          <description>Accusamus voluptate libero explicabo.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:33 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:58 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -409,18 +409,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '725'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="536" vrev="536" srcmd5="331e76f64b98dcd926efd5420d391cdb">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="c5e290237d1703a5dd6d4b80c7fcd403" baserev="c5e290237d1703a5dd6d4b80c7fcd403" xsrcmd5="ac91555f59e6d4ba720b53e9caf30b61" lsrcmd5="331e76f64b98dcd926efd5420d391cdb"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="83ddbbdedd916795fdd45f473c35fd87" size="53" mtime="1642674753"/>
-          <entry name="_link" md5="15d7acc94c31c387153f27e676e15ba0" size="119" mtime="1642674753"/>
-          <entry name="somefile.txt" md5="45fb3f46a9cc4279c3dea67a9da8dce8" size="66" mtime="1642674753"/>
+        <directory name="bar_package" rev="61" vrev="61" srcmd5="101a58ef998d929a13e46f8b46e1159d">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="4a52ccc3a6679621ba4c4327f4ab867b" baserev="4a52ccc3a6679621ba4c4327f4ab867b" xsrcmd5="5b766361c22accb627af40c27cb49f59" lsrcmd5="101a58ef998d929a13e46f8b46e1159d"/>
+          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1643641671"/>
+          <entry name="_config" md5="43f98edf34c9dde21767f7c18b15fcab" size="68" mtime="1643641678"/>
+          <entry name="_link" md5="f3da3827a61f2bbd41b4258e827e5dfa" size="119" mtime="1643641678"/>
+          <entry name="somefile.txt" md5="595860399644a42369d08442e84f856c" size="59" mtime="1643641678"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:33 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:58 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?view=info
@@ -446,15 +446,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '333'
+      - '331'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="536" vrev="2178" srcmd5="ac91555f59e6d4ba720b53e9caf30b61" lsrcmd5="331e76f64b98dcd926efd5420d391cdb" verifymd5="c5e290237d1703a5dd6d4b80c7fcd403">
+        <sourceinfo package="bar_package" rev="61" vrev="213" srcmd5="5b766361c22accb627af40c27cb49f59" lsrcmd5="101a58ef998d929a13e46f8b46e1159d" verifymd5="4a52ccc3a6679621ba4c4327f4ab867b">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:33 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:58 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -480,18 +480,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '725'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="536" vrev="536" srcmd5="331e76f64b98dcd926efd5420d391cdb">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="c5e290237d1703a5dd6d4b80c7fcd403" baserev="c5e290237d1703a5dd6d4b80c7fcd403" xsrcmd5="ac91555f59e6d4ba720b53e9caf30b61" lsrcmd5="331e76f64b98dcd926efd5420d391cdb"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="83ddbbdedd916795fdd45f473c35fd87" size="53" mtime="1642674753"/>
-          <entry name="_link" md5="15d7acc94c31c387153f27e676e15ba0" size="119" mtime="1642674753"/>
-          <entry name="somefile.txt" md5="45fb3f46a9cc4279c3dea67a9da8dce8" size="66" mtime="1642674753"/>
+        <directory name="bar_package" rev="61" vrev="61" srcmd5="101a58ef998d929a13e46f8b46e1159d">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="4a52ccc3a6679621ba4c4327f4ab867b" baserev="4a52ccc3a6679621ba4c4327f4ab867b" xsrcmd5="5b766361c22accb627af40c27cb49f59" lsrcmd5="101a58ef998d929a13e46f8b46e1159d"/>
+          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1643641671"/>
+          <entry name="_config" md5="43f98edf34c9dde21767f7c18b15fcab" size="68" mtime="1643641678"/>
+          <entry name="_link" md5="f3da3827a61f2bbd41b4258e827e5dfa" size="119" mtime="1643641678"/>
+          <entry name="somefile.txt" md5="595860399644a42369d08442e84f856c" size="59" mtime="1643641678"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:33 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:58 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -519,18 +519,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '370'
+      - '369'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="49c818d8940d2ad3fe17d42f557b8cd4">
+        <sourcediff key="198e087908cb95dd7cd7a8500d82df46">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="536" srcmd5="331e76f64b98dcd926efd5420d391cdb"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="61" srcmd5="101a58ef998d929a13e46f8b46e1159d"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:33 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:59 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -562,12 +562,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="2b24619518650cbc9cbc46e557f9fa83">
-          <old project="foo_project" package="bar_package" rev="c5e290237d1703a5dd6d4b80c7fcd403" srcmd5="c5e290237d1703a5dd6d4b80c7fcd403"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="ac91555f59e6d4ba720b53e9caf30b61" srcmd5="ac91555f59e6d4ba720b53e9caf30b61"/>
+        <sourcediff key="2f2aabf3d836fb17aed73a4134a8cd1d">
+          <old project="foo_project" package="bar_package" rev="4a52ccc3a6679621ba4c4327f4ab867b" srcmd5="4a52ccc3a6679621ba4c4327f4ab867b"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="5b766361c22accb627af40c27cb49f59" srcmd5="5b766361c22accb627af40c27cb49f59"/>
           <files/>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:33 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:59 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -635,7 +635,7 @@ http_interactions:
             <arch>aarch64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:33 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:59 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_branch_request?user=Iggy
@@ -661,19 +661,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="537" vrev="537">
-          <srcmd5>f627ece10666830ad564baa126c0a27e</srcmd5>
+        <revision rev="62" vrev="62">
+          <srcmd5>495e6915fd02f32c2ae5f6126e02aa9a</srcmd5>
           <version>unknown</version>
-          <time>1642674753</time>
+          <time>1643641679</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:33 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:59 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -681,8 +681,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>A Monstrous Regiment of Women</title>
-          <description>In consequuntur sit ut.</description>
+          <title>The Millstone</title>
+          <description>Accusamus voluptate libero explicabo.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -703,15 +703,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '193'
+      - '191'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>A Monstrous Regiment of Women</title>
-          <description>In consequuntur sit ut.</description>
+          <title>The Millstone</title>
+          <description>Accusamus voluptate libero explicabo.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:33 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:59 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -737,19 +737,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="537" vrev="537" srcmd5="f627ece10666830ad564baa126c0a27e">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="c5e290237d1703a5dd6d4b80c7fcd403" baserev="c5e290237d1703a5dd6d4b80c7fcd403" xsrcmd5="8385761fb96475f139076bdc9bbcd1cc" lsrcmd5="f627ece10666830ad564baa126c0a27e"/>
-          <serviceinfo code="succeeded" xsrcmd5="5a240af86f22b9964552f8217f43cac8"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="83ddbbdedd916795fdd45f473c35fd87" size="53" mtime="1642674753"/>
-          <entry name="_link" md5="15d7acc94c31c387153f27e676e15ba0" size="119" mtime="1642674753"/>
-          <entry name="somefile.txt" md5="45fb3f46a9cc4279c3dea67a9da8dce8" size="66" mtime="1642674753"/>
+        <directory name="bar_package" rev="62" vrev="62" srcmd5="495e6915fd02f32c2ae5f6126e02aa9a">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="4a52ccc3a6679621ba4c4327f4ab867b" baserev="4a52ccc3a6679621ba4c4327f4ab867b" xsrcmd5="1df190ef188335e544604121867a3a90" lsrcmd5="495e6915fd02f32c2ae5f6126e02aa9a"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="43f98edf34c9dde21767f7c18b15fcab" size="68" mtime="1643641678"/>
+          <entry name="_link" md5="f3da3827a61f2bbd41b4258e827e5dfa" size="119" mtime="1643641678"/>
+          <entry name="somefile.txt" md5="595860399644a42369d08442e84f856c" size="59" mtime="1643641678"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:33 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:59 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?view=info
@@ -775,15 +774,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '333'
+      - '331'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="537" vrev="2179" srcmd5="d2250ccd7173ba5a8a219f4fbfc73943" lsrcmd5="5a240af86f22b9964552f8217f43cac8" verifymd5="5e4c1e565e0da11d9c1e8607fe2085bb">
+        <sourceinfo package="bar_package" rev="62" vrev="214" srcmd5="1df190ef188335e544604121867a3a90" lsrcmd5="495e6915fd02f32c2ae5f6126e02aa9a" verifymd5="af4d2d068aedfb0842e5f2e7bc9da9b7">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:33 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:59 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -809,19 +808,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="537" vrev="537" srcmd5="f627ece10666830ad564baa126c0a27e">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="c5e290237d1703a5dd6d4b80c7fcd403" baserev="c5e290237d1703a5dd6d4b80c7fcd403" xsrcmd5="8385761fb96475f139076bdc9bbcd1cc" lsrcmd5="f627ece10666830ad564baa126c0a27e"/>
-          <serviceinfo code="succeeded" xsrcmd5="5a240af86f22b9964552f8217f43cac8"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="83ddbbdedd916795fdd45f473c35fd87" size="53" mtime="1642674753"/>
-          <entry name="_link" md5="15d7acc94c31c387153f27e676e15ba0" size="119" mtime="1642674753"/>
-          <entry name="somefile.txt" md5="45fb3f46a9cc4279c3dea67a9da8dce8" size="66" mtime="1642674753"/>
+        <directory name="bar_package" rev="62" vrev="62" srcmd5="495e6915fd02f32c2ae5f6126e02aa9a">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="4a52ccc3a6679621ba4c4327f4ab867b" baserev="4a52ccc3a6679621ba4c4327f4ab867b" xsrcmd5="1df190ef188335e544604121867a3a90" lsrcmd5="495e6915fd02f32c2ae5f6126e02aa9a"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="43f98edf34c9dde21767f7c18b15fcab" size="68" mtime="1643641678"/>
+          <entry name="_link" md5="f3da3827a61f2bbd41b4258e827e5dfa" size="119" mtime="1643641678"/>
+          <entry name="somefile.txt" md5="595860399644a42369d08442e84f856c" size="59" mtime="1643641678"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:33 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:59 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -849,18 +847,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '370'
+      - '369'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="400f0687b80d1adcafe9cca219853e26">
+        <sourcediff key="c462590a056548d75f8ddf69653da956">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="537" srcmd5="f627ece10666830ad564baa126c0a27e"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="62" srcmd5="495e6915fd02f32c2ae5f6126e02aa9a"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:33 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:59 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -892,14 +890,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="b24baff8c48512b88f40db152c81c4a4">
-          <old project="foo_project" package="bar_package" rev="c5e290237d1703a5dd6d4b80c7fcd403" srcmd5="c5e290237d1703a5dd6d4b80c7fcd403"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="d2250ccd7173ba5a8a219f4fbfc73943" srcmd5="d2250ccd7173ba5a8a219f4fbfc73943"/>
+        <sourcediff key="200de5854817cdce2e0969742bf503ef">
+          <old project="foo_project" package="bar_package" rev="4a52ccc3a6679621ba4c4327f4ab867b" srcmd5="4a52ccc3a6679621ba4c4327f4ab867b"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="1df190ef188335e544604121867a3a90" srcmd5="1df190ef188335e544604121867a3a90"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:33 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:59 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -925,19 +923,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="537" vrev="537" srcmd5="f627ece10666830ad564baa126c0a27e">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="c5e290237d1703a5dd6d4b80c7fcd403" baserev="c5e290237d1703a5dd6d4b80c7fcd403" xsrcmd5="8385761fb96475f139076bdc9bbcd1cc" lsrcmd5="f627ece10666830ad564baa126c0a27e"/>
-          <serviceinfo code="succeeded" xsrcmd5="5a240af86f22b9964552f8217f43cac8"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="83ddbbdedd916795fdd45f473c35fd87" size="53" mtime="1642674753"/>
-          <entry name="_link" md5="15d7acc94c31c387153f27e676e15ba0" size="119" mtime="1642674753"/>
-          <entry name="somefile.txt" md5="45fb3f46a9cc4279c3dea67a9da8dce8" size="66" mtime="1642674753"/>
+        <directory name="bar_package" rev="62" vrev="62" srcmd5="495e6915fd02f32c2ae5f6126e02aa9a">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="4a52ccc3a6679621ba4c4327f4ab867b" baserev="4a52ccc3a6679621ba4c4327f4ab867b" xsrcmd5="1df190ef188335e544604121867a3a90" lsrcmd5="495e6915fd02f32c2ae5f6126e02aa9a"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="43f98edf34c9dde21767f7c18b15fcab" size="68" mtime="1643641678"/>
+          <entry name="_link" md5="f3da3827a61f2bbd41b4258e827e5dfa" size="119" mtime="1643641678"/>
+          <entry name="somefile.txt" md5="595860399644a42369d08442e84f856c" size="59" mtime="1643641678"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:33 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:59 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '618'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="1df190ef188335e544604121867a3a90" vrev="214" srcmd5="1df190ef188335e544604121867a3a90">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="4a52ccc3a6679621ba4c4327f4ab867b" baserev="4a52ccc3a6679621ba4c4327f4ab867b" lsrcmd5="495e6915fd02f32c2ae5f6126e02aa9a"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="43f98edf34c9dde21767f7c18b15fcab" size="68" mtime="1643641678"/>
+          <entry name="somefile.txt" md5="595860399644a42369d08442e84f856c" size="59" mtime="1643641678"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:07:59 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -963,19 +996,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="537" vrev="537" srcmd5="f627ece10666830ad564baa126c0a27e">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="c5e290237d1703a5dd6d4b80c7fcd403" baserev="c5e290237d1703a5dd6d4b80c7fcd403" xsrcmd5="8385761fb96475f139076bdc9bbcd1cc" lsrcmd5="f627ece10666830ad564baa126c0a27e"/>
-          <serviceinfo code="succeeded" xsrcmd5="5a240af86f22b9964552f8217f43cac8"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="83ddbbdedd916795fdd45f473c35fd87" size="53" mtime="1642674753"/>
-          <entry name="_link" md5="15d7acc94c31c387153f27e676e15ba0" size="119" mtime="1642674753"/>
-          <entry name="somefile.txt" md5="45fb3f46a9cc4279c3dea67a9da8dce8" size="66" mtime="1642674753"/>
+        <directory name="bar_package" rev="62" vrev="62" srcmd5="495e6915fd02f32c2ae5f6126e02aa9a">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="4a52ccc3a6679621ba4c4327f4ab867b" baserev="4a52ccc3a6679621ba4c4327f4ab867b" xsrcmd5="1df190ef188335e544604121867a3a90" lsrcmd5="495e6915fd02f32c2ae5f6126e02aa9a"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="43f98edf34c9dde21767f7c18b15fcab" size="68" mtime="1643641678"/>
+          <entry name="_link" md5="f3da3827a61f2bbd41b4258e827e5dfa" size="119" mtime="1643641678"/>
+          <entry name="somefile.txt" md5="595860399644a42369d08442e84f856c" size="59" mtime="1643641678"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:33 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:59 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '618'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="1df190ef188335e544604121867a3a90" vrev="214" srcmd5="1df190ef188335e544604121867a3a90">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="4a52ccc3a6679621ba4c4327f4ab867b" baserev="4a52ccc3a6679621ba4c4327f4ab867b" lsrcmd5="495e6915fd02f32c2ae5f6126e02aa9a"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="43f98edf34c9dde21767f7c18b15fcab" size="68" mtime="1643641678"/>
+          <entry name="somefile.txt" md5="595860399644a42369d08442e84f856c" size="59" mtime="1643641678"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:07:59 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -1001,19 +1069,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="537" vrev="537" srcmd5="f627ece10666830ad564baa126c0a27e">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="c5e290237d1703a5dd6d4b80c7fcd403" baserev="c5e290237d1703a5dd6d4b80c7fcd403" xsrcmd5="8385761fb96475f139076bdc9bbcd1cc" lsrcmd5="f627ece10666830ad564baa126c0a27e"/>
-          <serviceinfo code="succeeded" xsrcmd5="5a240af86f22b9964552f8217f43cac8"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="83ddbbdedd916795fdd45f473c35fd87" size="53" mtime="1642674753"/>
-          <entry name="_link" md5="15d7acc94c31c387153f27e676e15ba0" size="119" mtime="1642674753"/>
-          <entry name="somefile.txt" md5="45fb3f46a9cc4279c3dea67a9da8dce8" size="66" mtime="1642674753"/>
+        <directory name="bar_package" rev="62" vrev="62" srcmd5="495e6915fd02f32c2ae5f6126e02aa9a">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="4a52ccc3a6679621ba4c4327f4ab867b" baserev="4a52ccc3a6679621ba4c4327f4ab867b" xsrcmd5="1df190ef188335e544604121867a3a90" lsrcmd5="495e6915fd02f32c2ae5f6126e02aa9a"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="43f98edf34c9dde21767f7c18b15fcab" size="68" mtime="1643641678"/>
+          <entry name="_link" md5="f3da3827a61f2bbd41b4258e827e5dfa" size="119" mtime="1643641678"/>
+          <entry name="somefile.txt" md5="595860399644a42369d08442e84f856c" size="59" mtime="1643641678"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:33 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:59 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '618'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="1df190ef188335e544604121867a3a90" vrev="214" srcmd5="1df190ef188335e544604121867a3a90">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="4a52ccc3a6679621ba4c4327f4ab867b" baserev="4a52ccc3a6679621ba4c4327f4ab867b" lsrcmd5="495e6915fd02f32c2ae5f6126e02aa9a"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="43f98edf34c9dde21767f7c18b15fcab" size="68" mtime="1643641678"/>
+          <entry name="somefile.txt" md5="595860399644a42369d08442e84f856c" size="59" mtime="1643641678"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:07:59 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -1039,19 +1142,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="537" vrev="537" srcmd5="f627ece10666830ad564baa126c0a27e">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="c5e290237d1703a5dd6d4b80c7fcd403" baserev="c5e290237d1703a5dd6d4b80c7fcd403" xsrcmd5="8385761fb96475f139076bdc9bbcd1cc" lsrcmd5="f627ece10666830ad564baa126c0a27e"/>
-          <serviceinfo code="succeeded" xsrcmd5="5a240af86f22b9964552f8217f43cac8"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="83ddbbdedd916795fdd45f473c35fd87" size="53" mtime="1642674753"/>
-          <entry name="_link" md5="15d7acc94c31c387153f27e676e15ba0" size="119" mtime="1642674753"/>
-          <entry name="somefile.txt" md5="45fb3f46a9cc4279c3dea67a9da8dce8" size="66" mtime="1642674753"/>
+        <directory name="bar_package" rev="62" vrev="62" srcmd5="495e6915fd02f32c2ae5f6126e02aa9a">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="4a52ccc3a6679621ba4c4327f4ab867b" baserev="4a52ccc3a6679621ba4c4327f4ab867b" xsrcmd5="1df190ef188335e544604121867a3a90" lsrcmd5="495e6915fd02f32c2ae5f6126e02aa9a"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="43f98edf34c9dde21767f7c18b15fcab" size="68" mtime="1643641678"/>
+          <entry name="_link" md5="f3da3827a61f2bbd41b4258e827e5dfa" size="119" mtime="1643641678"/>
+          <entry name="somefile.txt" md5="595860399644a42369d08442e84f856c" size="59" mtime="1643641678"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:34 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:59 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '618'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="1df190ef188335e544604121867a3a90" vrev="214" srcmd5="1df190ef188335e544604121867a3a90">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="4a52ccc3a6679621ba4c4327f4ab867b" baserev="4a52ccc3a6679621ba4c4327f4ab867b" lsrcmd5="495e6915fd02f32c2ae5f6126e02aa9a"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="43f98edf34c9dde21767f7c18b15fcab" size="68" mtime="1643641678"/>
+          <entry name="somefile.txt" md5="595860399644a42369d08442e84f856c" size="59" mtime="1643641678"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:07:59 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -1077,22 +1215,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="537" vrev="537" srcmd5="f627ece10666830ad564baa126c0a27e">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="c5e290237d1703a5dd6d4b80c7fcd403" baserev="c5e290237d1703a5dd6d4b80c7fcd403" xsrcmd5="8385761fb96475f139076bdc9bbcd1cc" lsrcmd5="f627ece10666830ad564baa126c0a27e"/>
-          <serviceinfo code="succeeded" xsrcmd5="5a240af86f22b9964552f8217f43cac8"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="83ddbbdedd916795fdd45f473c35fd87" size="53" mtime="1642674753"/>
-          <entry name="_link" md5="15d7acc94c31c387153f27e676e15ba0" size="119" mtime="1642674753"/>
-          <entry name="somefile.txt" md5="45fb3f46a9cc4279c3dea67a9da8dce8" size="66" mtime="1642674753"/>
+        <directory name="bar_package" rev="62" vrev="62" srcmd5="495e6915fd02f32c2ae5f6126e02aa9a">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="4a52ccc3a6679621ba4c4327f4ab867b" baserev="4a52ccc3a6679621ba4c4327f4ab867b" xsrcmd5="1df190ef188335e544604121867a3a90" lsrcmd5="495e6915fd02f32c2ae5f6126e02aa9a"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="43f98edf34c9dde21767f7c18b15fcab" size="68" mtime="1643641678"/>
+          <entry name="_link" md5="f3da3827a61f2bbd41b4258e827e5dfa" size="119" mtime="1643641678"/>
+          <entry name="somefile.txt" md5="595860399644a42369d08442e84f856c" size="59" mtime="1643641678"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:34 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:59 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1115,169 +1252,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '618'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="537" vrev="537" srcmd5="f627ece10666830ad564baa126c0a27e">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="c5e290237d1703a5dd6d4b80c7fcd403" baserev="c5e290237d1703a5dd6d4b80c7fcd403" xsrcmd5="8385761fb96475f139076bdc9bbcd1cc" lsrcmd5="f627ece10666830ad564baa126c0a27e"/>
-          <serviceinfo code="succeeded" xsrcmd5="5a240af86f22b9964552f8217f43cac8"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="83ddbbdedd916795fdd45f473c35fd87" size="53" mtime="1642674753"/>
-          <entry name="_link" md5="15d7acc94c31c387153f27e676e15ba0" size="119" mtime="1642674753"/>
-          <entry name="somefile.txt" md5="45fb3f46a9cc4279c3dea67a9da8dce8" size="66" mtime="1642674753"/>
+        <directory name="bar_package" rev="1df190ef188335e544604121867a3a90" vrev="214" srcmd5="1df190ef188335e544604121867a3a90">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="4a52ccc3a6679621ba4c4327f4ab867b" baserev="4a52ccc3a6679621ba4c4327f4ab867b" lsrcmd5="495e6915fd02f32c2ae5f6126e02aa9a"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="43f98edf34c9dde21767f7c18b15fcab" size="68" mtime="1643641678"/>
+          <entry name="somefile.txt" md5="595860399644a42369d08442e84f856c" size="59" mtime="1643641678"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:34 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '802'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="537" vrev="537" srcmd5="f627ece10666830ad564baa126c0a27e">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="c5e290237d1703a5dd6d4b80c7fcd403" baserev="c5e290237d1703a5dd6d4b80c7fcd403" xsrcmd5="8385761fb96475f139076bdc9bbcd1cc" lsrcmd5="f627ece10666830ad564baa126c0a27e"/>
-          <serviceinfo code="succeeded" xsrcmd5="5a240af86f22b9964552f8217f43cac8"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="83ddbbdedd916795fdd45f473c35fd87" size="53" mtime="1642674753"/>
-          <entry name="_link" md5="15d7acc94c31c387153f27e676e15ba0" size="119" mtime="1642674753"/>
-          <entry name="somefile.txt" md5="45fb3f46a9cc4279c3dea67a9da8dce8" size="66" mtime="1642674753"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:34 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '802'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="537" vrev="537" srcmd5="f627ece10666830ad564baa126c0a27e">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="c5e290237d1703a5dd6d4b80c7fcd403" baserev="c5e290237d1703a5dd6d4b80c7fcd403" xsrcmd5="8385761fb96475f139076bdc9bbcd1cc" lsrcmd5="f627ece10666830ad564baa126c0a27e"/>
-          <serviceinfo code="succeeded" xsrcmd5="5a240af86f22b9964552f8217f43cac8"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="83ddbbdedd916795fdd45f473c35fd87" size="53" mtime="1642674753"/>
-          <entry name="_link" md5="15d7acc94c31c387153f27e676e15ba0" size="119" mtime="1642674753"/>
-          <entry name="somefile.txt" md5="45fb3f46a9cc4279c3dea67a9da8dce8" size="66" mtime="1642674753"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:34 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '802'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="537" vrev="537" srcmd5="f627ece10666830ad564baa126c0a27e">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="c5e290237d1703a5dd6d4b80c7fcd403" baserev="c5e290237d1703a5dd6d4b80c7fcd403" xsrcmd5="8385761fb96475f139076bdc9bbcd1cc" lsrcmd5="f627ece10666830ad564baa126c0a27e"/>
-          <serviceinfo code="succeeded" xsrcmd5="5a240af86f22b9964552f8217f43cac8"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="83ddbbdedd916795fdd45f473c35fd87" size="53" mtime="1642674753"/>
-          <entry name="_link" md5="15d7acc94c31c387153f27e676e15ba0" size="119" mtime="1642674753"/>
-          <entry name="somefile.txt" md5="45fb3f46a9cc4279c3dea67a9da8dce8" size="66" mtime="1642674753"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:34 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '802'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="537" vrev="537" srcmd5="f627ece10666830ad564baa126c0a27e">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="c5e290237d1703a5dd6d4b80c7fcd403" baserev="c5e290237d1703a5dd6d4b80c7fcd403" xsrcmd5="8385761fb96475f139076bdc9bbcd1cc" lsrcmd5="f627ece10666830ad564baa126c0a27e"/>
-          <serviceinfo code="succeeded" xsrcmd5="5a240af86f22b9964552f8217f43cac8"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="83ddbbdedd916795fdd45f473c35fd87" size="53" mtime="1642674753"/>
-          <entry name="_link" md5="15d7acc94c31c387153f27e676e15ba0" size="119" mtime="1642674753"/>
-          <entry name="somefile.txt" md5="45fb3f46a9cc4279c3dea67a9da8dce8" size="66" mtime="1642674753"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:34 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:59 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/for_a_new_MR_event/behaves_like_successful_new_PR_or_MR_event/1_1_2_3_1_3.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/for_a_new_MR_event/behaves_like_successful_new_PR_or_MR_event/1_1_2_3_1_3.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:36 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:02 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_266
+    uri: http://backend:5352/source/foo_project/_meta?user=user_49
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>I Know Why the Caged Bird Sings</title>
+          <title>Dying of the Light</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '163'
+      - '150'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>I Know Why the Caged Bird Sings</title>
+          <title>Dying of the Light</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:36 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:02 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_267
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_50
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Such, Such Were the Joys</title>
-          <description>Et sunt facilis eligendi.</description>
+          <title>The Last Enemy</title>
+          <description>Veritatis pariatur nesciunt commodi.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,22 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '159'
+      - '160'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Such, Such Were the Joys</title>
-          <description>Et sunt facilis eligendi.</description>
+          <title>The Last Enemy</title>
+          <description>Veritatis pariatur nesciunt commodi.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:36 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:02 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Iure aut velit. Illum et reprehenderit. Dolor autem quis.
+      string: Optio beatae dolores. Et voluptates consequatur. Laudantium voluptatem
+        qui.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +144,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1647" vrev="1647">
-          <srcmd5>5fa8b9dacea4feb17986e4edb198b813</srcmd5>
+        <revision rev="157" vrev="157">
+          <srcmd5>aeae2dafaec3e8278c81a2f194d7ab20</srcmd5>
           <version>unknown</version>
-          <time>1642674756</time>
+          <time>1643641682</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:36 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:02 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Repudiandae dolor aut. Est iste vel. Consectetur culpa praesentium.
+      string: Molestiae cumque est. Tempora voluptatibus omnis. Sit qui similique.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +182,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1648" vrev="1648">
-          <srcmd5>3d38ba82c67f86cffc98b38c1d0acb17</srcmd5>
+        <revision rev="158" vrev="158">
+          <srcmd5>e5e21393f10a50ac0dba8a7a1a6ade52</srcmd5>
           <version>unknown</version>
-          <time>1642674756</time>
+          <time>1643641682</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:36 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:03 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -227,7 +228,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:32:36 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:03 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -267,7 +268,7 @@ http_interactions:
           <description>This project was created for package bar_package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:36 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:03 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -275,8 +276,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Such, Such Were the Joys</title>
-          <description>Et sunt facilis eligendi.</description>
+          <title>The Last Enemy</title>
+          <description>Veritatis pariatur nesciunt commodi.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -297,15 +298,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '190'
+      - '191'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Such, Such Were the Joys</title>
-          <description>Et sunt facilis eligendi.</description>
+          <title>The Last Enemy</title>
+          <description>Veritatis pariatur nesciunt commodi.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:36 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:03 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=branch&noservice=1&opackage=bar_package&oproject=foo_project&user=Iggy
@@ -333,19 +334,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="542" vrev="542">
-          <srcmd5>2f4042367ad09d38aa91d51c08327957</srcmd5>
+        <revision rev="67" vrev="67">
+          <srcmd5>4940bd77f739dc186ceb81027f6edc10</srcmd5>
           <version>unknown</version>
-          <time>1642674756</time>
+          <time>1643641683</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:36 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:03 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -353,8 +354,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Such, Such Were the Joys</title>
-          <description>Et sunt facilis eligendi.</description>
+          <title>The Last Enemy</title>
+          <description>Veritatis pariatur nesciunt commodi.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -375,15 +376,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '190'
+      - '191'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Such, Such Were the Joys</title>
-          <description>Et sunt facilis eligendi.</description>
+          <title>The Last Enemy</title>
+          <description>Veritatis pariatur nesciunt commodi.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:37 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:03 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -409,18 +410,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '725'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="542" vrev="542" srcmd5="2f4042367ad09d38aa91d51c08327957">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3d38ba82c67f86cffc98b38c1d0acb17" baserev="3d38ba82c67f86cffc98b38c1d0acb17" xsrcmd5="a64a19c319dd4d427345a632a06c75bb" lsrcmd5="2f4042367ad09d38aa91d51c08327957"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="aaea4b4069113c338cfe9aa5a48f368e" size="57" mtime="1642674756"/>
-          <entry name="_link" md5="dc39e267e050e93e858f71bc1f08cb18" size="119" mtime="1642674756"/>
-          <entry name="somefile.txt" md5="0594779ea70ae0800f181aaf522dccf9" size="67" mtime="1642674756"/>
+        <directory name="bar_package" rev="67" vrev="67" srcmd5="4940bd77f739dc186ceb81027f6edc10">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="e5e21393f10a50ac0dba8a7a1a6ade52" baserev="e5e21393f10a50ac0dba8a7a1a6ade52" xsrcmd5="4dcc38c25db1acad9e67ce779f640f0b" lsrcmd5="4940bd77f739dc186ceb81027f6edc10"/>
+          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1643641671"/>
+          <entry name="_config" md5="47f59c6779ec1bcaa88b1180d9d5af61" size="75" mtime="1643641682"/>
+          <entry name="_link" md5="34ded02f99ddac3435172780b47d5478" size="119" mtime="1643641683"/>
+          <entry name="somefile.txt" md5="ea990faa85be5712fe8cd5aae887876c" size="68" mtime="1643641682"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:37 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:03 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?view=info
@@ -446,15 +447,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '333'
+      - '331'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="542" vrev="2190" srcmd5="a64a19c319dd4d427345a632a06c75bb" lsrcmd5="2f4042367ad09d38aa91d51c08327957" verifymd5="3d38ba82c67f86cffc98b38c1d0acb17">
+        <sourceinfo package="bar_package" rev="67" vrev="225" srcmd5="4dcc38c25db1acad9e67ce779f640f0b" lsrcmd5="4940bd77f739dc186ceb81027f6edc10" verifymd5="e5e21393f10a50ac0dba8a7a1a6ade52">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:37 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:03 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -480,18 +481,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '725'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="542" vrev="542" srcmd5="2f4042367ad09d38aa91d51c08327957">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3d38ba82c67f86cffc98b38c1d0acb17" baserev="3d38ba82c67f86cffc98b38c1d0acb17" xsrcmd5="a64a19c319dd4d427345a632a06c75bb" lsrcmd5="2f4042367ad09d38aa91d51c08327957"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="aaea4b4069113c338cfe9aa5a48f368e" size="57" mtime="1642674756"/>
-          <entry name="_link" md5="dc39e267e050e93e858f71bc1f08cb18" size="119" mtime="1642674756"/>
-          <entry name="somefile.txt" md5="0594779ea70ae0800f181aaf522dccf9" size="67" mtime="1642674756"/>
+        <directory name="bar_package" rev="67" vrev="67" srcmd5="4940bd77f739dc186ceb81027f6edc10">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="e5e21393f10a50ac0dba8a7a1a6ade52" baserev="e5e21393f10a50ac0dba8a7a1a6ade52" xsrcmd5="4dcc38c25db1acad9e67ce779f640f0b" lsrcmd5="4940bd77f739dc186ceb81027f6edc10"/>
+          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1643641671"/>
+          <entry name="_config" md5="47f59c6779ec1bcaa88b1180d9d5af61" size="75" mtime="1643641682"/>
+          <entry name="_link" md5="34ded02f99ddac3435172780b47d5478" size="119" mtime="1643641683"/>
+          <entry name="somefile.txt" md5="ea990faa85be5712fe8cd5aae887876c" size="68" mtime="1643641682"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:37 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:03 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -519,18 +520,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '370'
+      - '369'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="95c8790cc5daed18f479fd5276e83b27">
+        <sourcediff key="96bf1149e5feecf58bce7d765012d24d">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="542" srcmd5="2f4042367ad09d38aa91d51c08327957"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="67" srcmd5="4940bd77f739dc186ceb81027f6edc10"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:37 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:03 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -562,12 +563,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="db5688a49cd83da117db302f1068b0c6">
-          <old project="foo_project" package="bar_package" rev="3d38ba82c67f86cffc98b38c1d0acb17" srcmd5="3d38ba82c67f86cffc98b38c1d0acb17"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="a64a19c319dd4d427345a632a06c75bb" srcmd5="a64a19c319dd4d427345a632a06c75bb"/>
+        <sourcediff key="c26007ae342c07e178c9f5ab755cae57">
+          <old project="foo_project" package="bar_package" rev="e5e21393f10a50ac0dba8a7a1a6ade52" srcmd5="e5e21393f10a50ac0dba8a7a1a6ade52"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="4dcc38c25db1acad9e67ce779f640f0b" srcmd5="4dcc38c25db1acad9e67ce779f640f0b"/>
           <files/>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:37 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:03 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -635,7 +636,7 @@ http_interactions:
             <arch>aarch64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:37 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:03 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_branch_request?user=Iggy
@@ -661,19 +662,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="543" vrev="543">
-          <srcmd5>f06a8655afc7acad432fcd502defc687</srcmd5>
+        <revision rev="68" vrev="68">
+          <srcmd5>e0776209e279c41e29bb53ca079962c4</srcmd5>
           <version>unknown</version>
-          <time>1642674757</time>
+          <time>1643641683</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:37 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:03 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -681,8 +682,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Such, Such Were the Joys</title>
-          <description>Et sunt facilis eligendi.</description>
+          <title>The Last Enemy</title>
+          <description>Veritatis pariatur nesciunt commodi.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -703,15 +704,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '190'
+      - '191'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Such, Such Were the Joys</title>
-          <description>Et sunt facilis eligendi.</description>
+          <title>The Last Enemy</title>
+          <description>Veritatis pariatur nesciunt commodi.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:37 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:03 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -737,19 +738,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="543" vrev="543" srcmd5="f06a8655afc7acad432fcd502defc687">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3d38ba82c67f86cffc98b38c1d0acb17" baserev="3d38ba82c67f86cffc98b38c1d0acb17" xsrcmd5="85ab7af4e3c988f40ff96f6c29a31ac2" lsrcmd5="f06a8655afc7acad432fcd502defc687"/>
-          <serviceinfo code="succeeded" xsrcmd5="ee41e1062b6a9f530a74fd8ccb6cc203"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="aaea4b4069113c338cfe9aa5a48f368e" size="57" mtime="1642674756"/>
-          <entry name="_link" md5="dc39e267e050e93e858f71bc1f08cb18" size="119" mtime="1642674756"/>
-          <entry name="somefile.txt" md5="0594779ea70ae0800f181aaf522dccf9" size="67" mtime="1642674756"/>
+        <directory name="bar_package" rev="68" vrev="68" srcmd5="e0776209e279c41e29bb53ca079962c4">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="e5e21393f10a50ac0dba8a7a1a6ade52" baserev="e5e21393f10a50ac0dba8a7a1a6ade52" xsrcmd5="dcaa57470057531a060d4ef74fee038a" lsrcmd5="e0776209e279c41e29bb53ca079962c4"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="47f59c6779ec1bcaa88b1180d9d5af61" size="75" mtime="1643641682"/>
+          <entry name="_link" md5="34ded02f99ddac3435172780b47d5478" size="119" mtime="1643641683"/>
+          <entry name="somefile.txt" md5="ea990faa85be5712fe8cd5aae887876c" size="68" mtime="1643641682"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:37 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:03 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?view=info
@@ -775,15 +775,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '333'
+      - '331'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="543" vrev="2191" srcmd5="baf7cd543e68cdf0dc676acb9eca0ad6" lsrcmd5="ee41e1062b6a9f530a74fd8ccb6cc203" verifymd5="30b57312371c6f643e97442d27955d88">
+        <sourceinfo package="bar_package" rev="68" vrev="226" srcmd5="dcaa57470057531a060d4ef74fee038a" lsrcmd5="e0776209e279c41e29bb53ca079962c4" verifymd5="47cd1f0120af0ef779e3014f47ac9b6e">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:37 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:03 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -809,19 +809,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="543" vrev="543" srcmd5="f06a8655afc7acad432fcd502defc687">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3d38ba82c67f86cffc98b38c1d0acb17" baserev="3d38ba82c67f86cffc98b38c1d0acb17" xsrcmd5="85ab7af4e3c988f40ff96f6c29a31ac2" lsrcmd5="f06a8655afc7acad432fcd502defc687"/>
-          <serviceinfo code="succeeded" xsrcmd5="ee41e1062b6a9f530a74fd8ccb6cc203"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="aaea4b4069113c338cfe9aa5a48f368e" size="57" mtime="1642674756"/>
-          <entry name="_link" md5="dc39e267e050e93e858f71bc1f08cb18" size="119" mtime="1642674756"/>
-          <entry name="somefile.txt" md5="0594779ea70ae0800f181aaf522dccf9" size="67" mtime="1642674756"/>
+        <directory name="bar_package" rev="68" vrev="68" srcmd5="e0776209e279c41e29bb53ca079962c4">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="e5e21393f10a50ac0dba8a7a1a6ade52" baserev="e5e21393f10a50ac0dba8a7a1a6ade52" xsrcmd5="dcaa57470057531a060d4ef74fee038a" lsrcmd5="e0776209e279c41e29bb53ca079962c4"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="47f59c6779ec1bcaa88b1180d9d5af61" size="75" mtime="1643641682"/>
+          <entry name="_link" md5="34ded02f99ddac3435172780b47d5478" size="119" mtime="1643641683"/>
+          <entry name="somefile.txt" md5="ea990faa85be5712fe8cd5aae887876c" size="68" mtime="1643641682"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:37 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:03 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -849,18 +848,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '370'
+      - '369'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="b0006673d5baf9b6dc7652725fa90762">
+        <sourcediff key="b2e07cb2ffd052e4bb7dfb4a3cebffd8">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="543" srcmd5="f06a8655afc7acad432fcd502defc687"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="68" srcmd5="e0776209e279c41e29bb53ca079962c4"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:37 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:04 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -892,14 +891,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="24168b9065ee872e2824427e1f4e4283">
-          <old project="foo_project" package="bar_package" rev="3d38ba82c67f86cffc98b38c1d0acb17" srcmd5="3d38ba82c67f86cffc98b38c1d0acb17"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="baf7cd543e68cdf0dc676acb9eca0ad6" srcmd5="baf7cd543e68cdf0dc676acb9eca0ad6"/>
+        <sourcediff key="48d161ef848d3a3e76c7fc483e38a69e">
+          <old project="foo_project" package="bar_package" rev="e5e21393f10a50ac0dba8a7a1a6ade52" srcmd5="e5e21393f10a50ac0dba8a7a1a6ade52"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="dcaa57470057531a060d4ef74fee038a" srcmd5="dcaa57470057531a060d4ef74fee038a"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:37 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:04 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -925,19 +924,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="543" vrev="543" srcmd5="f06a8655afc7acad432fcd502defc687">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3d38ba82c67f86cffc98b38c1d0acb17" baserev="3d38ba82c67f86cffc98b38c1d0acb17" xsrcmd5="85ab7af4e3c988f40ff96f6c29a31ac2" lsrcmd5="f06a8655afc7acad432fcd502defc687"/>
-          <serviceinfo code="succeeded" xsrcmd5="ee41e1062b6a9f530a74fd8ccb6cc203"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="aaea4b4069113c338cfe9aa5a48f368e" size="57" mtime="1642674756"/>
-          <entry name="_link" md5="dc39e267e050e93e858f71bc1f08cb18" size="119" mtime="1642674756"/>
-          <entry name="somefile.txt" md5="0594779ea70ae0800f181aaf522dccf9" size="67" mtime="1642674756"/>
+        <directory name="bar_package" rev="68" vrev="68" srcmd5="e0776209e279c41e29bb53ca079962c4">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="e5e21393f10a50ac0dba8a7a1a6ade52" baserev="e5e21393f10a50ac0dba8a7a1a6ade52" xsrcmd5="dcaa57470057531a060d4ef74fee038a" lsrcmd5="e0776209e279c41e29bb53ca079962c4"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="47f59c6779ec1bcaa88b1180d9d5af61" size="75" mtime="1643641682"/>
+          <entry name="_link" md5="34ded02f99ddac3435172780b47d5478" size="119" mtime="1643641683"/>
+          <entry name="somefile.txt" md5="ea990faa85be5712fe8cd5aae887876c" size="68" mtime="1643641682"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:37 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:04 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '618'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="dcaa57470057531a060d4ef74fee038a" vrev="226" srcmd5="dcaa57470057531a060d4ef74fee038a">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="e5e21393f10a50ac0dba8a7a1a6ade52" baserev="e5e21393f10a50ac0dba8a7a1a6ade52" lsrcmd5="e0776209e279c41e29bb53ca079962c4"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="47f59c6779ec1bcaa88b1180d9d5af61" size="75" mtime="1643641682"/>
+          <entry name="somefile.txt" md5="ea990faa85be5712fe8cd5aae887876c" size="68" mtime="1643641682"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:08:04 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -963,19 +997,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="543" vrev="543" srcmd5="f06a8655afc7acad432fcd502defc687">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3d38ba82c67f86cffc98b38c1d0acb17" baserev="3d38ba82c67f86cffc98b38c1d0acb17" xsrcmd5="85ab7af4e3c988f40ff96f6c29a31ac2" lsrcmd5="f06a8655afc7acad432fcd502defc687"/>
-          <serviceinfo code="succeeded" xsrcmd5="ee41e1062b6a9f530a74fd8ccb6cc203"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="aaea4b4069113c338cfe9aa5a48f368e" size="57" mtime="1642674756"/>
-          <entry name="_link" md5="dc39e267e050e93e858f71bc1f08cb18" size="119" mtime="1642674756"/>
-          <entry name="somefile.txt" md5="0594779ea70ae0800f181aaf522dccf9" size="67" mtime="1642674756"/>
+        <directory name="bar_package" rev="68" vrev="68" srcmd5="e0776209e279c41e29bb53ca079962c4">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="e5e21393f10a50ac0dba8a7a1a6ade52" baserev="e5e21393f10a50ac0dba8a7a1a6ade52" xsrcmd5="dcaa57470057531a060d4ef74fee038a" lsrcmd5="e0776209e279c41e29bb53ca079962c4"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="47f59c6779ec1bcaa88b1180d9d5af61" size="75" mtime="1643641682"/>
+          <entry name="_link" md5="34ded02f99ddac3435172780b47d5478" size="119" mtime="1643641683"/>
+          <entry name="somefile.txt" md5="ea990faa85be5712fe8cd5aae887876c" size="68" mtime="1643641682"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:37 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:04 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '618'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="dcaa57470057531a060d4ef74fee038a" vrev="226" srcmd5="dcaa57470057531a060d4ef74fee038a">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="e5e21393f10a50ac0dba8a7a1a6ade52" baserev="e5e21393f10a50ac0dba8a7a1a6ade52" lsrcmd5="e0776209e279c41e29bb53ca079962c4"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="47f59c6779ec1bcaa88b1180d9d5af61" size="75" mtime="1643641682"/>
+          <entry name="somefile.txt" md5="ea990faa85be5712fe8cd5aae887876c" size="68" mtime="1643641682"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:08:04 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -1001,19 +1070,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="543" vrev="543" srcmd5="f06a8655afc7acad432fcd502defc687">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3d38ba82c67f86cffc98b38c1d0acb17" baserev="3d38ba82c67f86cffc98b38c1d0acb17" xsrcmd5="85ab7af4e3c988f40ff96f6c29a31ac2" lsrcmd5="f06a8655afc7acad432fcd502defc687"/>
-          <serviceinfo code="succeeded" xsrcmd5="ee41e1062b6a9f530a74fd8ccb6cc203"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="aaea4b4069113c338cfe9aa5a48f368e" size="57" mtime="1642674756"/>
-          <entry name="_link" md5="dc39e267e050e93e858f71bc1f08cb18" size="119" mtime="1642674756"/>
-          <entry name="somefile.txt" md5="0594779ea70ae0800f181aaf522dccf9" size="67" mtime="1642674756"/>
+        <directory name="bar_package" rev="68" vrev="68" srcmd5="e0776209e279c41e29bb53ca079962c4">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="e5e21393f10a50ac0dba8a7a1a6ade52" baserev="e5e21393f10a50ac0dba8a7a1a6ade52" xsrcmd5="dcaa57470057531a060d4ef74fee038a" lsrcmd5="e0776209e279c41e29bb53ca079962c4"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="47f59c6779ec1bcaa88b1180d9d5af61" size="75" mtime="1643641682"/>
+          <entry name="_link" md5="34ded02f99ddac3435172780b47d5478" size="119" mtime="1643641683"/>
+          <entry name="somefile.txt" md5="ea990faa85be5712fe8cd5aae887876c" size="68" mtime="1643641682"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:37 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:04 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '618'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="dcaa57470057531a060d4ef74fee038a" vrev="226" srcmd5="dcaa57470057531a060d4ef74fee038a">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="e5e21393f10a50ac0dba8a7a1a6ade52" baserev="e5e21393f10a50ac0dba8a7a1a6ade52" lsrcmd5="e0776209e279c41e29bb53ca079962c4"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="47f59c6779ec1bcaa88b1180d9d5af61" size="75" mtime="1643641682"/>
+          <entry name="somefile.txt" md5="ea990faa85be5712fe8cd5aae887876c" size="68" mtime="1643641682"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:08:04 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -1039,19 +1143,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="543" vrev="543" srcmd5="f06a8655afc7acad432fcd502defc687">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3d38ba82c67f86cffc98b38c1d0acb17" baserev="3d38ba82c67f86cffc98b38c1d0acb17" xsrcmd5="85ab7af4e3c988f40ff96f6c29a31ac2" lsrcmd5="f06a8655afc7acad432fcd502defc687"/>
-          <serviceinfo code="succeeded" xsrcmd5="ee41e1062b6a9f530a74fd8ccb6cc203"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="aaea4b4069113c338cfe9aa5a48f368e" size="57" mtime="1642674756"/>
-          <entry name="_link" md5="dc39e267e050e93e858f71bc1f08cb18" size="119" mtime="1642674756"/>
-          <entry name="somefile.txt" md5="0594779ea70ae0800f181aaf522dccf9" size="67" mtime="1642674756"/>
+        <directory name="bar_package" rev="68" vrev="68" srcmd5="e0776209e279c41e29bb53ca079962c4">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="e5e21393f10a50ac0dba8a7a1a6ade52" baserev="e5e21393f10a50ac0dba8a7a1a6ade52" xsrcmd5="dcaa57470057531a060d4ef74fee038a" lsrcmd5="e0776209e279c41e29bb53ca079962c4"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="47f59c6779ec1bcaa88b1180d9d5af61" size="75" mtime="1643641682"/>
+          <entry name="_link" md5="34ded02f99ddac3435172780b47d5478" size="119" mtime="1643641683"/>
+          <entry name="somefile.txt" md5="ea990faa85be5712fe8cd5aae887876c" size="68" mtime="1643641682"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:37 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:04 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '618'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="dcaa57470057531a060d4ef74fee038a" vrev="226" srcmd5="dcaa57470057531a060d4ef74fee038a">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="e5e21393f10a50ac0dba8a7a1a6ade52" baserev="e5e21393f10a50ac0dba8a7a1a6ade52" lsrcmd5="e0776209e279c41e29bb53ca079962c4"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="47f59c6779ec1bcaa88b1180d9d5af61" size="75" mtime="1643641682"/>
+          <entry name="somefile.txt" md5="ea990faa85be5712fe8cd5aae887876c" size="68" mtime="1643641682"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:08:04 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -1077,22 +1216,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="543" vrev="543" srcmd5="f06a8655afc7acad432fcd502defc687">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3d38ba82c67f86cffc98b38c1d0acb17" baserev="3d38ba82c67f86cffc98b38c1d0acb17" xsrcmd5="85ab7af4e3c988f40ff96f6c29a31ac2" lsrcmd5="f06a8655afc7acad432fcd502defc687"/>
-          <serviceinfo code="succeeded" xsrcmd5="ee41e1062b6a9f530a74fd8ccb6cc203"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="aaea4b4069113c338cfe9aa5a48f368e" size="57" mtime="1642674756"/>
-          <entry name="_link" md5="dc39e267e050e93e858f71bc1f08cb18" size="119" mtime="1642674756"/>
-          <entry name="somefile.txt" md5="0594779ea70ae0800f181aaf522dccf9" size="67" mtime="1642674756"/>
+        <directory name="bar_package" rev="68" vrev="68" srcmd5="e0776209e279c41e29bb53ca079962c4">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="e5e21393f10a50ac0dba8a7a1a6ade52" baserev="e5e21393f10a50ac0dba8a7a1a6ade52" xsrcmd5="dcaa57470057531a060d4ef74fee038a" lsrcmd5="e0776209e279c41e29bb53ca079962c4"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="47f59c6779ec1bcaa88b1180d9d5af61" size="75" mtime="1643641682"/>
+          <entry name="_link" md5="34ded02f99ddac3435172780b47d5478" size="119" mtime="1643641683"/>
+          <entry name="somefile.txt" md5="ea990faa85be5712fe8cd5aae887876c" size="68" mtime="1643641682"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:37 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:04 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1115,171 +1253,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '618'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="543" vrev="543" srcmd5="f06a8655afc7acad432fcd502defc687">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3d38ba82c67f86cffc98b38c1d0acb17" baserev="3d38ba82c67f86cffc98b38c1d0acb17" xsrcmd5="85ab7af4e3c988f40ff96f6c29a31ac2" lsrcmd5="f06a8655afc7acad432fcd502defc687"/>
-          <serviceinfo code="succeeded" xsrcmd5="ee41e1062b6a9f530a74fd8ccb6cc203"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="aaea4b4069113c338cfe9aa5a48f368e" size="57" mtime="1642674756"/>
-          <entry name="_link" md5="dc39e267e050e93e858f71bc1f08cb18" size="119" mtime="1642674756"/>
-          <entry name="somefile.txt" md5="0594779ea70ae0800f181aaf522dccf9" size="67" mtime="1642674756"/>
+        <directory name="bar_package" rev="dcaa57470057531a060d4ef74fee038a" vrev="226" srcmd5="dcaa57470057531a060d4ef74fee038a">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="e5e21393f10a50ac0dba8a7a1a6ade52" baserev="e5e21393f10a50ac0dba8a7a1a6ade52" lsrcmd5="e0776209e279c41e29bb53ca079962c4"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="47f59c6779ec1bcaa88b1180d9d5af61" size="75" mtime="1643641682"/>
+          <entry name="somefile.txt" md5="ea990faa85be5712fe8cd5aae887876c" size="68" mtime="1643641682"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:37 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '802'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="543" vrev="543" srcmd5="f06a8655afc7acad432fcd502defc687">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3d38ba82c67f86cffc98b38c1d0acb17" baserev="3d38ba82c67f86cffc98b38c1d0acb17" xsrcmd5="85ab7af4e3c988f40ff96f6c29a31ac2" lsrcmd5="f06a8655afc7acad432fcd502defc687"/>
-          <serviceinfo code="succeeded" xsrcmd5="ee41e1062b6a9f530a74fd8ccb6cc203"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="aaea4b4069113c338cfe9aa5a48f368e" size="57" mtime="1642674756"/>
-          <entry name="_link" md5="dc39e267e050e93e858f71bc1f08cb18" size="119" mtime="1642674756"/>
-          <entry name="somefile.txt" md5="0594779ea70ae0800f181aaf522dccf9" size="67" mtime="1642674756"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:37 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '802'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="543" vrev="543" srcmd5="f06a8655afc7acad432fcd502defc687">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3d38ba82c67f86cffc98b38c1d0acb17" baserev="3d38ba82c67f86cffc98b38c1d0acb17" xsrcmd5="85ab7af4e3c988f40ff96f6c29a31ac2" lsrcmd5="f06a8655afc7acad432fcd502defc687"/>
-          <serviceinfo code="succeeded" xsrcmd5="ee41e1062b6a9f530a74fd8ccb6cc203"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="aaea4b4069113c338cfe9aa5a48f368e" size="57" mtime="1642674756"/>
-          <entry name="_link" md5="dc39e267e050e93e858f71bc1f08cb18" size="119" mtime="1642674756"/>
-          <entry name="somefile.txt" md5="0594779ea70ae0800f181aaf522dccf9" size="67" mtime="1642674756"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:37 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '802'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="543" vrev="543" srcmd5="f06a8655afc7acad432fcd502defc687">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3d38ba82c67f86cffc98b38c1d0acb17" baserev="3d38ba82c67f86cffc98b38c1d0acb17" xsrcmd5="85ab7af4e3c988f40ff96f6c29a31ac2" lsrcmd5="f06a8655afc7acad432fcd502defc687"/>
-          <serviceinfo code="succeeded" xsrcmd5="ee41e1062b6a9f530a74fd8ccb6cc203"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="aaea4b4069113c338cfe9aa5a48f368e" size="57" mtime="1642674756"/>
-          <entry name="_link" md5="dc39e267e050e93e858f71bc1f08cb18" size="119" mtime="1642674756"/>
-          <entry name="somefile.txt" md5="0594779ea70ae0800f181aaf522dccf9" size="67" mtime="1642674756"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:37 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '802'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="543" vrev="543" srcmd5="f06a8655afc7acad432fcd502defc687">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="3d38ba82c67f86cffc98b38c1d0acb17" baserev="3d38ba82c67f86cffc98b38c1d0acb17" xsrcmd5="85ab7af4e3c988f40ff96f6c29a31ac2" lsrcmd5="f06a8655afc7acad432fcd502defc687"/>
-          <serviceinfo code="succeeded" xsrcmd5="ee41e1062b6a9f530a74fd8ccb6cc203"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="aaea4b4069113c338cfe9aa5a48f368e" size="57" mtime="1642674756"/>
-          <entry name="_link" md5="dc39e267e050e93e858f71bc1f08cb18" size="119" mtime="1642674756"/>
-          <entry name="somefile.txt" md5="0594779ea70ae0800f181aaf522dccf9" size="67" mtime="1642674756"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:37 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:04 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_branch_request
@@ -1309,5 +1293,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"object_kind":null,"project":{"http_url":null},"object_attributes":{"source":{"default_branch":"123456789"}}}'
-  recorded_at: Thu, 20 Jan 2022 10:32:37 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:04 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/for_a_new_MR_event/behaves_like_successful_new_PR_or_MR_event/1_1_2_3_1_4.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/for_a_new_MR_event/behaves_like_successful_new_PR_or_MR_event/1_1_2_3_1_4.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:34 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:59 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_262
+    uri: http://backend:5352/source/foo_project/_meta?user=user_45
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>The Wives of Bath</title>
+          <title>That Hideous Strength</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '149'
+      - '153'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>The Wives of Bath</title>
+          <title>That Hideous Strength</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:34 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:00 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_263
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_46
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>After Many a Summer Dies the Swan</title>
-          <description>Adipisci ipsum laboriosam dolores.</description>
+          <title>Surprised by Joy</title>
+          <description>Fugit consectetur dolor molestias.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '177'
+      - '160'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>After Many a Summer Dies the Swan</title>
-          <description>Adipisci ipsum laboriosam dolores.</description>
+          <title>Surprised by Joy</title>
+          <description>Fugit consectetur dolor molestias.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:34 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:00 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Sit sequi autem. Neque et facilis. Consequuntur voluptatem molestias.
+      string: Cumque iure necessitatibus. Omnis voluptates dolor. Eos voluptate autem.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,26 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1643" vrev="1643">
-          <srcmd5>15f6ac01d1b37101a899f284a2e54483</srcmd5>
+        <revision rev="153" vrev="153">
+          <srcmd5>bb888d325d7c5c00dc878826ef0cf3fb</srcmd5>
           <version>unknown</version>
-          <time>1642674754</time>
+          <time>1643641680</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:34 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:00 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Nostrum facilis tempora. Et aut illo. Ut et illum.
+      string: Atque molestiae temporibus. Itaque natus voluptatem. Voluptas temporibus
+        sed.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +182,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1644" vrev="1644">
-          <srcmd5>145768af60a6bcaf489e2d93a35bfde6</srcmd5>
+        <revision rev="154" vrev="154">
+          <srcmd5>a4f2f1af062c2e9d6b2beffa5fea5e8a</srcmd5>
           <version>unknown</version>
-          <time>1642674754</time>
+          <time>1643641680</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:34 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:00 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -227,7 +228,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:32:34 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:00 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -267,7 +268,7 @@ http_interactions:
           <description>This project was created for package bar_package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:34 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:00 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -275,8 +276,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>After Many a Summer Dies the Swan</title>
-          <description>Adipisci ipsum laboriosam dolores.</description>
+          <title>Surprised by Joy</title>
+          <description>Fugit consectetur dolor molestias.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -297,15 +298,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '191'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>After Many a Summer Dies the Swan</title>
-          <description>Adipisci ipsum laboriosam dolores.</description>
+          <title>Surprised by Joy</title>
+          <description>Fugit consectetur dolor molestias.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:34 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:00 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=branch&noservice=1&opackage=bar_package&oproject=foo_project&user=Iggy
@@ -333,19 +334,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="538" vrev="538">
-          <srcmd5>42c7219a7dd81e72886cfc02413ee4b3</srcmd5>
+        <revision rev="63" vrev="63">
+          <srcmd5>ffa1a0aa9dc7b8ac9a55777d1b2f6152</srcmd5>
           <version>unknown</version>
-          <time>1642674754</time>
+          <time>1643641680</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:34 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:00 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -353,8 +354,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>After Many a Summer Dies the Swan</title>
-          <description>Adipisci ipsum laboriosam dolores.</description>
+          <title>Surprised by Joy</title>
+          <description>Fugit consectetur dolor molestias.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -375,15 +376,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '191'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>After Many a Summer Dies the Swan</title>
-          <description>Adipisci ipsum laboriosam dolores.</description>
+          <title>Surprised by Joy</title>
+          <description>Fugit consectetur dolor molestias.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:34 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:00 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -409,18 +410,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '725'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="538" vrev="538" srcmd5="42c7219a7dd81e72886cfc02413ee4b3">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="145768af60a6bcaf489e2d93a35bfde6" baserev="145768af60a6bcaf489e2d93a35bfde6" xsrcmd5="590865fcaf89bf6f402637aaea0689e9" lsrcmd5="42c7219a7dd81e72886cfc02413ee4b3"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="a77f06fd543a98015caa571fd2f0b676" size="69" mtime="1642674754"/>
-          <entry name="_link" md5="62832aced107ee3e8d8a1cd2200c5260" size="119" mtime="1642674754"/>
-          <entry name="somefile.txt" md5="3ad9edc8c13a61325d771bf149250349" size="50" mtime="1642674754"/>
+        <directory name="bar_package" rev="63" vrev="63" srcmd5="ffa1a0aa9dc7b8ac9a55777d1b2f6152">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="a4f2f1af062c2e9d6b2beffa5fea5e8a" baserev="a4f2f1af062c2e9d6b2beffa5fea5e8a" xsrcmd5="8ea4d96b5828f76feb52d8075d3ce7c6" lsrcmd5="ffa1a0aa9dc7b8ac9a55777d1b2f6152"/>
+          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1643641671"/>
+          <entry name="_config" md5="394a7c550df8f2f591a11c6a9210db91" size="72" mtime="1643641680"/>
+          <entry name="_link" md5="1b19e35daecc7a22341086f08d331e68" size="119" mtime="1643641680"/>
+          <entry name="somefile.txt" md5="d09cc43d9e701f5d4a55b5ba9b0efe15" size="77" mtime="1643641680"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:34 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:00 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?view=info
@@ -446,15 +447,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '333'
+      - '331'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="538" vrev="2182" srcmd5="590865fcaf89bf6f402637aaea0689e9" lsrcmd5="42c7219a7dd81e72886cfc02413ee4b3" verifymd5="145768af60a6bcaf489e2d93a35bfde6">
+        <sourceinfo package="bar_package" rev="63" vrev="217" srcmd5="8ea4d96b5828f76feb52d8075d3ce7c6" lsrcmd5="ffa1a0aa9dc7b8ac9a55777d1b2f6152" verifymd5="a4f2f1af062c2e9d6b2beffa5fea5e8a">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:34 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:00 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -480,18 +481,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '725'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="538" vrev="538" srcmd5="42c7219a7dd81e72886cfc02413ee4b3">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="145768af60a6bcaf489e2d93a35bfde6" baserev="145768af60a6bcaf489e2d93a35bfde6" xsrcmd5="590865fcaf89bf6f402637aaea0689e9" lsrcmd5="42c7219a7dd81e72886cfc02413ee4b3"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="a77f06fd543a98015caa571fd2f0b676" size="69" mtime="1642674754"/>
-          <entry name="_link" md5="62832aced107ee3e8d8a1cd2200c5260" size="119" mtime="1642674754"/>
-          <entry name="somefile.txt" md5="3ad9edc8c13a61325d771bf149250349" size="50" mtime="1642674754"/>
+        <directory name="bar_package" rev="63" vrev="63" srcmd5="ffa1a0aa9dc7b8ac9a55777d1b2f6152">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="a4f2f1af062c2e9d6b2beffa5fea5e8a" baserev="a4f2f1af062c2e9d6b2beffa5fea5e8a" xsrcmd5="8ea4d96b5828f76feb52d8075d3ce7c6" lsrcmd5="ffa1a0aa9dc7b8ac9a55777d1b2f6152"/>
+          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1643641671"/>
+          <entry name="_config" md5="394a7c550df8f2f591a11c6a9210db91" size="72" mtime="1643641680"/>
+          <entry name="_link" md5="1b19e35daecc7a22341086f08d331e68" size="119" mtime="1643641680"/>
+          <entry name="somefile.txt" md5="d09cc43d9e701f5d4a55b5ba9b0efe15" size="77" mtime="1643641680"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:34 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:00 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -519,18 +520,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '370'
+      - '369'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="82d00df4cc8134d41e1b4684de9c4133">
+        <sourcediff key="752727d2a924d41a420c138f08fa87fe">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="538" srcmd5="42c7219a7dd81e72886cfc02413ee4b3"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="63" srcmd5="ffa1a0aa9dc7b8ac9a55777d1b2f6152"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:34 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:00 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -562,12 +563,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="05be9cf21548ae31e69b23b2a1488bae">
-          <old project="foo_project" package="bar_package" rev="145768af60a6bcaf489e2d93a35bfde6" srcmd5="145768af60a6bcaf489e2d93a35bfde6"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="590865fcaf89bf6f402637aaea0689e9" srcmd5="590865fcaf89bf6f402637aaea0689e9"/>
+        <sourcediff key="3f42628e44d13de641573b044a55e5ee">
+          <old project="foo_project" package="bar_package" rev="a4f2f1af062c2e9d6b2beffa5fea5e8a" srcmd5="a4f2f1af062c2e9d6b2beffa5fea5e8a"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="8ea4d96b5828f76feb52d8075d3ce7c6" srcmd5="8ea4d96b5828f76feb52d8075d3ce7c6"/>
           <files/>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:34 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:00 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -635,7 +636,7 @@ http_interactions:
             <arch>aarch64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:34 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:00 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_branch_request?user=Iggy
@@ -661,19 +662,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="539" vrev="539">
-          <srcmd5>5471f318dd1c6afb93bfa73acbfcb13f</srcmd5>
+        <revision rev="64" vrev="64">
+          <srcmd5>48abd7876999c1d9d67ee9af8bcef63e</srcmd5>
           <version>unknown</version>
-          <time>1642674754</time>
+          <time>1643641680</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:35 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:00 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -681,8 +682,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>After Many a Summer Dies the Swan</title>
-          <description>Adipisci ipsum laboriosam dolores.</description>
+          <title>Surprised by Joy</title>
+          <description>Fugit consectetur dolor molestias.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -703,15 +704,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '191'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>After Many a Summer Dies the Swan</title>
-          <description>Adipisci ipsum laboriosam dolores.</description>
+          <title>Surprised by Joy</title>
+          <description>Fugit consectetur dolor molestias.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:35 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:00 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -737,19 +738,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="539" vrev="539" srcmd5="5471f318dd1c6afb93bfa73acbfcb13f">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="145768af60a6bcaf489e2d93a35bfde6" baserev="145768af60a6bcaf489e2d93a35bfde6" xsrcmd5="858ad429f6e67f724f52877fa80604bb" lsrcmd5="5471f318dd1c6afb93bfa73acbfcb13f"/>
-          <serviceinfo code="succeeded" xsrcmd5="b2b907720aa7df4d4c41e2761f37ad4a"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="a77f06fd543a98015caa571fd2f0b676" size="69" mtime="1642674754"/>
-          <entry name="_link" md5="62832aced107ee3e8d8a1cd2200c5260" size="119" mtime="1642674754"/>
-          <entry name="somefile.txt" md5="3ad9edc8c13a61325d771bf149250349" size="50" mtime="1642674754"/>
+        <directory name="bar_package" rev="64" vrev="64" srcmd5="48abd7876999c1d9d67ee9af8bcef63e">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="a4f2f1af062c2e9d6b2beffa5fea5e8a" baserev="a4f2f1af062c2e9d6b2beffa5fea5e8a" xsrcmd5="968263278f29b2d8a73068bcc65ec581" lsrcmd5="48abd7876999c1d9d67ee9af8bcef63e"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="394a7c550df8f2f591a11c6a9210db91" size="72" mtime="1643641680"/>
+          <entry name="_link" md5="1b19e35daecc7a22341086f08d331e68" size="119" mtime="1643641680"/>
+          <entry name="somefile.txt" md5="d09cc43d9e701f5d4a55b5ba9b0efe15" size="77" mtime="1643641680"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:35 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:00 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?view=info
@@ -775,15 +775,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '333'
+      - '331'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="539" vrev="2183" srcmd5="ce3b328dbcb34510c752c5319a0226d0" lsrcmd5="b2b907720aa7df4d4c41e2761f37ad4a" verifymd5="07bcdb409ce8dccc5628c0a0b597c046">
+        <sourceinfo package="bar_package" rev="64" vrev="218" srcmd5="968263278f29b2d8a73068bcc65ec581" lsrcmd5="48abd7876999c1d9d67ee9af8bcef63e" verifymd5="5684120f957fc858fc5e87836b975cb4">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:35 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:00 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -809,19 +809,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="539" vrev="539" srcmd5="5471f318dd1c6afb93bfa73acbfcb13f">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="145768af60a6bcaf489e2d93a35bfde6" baserev="145768af60a6bcaf489e2d93a35bfde6" xsrcmd5="858ad429f6e67f724f52877fa80604bb" lsrcmd5="5471f318dd1c6afb93bfa73acbfcb13f"/>
-          <serviceinfo code="succeeded" xsrcmd5="b2b907720aa7df4d4c41e2761f37ad4a"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="a77f06fd543a98015caa571fd2f0b676" size="69" mtime="1642674754"/>
-          <entry name="_link" md5="62832aced107ee3e8d8a1cd2200c5260" size="119" mtime="1642674754"/>
-          <entry name="somefile.txt" md5="3ad9edc8c13a61325d771bf149250349" size="50" mtime="1642674754"/>
+        <directory name="bar_package" rev="64" vrev="64" srcmd5="48abd7876999c1d9d67ee9af8bcef63e">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="a4f2f1af062c2e9d6b2beffa5fea5e8a" baserev="a4f2f1af062c2e9d6b2beffa5fea5e8a" xsrcmd5="968263278f29b2d8a73068bcc65ec581" lsrcmd5="48abd7876999c1d9d67ee9af8bcef63e"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="394a7c550df8f2f591a11c6a9210db91" size="72" mtime="1643641680"/>
+          <entry name="_link" md5="1b19e35daecc7a22341086f08d331e68" size="119" mtime="1643641680"/>
+          <entry name="somefile.txt" md5="d09cc43d9e701f5d4a55b5ba9b0efe15" size="77" mtime="1643641680"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:35 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:00 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -849,18 +848,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '370'
+      - '369'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="1d18123f940086c5f8f12973b0e136e9">
+        <sourcediff key="2a3f1d7a65356b3c5591efe929d6db29">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="539" srcmd5="5471f318dd1c6afb93bfa73acbfcb13f"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="64" srcmd5="48abd7876999c1d9d67ee9af8bcef63e"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:35 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:01 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -892,14 +891,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="858039cbbd206fbb2d1ff1e6f2219e55">
-          <old project="foo_project" package="bar_package" rev="145768af60a6bcaf489e2d93a35bfde6" srcmd5="145768af60a6bcaf489e2d93a35bfde6"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="ce3b328dbcb34510c752c5319a0226d0" srcmd5="ce3b328dbcb34510c752c5319a0226d0"/>
+        <sourcediff key="b4bdb030d7f3785a051d3ae31387c93d">
+          <old project="foo_project" package="bar_package" rev="a4f2f1af062c2e9d6b2beffa5fea5e8a" srcmd5="a4f2f1af062c2e9d6b2beffa5fea5e8a"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="968263278f29b2d8a73068bcc65ec581" srcmd5="968263278f29b2d8a73068bcc65ec581"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:35 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:01 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -925,19 +924,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="539" vrev="539" srcmd5="5471f318dd1c6afb93bfa73acbfcb13f">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="145768af60a6bcaf489e2d93a35bfde6" baserev="145768af60a6bcaf489e2d93a35bfde6" xsrcmd5="858ad429f6e67f724f52877fa80604bb" lsrcmd5="5471f318dd1c6afb93bfa73acbfcb13f"/>
-          <serviceinfo code="succeeded" xsrcmd5="b2b907720aa7df4d4c41e2761f37ad4a"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="a77f06fd543a98015caa571fd2f0b676" size="69" mtime="1642674754"/>
-          <entry name="_link" md5="62832aced107ee3e8d8a1cd2200c5260" size="119" mtime="1642674754"/>
-          <entry name="somefile.txt" md5="3ad9edc8c13a61325d771bf149250349" size="50" mtime="1642674754"/>
+        <directory name="bar_package" rev="64" vrev="64" srcmd5="48abd7876999c1d9d67ee9af8bcef63e">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="a4f2f1af062c2e9d6b2beffa5fea5e8a" baserev="a4f2f1af062c2e9d6b2beffa5fea5e8a" xsrcmd5="968263278f29b2d8a73068bcc65ec581" lsrcmd5="48abd7876999c1d9d67ee9af8bcef63e"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="394a7c550df8f2f591a11c6a9210db91" size="72" mtime="1643641680"/>
+          <entry name="_link" md5="1b19e35daecc7a22341086f08d331e68" size="119" mtime="1643641680"/>
+          <entry name="somefile.txt" md5="d09cc43d9e701f5d4a55b5ba9b0efe15" size="77" mtime="1643641680"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:35 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:01 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '618'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="968263278f29b2d8a73068bcc65ec581" vrev="218" srcmd5="968263278f29b2d8a73068bcc65ec581">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="a4f2f1af062c2e9d6b2beffa5fea5e8a" baserev="a4f2f1af062c2e9d6b2beffa5fea5e8a" lsrcmd5="48abd7876999c1d9d67ee9af8bcef63e"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="394a7c550df8f2f591a11c6a9210db91" size="72" mtime="1643641680"/>
+          <entry name="somefile.txt" md5="d09cc43d9e701f5d4a55b5ba9b0efe15" size="77" mtime="1643641680"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:08:01 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -963,19 +997,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="539" vrev="539" srcmd5="5471f318dd1c6afb93bfa73acbfcb13f">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="145768af60a6bcaf489e2d93a35bfde6" baserev="145768af60a6bcaf489e2d93a35bfde6" xsrcmd5="858ad429f6e67f724f52877fa80604bb" lsrcmd5="5471f318dd1c6afb93bfa73acbfcb13f"/>
-          <serviceinfo code="succeeded" xsrcmd5="b2b907720aa7df4d4c41e2761f37ad4a"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="a77f06fd543a98015caa571fd2f0b676" size="69" mtime="1642674754"/>
-          <entry name="_link" md5="62832aced107ee3e8d8a1cd2200c5260" size="119" mtime="1642674754"/>
-          <entry name="somefile.txt" md5="3ad9edc8c13a61325d771bf149250349" size="50" mtime="1642674754"/>
+        <directory name="bar_package" rev="64" vrev="64" srcmd5="48abd7876999c1d9d67ee9af8bcef63e">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="a4f2f1af062c2e9d6b2beffa5fea5e8a" baserev="a4f2f1af062c2e9d6b2beffa5fea5e8a" xsrcmd5="968263278f29b2d8a73068bcc65ec581" lsrcmd5="48abd7876999c1d9d67ee9af8bcef63e"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="394a7c550df8f2f591a11c6a9210db91" size="72" mtime="1643641680"/>
+          <entry name="_link" md5="1b19e35daecc7a22341086f08d331e68" size="119" mtime="1643641680"/>
+          <entry name="somefile.txt" md5="d09cc43d9e701f5d4a55b5ba9b0efe15" size="77" mtime="1643641680"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:35 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:01 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '618'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="968263278f29b2d8a73068bcc65ec581" vrev="218" srcmd5="968263278f29b2d8a73068bcc65ec581">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="a4f2f1af062c2e9d6b2beffa5fea5e8a" baserev="a4f2f1af062c2e9d6b2beffa5fea5e8a" lsrcmd5="48abd7876999c1d9d67ee9af8bcef63e"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="394a7c550df8f2f591a11c6a9210db91" size="72" mtime="1643641680"/>
+          <entry name="somefile.txt" md5="d09cc43d9e701f5d4a55b5ba9b0efe15" size="77" mtime="1643641680"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:08:01 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -1001,19 +1070,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="539" vrev="539" srcmd5="5471f318dd1c6afb93bfa73acbfcb13f">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="145768af60a6bcaf489e2d93a35bfde6" baserev="145768af60a6bcaf489e2d93a35bfde6" xsrcmd5="858ad429f6e67f724f52877fa80604bb" lsrcmd5="5471f318dd1c6afb93bfa73acbfcb13f"/>
-          <serviceinfo code="succeeded" xsrcmd5="b2b907720aa7df4d4c41e2761f37ad4a"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="a77f06fd543a98015caa571fd2f0b676" size="69" mtime="1642674754"/>
-          <entry name="_link" md5="62832aced107ee3e8d8a1cd2200c5260" size="119" mtime="1642674754"/>
-          <entry name="somefile.txt" md5="3ad9edc8c13a61325d771bf149250349" size="50" mtime="1642674754"/>
+        <directory name="bar_package" rev="64" vrev="64" srcmd5="48abd7876999c1d9d67ee9af8bcef63e">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="a4f2f1af062c2e9d6b2beffa5fea5e8a" baserev="a4f2f1af062c2e9d6b2beffa5fea5e8a" xsrcmd5="968263278f29b2d8a73068bcc65ec581" lsrcmd5="48abd7876999c1d9d67ee9af8bcef63e"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="394a7c550df8f2f591a11c6a9210db91" size="72" mtime="1643641680"/>
+          <entry name="_link" md5="1b19e35daecc7a22341086f08d331e68" size="119" mtime="1643641680"/>
+          <entry name="somefile.txt" md5="d09cc43d9e701f5d4a55b5ba9b0efe15" size="77" mtime="1643641680"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:35 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:01 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '618'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="968263278f29b2d8a73068bcc65ec581" vrev="218" srcmd5="968263278f29b2d8a73068bcc65ec581">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="a4f2f1af062c2e9d6b2beffa5fea5e8a" baserev="a4f2f1af062c2e9d6b2beffa5fea5e8a" lsrcmd5="48abd7876999c1d9d67ee9af8bcef63e"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="394a7c550df8f2f591a11c6a9210db91" size="72" mtime="1643641680"/>
+          <entry name="somefile.txt" md5="d09cc43d9e701f5d4a55b5ba9b0efe15" size="77" mtime="1643641680"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:08:01 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -1039,19 +1143,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="539" vrev="539" srcmd5="5471f318dd1c6afb93bfa73acbfcb13f">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="145768af60a6bcaf489e2d93a35bfde6" baserev="145768af60a6bcaf489e2d93a35bfde6" xsrcmd5="858ad429f6e67f724f52877fa80604bb" lsrcmd5="5471f318dd1c6afb93bfa73acbfcb13f"/>
-          <serviceinfo code="succeeded" xsrcmd5="b2b907720aa7df4d4c41e2761f37ad4a"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="a77f06fd543a98015caa571fd2f0b676" size="69" mtime="1642674754"/>
-          <entry name="_link" md5="62832aced107ee3e8d8a1cd2200c5260" size="119" mtime="1642674754"/>
-          <entry name="somefile.txt" md5="3ad9edc8c13a61325d771bf149250349" size="50" mtime="1642674754"/>
+        <directory name="bar_package" rev="64" vrev="64" srcmd5="48abd7876999c1d9d67ee9af8bcef63e">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="a4f2f1af062c2e9d6b2beffa5fea5e8a" baserev="a4f2f1af062c2e9d6b2beffa5fea5e8a" xsrcmd5="968263278f29b2d8a73068bcc65ec581" lsrcmd5="48abd7876999c1d9d67ee9af8bcef63e"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="394a7c550df8f2f591a11c6a9210db91" size="72" mtime="1643641680"/>
+          <entry name="_link" md5="1b19e35daecc7a22341086f08d331e68" size="119" mtime="1643641680"/>
+          <entry name="somefile.txt" md5="d09cc43d9e701f5d4a55b5ba9b0efe15" size="77" mtime="1643641680"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:35 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:01 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '618'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="968263278f29b2d8a73068bcc65ec581" vrev="218" srcmd5="968263278f29b2d8a73068bcc65ec581">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="a4f2f1af062c2e9d6b2beffa5fea5e8a" baserev="a4f2f1af062c2e9d6b2beffa5fea5e8a" lsrcmd5="48abd7876999c1d9d67ee9af8bcef63e"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="394a7c550df8f2f591a11c6a9210db91" size="72" mtime="1643641680"/>
+          <entry name="somefile.txt" md5="d09cc43d9e701f5d4a55b5ba9b0efe15" size="77" mtime="1643641680"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:08:01 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -1077,22 +1216,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="539" vrev="539" srcmd5="5471f318dd1c6afb93bfa73acbfcb13f">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="145768af60a6bcaf489e2d93a35bfde6" baserev="145768af60a6bcaf489e2d93a35bfde6" xsrcmd5="858ad429f6e67f724f52877fa80604bb" lsrcmd5="5471f318dd1c6afb93bfa73acbfcb13f"/>
-          <serviceinfo code="succeeded" xsrcmd5="b2b907720aa7df4d4c41e2761f37ad4a"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="a77f06fd543a98015caa571fd2f0b676" size="69" mtime="1642674754"/>
-          <entry name="_link" md5="62832aced107ee3e8d8a1cd2200c5260" size="119" mtime="1642674754"/>
-          <entry name="somefile.txt" md5="3ad9edc8c13a61325d771bf149250349" size="50" mtime="1642674754"/>
+        <directory name="bar_package" rev="64" vrev="64" srcmd5="48abd7876999c1d9d67ee9af8bcef63e">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="a4f2f1af062c2e9d6b2beffa5fea5e8a" baserev="a4f2f1af062c2e9d6b2beffa5fea5e8a" xsrcmd5="968263278f29b2d8a73068bcc65ec581" lsrcmd5="48abd7876999c1d9d67ee9af8bcef63e"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="394a7c550df8f2f591a11c6a9210db91" size="72" mtime="1643641680"/>
+          <entry name="_link" md5="1b19e35daecc7a22341086f08d331e68" size="119" mtime="1643641680"/>
+          <entry name="somefile.txt" md5="d09cc43d9e701f5d4a55b5ba9b0efe15" size="77" mtime="1643641680"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:35 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:01 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1115,171 +1253,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '618'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="539" vrev="539" srcmd5="5471f318dd1c6afb93bfa73acbfcb13f">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="145768af60a6bcaf489e2d93a35bfde6" baserev="145768af60a6bcaf489e2d93a35bfde6" xsrcmd5="858ad429f6e67f724f52877fa80604bb" lsrcmd5="5471f318dd1c6afb93bfa73acbfcb13f"/>
-          <serviceinfo code="succeeded" xsrcmd5="b2b907720aa7df4d4c41e2761f37ad4a"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="a77f06fd543a98015caa571fd2f0b676" size="69" mtime="1642674754"/>
-          <entry name="_link" md5="62832aced107ee3e8d8a1cd2200c5260" size="119" mtime="1642674754"/>
-          <entry name="somefile.txt" md5="3ad9edc8c13a61325d771bf149250349" size="50" mtime="1642674754"/>
+        <directory name="bar_package" rev="968263278f29b2d8a73068bcc65ec581" vrev="218" srcmd5="968263278f29b2d8a73068bcc65ec581">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="a4f2f1af062c2e9d6b2beffa5fea5e8a" baserev="a4f2f1af062c2e9d6b2beffa5fea5e8a" lsrcmd5="48abd7876999c1d9d67ee9af8bcef63e"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="394a7c550df8f2f591a11c6a9210db91" size="72" mtime="1643641680"/>
+          <entry name="somefile.txt" md5="d09cc43d9e701f5d4a55b5ba9b0efe15" size="77" mtime="1643641680"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:35 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '802'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="539" vrev="539" srcmd5="5471f318dd1c6afb93bfa73acbfcb13f">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="145768af60a6bcaf489e2d93a35bfde6" baserev="145768af60a6bcaf489e2d93a35bfde6" xsrcmd5="858ad429f6e67f724f52877fa80604bb" lsrcmd5="5471f318dd1c6afb93bfa73acbfcb13f"/>
-          <serviceinfo code="succeeded" xsrcmd5="b2b907720aa7df4d4c41e2761f37ad4a"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="a77f06fd543a98015caa571fd2f0b676" size="69" mtime="1642674754"/>
-          <entry name="_link" md5="62832aced107ee3e8d8a1cd2200c5260" size="119" mtime="1642674754"/>
-          <entry name="somefile.txt" md5="3ad9edc8c13a61325d771bf149250349" size="50" mtime="1642674754"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:35 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '802'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="539" vrev="539" srcmd5="5471f318dd1c6afb93bfa73acbfcb13f">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="145768af60a6bcaf489e2d93a35bfde6" baserev="145768af60a6bcaf489e2d93a35bfde6" xsrcmd5="858ad429f6e67f724f52877fa80604bb" lsrcmd5="5471f318dd1c6afb93bfa73acbfcb13f"/>
-          <serviceinfo code="succeeded" xsrcmd5="b2b907720aa7df4d4c41e2761f37ad4a"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="a77f06fd543a98015caa571fd2f0b676" size="69" mtime="1642674754"/>
-          <entry name="_link" md5="62832aced107ee3e8d8a1cd2200c5260" size="119" mtime="1642674754"/>
-          <entry name="somefile.txt" md5="3ad9edc8c13a61325d771bf149250349" size="50" mtime="1642674754"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:35 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '802'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="539" vrev="539" srcmd5="5471f318dd1c6afb93bfa73acbfcb13f">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="145768af60a6bcaf489e2d93a35bfde6" baserev="145768af60a6bcaf489e2d93a35bfde6" xsrcmd5="858ad429f6e67f724f52877fa80604bb" lsrcmd5="5471f318dd1c6afb93bfa73acbfcb13f"/>
-          <serviceinfo code="succeeded" xsrcmd5="b2b907720aa7df4d4c41e2761f37ad4a"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="a77f06fd543a98015caa571fd2f0b676" size="69" mtime="1642674754"/>
-          <entry name="_link" md5="62832aced107ee3e8d8a1cd2200c5260" size="119" mtime="1642674754"/>
-          <entry name="somefile.txt" md5="3ad9edc8c13a61325d771bf149250349" size="50" mtime="1642674754"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:35 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '802'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="539" vrev="539" srcmd5="5471f318dd1c6afb93bfa73acbfcb13f">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="145768af60a6bcaf489e2d93a35bfde6" baserev="145768af60a6bcaf489e2d93a35bfde6" xsrcmd5="858ad429f6e67f724f52877fa80604bb" lsrcmd5="5471f318dd1c6afb93bfa73acbfcb13f"/>
-          <serviceinfo code="succeeded" xsrcmd5="b2b907720aa7df4d4c41e2761f37ad4a"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="a77f06fd543a98015caa571fd2f0b676" size="69" mtime="1642674754"/>
-          <entry name="_link" md5="62832aced107ee3e8d8a1cd2200c5260" size="119" mtime="1642674754"/>
-          <entry name="somefile.txt" md5="3ad9edc8c13a61325d771bf149250349" size="50" mtime="1642674754"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:35 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:01 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_branch_request
@@ -1309,5 +1293,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"object_kind":null,"project":{"http_url":null},"object_attributes":{"source":{"default_branch":"123456789"}}}'
-  recorded_at: Thu, 20 Jan 2022 10:32:35 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:01 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/for_a_new_MR_event/behaves_like_successful_new_PR_or_MR_event/1_1_2_3_1_5.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/for_a_new_MR_event/behaves_like_successful_new_PR_or_MR_event/1_1_2_3_1_5.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:37 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:04 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_268
+    uri: http://backend:5352/source/foo_project/_meta?user=user_51
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>To Sail Beyond the Sunset</title>
+          <title>From Here to Eternity</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '157'
+      - '153'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>To Sail Beyond the Sunset</title>
+          <title>From Here to Eternity</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:37 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:04 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_269
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_52
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Wings of the Dove</title>
-          <description>Assumenda voluptas qui et.</description>
+          <title>The Last Enemy</title>
+          <description>Commodi aperiam non nihil.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '157'
+      - '150'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Wings of the Dove</title>
-          <description>Assumenda voluptas qui et.</description>
+          <title>The Last Enemy</title>
+          <description>Commodi aperiam non nihil.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:37 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:04 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Reprehenderit aliquam quibusdam. Autem aut minima. Qui eum dignissimos.
+      string: Quia ut eaque. Veniam iusto maxime. Veritatis nobis eligendi.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1649" vrev="1649">
-          <srcmd5>b0e979bb824383ef18a2bb83c312e3e5</srcmd5>
+        <revision rev="159" vrev="159">
+          <srcmd5>6bbc6f17adb1216eb1892961413d2022</srcmd5>
           <version>unknown</version>
-          <time>1642674757</time>
+          <time>1643641684</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:37 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:04 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Consequatur veritatis sunt. Ea non sit. Quia consequatur dolorum.
+      string: Non molestiae officia. Dolorem nostrum tenetur. Maiores et porro.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +181,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1650" vrev="1650">
-          <srcmd5>e96f2416509066dbe7aa04a8f862e091</srcmd5>
+        <revision rev="160" vrev="160">
+          <srcmd5>d865d960686e7d728469ac752a82e091</srcmd5>
           <version>unknown</version>
-          <time>1642674757</time>
+          <time>1643641684</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:38 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:04 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -227,7 +227,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:32:38 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:04 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -267,7 +267,7 @@ http_interactions:
           <description>This project was created for package bar_package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:38 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:04 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -275,8 +275,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Wings of the Dove</title>
-          <description>Assumenda voluptas qui et.</description>
+          <title>The Last Enemy</title>
+          <description>Commodi aperiam non nihil.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -297,15 +297,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '188'
+      - '181'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Wings of the Dove</title>
-          <description>Assumenda voluptas qui et.</description>
+          <title>The Last Enemy</title>
+          <description>Commodi aperiam non nihil.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:38 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:04 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=branch&noservice=1&opackage=bar_package&oproject=foo_project&user=Iggy
@@ -333,19 +333,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="544" vrev="544">
-          <srcmd5>8e14d6cea0cde285b85b9ff7f32fc2b7</srcmd5>
+        <revision rev="69" vrev="69">
+          <srcmd5>9564d8f8e161c35680937282aa328ea2</srcmd5>
           <version>unknown</version>
-          <time>1642674758</time>
+          <time>1643641684</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:38 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:04 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -353,8 +353,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Wings of the Dove</title>
-          <description>Assumenda voluptas qui et.</description>
+          <title>The Last Enemy</title>
+          <description>Commodi aperiam non nihil.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -375,15 +375,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '188'
+      - '181'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Wings of the Dove</title>
-          <description>Assumenda voluptas qui et.</description>
+          <title>The Last Enemy</title>
+          <description>Commodi aperiam non nihil.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:38 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:04 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -409,18 +409,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '725'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="544" vrev="544" srcmd5="8e14d6cea0cde285b85b9ff7f32fc2b7">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="e96f2416509066dbe7aa04a8f862e091" baserev="e96f2416509066dbe7aa04a8f862e091" xsrcmd5="82262c970a723bfe3ff20abd6dffc2e3" lsrcmd5="8e14d6cea0cde285b85b9ff7f32fc2b7"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="5cd73fcbe1b5974c7c6b7b3ad3c3cc4a" size="71" mtime="1642674757"/>
-          <entry name="_link" md5="028bf1aa0518e0efb16a9d5e082f6feb" size="119" mtime="1642674758"/>
-          <entry name="somefile.txt" md5="3d2c1237c1d0f382b78202549ed70de4" size="65" mtime="1642674757"/>
+        <directory name="bar_package" rev="69" vrev="69" srcmd5="9564d8f8e161c35680937282aa328ea2">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="d865d960686e7d728469ac752a82e091" baserev="d865d960686e7d728469ac752a82e091" xsrcmd5="bbb1116af3c29b502391c7e55a744b41" lsrcmd5="9564d8f8e161c35680937282aa328ea2"/>
+          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1643641671"/>
+          <entry name="_config" md5="ad1fd8a7f5cdf71a88b8cb0088797db9" size="61" mtime="1643641684"/>
+          <entry name="_link" md5="6fb6b9d9bb067af6d3c6c08f6d684e4e" size="119" mtime="1643641684"/>
+          <entry name="somefile.txt" md5="9bb9277b99781bd72726b1d78c4c9ef6" size="65" mtime="1643641684"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:38 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:04 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?view=info
@@ -446,15 +446,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '333'
+      - '331'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="544" vrev="2194" srcmd5="82262c970a723bfe3ff20abd6dffc2e3" lsrcmd5="8e14d6cea0cde285b85b9ff7f32fc2b7" verifymd5="e96f2416509066dbe7aa04a8f862e091">
+        <sourceinfo package="bar_package" rev="69" vrev="229" srcmd5="bbb1116af3c29b502391c7e55a744b41" lsrcmd5="9564d8f8e161c35680937282aa328ea2" verifymd5="d865d960686e7d728469ac752a82e091">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:38 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:04 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -480,18 +480,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '725'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="544" vrev="544" srcmd5="8e14d6cea0cde285b85b9ff7f32fc2b7">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="e96f2416509066dbe7aa04a8f862e091" baserev="e96f2416509066dbe7aa04a8f862e091" xsrcmd5="82262c970a723bfe3ff20abd6dffc2e3" lsrcmd5="8e14d6cea0cde285b85b9ff7f32fc2b7"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="5cd73fcbe1b5974c7c6b7b3ad3c3cc4a" size="71" mtime="1642674757"/>
-          <entry name="_link" md5="028bf1aa0518e0efb16a9d5e082f6feb" size="119" mtime="1642674758"/>
-          <entry name="somefile.txt" md5="3d2c1237c1d0f382b78202549ed70de4" size="65" mtime="1642674757"/>
+        <directory name="bar_package" rev="69" vrev="69" srcmd5="9564d8f8e161c35680937282aa328ea2">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="d865d960686e7d728469ac752a82e091" baserev="d865d960686e7d728469ac752a82e091" xsrcmd5="bbb1116af3c29b502391c7e55a744b41" lsrcmd5="9564d8f8e161c35680937282aa328ea2"/>
+          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1643641671"/>
+          <entry name="_config" md5="ad1fd8a7f5cdf71a88b8cb0088797db9" size="61" mtime="1643641684"/>
+          <entry name="_link" md5="6fb6b9d9bb067af6d3c6c08f6d684e4e" size="119" mtime="1643641684"/>
+          <entry name="somefile.txt" md5="9bb9277b99781bd72726b1d78c4c9ef6" size="65" mtime="1643641684"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:38 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:04 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -519,18 +519,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '370'
+      - '369'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="d6a044288e25b04b33bf50b5e8eb297f">
+        <sourcediff key="e6777895d394f0616e77dab12a9d284a">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="544" srcmd5="8e14d6cea0cde285b85b9ff7f32fc2b7"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="69" srcmd5="9564d8f8e161c35680937282aa328ea2"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:38 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:05 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -562,12 +562,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="c4ca6cb98afcb53742cf753b403d53e6">
-          <old project="foo_project" package="bar_package" rev="e96f2416509066dbe7aa04a8f862e091" srcmd5="e96f2416509066dbe7aa04a8f862e091"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="82262c970a723bfe3ff20abd6dffc2e3" srcmd5="82262c970a723bfe3ff20abd6dffc2e3"/>
+        <sourcediff key="edabac3018174408fd658d1f1e40bfcc">
+          <old project="foo_project" package="bar_package" rev="d865d960686e7d728469ac752a82e091" srcmd5="d865d960686e7d728469ac752a82e091"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="bbb1116af3c29b502391c7e55a744b41" srcmd5="bbb1116af3c29b502391c7e55a744b41"/>
           <files/>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:38 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:05 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -635,7 +635,7 @@ http_interactions:
             <arch>aarch64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:38 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:05 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_branch_request?user=Iggy
@@ -661,19 +661,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="545" vrev="545">
-          <srcmd5>fd532918a957413911c3b289dc5ea168</srcmd5>
+        <revision rev="70" vrev="70">
+          <srcmd5>f4960cb2aa0f09d238ebc87aa54427c2</srcmd5>
           <version>unknown</version>
-          <time>1642674758</time>
+          <time>1643641685</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:38 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:05 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -681,8 +681,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Wings of the Dove</title>
-          <description>Assumenda voluptas qui et.</description>
+          <title>The Last Enemy</title>
+          <description>Commodi aperiam non nihil.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -703,15 +703,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '188'
+      - '181'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Wings of the Dove</title>
-          <description>Assumenda voluptas qui et.</description>
+          <title>The Last Enemy</title>
+          <description>Commodi aperiam non nihil.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:38 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:05 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -737,19 +737,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="545" vrev="545" srcmd5="fd532918a957413911c3b289dc5ea168">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="e96f2416509066dbe7aa04a8f862e091" baserev="e96f2416509066dbe7aa04a8f862e091" xsrcmd5="0f14c4c9086596a60544de5383f69dc9" lsrcmd5="fd532918a957413911c3b289dc5ea168"/>
-          <serviceinfo code="succeeded" xsrcmd5="498348d205e347c2dfa2f7513238e3fb"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="5cd73fcbe1b5974c7c6b7b3ad3c3cc4a" size="71" mtime="1642674757"/>
-          <entry name="_link" md5="028bf1aa0518e0efb16a9d5e082f6feb" size="119" mtime="1642674758"/>
-          <entry name="somefile.txt" md5="3d2c1237c1d0f382b78202549ed70de4" size="65" mtime="1642674757"/>
+        <directory name="bar_package" rev="70" vrev="70" srcmd5="f4960cb2aa0f09d238ebc87aa54427c2">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="d865d960686e7d728469ac752a82e091" baserev="d865d960686e7d728469ac752a82e091" xsrcmd5="099935681a5776adda4a5b3552135171" lsrcmd5="f4960cb2aa0f09d238ebc87aa54427c2"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="ad1fd8a7f5cdf71a88b8cb0088797db9" size="61" mtime="1643641684"/>
+          <entry name="_link" md5="6fb6b9d9bb067af6d3c6c08f6d684e4e" size="119" mtime="1643641684"/>
+          <entry name="somefile.txt" md5="9bb9277b99781bd72726b1d78c4c9ef6" size="65" mtime="1643641684"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:38 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:05 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?view=info
@@ -775,15 +774,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '333'
+      - '331'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="545" vrev="2195" srcmd5="f79959bbc9575706cf055506118bbf78" lsrcmd5="498348d205e347c2dfa2f7513238e3fb" verifymd5="77e6930e48c6209283e8859f5115f5bf">
+        <sourceinfo package="bar_package" rev="70" vrev="230" srcmd5="099935681a5776adda4a5b3552135171" lsrcmd5="f4960cb2aa0f09d238ebc87aa54427c2" verifymd5="abbefc100c60d9154fd0098eaf42aff5">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:38 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:05 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -809,19 +808,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="545" vrev="545" srcmd5="fd532918a957413911c3b289dc5ea168">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="e96f2416509066dbe7aa04a8f862e091" baserev="e96f2416509066dbe7aa04a8f862e091" xsrcmd5="0f14c4c9086596a60544de5383f69dc9" lsrcmd5="fd532918a957413911c3b289dc5ea168"/>
-          <serviceinfo code="succeeded" xsrcmd5="498348d205e347c2dfa2f7513238e3fb"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="5cd73fcbe1b5974c7c6b7b3ad3c3cc4a" size="71" mtime="1642674757"/>
-          <entry name="_link" md5="028bf1aa0518e0efb16a9d5e082f6feb" size="119" mtime="1642674758"/>
-          <entry name="somefile.txt" md5="3d2c1237c1d0f382b78202549ed70de4" size="65" mtime="1642674757"/>
+        <directory name="bar_package" rev="70" vrev="70" srcmd5="f4960cb2aa0f09d238ebc87aa54427c2">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="d865d960686e7d728469ac752a82e091" baserev="d865d960686e7d728469ac752a82e091" xsrcmd5="099935681a5776adda4a5b3552135171" lsrcmd5="f4960cb2aa0f09d238ebc87aa54427c2"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="ad1fd8a7f5cdf71a88b8cb0088797db9" size="61" mtime="1643641684"/>
+          <entry name="_link" md5="6fb6b9d9bb067af6d3c6c08f6d684e4e" size="119" mtime="1643641684"/>
+          <entry name="somefile.txt" md5="9bb9277b99781bd72726b1d78c4c9ef6" size="65" mtime="1643641684"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:38 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:05 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -849,18 +847,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '370'
+      - '369'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="9bc022da4ed1b65547590eea66a5c200">
+        <sourcediff key="40b467f04c8ee94189338c18a0088d30">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="545" srcmd5="fd532918a957413911c3b289dc5ea168"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="70" srcmd5="f4960cb2aa0f09d238ebc87aa54427c2"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:38 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:05 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -892,14 +890,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="b6419f8be89b5e28fd6539b27da1a6c1">
-          <old project="foo_project" package="bar_package" rev="e96f2416509066dbe7aa04a8f862e091" srcmd5="e96f2416509066dbe7aa04a8f862e091"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="f79959bbc9575706cf055506118bbf78" srcmd5="f79959bbc9575706cf055506118bbf78"/>
+        <sourcediff key="2dda64b09a0fe784d3f0b03b81733fe3">
+          <old project="foo_project" package="bar_package" rev="d865d960686e7d728469ac752a82e091" srcmd5="d865d960686e7d728469ac752a82e091"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="099935681a5776adda4a5b3552135171" srcmd5="099935681a5776adda4a5b3552135171"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:38 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:05 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -925,19 +923,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="545" vrev="545" srcmd5="fd532918a957413911c3b289dc5ea168">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="e96f2416509066dbe7aa04a8f862e091" baserev="e96f2416509066dbe7aa04a8f862e091" xsrcmd5="0f14c4c9086596a60544de5383f69dc9" lsrcmd5="fd532918a957413911c3b289dc5ea168"/>
-          <serviceinfo code="succeeded" xsrcmd5="498348d205e347c2dfa2f7513238e3fb"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="5cd73fcbe1b5974c7c6b7b3ad3c3cc4a" size="71" mtime="1642674757"/>
-          <entry name="_link" md5="028bf1aa0518e0efb16a9d5e082f6feb" size="119" mtime="1642674758"/>
-          <entry name="somefile.txt" md5="3d2c1237c1d0f382b78202549ed70de4" size="65" mtime="1642674757"/>
+        <directory name="bar_package" rev="70" vrev="70" srcmd5="f4960cb2aa0f09d238ebc87aa54427c2">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="d865d960686e7d728469ac752a82e091" baserev="d865d960686e7d728469ac752a82e091" xsrcmd5="099935681a5776adda4a5b3552135171" lsrcmd5="f4960cb2aa0f09d238ebc87aa54427c2"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="ad1fd8a7f5cdf71a88b8cb0088797db9" size="61" mtime="1643641684"/>
+          <entry name="_link" md5="6fb6b9d9bb067af6d3c6c08f6d684e4e" size="119" mtime="1643641684"/>
+          <entry name="somefile.txt" md5="9bb9277b99781bd72726b1d78c4c9ef6" size="65" mtime="1643641684"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:38 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:05 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '618'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="099935681a5776adda4a5b3552135171" vrev="230" srcmd5="099935681a5776adda4a5b3552135171">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="d865d960686e7d728469ac752a82e091" baserev="d865d960686e7d728469ac752a82e091" lsrcmd5="f4960cb2aa0f09d238ebc87aa54427c2"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="ad1fd8a7f5cdf71a88b8cb0088797db9" size="61" mtime="1643641684"/>
+          <entry name="somefile.txt" md5="9bb9277b99781bd72726b1d78c4c9ef6" size="65" mtime="1643641684"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:08:05 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -963,19 +996,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="545" vrev="545" srcmd5="fd532918a957413911c3b289dc5ea168">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="e96f2416509066dbe7aa04a8f862e091" baserev="e96f2416509066dbe7aa04a8f862e091" xsrcmd5="0f14c4c9086596a60544de5383f69dc9" lsrcmd5="fd532918a957413911c3b289dc5ea168"/>
-          <serviceinfo code="succeeded" xsrcmd5="498348d205e347c2dfa2f7513238e3fb"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="5cd73fcbe1b5974c7c6b7b3ad3c3cc4a" size="71" mtime="1642674757"/>
-          <entry name="_link" md5="028bf1aa0518e0efb16a9d5e082f6feb" size="119" mtime="1642674758"/>
-          <entry name="somefile.txt" md5="3d2c1237c1d0f382b78202549ed70de4" size="65" mtime="1642674757"/>
+        <directory name="bar_package" rev="70" vrev="70" srcmd5="f4960cb2aa0f09d238ebc87aa54427c2">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="d865d960686e7d728469ac752a82e091" baserev="d865d960686e7d728469ac752a82e091" xsrcmd5="099935681a5776adda4a5b3552135171" lsrcmd5="f4960cb2aa0f09d238ebc87aa54427c2"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="ad1fd8a7f5cdf71a88b8cb0088797db9" size="61" mtime="1643641684"/>
+          <entry name="_link" md5="6fb6b9d9bb067af6d3c6c08f6d684e4e" size="119" mtime="1643641684"/>
+          <entry name="somefile.txt" md5="9bb9277b99781bd72726b1d78c4c9ef6" size="65" mtime="1643641684"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:38 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:05 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '618'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="099935681a5776adda4a5b3552135171" vrev="230" srcmd5="099935681a5776adda4a5b3552135171">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="d865d960686e7d728469ac752a82e091" baserev="d865d960686e7d728469ac752a82e091" lsrcmd5="f4960cb2aa0f09d238ebc87aa54427c2"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="ad1fd8a7f5cdf71a88b8cb0088797db9" size="61" mtime="1643641684"/>
+          <entry name="somefile.txt" md5="9bb9277b99781bd72726b1d78c4c9ef6" size="65" mtime="1643641684"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:08:05 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -1001,19 +1069,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="545" vrev="545" srcmd5="fd532918a957413911c3b289dc5ea168">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="e96f2416509066dbe7aa04a8f862e091" baserev="e96f2416509066dbe7aa04a8f862e091" xsrcmd5="0f14c4c9086596a60544de5383f69dc9" lsrcmd5="fd532918a957413911c3b289dc5ea168"/>
-          <serviceinfo code="succeeded" xsrcmd5="498348d205e347c2dfa2f7513238e3fb"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="5cd73fcbe1b5974c7c6b7b3ad3c3cc4a" size="71" mtime="1642674757"/>
-          <entry name="_link" md5="028bf1aa0518e0efb16a9d5e082f6feb" size="119" mtime="1642674758"/>
-          <entry name="somefile.txt" md5="3d2c1237c1d0f382b78202549ed70de4" size="65" mtime="1642674757"/>
+        <directory name="bar_package" rev="70" vrev="70" srcmd5="f4960cb2aa0f09d238ebc87aa54427c2">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="d865d960686e7d728469ac752a82e091" baserev="d865d960686e7d728469ac752a82e091" xsrcmd5="099935681a5776adda4a5b3552135171" lsrcmd5="f4960cb2aa0f09d238ebc87aa54427c2"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="ad1fd8a7f5cdf71a88b8cb0088797db9" size="61" mtime="1643641684"/>
+          <entry name="_link" md5="6fb6b9d9bb067af6d3c6c08f6d684e4e" size="119" mtime="1643641684"/>
+          <entry name="somefile.txt" md5="9bb9277b99781bd72726b1d78c4c9ef6" size="65" mtime="1643641684"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:38 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:05 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '618'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="099935681a5776adda4a5b3552135171" vrev="230" srcmd5="099935681a5776adda4a5b3552135171">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="d865d960686e7d728469ac752a82e091" baserev="d865d960686e7d728469ac752a82e091" lsrcmd5="f4960cb2aa0f09d238ebc87aa54427c2"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="ad1fd8a7f5cdf71a88b8cb0088797db9" size="61" mtime="1643641684"/>
+          <entry name="somefile.txt" md5="9bb9277b99781bd72726b1d78c4c9ef6" size="65" mtime="1643641684"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:08:05 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -1039,19 +1142,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="545" vrev="545" srcmd5="fd532918a957413911c3b289dc5ea168">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="e96f2416509066dbe7aa04a8f862e091" baserev="e96f2416509066dbe7aa04a8f862e091" xsrcmd5="0f14c4c9086596a60544de5383f69dc9" lsrcmd5="fd532918a957413911c3b289dc5ea168"/>
-          <serviceinfo code="succeeded" xsrcmd5="498348d205e347c2dfa2f7513238e3fb"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="5cd73fcbe1b5974c7c6b7b3ad3c3cc4a" size="71" mtime="1642674757"/>
-          <entry name="_link" md5="028bf1aa0518e0efb16a9d5e082f6feb" size="119" mtime="1642674758"/>
-          <entry name="somefile.txt" md5="3d2c1237c1d0f382b78202549ed70de4" size="65" mtime="1642674757"/>
+        <directory name="bar_package" rev="70" vrev="70" srcmd5="f4960cb2aa0f09d238ebc87aa54427c2">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="d865d960686e7d728469ac752a82e091" baserev="d865d960686e7d728469ac752a82e091" xsrcmd5="099935681a5776adda4a5b3552135171" lsrcmd5="f4960cb2aa0f09d238ebc87aa54427c2"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="ad1fd8a7f5cdf71a88b8cb0088797db9" size="61" mtime="1643641684"/>
+          <entry name="_link" md5="6fb6b9d9bb067af6d3c6c08f6d684e4e" size="119" mtime="1643641684"/>
+          <entry name="somefile.txt" md5="9bb9277b99781bd72726b1d78c4c9ef6" size="65" mtime="1643641684"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:38 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:05 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '618'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="099935681a5776adda4a5b3552135171" vrev="230" srcmd5="099935681a5776adda4a5b3552135171">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="d865d960686e7d728469ac752a82e091" baserev="d865d960686e7d728469ac752a82e091" lsrcmd5="f4960cb2aa0f09d238ebc87aa54427c2"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="ad1fd8a7f5cdf71a88b8cb0088797db9" size="61" mtime="1643641684"/>
+          <entry name="somefile.txt" md5="9bb9277b99781bd72726b1d78c4c9ef6" size="65" mtime="1643641684"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:08:05 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -1077,22 +1215,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="545" vrev="545" srcmd5="fd532918a957413911c3b289dc5ea168">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="e96f2416509066dbe7aa04a8f862e091" baserev="e96f2416509066dbe7aa04a8f862e091" xsrcmd5="0f14c4c9086596a60544de5383f69dc9" lsrcmd5="fd532918a957413911c3b289dc5ea168"/>
-          <serviceinfo code="succeeded" xsrcmd5="498348d205e347c2dfa2f7513238e3fb"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="5cd73fcbe1b5974c7c6b7b3ad3c3cc4a" size="71" mtime="1642674757"/>
-          <entry name="_link" md5="028bf1aa0518e0efb16a9d5e082f6feb" size="119" mtime="1642674758"/>
-          <entry name="somefile.txt" md5="3d2c1237c1d0f382b78202549ed70de4" size="65" mtime="1642674757"/>
+        <directory name="bar_package" rev="70" vrev="70" srcmd5="f4960cb2aa0f09d238ebc87aa54427c2">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="d865d960686e7d728469ac752a82e091" baserev="d865d960686e7d728469ac752a82e091" xsrcmd5="099935681a5776adda4a5b3552135171" lsrcmd5="f4960cb2aa0f09d238ebc87aa54427c2"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="ad1fd8a7f5cdf71a88b8cb0088797db9" size="61" mtime="1643641684"/>
+          <entry name="_link" md5="6fb6b9d9bb067af6d3c6c08f6d684e4e" size="119" mtime="1643641684"/>
+          <entry name="somefile.txt" md5="9bb9277b99781bd72726b1d78c4c9ef6" size="65" mtime="1643641684"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:38 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:05 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1115,169 +1252,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '618'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="545" vrev="545" srcmd5="fd532918a957413911c3b289dc5ea168">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="e96f2416509066dbe7aa04a8f862e091" baserev="e96f2416509066dbe7aa04a8f862e091" xsrcmd5="0f14c4c9086596a60544de5383f69dc9" lsrcmd5="fd532918a957413911c3b289dc5ea168"/>
-          <serviceinfo code="succeeded" xsrcmd5="498348d205e347c2dfa2f7513238e3fb"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="5cd73fcbe1b5974c7c6b7b3ad3c3cc4a" size="71" mtime="1642674757"/>
-          <entry name="_link" md5="028bf1aa0518e0efb16a9d5e082f6feb" size="119" mtime="1642674758"/>
-          <entry name="somefile.txt" md5="3d2c1237c1d0f382b78202549ed70de4" size="65" mtime="1642674757"/>
+        <directory name="bar_package" rev="099935681a5776adda4a5b3552135171" vrev="230" srcmd5="099935681a5776adda4a5b3552135171">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="d865d960686e7d728469ac752a82e091" baserev="d865d960686e7d728469ac752a82e091" lsrcmd5="f4960cb2aa0f09d238ebc87aa54427c2"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="ad1fd8a7f5cdf71a88b8cb0088797db9" size="61" mtime="1643641684"/>
+          <entry name="somefile.txt" md5="9bb9277b99781bd72726b1d78c4c9ef6" size="65" mtime="1643641684"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:38 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '802'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="545" vrev="545" srcmd5="fd532918a957413911c3b289dc5ea168">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="e96f2416509066dbe7aa04a8f862e091" baserev="e96f2416509066dbe7aa04a8f862e091" xsrcmd5="0f14c4c9086596a60544de5383f69dc9" lsrcmd5="fd532918a957413911c3b289dc5ea168"/>
-          <serviceinfo code="succeeded" xsrcmd5="498348d205e347c2dfa2f7513238e3fb"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="5cd73fcbe1b5974c7c6b7b3ad3c3cc4a" size="71" mtime="1642674757"/>
-          <entry name="_link" md5="028bf1aa0518e0efb16a9d5e082f6feb" size="119" mtime="1642674758"/>
-          <entry name="somefile.txt" md5="3d2c1237c1d0f382b78202549ed70de4" size="65" mtime="1642674757"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:38 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '802'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="545" vrev="545" srcmd5="fd532918a957413911c3b289dc5ea168">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="e96f2416509066dbe7aa04a8f862e091" baserev="e96f2416509066dbe7aa04a8f862e091" xsrcmd5="0f14c4c9086596a60544de5383f69dc9" lsrcmd5="fd532918a957413911c3b289dc5ea168"/>
-          <serviceinfo code="succeeded" xsrcmd5="498348d205e347c2dfa2f7513238e3fb"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="5cd73fcbe1b5974c7c6b7b3ad3c3cc4a" size="71" mtime="1642674757"/>
-          <entry name="_link" md5="028bf1aa0518e0efb16a9d5e082f6feb" size="119" mtime="1642674758"/>
-          <entry name="somefile.txt" md5="3d2c1237c1d0f382b78202549ed70de4" size="65" mtime="1642674757"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:38 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '802'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="545" vrev="545" srcmd5="fd532918a957413911c3b289dc5ea168">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="e96f2416509066dbe7aa04a8f862e091" baserev="e96f2416509066dbe7aa04a8f862e091" xsrcmd5="0f14c4c9086596a60544de5383f69dc9" lsrcmd5="fd532918a957413911c3b289dc5ea168"/>
-          <serviceinfo code="succeeded" xsrcmd5="498348d205e347c2dfa2f7513238e3fb"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="5cd73fcbe1b5974c7c6b7b3ad3c3cc4a" size="71" mtime="1642674757"/>
-          <entry name="_link" md5="028bf1aa0518e0efb16a9d5e082f6feb" size="119" mtime="1642674758"/>
-          <entry name="somefile.txt" md5="3d2c1237c1d0f382b78202549ed70de4" size="65" mtime="1642674757"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:38 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '802'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="545" vrev="545" srcmd5="fd532918a957413911c3b289dc5ea168">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="e96f2416509066dbe7aa04a8f862e091" baserev="e96f2416509066dbe7aa04a8f862e091" xsrcmd5="0f14c4c9086596a60544de5383f69dc9" lsrcmd5="fd532918a957413911c3b289dc5ea168"/>
-          <serviceinfo code="succeeded" xsrcmd5="498348d205e347c2dfa2f7513238e3fb"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="5cd73fcbe1b5974c7c6b7b3ad3c3cc4a" size="71" mtime="1642674757"/>
-          <entry name="_link" md5="028bf1aa0518e0efb16a9d5e082f6feb" size="119" mtime="1642674758"/>
-          <entry name="somefile.txt" md5="3d2c1237c1d0f382b78202549ed70de4" size="65" mtime="1642674757"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:38 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:05 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/for_a_new_MR_event/behaves_like_successful_new_PR_or_MR_event/1_1_2_3_1_6.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/for_a_new_MR_event/behaves_like_successful_new_PR_or_MR_event/1_1_2_3_1_6.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:31 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:05 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_258
+    uri: http://backend:5352/source/foo_project/_meta?user=user_53
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Françoise Sagan</title>
+          <title>Brandy of the Damned</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,21 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '148'
+      - '152'
     body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        PHByb2plY3QgbmFtZT0iZm9vX3Byb2plY3QiPgogIDx0aXRsZT5GcmFuw6dvaXNlIFNhZ2FuPC90aXRsZT4KICA8ZGVzY3JpcHRpb24+PC9kZXNjcmlwdGlvbj4KICA8cGVyc29uIHVzZXJpZD0iSWdneSIgcm9sZT0ibWFpbnRhaW5lciIvPgo8L3Byb2plY3Q+Cg==
-  recorded_at: Thu, 20 Jan 2022 10:32:31 GMT
+      encoding: UTF-8
+      string: |
+        <project name="foo_project">
+          <title>Brandy of the Damned</title>
+          <description></description>
+          <person userid="Iggy" role="maintainer"/>
+        </project>
+  recorded_at: Mon, 31 Jan 2022 15:08:05 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_259
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_54
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Blue Remembered Earth</title>
-          <description>Vel rerum quis qui.</description>
+          <title>The Proper Study</title>
+          <description>Voluptas commodi ex rem.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -110,16 +114,17 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Blue Remembered Earth</title>
-          <description>Vel rerum quis qui.</description>
+          <title>The Proper Study</title>
+          <description>Voluptas commodi ex rem.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:31 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:05 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Totam quasi quo. Cumque voluptatem qui. Veritatis nisi iusto.
+      string: Cum nesciunt quisquam. Fugiat atque pariatur. Consequatur doloremque
+        enim.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -139,25 +144,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1639" vrev="1639">
-          <srcmd5>f926609977179e761495150d5997bb1c</srcmd5>
+        <revision rev="161" vrev="161">
+          <srcmd5>de620641357777e54a498b1550bab578</srcmd5>
           <version>unknown</version>
-          <time>1642674751</time>
+          <time>1643641686</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:31 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Dignissimos quas quia. Cum sed repellat. Et ut culpa.
+      string: Et voluptatem tempore. Quos culpa possimus. Recusandae non error.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -177,19 +182,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1640" vrev="1640">
-          <srcmd5>72d65c1e4f57f439b821a54aeeb6a7c2</srcmd5>
+        <revision rev="162" vrev="162">
+          <srcmd5>84a009462870d539ac095a17add602d2</srcmd5>
           <version>unknown</version>
-          <time>1642674751</time>
+          <time>1643641686</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:31 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:06 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -223,7 +228,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:32:31 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -263,7 +268,7 @@ http_interactions:
           <description>This project was created for package bar_package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:32 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -271,8 +276,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Blue Remembered Earth</title>
-          <description>Vel rerum quis qui.</description>
+          <title>The Proper Study</title>
+          <description>Voluptas commodi ex rem.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -298,10 +303,10 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Blue Remembered Earth</title>
-          <description>Vel rerum quis qui.</description>
+          <title>The Proper Study</title>
+          <description>Voluptas commodi ex rem.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:32 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:06 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=branch&noservice=1&opackage=bar_package&oproject=foo_project&user=Iggy
@@ -329,19 +334,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="534" vrev="534">
-          <srcmd5>6cc2ff4d0927b428defd6a43b1db1a67</srcmd5>
+        <revision rev="71" vrev="71">
+          <srcmd5>7a86f2d50aeec25ea0fa1a25e9b3f2d1</srcmd5>
           <version>unknown</version>
-          <time>1642674752</time>
+          <time>1643641686</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:32 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -349,8 +354,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Blue Remembered Earth</title>
-          <description>Vel rerum quis qui.</description>
+          <title>The Proper Study</title>
+          <description>Voluptas commodi ex rem.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -376,10 +381,10 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Blue Remembered Earth</title>
-          <description>Vel rerum quis qui.</description>
+          <title>The Proper Study</title>
+          <description>Voluptas commodi ex rem.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:32 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:06 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -405,18 +410,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '725'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="534" vrev="534" srcmd5="6cc2ff4d0927b428defd6a43b1db1a67">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="72d65c1e4f57f439b821a54aeeb6a7c2" baserev="72d65c1e4f57f439b821a54aeeb6a7c2" xsrcmd5="ed13159fd1d6c52b64cd89b92c1b06ea" lsrcmd5="6cc2ff4d0927b428defd6a43b1db1a67"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="1d1b9e02c16f0abc8aeda0d0b1f89874" size="61" mtime="1642674751"/>
-          <entry name="_link" md5="9ae1cdfa353f7dfa2801095550134df2" size="119" mtime="1642674752"/>
-          <entry name="somefile.txt" md5="d30b4761c414fe0828ee4bd2756b49d3" size="53" mtime="1642674751"/>
+        <directory name="bar_package" rev="71" vrev="71" srcmd5="7a86f2d50aeec25ea0fa1a25e9b3f2d1">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="84a009462870d539ac095a17add602d2" baserev="84a009462870d539ac095a17add602d2" xsrcmd5="90f6c1079c05519ed60fe8052faccaa9" lsrcmd5="7a86f2d50aeec25ea0fa1a25e9b3f2d1"/>
+          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1643641671"/>
+          <entry name="_config" md5="77df3c993823300702edea888a865ece" size="74" mtime="1643641686"/>
+          <entry name="_link" md5="1c0b5cdc1939e8e93af148eeb4113b24" size="119" mtime="1643641686"/>
+          <entry name="somefile.txt" md5="c1fd23205f765c20433e1050bf644367" size="65" mtime="1643641686"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:32 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:06 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?view=info
@@ -442,15 +447,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '333'
+      - '331'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="534" vrev="2174" srcmd5="ed13159fd1d6c52b64cd89b92c1b06ea" lsrcmd5="6cc2ff4d0927b428defd6a43b1db1a67" verifymd5="72d65c1e4f57f439b821a54aeeb6a7c2">
+        <sourceinfo package="bar_package" rev="71" vrev="233" srcmd5="90f6c1079c05519ed60fe8052faccaa9" lsrcmd5="7a86f2d50aeec25ea0fa1a25e9b3f2d1" verifymd5="84a009462870d539ac095a17add602d2">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:32 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:06 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -476,18 +481,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '725'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="534" vrev="534" srcmd5="6cc2ff4d0927b428defd6a43b1db1a67">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="72d65c1e4f57f439b821a54aeeb6a7c2" baserev="72d65c1e4f57f439b821a54aeeb6a7c2" xsrcmd5="ed13159fd1d6c52b64cd89b92c1b06ea" lsrcmd5="6cc2ff4d0927b428defd6a43b1db1a67"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="1d1b9e02c16f0abc8aeda0d0b1f89874" size="61" mtime="1642674751"/>
-          <entry name="_link" md5="9ae1cdfa353f7dfa2801095550134df2" size="119" mtime="1642674752"/>
-          <entry name="somefile.txt" md5="d30b4761c414fe0828ee4bd2756b49d3" size="53" mtime="1642674751"/>
+        <directory name="bar_package" rev="71" vrev="71" srcmd5="7a86f2d50aeec25ea0fa1a25e9b3f2d1">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="84a009462870d539ac095a17add602d2" baserev="84a009462870d539ac095a17add602d2" xsrcmd5="90f6c1079c05519ed60fe8052faccaa9" lsrcmd5="7a86f2d50aeec25ea0fa1a25e9b3f2d1"/>
+          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1643641671"/>
+          <entry name="_config" md5="77df3c993823300702edea888a865ece" size="74" mtime="1643641686"/>
+          <entry name="_link" md5="1c0b5cdc1939e8e93af148eeb4113b24" size="119" mtime="1643641686"/>
+          <entry name="somefile.txt" md5="c1fd23205f765c20433e1050bf644367" size="65" mtime="1643641686"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:32 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:06 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -515,18 +520,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '370'
+      - '369'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="f7c463015454098af4a153c9c27de123">
+        <sourcediff key="57aeace17208256d2549fd952ec1b3f7">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="534" srcmd5="6cc2ff4d0927b428defd6a43b1db1a67"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="71" srcmd5="7a86f2d50aeec25ea0fa1a25e9b3f2d1"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:32 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:06 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -558,12 +563,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="c8426a21e420f7162ce62cbcb106577a">
-          <old project="foo_project" package="bar_package" rev="72d65c1e4f57f439b821a54aeeb6a7c2" srcmd5="72d65c1e4f57f439b821a54aeeb6a7c2"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="ed13159fd1d6c52b64cd89b92c1b06ea" srcmd5="ed13159fd1d6c52b64cd89b92c1b06ea"/>
+        <sourcediff key="dc411514ecc7ba56745fc9ed89ea9a37">
+          <old project="foo_project" package="bar_package" rev="84a009462870d539ac095a17add602d2" srcmd5="84a009462870d539ac095a17add602d2"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="90f6c1079c05519ed60fe8052faccaa9" srcmd5="90f6c1079c05519ed60fe8052faccaa9"/>
           <files/>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:32 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -631,7 +636,7 @@ http_interactions:
             <arch>aarch64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:32 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_branch_request?user=Iggy
@@ -657,19 +662,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="535" vrev="535">
-          <srcmd5>5b5eeb27d62601dd7909c0a2826c06aa</srcmd5>
+        <revision rev="72" vrev="72">
+          <srcmd5>63b1a736078b4475b3bf44a238649d4b</srcmd5>
           <version>unknown</version>
-          <time>1642674752</time>
+          <time>1643641686</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:32 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -677,8 +682,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Blue Remembered Earth</title>
-          <description>Vel rerum quis qui.</description>
+          <title>The Proper Study</title>
+          <description>Voluptas commodi ex rem.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -704,10 +709,10 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Blue Remembered Earth</title>
-          <description>Vel rerum quis qui.</description>
+          <title>The Proper Study</title>
+          <description>Voluptas commodi ex rem.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:32 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:06 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -733,19 +738,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="535" vrev="535" srcmd5="5b5eeb27d62601dd7909c0a2826c06aa">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="72d65c1e4f57f439b821a54aeeb6a7c2" baserev="72d65c1e4f57f439b821a54aeeb6a7c2" xsrcmd5="c0033dbe148a2441b14d1cd67cf90ccd" lsrcmd5="5b5eeb27d62601dd7909c0a2826c06aa"/>
-          <serviceinfo code="succeeded" xsrcmd5="91f5aa2dcbb43738654c6cd5e2b675b6"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="1d1b9e02c16f0abc8aeda0d0b1f89874" size="61" mtime="1642674751"/>
-          <entry name="_link" md5="9ae1cdfa353f7dfa2801095550134df2" size="119" mtime="1642674752"/>
-          <entry name="somefile.txt" md5="d30b4761c414fe0828ee4bd2756b49d3" size="53" mtime="1642674751"/>
+        <directory name="bar_package" rev="72" vrev="72" srcmd5="63b1a736078b4475b3bf44a238649d4b">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="84a009462870d539ac095a17add602d2" baserev="84a009462870d539ac095a17add602d2" xsrcmd5="899fb46781dc43608d2aea94fd7ded71" lsrcmd5="63b1a736078b4475b3bf44a238649d4b"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="77df3c993823300702edea888a865ece" size="74" mtime="1643641686"/>
+          <entry name="_link" md5="1c0b5cdc1939e8e93af148eeb4113b24" size="119" mtime="1643641686"/>
+          <entry name="somefile.txt" md5="c1fd23205f765c20433e1050bf644367" size="65" mtime="1643641686"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:32 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:06 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?view=info
@@ -771,15 +775,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '333'
+      - '331'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="535" vrev="2175" srcmd5="ca5ce46c0b01ec3ab17a2e690275419a" lsrcmd5="91f5aa2dcbb43738654c6cd5e2b675b6" verifymd5="bc9969b785361a67602bd3aefa866cca">
+        <sourceinfo package="bar_package" rev="72" vrev="234" srcmd5="899fb46781dc43608d2aea94fd7ded71" lsrcmd5="63b1a736078b4475b3bf44a238649d4b" verifymd5="b9351e364a5eb78c2f47033ea5d51b16">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:32 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:06 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -805,19 +809,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="535" vrev="535" srcmd5="5b5eeb27d62601dd7909c0a2826c06aa">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="72d65c1e4f57f439b821a54aeeb6a7c2" baserev="72d65c1e4f57f439b821a54aeeb6a7c2" xsrcmd5="c0033dbe148a2441b14d1cd67cf90ccd" lsrcmd5="5b5eeb27d62601dd7909c0a2826c06aa"/>
-          <serviceinfo code="succeeded" xsrcmd5="91f5aa2dcbb43738654c6cd5e2b675b6"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="1d1b9e02c16f0abc8aeda0d0b1f89874" size="61" mtime="1642674751"/>
-          <entry name="_link" md5="9ae1cdfa353f7dfa2801095550134df2" size="119" mtime="1642674752"/>
-          <entry name="somefile.txt" md5="d30b4761c414fe0828ee4bd2756b49d3" size="53" mtime="1642674751"/>
+        <directory name="bar_package" rev="72" vrev="72" srcmd5="63b1a736078b4475b3bf44a238649d4b">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="84a009462870d539ac095a17add602d2" baserev="84a009462870d539ac095a17add602d2" xsrcmd5="899fb46781dc43608d2aea94fd7ded71" lsrcmd5="63b1a736078b4475b3bf44a238649d4b"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="77df3c993823300702edea888a865ece" size="74" mtime="1643641686"/>
+          <entry name="_link" md5="1c0b5cdc1939e8e93af148eeb4113b24" size="119" mtime="1643641686"/>
+          <entry name="somefile.txt" md5="c1fd23205f765c20433e1050bf644367" size="65" mtime="1643641686"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:32 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:06 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -845,18 +848,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '370'
+      - '369'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="0122b55a0954403ea2e3870a54321718">
+        <sourcediff key="168e01875b78a0f8fbf7a8e9e987c7cd">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="535" srcmd5="5b5eeb27d62601dd7909c0a2826c06aa"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="72" srcmd5="63b1a736078b4475b3bf44a238649d4b"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:32 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:07 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -888,14 +891,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="ebc309003e7b02a39066d49074d3c4a6">
-          <old project="foo_project" package="bar_package" rev="72d65c1e4f57f439b821a54aeeb6a7c2" srcmd5="72d65c1e4f57f439b821a54aeeb6a7c2"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="ca5ce46c0b01ec3ab17a2e690275419a" srcmd5="ca5ce46c0b01ec3ab17a2e690275419a"/>
+        <sourcediff key="ebd037973b5f4ca82ccb029784f7bcfd">
+          <old project="foo_project" package="bar_package" rev="84a009462870d539ac095a17add602d2" srcmd5="84a009462870d539ac095a17add602d2"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="899fb46781dc43608d2aea94fd7ded71" srcmd5="899fb46781dc43608d2aea94fd7ded71"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:32 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:07 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -921,19 +924,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="535" vrev="535" srcmd5="5b5eeb27d62601dd7909c0a2826c06aa">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="72d65c1e4f57f439b821a54aeeb6a7c2" baserev="72d65c1e4f57f439b821a54aeeb6a7c2" xsrcmd5="c0033dbe148a2441b14d1cd67cf90ccd" lsrcmd5="5b5eeb27d62601dd7909c0a2826c06aa"/>
-          <serviceinfo code="succeeded" xsrcmd5="91f5aa2dcbb43738654c6cd5e2b675b6"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="1d1b9e02c16f0abc8aeda0d0b1f89874" size="61" mtime="1642674751"/>
-          <entry name="_link" md5="9ae1cdfa353f7dfa2801095550134df2" size="119" mtime="1642674752"/>
-          <entry name="somefile.txt" md5="d30b4761c414fe0828ee4bd2756b49d3" size="53" mtime="1642674751"/>
+        <directory name="bar_package" rev="72" vrev="72" srcmd5="63b1a736078b4475b3bf44a238649d4b">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="84a009462870d539ac095a17add602d2" baserev="84a009462870d539ac095a17add602d2" xsrcmd5="899fb46781dc43608d2aea94fd7ded71" lsrcmd5="63b1a736078b4475b3bf44a238649d4b"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="77df3c993823300702edea888a865ece" size="74" mtime="1643641686"/>
+          <entry name="_link" md5="1c0b5cdc1939e8e93af148eeb4113b24" size="119" mtime="1643641686"/>
+          <entry name="somefile.txt" md5="c1fd23205f765c20433e1050bf644367" size="65" mtime="1643641686"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:32 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:07 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '618'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="899fb46781dc43608d2aea94fd7ded71" vrev="234" srcmd5="899fb46781dc43608d2aea94fd7ded71">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="84a009462870d539ac095a17add602d2" baserev="84a009462870d539ac095a17add602d2" lsrcmd5="63b1a736078b4475b3bf44a238649d4b"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="77df3c993823300702edea888a865ece" size="74" mtime="1643641686"/>
+          <entry name="somefile.txt" md5="c1fd23205f765c20433e1050bf644367" size="65" mtime="1643641686"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:08:07 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -959,19 +997,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="535" vrev="535" srcmd5="5b5eeb27d62601dd7909c0a2826c06aa">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="72d65c1e4f57f439b821a54aeeb6a7c2" baserev="72d65c1e4f57f439b821a54aeeb6a7c2" xsrcmd5="c0033dbe148a2441b14d1cd67cf90ccd" lsrcmd5="5b5eeb27d62601dd7909c0a2826c06aa"/>
-          <serviceinfo code="succeeded" xsrcmd5="91f5aa2dcbb43738654c6cd5e2b675b6"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="1d1b9e02c16f0abc8aeda0d0b1f89874" size="61" mtime="1642674751"/>
-          <entry name="_link" md5="9ae1cdfa353f7dfa2801095550134df2" size="119" mtime="1642674752"/>
-          <entry name="somefile.txt" md5="d30b4761c414fe0828ee4bd2756b49d3" size="53" mtime="1642674751"/>
+        <directory name="bar_package" rev="72" vrev="72" srcmd5="63b1a736078b4475b3bf44a238649d4b">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="84a009462870d539ac095a17add602d2" baserev="84a009462870d539ac095a17add602d2" xsrcmd5="899fb46781dc43608d2aea94fd7ded71" lsrcmd5="63b1a736078b4475b3bf44a238649d4b"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="77df3c993823300702edea888a865ece" size="74" mtime="1643641686"/>
+          <entry name="_link" md5="1c0b5cdc1939e8e93af148eeb4113b24" size="119" mtime="1643641686"/>
+          <entry name="somefile.txt" md5="c1fd23205f765c20433e1050bf644367" size="65" mtime="1643641686"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:32 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:07 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '618'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="899fb46781dc43608d2aea94fd7ded71" vrev="234" srcmd5="899fb46781dc43608d2aea94fd7ded71">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="84a009462870d539ac095a17add602d2" baserev="84a009462870d539ac095a17add602d2" lsrcmd5="63b1a736078b4475b3bf44a238649d4b"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="77df3c993823300702edea888a865ece" size="74" mtime="1643641686"/>
+          <entry name="somefile.txt" md5="c1fd23205f765c20433e1050bf644367" size="65" mtime="1643641686"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:08:07 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -997,19 +1070,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="535" vrev="535" srcmd5="5b5eeb27d62601dd7909c0a2826c06aa">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="72d65c1e4f57f439b821a54aeeb6a7c2" baserev="72d65c1e4f57f439b821a54aeeb6a7c2" xsrcmd5="c0033dbe148a2441b14d1cd67cf90ccd" lsrcmd5="5b5eeb27d62601dd7909c0a2826c06aa"/>
-          <serviceinfo code="succeeded" xsrcmd5="91f5aa2dcbb43738654c6cd5e2b675b6"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="1d1b9e02c16f0abc8aeda0d0b1f89874" size="61" mtime="1642674751"/>
-          <entry name="_link" md5="9ae1cdfa353f7dfa2801095550134df2" size="119" mtime="1642674752"/>
-          <entry name="somefile.txt" md5="d30b4761c414fe0828ee4bd2756b49d3" size="53" mtime="1642674751"/>
+        <directory name="bar_package" rev="72" vrev="72" srcmd5="63b1a736078b4475b3bf44a238649d4b">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="84a009462870d539ac095a17add602d2" baserev="84a009462870d539ac095a17add602d2" xsrcmd5="899fb46781dc43608d2aea94fd7ded71" lsrcmd5="63b1a736078b4475b3bf44a238649d4b"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="77df3c993823300702edea888a865ece" size="74" mtime="1643641686"/>
+          <entry name="_link" md5="1c0b5cdc1939e8e93af148eeb4113b24" size="119" mtime="1643641686"/>
+          <entry name="somefile.txt" md5="c1fd23205f765c20433e1050bf644367" size="65" mtime="1643641686"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:32 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:07 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '618'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="899fb46781dc43608d2aea94fd7ded71" vrev="234" srcmd5="899fb46781dc43608d2aea94fd7ded71">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="84a009462870d539ac095a17add602d2" baserev="84a009462870d539ac095a17add602d2" lsrcmd5="63b1a736078b4475b3bf44a238649d4b"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="77df3c993823300702edea888a865ece" size="74" mtime="1643641686"/>
+          <entry name="somefile.txt" md5="c1fd23205f765c20433e1050bf644367" size="65" mtime="1643641686"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:08:07 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -1035,19 +1143,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="535" vrev="535" srcmd5="5b5eeb27d62601dd7909c0a2826c06aa">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="72d65c1e4f57f439b821a54aeeb6a7c2" baserev="72d65c1e4f57f439b821a54aeeb6a7c2" xsrcmd5="c0033dbe148a2441b14d1cd67cf90ccd" lsrcmd5="5b5eeb27d62601dd7909c0a2826c06aa"/>
-          <serviceinfo code="succeeded" xsrcmd5="91f5aa2dcbb43738654c6cd5e2b675b6"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="1d1b9e02c16f0abc8aeda0d0b1f89874" size="61" mtime="1642674751"/>
-          <entry name="_link" md5="9ae1cdfa353f7dfa2801095550134df2" size="119" mtime="1642674752"/>
-          <entry name="somefile.txt" md5="d30b4761c414fe0828ee4bd2756b49d3" size="53" mtime="1642674751"/>
+        <directory name="bar_package" rev="72" vrev="72" srcmd5="63b1a736078b4475b3bf44a238649d4b">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="84a009462870d539ac095a17add602d2" baserev="84a009462870d539ac095a17add602d2" xsrcmd5="899fb46781dc43608d2aea94fd7ded71" lsrcmd5="63b1a736078b4475b3bf44a238649d4b"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="77df3c993823300702edea888a865ece" size="74" mtime="1643641686"/>
+          <entry name="_link" md5="1c0b5cdc1939e8e93af148eeb4113b24" size="119" mtime="1643641686"/>
+          <entry name="somefile.txt" md5="c1fd23205f765c20433e1050bf644367" size="65" mtime="1643641686"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:32 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:07 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '618'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="899fb46781dc43608d2aea94fd7ded71" vrev="234" srcmd5="899fb46781dc43608d2aea94fd7ded71">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="84a009462870d539ac095a17add602d2" baserev="84a009462870d539ac095a17add602d2" lsrcmd5="63b1a736078b4475b3bf44a238649d4b"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="77df3c993823300702edea888a865ece" size="74" mtime="1643641686"/>
+          <entry name="somefile.txt" md5="c1fd23205f765c20433e1050bf644367" size="65" mtime="1643641686"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:08:07 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -1073,22 +1216,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="535" vrev="535" srcmd5="5b5eeb27d62601dd7909c0a2826c06aa">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="72d65c1e4f57f439b821a54aeeb6a7c2" baserev="72d65c1e4f57f439b821a54aeeb6a7c2" xsrcmd5="c0033dbe148a2441b14d1cd67cf90ccd" lsrcmd5="5b5eeb27d62601dd7909c0a2826c06aa"/>
-          <serviceinfo code="succeeded" xsrcmd5="91f5aa2dcbb43738654c6cd5e2b675b6"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="1d1b9e02c16f0abc8aeda0d0b1f89874" size="61" mtime="1642674751"/>
-          <entry name="_link" md5="9ae1cdfa353f7dfa2801095550134df2" size="119" mtime="1642674752"/>
-          <entry name="somefile.txt" md5="d30b4761c414fe0828ee4bd2756b49d3" size="53" mtime="1642674751"/>
+        <directory name="bar_package" rev="72" vrev="72" srcmd5="63b1a736078b4475b3bf44a238649d4b">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="84a009462870d539ac095a17add602d2" baserev="84a009462870d539ac095a17add602d2" xsrcmd5="899fb46781dc43608d2aea94fd7ded71" lsrcmd5="63b1a736078b4475b3bf44a238649d4b"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="77df3c993823300702edea888a865ece" size="74" mtime="1643641686"/>
+          <entry name="_link" md5="1c0b5cdc1939e8e93af148eeb4113b24" size="119" mtime="1643641686"/>
+          <entry name="somefile.txt" md5="c1fd23205f765c20433e1050bf644367" size="65" mtime="1643641686"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:32 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:07 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1111,169 +1253,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '618'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="535" vrev="535" srcmd5="5b5eeb27d62601dd7909c0a2826c06aa">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="72d65c1e4f57f439b821a54aeeb6a7c2" baserev="72d65c1e4f57f439b821a54aeeb6a7c2" xsrcmd5="c0033dbe148a2441b14d1cd67cf90ccd" lsrcmd5="5b5eeb27d62601dd7909c0a2826c06aa"/>
-          <serviceinfo code="succeeded" xsrcmd5="91f5aa2dcbb43738654c6cd5e2b675b6"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="1d1b9e02c16f0abc8aeda0d0b1f89874" size="61" mtime="1642674751"/>
-          <entry name="_link" md5="9ae1cdfa353f7dfa2801095550134df2" size="119" mtime="1642674752"/>
-          <entry name="somefile.txt" md5="d30b4761c414fe0828ee4bd2756b49d3" size="53" mtime="1642674751"/>
+        <directory name="bar_package" rev="899fb46781dc43608d2aea94fd7ded71" vrev="234" srcmd5="899fb46781dc43608d2aea94fd7ded71">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="84a009462870d539ac095a17add602d2" baserev="84a009462870d539ac095a17add602d2" lsrcmd5="63b1a736078b4475b3bf44a238649d4b"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="77df3c993823300702edea888a865ece" size="74" mtime="1643641686"/>
+          <entry name="somefile.txt" md5="c1fd23205f765c20433e1050bf644367" size="65" mtime="1643641686"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:32 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '802'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="535" vrev="535" srcmd5="5b5eeb27d62601dd7909c0a2826c06aa">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="72d65c1e4f57f439b821a54aeeb6a7c2" baserev="72d65c1e4f57f439b821a54aeeb6a7c2" xsrcmd5="c0033dbe148a2441b14d1cd67cf90ccd" lsrcmd5="5b5eeb27d62601dd7909c0a2826c06aa"/>
-          <serviceinfo code="succeeded" xsrcmd5="91f5aa2dcbb43738654c6cd5e2b675b6"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="1d1b9e02c16f0abc8aeda0d0b1f89874" size="61" mtime="1642674751"/>
-          <entry name="_link" md5="9ae1cdfa353f7dfa2801095550134df2" size="119" mtime="1642674752"/>
-          <entry name="somefile.txt" md5="d30b4761c414fe0828ee4bd2756b49d3" size="53" mtime="1642674751"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:32 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '802'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="535" vrev="535" srcmd5="5b5eeb27d62601dd7909c0a2826c06aa">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="72d65c1e4f57f439b821a54aeeb6a7c2" baserev="72d65c1e4f57f439b821a54aeeb6a7c2" xsrcmd5="c0033dbe148a2441b14d1cd67cf90ccd" lsrcmd5="5b5eeb27d62601dd7909c0a2826c06aa"/>
-          <serviceinfo code="succeeded" xsrcmd5="91f5aa2dcbb43738654c6cd5e2b675b6"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="1d1b9e02c16f0abc8aeda0d0b1f89874" size="61" mtime="1642674751"/>
-          <entry name="_link" md5="9ae1cdfa353f7dfa2801095550134df2" size="119" mtime="1642674752"/>
-          <entry name="somefile.txt" md5="d30b4761c414fe0828ee4bd2756b49d3" size="53" mtime="1642674751"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:32 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '802'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="535" vrev="535" srcmd5="5b5eeb27d62601dd7909c0a2826c06aa">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="72d65c1e4f57f439b821a54aeeb6a7c2" baserev="72d65c1e4f57f439b821a54aeeb6a7c2" xsrcmd5="c0033dbe148a2441b14d1cd67cf90ccd" lsrcmd5="5b5eeb27d62601dd7909c0a2826c06aa"/>
-          <serviceinfo code="succeeded" xsrcmd5="91f5aa2dcbb43738654c6cd5e2b675b6"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="1d1b9e02c16f0abc8aeda0d0b1f89874" size="61" mtime="1642674751"/>
-          <entry name="_link" md5="9ae1cdfa353f7dfa2801095550134df2" size="119" mtime="1642674752"/>
-          <entry name="somefile.txt" md5="d30b4761c414fe0828ee4bd2756b49d3" size="53" mtime="1642674751"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:32 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '802'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="535" vrev="535" srcmd5="5b5eeb27d62601dd7909c0a2826c06aa">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="72d65c1e4f57f439b821a54aeeb6a7c2" baserev="72d65c1e4f57f439b821a54aeeb6a7c2" xsrcmd5="c0033dbe148a2441b14d1cd67cf90ccd" lsrcmd5="5b5eeb27d62601dd7909c0a2826c06aa"/>
-          <serviceinfo code="succeeded" xsrcmd5="91f5aa2dcbb43738654c6cd5e2b675b6"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="1d1b9e02c16f0abc8aeda0d0b1f89874" size="61" mtime="1642674751"/>
-          <entry name="_link" md5="9ae1cdfa353f7dfa2801095550134df2" size="119" mtime="1642674752"/>
-          <entry name="somefile.txt" md5="d30b4761c414fe0828ee4bd2756b49d3" size="53" mtime="1642674751"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:32 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:07 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/for_a_new_MR_event/behaves_like_successful_new_PR_or_MR_event/only_reports_for_repositories_and_architectures_matching_the_filters.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/for_a_new_MR_event/behaves_like_successful_new_PR_or_MR_event/only_reports_for_repositories_and_architectures_matching_the_filters.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:35 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:01 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_264
+    uri: http://backend:5352/source/foo_project/_meta?user=user_47
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>To Say Nothing of the Dog</title>
+          <title>Brandy of the Damned</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '157'
+      - '152'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>To Say Nothing of the Dog</title>
+          <title>Brandy of the Damned</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:35 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:01 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_265
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_48
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Green Bay Tree</title>
-          <description>Odit ad quod sapiente.</description>
+          <title>All Passion Spent</title>
+          <description>Necessitatibus blanditiis et sed.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '150'
+      - '160'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Green Bay Tree</title>
-          <description>Odit ad quod sapiente.</description>
+          <title>All Passion Spent</title>
+          <description>Necessitatibus blanditiis et sed.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:35 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:01 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Temporibus esse molestiae. Corporis qui commodi. Rem dolorem odit.
+      string: Saepe sed et. Et assumenda eius. Eum non eaque.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1645" vrev="1645">
-          <srcmd5>53f5b847db4db8a904a48be9a0981845</srcmd5>
+        <revision rev="155" vrev="155">
+          <srcmd5>178111920d5c4c51a276c5b12ef8e0d6</srcmd5>
           <version>unknown</version>
-          <time>1642674755</time>
+          <time>1643641681</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:35 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:01 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Suscipit nulla temporibus. Aliquam iure vitae. Voluptates maiores dignissimos.
+      string: Culpa ea non. Eum maiores aliquam. Vel officia distinctio.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +181,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1646" vrev="1646">
-          <srcmd5>c829d913193ed559a120d53a8a40bc46</srcmd5>
+        <revision rev="156" vrev="156">
+          <srcmd5>6a5b8f06b8c562bb1e52dc2cf6cd7836</srcmd5>
           <version>unknown</version>
-          <time>1642674755</time>
+          <time>1643641681</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:35 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:01 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -227,7 +227,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:32:35 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:01 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -267,7 +267,7 @@ http_interactions:
           <description>This project was created for package bar_package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:35 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:01 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -275,8 +275,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Green Bay Tree</title>
-          <description>Odit ad quod sapiente.</description>
+          <title>All Passion Spent</title>
+          <description>Necessitatibus blanditiis et sed.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -297,15 +297,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '181'
+      - '191'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Green Bay Tree</title>
-          <description>Odit ad quod sapiente.</description>
+          <title>All Passion Spent</title>
+          <description>Necessitatibus blanditiis et sed.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:35 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:01 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=branch&noservice=1&opackage=bar_package&oproject=foo_project&user=Iggy
@@ -333,19 +333,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="540" vrev="540">
-          <srcmd5>f2919748146f3e8f5399a8e50a08c2b5</srcmd5>
+        <revision rev="65" vrev="65">
+          <srcmd5>5143bce27adfc92722dde1deee62d8f9</srcmd5>
           <version>unknown</version>
-          <time>1642674755</time>
+          <time>1643641681</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:35 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:01 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -353,8 +353,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Green Bay Tree</title>
-          <description>Odit ad quod sapiente.</description>
+          <title>All Passion Spent</title>
+          <description>Necessitatibus blanditiis et sed.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -375,15 +375,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '181'
+      - '191'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Green Bay Tree</title>
-          <description>Odit ad quod sapiente.</description>
+          <title>All Passion Spent</title>
+          <description>Necessitatibus blanditiis et sed.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:35 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:01 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -409,18 +409,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '725'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="540" vrev="540" srcmd5="f2919748146f3e8f5399a8e50a08c2b5">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="c829d913193ed559a120d53a8a40bc46" baserev="c829d913193ed559a120d53a8a40bc46" xsrcmd5="e71942418761d85335f9bae34011bea6" lsrcmd5="f2919748146f3e8f5399a8e50a08c2b5"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="8b7aae3c6c4b15b1851a3631623f54cc" size="66" mtime="1642674755"/>
-          <entry name="_link" md5="6f86a50232ed06a4b95fa69f17594b73" size="119" mtime="1642674755"/>
-          <entry name="somefile.txt" md5="f228c1a21303e8f2a5842ce7fe806e61" size="78" mtime="1642674755"/>
+        <directory name="bar_package" rev="65" vrev="65" srcmd5="5143bce27adfc92722dde1deee62d8f9">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="6a5b8f06b8c562bb1e52dc2cf6cd7836" baserev="6a5b8f06b8c562bb1e52dc2cf6cd7836" xsrcmd5="09fcc9be59ec347d632feb09b8873be2" lsrcmd5="5143bce27adfc92722dde1deee62d8f9"/>
+          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1643641671"/>
+          <entry name="_config" md5="7033ed5308f4d170b5f81e0959bd2924" size="47" mtime="1643641681"/>
+          <entry name="_link" md5="bcc00ecbbd2a79c36dad30234fe9523c" size="119" mtime="1643641681"/>
+          <entry name="somefile.txt" md5="f833437f7990cb8fdf59b719c28ab937" size="58" mtime="1643641681"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:35 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:01 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?view=info
@@ -446,15 +446,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '333'
+      - '331'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="540" vrev="2186" srcmd5="e71942418761d85335f9bae34011bea6" lsrcmd5="f2919748146f3e8f5399a8e50a08c2b5" verifymd5="c829d913193ed559a120d53a8a40bc46">
+        <sourceinfo package="bar_package" rev="65" vrev="221" srcmd5="09fcc9be59ec347d632feb09b8873be2" lsrcmd5="5143bce27adfc92722dde1deee62d8f9" verifymd5="6a5b8f06b8c562bb1e52dc2cf6cd7836">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:35 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:02 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -480,18 +480,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '725'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="540" vrev="540" srcmd5="f2919748146f3e8f5399a8e50a08c2b5">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="c829d913193ed559a120d53a8a40bc46" baserev="c829d913193ed559a120d53a8a40bc46" xsrcmd5="e71942418761d85335f9bae34011bea6" lsrcmd5="f2919748146f3e8f5399a8e50a08c2b5"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="8b7aae3c6c4b15b1851a3631623f54cc" size="66" mtime="1642674755"/>
-          <entry name="_link" md5="6f86a50232ed06a4b95fa69f17594b73" size="119" mtime="1642674755"/>
-          <entry name="somefile.txt" md5="f228c1a21303e8f2a5842ce7fe806e61" size="78" mtime="1642674755"/>
+        <directory name="bar_package" rev="65" vrev="65" srcmd5="5143bce27adfc92722dde1deee62d8f9">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="6a5b8f06b8c562bb1e52dc2cf6cd7836" baserev="6a5b8f06b8c562bb1e52dc2cf6cd7836" xsrcmd5="09fcc9be59ec347d632feb09b8873be2" lsrcmd5="5143bce27adfc92722dde1deee62d8f9"/>
+          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1643641671"/>
+          <entry name="_config" md5="7033ed5308f4d170b5f81e0959bd2924" size="47" mtime="1643641681"/>
+          <entry name="_link" md5="bcc00ecbbd2a79c36dad30234fe9523c" size="119" mtime="1643641681"/>
+          <entry name="somefile.txt" md5="f833437f7990cb8fdf59b719c28ab937" size="58" mtime="1643641681"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:35 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:02 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -519,18 +519,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '370'
+      - '369'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="d3dd938b635eeb1998aa8847e22d297a">
+        <sourcediff key="347dec42942714781c0a38ad4313ae43">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="540" srcmd5="f2919748146f3e8f5399a8e50a08c2b5"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="65" srcmd5="5143bce27adfc92722dde1deee62d8f9"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:35 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:02 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -562,12 +562,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="8aa123a9400c21da1ad3ceefa9dcefde">
-          <old project="foo_project" package="bar_package" rev="c829d913193ed559a120d53a8a40bc46" srcmd5="c829d913193ed559a120d53a8a40bc46"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="e71942418761d85335f9bae34011bea6" srcmd5="e71942418761d85335f9bae34011bea6"/>
+        <sourcediff key="3dc231a140d8043bcc41124af5a307f4">
+          <old project="foo_project" package="bar_package" rev="6a5b8f06b8c562bb1e52dc2cf6cd7836" srcmd5="6a5b8f06b8c562bb1e52dc2cf6cd7836"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="09fcc9be59ec347d632feb09b8873be2" srcmd5="09fcc9be59ec347d632feb09b8873be2"/>
           <files/>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:35 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:02 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -635,7 +635,7 @@ http_interactions:
             <arch>aarch64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:36 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:02 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_branch_request?user=Iggy
@@ -661,19 +661,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="541" vrev="541">
-          <srcmd5>050ca28be41f90327827f0b3809a86a6</srcmd5>
+        <revision rev="66" vrev="66">
+          <srcmd5>e9ef99e352eb3d0465724036c06c8ba6</srcmd5>
           <version>unknown</version>
-          <time>1642674756</time>
+          <time>1643641682</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:36 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:02 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -681,8 +681,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Green Bay Tree</title>
-          <description>Odit ad quod sapiente.</description>
+          <title>All Passion Spent</title>
+          <description>Necessitatibus blanditiis et sed.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -703,15 +703,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '181'
+      - '191'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Green Bay Tree</title>
-          <description>Odit ad quod sapiente.</description>
+          <title>All Passion Spent</title>
+          <description>Necessitatibus blanditiis et sed.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:36 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:02 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -737,19 +737,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="541" vrev="541" srcmd5="050ca28be41f90327827f0b3809a86a6">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="c829d913193ed559a120d53a8a40bc46" baserev="c829d913193ed559a120d53a8a40bc46" xsrcmd5="1440b3e61dc537b036996d6da4691736" lsrcmd5="050ca28be41f90327827f0b3809a86a6"/>
-          <serviceinfo code="succeeded" xsrcmd5="90260562ecfa19ed9ae8920ae9e62ac2"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="8b7aae3c6c4b15b1851a3631623f54cc" size="66" mtime="1642674755"/>
-          <entry name="_link" md5="6f86a50232ed06a4b95fa69f17594b73" size="119" mtime="1642674755"/>
-          <entry name="somefile.txt" md5="f228c1a21303e8f2a5842ce7fe806e61" size="78" mtime="1642674755"/>
+        <directory name="bar_package" rev="66" vrev="66" srcmd5="e9ef99e352eb3d0465724036c06c8ba6">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="6a5b8f06b8c562bb1e52dc2cf6cd7836" baserev="6a5b8f06b8c562bb1e52dc2cf6cd7836" xsrcmd5="1823a91ca0ef488096d0874dd28e4558" lsrcmd5="e9ef99e352eb3d0465724036c06c8ba6"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="7033ed5308f4d170b5f81e0959bd2924" size="47" mtime="1643641681"/>
+          <entry name="_link" md5="bcc00ecbbd2a79c36dad30234fe9523c" size="119" mtime="1643641681"/>
+          <entry name="somefile.txt" md5="f833437f7990cb8fdf59b719c28ab937" size="58" mtime="1643641681"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:36 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:02 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?view=info
@@ -775,15 +774,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '333'
+      - '331'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="541" vrev="2187" srcmd5="e1591ab3baf214f1526b79b37aee28bd" lsrcmd5="90260562ecfa19ed9ae8920ae9e62ac2" verifymd5="ef6963e1e1aebc43b3ee7182180a7d9d">
+        <sourceinfo package="bar_package" rev="66" vrev="222" srcmd5="1823a91ca0ef488096d0874dd28e4558" lsrcmd5="e9ef99e352eb3d0465724036c06c8ba6" verifymd5="62861a517e81262426852f7cac6a8f54">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:36 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:02 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -809,19 +808,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="541" vrev="541" srcmd5="050ca28be41f90327827f0b3809a86a6">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="c829d913193ed559a120d53a8a40bc46" baserev="c829d913193ed559a120d53a8a40bc46" xsrcmd5="1440b3e61dc537b036996d6da4691736" lsrcmd5="050ca28be41f90327827f0b3809a86a6"/>
-          <serviceinfo code="succeeded" xsrcmd5="90260562ecfa19ed9ae8920ae9e62ac2"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="8b7aae3c6c4b15b1851a3631623f54cc" size="66" mtime="1642674755"/>
-          <entry name="_link" md5="6f86a50232ed06a4b95fa69f17594b73" size="119" mtime="1642674755"/>
-          <entry name="somefile.txt" md5="f228c1a21303e8f2a5842ce7fe806e61" size="78" mtime="1642674755"/>
+        <directory name="bar_package" rev="66" vrev="66" srcmd5="e9ef99e352eb3d0465724036c06c8ba6">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="6a5b8f06b8c562bb1e52dc2cf6cd7836" baserev="6a5b8f06b8c562bb1e52dc2cf6cd7836" xsrcmd5="1823a91ca0ef488096d0874dd28e4558" lsrcmd5="e9ef99e352eb3d0465724036c06c8ba6"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="7033ed5308f4d170b5f81e0959bd2924" size="47" mtime="1643641681"/>
+          <entry name="_link" md5="bcc00ecbbd2a79c36dad30234fe9523c" size="119" mtime="1643641681"/>
+          <entry name="somefile.txt" md5="f833437f7990cb8fdf59b719c28ab937" size="58" mtime="1643641681"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:36 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:02 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -849,18 +847,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '370'
+      - '369'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="0d56cbaf8c390bd7f0f71a2d4fb6faf9">
+        <sourcediff key="fc1f775efee987c322c30bd466d51443">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="541" srcmd5="050ca28be41f90327827f0b3809a86a6"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="66" srcmd5="e9ef99e352eb3d0465724036c06c8ba6"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:36 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:02 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -892,14 +890,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="5f6b87a55b5d62da9e1544642b982c9b">
-          <old project="foo_project" package="bar_package" rev="c829d913193ed559a120d53a8a40bc46" srcmd5="c829d913193ed559a120d53a8a40bc46"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="e1591ab3baf214f1526b79b37aee28bd" srcmd5="e1591ab3baf214f1526b79b37aee28bd"/>
+        <sourcediff key="196f701aee8663350525ceb6d73a82bf">
+          <old project="foo_project" package="bar_package" rev="6a5b8f06b8c562bb1e52dc2cf6cd7836" srcmd5="6a5b8f06b8c562bb1e52dc2cf6cd7836"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="1823a91ca0ef488096d0874dd28e4558" srcmd5="1823a91ca0ef488096d0874dd28e4558"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:36 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:02 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -925,19 +923,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="541" vrev="541" srcmd5="050ca28be41f90327827f0b3809a86a6">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="c829d913193ed559a120d53a8a40bc46" baserev="c829d913193ed559a120d53a8a40bc46" xsrcmd5="1440b3e61dc537b036996d6da4691736" lsrcmd5="050ca28be41f90327827f0b3809a86a6"/>
-          <serviceinfo code="succeeded" xsrcmd5="90260562ecfa19ed9ae8920ae9e62ac2"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="8b7aae3c6c4b15b1851a3631623f54cc" size="66" mtime="1642674755"/>
-          <entry name="_link" md5="6f86a50232ed06a4b95fa69f17594b73" size="119" mtime="1642674755"/>
-          <entry name="somefile.txt" md5="f228c1a21303e8f2a5842ce7fe806e61" size="78" mtime="1642674755"/>
+        <directory name="bar_package" rev="66" vrev="66" srcmd5="e9ef99e352eb3d0465724036c06c8ba6">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="6a5b8f06b8c562bb1e52dc2cf6cd7836" baserev="6a5b8f06b8c562bb1e52dc2cf6cd7836" xsrcmd5="1823a91ca0ef488096d0874dd28e4558" lsrcmd5="e9ef99e352eb3d0465724036c06c8ba6"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="7033ed5308f4d170b5f81e0959bd2924" size="47" mtime="1643641681"/>
+          <entry name="_link" md5="bcc00ecbbd2a79c36dad30234fe9523c" size="119" mtime="1643641681"/>
+          <entry name="somefile.txt" md5="f833437f7990cb8fdf59b719c28ab937" size="58" mtime="1643641681"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:36 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:02 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '618'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package" rev="1823a91ca0ef488096d0874dd28e4558" vrev="222" srcmd5="1823a91ca0ef488096d0874dd28e4558">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="6a5b8f06b8c562bb1e52dc2cf6cd7836" baserev="6a5b8f06b8c562bb1e52dc2cf6cd7836" lsrcmd5="e9ef99e352eb3d0465724036c06c8ba6"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="7033ed5308f4d170b5f81e0959bd2924" size="47" mtime="1643641681"/>
+          <entry name="somefile.txt" md5="f833437f7990cb8fdf59b719c28ab937" size="58" mtime="1643641681"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:08:02 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -963,22 +996,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="541" vrev="541" srcmd5="050ca28be41f90327827f0b3809a86a6">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="c829d913193ed559a120d53a8a40bc46" baserev="c829d913193ed559a120d53a8a40bc46" xsrcmd5="1440b3e61dc537b036996d6da4691736" lsrcmd5="050ca28be41f90327827f0b3809a86a6"/>
-          <serviceinfo code="succeeded" xsrcmd5="90260562ecfa19ed9ae8920ae9e62ac2"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="8b7aae3c6c4b15b1851a3631623f54cc" size="66" mtime="1642674755"/>
-          <entry name="_link" md5="6f86a50232ed06a4b95fa69f17594b73" size="119" mtime="1642674755"/>
-          <entry name="somefile.txt" md5="f228c1a21303e8f2a5842ce7fe806e61" size="78" mtime="1642674755"/>
+        <directory name="bar_package" rev="66" vrev="66" srcmd5="e9ef99e352eb3d0465724036c06c8ba6">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="6a5b8f06b8c562bb1e52dc2cf6cd7836" baserev="6a5b8f06b8c562bb1e52dc2cf6cd7836" xsrcmd5="1823a91ca0ef488096d0874dd28e4558" lsrcmd5="e9ef99e352eb3d0465724036c06c8ba6"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="7033ed5308f4d170b5f81e0959bd2924" size="47" mtime="1643641681"/>
+          <entry name="_link" md5="bcc00ecbbd2a79c36dad30234fe9523c" size="119" mtime="1643641681"/>
+          <entry name="somefile.txt" md5="f833437f7990cb8fdf59b719c28ab937" size="58" mtime="1643641681"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:36 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:02 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
+    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1001,55 +1033,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '618'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="541" vrev="541" srcmd5="050ca28be41f90327827f0b3809a86a6">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="c829d913193ed559a120d53a8a40bc46" baserev="c829d913193ed559a120d53a8a40bc46" xsrcmd5="1440b3e61dc537b036996d6da4691736" lsrcmd5="050ca28be41f90327827f0b3809a86a6"/>
-          <serviceinfo code="succeeded" xsrcmd5="90260562ecfa19ed9ae8920ae9e62ac2"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="8b7aae3c6c4b15b1851a3631623f54cc" size="66" mtime="1642674755"/>
-          <entry name="_link" md5="6f86a50232ed06a4b95fa69f17594b73" size="119" mtime="1642674755"/>
-          <entry name="somefile.txt" md5="f228c1a21303e8f2a5842ce7fe806e61" size="78" mtime="1642674755"/>
+        <directory name="bar_package" rev="1823a91ca0ef488096d0874dd28e4558" vrev="222" srcmd5="1823a91ca0ef488096d0874dd28e4558">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="6a5b8f06b8c562bb1e52dc2cf6cd7836" baserev="6a5b8f06b8c562bb1e52dc2cf6cd7836" lsrcmd5="e9ef99e352eb3d0465724036c06c8ba6"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="7033ed5308f4d170b5f81e0959bd2924" size="47" mtime="1643641681"/>
+          <entry name="somefile.txt" md5="f833437f7990cb8fdf59b719c28ab937" size="58" mtime="1643641681"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:36 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '802'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package" rev="541" vrev="541" srcmd5="050ca28be41f90327827f0b3809a86a6">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="c829d913193ed559a120d53a8a40bc46" baserev="c829d913193ed559a120d53a8a40bc46" xsrcmd5="1440b3e61dc537b036996d6da4691736" lsrcmd5="050ca28be41f90327827f0b3809a86a6"/>
-          <serviceinfo code="succeeded" xsrcmd5="90260562ecfa19ed9ae8920ae9e62ac2"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="8b7aae3c6c4b15b1851a3631623f54cc" size="66" mtime="1642674755"/>
-          <entry name="_link" md5="6f86a50232ed06a4b95fa69f17594b73" size="119" mtime="1642674755"/>
-          <entry name="somefile.txt" md5="f228c1a21303e8f2a5842ce7fe806e61" size="78" mtime="1642674755"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:36 GMT
+  recorded_at: Mon, 31 Jan 2022 15:08:02 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/for_an_updated_MR_event/when_the_branched_package_already_existed/behaves_like_successful_update_event_when_the_branch_package_already_exists/1_1_2_4_1_1_1.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/for_an_updated_MR_event/when_the_branched_package_already_existed/behaves_like_successful_update_event_when_the_branch_package_already_exists/1_1_2_4_1_1_1.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:40 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:55 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_274
+    uri: http://backend:5352/source/foo_project/_meta?user=user_33
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>That Good Night</title>
+          <title>Look Homeward, Angel</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '147'
+      - '152'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>That Good Night</title>
+          <title>Look Homeward, Angel</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:40 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:55 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_275
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_34
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Nectar in a Sieve</title>
-          <description>Consequatur qui dolorum earum.</description>
+          <title>Waiting for the Barbarians</title>
+          <description>Provident quia dolores consequatur.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '157'
+      - '171'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Nectar in a Sieve</title>
-          <description>Consequatur qui dolorum earum.</description>
+          <title>Waiting for the Barbarians</title>
+          <description>Provident quia dolores consequatur.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:40 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:55 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Ut pariatur voluptates. Fugit dolor alias. Tempore voluptatibus est.
+      string: Quod repudiandae aliquam. Error ex dolorem. Et necessitatibus eaque.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1656" vrev="1656">
-          <srcmd5>ce3ccd26a9aa448868feaebd5eb76344</srcmd5>
+        <revision rev="139" vrev="139">
+          <srcmd5>6b059e5bdfb72e9a480a8340bf3c7d17</srcmd5>
           <version>unknown</version>
-          <time>1642674760</time>
+          <time>1643641675</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:40 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:55 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Rerum iure ut. Minus quaerat eius. Non quia velit.
+      string: Est est quo. Optio mollitia sit. Nemo sit error.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +181,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1657" vrev="1657">
-          <srcmd5>3080850d1d94b2f3b7e84ab1995b2215</srcmd5>
+        <revision rev="140" vrev="140">
+          <srcmd5>63b6f2f5c0ce80510eecd80a5fe354b8</srcmd5>
           <version>unknown</version>
-          <time>1642674760</time>
+          <time>1643641675</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:40 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:55 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -201,7 +201,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Green Bay Tree</title>
+          <title>The Man Within</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -224,16 +224,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '181'
+      - '177'
     body:
       encoding: UTF-8
       string: |
         <project name="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Green Bay Tree</title>
+          <title>The Man Within</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:40 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:55 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -241,8 +241,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Jacob Have I Loved</title>
-          <description>Sunt voluptate vero aut.</description>
+          <title>Alone on a Wide, Wide Sea</title>
+          <description>Ut repudiandae culpa eaque.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -263,21 +263,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '183'
+      - '193'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Jacob Have I Loved</title>
-          <description>Sunt voluptate vero aut.</description>
+          <title>Alone on a Wide, Wide Sea</title>
+          <description>Ut repudiandae culpa eaque.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:40 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:55 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_config
     body:
       encoding: UTF-8
-      string: Ut nostrum vel. Voluptatem assumenda praesentium. Modi tempore quibusdam.
+      string: Mollitia ad sint. Ut ea autem. Ut deleniti officia.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -297,25 +297,26 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="549" vrev="549">
-          <srcmd5>3bddd7226b4c55507c8ffbaa1547fb4e</srcmd5>
+        <revision rev="55" vrev="55">
+          <srcmd5>a9a9a49367424999d210045921b99139</srcmd5>
           <version>unknown</version>
-          <time>1642674760</time>
+          <time>1643641675</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:40 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:55 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Repudiandae officia aut. Perferendis deleniti est. Veniam commodi consequatur.
+      string: Maiores officiis voluptatem. Quasi voluptas recusandae. Id consectetur
+        ea.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -335,19 +336,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="550" vrev="550">
-          <srcmd5>85f423ece445daa15b83cfed55df3d5e</srcmd5>
+        <revision rev="56" vrev="56">
+          <srcmd5>92e69388438cb05cce9ad0419af06a19</srcmd5>
           <version>unknown</version>
-          <time>1642674760</time>
+          <time>1643641675</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:40 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:55 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_branch_request?user=Iggy
@@ -373,28 +374,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '210'
+      - '208'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1658" vrev="1658">
-          <srcmd5>3080850d1d94b2f3b7e84ab1995b2215</srcmd5>
+        <revision rev="141" vrev="141">
+          <srcmd5>63b6f2f5c0ce80510eecd80a5fe354b8</srcmd5>
           <version>unknown</version>
-          <time>1642674760</time>
+          <time>1643641675</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:40 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:55 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_275
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_34
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Nectar in a Sieve</title>
-          <description>Consequatur qui dolorum earum.</description>
+          <title>Waiting for the Barbarians</title>
+          <description>Provident quia dolores consequatur.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -415,15 +416,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '157'
+      - '171'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Nectar in a Sieve</title>
-          <description>Consequatur qui dolorum earum.</description>
+          <title>Waiting for the Barbarians</title>
+          <description>Provident quia dolores consequatur.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:40 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:55 GMT
 - request:
     method: get
     uri: http://backend:5352/source/foo_project/bar_package
@@ -449,16 +450,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '405'
+      - '403'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="1658" vrev="1658" srcmd5="3080850d1d94b2f3b7e84ab1995b2215">
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="c56f86d1716dcb55067eb8210a00ed1e" size="68" mtime="1642674760"/>
-          <entry name="somefile.txt" md5="88702e82a7e9f5efb4fc36c65e9261e5" size="50" mtime="1642674760"/>
+        <directory name="bar_package" rev="141" vrev="141" srcmd5="63b6f2f5c0ce80510eecd80a5fe354b8">
+          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1643641671"/>
+          <entry name="_config" md5="c1e5da6f62c2d498d6cbf93f71651868" size="68" mtime="1643641675"/>
+          <entry name="somefile.txt" md5="310efce7652c89ab196968dc065fe58d" size="48" mtime="1643641675"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:40 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:55 GMT
 - request:
     method: get
     uri: http://backend:5352/source/foo_project/bar_package?view=info
@@ -484,14 +485,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '235'
+      - '233'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="1658" vrev="1658" srcmd5="3080850d1d94b2f3b7e84ab1995b2215" verifymd5="3080850d1d94b2f3b7e84ab1995b2215">
+        <sourceinfo package="bar_package" rev="141" vrev="141" srcmd5="63b6f2f5c0ce80510eecd80a5fe354b8" verifymd5="63b6f2f5c0ce80510eecd80a5fe354b8">
           <error>bad build configuration, no build type defined or detected</error>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:40 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:55 GMT
 - request:
     method: get
     uri: http://backend:5352/source/foo_project/bar_package
@@ -517,16 +518,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '405'
+      - '403'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="1658" vrev="1658" srcmd5="3080850d1d94b2f3b7e84ab1995b2215">
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="c56f86d1716dcb55067eb8210a00ed1e" size="68" mtime="1642674760"/>
-          <entry name="somefile.txt" md5="88702e82a7e9f5efb4fc36c65e9261e5" size="50" mtime="1642674760"/>
+        <directory name="bar_package" rev="141" vrev="141" srcmd5="63b6f2f5c0ce80510eecd80a5fe354b8">
+          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1643641671"/>
+          <entry name="_config" md5="c1e5da6f62c2d498d6cbf93f71651868" size="68" mtime="1643641675"/>
+          <entry name="somefile.txt" md5="310efce7652c89ab196968dc065fe58d" size="48" mtime="1643641675"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:40 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:55 GMT
 - request:
     method: post
     uri: http://backend:5352/source/foo_project/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -554,18 +555,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '309'
+      - '308'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="5e6fb585d2605fb5cb4f3cb11a6932f6">
+        <sourcediff key="964ef79f4dac804ae0ecaecd975c51ef">
           <old project="foo_project" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="foo_project" package="bar_package" rev="1658" srcmd5="3080850d1d94b2f3b7e84ab1995b2215"/>
+          <new project="foo_project" package="bar_package" rev="141" srcmd5="63b6f2f5c0ce80510eecd80a5fe354b8"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:40 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:55 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_branch_request?user=Iggy
@@ -591,19 +592,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="551" vrev="551">
-          <srcmd5>9d94cf054a2a05890f2cdda8988abbf1</srcmd5>
+        <revision rev="57" vrev="57">
+          <srcmd5>92e69388438cb05cce9ad0419af06a19</srcmd5>
           <version>unknown</version>
-          <time>1642674760</time>
+          <time>1643641675</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:40 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:55 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -611,8 +612,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Jacob Have I Loved</title>
-          <description>Sunt voluptate vero aut.</description>
+          <title>Alone on a Wide, Wide Sea</title>
+          <description>Ut repudiandae culpa eaque.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -633,15 +634,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '183'
+      - '193'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Jacob Have I Loved</title>
-          <description>Sunt voluptate vero aut.</description>
+          <title>Alone on a Wide, Wide Sea</title>
+          <description>Ut repudiandae culpa eaque.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:40 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:55 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -667,21 +668,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '832'
+      - '671'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="551" vrev="551" srcmd5="9d94cf054a2a05890f2cdda8988abbf1">
-          <linkinfo project="foo_project" package="bar_package" baserev="e96f2416509066dbe7aa04a8f862e091" xsrcmd5="d393b6b8e286aadf664df1693aebd43d" error="conflict in file _config"/>
-          <serviceinfo code="failed" xsrcmd5="1350fe40044e8ff8fc960bb276a026c8">
-            <error>service error: bad link: conflict in file _config</error>
-          </serviceinfo>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="f822dad13792517948097ff053247e4f" size="73" mtime="1642674760"/>
-          <entry name="_link" md5="028bf1aa0518e0efb16a9d5e082f6feb" size="119" mtime="1642674758"/>
-          <entry name="somefile.txt" md5="9ac8409b7a05964195365401aaf9d4da" size="78" mtime="1642674760"/>
+        <directory name="bar_package" rev="57" vrev="57" srcmd5="92e69388438cb05cce9ad0419af06a19">
+          <linkinfo project="foo_project" package="bar_package" baserev="11ed5f7df3c46b42eaa6bd5e17fc4232" xsrcmd5="5deeb534b849d55c6b03cddb01cfde33" error="conflict in file _config"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="60307b5c484dcbbaa8a424e5a69a198d" size="51" mtime="1643641675"/>
+          <entry name="_link" md5="0ed866dcf37c02d96fa6359bfc74102c" size="119" mtime="1643641670"/>
+          <entry name="somefile.txt" md5="d935531904709359ccd82bc00f32dd0d" size="74" mtime="1643641675"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:41 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:55 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?view=info
@@ -707,14 +705,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '179'
+      - '254'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="551" vrev="551" srcmd5="9d94cf054a2a05890f2cdda8988abbf1">
-          <error>service error: bad link: conflict in file _config</error>
+        <sourceinfo package="bar_package" rev="57" vrev="198" srcmd5="92e69388438cb05cce9ad0419af06a19" verifymd5="92e69388438cb05cce9ad0419af06a19">
+          <error>conflict in file _config</error>
+          <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:41 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:55 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -740,21 +739,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '832'
+      - '671'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="551" vrev="551" srcmd5="9d94cf054a2a05890f2cdda8988abbf1">
-          <linkinfo project="foo_project" package="bar_package" baserev="e96f2416509066dbe7aa04a8f862e091" xsrcmd5="d393b6b8e286aadf664df1693aebd43d" error="conflict in file _config"/>
-          <serviceinfo code="failed" xsrcmd5="1350fe40044e8ff8fc960bb276a026c8">
-            <error>service error: bad link: conflict in file _config</error>
-          </serviceinfo>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="f822dad13792517948097ff053247e4f" size="73" mtime="1642674760"/>
-          <entry name="_link" md5="028bf1aa0518e0efb16a9d5e082f6feb" size="119" mtime="1642674758"/>
-          <entry name="somefile.txt" md5="9ac8409b7a05964195365401aaf9d4da" size="78" mtime="1642674760"/>
+        <directory name="bar_package" rev="57" vrev="57" srcmd5="92e69388438cb05cce9ad0419af06a19">
+          <linkinfo project="foo_project" package="bar_package" baserev="11ed5f7df3c46b42eaa6bd5e17fc4232" xsrcmd5="5deeb534b849d55c6b03cddb01cfde33" error="conflict in file _config"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="60307b5c484dcbbaa8a424e5a69a198d" size="51" mtime="1643641675"/>
+          <entry name="_link" md5="0ed866dcf37c02d96fa6359bfc74102c" size="119" mtime="1643641670"/>
+          <entry name="somefile.txt" md5="d935531904709359ccd82bc00f32dd0d" size="74" mtime="1643641675"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:41 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:55 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -782,18 +778,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '370'
+      - '369'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="25c2b6e376d86bcfdf06015b24943a0e">
+        <sourcediff key="50f27c5830035a4f49ac33c110205d5e">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="551" srcmd5="9d94cf054a2a05890f2cdda8988abbf1"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="57" srcmd5="92e69388438cb05cce9ad0419af06a19"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:41 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:55 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -811,8 +807,8 @@ http_interactions:
       - Ruby
   response:
     status:
-      code: 400
-      message: service error  bad link  conflict in file _config
+      code: 200
+      message: OK
     headers:
       Content-Type:
       - text/xml
@@ -821,12 +817,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '101'
+      - '399'
     body:
       encoding: UTF-8
       string: |
-        <status code="400">
-          <summary>service error: bad link: conflict in file _config</summary>
-        </status>
-  recorded_at: Thu, 20 Jan 2022 10:32:41 GMT
+        <sourcediff key="5d53373d08152fb51bf6543d95440362">
+          <old project="foo_project" package="bar_package" rev="11ed5f7df3c46b42eaa6bd5e17fc4232" srcmd5="11ed5f7df3c46b42eaa6bd5e17fc4232"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="a0a148a646d155e940577b2ded61a7cb" srcmd5="a0a148a646d155e940577b2ded61a7cb"/>
+          <files/>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Mon, 31 Jan 2022 15:07:56 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/for_an_updated_MR_event/when_the_branched_package_already_existed/behaves_like_successful_update_event_when_the_branch_package_already_exists/1_1_2_4_1_1_2.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/for_an_updated_MR_event/when_the_branched_package_already_existed/behaves_like_successful_update_event_when_the_branch_package_already_exists/1_1_2_4_1_1_2.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:42 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:56 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_278
+    uri: http://backend:5352/source/foo_project/_meta?user=user_35
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>A Confederacy of Dunces</title>
+          <title>This Side of Paradise</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '155'
+      - '153'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>A Confederacy of Dunces</title>
+          <title>This Side of Paradise</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:42 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:56 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_279
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_36
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Time of our Darkness</title>
-          <description>Similique occaecati et cum.</description>
+          <title>Many Waters</title>
+          <description>Illo odit velit ullam.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '157'
+      - '143'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Time of our Darkness</title>
-          <description>Similique occaecati et cum.</description>
+          <title>Many Waters</title>
+          <description>Illo odit velit ullam.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:42 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:56 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Cum dolores qui. Eligendi eius quis. Porro accusantium praesentium.
+      string: Et eos amet. Et dolor ut. Suscipit aut repellat.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,26 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1662" vrev="1662">
-          <srcmd5>e0d63f7d7ca244817c6b76cd9e9302ca</srcmd5>
+        <revision rev="142" vrev="142">
+          <srcmd5>3aa2ab063d01debff4284789fd2e90b2</srcmd5>
           <version>unknown</version>
-          <time>1642674762</time>
+          <time>1643641676</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:42 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:56 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Repellat eligendi cupiditate. Possimus ab eos. Exercitationem quibusdam
-        delectus.
+      string: Similique iure nesciunt. Sint ut dolores. Natus placeat quam.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -182,19 +181,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1663" vrev="1663">
-          <srcmd5>28e6671d29a161b791b6efcae3dbd892</srcmd5>
+        <revision rev="143" vrev="143">
+          <srcmd5>d30ac0b684cd0d754c2bb090d5f0c1f8</srcmd5>
           <version>unknown</version>
-          <time>1642674762</time>
+          <time>1643641676</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:42 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:56 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -202,7 +201,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Oh! To be in England</title>
+          <title>Wildfire at Midnight</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -230,11 +229,11 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Oh! To be in England</title>
+          <title>Wildfire at Midnight</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:42 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:56 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -242,8 +241,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>No Highway</title>
-          <description>Non commodi id et.</description>
+          <title>What's Become of Waring</title>
+          <description>Ea quia est distinctio.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -264,21 +263,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '169'
+      - '187'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>No Highway</title>
-          <description>Non commodi id et.</description>
+          <title>What's Become of Waring</title>
+          <description>Ea quia est distinctio.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:42 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:56 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_config
     body:
       encoding: UTF-8
-      string: Beatae dolore facere. Sit laborum natus. Et minus dolorem.
+      string: Alias aut repellendus. Quia labore voluptas. Ullam sapiente ipsum.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -298,25 +297,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="555" vrev="555">
-          <srcmd5>0788a4505bde6d2b534a9e79af82d695</srcmd5>
+        <revision rev="58" vrev="58">
+          <srcmd5>fc7385b2189ac82e0ba6ef9d27c59303</srcmd5>
           <version>unknown</version>
-          <time>1642674762</time>
+          <time>1643641676</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:42 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:56 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Ratione impedit molestias. Et voluptate modi. Aut non ut.
+      string: Accusantium nostrum veritatis. Voluptas nihil occaecati. Eum est ex.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -336,19 +335,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="556" vrev="556">
-          <srcmd5>6342336be9f252466df900664b7dbe82</srcmd5>
+        <revision rev="59" vrev="59">
+          <srcmd5>62a4d8c1d6158e0ecfaa3638fc526d37</srcmd5>
           <version>unknown</version>
-          <time>1642674762</time>
+          <time>1643641676</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:42 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:56 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_branch_request?user=Iggy
@@ -374,28 +373,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '210'
+      - '208'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1664" vrev="1664">
-          <srcmd5>28e6671d29a161b791b6efcae3dbd892</srcmd5>
+        <revision rev="144" vrev="144">
+          <srcmd5>d30ac0b684cd0d754c2bb090d5f0c1f8</srcmd5>
           <version>unknown</version>
-          <time>1642674762</time>
+          <time>1643641676</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:42 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:56 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_279
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_36
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Time of our Darkness</title>
-          <description>Similique occaecati et cum.</description>
+          <title>Many Waters</title>
+          <description>Illo odit velit ullam.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -416,15 +415,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '157'
+      - '143'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Time of our Darkness</title>
-          <description>Similique occaecati et cum.</description>
+          <title>Many Waters</title>
+          <description>Illo odit velit ullam.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:42 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:56 GMT
 - request:
     method: get
     uri: http://backend:5352/source/foo_project/bar_package
@@ -450,16 +449,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '405'
+      - '403'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="1664" vrev="1664" srcmd5="28e6671d29a161b791b6efcae3dbd892">
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="d344912fc193873262f9ca52f427bbac" size="67" mtime="1642674762"/>
-          <entry name="somefile.txt" md5="1dd365b87c2f4a86b1822749bf6bf260" size="81" mtime="1642674762"/>
+        <directory name="bar_package" rev="144" vrev="144" srcmd5="d30ac0b684cd0d754c2bb090d5f0c1f8">
+          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1643641671"/>
+          <entry name="_config" md5="e200aa7357ff29cc69269bc30f8b6573" size="48" mtime="1643641676"/>
+          <entry name="somefile.txt" md5="5764cd9dc6430097f55dd9621c38ecf5" size="61" mtime="1643641676"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:42 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:56 GMT
 - request:
     method: get
     uri: http://backend:5352/source/foo_project/bar_package?view=info
@@ -485,14 +484,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '235'
+      - '233'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="1664" vrev="1664" srcmd5="28e6671d29a161b791b6efcae3dbd892" verifymd5="28e6671d29a161b791b6efcae3dbd892">
+        <sourceinfo package="bar_package" rev="144" vrev="144" srcmd5="d30ac0b684cd0d754c2bb090d5f0c1f8" verifymd5="d30ac0b684cd0d754c2bb090d5f0c1f8">
           <error>bad build configuration, no build type defined or detected</error>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:42 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:56 GMT
 - request:
     method: get
     uri: http://backend:5352/source/foo_project/bar_package
@@ -518,16 +517,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '405'
+      - '403'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="1664" vrev="1664" srcmd5="28e6671d29a161b791b6efcae3dbd892">
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="d344912fc193873262f9ca52f427bbac" size="67" mtime="1642674762"/>
-          <entry name="somefile.txt" md5="1dd365b87c2f4a86b1822749bf6bf260" size="81" mtime="1642674762"/>
+        <directory name="bar_package" rev="144" vrev="144" srcmd5="d30ac0b684cd0d754c2bb090d5f0c1f8">
+          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1643641671"/>
+          <entry name="_config" md5="e200aa7357ff29cc69269bc30f8b6573" size="48" mtime="1643641676"/>
+          <entry name="somefile.txt" md5="5764cd9dc6430097f55dd9621c38ecf5" size="61" mtime="1643641676"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:42 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:56 GMT
 - request:
     method: post
     uri: http://backend:5352/source/foo_project/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -555,18 +554,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '309'
+      - '308'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="d61d4aab647420056e08f0d2a726a49f">
+        <sourcediff key="9ccf8ec5b6a068dc988a706793b89c21">
           <old project="foo_project" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="foo_project" package="bar_package" rev="1664" srcmd5="28e6671d29a161b791b6efcae3dbd892"/>
+          <new project="foo_project" package="bar_package" rev="144" srcmd5="d30ac0b684cd0d754c2bb090d5f0c1f8"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:42 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:56 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_branch_request?user=Iggy
@@ -592,19 +591,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="557" vrev="557">
-          <srcmd5>7f374c4f83e71741ff83be95ca2b200e</srcmd5>
+        <revision rev="60" vrev="60">
+          <srcmd5>62a4d8c1d6158e0ecfaa3638fc526d37</srcmd5>
           <version>unknown</version>
-          <time>1642674762</time>
+          <time>1643641676</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:42 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:56 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -612,8 +611,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>No Highway</title>
-          <description>Non commodi id et.</description>
+          <title>What's Become of Waring</title>
+          <description>Ea quia est distinctio.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -634,15 +633,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '169'
+      - '187'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>No Highway</title>
-          <description>Non commodi id et.</description>
+          <title>What's Become of Waring</title>
+          <description>Ea quia est distinctio.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:42 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:56 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -668,21 +667,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '832'
+      - '671'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="557" vrev="557" srcmd5="7f374c4f83e71741ff83be95ca2b200e">
-          <linkinfo project="foo_project" package="bar_package" baserev="e96f2416509066dbe7aa04a8f862e091" xsrcmd5="24ff0962839340d690bc4545ff926e33" error="conflict in file _config"/>
-          <serviceinfo code="failed" xsrcmd5="a9f62807f039898323431cbb8e4fbc0d">
-            <error>service error: bad link: conflict in file _config</error>
-          </serviceinfo>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="3e8d12342854131218155ff443e64723" size="58" mtime="1642674762"/>
-          <entry name="_link" md5="028bf1aa0518e0efb16a9d5e082f6feb" size="119" mtime="1642674758"/>
-          <entry name="somefile.txt" md5="a0e656e2c26d86513e47304951520351" size="57" mtime="1642674762"/>
+        <directory name="bar_package" rev="60" vrev="60" srcmd5="62a4d8c1d6158e0ecfaa3638fc526d37">
+          <linkinfo project="foo_project" package="bar_package" baserev="11ed5f7df3c46b42eaa6bd5e17fc4232" xsrcmd5="9e1fe75efb1e5269564974c7cf8170c4" error="conflict in file _config"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="a5c3c2cb88fbd6e1cd2ded2d81d4b409" size="66" mtime="1643641676"/>
+          <entry name="_link" md5="0ed866dcf37c02d96fa6359bfc74102c" size="119" mtime="1643641670"/>
+          <entry name="somefile.txt" md5="ede1e7786e4fd9a3e0f725c9a40ab96e" size="68" mtime="1643641676"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:42 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:56 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?view=info
@@ -708,14 +704,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '179'
+      - '254'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="557" vrev="557" srcmd5="7f374c4f83e71741ff83be95ca2b200e">
-          <error>service error: bad link: conflict in file _config</error>
+        <sourceinfo package="bar_package" rev="60" vrev="204" srcmd5="62a4d8c1d6158e0ecfaa3638fc526d37" verifymd5="62a4d8c1d6158e0ecfaa3638fc526d37">
+          <error>conflict in file _config</error>
+          <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:42 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:56 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -741,21 +738,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '832'
+      - '671'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="557" vrev="557" srcmd5="7f374c4f83e71741ff83be95ca2b200e">
-          <linkinfo project="foo_project" package="bar_package" baserev="e96f2416509066dbe7aa04a8f862e091" xsrcmd5="24ff0962839340d690bc4545ff926e33" error="conflict in file _config"/>
-          <serviceinfo code="failed" xsrcmd5="a9f62807f039898323431cbb8e4fbc0d">
-            <error>service error: bad link: conflict in file _config</error>
-          </serviceinfo>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="3e8d12342854131218155ff443e64723" size="58" mtime="1642674762"/>
-          <entry name="_link" md5="028bf1aa0518e0efb16a9d5e082f6feb" size="119" mtime="1642674758"/>
-          <entry name="somefile.txt" md5="a0e656e2c26d86513e47304951520351" size="57" mtime="1642674762"/>
+        <directory name="bar_package" rev="60" vrev="60" srcmd5="62a4d8c1d6158e0ecfaa3638fc526d37">
+          <linkinfo project="foo_project" package="bar_package" baserev="11ed5f7df3c46b42eaa6bd5e17fc4232" xsrcmd5="9e1fe75efb1e5269564974c7cf8170c4" error="conflict in file _config"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="a5c3c2cb88fbd6e1cd2ded2d81d4b409" size="66" mtime="1643641676"/>
+          <entry name="_link" md5="0ed866dcf37c02d96fa6359bfc74102c" size="119" mtime="1643641670"/>
+          <entry name="somefile.txt" md5="ede1e7786e4fd9a3e0f725c9a40ab96e" size="68" mtime="1643641676"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:42 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:56 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -783,18 +777,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '370'
+      - '369'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="216bfe4c29fc896816b97e65dd345431">
+        <sourcediff key="e1eada1fd4841f2a02c782f5217d3549">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="557" srcmd5="7f374c4f83e71741ff83be95ca2b200e"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="60" srcmd5="62a4d8c1d6158e0ecfaa3638fc526d37"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:42 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:56 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -812,8 +806,8 @@ http_interactions:
       - Ruby
   response:
     status:
-      code: 400
-      message: service error  bad link  conflict in file _config
+      code: 200
+      message: OK
     headers:
       Content-Type:
       - text/xml
@@ -822,14 +816,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '101'
+      - '399'
     body:
       encoding: UTF-8
       string: |
-        <status code="400">
-          <summary>service error: bad link: conflict in file _config</summary>
-        </status>
-  recorded_at: Thu, 20 Jan 2022 10:32:42 GMT
+        <sourcediff key="55275110a63a1148737e3fac78f478d7">
+          <old project="foo_project" package="bar_package" rev="11ed5f7df3c46b42eaa6bd5e17fc4232" srcmd5="11ed5f7df3c46b42eaa6bd5e17fc4232"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="3848f152be13a5ac8112da88cf9503a8" srcmd5="3848f152be13a5ac8112da88cf9503a8"/>
+          <files/>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Mon, 31 Jan 2022 15:07:57 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_branch_request
@@ -859,5 +857,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"object_kind":null,"project":{"http_url":null},"object_attributes":{"source":{"default_branch":"123456789"}}}'
-  recorded_at: Thu, 20 Jan 2022 10:32:42 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:57 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/for_an_updated_MR_event/when_the_branched_package_already_existed/behaves_like_successful_update_event_when_the_branch_package_already_exists/1_1_2_4_1_1_4.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/for_an_updated_MR_event/when_the_branched_package_already_existed/behaves_like_successful_update_event_when_the_branch_package_already_exists/1_1_2_4_1_1_4.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:39 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:53 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_272
+    uri: http://backend:5352/source/foo_project/_meta?user=user_29
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>The Torment of Others</title>
+          <title>The Widening Gyre</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '153'
+      - '149'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>The Torment of Others</title>
+          <title>The Widening Gyre</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:39 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:53 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_273
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_30
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Time To Murder And Create</title>
-          <description>Consequatur maxime consectetur voluptas.</description>
+          <title>The House of Mirth</title>
+          <description>Suscipit cum alias dignissimos.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '175'
+      - '159'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Time To Murder And Create</title>
-          <description>Consequatur maxime consectetur voluptas.</description>
+          <title>The House of Mirth</title>
+          <description>Suscipit cum alias dignissimos.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:39 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Et et exercitationem. Veritatis unde aut. Molestiae earum repellat.
+      string: Qui dolorem doloremque. Omnis necessitatibus amet. Tempore dolor itaque.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1653" vrev="1653">
-          <srcmd5>35136c8e513da9626b7ce8533b7cc7de</srcmd5>
+        <revision rev="133" vrev="133">
+          <srcmd5>40251f2126a3280ded97dcb17bc251d9</srcmd5>
           <version>unknown</version>
-          <time>1642674759</time>
+          <time>1643641673</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:39 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Corrupti quos facere. Saepe aspernatur aperiam. Est nostrum necessitatibus.
+      string: Totam quo dolor. Corporis officiis reprehenderit. Enim aut et.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +181,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1654" vrev="1654">
-          <srcmd5>7460dbb9727433850a33ddc622f18e57</srcmd5>
+        <revision rev="134" vrev="134">
+          <srcmd5>bee1f4cfb08469308ac7d6e1eead7538</srcmd5>
           <version>unknown</version>
-          <time>1642674759</time>
+          <time>1643641673</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:39 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -201,7 +201,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Infinite Jest</title>
+          <title>No Highway</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -224,16 +224,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '176'
+      - '173'
     body:
       encoding: UTF-8
       string: |
         <project name="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Infinite Jest</title>
+          <title>No Highway</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:39 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -241,8 +241,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Time To Murder And Create</title>
-          <description>Quis exercitationem et accusamus.</description>
+          <title>O Pioneers!</title>
+          <description>Iste incidunt voluptatem quis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -263,21 +263,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '199'
+      - '182'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Time To Murder And Create</title>
-          <description>Quis exercitationem et accusamus.</description>
+          <title>O Pioneers!</title>
+          <description>Iste incidunt voluptatem quis.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:39 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_config
     body:
       encoding: UTF-8
-      string: Sit qui eos. Ducimus porro impedit. Est quisquam rerum.
+      string: Alias aspernatur pariatur. Magni consequuntur et. Est harum corrupti.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -297,25 +297,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="546" vrev="546">
-          <srcmd5>3c8ad94a424a22ec94d7f8183dfe777d</srcmd5>
+        <revision rev="49" vrev="49">
+          <srcmd5>1333f9d53c34767c9be06198f9d2fd18</srcmd5>
           <version>unknown</version>
-          <time>1642674759</time>
+          <time>1643641673</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:39 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Aut qui omnis. Debitis quae earum. Qui ut maxime.
+      string: Assumenda modi placeat. Nulla magnam consequatur. Sapiente et totam.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -335,19 +335,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="547" vrev="547">
-          <srcmd5>be3900ba1bcc4ba1f617c6a93f71018e</srcmd5>
+        <revision rev="50" vrev="50">
+          <srcmd5>39ee0eec55e50846de7fe267c80787ab</srcmd5>
           <version>unknown</version>
-          <time>1642674759</time>
+          <time>1643641673</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:39 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_branch_request?user=Iggy
@@ -373,28 +373,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '210'
+      - '208'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1655" vrev="1655">
-          <srcmd5>7460dbb9727433850a33ddc622f18e57</srcmd5>
+        <revision rev="135" vrev="135">
+          <srcmd5>bee1f4cfb08469308ac7d6e1eead7538</srcmd5>
           <version>unknown</version>
-          <time>1642674759</time>
+          <time>1643641673</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:39 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:53 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_273
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_30
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Time To Murder And Create</title>
-          <description>Consequatur maxime consectetur voluptas.</description>
+          <title>The House of Mirth</title>
+          <description>Suscipit cum alias dignissimos.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -415,15 +415,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '175'
+      - '159'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Time To Murder And Create</title>
-          <description>Consequatur maxime consectetur voluptas.</description>
+          <title>The House of Mirth</title>
+          <description>Suscipit cum alias dignissimos.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:39 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:53 GMT
 - request:
     method: get
     uri: http://backend:5352/source/foo_project/bar_package
@@ -449,16 +449,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '405'
+      - '403'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="1655" vrev="1655" srcmd5="7460dbb9727433850a33ddc622f18e57">
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="51a83c164220878685500d1e0fae8893" size="67" mtime="1642674759"/>
-          <entry name="somefile.txt" md5="7f3c18a15891dfa6ed9adb6eece005cd" size="75" mtime="1642674759"/>
+        <directory name="bar_package" rev="135" vrev="135" srcmd5="bee1f4cfb08469308ac7d6e1eead7538">
+          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1643641671"/>
+          <entry name="_config" md5="ef37fcfd846dfa6ce3f353441b4fd72a" size="72" mtime="1643641673"/>
+          <entry name="somefile.txt" md5="d3c10f73b367f20e82bdd38d9355d688" size="62" mtime="1643641673"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:39 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:53 GMT
 - request:
     method: get
     uri: http://backend:5352/source/foo_project/bar_package?view=info
@@ -484,14 +484,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '235'
+      - '233'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="1655" vrev="1655" srcmd5="7460dbb9727433850a33ddc622f18e57" verifymd5="7460dbb9727433850a33ddc622f18e57">
+        <sourceinfo package="bar_package" rev="135" vrev="135" srcmd5="bee1f4cfb08469308ac7d6e1eead7538" verifymd5="bee1f4cfb08469308ac7d6e1eead7538">
           <error>bad build configuration, no build type defined or detected</error>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:39 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:53 GMT
 - request:
     method: get
     uri: http://backend:5352/source/foo_project/bar_package
@@ -517,16 +517,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '405'
+      - '403'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="1655" vrev="1655" srcmd5="7460dbb9727433850a33ddc622f18e57">
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="51a83c164220878685500d1e0fae8893" size="67" mtime="1642674759"/>
-          <entry name="somefile.txt" md5="7f3c18a15891dfa6ed9adb6eece005cd" size="75" mtime="1642674759"/>
+        <directory name="bar_package" rev="135" vrev="135" srcmd5="bee1f4cfb08469308ac7d6e1eead7538">
+          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1643641671"/>
+          <entry name="_config" md5="ef37fcfd846dfa6ce3f353441b4fd72a" size="72" mtime="1643641673"/>
+          <entry name="somefile.txt" md5="d3c10f73b367f20e82bdd38d9355d688" size="62" mtime="1643641673"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:39 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:53 GMT
 - request:
     method: post
     uri: http://backend:5352/source/foo_project/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -554,18 +554,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '309'
+      - '308'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="ec0bb33c5f136e278ec6af47e8d5c86d">
+        <sourcediff key="bf93c423597a378cbd3dfeb000319678">
           <old project="foo_project" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="foo_project" package="bar_package" rev="1655" srcmd5="7460dbb9727433850a33ddc622f18e57"/>
+          <new project="foo_project" package="bar_package" rev="135" srcmd5="bee1f4cfb08469308ac7d6e1eead7538"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:39 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_branch_request?user=Iggy
@@ -591,19 +591,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="548" vrev="548">
-          <srcmd5>fce7208d37c82bf8adcf076dd608383d</srcmd5>
+        <revision rev="51" vrev="51">
+          <srcmd5>39ee0eec55e50846de7fe267c80787ab</srcmd5>
           <version>unknown</version>
-          <time>1642674760</time>
+          <time>1643641673</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:40 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:54 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -611,8 +611,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Time To Murder And Create</title>
-          <description>Quis exercitationem et accusamus.</description>
+          <title>O Pioneers!</title>
+          <description>Iste incidunt voluptatem quis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -633,15 +633,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '199'
+      - '182'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Time To Murder And Create</title>
-          <description>Quis exercitationem et accusamus.</description>
+          <title>O Pioneers!</title>
+          <description>Iste incidunt voluptatem quis.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:40 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:54 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -667,21 +667,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '832'
+      - '671'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="548" vrev="548" srcmd5="fce7208d37c82bf8adcf076dd608383d">
-          <linkinfo project="foo_project" package="bar_package" baserev="e96f2416509066dbe7aa04a8f862e091" xsrcmd5="36eac65a114663a8a06362ea5d8fe6c3" error="conflict in file _config"/>
-          <serviceinfo code="failed" xsrcmd5="544eb0cda9f23ba31f4ed0da7d5c9f9e">
-            <error>service error: bad link: conflict in file _config</error>
-          </serviceinfo>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="2c826325c5e9a04edd473400d33c5e25" size="55" mtime="1642674759"/>
-          <entry name="_link" md5="028bf1aa0518e0efb16a9d5e082f6feb" size="119" mtime="1642674758"/>
-          <entry name="somefile.txt" md5="cf8cd8c784187860b86a49e9c08dc716" size="49" mtime="1642674759"/>
+        <directory name="bar_package" rev="51" vrev="51" srcmd5="39ee0eec55e50846de7fe267c80787ab">
+          <linkinfo project="foo_project" package="bar_package" baserev="11ed5f7df3c46b42eaa6bd5e17fc4232" xsrcmd5="1b8ea192ac0a80195413c26bef8eee6b" error="conflict in file _config"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="90aa128a2027214b580e2a04bf14e98f" size="69" mtime="1643641673"/>
+          <entry name="_link" md5="0ed866dcf37c02d96fa6359bfc74102c" size="119" mtime="1643641670"/>
+          <entry name="somefile.txt" md5="cb55536663fd6d5ba0d1b88bc5bd821c" size="68" mtime="1643641673"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:40 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:54 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?view=info
@@ -707,14 +704,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '179'
+      - '254'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="548" vrev="548" srcmd5="fce7208d37c82bf8adcf076dd608383d">
-          <error>service error: bad link: conflict in file _config</error>
+        <sourceinfo package="bar_package" rev="51" vrev="186" srcmd5="39ee0eec55e50846de7fe267c80787ab" verifymd5="39ee0eec55e50846de7fe267c80787ab">
+          <error>conflict in file _config</error>
+          <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:40 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:54 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -740,21 +738,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '832'
+      - '671'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="548" vrev="548" srcmd5="fce7208d37c82bf8adcf076dd608383d">
-          <linkinfo project="foo_project" package="bar_package" baserev="e96f2416509066dbe7aa04a8f862e091" xsrcmd5="36eac65a114663a8a06362ea5d8fe6c3" error="conflict in file _config"/>
-          <serviceinfo code="failed" xsrcmd5="544eb0cda9f23ba31f4ed0da7d5c9f9e">
-            <error>service error: bad link: conflict in file _config</error>
-          </serviceinfo>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="2c826325c5e9a04edd473400d33c5e25" size="55" mtime="1642674759"/>
-          <entry name="_link" md5="028bf1aa0518e0efb16a9d5e082f6feb" size="119" mtime="1642674758"/>
-          <entry name="somefile.txt" md5="cf8cd8c784187860b86a49e9c08dc716" size="49" mtime="1642674759"/>
+        <directory name="bar_package" rev="51" vrev="51" srcmd5="39ee0eec55e50846de7fe267c80787ab">
+          <linkinfo project="foo_project" package="bar_package" baserev="11ed5f7df3c46b42eaa6bd5e17fc4232" xsrcmd5="1b8ea192ac0a80195413c26bef8eee6b" error="conflict in file _config"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="90aa128a2027214b580e2a04bf14e98f" size="69" mtime="1643641673"/>
+          <entry name="_link" md5="0ed866dcf37c02d96fa6359bfc74102c" size="119" mtime="1643641670"/>
+          <entry name="somefile.txt" md5="cb55536663fd6d5ba0d1b88bc5bd821c" size="68" mtime="1643641673"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:40 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:54 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -782,18 +777,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '370'
+      - '369'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="13c4095053f919461b71091c354e32d3">
+        <sourcediff key="012879eb9330aca59f561faef70df4d4">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="548" srcmd5="fce7208d37c82bf8adcf076dd608383d"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="51" srcmd5="39ee0eec55e50846de7fe267c80787ab"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:40 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:54 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -811,8 +806,8 @@ http_interactions:
       - Ruby
   response:
     status:
-      code: 400
-      message: service error  bad link  conflict in file _config
+      code: 200
+      message: OK
     headers:
       Content-Type:
       - text/xml
@@ -821,12 +816,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '101'
+      - '399'
     body:
       encoding: UTF-8
       string: |
-        <status code="400">
-          <summary>service error: bad link: conflict in file _config</summary>
-        </status>
-  recorded_at: Thu, 20 Jan 2022 10:32:40 GMT
+        <sourcediff key="41be996d3bf2669c7c6196142d5328ec">
+          <old project="foo_project" package="bar_package" rev="11ed5f7df3c46b42eaa6bd5e17fc4232" srcmd5="11ed5f7df3c46b42eaa6bd5e17fc4232"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="5aee6a58d5706b2a1b2cf6c94865c1f7" srcmd5="5aee6a58d5706b2a1b2cf6c94865c1f7"/>
+          <files/>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Mon, 31 Jan 2022 15:07:54 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/for_an_updated_MR_event/when_the_branched_package_already_existed/behaves_like_successful_update_event_when_the_branch_package_already_exists/1_1_2_4_1_1_5.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/for_an_updated_MR_event/when_the_branched_package_already_existed/behaves_like_successful_update_event_when_the_branch_package_already_exists/1_1_2_4_1_1_5.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:41 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:54 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_276
+    uri: http://backend:5352/source/foo_project/_meta?user=user_31
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Paths of Glory</title>
+          <title>A Catskill Eagle</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '146'
+      - '148'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Paths of Glory</title>
+          <title>A Catskill Eagle</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:41 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:54 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_277
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_32
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Stars' Tennis Balls</title>
-          <description>Iure natus asperiores sint.</description>
+          <title>A Confederacy of Dunces</title>
+          <description>Est ad omnis velit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '160'
+      - '152'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Stars' Tennis Balls</title>
-          <description>Iure natus asperiores sint.</description>
+          <title>A Confederacy of Dunces</title>
+          <description>Est ad omnis velit.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:41 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:54 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Voluptatem molestiae aut. Voluptate enim atque. Ex quibusdam praesentium.
+      string: Quas incidunt voluptas. Ea possimus dolorem. Dolores consequatur ipsa.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1659" vrev="1659">
-          <srcmd5>a4488481fccb69cc83a0cff749337033</srcmd5>
+        <revision rev="136" vrev="136">
+          <srcmd5>59aa2f7d33499fb4d6a8b1be99133f43</srcmd5>
           <version>unknown</version>
-          <time>1642674761</time>
+          <time>1643641674</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:41 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:54 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Commodi sit harum. Consequatur alias eos. Deleniti voluptas officia.
+      string: Corrupti illo quia. Fugit odio sit. Adipisci rerum nihil.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +181,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1660" vrev="1660">
-          <srcmd5>5549437ff51e5b3a47cd59a5cdfa268d</srcmd5>
+        <revision rev="137" vrev="137">
+          <srcmd5>18fed45628c0a070977f14109347e1f3</srcmd5>
           <version>unknown</version>
-          <time>1642674761</time>
+          <time>1643641674</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:41 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:54 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -201,7 +201,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Violent Bear It Away</title>
+          <title>Fame Is the Spur</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -224,16 +224,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '187'
+      - '179'
     body:
       encoding: UTF-8
       string: |
         <project name="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Violent Bear It Away</title>
+          <title>Fame Is the Spur</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:41 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:54 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -241,8 +241,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Precious Bane</title>
-          <description>Voluptates rerum fuga quisquam.</description>
+          <title>Behold the Man</title>
+          <description>A sit commodi dolore.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -263,21 +263,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '185'
+      - '176'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Precious Bane</title>
-          <description>Voluptates rerum fuga quisquam.</description>
+          <title>Behold the Man</title>
+          <description>A sit commodi dolore.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:41 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:54 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_config
     body:
       encoding: UTF-8
-      string: Id nihil a. Exercitationem animi beatae. Occaecati sequi corrupti.
+      string: Omnis soluta nihil. Corporis rerum ipsam. Et necessitatibus voluptas.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -297,25 +297,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="552" vrev="552">
-          <srcmd5>d5270f779765a8f98bf5f7317a28453c</srcmd5>
+        <revision rev="52" vrev="52">
+          <srcmd5>3c5d84d978141bc208756fd4a22af714</srcmd5>
           <version>unknown</version>
-          <time>1642674761</time>
+          <time>1643641674</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:41 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:54 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Eos aut qui. Id velit ut. Sint ipsam iusto.
+      string: Fugiat dolorem iure. Et perspiciatis est. Sequi dolorem in.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -335,19 +335,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="553" vrev="553">
-          <srcmd5>84be84170c4996d027ba861b16948434</srcmd5>
+        <revision rev="53" vrev="53">
+          <srcmd5>5c10046133b211b4c2b50e7f0ff99eab</srcmd5>
           <version>unknown</version>
-          <time>1642674761</time>
+          <time>1643641674</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:41 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:54 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_branch_request?user=Iggy
@@ -373,28 +373,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '210'
+      - '208'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1661" vrev="1661">
-          <srcmd5>5549437ff51e5b3a47cd59a5cdfa268d</srcmd5>
+        <revision rev="138" vrev="138">
+          <srcmd5>18fed45628c0a070977f14109347e1f3</srcmd5>
           <version>unknown</version>
-          <time>1642674761</time>
+          <time>1643641674</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:41 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:54 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_277
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_32
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Stars' Tennis Balls</title>
-          <description>Iure natus asperiores sint.</description>
+          <title>A Confederacy of Dunces</title>
+          <description>Est ad omnis velit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -415,15 +415,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '160'
+      - '152'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Stars' Tennis Balls</title>
-          <description>Iure natus asperiores sint.</description>
+          <title>A Confederacy of Dunces</title>
+          <description>Est ad omnis velit.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:41 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:54 GMT
 - request:
     method: get
     uri: http://backend:5352/source/foo_project/bar_package
@@ -449,16 +449,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '405'
+      - '403'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="1661" vrev="1661" srcmd5="5549437ff51e5b3a47cd59a5cdfa268d">
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="ba8eaf8d0783a7b6f347c60f8e0b50ba" size="73" mtime="1642674761"/>
-          <entry name="somefile.txt" md5="f325e7e66bd0716c0fa49ed01db0e5a3" size="68" mtime="1642674761"/>
+        <directory name="bar_package" rev="138" vrev="138" srcmd5="18fed45628c0a070977f14109347e1f3">
+          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1643641671"/>
+          <entry name="_config" md5="098cc080266615fefc85fd7f9e14bfc1" size="70" mtime="1643641674"/>
+          <entry name="somefile.txt" md5="7399f1ce7798a27f96122dd7558d94e9" size="57" mtime="1643641674"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:41 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:54 GMT
 - request:
     method: get
     uri: http://backend:5352/source/foo_project/bar_package?view=info
@@ -484,14 +484,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '235'
+      - '233'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="1661" vrev="1661" srcmd5="5549437ff51e5b3a47cd59a5cdfa268d" verifymd5="5549437ff51e5b3a47cd59a5cdfa268d">
+        <sourceinfo package="bar_package" rev="138" vrev="138" srcmd5="18fed45628c0a070977f14109347e1f3" verifymd5="18fed45628c0a070977f14109347e1f3">
           <error>bad build configuration, no build type defined or detected</error>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:41 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:54 GMT
 - request:
     method: get
     uri: http://backend:5352/source/foo_project/bar_package
@@ -517,16 +517,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '405'
+      - '403'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="1661" vrev="1661" srcmd5="5549437ff51e5b3a47cd59a5cdfa268d">
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="ba8eaf8d0783a7b6f347c60f8e0b50ba" size="73" mtime="1642674761"/>
-          <entry name="somefile.txt" md5="f325e7e66bd0716c0fa49ed01db0e5a3" size="68" mtime="1642674761"/>
+        <directory name="bar_package" rev="138" vrev="138" srcmd5="18fed45628c0a070977f14109347e1f3">
+          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1643641671"/>
+          <entry name="_config" md5="098cc080266615fefc85fd7f9e14bfc1" size="70" mtime="1643641674"/>
+          <entry name="somefile.txt" md5="7399f1ce7798a27f96122dd7558d94e9" size="57" mtime="1643641674"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:41 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:54 GMT
 - request:
     method: post
     uri: http://backend:5352/source/foo_project/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -554,18 +554,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '309'
+      - '308'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="11478b929f270233869995deee467693">
+        <sourcediff key="aa5cb4a485c0b2a6acf266386c1ae7e7">
           <old project="foo_project" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="foo_project" package="bar_package" rev="1661" srcmd5="5549437ff51e5b3a47cd59a5cdfa268d"/>
+          <new project="foo_project" package="bar_package" rev="138" srcmd5="18fed45628c0a070977f14109347e1f3"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:41 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:54 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_branch_request?user=Iggy
@@ -591,19 +591,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="554" vrev="554">
-          <srcmd5>606964a68ea7203548b5101247d972b9</srcmd5>
+        <revision rev="54" vrev="54">
+          <srcmd5>5c10046133b211b4c2b50e7f0ff99eab</srcmd5>
           <version>unknown</version>
-          <time>1642674761</time>
+          <time>1643641674</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:41 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:54 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -611,8 +611,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Precious Bane</title>
-          <description>Voluptates rerum fuga quisquam.</description>
+          <title>Behold the Man</title>
+          <description>A sit commodi dolore.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -633,15 +633,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '185'
+      - '176'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Precious Bane</title>
-          <description>Voluptates rerum fuga quisquam.</description>
+          <title>Behold the Man</title>
+          <description>A sit commodi dolore.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:41 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:54 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -667,21 +667,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '832'
+      - '671'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="554" vrev="554" srcmd5="606964a68ea7203548b5101247d972b9">
-          <linkinfo project="foo_project" package="bar_package" baserev="e96f2416509066dbe7aa04a8f862e091" xsrcmd5="14f6a9facf00cb83495ac6cee5f15f55" error="conflict in file _config"/>
-          <serviceinfo code="failed" xsrcmd5="4adb1616aa2e44c6e5d5d0fb32bc4af6">
-            <error>service error: bad link: conflict in file _config</error>
-          </serviceinfo>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="163daa31cf6f144cf6626e377853380e" size="66" mtime="1642674761"/>
-          <entry name="_link" md5="028bf1aa0518e0efb16a9d5e082f6feb" size="119" mtime="1642674758"/>
-          <entry name="somefile.txt" md5="4b42b4a8ce329f7fef170824eebaa4a4" size="43" mtime="1642674761"/>
+        <directory name="bar_package" rev="54" vrev="54" srcmd5="5c10046133b211b4c2b50e7f0ff99eab">
+          <linkinfo project="foo_project" package="bar_package" baserev="11ed5f7df3c46b42eaa6bd5e17fc4232" xsrcmd5="509b10d513c4e9d64e83c143f287230a" error="conflict in file _config"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="6a0d7d217a494df08f17536b23b785fd" size="69" mtime="1643641674"/>
+          <entry name="_link" md5="0ed866dcf37c02d96fa6359bfc74102c" size="119" mtime="1643641670"/>
+          <entry name="somefile.txt" md5="499f7d1444405d3a7b2571120a8749ce" size="59" mtime="1643641674"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:41 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:54 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?view=info
@@ -707,14 +704,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '179'
+      - '254'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="554" vrev="554" srcmd5="606964a68ea7203548b5101247d972b9">
-          <error>service error: bad link: conflict in file _config</error>
+        <sourceinfo package="bar_package" rev="54" vrev="192" srcmd5="5c10046133b211b4c2b50e7f0ff99eab" verifymd5="5c10046133b211b4c2b50e7f0ff99eab">
+          <error>conflict in file _config</error>
+          <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:41 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:54 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -740,21 +738,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '832'
+      - '671'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="554" vrev="554" srcmd5="606964a68ea7203548b5101247d972b9">
-          <linkinfo project="foo_project" package="bar_package" baserev="e96f2416509066dbe7aa04a8f862e091" xsrcmd5="14f6a9facf00cb83495ac6cee5f15f55" error="conflict in file _config"/>
-          <serviceinfo code="failed" xsrcmd5="4adb1616aa2e44c6e5d5d0fb32bc4af6">
-            <error>service error: bad link: conflict in file _config</error>
-          </serviceinfo>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="163daa31cf6f144cf6626e377853380e" size="66" mtime="1642674761"/>
-          <entry name="_link" md5="028bf1aa0518e0efb16a9d5e082f6feb" size="119" mtime="1642674758"/>
-          <entry name="somefile.txt" md5="4b42b4a8ce329f7fef170824eebaa4a4" size="43" mtime="1642674761"/>
+        <directory name="bar_package" rev="54" vrev="54" srcmd5="5c10046133b211b4c2b50e7f0ff99eab">
+          <linkinfo project="foo_project" package="bar_package" baserev="11ed5f7df3c46b42eaa6bd5e17fc4232" xsrcmd5="509b10d513c4e9d64e83c143f287230a" error="conflict in file _config"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="6a0d7d217a494df08f17536b23b785fd" size="69" mtime="1643641674"/>
+          <entry name="_link" md5="0ed866dcf37c02d96fa6359bfc74102c" size="119" mtime="1643641670"/>
+          <entry name="somefile.txt" md5="499f7d1444405d3a7b2571120a8749ce" size="59" mtime="1643641674"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:41 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:54 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -782,18 +777,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '370'
+      - '369'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="d36b5d475fe23b417f67cdeecd8d50be">
+        <sourcediff key="0217d0013f7a4cba4a2e3643f10cd27a">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="554" srcmd5="606964a68ea7203548b5101247d972b9"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="54" srcmd5="5c10046133b211b4c2b50e7f0ff99eab"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:41 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:55 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -811,8 +806,8 @@ http_interactions:
       - Ruby
   response:
     status:
-      code: 400
-      message: service error  bad link  conflict in file _config
+      code: 200
+      message: OK
     headers:
       Content-Type:
       - text/xml
@@ -821,12 +816,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '101'
+      - '399'
     body:
       encoding: UTF-8
       string: |
-        <status code="400">
-          <summary>service error: bad link: conflict in file _config</summary>
-        </status>
-  recorded_at: Thu, 20 Jan 2022 10:32:41 GMT
+        <sourcediff key="1cacf18c25a7e45e4732ce5f712a343a">
+          <old project="foo_project" package="bar_package" rev="11ed5f7df3c46b42eaa6bd5e17fc4232" srcmd5="11ed5f7df3c46b42eaa6bd5e17fc4232"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="a16134700df2224c12ec0ff3fdf57837" srcmd5="a16134700df2224c12ec0ff3fdf57837"/>
+          <files/>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Mon, 31 Jan 2022 15:07:55 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/for_an_updated_MR_event/when_the_branched_package_already_existed/behaves_like_successful_update_event_when_the_branch_package_already_exists/1_1_2_4_1_1_6.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/for_an_updated_MR_event/when_the_branched_package_already_existed/behaves_like_successful_update_event_when_the_branch_package_already_exists/1_1_2_4_1_1_6.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:43 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:51 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_282
+    uri: http://backend:5352/source/foo_project/_meta?user=user_25
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>If Not Now, When?</title>
+          <title>Eyeless in Gaza</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '149'
+      - '147'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>If Not Now, When?</title>
+          <title>Eyeless in Gaza</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:44 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:51 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_283
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_26
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>O Pioneers!</title>
-          <description>Voluptatem ab id eum.</description>
+          <title>Recalled to Life</title>
+          <description>Voluptatem est similique odit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '142'
+      - '156'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>O Pioneers!</title>
-          <description>Voluptatem ab id eum.</description>
+          <title>Recalled to Life</title>
+          <description>Voluptatem est similique odit.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:44 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:51 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Animi facere sint. Quia quaerat totam. Ab minima doloremque.
+      string: Ut neque non. A laudantium dolores. Quos in et.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1668" vrev="1668">
-          <srcmd5>8eddc3f9818de65d8d52b2cedcd212f7</srcmd5>
+        <revision rev="127" vrev="127">
+          <srcmd5>f88a71dfe0fbf699dd8d5e8cd774417f</srcmd5>
           <version>unknown</version>
-          <time>1642674764</time>
+          <time>1643641671</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:44 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:51 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Sed eligendi cum. Numquam sunt ut. Quasi impedit perferendis.
+      string: Enim rerum atque. Eius quia doloribus. Ipsum inventore occaecati.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +181,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1669" vrev="1669">
-          <srcmd5>c63109951e2571e83b2e1d87ddefdf80</srcmd5>
+        <revision rev="128" vrev="128">
+          <srcmd5>4dd1cc489eb55145872479a1d6f06c0a</srcmd5>
           <version>unknown</version>
-          <time>1642674764</time>
+          <time>1643641671</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:44 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:51 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -201,7 +201,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Taming a Sea Horse</title>
+          <title>Endless Night</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -224,16 +224,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '181'
+      - '176'
     body:
       encoding: UTF-8
       string: |
         <project name="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Taming a Sea Horse</title>
+          <title>Endless Night</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:44 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:51 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -241,8 +241,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Last Enemy</title>
-          <description>Voluptatem architecto sunt aut.</description>
+          <title>The Wind's Twelve Quarters</title>
+          <description>Sit assumenda numquam quo.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -263,21 +263,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '186'
+      - '193'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Last Enemy</title>
-          <description>Voluptatem architecto sunt aut.</description>
+          <title>The Wind's Twelve Quarters</title>
+          <description>Sit assumenda numquam quo.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:44 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:51 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_config
     body:
       encoding: UTF-8
-      string: Iure dolores qui. Quisquam saepe ullam. Aut ipsam error.
+      string: Numquam eos magnam. Et fugit quia. Cumque dolor est.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -297,25 +297,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="561" vrev="561">
-          <srcmd5>cd80c97cfa8fe9efb6ea9b6f6f509656</srcmd5>
+        <revision rev="43" vrev="43">
+          <srcmd5>97fee4dcb947f6c923e9cede6342dc8f</srcmd5>
           <version>unknown</version>
-          <time>1642674764</time>
+          <time>1643641671</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:44 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:51 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Sit natus qui. Vitae autem eius. Aut sunt odit.
+      string: Quo omnis vero. Sit est corrupti. Soluta placeat possimus.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -335,19 +335,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="562" vrev="562">
-          <srcmd5>69a045cc3654ff9e0e523538818d4ac3</srcmd5>
+        <revision rev="44" vrev="44">
+          <srcmd5>c2c1ee846c27e5c8765ec74235a8edde</srcmd5>
           <version>unknown</version>
-          <time>1642674764</time>
+          <time>1643641671</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:44 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:51 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_branch_request?user=Iggy
@@ -373,28 +373,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '210'
+      - '208'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1670" vrev="1670">
-          <srcmd5>c63109951e2571e83b2e1d87ddefdf80</srcmd5>
+        <revision rev="129" vrev="129">
+          <srcmd5>3fc44fc077d4056e5cf33559adb73220</srcmd5>
           <version>unknown</version>
-          <time>1642674764</time>
+          <time>1643641671</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:44 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:51 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_283
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_26
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>O Pioneers!</title>
-          <description>Voluptatem ab id eum.</description>
+          <title>Recalled to Life</title>
+          <description>Voluptatem est similique odit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -415,15 +415,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '142'
+      - '156'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>O Pioneers!</title>
-          <description>Voluptatem ab id eum.</description>
+          <title>Recalled to Life</title>
+          <description>Voluptatem est similique odit.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:44 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:51 GMT
 - request:
     method: get
     uri: http://backend:5352/source/foo_project/bar_package
@@ -449,16 +449,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '405'
+      - '403'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="1670" vrev="1670" srcmd5="c63109951e2571e83b2e1d87ddefdf80">
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="ac2ced0a4dbea937fe7958d40b9c73b4" size="60" mtime="1642674764"/>
-          <entry name="somefile.txt" md5="743b60aca1735686e4678406e49bc026" size="61" mtime="1642674764"/>
+        <directory name="bar_package" rev="129" vrev="129" srcmd5="3fc44fc077d4056e5cf33559adb73220">
+          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1643641671"/>
+          <entry name="_config" md5="6ec4735d41401b367085424bd04790b8" size="47" mtime="1643641671"/>
+          <entry name="somefile.txt" md5="c5dbec6d3cc39caf173b654d366984e3" size="65" mtime="1643641671"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:44 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:51 GMT
 - request:
     method: get
     uri: http://backend:5352/source/foo_project/bar_package?view=info
@@ -484,14 +484,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '235'
+      - '233'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="1670" vrev="1670" srcmd5="c63109951e2571e83b2e1d87ddefdf80" verifymd5="c63109951e2571e83b2e1d87ddefdf80">
+        <sourceinfo package="bar_package" rev="129" vrev="129" srcmd5="3fc44fc077d4056e5cf33559adb73220" verifymd5="3fc44fc077d4056e5cf33559adb73220">
           <error>bad build configuration, no build type defined or detected</error>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:44 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:51 GMT
 - request:
     method: get
     uri: http://backend:5352/source/foo_project/bar_package
@@ -517,16 +517,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '405'
+      - '403'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="1670" vrev="1670" srcmd5="c63109951e2571e83b2e1d87ddefdf80">
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="ac2ced0a4dbea937fe7958d40b9c73b4" size="60" mtime="1642674764"/>
-          <entry name="somefile.txt" md5="743b60aca1735686e4678406e49bc026" size="61" mtime="1642674764"/>
+        <directory name="bar_package" rev="129" vrev="129" srcmd5="3fc44fc077d4056e5cf33559adb73220">
+          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1643641671"/>
+          <entry name="_config" md5="6ec4735d41401b367085424bd04790b8" size="47" mtime="1643641671"/>
+          <entry name="somefile.txt" md5="c5dbec6d3cc39caf173b654d366984e3" size="65" mtime="1643641671"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:44 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:51 GMT
 - request:
     method: post
     uri: http://backend:5352/source/foo_project/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -554,18 +554,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '309'
+      - '308'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="b1c9444e42951aa494884e9fe1e26898">
+        <sourcediff key="e4029d855dc6f0695f69296986055f38">
           <old project="foo_project" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="foo_project" package="bar_package" rev="1670" srcmd5="c63109951e2571e83b2e1d87ddefdf80"/>
+          <new project="foo_project" package="bar_package" rev="129" srcmd5="3fc44fc077d4056e5cf33559adb73220"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:44 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:51 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_branch_request?user=Iggy
@@ -591,19 +591,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="563" vrev="563">
-          <srcmd5>0ef4a4a0c7b3cb2e1fe8e13a747a51b2</srcmd5>
+        <revision rev="45" vrev="45">
+          <srcmd5>c2c1ee846c27e5c8765ec74235a8edde</srcmd5>
           <version>unknown</version>
-          <time>1642674764</time>
+          <time>1643641671</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:44 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:51 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -611,8 +611,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Last Enemy</title>
-          <description>Voluptatem architecto sunt aut.</description>
+          <title>The Wind's Twelve Quarters</title>
+          <description>Sit assumenda numquam quo.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -633,15 +633,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '186'
+      - '193'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Last Enemy</title>
-          <description>Voluptatem architecto sunt aut.</description>
+          <title>The Wind's Twelve Quarters</title>
+          <description>Sit assumenda numquam quo.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:44 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:51 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -667,21 +667,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '832'
+      - '671'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="563" vrev="563" srcmd5="0ef4a4a0c7b3cb2e1fe8e13a747a51b2">
-          <linkinfo project="foo_project" package="bar_package" baserev="e96f2416509066dbe7aa04a8f862e091" xsrcmd5="f2d3854b9bfde0895a383171217bf9f4" error="conflict in file _config"/>
-          <serviceinfo code="failed" xsrcmd5="9d995051921c60b9571ad729699f78cc">
-            <error>service error: bad link: conflict in file _config</error>
-          </serviceinfo>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="42149c5f767c84b29ae0ccbf65028bd2" size="56" mtime="1642674764"/>
-          <entry name="_link" md5="028bf1aa0518e0efb16a9d5e082f6feb" size="119" mtime="1642674758"/>
-          <entry name="somefile.txt" md5="d70ea7b5fee61da2dac3fdc3b3b45d72" size="47" mtime="1642674764"/>
+        <directory name="bar_package" rev="45" vrev="45" srcmd5="c2c1ee846c27e5c8765ec74235a8edde">
+          <linkinfo project="foo_project" package="bar_package" baserev="11ed5f7df3c46b42eaa6bd5e17fc4232" xsrcmd5="5fb55a80fa60b0d43d896b0c1ab9971d" error="conflict in file _config"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="b66e9cdcc7ef5af872b17867391158b7" size="52" mtime="1643641671"/>
+          <entry name="_link" md5="0ed866dcf37c02d96fa6359bfc74102c" size="119" mtime="1643641670"/>
+          <entry name="somefile.txt" md5="bfef4df835f9ed28f930b3609eed4cf2" size="58" mtime="1643641671"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:44 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:51 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?view=info
@@ -707,14 +704,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '179'
+      - '254'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="563" vrev="563" srcmd5="0ef4a4a0c7b3cb2e1fe8e13a747a51b2">
-          <error>service error: bad link: conflict in file _config</error>
+        <sourceinfo package="bar_package" rev="45" vrev="174" srcmd5="c2c1ee846c27e5c8765ec74235a8edde" verifymd5="c2c1ee846c27e5c8765ec74235a8edde">
+          <error>conflict in file _config</error>
+          <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:44 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:52 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -740,21 +738,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '832'
+      - '671'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="563" vrev="563" srcmd5="0ef4a4a0c7b3cb2e1fe8e13a747a51b2">
-          <linkinfo project="foo_project" package="bar_package" baserev="e96f2416509066dbe7aa04a8f862e091" xsrcmd5="f2d3854b9bfde0895a383171217bf9f4" error="conflict in file _config"/>
-          <serviceinfo code="failed" xsrcmd5="9d995051921c60b9571ad729699f78cc">
-            <error>service error: bad link: conflict in file _config</error>
-          </serviceinfo>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="42149c5f767c84b29ae0ccbf65028bd2" size="56" mtime="1642674764"/>
-          <entry name="_link" md5="028bf1aa0518e0efb16a9d5e082f6feb" size="119" mtime="1642674758"/>
-          <entry name="somefile.txt" md5="d70ea7b5fee61da2dac3fdc3b3b45d72" size="47" mtime="1642674764"/>
+        <directory name="bar_package" rev="45" vrev="45" srcmd5="c2c1ee846c27e5c8765ec74235a8edde">
+          <linkinfo project="foo_project" package="bar_package" baserev="11ed5f7df3c46b42eaa6bd5e17fc4232" xsrcmd5="5fb55a80fa60b0d43d896b0c1ab9971d" error="conflict in file _config"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="b66e9cdcc7ef5af872b17867391158b7" size="52" mtime="1643641671"/>
+          <entry name="_link" md5="0ed866dcf37c02d96fa6359bfc74102c" size="119" mtime="1643641670"/>
+          <entry name="somefile.txt" md5="bfef4df835f9ed28f930b3609eed4cf2" size="58" mtime="1643641671"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:44 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:52 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -782,18 +777,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '370'
+      - '369'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="f0dd476b253fb5539efc3cc4808931e9">
+        <sourcediff key="b924b5aab89543694620a01de6b2d9a7">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="563" srcmd5="0ef4a4a0c7b3cb2e1fe8e13a747a51b2"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="45" srcmd5="c2c1ee846c27e5c8765ec74235a8edde"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:44 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:52 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -811,8 +806,8 @@ http_interactions:
       - Ruby
   response:
     status:
-      code: 400
-      message: service error  bad link  conflict in file _config
+      code: 200
+      message: OK
     headers:
       Content-Type:
       - text/xml
@@ -821,12 +816,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '101'
+      - '399'
     body:
       encoding: UTF-8
       string: |
-        <status code="400">
-          <summary>service error: bad link: conflict in file _config</summary>
-        </status>
-  recorded_at: Thu, 20 Jan 2022 10:32:44 GMT
+        <sourcediff key="535b080bc867bcc731b0adab9e9f17dd">
+          <old project="foo_project" package="bar_package" rev="11ed5f7df3c46b42eaa6bd5e17fc4232" srcmd5="11ed5f7df3c46b42eaa6bd5e17fc4232"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="d3992d6b01a974d2bb66a150f90afddd" srcmd5="d3992d6b01a974d2bb66a150f90afddd"/>
+          <files/>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Mon, 31 Jan 2022 15:07:52 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/for_an_updated_MR_event/when_the_branched_package_already_existed/behaves_like_successful_update_event_when_the_branch_package_already_exists/updates__branch_request_file_including_new_commit_sha.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/for_an_updated_MR_event/when_the_branched_package_already_existed/behaves_like_successful_update_event_when_the_branch_package_already_exists/updates__branch_request_file_including_new_commit_sha.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:43 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:52 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_280
+    uri: http://backend:5352/source/foo_project/_meta?user=user_27
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Things Fall Apart</title>
+          <title>Everything is Illuminated</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '149'
+      - '157'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Things Fall Apart</title>
+          <title>Everything is Illuminated</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:43 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:52 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_281
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_28
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Antic Hay</title>
-          <description>Assumenda inventore hic voluptatem.</description>
+          <title>I Know Why the Caged Bird Sings</title>
+          <description>Et provident excepturi ea.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '154'
+      - '167'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Antic Hay</title>
-          <description>Assumenda inventore hic voluptatem.</description>
+          <title>I Know Why the Caged Bird Sings</title>
+          <description>Et provident excepturi ea.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:43 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:52 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Suscipit debitis labore. Quas voluptas ad. Deserunt distinctio soluta.
+      string: Natus odio repellat. Dolores veritatis est. Aut natus iure.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1665" vrev="1665">
-          <srcmd5>ee0f963339e1084d60f1f5865719760d</srcmd5>
+        <revision rev="130" vrev="130">
+          <srcmd5>596b2d99573b03cb804b44de0e1c3565</srcmd5>
           <version>unknown</version>
-          <time>1642674763</time>
+          <time>1643641672</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:43 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:52 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Libero et aliquam. Cum voluptatem deserunt. Esse facere eligendi.
+      string: Possimus at quia. Sit doloribus ipsa. Soluta iure quos.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +181,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1666" vrev="1666">
-          <srcmd5>ac619e6ccdff230ffa3663773c9ff3b2</srcmd5>
+        <revision rev="131" vrev="131">
+          <srcmd5>e9848489ddf0f5ed9a39c3668e4858ce</srcmd5>
           <version>unknown</version>
-          <time>1642674763</time>
+          <time>1643641672</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:43 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:52 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -201,7 +201,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Pale Kings and Princes</title>
+          <title>Such, Such Were the Joys</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -224,16 +224,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '185'
+      - '187'
     body:
       encoding: UTF-8
       string: |
         <project name="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Pale Kings and Princes</title>
+          <title>Such, Such Were the Joys</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:43 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:52 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -241,8 +241,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Moving Finger</title>
-          <description>A hic consequuntur numquam.</description>
+          <title>I Sing the Body Electric</title>
+          <description>Aliquam consequatur minus sit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -263,21 +263,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '185'
+      - '195'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Moving Finger</title>
-          <description>A hic consequuntur numquam.</description>
+          <title>I Sing the Body Electric</title>
+          <description>Aliquam consequatur minus sit.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:43 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:52 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_config
     body:
       encoding: UTF-8
-      string: Perferendis qui iusto. Aut quas tenetur. Aut magni est.
+      string: Et voluptatem adipisci. Vel et cupiditate. Maiores culpa repellendus.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -297,25 +297,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="558" vrev="558">
-          <srcmd5>522786caeaa2f0383b944a00b12cd3f1</srcmd5>
+        <revision rev="46" vrev="46">
+          <srcmd5>3547be0a00be17b1a900a27ec2dc0786</srcmd5>
           <version>unknown</version>
-          <time>1642674763</time>
+          <time>1643641672</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:43 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:52 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Voluptate eos temporibus. Cum recusandae id. Eos omnis sed.
+      string: Non praesentium qui. Ut tenetur rerum. Illo recusandae aut.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -335,19 +335,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="559" vrev="559">
-          <srcmd5>0d51111d9dd48bae453401f294629b81</srcmd5>
+        <revision rev="47" vrev="47">
+          <srcmd5>94a9d209c14c57724f71b84ac74fc06e</srcmd5>
           <version>unknown</version>
-          <time>1642674763</time>
+          <time>1643641672</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:43 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:52 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_branch_request?user=Iggy
@@ -373,28 +373,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '210'
+      - '208'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1667" vrev="1667">
-          <srcmd5>ac619e6ccdff230ffa3663773c9ff3b2</srcmd5>
+        <revision rev="132" vrev="132">
+          <srcmd5>e9848489ddf0f5ed9a39c3668e4858ce</srcmd5>
           <version>unknown</version>
-          <time>1642674763</time>
+          <time>1643641672</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:43 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:52 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_281
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_28
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Antic Hay</title>
-          <description>Assumenda inventore hic voluptatem.</description>
+          <title>I Know Why the Caged Bird Sings</title>
+          <description>Et provident excepturi ea.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -415,15 +415,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '154'
+      - '167'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Antic Hay</title>
-          <description>Assumenda inventore hic voluptatem.</description>
+          <title>I Know Why the Caged Bird Sings</title>
+          <description>Et provident excepturi ea.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:43 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:52 GMT
 - request:
     method: get
     uri: http://backend:5352/source/foo_project/bar_package
@@ -449,16 +449,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '405'
+      - '403'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="1667" vrev="1667" srcmd5="ac619e6ccdff230ffa3663773c9ff3b2">
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="8cb51d0b3b6b52449f051ddef2e77e79" size="70" mtime="1642674763"/>
-          <entry name="somefile.txt" md5="1ea96b897a7999e8b1d6ba23c1aefb30" size="65" mtime="1642674763"/>
+        <directory name="bar_package" rev="132" vrev="132" srcmd5="e9848489ddf0f5ed9a39c3668e4858ce">
+          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1643641671"/>
+          <entry name="_config" md5="e23600da0c2a20035fe68ecfb657d51d" size="59" mtime="1643641672"/>
+          <entry name="somefile.txt" md5="b42556374d7c79418ca9d285bc854240" size="55" mtime="1643641672"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:43 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:52 GMT
 - request:
     method: get
     uri: http://backend:5352/source/foo_project/bar_package?view=info
@@ -484,14 +484,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '235'
+      - '233'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="1667" vrev="1667" srcmd5="ac619e6ccdff230ffa3663773c9ff3b2" verifymd5="ac619e6ccdff230ffa3663773c9ff3b2">
+        <sourceinfo package="bar_package" rev="132" vrev="132" srcmd5="e9848489ddf0f5ed9a39c3668e4858ce" verifymd5="e9848489ddf0f5ed9a39c3668e4858ce">
           <error>bad build configuration, no build type defined or detected</error>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:43 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:52 GMT
 - request:
     method: get
     uri: http://backend:5352/source/foo_project/bar_package
@@ -517,16 +517,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '405'
+      - '403'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="1667" vrev="1667" srcmd5="ac619e6ccdff230ffa3663773c9ff3b2">
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="8cb51d0b3b6b52449f051ddef2e77e79" size="70" mtime="1642674763"/>
-          <entry name="somefile.txt" md5="1ea96b897a7999e8b1d6ba23c1aefb30" size="65" mtime="1642674763"/>
+        <directory name="bar_package" rev="132" vrev="132" srcmd5="e9848489ddf0f5ed9a39c3668e4858ce">
+          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1643641671"/>
+          <entry name="_config" md5="e23600da0c2a20035fe68ecfb657d51d" size="59" mtime="1643641672"/>
+          <entry name="somefile.txt" md5="b42556374d7c79418ca9d285bc854240" size="55" mtime="1643641672"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:43 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:52 GMT
 - request:
     method: post
     uri: http://backend:5352/source/foo_project/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -554,18 +554,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '309'
+      - '308'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="67f4c9cf0c4ae0faf0bc51dc848e0aad">
+        <sourcediff key="dc5d1f0b34ff147ff15291c765edc3ac">
           <old project="foo_project" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="foo_project" package="bar_package" rev="1667" srcmd5="ac619e6ccdff230ffa3663773c9ff3b2"/>
+          <new project="foo_project" package="bar_package" rev="132" srcmd5="e9848489ddf0f5ed9a39c3668e4858ce"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:43 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:52 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_branch_request?user=Iggy
@@ -591,19 +591,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="560" vrev="560">
-          <srcmd5>d30ef6841b6a96e4c838ea6d6de42232</srcmd5>
+        <revision rev="48" vrev="48">
+          <srcmd5>94a9d209c14c57724f71b84ac74fc06e</srcmd5>
           <version>unknown</version>
-          <time>1642674763</time>
+          <time>1643641672</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:43 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:52 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -611,8 +611,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Moving Finger</title>
-          <description>A hic consequuntur numquam.</description>
+          <title>I Sing the Body Electric</title>
+          <description>Aliquam consequatur minus sit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -633,15 +633,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '185'
+      - '195'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Moving Finger</title>
-          <description>A hic consequuntur numquam.</description>
+          <title>I Sing the Body Electric</title>
+          <description>Aliquam consequatur minus sit.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:43 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:52 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -667,21 +667,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '832'
+      - '671'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="560" vrev="560" srcmd5="d30ef6841b6a96e4c838ea6d6de42232">
-          <linkinfo project="foo_project" package="bar_package" baserev="e96f2416509066dbe7aa04a8f862e091" xsrcmd5="04f17f03a0b1caf019133df5ec5c4036" error="conflict in file _config"/>
-          <serviceinfo code="failed" xsrcmd5="71392b198bdfd5020b889a3db63ea85f">
-            <error>service error: bad link: conflict in file _config</error>
-          </serviceinfo>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="04bcc82d761b3553588f5066249ef559" size="55" mtime="1642674763"/>
-          <entry name="_link" md5="028bf1aa0518e0efb16a9d5e082f6feb" size="119" mtime="1642674758"/>
-          <entry name="somefile.txt" md5="2a676da6048d828c154be4f219bf0d29" size="59" mtime="1642674763"/>
+        <directory name="bar_package" rev="48" vrev="48" srcmd5="94a9d209c14c57724f71b84ac74fc06e">
+          <linkinfo project="foo_project" package="bar_package" baserev="11ed5f7df3c46b42eaa6bd5e17fc4232" xsrcmd5="a9965bde3e9ac4f9f1c41d6585cac23b" error="conflict in file _config"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="d26d256a19e9ed18f0f5550a4ccbc80a" size="69" mtime="1643641672"/>
+          <entry name="_link" md5="0ed866dcf37c02d96fa6359bfc74102c" size="119" mtime="1643641670"/>
+          <entry name="somefile.txt" md5="ac0517a94637af3632f44d48af5025dc" size="59" mtime="1643641672"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:43 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:52 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?view=info
@@ -707,14 +704,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '179'
+      - '254'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="560" vrev="560" srcmd5="d30ef6841b6a96e4c838ea6d6de42232">
-          <error>service error: bad link: conflict in file _config</error>
+        <sourceinfo package="bar_package" rev="48" vrev="180" srcmd5="94a9d209c14c57724f71b84ac74fc06e" verifymd5="94a9d209c14c57724f71b84ac74fc06e">
+          <error>conflict in file _config</error>
+          <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:43 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:53 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -740,21 +738,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '832'
+      - '671'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="560" vrev="560" srcmd5="d30ef6841b6a96e4c838ea6d6de42232">
-          <linkinfo project="foo_project" package="bar_package" baserev="e96f2416509066dbe7aa04a8f862e091" xsrcmd5="04f17f03a0b1caf019133df5ec5c4036" error="conflict in file _config"/>
-          <serviceinfo code="failed" xsrcmd5="71392b198bdfd5020b889a3db63ea85f">
-            <error>service error: bad link: conflict in file _config</error>
-          </serviceinfo>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="04bcc82d761b3553588f5066249ef559" size="55" mtime="1642674763"/>
-          <entry name="_link" md5="028bf1aa0518e0efb16a9d5e082f6feb" size="119" mtime="1642674758"/>
-          <entry name="somefile.txt" md5="2a676da6048d828c154be4f219bf0d29" size="59" mtime="1642674763"/>
+        <directory name="bar_package" rev="48" vrev="48" srcmd5="94a9d209c14c57724f71b84ac74fc06e">
+          <linkinfo project="foo_project" package="bar_package" baserev="11ed5f7df3c46b42eaa6bd5e17fc4232" xsrcmd5="a9965bde3e9ac4f9f1c41d6585cac23b" error="conflict in file _config"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="d26d256a19e9ed18f0f5550a4ccbc80a" size="69" mtime="1643641672"/>
+          <entry name="_link" md5="0ed866dcf37c02d96fa6359bfc74102c" size="119" mtime="1643641670"/>
+          <entry name="somefile.txt" md5="ac0517a94637af3632f44d48af5025dc" size="59" mtime="1643641672"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:43 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:53 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -782,18 +777,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '370'
+      - '369'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="f4e9ef8d3017a87f7ebc3f9384893734">
+        <sourcediff key="4680fd2e92c1f9a34be0c59cab6adb5c">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="560" srcmd5="d30ef6841b6a96e4c838ea6d6de42232"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="48" srcmd5="94a9d209c14c57724f71b84ac74fc06e"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:43 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:53 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -811,8 +806,8 @@ http_interactions:
       - Ruby
   response:
     status:
-      code: 400
-      message: service error  bad link  conflict in file _config
+      code: 200
+      message: OK
     headers:
       Content-Type:
       - text/xml
@@ -821,14 +816,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '101'
+      - '399'
     body:
       encoding: UTF-8
       string: |
-        <status code="400">
-          <summary>service error: bad link: conflict in file _config</summary>
-        </status>
-  recorded_at: Thu, 20 Jan 2022 10:32:43 GMT
+        <sourcediff key="b8e1c61ed94bf6847dca4c7391aedfea">
+          <old project="foo_project" package="bar_package" rev="11ed5f7df3c46b42eaa6bd5e17fc4232" srcmd5="11ed5f7df3c46b42eaa6bd5e17fc4232"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="9b3b16dcd7c7582848c25a8926c163c8" srcmd5="9b3b16dcd7c7582848c25a8926c163c8"/>
+          <files/>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Mon, 31 Jan 2022 15:07:53 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_branch_request
@@ -858,5 +857,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"object_kind":null,"project":{"http_url":null},"object_attributes":{"source":{"default_branch":"123456789"}}}'
-  recorded_at: Thu, 20 Jan 2022 10:32:43 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:53 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/for_an_updated_MR_event/when_the_branched_package_did_not_exist/behaves_like_non-existent_branched_package/1_1_2_4_2_1_1.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/for_an_updated_MR_event/when_the_branched_package_did_not_exist/behaves_like_non-existent_branched_package/1_1_2_4_2_1_1.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:44 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:50 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_284
+    uri: http://backend:5352/source/foo_project/_meta?user=user_23
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Let Us Now Praise Famous Men</title>
+          <title>Gone with the Wind</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '160'
+      - '150'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Let Us Now Praise Famous Men</title>
+          <title>Gone with the Wind</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:44 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:50 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_285
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_24
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Doors of Perception</title>
-          <description>Enim voluptas sint nam.</description>
+          <title>Absalom, Absalom!</title>
+          <description>Omnis molestias reprehenderit pariatur.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '156'
+      - '166'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Doors of Perception</title>
-          <description>Enim voluptas sint nam.</description>
+          <title>Absalom, Absalom!</title>
+          <description>Omnis molestias reprehenderit pariatur.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:44 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:50 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Dolores iure velit. Et et modi. Illo eum voluptatibus.
+      string: Ducimus et rerum. Dolore et necessitatibus. Quisquam rerum tempora.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,26 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1671" vrev="1671">
-          <srcmd5>96178d462827753a9a5a13673ac1c125</srcmd5>
+        <revision rev="125" vrev="125">
+          <srcmd5>41bcdc3caf87fe824dfddb9ff69577c1</srcmd5>
           <version>unknown</version>
-          <time>1642674764</time>
+          <time>1643641670</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:45 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:50 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Sint et dolor. Qui sed iure. Rerum mollitia earum.
+      string: Tempore distinctio occaecati. Ut mollitia reprehenderit. Laudantium
+        aut et.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +182,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1672" vrev="1672">
-          <srcmd5>73913271c33ce856d5bd2573d849532c</srcmd5>
+        <revision rev="126" vrev="126">
+          <srcmd5>11ed5f7df3c46b42eaa6bd5e17fc4232</srcmd5>
           <version>unknown</version>
-          <time>1642674765</time>
+          <time>1643641670</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:45 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:50 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -227,7 +228,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:32:45 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:50 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -267,7 +268,7 @@ http_interactions:
           <description>This project was created for package bar_package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:45 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:50 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -275,8 +276,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Doors of Perception</title>
-          <description>Enim voluptas sint nam.</description>
+          <title>Absalom, Absalom!</title>
+          <description>Omnis molestias reprehenderit pariatur.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -297,15 +298,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '187'
+      - '197'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Doors of Perception</title>
-          <description>Enim voluptas sint nam.</description>
+          <title>Absalom, Absalom!</title>
+          <description>Omnis molestias reprehenderit pariatur.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:45 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:50 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=branch&noservice=1&opackage=bar_package&oproject=foo_project&user=Iggy
@@ -333,19 +334,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="564" vrev="564">
-          <srcmd5>a7bbe6ee88c54c0673a943f94a59e1da</srcmd5>
+        <revision rev="41" vrev="41">
+          <srcmd5>85b84cffa8b9ab2beec8bafd0e19df3c</srcmd5>
           <version>unknown</version>
-          <time>1642674765</time>
+          <time>1643641670</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:45 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:50 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -353,8 +354,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Doors of Perception</title>
-          <description>Enim voluptas sint nam.</description>
+          <title>Absalom, Absalom!</title>
+          <description>Omnis molestias reprehenderit pariatur.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -375,15 +376,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '187'
+      - '197'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Doors of Perception</title>
-          <description>Enim voluptas sint nam.</description>
+          <title>Absalom, Absalom!</title>
+          <description>Omnis molestias reprehenderit pariatur.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:45 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:50 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -409,18 +410,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '725'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="564" vrev="564" srcmd5="a7bbe6ee88c54c0673a943f94a59e1da">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="73913271c33ce856d5bd2573d849532c" baserev="73913271c33ce856d5bd2573d849532c" xsrcmd5="a6ab768b3c30155265fac1aee6bfdec8" lsrcmd5="a7bbe6ee88c54c0673a943f94a59e1da"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="4b6b0fade7cfabb1d426ccd885267061" size="54" mtime="1642674764"/>
-          <entry name="_link" md5="5d5d590673ea8eb8820581cf75d0e4f8" size="119" mtime="1642674765"/>
-          <entry name="somefile.txt" md5="c9444a8e3f41bd117b6e39a2e65d0237" size="50" mtime="1642674765"/>
+        <directory name="bar_package" rev="41" vrev="41" srcmd5="85b84cffa8b9ab2beec8bafd0e19df3c">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="11ed5f7df3c46b42eaa6bd5e17fc4232" baserev="11ed5f7df3c46b42eaa6bd5e17fc4232" xsrcmd5="89c3b39a58db6c59dc74c34dd633d5a1" lsrcmd5="85b84cffa8b9ab2beec8bafd0e19df3c"/>
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="c94cfa76b587c870757c9b7285b9443c" size="67" mtime="1643641670"/>
+          <entry name="_link" md5="0ed866dcf37c02d96fa6359bfc74102c" size="119" mtime="1643641670"/>
+          <entry name="somefile.txt" md5="ad0cd43ecb4322fa9b5087206212345a" size="75" mtime="1643641670"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:45 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:50 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?view=info
@@ -446,15 +447,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '333'
+      - '331'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="564" vrev="2236" srcmd5="a6ab768b3c30155265fac1aee6bfdec8" lsrcmd5="a7bbe6ee88c54c0673a943f94a59e1da" verifymd5="73913271c33ce856d5bd2573d849532c">
+        <sourceinfo package="bar_package" rev="41" vrev="167" srcmd5="89c3b39a58db6c59dc74c34dd633d5a1" lsrcmd5="85b84cffa8b9ab2beec8bafd0e19df3c" verifymd5="11ed5f7df3c46b42eaa6bd5e17fc4232">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:45 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:50 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -480,18 +481,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '725'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="564" vrev="564" srcmd5="a7bbe6ee88c54c0673a943f94a59e1da">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="73913271c33ce856d5bd2573d849532c" baserev="73913271c33ce856d5bd2573d849532c" xsrcmd5="a6ab768b3c30155265fac1aee6bfdec8" lsrcmd5="a7bbe6ee88c54c0673a943f94a59e1da"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="4b6b0fade7cfabb1d426ccd885267061" size="54" mtime="1642674764"/>
-          <entry name="_link" md5="5d5d590673ea8eb8820581cf75d0e4f8" size="119" mtime="1642674765"/>
-          <entry name="somefile.txt" md5="c9444a8e3f41bd117b6e39a2e65d0237" size="50" mtime="1642674765"/>
+        <directory name="bar_package" rev="41" vrev="41" srcmd5="85b84cffa8b9ab2beec8bafd0e19df3c">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="11ed5f7df3c46b42eaa6bd5e17fc4232" baserev="11ed5f7df3c46b42eaa6bd5e17fc4232" xsrcmd5="89c3b39a58db6c59dc74c34dd633d5a1" lsrcmd5="85b84cffa8b9ab2beec8bafd0e19df3c"/>
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="c94cfa76b587c870757c9b7285b9443c" size="67" mtime="1643641670"/>
+          <entry name="_link" md5="0ed866dcf37c02d96fa6359bfc74102c" size="119" mtime="1643641670"/>
+          <entry name="somefile.txt" md5="ad0cd43ecb4322fa9b5087206212345a" size="75" mtime="1643641670"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:45 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:50 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -519,18 +520,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '370'
+      - '369'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="5e686ed73f96a936b1a02b9060902a7c">
+        <sourcediff key="d23fb7ef3b8bd0aabc625aa11654e876">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="564" srcmd5="a7bbe6ee88c54c0673a943f94a59e1da"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="41" srcmd5="85b84cffa8b9ab2beec8bafd0e19df3c"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:45 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:50 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -562,12 +563,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="dba9e3eb5b01cb924bc110647c71e9c8">
-          <old project="foo_project" package="bar_package" rev="73913271c33ce856d5bd2573d849532c" srcmd5="73913271c33ce856d5bd2573d849532c"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="a6ab768b3c30155265fac1aee6bfdec8" srcmd5="a6ab768b3c30155265fac1aee6bfdec8"/>
+        <sourcediff key="dd36bc6ef87d910e26e6f2aa7b26dd8a">
+          <old project="foo_project" package="bar_package" rev="11ed5f7df3c46b42eaa6bd5e17fc4232" srcmd5="11ed5f7df3c46b42eaa6bd5e17fc4232"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="89c3b39a58db6c59dc74c34dd633d5a1" srcmd5="89c3b39a58db6c59dc74c34dd633d5a1"/>
           <files/>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:45 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:50 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -613,7 +614,7 @@ http_interactions:
             <disable/>
           </publish>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:45 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:50 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_branch_request?user=Iggy
@@ -639,19 +640,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="565" vrev="565">
-          <srcmd5>1702195466e595b336015f376d87e7dd</srcmd5>
+        <revision rev="42" vrev="42">
+          <srcmd5>4e70717388ff951083bac903f9d17132</srcmd5>
           <version>unknown</version>
-          <time>1642674765</time>
+          <time>1643641670</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:45 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:50 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -659,8 +660,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Doors of Perception</title>
-          <description>Enim voluptas sint nam.</description>
+          <title>Absalom, Absalom!</title>
+          <description>Omnis molestias reprehenderit pariatur.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -681,15 +682,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '187'
+      - '197'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>The Doors of Perception</title>
-          <description>Enim voluptas sint nam.</description>
+          <title>Absalom, Absalom!</title>
+          <description>Omnis molestias reprehenderit pariatur.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:45 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:50 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -715,19 +716,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="565" vrev="565" srcmd5="1702195466e595b336015f376d87e7dd">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="73913271c33ce856d5bd2573d849532c" baserev="73913271c33ce856d5bd2573d849532c" xsrcmd5="4a834d1ec9224e89a403e315ff26d756" lsrcmd5="1702195466e595b336015f376d87e7dd"/>
-          <serviceinfo code="succeeded" xsrcmd5="e975976d4c6a4b5938fd0fae34ab1ce9"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="4b6b0fade7cfabb1d426ccd885267061" size="54" mtime="1642674764"/>
-          <entry name="_link" md5="5d5d590673ea8eb8820581cf75d0e4f8" size="119" mtime="1642674765"/>
-          <entry name="somefile.txt" md5="c9444a8e3f41bd117b6e39a2e65d0237" size="50" mtime="1642674765"/>
+        <directory name="bar_package" rev="42" vrev="42" srcmd5="4e70717388ff951083bac903f9d17132">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="11ed5f7df3c46b42eaa6bd5e17fc4232" baserev="11ed5f7df3c46b42eaa6bd5e17fc4232" xsrcmd5="9581816176cb62f768e130cab6b521ef" lsrcmd5="4e70717388ff951083bac903f9d17132"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="c94cfa76b587c870757c9b7285b9443c" size="67" mtime="1643641670"/>
+          <entry name="_link" md5="0ed866dcf37c02d96fa6359bfc74102c" size="119" mtime="1643641670"/>
+          <entry name="somefile.txt" md5="ad0cd43ecb4322fa9b5087206212345a" size="75" mtime="1643641670"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:45 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:50 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?view=info
@@ -753,15 +753,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '333'
+      - '331'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="565" vrev="2237" srcmd5="ba7f00fc07f09bd75fb1da357b8ca336" lsrcmd5="e975976d4c6a4b5938fd0fae34ab1ce9" verifymd5="c8a1132c21f004d0c93a6c1e01ac5652">
+        <sourceinfo package="bar_package" rev="42" vrev="168" srcmd5="9581816176cb62f768e130cab6b521ef" lsrcmd5="4e70717388ff951083bac903f9d17132" verifymd5="4f6c59df10374b5620e7be2b0f26c44c">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:45 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:51 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -787,19 +787,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="565" vrev="565" srcmd5="1702195466e595b336015f376d87e7dd">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="73913271c33ce856d5bd2573d849532c" baserev="73913271c33ce856d5bd2573d849532c" xsrcmd5="4a834d1ec9224e89a403e315ff26d756" lsrcmd5="1702195466e595b336015f376d87e7dd"/>
-          <serviceinfo code="succeeded" xsrcmd5="e975976d4c6a4b5938fd0fae34ab1ce9"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="4b6b0fade7cfabb1d426ccd885267061" size="54" mtime="1642674764"/>
-          <entry name="_link" md5="5d5d590673ea8eb8820581cf75d0e4f8" size="119" mtime="1642674765"/>
-          <entry name="somefile.txt" md5="c9444a8e3f41bd117b6e39a2e65d0237" size="50" mtime="1642674765"/>
+        <directory name="bar_package" rev="42" vrev="42" srcmd5="4e70717388ff951083bac903f9d17132">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="11ed5f7df3c46b42eaa6bd5e17fc4232" baserev="11ed5f7df3c46b42eaa6bd5e17fc4232" xsrcmd5="9581816176cb62f768e130cab6b521ef" lsrcmd5="4e70717388ff951083bac903f9d17132"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="c94cfa76b587c870757c9b7285b9443c" size="67" mtime="1643641670"/>
+          <entry name="_link" md5="0ed866dcf37c02d96fa6359bfc74102c" size="119" mtime="1643641670"/>
+          <entry name="somefile.txt" md5="ad0cd43ecb4322fa9b5087206212345a" size="75" mtime="1643641670"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:45 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:51 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -827,18 +826,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '370'
+      - '369'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="063bc78e7bc8c464b921ebd9207cdccb">
+        <sourcediff key="991758a0ac5b70d93defa02843484b9c">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="565" srcmd5="1702195466e595b336015f376d87e7dd"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="42" srcmd5="4e70717388ff951083bac903f9d17132"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:45 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:51 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -870,12 +869,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="d86246f860bc49b7d846966f8cdd3ab0">
-          <old project="foo_project" package="bar_package" rev="73913271c33ce856d5bd2573d849532c" srcmd5="73913271c33ce856d5bd2573d849532c"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="ba7f00fc07f09bd75fb1da357b8ca336" srcmd5="ba7f00fc07f09bd75fb1da357b8ca336"/>
+        <sourcediff key="eadf21d6e24d829e141cb0842df80b3e">
+          <old project="foo_project" package="bar_package" rev="11ed5f7df3c46b42eaa6bd5e17fc4232" srcmd5="11ed5f7df3c46b42eaa6bd5e17fc4232"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="9581816176cb62f768e130cab6b521ef" srcmd5="9581816176cb62f768e130cab6b521ef"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:45 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:51 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/for_an_updated_MR_event/when_the_branched_package_did_not_exist/behaves_like_non-existent_branched_package/1_1_2_4_2_1_2.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/for_an_updated_MR_event/when_the_branched_package_did_not_exist/behaves_like_non-existent_branched_package/1_1_2_4_2_1_2.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:45 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:48 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_286
+    uri: http://backend:5352/source/foo_project/_meta?user=user_21
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>What's Become of Waring</title>
+          <title>Precious Bane</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '155'
+      - '145'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>What's Become of Waring</title>
+          <title>Precious Bane</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:45 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:48 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_287
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_22
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Dying of the Light</title>
-          <description>Sapiente perspiciatis consequatur unde.</description>
+          <title>The Doors of Perception</title>
+          <description>Nihil dignissimos vel aut.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '159'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Dying of the Light</title>
-          <description>Sapiente perspiciatis consequatur unde.</description>
+          <title>The Doors of Perception</title>
+          <description>Nihil dignissimos vel aut.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:45 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:48 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Ea tenetur aspernatur. Corrupti occaecati praesentium. Et dolores quae.
+      string: Nihil laudantium ut. Nihil et vitae. Quia et nesciunt.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1673" vrev="1673">
-          <srcmd5>146b00bdb4050e45471a4a85c7afea71</srcmd5>
+        <revision rev="123" vrev="123">
+          <srcmd5>7f648f3095271f9f98e562d1acf0781d</srcmd5>
           <version>unknown</version>
-          <time>1642674765</time>
+          <time>1643641668</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:45 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:48 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Repudiandae recusandae sed. Rerum nesciunt et. Sed eos dolor.
+      string: Quos tenetur repudiandae. Perferendis qui tempora. Velit quos omnis.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +181,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1674" vrev="1674">
-          <srcmd5>61229f25d978228f07c6c4d9b65249b2</srcmd5>
+        <revision rev="124" vrev="124">
+          <srcmd5>4f6e030f438019b53d66286b8d5427b4</srcmd5>
           <version>unknown</version>
-          <time>1642674765</time>
+          <time>1643641668</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:45 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:48 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -227,7 +227,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:32:45 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:48 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -267,7 +267,7 @@ http_interactions:
           <description>This project was created for package bar_package via attribute OBS:Maintained</description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:46 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:48 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -275,8 +275,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Dying of the Light</title>
-          <description>Sapiente perspiciatis consequatur unde.</description>
+          <title>The Doors of Perception</title>
+          <description>Nihil dignissimos vel aut.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -297,15 +297,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '198'
+      - '190'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Dying of the Light</title>
-          <description>Sapiente perspiciatis consequatur unde.</description>
+          <title>The Doors of Perception</title>
+          <description>Nihil dignissimos vel aut.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:46 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:48 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=branch&noservice=1&opackage=bar_package&oproject=foo_project&user=Iggy
@@ -333,19 +333,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="566" vrev="566">
-          <srcmd5>c2043fe943c3c09aacd366521d67fafd</srcmd5>
+        <revision rev="39" vrev="39">
+          <srcmd5>6976d447e49288e10c9bf94ff981ad87</srcmd5>
           <version>unknown</version>
-          <time>1642674766</time>
+          <time>1643641669</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:46 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -353,8 +353,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Dying of the Light</title>
-          <description>Sapiente perspiciatis consequatur unde.</description>
+          <title>The Doors of Perception</title>
+          <description>Nihil dignissimos vel aut.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -375,15 +375,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '198'
+      - '190'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Dying of the Light</title>
-          <description>Sapiente perspiciatis consequatur unde.</description>
+          <title>The Doors of Perception</title>
+          <description>Nihil dignissimos vel aut.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:46 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:49 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -409,18 +409,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '725'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="566" vrev="566" srcmd5="c2043fe943c3c09aacd366521d67fafd">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="61229f25d978228f07c6c4d9b65249b2" baserev="61229f25d978228f07c6c4d9b65249b2" xsrcmd5="eed7e7a0d2e5e818996733efc2fa5b71" lsrcmd5="c2043fe943c3c09aacd366521d67fafd"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="78561d17d7ffa3b5b308999dc7047c10" size="71" mtime="1642674765"/>
-          <entry name="_link" md5="0e800f04bf390b5dc78e76f5f064ae82" size="119" mtime="1642674766"/>
-          <entry name="somefile.txt" md5="1157f15403fc39607f81f89d78534dc7" size="61" mtime="1642674765"/>
+        <directory name="bar_package" rev="39" vrev="39" srcmd5="6976d447e49288e10c9bf94ff981ad87">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="4f6e030f438019b53d66286b8d5427b4" baserev="4f6e030f438019b53d66286b8d5427b4" xsrcmd5="75e872581b48784d23d757976531a1b4" lsrcmd5="6976d447e49288e10c9bf94ff981ad87"/>
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="41fb5472c63e0f0d80902a1e741122bb" size="54" mtime="1643641668"/>
+          <entry name="_link" md5="a9487de068890f2fa9240ead0222fe74" size="119" mtime="1643641668"/>
+          <entry name="somefile.txt" md5="a364bc046a46524b47e3561944dd07e2" size="68" mtime="1643641668"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:46 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:49 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?view=info
@@ -446,15 +446,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '333'
+      - '331'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="566" vrev="2240" srcmd5="eed7e7a0d2e5e818996733efc2fa5b71" lsrcmd5="c2043fe943c3c09aacd366521d67fafd" verifymd5="61229f25d978228f07c6c4d9b65249b2">
+        <sourceinfo package="bar_package" rev="39" vrev="163" srcmd5="75e872581b48784d23d757976531a1b4" lsrcmd5="6976d447e49288e10c9bf94ff981ad87" verifymd5="4f6e030f438019b53d66286b8d5427b4">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:46 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:49 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -480,18 +480,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '725'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="566" vrev="566" srcmd5="c2043fe943c3c09aacd366521d67fafd">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="61229f25d978228f07c6c4d9b65249b2" baserev="61229f25d978228f07c6c4d9b65249b2" xsrcmd5="eed7e7a0d2e5e818996733efc2fa5b71" lsrcmd5="c2043fe943c3c09aacd366521d67fafd"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="78561d17d7ffa3b5b308999dc7047c10" size="71" mtime="1642674765"/>
-          <entry name="_link" md5="0e800f04bf390b5dc78e76f5f064ae82" size="119" mtime="1642674766"/>
-          <entry name="somefile.txt" md5="1157f15403fc39607f81f89d78534dc7" size="61" mtime="1642674765"/>
+        <directory name="bar_package" rev="39" vrev="39" srcmd5="6976d447e49288e10c9bf94ff981ad87">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="4f6e030f438019b53d66286b8d5427b4" baserev="4f6e030f438019b53d66286b8d5427b4" xsrcmd5="75e872581b48784d23d757976531a1b4" lsrcmd5="6976d447e49288e10c9bf94ff981ad87"/>
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="41fb5472c63e0f0d80902a1e741122bb" size="54" mtime="1643641668"/>
+          <entry name="_link" md5="a9487de068890f2fa9240ead0222fe74" size="119" mtime="1643641668"/>
+          <entry name="somefile.txt" md5="a364bc046a46524b47e3561944dd07e2" size="68" mtime="1643641668"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:46 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:49 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -519,18 +519,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '370'
+      - '369'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="525109c169fa69ef2533e793211a4c77">
+        <sourcediff key="24817a2f566cb6a2893b6c50e93c064d">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="566" srcmd5="c2043fe943c3c09aacd366521d67fafd"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="39" srcmd5="6976d447e49288e10c9bf94ff981ad87"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:46 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:49 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -562,12 +562,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="723479b4b52d7a30a6217199a88e6c56">
-          <old project="foo_project" package="bar_package" rev="61229f25d978228f07c6c4d9b65249b2" srcmd5="61229f25d978228f07c6c4d9b65249b2"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="eed7e7a0d2e5e818996733efc2fa5b71" srcmd5="eed7e7a0d2e5e818996733efc2fa5b71"/>
+        <sourcediff key="78ee1232a370d2a590f41b79767847c6">
+          <old project="foo_project" package="bar_package" rev="4f6e030f438019b53d66286b8d5427b4" srcmd5="4f6e030f438019b53d66286b8d5427b4"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="75e872581b48784d23d757976531a1b4" srcmd5="75e872581b48784d23d757976531a1b4"/>
           <files/>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:46 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/_meta?user=Iggy
@@ -613,7 +613,7 @@ http_interactions:
             <disable/>
           </publish>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:46 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_branch_request?user=Iggy
@@ -639,19 +639,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="567" vrev="567">
-          <srcmd5>c385cc392f924a99e9e2137e814cab25</srcmd5>
+        <revision rev="40" vrev="40">
+          <srcmd5>f4d478f43c98c36be16389a89732c775</srcmd5>
           <version>unknown</version>
-          <time>1642674766</time>
+          <time>1643641669</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:46 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package/_meta?user=Iggy
@@ -659,8 +659,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Dying of the Light</title>
-          <description>Sapiente perspiciatis consequatur unde.</description>
+          <title>The Doors of Perception</title>
+          <description>Nihil dignissimos vel aut.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -681,15 +681,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '198'
+      - '190'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="home:Iggy:openSUSE:open-build-service:PR-1">
-          <title>Dying of the Light</title>
-          <description>Sapiente perspiciatis consequatur unde.</description>
+          <title>The Doors of Perception</title>
+          <description>Nihil dignissimos vel aut.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:46 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:49 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -715,19 +715,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="567" vrev="567" srcmd5="c385cc392f924a99e9e2137e814cab25">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="61229f25d978228f07c6c4d9b65249b2" baserev="61229f25d978228f07c6c4d9b65249b2" xsrcmd5="5feb3872bfd14bdd6d86a1fcaadc9aef" lsrcmd5="c385cc392f924a99e9e2137e814cab25"/>
-          <serviceinfo code="succeeded" xsrcmd5="3f623ef921ac24fbf2c31d5f31f38b0a"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="78561d17d7ffa3b5b308999dc7047c10" size="71" mtime="1642674765"/>
-          <entry name="_link" md5="0e800f04bf390b5dc78e76f5f064ae82" size="119" mtime="1642674766"/>
-          <entry name="somefile.txt" md5="1157f15403fc39607f81f89d78534dc7" size="61" mtime="1642674765"/>
+        <directory name="bar_package" rev="40" vrev="40" srcmd5="f4d478f43c98c36be16389a89732c775">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="4f6e030f438019b53d66286b8d5427b4" baserev="4f6e030f438019b53d66286b8d5427b4" xsrcmd5="3403c8f900b79158b3a044654ec81898" lsrcmd5="f4d478f43c98c36be16389a89732c775"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="41fb5472c63e0f0d80902a1e741122bb" size="54" mtime="1643641668"/>
+          <entry name="_link" md5="a9487de068890f2fa9240ead0222fe74" size="119" mtime="1643641668"/>
+          <entry name="somefile.txt" md5="a364bc046a46524b47e3561944dd07e2" size="68" mtime="1643641668"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:46 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:49 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?view=info
@@ -753,15 +752,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '333'
+      - '331'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package" rev="567" vrev="2241" srcmd5="9b44c720ca0a64a4f5177668f0024037" lsrcmd5="3f623ef921ac24fbf2c31d5f31f38b0a" verifymd5="44caf88a0f6103b73b6a5fa20b18d85d">
+        <sourceinfo package="bar_package" rev="40" vrev="164" srcmd5="3403c8f900b79158b3a044654ec81898" lsrcmd5="f4d478f43c98c36be16389a89732c775" verifymd5="a9f09911d1d77421784888dabf3ae83a">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:46 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:49 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package
@@ -787,19 +786,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '802'
+      - '723'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package" rev="567" vrev="567" srcmd5="c385cc392f924a99e9e2137e814cab25">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="61229f25d978228f07c6c4d9b65249b2" baserev="61229f25d978228f07c6c4d9b65249b2" xsrcmd5="5feb3872bfd14bdd6d86a1fcaadc9aef" lsrcmd5="c385cc392f924a99e9e2137e814cab25"/>
-          <serviceinfo code="succeeded" xsrcmd5="3f623ef921ac24fbf2c31d5f31f38b0a"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597680"/>
-          <entry name="_config" md5="78561d17d7ffa3b5b308999dc7047c10" size="71" mtime="1642674765"/>
-          <entry name="_link" md5="0e800f04bf390b5dc78e76f5f064ae82" size="119" mtime="1642674766"/>
-          <entry name="somefile.txt" md5="1157f15403fc39607f81f89d78534dc7" size="61" mtime="1642674765"/>
+        <directory name="bar_package" rev="40" vrev="40" srcmd5="f4d478f43c98c36be16389a89732c775">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="4f6e030f438019b53d66286b8d5427b4" baserev="4f6e030f438019b53d66286b8d5427b4" xsrcmd5="3403c8f900b79158b3a044654ec81898" lsrcmd5="f4d478f43c98c36be16389a89732c775"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641669"/>
+          <entry name="_config" md5="41fb5472c63e0f0d80902a1e741122bb" size="54" mtime="1643641668"/>
+          <entry name="_link" md5="a9487de068890f2fa9240ead0222fe74" size="119" mtime="1643641668"/>
+          <entry name="somefile.txt" md5="a364bc046a46524b47e3561944dd07e2" size="68" mtime="1643641668"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:46 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:49 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -827,18 +825,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '370'
+      - '369'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="066af97801774949eb08575ff0efa5c9">
+        <sourcediff key="dae69387ce073f3dd185666332029282">
           <old project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="567" srcmd5="c385cc392f924a99e9e2137e814cab25"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="40" srcmd5="f4d478f43c98c36be16389a89732c775"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:46 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:49 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy:openSUSE:open-build-service:PR-1/bar_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -870,12 +868,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="465c5f5b5f69d226fe45039d1dcb885d">
-          <old project="foo_project" package="bar_package" rev="61229f25d978228f07c6c4d9b65249b2" srcmd5="61229f25d978228f07c6c4d9b65249b2"/>
-          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="9b44c720ca0a64a4f5177668f0024037" srcmd5="9b44c720ca0a64a4f5177668f0024037"/>
+        <sourcediff key="df2f7910eb10a0b81177e09a81a47074">
+          <old project="foo_project" package="bar_package" rev="4f6e030f438019b53d66286b8d5427b4" srcmd5="4f6e030f438019b53d66286b8d5427b4"/>
+          <new project="home:Iggy:openSUSE:open-build-service:PR-1" package="bar_package" rev="3403c8f900b79158b3a044654ec81898" srcmd5="3403c8f900b79158b3a044654ec81898"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:46 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:49 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/with_a_push_event_for_a_commit/behaves_like_failed_when_source_package_does_not_exist/1_1_2_5_2_1.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/with_a_push_event_for_a_commit/behaves_like_failed_when_source_package_does_not_exist/1_1_2_5_2_1.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:20 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:47 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_234
+    uri: http://backend:5352/source/foo_project/_meta?user=user_17
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Alone on a Wide, Wide Sea</title>
+          <title>After Many a Summer Dies the Swan</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '157'
+      - '165'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Alone on a Wide, Wide Sea</title>
+          <title>After Many a Summer Dies the Swan</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:47 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_235
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_18
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Mother Night</title>
-          <description>Neque est voluptatem odio.</description>
+          <title>A Passage to India</title>
+          <description>Et omnis mollitia id.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '148'
+      - '149'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Mother Night</title>
-          <description>Neque est voluptatem odio.</description>
+          <title>A Passage to India</title>
+          <description>Et omnis mollitia id.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Est tempora placeat. Saepe sed magni. Voluptatem fugit consequatur.
+      string: Dicta non reiciendis. Qui molestiae est. Excepturi enim sint.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1615" vrev="1615">
-          <srcmd5>aba10fad2fc460856d76bfd7c3b0f6db</srcmd5>
+        <revision rev="119" vrev="119">
+          <srcmd5>04ed8fe5b468440c43f6a49285d522eb</srcmd5>
           <version>unknown</version>
-          <time>1642674741</time>
+          <time>1643641667</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Corporis odit dolor. Consequatur accusamus quo. Vel rerum ullam.
+      string: Ut velit qui. Molestiae quia voluptatum. Quod error molestiae.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,17 +181,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1616" vrev="1616">
-          <srcmd5>b6bc5b4041d17e248766bf7cf5e4234f</srcmd5>
+        <revision rev="120" vrev="120">
+          <srcmd5>c14c984dcc036690d10489cc424569fb</srcmd5>
           <version>unknown</version>
-          <time>1642674741</time>
+          <time>1643641667</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:47 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/with_a_push_event_for_a_commit/behaves_like_failed_without_branch_permissions/1_1_2_5_3_1.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/with_a_push_event_for_a_commit/behaves_like_failed_without_branch_permissions/1_1_2_5_3_1.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:36 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_236
+    uri: http://backend:5352/source/foo_project/_meta?user=user_1
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Recalled to Life</title>
+          <title>Fair Stood the Wind for France</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '148'
+      - '162'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Recalled to Life</title>
+          <title>Fair Stood the Wind for France</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:36 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_237
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_2
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Line of Beauty</title>
-          <description>Autem non enim explicabo.</description>
+          <title>This Lime Tree Bower</title>
+          <description>Et fugiat sit amet.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,22 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '153'
+      - '149'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Line of Beauty</title>
-          <description>Autem non enim explicabo.</description>
+          <title>This Lime Tree Bower</title>
+          <description>Et fugiat sit amet.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:36 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Architecto molestiae necessitatibus. Accusamus magnam nobis. Cumque
-        ipsum voluptates.
+      string: Cumque vel quia. Nostrum quasi dolore. Molestiae omnis ipsam.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -144,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1617" vrev="1617">
-          <srcmd5>27e47113f03a55ede68433355c6c2adb</srcmd5>
+        <revision rev="103" vrev="103">
+          <srcmd5>4c35ae2da433f072a6a6fb6d0ae53f0c</srcmd5>
           <version>unknown</version>
-          <time>1642674741</time>
+          <time>1643641656</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:36 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Vero ut harum. Sunt nesciunt odio. Velit officia et.
+      string: Et perspiciatis culpa. Tempore pariatur et. Maiores dolorem dolores.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -182,17 +181,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1618" vrev="1618">
-          <srcmd5>bc506b41f44e2d5c3d6a6c3dbe451d68</srcmd5>
+        <revision rev="104" vrev="104">
+          <srcmd5>42693843c624b254490a1e2eff731a6f</srcmd5>
           <version>unknown</version>
-          <time>1642674741</time>
+          <time>1643641656</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:36 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/with_a_push_event_for_a_commit/behaves_like_fails_with_insufficient_write_permission_on_target_project/1_1_2_5_4_1.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/with_a_push_event_for_a_commit/behaves_like_fails_with_insufficient_write_permission_on_target_project/1_1_2_5_4_1.yml
@@ -39,10 +39,10 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:20 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:48 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_232
+    uri: http://backend:5352/source/foo_project/_meta?user=user_19
     body:
       encoding: UTF-8
       string: |
@@ -79,16 +79,16 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:20 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:48 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_233
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_20
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Now Sleeps the Crimson Petal</title>
-          <description>Est ducimus qui eum.</description>
+          <title>The World, the Flesh and the Devil</title>
+          <description>Corrupti sit et sint.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '158'
+      - '165'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Now Sleeps the Crimson Petal</title>
-          <description>Est ducimus qui eum.</description>
+          <title>The World, the Flesh and the Devil</title>
+          <description>Corrupti sit et sint.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:20 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:48 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Quibusdam non illum. Pariatur dolorum deserunt. Quae quia dolor.
+      string: Rerum nostrum et. Autem nemo maxime. Ipsa rerum suscipit.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,26 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1613" vrev="1613">
-          <srcmd5>5e26578033d19299b764b4d25135501d</srcmd5>
+        <revision rev="121" vrev="121">
+          <srcmd5>d71639e89bd44c2ebf6c6459d4a722a0</srcmd5>
           <version>unknown</version>
-          <time>1642674740</time>
+          <time>1643641668</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:20 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:48 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Laudantium aut est. Possimus adipisci neque. Et necessitatibus officiis.
+      string: Temporibus voluptas sapiente. Error eius mollitia. Magni praesentium
+        iste.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +182,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1614" vrev="1614">
-          <srcmd5>62e78eaedf3838a97c4eb6f074f5fe16</srcmd5>
+        <revision rev="122" vrev="122">
+          <srcmd5>773b5caddbb904b93186784781babbba</srcmd5>
           <version>unknown</version>
-          <time>1642674740</time>
+          <time>1643641668</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:20 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:48 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_without_maintainer_rights/_meta?user=Iggy
@@ -201,7 +202,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="project_without_maintainer_rights">
-          <title>The Millstone</title>
+          <title>In a Dry Season</title>
           <description/>
         </project>
     headers:
@@ -223,15 +224,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '123'
+      - '125'
     body:
       encoding: UTF-8
       string: |
         <project name="project_without_maintainer_rights">
-          <title>The Millstone</title>
+          <title>In a Dry Season</title>
           <description></description>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:20 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:48 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -265,5 +266,5 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:32:20 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:48 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/with_a_push_event_for_a_commit/behaves_like_successful_new_PR_or_MR_event/1_1_2_5_1_1.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/with_a_push_event_for_a_commit/behaves_like_successful_new_PR_or_MR_event/1_1_2_5_1_1.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:44 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_242
+    uri: http://backend:5352/source/foo_project/_meta?user=user_13
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Taming a Sea Horse</title>
+          <title>In a Dry Season</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '150'
+      - '147'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Taming a Sea Horse</title>
+          <title>In a Dry Season</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:44 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_243
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_14
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Postern of Fate</title>
-          <description>Dolorem temporibus in aut.</description>
+          <title>No Longer at Ease</title>
+          <description>Natus consequatur suscipit temporibus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '151'
+      - '165'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Postern of Fate</title>
-          <description>Dolorem temporibus in aut.</description>
+          <title>No Longer at Ease</title>
+          <description>Natus consequatur suscipit temporibus.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:44 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Quos quia dolorum. Nulla labore est. Cum exercitationem provident.
+      string: Aut est nihil. Error iusto a. Quia rerum corrupti.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1623" vrev="1623">
-          <srcmd5>141f08d52232a2c66b8c843e1f676f15</srcmd5>
+        <revision rev="115" vrev="115">
+          <srcmd5>bda35de11ced450ff1f11aa7e9247276</srcmd5>
           <version>unknown</version>
-          <time>1642674744</time>
+          <time>1643641664</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:44 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Voluptatem ipsam nobis. Voluptatibus mollitia et. Nam qui sit.
+      string: Facilis sint deserunt. Ratione quae nulla. Reprehenderit quis quasi.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +181,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1624" vrev="1624">
-          <srcmd5>27702018fefcfea9bc6f1a5574a1182a</srcmd5>
+        <revision rev="116" vrev="116">
+          <srcmd5>1b70b42f7239ee7509fc9c8d1894a543</srcmd5>
           <version>unknown</version>
-          <time>1642674744</time>
+          <time>1643641664</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:44 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -227,7 +227,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:32:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:45 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_meta?user=Iggy
@@ -235,8 +235,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>Postern of Fate</title>
-          <description>Dolorem temporibus in aut.</description>
+          <title>No Longer at Ease</title>
+          <description>Natus consequatur suscipit temporibus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -257,15 +257,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '159'
+      - '173'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>Postern of Fate</title>
-          <description>Dolorem temporibus in aut.</description>
+          <title>No Longer at Ease</title>
+          <description>Natus consequatur suscipit temporibus.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:45 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=branch&noservice=1&opackage=bar_package&oproject=foo_project&user=Iggy
@@ -293,19 +293,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="101" vrev="101">
-          <srcmd5>4a1be640ac98ffa26145f8fb01c88a35</srcmd5>
+        <revision rev="39" vrev="39">
+          <srcmd5>6d3543f3fdc94904c3b66a58b47d4d03</srcmd5>
           <version>unknown</version>
-          <time>1642674744</time>
+          <time>1643641665</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:45 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_meta?user=Iggy
@@ -313,8 +313,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>Postern of Fate</title>
-          <description>Dolorem temporibus in aut.</description>
+          <title>No Longer at Ease</title>
+          <description>Natus consequatur suscipit temporibus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -335,15 +335,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '159'
+      - '173'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>Postern of Fate</title>
-          <description>Dolorem temporibus in aut.</description>
+          <title>No Longer at Ease</title>
+          <description>Natus consequatur suscipit temporibus.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:45 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -369,18 +369,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '735'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="101" vrev="101" srcmd5="4a1be640ac98ffa26145f8fb01c88a35">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="27702018fefcfea9bc6f1a5574a1182a" baserev="27702018fefcfea9bc6f1a5574a1182a" xsrcmd5="b546b8161343a636fd702ed4fc5aa407" lsrcmd5="4a1be640ac98ffa26145f8fb01c88a35"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="d10734e2ab4afed3dce41539e3c06519" size="66" mtime="1642674744"/>
-          <entry name="_link" md5="5f9f8f6fe7f5088097a11d18589d5938" size="141" mtime="1642674744"/>
-          <entry name="somefile.txt" md5="5430e2aae46a683423a62b91042f2c17" size="62" mtime="1642674744"/>
+        <directory name="bar_package-123456789" rev="39" vrev="39" srcmd5="6d3543f3fdc94904c3b66a58b47d4d03">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="1b70b42f7239ee7509fc9c8d1894a543" baserev="1b70b42f7239ee7509fc9c8d1894a543" xsrcmd5="d32b4e3e2f4620ebab17749b3ac9f955" lsrcmd5="6d3543f3fdc94904c3b66a58b47d4d03"/>
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="e155ab45dc14eebf09d7035891741f98" size="50" mtime="1643641664"/>
+          <entry name="_link" md5="7ef2bc2eca03f8774a088711797bc931" size="141" mtime="1643641665"/>
+          <entry name="somefile.txt" md5="797e07d021f8daa49562842fbd7b3dfc" size="68" mtime="1643641664"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:45 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?view=info
@@ -406,15 +406,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '343'
+      - '341'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package-123456789" rev="101" vrev="1725" srcmd5="b546b8161343a636fd702ed4fc5aa407" lsrcmd5="4a1be640ac98ffa26145f8fb01c88a35" verifymd5="27702018fefcfea9bc6f1a5574a1182a">
+        <sourceinfo package="bar_package-123456789" rev="39" vrev="155" srcmd5="d32b4e3e2f4620ebab17749b3ac9f955" lsrcmd5="6d3543f3fdc94904c3b66a58b47d4d03" verifymd5="1b70b42f7239ee7509fc9c8d1894a543">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:45 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -440,18 +440,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '735'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="101" vrev="101" srcmd5="4a1be640ac98ffa26145f8fb01c88a35">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="27702018fefcfea9bc6f1a5574a1182a" baserev="27702018fefcfea9bc6f1a5574a1182a" xsrcmd5="b546b8161343a636fd702ed4fc5aa407" lsrcmd5="4a1be640ac98ffa26145f8fb01c88a35"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="d10734e2ab4afed3dce41539e3c06519" size="66" mtime="1642674744"/>
-          <entry name="_link" md5="5f9f8f6fe7f5088097a11d18589d5938" size="141" mtime="1642674744"/>
-          <entry name="somefile.txt" md5="5430e2aae46a683423a62b91042f2c17" size="62" mtime="1642674744"/>
+        <directory name="bar_package-123456789" rev="39" vrev="39" srcmd5="6d3543f3fdc94904c3b66a58b47d4d03">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="1b70b42f7239ee7509fc9c8d1894a543" baserev="1b70b42f7239ee7509fc9c8d1894a543" xsrcmd5="d32b4e3e2f4620ebab17749b3ac9f955" lsrcmd5="6d3543f3fdc94904c3b66a58b47d4d03"/>
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="e155ab45dc14eebf09d7035891741f98" size="50" mtime="1643641664"/>
+          <entry name="_link" md5="7ef2bc2eca03f8774a088711797bc931" size="141" mtime="1643641665"/>
+          <entry name="somefile.txt" md5="797e07d021f8daa49562842fbd7b3dfc" size="68" mtime="1643641664"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:45 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -479,18 +479,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '324'
+      - '323'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="983780eb4a8a4e55014fcc05e15e7f58">
+        <sourcediff key="565e0ed3f743731232be3bacaa5a87a7">
           <old project="home:Iggy" package="bar_package-123456789" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="101" srcmd5="4a1be640ac98ffa26145f8fb01c88a35"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="39" srcmd5="6d3543f3fdc94904c3b66a58b47d4d03"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:45 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -522,14 +522,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="00fc41edd90783fa60e4ffecd6a2640d">
-          <old project="foo_project" package="bar_package" rev="27702018fefcfea9bc6f1a5574a1182a" srcmd5="27702018fefcfea9bc6f1a5574a1182a"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="b546b8161343a636fd702ed4fc5aa407" srcmd5="b546b8161343a636fd702ed4fc5aa407"/>
+        <sourcediff key="0aa5f53a11f169a4e475780072ea3896">
+          <old project="foo_project" package="bar_package" rev="1b70b42f7239ee7509fc9c8d1894a543" srcmd5="1b70b42f7239ee7509fc9c8d1894a543"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="d32b4e3e2f4620ebab17749b3ac9f955" srcmd5="d32b4e3e2f4620ebab17749b3ac9f955"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:45 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/_meta?user=Iggy
@@ -587,7 +587,7 @@ http_interactions:
             <arch>aarch64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:45 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_branch_request?user=Iggy
@@ -613,19 +613,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="102" vrev="102">
-          <srcmd5>2245f080500ddb7b4a3cebb8fac70f79</srcmd5>
+        <revision rev="40" vrev="40">
+          <srcmd5>36a28e224c97ae78be84cf239b0c4892</srcmd5>
           <version>unknown</version>
-          <time>1642674744</time>
+          <time>1643641665</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:45 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_meta?user=Iggy
@@ -633,8 +633,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>Postern of Fate</title>
-          <description>Dolorem temporibus in aut.</description>
+          <title>No Longer at Ease</title>
+          <description>Natus consequatur suscipit temporibus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -655,15 +655,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '159'
+      - '173'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>Postern of Fate</title>
-          <description>Dolorem temporibus in aut.</description>
+          <title>No Longer at Ease</title>
+          <description>Natus consequatur suscipit temporibus.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:24 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:45 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -689,19 +689,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="102" vrev="102" srcmd5="2245f080500ddb7b4a3cebb8fac70f79">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="27702018fefcfea9bc6f1a5574a1182a" baserev="27702018fefcfea9bc6f1a5574a1182a" xsrcmd5="f13aca3e11a40547549c0fda824c6206" lsrcmd5="2245f080500ddb7b4a3cebb8fac70f79"/>
-          <serviceinfo code="succeeded" xsrcmd5="aec9320cbe053792234c246ea176e068"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="d10734e2ab4afed3dce41539e3c06519" size="66" mtime="1642674744"/>
-          <entry name="_link" md5="5f9f8f6fe7f5088097a11d18589d5938" size="141" mtime="1642674744"/>
-          <entry name="somefile.txt" md5="5430e2aae46a683423a62b91042f2c17" size="62" mtime="1642674744"/>
+        <directory name="bar_package-123456789" rev="40" vrev="40" srcmd5="36a28e224c97ae78be84cf239b0c4892">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="1b70b42f7239ee7509fc9c8d1894a543" baserev="1b70b42f7239ee7509fc9c8d1894a543" xsrcmd5="243eb7c8a505686515b569f57f1a44c5" lsrcmd5="36a28e224c97ae78be84cf239b0c4892"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="e155ab45dc14eebf09d7035891741f98" size="50" mtime="1643641664"/>
+          <entry name="_link" md5="7ef2bc2eca03f8774a088711797bc931" size="141" mtime="1643641665"/>
+          <entry name="somefile.txt" md5="797e07d021f8daa49562842fbd7b3dfc" size="68" mtime="1643641664"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:45 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?view=info
@@ -727,15 +726,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '343'
+      - '341'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package-123456789" rev="102" vrev="1726" srcmd5="f687324f954a9267b4e3996e072677d4" lsrcmd5="aec9320cbe053792234c246ea176e068" verifymd5="f00b9f1a837f9ab9fde2bd4b6b091f72">
+        <sourceinfo package="bar_package-123456789" rev="40" vrev="156" srcmd5="243eb7c8a505686515b569f57f1a44c5" lsrcmd5="36a28e224c97ae78be84cf239b0c4892" verifymd5="b5d7fa314200ea5cf0daea476fc8ee2d">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:45 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -761,19 +760,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="102" vrev="102" srcmd5="2245f080500ddb7b4a3cebb8fac70f79">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="27702018fefcfea9bc6f1a5574a1182a" baserev="27702018fefcfea9bc6f1a5574a1182a" xsrcmd5="f13aca3e11a40547549c0fda824c6206" lsrcmd5="2245f080500ddb7b4a3cebb8fac70f79"/>
-          <serviceinfo code="succeeded" xsrcmd5="aec9320cbe053792234c246ea176e068"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="d10734e2ab4afed3dce41539e3c06519" size="66" mtime="1642674744"/>
-          <entry name="_link" md5="5f9f8f6fe7f5088097a11d18589d5938" size="141" mtime="1642674744"/>
-          <entry name="somefile.txt" md5="5430e2aae46a683423a62b91042f2c17" size="62" mtime="1642674744"/>
+        <directory name="bar_package-123456789" rev="40" vrev="40" srcmd5="36a28e224c97ae78be84cf239b0c4892">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="1b70b42f7239ee7509fc9c8d1894a543" baserev="1b70b42f7239ee7509fc9c8d1894a543" xsrcmd5="243eb7c8a505686515b569f57f1a44c5" lsrcmd5="36a28e224c97ae78be84cf239b0c4892"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="e155ab45dc14eebf09d7035891741f98" size="50" mtime="1643641664"/>
+          <entry name="_link" md5="7ef2bc2eca03f8774a088711797bc931" size="141" mtime="1643641665"/>
+          <entry name="somefile.txt" md5="797e07d021f8daa49562842fbd7b3dfc" size="68" mtime="1643641664"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:45 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -801,18 +799,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '324'
+      - '323'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="d15799fa70952ffd362619d37bc09c79">
+        <sourcediff key="9f7d898e2596136de3323b3dd8e82c21">
           <old project="home:Iggy" package="bar_package-123456789" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="102" srcmd5="2245f080500ddb7b4a3cebb8fac70f79"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="40" srcmd5="36a28e224c97ae78be84cf239b0c4892"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:45 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -844,14 +842,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="f95e32b75463b5c35d9db25d311b0e69">
-          <old project="foo_project" package="bar_package" rev="27702018fefcfea9bc6f1a5574a1182a" srcmd5="27702018fefcfea9bc6f1a5574a1182a"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="f687324f954a9267b4e3996e072677d4" srcmd5="f687324f954a9267b4e3996e072677d4"/>
+        <sourcediff key="aa15c9508b16c8ee6d1c2ef14a87f3a2">
+          <old project="foo_project" package="bar_package" rev="1b70b42f7239ee7509fc9c8d1894a543" srcmd5="1b70b42f7239ee7509fc9c8d1894a543"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="243eb7c8a505686515b569f57f1a44c5" srcmd5="243eb7c8a505686515b569f57f1a44c5"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:45 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -877,19 +875,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="102" vrev="102" srcmd5="2245f080500ddb7b4a3cebb8fac70f79">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="27702018fefcfea9bc6f1a5574a1182a" baserev="27702018fefcfea9bc6f1a5574a1182a" xsrcmd5="f13aca3e11a40547549c0fda824c6206" lsrcmd5="2245f080500ddb7b4a3cebb8fac70f79"/>
-          <serviceinfo code="succeeded" xsrcmd5="aec9320cbe053792234c246ea176e068"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="d10734e2ab4afed3dce41539e3c06519" size="66" mtime="1642674744"/>
-          <entry name="_link" md5="5f9f8f6fe7f5088097a11d18589d5938" size="141" mtime="1642674744"/>
-          <entry name="somefile.txt" md5="5430e2aae46a683423a62b91042f2c17" size="62" mtime="1642674744"/>
+        <directory name="bar_package-123456789" rev="40" vrev="40" srcmd5="36a28e224c97ae78be84cf239b0c4892">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="1b70b42f7239ee7509fc9c8d1894a543" baserev="1b70b42f7239ee7509fc9c8d1894a543" xsrcmd5="243eb7c8a505686515b569f57f1a44c5" lsrcmd5="36a28e224c97ae78be84cf239b0c4892"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="e155ab45dc14eebf09d7035891741f98" size="50" mtime="1643641664"/>
+          <entry name="_link" md5="7ef2bc2eca03f8774a088711797bc931" size="141" mtime="1643641665"/>
+          <entry name="somefile.txt" md5="797e07d021f8daa49562842fbd7b3dfc" size="68" mtime="1643641664"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:45 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '628'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="243eb7c8a505686515b569f57f1a44c5" vrev="156" srcmd5="243eb7c8a505686515b569f57f1a44c5">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="1b70b42f7239ee7509fc9c8d1894a543" baserev="1b70b42f7239ee7509fc9c8d1894a543" lsrcmd5="36a28e224c97ae78be84cf239b0c4892"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="e155ab45dc14eebf09d7035891741f98" size="50" mtime="1643641664"/>
+          <entry name="somefile.txt" md5="797e07d021f8daa49562842fbd7b3dfc" size="68" mtime="1643641664"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:07:45 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -915,19 +948,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="102" vrev="102" srcmd5="2245f080500ddb7b4a3cebb8fac70f79">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="27702018fefcfea9bc6f1a5574a1182a" baserev="27702018fefcfea9bc6f1a5574a1182a" xsrcmd5="f13aca3e11a40547549c0fda824c6206" lsrcmd5="2245f080500ddb7b4a3cebb8fac70f79"/>
-          <serviceinfo code="succeeded" xsrcmd5="aec9320cbe053792234c246ea176e068"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="d10734e2ab4afed3dce41539e3c06519" size="66" mtime="1642674744"/>
-          <entry name="_link" md5="5f9f8f6fe7f5088097a11d18589d5938" size="141" mtime="1642674744"/>
-          <entry name="somefile.txt" md5="5430e2aae46a683423a62b91042f2c17" size="62" mtime="1642674744"/>
+        <directory name="bar_package-123456789" rev="40" vrev="40" srcmd5="36a28e224c97ae78be84cf239b0c4892">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="1b70b42f7239ee7509fc9c8d1894a543" baserev="1b70b42f7239ee7509fc9c8d1894a543" xsrcmd5="243eb7c8a505686515b569f57f1a44c5" lsrcmd5="36a28e224c97ae78be84cf239b0c4892"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="e155ab45dc14eebf09d7035891741f98" size="50" mtime="1643641664"/>
+          <entry name="_link" md5="7ef2bc2eca03f8774a088711797bc931" size="141" mtime="1643641665"/>
+          <entry name="somefile.txt" md5="797e07d021f8daa49562842fbd7b3dfc" size="68" mtime="1643641664"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:45 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '628'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="243eb7c8a505686515b569f57f1a44c5" vrev="156" srcmd5="243eb7c8a505686515b569f57f1a44c5">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="1b70b42f7239ee7509fc9c8d1894a543" baserev="1b70b42f7239ee7509fc9c8d1894a543" lsrcmd5="36a28e224c97ae78be84cf239b0c4892"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="e155ab45dc14eebf09d7035891741f98" size="50" mtime="1643641664"/>
+          <entry name="somefile.txt" md5="797e07d021f8daa49562842fbd7b3dfc" size="68" mtime="1643641664"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:07:45 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -953,19 +1021,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="102" vrev="102" srcmd5="2245f080500ddb7b4a3cebb8fac70f79">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="27702018fefcfea9bc6f1a5574a1182a" baserev="27702018fefcfea9bc6f1a5574a1182a" xsrcmd5="f13aca3e11a40547549c0fda824c6206" lsrcmd5="2245f080500ddb7b4a3cebb8fac70f79"/>
-          <serviceinfo code="succeeded" xsrcmd5="aec9320cbe053792234c246ea176e068"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="d10734e2ab4afed3dce41539e3c06519" size="66" mtime="1642674744"/>
-          <entry name="_link" md5="5f9f8f6fe7f5088097a11d18589d5938" size="141" mtime="1642674744"/>
-          <entry name="somefile.txt" md5="5430e2aae46a683423a62b91042f2c17" size="62" mtime="1642674744"/>
+        <directory name="bar_package-123456789" rev="40" vrev="40" srcmd5="36a28e224c97ae78be84cf239b0c4892">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="1b70b42f7239ee7509fc9c8d1894a543" baserev="1b70b42f7239ee7509fc9c8d1894a543" xsrcmd5="243eb7c8a505686515b569f57f1a44c5" lsrcmd5="36a28e224c97ae78be84cf239b0c4892"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="e155ab45dc14eebf09d7035891741f98" size="50" mtime="1643641664"/>
+          <entry name="_link" md5="7ef2bc2eca03f8774a088711797bc931" size="141" mtime="1643641665"/>
+          <entry name="somefile.txt" md5="797e07d021f8daa49562842fbd7b3dfc" size="68" mtime="1643641664"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:45 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '628'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="243eb7c8a505686515b569f57f1a44c5" vrev="156" srcmd5="243eb7c8a505686515b569f57f1a44c5">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="1b70b42f7239ee7509fc9c8d1894a543" baserev="1b70b42f7239ee7509fc9c8d1894a543" lsrcmd5="36a28e224c97ae78be84cf239b0c4892"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="e155ab45dc14eebf09d7035891741f98" size="50" mtime="1643641664"/>
+          <entry name="somefile.txt" md5="797e07d021f8daa49562842fbd7b3dfc" size="68" mtime="1643641664"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:07:45 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -991,19 +1094,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="102" vrev="102" srcmd5="2245f080500ddb7b4a3cebb8fac70f79">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="27702018fefcfea9bc6f1a5574a1182a" baserev="27702018fefcfea9bc6f1a5574a1182a" xsrcmd5="f13aca3e11a40547549c0fda824c6206" lsrcmd5="2245f080500ddb7b4a3cebb8fac70f79"/>
-          <serviceinfo code="succeeded" xsrcmd5="aec9320cbe053792234c246ea176e068"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="d10734e2ab4afed3dce41539e3c06519" size="66" mtime="1642674744"/>
-          <entry name="_link" md5="5f9f8f6fe7f5088097a11d18589d5938" size="141" mtime="1642674744"/>
-          <entry name="somefile.txt" md5="5430e2aae46a683423a62b91042f2c17" size="62" mtime="1642674744"/>
+        <directory name="bar_package-123456789" rev="40" vrev="40" srcmd5="36a28e224c97ae78be84cf239b0c4892">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="1b70b42f7239ee7509fc9c8d1894a543" baserev="1b70b42f7239ee7509fc9c8d1894a543" xsrcmd5="243eb7c8a505686515b569f57f1a44c5" lsrcmd5="36a28e224c97ae78be84cf239b0c4892"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="e155ab45dc14eebf09d7035891741f98" size="50" mtime="1643641664"/>
+          <entry name="_link" md5="7ef2bc2eca03f8774a088711797bc931" size="141" mtime="1643641665"/>
+          <entry name="somefile.txt" md5="797e07d021f8daa49562842fbd7b3dfc" size="68" mtime="1643641664"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:45 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '628'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="243eb7c8a505686515b569f57f1a44c5" vrev="156" srcmd5="243eb7c8a505686515b569f57f1a44c5">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="1b70b42f7239ee7509fc9c8d1894a543" baserev="1b70b42f7239ee7509fc9c8d1894a543" lsrcmd5="36a28e224c97ae78be84cf239b0c4892"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="e155ab45dc14eebf09d7035891741f98" size="50" mtime="1643641664"/>
+          <entry name="somefile.txt" md5="797e07d021f8daa49562842fbd7b3dfc" size="68" mtime="1643641664"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:07:45 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -1029,22 +1167,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="102" vrev="102" srcmd5="2245f080500ddb7b4a3cebb8fac70f79">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="27702018fefcfea9bc6f1a5574a1182a" baserev="27702018fefcfea9bc6f1a5574a1182a" xsrcmd5="f13aca3e11a40547549c0fda824c6206" lsrcmd5="2245f080500ddb7b4a3cebb8fac70f79"/>
-          <serviceinfo code="succeeded" xsrcmd5="aec9320cbe053792234c246ea176e068"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="d10734e2ab4afed3dce41539e3c06519" size="66" mtime="1642674744"/>
-          <entry name="_link" md5="5f9f8f6fe7f5088097a11d18589d5938" size="141" mtime="1642674744"/>
-          <entry name="somefile.txt" md5="5430e2aae46a683423a62b91042f2c17" size="62" mtime="1642674744"/>
+        <directory name="bar_package-123456789" rev="40" vrev="40" srcmd5="36a28e224c97ae78be84cf239b0c4892">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="1b70b42f7239ee7509fc9c8d1894a543" baserev="1b70b42f7239ee7509fc9c8d1894a543" xsrcmd5="243eb7c8a505686515b569f57f1a44c5" lsrcmd5="36a28e224c97ae78be84cf239b0c4892"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="e155ab45dc14eebf09d7035891741f98" size="50" mtime="1643641664"/>
+          <entry name="_link" md5="7ef2bc2eca03f8774a088711797bc931" size="141" mtime="1643641665"/>
+          <entry name="somefile.txt" md5="797e07d021f8daa49562842fbd7b3dfc" size="68" mtime="1643641664"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:45 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1067,169 +1204,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '628'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="102" vrev="102" srcmd5="2245f080500ddb7b4a3cebb8fac70f79">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="27702018fefcfea9bc6f1a5574a1182a" baserev="27702018fefcfea9bc6f1a5574a1182a" xsrcmd5="f13aca3e11a40547549c0fda824c6206" lsrcmd5="2245f080500ddb7b4a3cebb8fac70f79"/>
-          <serviceinfo code="succeeded" xsrcmd5="aec9320cbe053792234c246ea176e068"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="d10734e2ab4afed3dce41539e3c06519" size="66" mtime="1642674744"/>
-          <entry name="_link" md5="5f9f8f6fe7f5088097a11d18589d5938" size="141" mtime="1642674744"/>
-          <entry name="somefile.txt" md5="5430e2aae46a683423a62b91042f2c17" size="62" mtime="1642674744"/>
+        <directory name="bar_package-123456789" rev="243eb7c8a505686515b569f57f1a44c5" vrev="156" srcmd5="243eb7c8a505686515b569f57f1a44c5">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="1b70b42f7239ee7509fc9c8d1894a543" baserev="1b70b42f7239ee7509fc9c8d1894a543" lsrcmd5="36a28e224c97ae78be84cf239b0c4892"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="e155ab45dc14eebf09d7035891741f98" size="50" mtime="1643641664"/>
+          <entry name="somefile.txt" md5="797e07d021f8daa49562842fbd7b3dfc" size="68" mtime="1643641664"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:25 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '812'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="102" vrev="102" srcmd5="2245f080500ddb7b4a3cebb8fac70f79">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="27702018fefcfea9bc6f1a5574a1182a" baserev="27702018fefcfea9bc6f1a5574a1182a" xsrcmd5="f13aca3e11a40547549c0fda824c6206" lsrcmd5="2245f080500ddb7b4a3cebb8fac70f79"/>
-          <serviceinfo code="succeeded" xsrcmd5="aec9320cbe053792234c246ea176e068"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="d10734e2ab4afed3dce41539e3c06519" size="66" mtime="1642674744"/>
-          <entry name="_link" md5="5f9f8f6fe7f5088097a11d18589d5938" size="141" mtime="1642674744"/>
-          <entry name="somefile.txt" md5="5430e2aae46a683423a62b91042f2c17" size="62" mtime="1642674744"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:25 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '812'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="102" vrev="102" srcmd5="2245f080500ddb7b4a3cebb8fac70f79">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="27702018fefcfea9bc6f1a5574a1182a" baserev="27702018fefcfea9bc6f1a5574a1182a" xsrcmd5="f13aca3e11a40547549c0fda824c6206" lsrcmd5="2245f080500ddb7b4a3cebb8fac70f79"/>
-          <serviceinfo code="succeeded" xsrcmd5="aec9320cbe053792234c246ea176e068"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="d10734e2ab4afed3dce41539e3c06519" size="66" mtime="1642674744"/>
-          <entry name="_link" md5="5f9f8f6fe7f5088097a11d18589d5938" size="141" mtime="1642674744"/>
-          <entry name="somefile.txt" md5="5430e2aae46a683423a62b91042f2c17" size="62" mtime="1642674744"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:25 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '812'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="102" vrev="102" srcmd5="2245f080500ddb7b4a3cebb8fac70f79">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="27702018fefcfea9bc6f1a5574a1182a" baserev="27702018fefcfea9bc6f1a5574a1182a" xsrcmd5="f13aca3e11a40547549c0fda824c6206" lsrcmd5="2245f080500ddb7b4a3cebb8fac70f79"/>
-          <serviceinfo code="succeeded" xsrcmd5="aec9320cbe053792234c246ea176e068"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="d10734e2ab4afed3dce41539e3c06519" size="66" mtime="1642674744"/>
-          <entry name="_link" md5="5f9f8f6fe7f5088097a11d18589d5938" size="141" mtime="1642674744"/>
-          <entry name="somefile.txt" md5="5430e2aae46a683423a62b91042f2c17" size="62" mtime="1642674744"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:25 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '812'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="102" vrev="102" srcmd5="2245f080500ddb7b4a3cebb8fac70f79">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="27702018fefcfea9bc6f1a5574a1182a" baserev="27702018fefcfea9bc6f1a5574a1182a" xsrcmd5="f13aca3e11a40547549c0fda824c6206" lsrcmd5="2245f080500ddb7b4a3cebb8fac70f79"/>
-          <serviceinfo code="succeeded" xsrcmd5="aec9320cbe053792234c246ea176e068"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="d10734e2ab4afed3dce41539e3c06519" size="66" mtime="1642674744"/>
-          <entry name="_link" md5="5f9f8f6fe7f5088097a11d18589d5938" size="141" mtime="1642674744"/>
-          <entry name="somefile.txt" md5="5430e2aae46a683423a62b91042f2c17" size="62" mtime="1642674744"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:45 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/with_a_push_event_for_a_commit/behaves_like_successful_new_PR_or_MR_event/1_1_2_5_1_2.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/with_a_push_event_for_a_commit/behaves_like_successful_new_PR_or_MR_event/1_1_2_5_1_2.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:27 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:46 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_248
+    uri: http://backend:5352/source/foo_project/_meta?user=user_15
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Ah, Wilderness!</title>
+          <title>Cabbages and Kings</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '147'
+      - '150'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Ah, Wilderness!</title>
+          <title>Cabbages and Kings</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:27 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:46 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_249
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_16
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Wives of Bath</title>
-          <description>Quia consequatur eum et.</description>
+          <title>Tender Is the Night</title>
+          <description>Sint autem ut iusto.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,22 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '151'
+      - '149'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Wives of Bath</title>
-          <description>Quia consequatur eum et.</description>
+          <title>Tender Is the Night</title>
+          <description>Sint autem ut iusto.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:27 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Incidunt in consequuntur. Natus ullam consequatur. Officia inventore
-        voluptatem.
+      string: Rerum quos sunt. Ipsam porro fugit. Error fugit quia.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -144,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1629" vrev="1629">
-          <srcmd5>e9a4cbb5e58898cee7f73f5cbe4e0e2d</srcmd5>
+        <revision rev="117" vrev="117">
+          <srcmd5>576d57f92423794792d8d813cba6fb81</srcmd5>
           <version>unknown</version>
-          <time>1642674747</time>
+          <time>1643641666</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:27 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Vel ut eius. Aspernatur non numquam. Quam magni deserunt.
+      string: Culpa ea quam. Ea doloremque rerum. Nisi aut explicabo.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -182,19 +181,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1630" vrev="1630">
-          <srcmd5>4d212cf3ab2d4405f2c121533bea4bf6</srcmd5>
+        <revision rev="118" vrev="118">
+          <srcmd5>743d61d6f7e4284c5ffa5244aa87ae85</srcmd5>
           <version>unknown</version>
-          <time>1642674747</time>
+          <time>1643641666</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:27 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:46 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -228,7 +227,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:32:27 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_meta?user=Iggy
@@ -236,8 +235,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>The Wives of Bath</title>
-          <description>Quia consequatur eum et.</description>
+          <title>Tender Is the Night</title>
+          <description>Sint autem ut iusto.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -258,15 +257,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '159'
+      - '157'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>The Wives of Bath</title>
-          <description>Quia consequatur eum et.</description>
+          <title>Tender Is the Night</title>
+          <description>Sint autem ut iusto.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:46 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=branch&noservice=1&opackage=bar_package&oproject=foo_project&user=Iggy
@@ -294,19 +293,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="107" vrev="107">
-          <srcmd5>f389f5136e37bad74850dd75f8b848db</srcmd5>
+        <revision rev="41" vrev="41">
+          <srcmd5>69b20c08fdab1592b2c18fa49c6d44e0</srcmd5>
           <version>unknown</version>
-          <time>1642674748</time>
+          <time>1643641666</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_meta?user=Iggy
@@ -314,8 +313,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>The Wives of Bath</title>
-          <description>Quia consequatur eum et.</description>
+          <title>Tender Is the Night</title>
+          <description>Sint autem ut iusto.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -336,15 +335,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '159'
+      - '157'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>The Wives of Bath</title>
-          <description>Quia consequatur eum et.</description>
+          <title>Tender Is the Night</title>
+          <description>Sint autem ut iusto.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:46 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -370,18 +369,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '735'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="107" vrev="107" srcmd5="f389f5136e37bad74850dd75f8b848db">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="4d212cf3ab2d4405f2c121533bea4bf6" baserev="4d212cf3ab2d4405f2c121533bea4bf6" xsrcmd5="0d21cf3cba74117273c3904cb3763096" lsrcmd5="f389f5136e37bad74850dd75f8b848db"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="4e1e3878e7d9d8f236b16b2c49d0b180" size="80" mtime="1642674747"/>
-          <entry name="_link" md5="2b487120d0f9fcb2581a69fa6482e6f2" size="141" mtime="1642674748"/>
-          <entry name="somefile.txt" md5="b2acef30fba6cb86ec0b98b1b4783731" size="57" mtime="1642674747"/>
+        <directory name="bar_package-123456789" rev="41" vrev="41" srcmd5="69b20c08fdab1592b2c18fa49c6d44e0">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="743d61d6f7e4284c5ffa5244aa87ae85" baserev="743d61d6f7e4284c5ffa5244aa87ae85" xsrcmd5="bc13d5b3bb9287d65165931525a98674" lsrcmd5="69b20c08fdab1592b2c18fa49c6d44e0"/>
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="3da59d3524ac0ce78c1b5a3adf846ae3" size="53" mtime="1643641666"/>
+          <entry name="_link" md5="bd387d4b53e69156a1c0188596414a54" size="141" mtime="1643641666"/>
+          <entry name="somefile.txt" md5="45409574c19976999b732e29f8b83b63" size="55" mtime="1643641666"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:46 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?view=info
@@ -407,15 +406,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '343'
+      - '341'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package-123456789" rev="107" vrev="1737" srcmd5="0d21cf3cba74117273c3904cb3763096" lsrcmd5="f389f5136e37bad74850dd75f8b848db" verifymd5="4d212cf3ab2d4405f2c121533bea4bf6">
+        <sourceinfo package="bar_package-123456789" rev="41" vrev="159" srcmd5="bc13d5b3bb9287d65165931525a98674" lsrcmd5="69b20c08fdab1592b2c18fa49c6d44e0" verifymd5="743d61d6f7e4284c5ffa5244aa87ae85">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:46 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -441,18 +440,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '735'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="107" vrev="107" srcmd5="f389f5136e37bad74850dd75f8b848db">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="4d212cf3ab2d4405f2c121533bea4bf6" baserev="4d212cf3ab2d4405f2c121533bea4bf6" xsrcmd5="0d21cf3cba74117273c3904cb3763096" lsrcmd5="f389f5136e37bad74850dd75f8b848db"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="4e1e3878e7d9d8f236b16b2c49d0b180" size="80" mtime="1642674747"/>
-          <entry name="_link" md5="2b487120d0f9fcb2581a69fa6482e6f2" size="141" mtime="1642674748"/>
-          <entry name="somefile.txt" md5="b2acef30fba6cb86ec0b98b1b4783731" size="57" mtime="1642674747"/>
+        <directory name="bar_package-123456789" rev="41" vrev="41" srcmd5="69b20c08fdab1592b2c18fa49c6d44e0">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="743d61d6f7e4284c5ffa5244aa87ae85" baserev="743d61d6f7e4284c5ffa5244aa87ae85" xsrcmd5="bc13d5b3bb9287d65165931525a98674" lsrcmd5="69b20c08fdab1592b2c18fa49c6d44e0"/>
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="3da59d3524ac0ce78c1b5a3adf846ae3" size="53" mtime="1643641666"/>
+          <entry name="_link" md5="bd387d4b53e69156a1c0188596414a54" size="141" mtime="1643641666"/>
+          <entry name="somefile.txt" md5="45409574c19976999b732e29f8b83b63" size="55" mtime="1643641666"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:46 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -480,18 +479,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '324'
+      - '323'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="146510eaf3514830681c46e78027c912">
+        <sourcediff key="fd7bf096838769ffe007571d7f949708">
           <old project="home:Iggy" package="bar_package-123456789" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="107" srcmd5="f389f5136e37bad74850dd75f8b848db"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="41" srcmd5="69b20c08fdab1592b2c18fa49c6d44e0"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:46 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -523,14 +522,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="2e34ba025a71b4f041e1c5c96f022978">
-          <old project="foo_project" package="bar_package" rev="4d212cf3ab2d4405f2c121533bea4bf6" srcmd5="4d212cf3ab2d4405f2c121533bea4bf6"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="0d21cf3cba74117273c3904cb3763096" srcmd5="0d21cf3cba74117273c3904cb3763096"/>
+        <sourcediff key="15257fd3b8b0ac892b518ad5d84e4de3">
+          <old project="foo_project" package="bar_package" rev="743d61d6f7e4284c5ffa5244aa87ae85" srcmd5="743d61d6f7e4284c5ffa5244aa87ae85"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="bc13d5b3bb9287d65165931525a98674" srcmd5="bc13d5b3bb9287d65165931525a98674"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/_meta?user=Iggy
@@ -588,7 +587,7 @@ http_interactions:
             <arch>aarch64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_branch_request?user=Iggy
@@ -614,19 +613,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="108" vrev="108">
-          <srcmd5>2164ead059e1fe57fd88b4c063da7dd7</srcmd5>
+        <revision rev="42" vrev="42">
+          <srcmd5>aec2d12649ffc1728f9ca1f1cdfe4f78</srcmd5>
           <version>unknown</version>
-          <time>1642674748</time>
+          <time>1643641667</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_meta?user=Iggy
@@ -634,8 +633,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>The Wives of Bath</title>
-          <description>Quia consequatur eum et.</description>
+          <title>Tender Is the Night</title>
+          <description>Sint autem ut iusto.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -656,15 +655,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '159'
+      - '157'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>The Wives of Bath</title>
-          <description>Quia consequatur eum et.</description>
+          <title>Tender Is the Night</title>
+          <description>Sint autem ut iusto.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:47 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -690,19 +689,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="108" vrev="108" srcmd5="2164ead059e1fe57fd88b4c063da7dd7">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="4d212cf3ab2d4405f2c121533bea4bf6" baserev="4d212cf3ab2d4405f2c121533bea4bf6" xsrcmd5="6f0870ce2da766aa506fd9b7d731acdc" lsrcmd5="2164ead059e1fe57fd88b4c063da7dd7"/>
-          <serviceinfo code="succeeded" xsrcmd5="18e6db9b7f5c3a8c3071a9a4bddf734b"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="4e1e3878e7d9d8f236b16b2c49d0b180" size="80" mtime="1642674747"/>
-          <entry name="_link" md5="2b487120d0f9fcb2581a69fa6482e6f2" size="141" mtime="1642674748"/>
-          <entry name="somefile.txt" md5="b2acef30fba6cb86ec0b98b1b4783731" size="57" mtime="1642674747"/>
+        <directory name="bar_package-123456789" rev="42" vrev="42" srcmd5="aec2d12649ffc1728f9ca1f1cdfe4f78">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="743d61d6f7e4284c5ffa5244aa87ae85" baserev="743d61d6f7e4284c5ffa5244aa87ae85" xsrcmd5="db1bb9ca01434c38a8f94dbc75831d20" lsrcmd5="aec2d12649ffc1728f9ca1f1cdfe4f78"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="3da59d3524ac0ce78c1b5a3adf846ae3" size="53" mtime="1643641666"/>
+          <entry name="_link" md5="bd387d4b53e69156a1c0188596414a54" size="141" mtime="1643641666"/>
+          <entry name="somefile.txt" md5="45409574c19976999b732e29f8b83b63" size="55" mtime="1643641666"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:47 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?view=info
@@ -728,15 +726,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '343'
+      - '341'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package-123456789" rev="108" vrev="1738" srcmd5="3342b3ce25308bdf9b3b946e7c8c59c3" lsrcmd5="18e6db9b7f5c3a8c3071a9a4bddf734b" verifymd5="377727e1f8df65df8802104b68bdc421">
+        <sourceinfo package="bar_package-123456789" rev="42" vrev="160" srcmd5="db1bb9ca01434c38a8f94dbc75831d20" lsrcmd5="aec2d12649ffc1728f9ca1f1cdfe4f78" verifymd5="e878e215558cf4655adb7d1d00b5987d">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:47 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -762,19 +760,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="108" vrev="108" srcmd5="2164ead059e1fe57fd88b4c063da7dd7">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="4d212cf3ab2d4405f2c121533bea4bf6" baserev="4d212cf3ab2d4405f2c121533bea4bf6" xsrcmd5="6f0870ce2da766aa506fd9b7d731acdc" lsrcmd5="2164ead059e1fe57fd88b4c063da7dd7"/>
-          <serviceinfo code="succeeded" xsrcmd5="18e6db9b7f5c3a8c3071a9a4bddf734b"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="4e1e3878e7d9d8f236b16b2c49d0b180" size="80" mtime="1642674747"/>
-          <entry name="_link" md5="2b487120d0f9fcb2581a69fa6482e6f2" size="141" mtime="1642674748"/>
-          <entry name="somefile.txt" md5="b2acef30fba6cb86ec0b98b1b4783731" size="57" mtime="1642674747"/>
+        <directory name="bar_package-123456789" rev="42" vrev="42" srcmd5="aec2d12649ffc1728f9ca1f1cdfe4f78">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="743d61d6f7e4284c5ffa5244aa87ae85" baserev="743d61d6f7e4284c5ffa5244aa87ae85" xsrcmd5="db1bb9ca01434c38a8f94dbc75831d20" lsrcmd5="aec2d12649ffc1728f9ca1f1cdfe4f78"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="3da59d3524ac0ce78c1b5a3adf846ae3" size="53" mtime="1643641666"/>
+          <entry name="_link" md5="bd387d4b53e69156a1c0188596414a54" size="141" mtime="1643641666"/>
+          <entry name="somefile.txt" md5="45409574c19976999b732e29f8b83b63" size="55" mtime="1643641666"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:47 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -802,18 +799,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '324'
+      - '323'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="41b31d954d2e0898abb927b6b517f560">
+        <sourcediff key="e5743c986ebd8b72ffc4caf963e30f44">
           <old project="home:Iggy" package="bar_package-123456789" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="108" srcmd5="2164ead059e1fe57fd88b4c063da7dd7"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="42" srcmd5="aec2d12649ffc1728f9ca1f1cdfe4f78"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:47 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -845,14 +842,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="e653359a06c7b98d96f652a44e4af6b8">
-          <old project="foo_project" package="bar_package" rev="4d212cf3ab2d4405f2c121533bea4bf6" srcmd5="4d212cf3ab2d4405f2c121533bea4bf6"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="3342b3ce25308bdf9b3b946e7c8c59c3" srcmd5="3342b3ce25308bdf9b3b946e7c8c59c3"/>
+        <sourcediff key="0958455cdd21b97f976566104b8f5d72">
+          <old project="foo_project" package="bar_package" rev="743d61d6f7e4284c5ffa5244aa87ae85" srcmd5="743d61d6f7e4284c5ffa5244aa87ae85"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="db1bb9ca01434c38a8f94dbc75831d20" srcmd5="db1bb9ca01434c38a8f94dbc75831d20"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:47 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -878,19 +875,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="108" vrev="108" srcmd5="2164ead059e1fe57fd88b4c063da7dd7">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="4d212cf3ab2d4405f2c121533bea4bf6" baserev="4d212cf3ab2d4405f2c121533bea4bf6" xsrcmd5="6f0870ce2da766aa506fd9b7d731acdc" lsrcmd5="2164ead059e1fe57fd88b4c063da7dd7"/>
-          <serviceinfo code="succeeded" xsrcmd5="18e6db9b7f5c3a8c3071a9a4bddf734b"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="4e1e3878e7d9d8f236b16b2c49d0b180" size="80" mtime="1642674747"/>
-          <entry name="_link" md5="2b487120d0f9fcb2581a69fa6482e6f2" size="141" mtime="1642674748"/>
-          <entry name="somefile.txt" md5="b2acef30fba6cb86ec0b98b1b4783731" size="57" mtime="1642674747"/>
+        <directory name="bar_package-123456789" rev="42" vrev="42" srcmd5="aec2d12649ffc1728f9ca1f1cdfe4f78">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="743d61d6f7e4284c5ffa5244aa87ae85" baserev="743d61d6f7e4284c5ffa5244aa87ae85" xsrcmd5="db1bb9ca01434c38a8f94dbc75831d20" lsrcmd5="aec2d12649ffc1728f9ca1f1cdfe4f78"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="3da59d3524ac0ce78c1b5a3adf846ae3" size="53" mtime="1643641666"/>
+          <entry name="_link" md5="bd387d4b53e69156a1c0188596414a54" size="141" mtime="1643641666"/>
+          <entry name="somefile.txt" md5="45409574c19976999b732e29f8b83b63" size="55" mtime="1643641666"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:47 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '628'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="db1bb9ca01434c38a8f94dbc75831d20" vrev="160" srcmd5="db1bb9ca01434c38a8f94dbc75831d20">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="743d61d6f7e4284c5ffa5244aa87ae85" baserev="743d61d6f7e4284c5ffa5244aa87ae85" lsrcmd5="aec2d12649ffc1728f9ca1f1cdfe4f78"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="3da59d3524ac0ce78c1b5a3adf846ae3" size="53" mtime="1643641666"/>
+          <entry name="somefile.txt" md5="45409574c19976999b732e29f8b83b63" size="55" mtime="1643641666"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:07:47 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -916,19 +948,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="108" vrev="108" srcmd5="2164ead059e1fe57fd88b4c063da7dd7">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="4d212cf3ab2d4405f2c121533bea4bf6" baserev="4d212cf3ab2d4405f2c121533bea4bf6" xsrcmd5="6f0870ce2da766aa506fd9b7d731acdc" lsrcmd5="2164ead059e1fe57fd88b4c063da7dd7"/>
-          <serviceinfo code="succeeded" xsrcmd5="18e6db9b7f5c3a8c3071a9a4bddf734b"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="4e1e3878e7d9d8f236b16b2c49d0b180" size="80" mtime="1642674747"/>
-          <entry name="_link" md5="2b487120d0f9fcb2581a69fa6482e6f2" size="141" mtime="1642674748"/>
-          <entry name="somefile.txt" md5="b2acef30fba6cb86ec0b98b1b4783731" size="57" mtime="1642674747"/>
+        <directory name="bar_package-123456789" rev="42" vrev="42" srcmd5="aec2d12649ffc1728f9ca1f1cdfe4f78">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="743d61d6f7e4284c5ffa5244aa87ae85" baserev="743d61d6f7e4284c5ffa5244aa87ae85" xsrcmd5="db1bb9ca01434c38a8f94dbc75831d20" lsrcmd5="aec2d12649ffc1728f9ca1f1cdfe4f78"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="3da59d3524ac0ce78c1b5a3adf846ae3" size="53" mtime="1643641666"/>
+          <entry name="_link" md5="bd387d4b53e69156a1c0188596414a54" size="141" mtime="1643641666"/>
+          <entry name="somefile.txt" md5="45409574c19976999b732e29f8b83b63" size="55" mtime="1643641666"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:47 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '628'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="db1bb9ca01434c38a8f94dbc75831d20" vrev="160" srcmd5="db1bb9ca01434c38a8f94dbc75831d20">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="743d61d6f7e4284c5ffa5244aa87ae85" baserev="743d61d6f7e4284c5ffa5244aa87ae85" lsrcmd5="aec2d12649ffc1728f9ca1f1cdfe4f78"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="3da59d3524ac0ce78c1b5a3adf846ae3" size="53" mtime="1643641666"/>
+          <entry name="somefile.txt" md5="45409574c19976999b732e29f8b83b63" size="55" mtime="1643641666"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:07:47 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -954,19 +1021,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="108" vrev="108" srcmd5="2164ead059e1fe57fd88b4c063da7dd7">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="4d212cf3ab2d4405f2c121533bea4bf6" baserev="4d212cf3ab2d4405f2c121533bea4bf6" xsrcmd5="6f0870ce2da766aa506fd9b7d731acdc" lsrcmd5="2164ead059e1fe57fd88b4c063da7dd7"/>
-          <serviceinfo code="succeeded" xsrcmd5="18e6db9b7f5c3a8c3071a9a4bddf734b"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="4e1e3878e7d9d8f236b16b2c49d0b180" size="80" mtime="1642674747"/>
-          <entry name="_link" md5="2b487120d0f9fcb2581a69fa6482e6f2" size="141" mtime="1642674748"/>
-          <entry name="somefile.txt" md5="b2acef30fba6cb86ec0b98b1b4783731" size="57" mtime="1642674747"/>
+        <directory name="bar_package-123456789" rev="42" vrev="42" srcmd5="aec2d12649ffc1728f9ca1f1cdfe4f78">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="743d61d6f7e4284c5ffa5244aa87ae85" baserev="743d61d6f7e4284c5ffa5244aa87ae85" xsrcmd5="db1bb9ca01434c38a8f94dbc75831d20" lsrcmd5="aec2d12649ffc1728f9ca1f1cdfe4f78"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="3da59d3524ac0ce78c1b5a3adf846ae3" size="53" mtime="1643641666"/>
+          <entry name="_link" md5="bd387d4b53e69156a1c0188596414a54" size="141" mtime="1643641666"/>
+          <entry name="somefile.txt" md5="45409574c19976999b732e29f8b83b63" size="55" mtime="1643641666"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:47 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '628'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="db1bb9ca01434c38a8f94dbc75831d20" vrev="160" srcmd5="db1bb9ca01434c38a8f94dbc75831d20">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="743d61d6f7e4284c5ffa5244aa87ae85" baserev="743d61d6f7e4284c5ffa5244aa87ae85" lsrcmd5="aec2d12649ffc1728f9ca1f1cdfe4f78"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="3da59d3524ac0ce78c1b5a3adf846ae3" size="53" mtime="1643641666"/>
+          <entry name="somefile.txt" md5="45409574c19976999b732e29f8b83b63" size="55" mtime="1643641666"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:07:47 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -992,19 +1094,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="108" vrev="108" srcmd5="2164ead059e1fe57fd88b4c063da7dd7">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="4d212cf3ab2d4405f2c121533bea4bf6" baserev="4d212cf3ab2d4405f2c121533bea4bf6" xsrcmd5="6f0870ce2da766aa506fd9b7d731acdc" lsrcmd5="2164ead059e1fe57fd88b4c063da7dd7"/>
-          <serviceinfo code="succeeded" xsrcmd5="18e6db9b7f5c3a8c3071a9a4bddf734b"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="4e1e3878e7d9d8f236b16b2c49d0b180" size="80" mtime="1642674747"/>
-          <entry name="_link" md5="2b487120d0f9fcb2581a69fa6482e6f2" size="141" mtime="1642674748"/>
-          <entry name="somefile.txt" md5="b2acef30fba6cb86ec0b98b1b4783731" size="57" mtime="1642674747"/>
+        <directory name="bar_package-123456789" rev="42" vrev="42" srcmd5="aec2d12649ffc1728f9ca1f1cdfe4f78">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="743d61d6f7e4284c5ffa5244aa87ae85" baserev="743d61d6f7e4284c5ffa5244aa87ae85" xsrcmd5="db1bb9ca01434c38a8f94dbc75831d20" lsrcmd5="aec2d12649ffc1728f9ca1f1cdfe4f78"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="3da59d3524ac0ce78c1b5a3adf846ae3" size="53" mtime="1643641666"/>
+          <entry name="_link" md5="bd387d4b53e69156a1c0188596414a54" size="141" mtime="1643641666"/>
+          <entry name="somefile.txt" md5="45409574c19976999b732e29f8b83b63" size="55" mtime="1643641666"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:47 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '628'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="db1bb9ca01434c38a8f94dbc75831d20" vrev="160" srcmd5="db1bb9ca01434c38a8f94dbc75831d20">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="743d61d6f7e4284c5ffa5244aa87ae85" baserev="743d61d6f7e4284c5ffa5244aa87ae85" lsrcmd5="aec2d12649ffc1728f9ca1f1cdfe4f78"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="3da59d3524ac0ce78c1b5a3adf846ae3" size="53" mtime="1643641666"/>
+          <entry name="somefile.txt" md5="45409574c19976999b732e29f8b83b63" size="55" mtime="1643641666"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:07:47 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -1030,22 +1167,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="108" vrev="108" srcmd5="2164ead059e1fe57fd88b4c063da7dd7">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="4d212cf3ab2d4405f2c121533bea4bf6" baserev="4d212cf3ab2d4405f2c121533bea4bf6" xsrcmd5="6f0870ce2da766aa506fd9b7d731acdc" lsrcmd5="2164ead059e1fe57fd88b4c063da7dd7"/>
-          <serviceinfo code="succeeded" xsrcmd5="18e6db9b7f5c3a8c3071a9a4bddf734b"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="4e1e3878e7d9d8f236b16b2c49d0b180" size="80" mtime="1642674747"/>
-          <entry name="_link" md5="2b487120d0f9fcb2581a69fa6482e6f2" size="141" mtime="1642674748"/>
-          <entry name="somefile.txt" md5="b2acef30fba6cb86ec0b98b1b4783731" size="57" mtime="1642674747"/>
+        <directory name="bar_package-123456789" rev="42" vrev="42" srcmd5="aec2d12649ffc1728f9ca1f1cdfe4f78">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="743d61d6f7e4284c5ffa5244aa87ae85" baserev="743d61d6f7e4284c5ffa5244aa87ae85" xsrcmd5="db1bb9ca01434c38a8f94dbc75831d20" lsrcmd5="aec2d12649ffc1728f9ca1f1cdfe4f78"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="3da59d3524ac0ce78c1b5a3adf846ae3" size="53" mtime="1643641666"/>
+          <entry name="_link" md5="bd387d4b53e69156a1c0188596414a54" size="141" mtime="1643641666"/>
+          <entry name="somefile.txt" md5="45409574c19976999b732e29f8b83b63" size="55" mtime="1643641666"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:47 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1068,169 +1204,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '628'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="108" vrev="108" srcmd5="2164ead059e1fe57fd88b4c063da7dd7">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="4d212cf3ab2d4405f2c121533bea4bf6" baserev="4d212cf3ab2d4405f2c121533bea4bf6" xsrcmd5="6f0870ce2da766aa506fd9b7d731acdc" lsrcmd5="2164ead059e1fe57fd88b4c063da7dd7"/>
-          <serviceinfo code="succeeded" xsrcmd5="18e6db9b7f5c3a8c3071a9a4bddf734b"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="4e1e3878e7d9d8f236b16b2c49d0b180" size="80" mtime="1642674747"/>
-          <entry name="_link" md5="2b487120d0f9fcb2581a69fa6482e6f2" size="141" mtime="1642674748"/>
-          <entry name="somefile.txt" md5="b2acef30fba6cb86ec0b98b1b4783731" size="57" mtime="1642674747"/>
+        <directory name="bar_package-123456789" rev="db1bb9ca01434c38a8f94dbc75831d20" vrev="160" srcmd5="db1bb9ca01434c38a8f94dbc75831d20">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="743d61d6f7e4284c5ffa5244aa87ae85" baserev="743d61d6f7e4284c5ffa5244aa87ae85" lsrcmd5="aec2d12649ffc1728f9ca1f1cdfe4f78"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="3da59d3524ac0ce78c1b5a3adf846ae3" size="53" mtime="1643641666"/>
+          <entry name="somefile.txt" md5="45409574c19976999b732e29f8b83b63" size="55" mtime="1643641666"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:28 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '812'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="108" vrev="108" srcmd5="2164ead059e1fe57fd88b4c063da7dd7">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="4d212cf3ab2d4405f2c121533bea4bf6" baserev="4d212cf3ab2d4405f2c121533bea4bf6" xsrcmd5="6f0870ce2da766aa506fd9b7d731acdc" lsrcmd5="2164ead059e1fe57fd88b4c063da7dd7"/>
-          <serviceinfo code="succeeded" xsrcmd5="18e6db9b7f5c3a8c3071a9a4bddf734b"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="4e1e3878e7d9d8f236b16b2c49d0b180" size="80" mtime="1642674747"/>
-          <entry name="_link" md5="2b487120d0f9fcb2581a69fa6482e6f2" size="141" mtime="1642674748"/>
-          <entry name="somefile.txt" md5="b2acef30fba6cb86ec0b98b1b4783731" size="57" mtime="1642674747"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:28 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '812'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="108" vrev="108" srcmd5="2164ead059e1fe57fd88b4c063da7dd7">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="4d212cf3ab2d4405f2c121533bea4bf6" baserev="4d212cf3ab2d4405f2c121533bea4bf6" xsrcmd5="6f0870ce2da766aa506fd9b7d731acdc" lsrcmd5="2164ead059e1fe57fd88b4c063da7dd7"/>
-          <serviceinfo code="succeeded" xsrcmd5="18e6db9b7f5c3a8c3071a9a4bddf734b"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="4e1e3878e7d9d8f236b16b2c49d0b180" size="80" mtime="1642674747"/>
-          <entry name="_link" md5="2b487120d0f9fcb2581a69fa6482e6f2" size="141" mtime="1642674748"/>
-          <entry name="somefile.txt" md5="b2acef30fba6cb86ec0b98b1b4783731" size="57" mtime="1642674747"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:28 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '812'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="108" vrev="108" srcmd5="2164ead059e1fe57fd88b4c063da7dd7">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="4d212cf3ab2d4405f2c121533bea4bf6" baserev="4d212cf3ab2d4405f2c121533bea4bf6" xsrcmd5="6f0870ce2da766aa506fd9b7d731acdc" lsrcmd5="2164ead059e1fe57fd88b4c063da7dd7"/>
-          <serviceinfo code="succeeded" xsrcmd5="18e6db9b7f5c3a8c3071a9a4bddf734b"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="4e1e3878e7d9d8f236b16b2c49d0b180" size="80" mtime="1642674747"/>
-          <entry name="_link" md5="2b487120d0f9fcb2581a69fa6482e6f2" size="141" mtime="1642674748"/>
-          <entry name="somefile.txt" md5="b2acef30fba6cb86ec0b98b1b4783731" size="57" mtime="1642674747"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:28 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '812'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="108" vrev="108" srcmd5="2164ead059e1fe57fd88b4c063da7dd7">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="4d212cf3ab2d4405f2c121533bea4bf6" baserev="4d212cf3ab2d4405f2c121533bea4bf6" xsrcmd5="6f0870ce2da766aa506fd9b7d731acdc" lsrcmd5="2164ead059e1fe57fd88b4c063da7dd7"/>
-          <serviceinfo code="succeeded" xsrcmd5="18e6db9b7f5c3a8c3071a9a4bddf734b"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="4e1e3878e7d9d8f236b16b2c49d0b180" size="80" mtime="1642674747"/>
-          <entry name="_link" md5="2b487120d0f9fcb2581a69fa6482e6f2" size="141" mtime="1642674748"/>
-          <entry name="somefile.txt" md5="b2acef30fba6cb86ec0b98b1b4783731" size="57" mtime="1642674747"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:47 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/with_a_push_event_for_a_commit/behaves_like_successful_new_PR_or_MR_event/1_1_2_5_1_3.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/with_a_push_event_for_a_commit/behaves_like_successful_new_PR_or_MR_event/1_1_2_5_1_3.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:26 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:41 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_246
+    uri: http://backend:5352/source/foo_project/_meta?user=user_9
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Cover Her Face</title>
+          <title>A Farewell to Arms</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '146'
+      - '150'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Cover Her Face</title>
+          <title>A Farewell to Arms</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:26 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:41 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_247
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_10
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Soldier's Art</title>
-          <description>Labore quas quia qui.</description>
+          <title>Beyond the Mexique Bay</title>
+          <description>Sed sint velit quod.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '148'
+      - '152'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>The Soldier's Art</title>
-          <description>Labore quas quia qui.</description>
+          <title>Beyond the Mexique Bay</title>
+          <description>Sed sint velit quod.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:26 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:41 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Alias impedit voluptatem. Quos aut numquam. Laudantium blanditiis voluptas.
+      string: Earum commodi corrupti. Accusamus architecto ullam. Ullam alias magni.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1627" vrev="1627">
-          <srcmd5>4b67c6e2f4468606953a39a6fd5fd9d1</srcmd5>
+        <revision rev="111" vrev="111">
+          <srcmd5>f702d4ea2fdfec50c78de04b186da026</srcmd5>
           <version>unknown</version>
-          <time>1642674746</time>
+          <time>1643641661</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:26 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:41 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Quod sint optio. Fuga in nulla. Officia dolore esse.
+      string: Alias aut omnis. Delectus quos deleniti. Voluptate molestiae qui.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +181,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1628" vrev="1628">
-          <srcmd5>f67c9b663a1a9d41235337eb104068f6</srcmd5>
+        <revision rev="112" vrev="112">
+          <srcmd5>79502988565932e234d7054ada7fc4fd</srcmd5>
           <version>unknown</version>
-          <time>1642674746</time>
+          <time>1643641661</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:26 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:41 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -227,7 +227,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:32:26 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:42 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_meta?user=Iggy
@@ -235,8 +235,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>The Soldier's Art</title>
-          <description>Labore quas quia qui.</description>
+          <title>Beyond the Mexique Bay</title>
+          <description>Sed sint velit quod.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -257,15 +257,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '156'
+      - '160'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>The Soldier's Art</title>
-          <description>Labore quas quia qui.</description>
+          <title>Beyond the Mexique Bay</title>
+          <description>Sed sint velit quod.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:26 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:42 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=branch&noservice=1&opackage=bar_package&oproject=foo_project&user=Iggy
@@ -293,19 +293,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="105" vrev="105">
-          <srcmd5>78eaa28eba2b5486a8a7032e32919726</srcmd5>
+        <revision rev="35" vrev="35">
+          <srcmd5>bd46dd61e7dca84cf3864482a7039001</srcmd5>
           <version>unknown</version>
-          <time>1642674746</time>
+          <time>1643641662</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:26 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:42 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_meta?user=Iggy
@@ -313,8 +313,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>The Soldier's Art</title>
-          <description>Labore quas quia qui.</description>
+          <title>Beyond the Mexique Bay</title>
+          <description>Sed sint velit quod.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -335,15 +335,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '156'
+      - '160'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>The Soldier's Art</title>
-          <description>Labore quas quia qui.</description>
+          <title>Beyond the Mexique Bay</title>
+          <description>Sed sint velit quod.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:26 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:42 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -369,18 +369,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '735'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="105" vrev="105" srcmd5="78eaa28eba2b5486a8a7032e32919726">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="f67c9b663a1a9d41235337eb104068f6" baserev="f67c9b663a1a9d41235337eb104068f6" xsrcmd5="c4e7cc3dec6a7f7ab1fa5dd44e131573" lsrcmd5="78eaa28eba2b5486a8a7032e32919726"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="615d521f759cf36885d04e06b92064bf" size="75" mtime="1642674746"/>
-          <entry name="_link" md5="caf84decc0099bc4ee9fb2aed990456e" size="141" mtime="1642674746"/>
-          <entry name="somefile.txt" md5="179de56854b7fdb98a3dab43576c4c13" size="52" mtime="1642674746"/>
+        <directory name="bar_package-123456789" rev="35" vrev="35" srcmd5="bd46dd61e7dca84cf3864482a7039001">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="79502988565932e234d7054ada7fc4fd" baserev="79502988565932e234d7054ada7fc4fd" xsrcmd5="6ef8bd56a90a64c577fd1bf56887d5c1" lsrcmd5="bd46dd61e7dca84cf3864482a7039001"/>
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="574efbdc6bb51ef8552c00f863c1d032" size="70" mtime="1643641661"/>
+          <entry name="_link" md5="481bb29ee837a29106c0890eb859731a" size="141" mtime="1643641662"/>
+          <entry name="somefile.txt" md5="ab3bb33d158e8fae3912de6e8f0ae7ee" size="65" mtime="1643641661"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:27 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:42 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?view=info
@@ -406,15 +406,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '343'
+      - '341'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package-123456789" rev="105" vrev="1733" srcmd5="c4e7cc3dec6a7f7ab1fa5dd44e131573" lsrcmd5="78eaa28eba2b5486a8a7032e32919726" verifymd5="f67c9b663a1a9d41235337eb104068f6">
+        <sourceinfo package="bar_package-123456789" rev="35" vrev="147" srcmd5="6ef8bd56a90a64c577fd1bf56887d5c1" lsrcmd5="bd46dd61e7dca84cf3864482a7039001" verifymd5="79502988565932e234d7054ada7fc4fd">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:27 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:42 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -440,18 +440,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '735'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="105" vrev="105" srcmd5="78eaa28eba2b5486a8a7032e32919726">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="f67c9b663a1a9d41235337eb104068f6" baserev="f67c9b663a1a9d41235337eb104068f6" xsrcmd5="c4e7cc3dec6a7f7ab1fa5dd44e131573" lsrcmd5="78eaa28eba2b5486a8a7032e32919726"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="615d521f759cf36885d04e06b92064bf" size="75" mtime="1642674746"/>
-          <entry name="_link" md5="caf84decc0099bc4ee9fb2aed990456e" size="141" mtime="1642674746"/>
-          <entry name="somefile.txt" md5="179de56854b7fdb98a3dab43576c4c13" size="52" mtime="1642674746"/>
+        <directory name="bar_package-123456789" rev="35" vrev="35" srcmd5="bd46dd61e7dca84cf3864482a7039001">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="79502988565932e234d7054ada7fc4fd" baserev="79502988565932e234d7054ada7fc4fd" xsrcmd5="6ef8bd56a90a64c577fd1bf56887d5c1" lsrcmd5="bd46dd61e7dca84cf3864482a7039001"/>
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="574efbdc6bb51ef8552c00f863c1d032" size="70" mtime="1643641661"/>
+          <entry name="_link" md5="481bb29ee837a29106c0890eb859731a" size="141" mtime="1643641662"/>
+          <entry name="somefile.txt" md5="ab3bb33d158e8fae3912de6e8f0ae7ee" size="65" mtime="1643641661"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:27 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:42 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -479,18 +479,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '324'
+      - '323'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="acc3b6394110da14bce8cb4f93578287">
+        <sourcediff key="be69c651d7b4c5b30e6bc22685daef00">
           <old project="home:Iggy" package="bar_package-123456789" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="105" srcmd5="78eaa28eba2b5486a8a7032e32919726"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="35" srcmd5="bd46dd61e7dca84cf3864482a7039001"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:27 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:42 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -522,14 +522,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="d9d9cdaf74f9f6236eafd322568c310e">
-          <old project="foo_project" package="bar_package" rev="f67c9b663a1a9d41235337eb104068f6" srcmd5="f67c9b663a1a9d41235337eb104068f6"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="c4e7cc3dec6a7f7ab1fa5dd44e131573" srcmd5="c4e7cc3dec6a7f7ab1fa5dd44e131573"/>
+        <sourcediff key="1399aa6345aa1c779ba86adacb4077eb">
+          <old project="foo_project" package="bar_package" rev="79502988565932e234d7054ada7fc4fd" srcmd5="79502988565932e234d7054ada7fc4fd"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="6ef8bd56a90a64c577fd1bf56887d5c1" srcmd5="6ef8bd56a90a64c577fd1bf56887d5c1"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:27 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:42 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/_meta?user=Iggy
@@ -587,7 +587,7 @@ http_interactions:
             <arch>aarch64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:27 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:42 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_branch_request?user=Iggy
@@ -613,19 +613,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="106" vrev="106">
-          <srcmd5>2e0ec40ad9c26c4a3f7e306d4cc7d8e2</srcmd5>
+        <revision rev="36" vrev="36">
+          <srcmd5>55f00de62a29e32d63528cc579579017</srcmd5>
           <version>unknown</version>
-          <time>1642674747</time>
+          <time>1643641662</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:27 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:42 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_meta?user=Iggy
@@ -633,8 +633,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>The Soldier's Art</title>
-          <description>Labore quas quia qui.</description>
+          <title>Beyond the Mexique Bay</title>
+          <description>Sed sint velit quod.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -655,15 +655,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '156'
+      - '160'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>The Soldier's Art</title>
-          <description>Labore quas quia qui.</description>
+          <title>Beyond the Mexique Bay</title>
+          <description>Sed sint velit quod.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:27 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:42 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -689,19 +689,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="106" vrev="106" srcmd5="2e0ec40ad9c26c4a3f7e306d4cc7d8e2">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="f67c9b663a1a9d41235337eb104068f6" baserev="f67c9b663a1a9d41235337eb104068f6" xsrcmd5="6d9a9774c0e9b6dae82636b55eccea1c" lsrcmd5="2e0ec40ad9c26c4a3f7e306d4cc7d8e2"/>
-          <serviceinfo code="succeeded" xsrcmd5="3bc103c2ae4b86732e6be3e49a70990a"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="615d521f759cf36885d04e06b92064bf" size="75" mtime="1642674746"/>
-          <entry name="_link" md5="caf84decc0099bc4ee9fb2aed990456e" size="141" mtime="1642674746"/>
-          <entry name="somefile.txt" md5="179de56854b7fdb98a3dab43576c4c13" size="52" mtime="1642674746"/>
+        <directory name="bar_package-123456789" rev="36" vrev="36" srcmd5="55f00de62a29e32d63528cc579579017">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="79502988565932e234d7054ada7fc4fd" baserev="79502988565932e234d7054ada7fc4fd" xsrcmd5="4a65c7b3b9f9c97bb7222b837533c826" lsrcmd5="55f00de62a29e32d63528cc579579017"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="574efbdc6bb51ef8552c00f863c1d032" size="70" mtime="1643641661"/>
+          <entry name="_link" md5="481bb29ee837a29106c0890eb859731a" size="141" mtime="1643641662"/>
+          <entry name="somefile.txt" md5="ab3bb33d158e8fae3912de6e8f0ae7ee" size="65" mtime="1643641661"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:27 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:42 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?view=info
@@ -727,15 +726,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '343'
+      - '341'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package-123456789" rev="106" vrev="1734" srcmd5="3dac252ff1236e86fda440f8de7f536e" lsrcmd5="3bc103c2ae4b86732e6be3e49a70990a" verifymd5="64eb52dba715026c78b4ca2a9b1964ce">
+        <sourceinfo package="bar_package-123456789" rev="36" vrev="148" srcmd5="4a65c7b3b9f9c97bb7222b837533c826" lsrcmd5="55f00de62a29e32d63528cc579579017" verifymd5="c9099c2474db5b39527ba6e1a9c68cf4">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:27 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:42 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -761,19 +760,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="106" vrev="106" srcmd5="2e0ec40ad9c26c4a3f7e306d4cc7d8e2">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="f67c9b663a1a9d41235337eb104068f6" baserev="f67c9b663a1a9d41235337eb104068f6" xsrcmd5="6d9a9774c0e9b6dae82636b55eccea1c" lsrcmd5="2e0ec40ad9c26c4a3f7e306d4cc7d8e2"/>
-          <serviceinfo code="succeeded" xsrcmd5="3bc103c2ae4b86732e6be3e49a70990a"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="615d521f759cf36885d04e06b92064bf" size="75" mtime="1642674746"/>
-          <entry name="_link" md5="caf84decc0099bc4ee9fb2aed990456e" size="141" mtime="1642674746"/>
-          <entry name="somefile.txt" md5="179de56854b7fdb98a3dab43576c4c13" size="52" mtime="1642674746"/>
+        <directory name="bar_package-123456789" rev="36" vrev="36" srcmd5="55f00de62a29e32d63528cc579579017">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="79502988565932e234d7054ada7fc4fd" baserev="79502988565932e234d7054ada7fc4fd" xsrcmd5="4a65c7b3b9f9c97bb7222b837533c826" lsrcmd5="55f00de62a29e32d63528cc579579017"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="574efbdc6bb51ef8552c00f863c1d032" size="70" mtime="1643641661"/>
+          <entry name="_link" md5="481bb29ee837a29106c0890eb859731a" size="141" mtime="1643641662"/>
+          <entry name="somefile.txt" md5="ab3bb33d158e8fae3912de6e8f0ae7ee" size="65" mtime="1643641661"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:27 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:42 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -801,18 +799,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '324'
+      - '323'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="64f0de8580e81ce1edaa02afa5678b92">
+        <sourcediff key="d2bd753f33bf0496c81f14919800f520">
           <old project="home:Iggy" package="bar_package-123456789" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="106" srcmd5="2e0ec40ad9c26c4a3f7e306d4cc7d8e2"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="36" srcmd5="55f00de62a29e32d63528cc579579017"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:27 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:42 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -844,14 +842,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="62c214a017416aa35f96833211287a18">
-          <old project="foo_project" package="bar_package" rev="f67c9b663a1a9d41235337eb104068f6" srcmd5="f67c9b663a1a9d41235337eb104068f6"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="3dac252ff1236e86fda440f8de7f536e" srcmd5="3dac252ff1236e86fda440f8de7f536e"/>
+        <sourcediff key="129adbfc5ce8f72eb6a3f75b9b311bd1">
+          <old project="foo_project" package="bar_package" rev="79502988565932e234d7054ada7fc4fd" srcmd5="79502988565932e234d7054ada7fc4fd"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="4a65c7b3b9f9c97bb7222b837533c826" srcmd5="4a65c7b3b9f9c97bb7222b837533c826"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:27 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:42 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -877,19 +875,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="106" vrev="106" srcmd5="2e0ec40ad9c26c4a3f7e306d4cc7d8e2">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="f67c9b663a1a9d41235337eb104068f6" baserev="f67c9b663a1a9d41235337eb104068f6" xsrcmd5="6d9a9774c0e9b6dae82636b55eccea1c" lsrcmd5="2e0ec40ad9c26c4a3f7e306d4cc7d8e2"/>
-          <serviceinfo code="succeeded" xsrcmd5="3bc103c2ae4b86732e6be3e49a70990a"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="615d521f759cf36885d04e06b92064bf" size="75" mtime="1642674746"/>
-          <entry name="_link" md5="caf84decc0099bc4ee9fb2aed990456e" size="141" mtime="1642674746"/>
-          <entry name="somefile.txt" md5="179de56854b7fdb98a3dab43576c4c13" size="52" mtime="1642674746"/>
+        <directory name="bar_package-123456789" rev="36" vrev="36" srcmd5="55f00de62a29e32d63528cc579579017">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="79502988565932e234d7054ada7fc4fd" baserev="79502988565932e234d7054ada7fc4fd" xsrcmd5="4a65c7b3b9f9c97bb7222b837533c826" lsrcmd5="55f00de62a29e32d63528cc579579017"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="574efbdc6bb51ef8552c00f863c1d032" size="70" mtime="1643641661"/>
+          <entry name="_link" md5="481bb29ee837a29106c0890eb859731a" size="141" mtime="1643641662"/>
+          <entry name="somefile.txt" md5="ab3bb33d158e8fae3912de6e8f0ae7ee" size="65" mtime="1643641661"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:27 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:42 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '628'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="4a65c7b3b9f9c97bb7222b837533c826" vrev="148" srcmd5="4a65c7b3b9f9c97bb7222b837533c826">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="79502988565932e234d7054ada7fc4fd" baserev="79502988565932e234d7054ada7fc4fd" lsrcmd5="55f00de62a29e32d63528cc579579017"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="574efbdc6bb51ef8552c00f863c1d032" size="70" mtime="1643641661"/>
+          <entry name="somefile.txt" md5="ab3bb33d158e8fae3912de6e8f0ae7ee" size="65" mtime="1643641661"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:07:42 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -915,19 +948,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="106" vrev="106" srcmd5="2e0ec40ad9c26c4a3f7e306d4cc7d8e2">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="f67c9b663a1a9d41235337eb104068f6" baserev="f67c9b663a1a9d41235337eb104068f6" xsrcmd5="6d9a9774c0e9b6dae82636b55eccea1c" lsrcmd5="2e0ec40ad9c26c4a3f7e306d4cc7d8e2"/>
-          <serviceinfo code="succeeded" xsrcmd5="3bc103c2ae4b86732e6be3e49a70990a"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="615d521f759cf36885d04e06b92064bf" size="75" mtime="1642674746"/>
-          <entry name="_link" md5="caf84decc0099bc4ee9fb2aed990456e" size="141" mtime="1642674746"/>
-          <entry name="somefile.txt" md5="179de56854b7fdb98a3dab43576c4c13" size="52" mtime="1642674746"/>
+        <directory name="bar_package-123456789" rev="36" vrev="36" srcmd5="55f00de62a29e32d63528cc579579017">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="79502988565932e234d7054ada7fc4fd" baserev="79502988565932e234d7054ada7fc4fd" xsrcmd5="4a65c7b3b9f9c97bb7222b837533c826" lsrcmd5="55f00de62a29e32d63528cc579579017"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="574efbdc6bb51ef8552c00f863c1d032" size="70" mtime="1643641661"/>
+          <entry name="_link" md5="481bb29ee837a29106c0890eb859731a" size="141" mtime="1643641662"/>
+          <entry name="somefile.txt" md5="ab3bb33d158e8fae3912de6e8f0ae7ee" size="65" mtime="1643641661"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:27 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:42 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '628'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="4a65c7b3b9f9c97bb7222b837533c826" vrev="148" srcmd5="4a65c7b3b9f9c97bb7222b837533c826">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="79502988565932e234d7054ada7fc4fd" baserev="79502988565932e234d7054ada7fc4fd" lsrcmd5="55f00de62a29e32d63528cc579579017"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="574efbdc6bb51ef8552c00f863c1d032" size="70" mtime="1643641661"/>
+          <entry name="somefile.txt" md5="ab3bb33d158e8fae3912de6e8f0ae7ee" size="65" mtime="1643641661"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:07:42 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -953,19 +1021,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="106" vrev="106" srcmd5="2e0ec40ad9c26c4a3f7e306d4cc7d8e2">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="f67c9b663a1a9d41235337eb104068f6" baserev="f67c9b663a1a9d41235337eb104068f6" xsrcmd5="6d9a9774c0e9b6dae82636b55eccea1c" lsrcmd5="2e0ec40ad9c26c4a3f7e306d4cc7d8e2"/>
-          <serviceinfo code="succeeded" xsrcmd5="3bc103c2ae4b86732e6be3e49a70990a"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="615d521f759cf36885d04e06b92064bf" size="75" mtime="1642674746"/>
-          <entry name="_link" md5="caf84decc0099bc4ee9fb2aed990456e" size="141" mtime="1642674746"/>
-          <entry name="somefile.txt" md5="179de56854b7fdb98a3dab43576c4c13" size="52" mtime="1642674746"/>
+        <directory name="bar_package-123456789" rev="36" vrev="36" srcmd5="55f00de62a29e32d63528cc579579017">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="79502988565932e234d7054ada7fc4fd" baserev="79502988565932e234d7054ada7fc4fd" xsrcmd5="4a65c7b3b9f9c97bb7222b837533c826" lsrcmd5="55f00de62a29e32d63528cc579579017"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="574efbdc6bb51ef8552c00f863c1d032" size="70" mtime="1643641661"/>
+          <entry name="_link" md5="481bb29ee837a29106c0890eb859731a" size="141" mtime="1643641662"/>
+          <entry name="somefile.txt" md5="ab3bb33d158e8fae3912de6e8f0ae7ee" size="65" mtime="1643641661"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:27 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:42 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '628'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="4a65c7b3b9f9c97bb7222b837533c826" vrev="148" srcmd5="4a65c7b3b9f9c97bb7222b837533c826">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="79502988565932e234d7054ada7fc4fd" baserev="79502988565932e234d7054ada7fc4fd" lsrcmd5="55f00de62a29e32d63528cc579579017"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="574efbdc6bb51ef8552c00f863c1d032" size="70" mtime="1643641661"/>
+          <entry name="somefile.txt" md5="ab3bb33d158e8fae3912de6e8f0ae7ee" size="65" mtime="1643641661"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:07:42 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -991,19 +1094,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="106" vrev="106" srcmd5="2e0ec40ad9c26c4a3f7e306d4cc7d8e2">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="f67c9b663a1a9d41235337eb104068f6" baserev="f67c9b663a1a9d41235337eb104068f6" xsrcmd5="6d9a9774c0e9b6dae82636b55eccea1c" lsrcmd5="2e0ec40ad9c26c4a3f7e306d4cc7d8e2"/>
-          <serviceinfo code="succeeded" xsrcmd5="3bc103c2ae4b86732e6be3e49a70990a"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="615d521f759cf36885d04e06b92064bf" size="75" mtime="1642674746"/>
-          <entry name="_link" md5="caf84decc0099bc4ee9fb2aed990456e" size="141" mtime="1642674746"/>
-          <entry name="somefile.txt" md5="179de56854b7fdb98a3dab43576c4c13" size="52" mtime="1642674746"/>
+        <directory name="bar_package-123456789" rev="36" vrev="36" srcmd5="55f00de62a29e32d63528cc579579017">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="79502988565932e234d7054ada7fc4fd" baserev="79502988565932e234d7054ada7fc4fd" xsrcmd5="4a65c7b3b9f9c97bb7222b837533c826" lsrcmd5="55f00de62a29e32d63528cc579579017"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="574efbdc6bb51ef8552c00f863c1d032" size="70" mtime="1643641661"/>
+          <entry name="_link" md5="481bb29ee837a29106c0890eb859731a" size="141" mtime="1643641662"/>
+          <entry name="somefile.txt" md5="ab3bb33d158e8fae3912de6e8f0ae7ee" size="65" mtime="1643641661"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:27 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:42 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '628'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="4a65c7b3b9f9c97bb7222b837533c826" vrev="148" srcmd5="4a65c7b3b9f9c97bb7222b837533c826">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="79502988565932e234d7054ada7fc4fd" baserev="79502988565932e234d7054ada7fc4fd" lsrcmd5="55f00de62a29e32d63528cc579579017"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="574efbdc6bb51ef8552c00f863c1d032" size="70" mtime="1643641661"/>
+          <entry name="somefile.txt" md5="ab3bb33d158e8fae3912de6e8f0ae7ee" size="65" mtime="1643641661"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:07:42 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -1029,22 +1167,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="106" vrev="106" srcmd5="2e0ec40ad9c26c4a3f7e306d4cc7d8e2">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="f67c9b663a1a9d41235337eb104068f6" baserev="f67c9b663a1a9d41235337eb104068f6" xsrcmd5="6d9a9774c0e9b6dae82636b55eccea1c" lsrcmd5="2e0ec40ad9c26c4a3f7e306d4cc7d8e2"/>
-          <serviceinfo code="succeeded" xsrcmd5="3bc103c2ae4b86732e6be3e49a70990a"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="615d521f759cf36885d04e06b92064bf" size="75" mtime="1642674746"/>
-          <entry name="_link" md5="caf84decc0099bc4ee9fb2aed990456e" size="141" mtime="1642674746"/>
-          <entry name="somefile.txt" md5="179de56854b7fdb98a3dab43576c4c13" size="52" mtime="1642674746"/>
+        <directory name="bar_package-123456789" rev="36" vrev="36" srcmd5="55f00de62a29e32d63528cc579579017">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="79502988565932e234d7054ada7fc4fd" baserev="79502988565932e234d7054ada7fc4fd" xsrcmd5="4a65c7b3b9f9c97bb7222b837533c826" lsrcmd5="55f00de62a29e32d63528cc579579017"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="574efbdc6bb51ef8552c00f863c1d032" size="70" mtime="1643641661"/>
+          <entry name="_link" md5="481bb29ee837a29106c0890eb859731a" size="141" mtime="1643641662"/>
+          <entry name="somefile.txt" md5="ab3bb33d158e8fae3912de6e8f0ae7ee" size="65" mtime="1643641661"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:27 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:42 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1067,171 +1204,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '628'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="106" vrev="106" srcmd5="2e0ec40ad9c26c4a3f7e306d4cc7d8e2">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="f67c9b663a1a9d41235337eb104068f6" baserev="f67c9b663a1a9d41235337eb104068f6" xsrcmd5="6d9a9774c0e9b6dae82636b55eccea1c" lsrcmd5="2e0ec40ad9c26c4a3f7e306d4cc7d8e2"/>
-          <serviceinfo code="succeeded" xsrcmd5="3bc103c2ae4b86732e6be3e49a70990a"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="615d521f759cf36885d04e06b92064bf" size="75" mtime="1642674746"/>
-          <entry name="_link" md5="caf84decc0099bc4ee9fb2aed990456e" size="141" mtime="1642674746"/>
-          <entry name="somefile.txt" md5="179de56854b7fdb98a3dab43576c4c13" size="52" mtime="1642674746"/>
+        <directory name="bar_package-123456789" rev="4a65c7b3b9f9c97bb7222b837533c826" vrev="148" srcmd5="4a65c7b3b9f9c97bb7222b837533c826">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="79502988565932e234d7054ada7fc4fd" baserev="79502988565932e234d7054ada7fc4fd" lsrcmd5="55f00de62a29e32d63528cc579579017"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="574efbdc6bb51ef8552c00f863c1d032" size="70" mtime="1643641661"/>
+          <entry name="somefile.txt" md5="ab3bb33d158e8fae3912de6e8f0ae7ee" size="65" mtime="1643641661"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:27 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '812'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="106" vrev="106" srcmd5="2e0ec40ad9c26c4a3f7e306d4cc7d8e2">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="f67c9b663a1a9d41235337eb104068f6" baserev="f67c9b663a1a9d41235337eb104068f6" xsrcmd5="6d9a9774c0e9b6dae82636b55eccea1c" lsrcmd5="2e0ec40ad9c26c4a3f7e306d4cc7d8e2"/>
-          <serviceinfo code="succeeded" xsrcmd5="3bc103c2ae4b86732e6be3e49a70990a"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="615d521f759cf36885d04e06b92064bf" size="75" mtime="1642674746"/>
-          <entry name="_link" md5="caf84decc0099bc4ee9fb2aed990456e" size="141" mtime="1642674746"/>
-          <entry name="somefile.txt" md5="179de56854b7fdb98a3dab43576c4c13" size="52" mtime="1642674746"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:27 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '812'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="106" vrev="106" srcmd5="2e0ec40ad9c26c4a3f7e306d4cc7d8e2">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="f67c9b663a1a9d41235337eb104068f6" baserev="f67c9b663a1a9d41235337eb104068f6" xsrcmd5="6d9a9774c0e9b6dae82636b55eccea1c" lsrcmd5="2e0ec40ad9c26c4a3f7e306d4cc7d8e2"/>
-          <serviceinfo code="succeeded" xsrcmd5="3bc103c2ae4b86732e6be3e49a70990a"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="615d521f759cf36885d04e06b92064bf" size="75" mtime="1642674746"/>
-          <entry name="_link" md5="caf84decc0099bc4ee9fb2aed990456e" size="141" mtime="1642674746"/>
-          <entry name="somefile.txt" md5="179de56854b7fdb98a3dab43576c4c13" size="52" mtime="1642674746"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:27 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '812'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="106" vrev="106" srcmd5="2e0ec40ad9c26c4a3f7e306d4cc7d8e2">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="f67c9b663a1a9d41235337eb104068f6" baserev="f67c9b663a1a9d41235337eb104068f6" xsrcmd5="6d9a9774c0e9b6dae82636b55eccea1c" lsrcmd5="2e0ec40ad9c26c4a3f7e306d4cc7d8e2"/>
-          <serviceinfo code="succeeded" xsrcmd5="3bc103c2ae4b86732e6be3e49a70990a"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="615d521f759cf36885d04e06b92064bf" size="75" mtime="1642674746"/>
-          <entry name="_link" md5="caf84decc0099bc4ee9fb2aed990456e" size="141" mtime="1642674746"/>
-          <entry name="somefile.txt" md5="179de56854b7fdb98a3dab43576c4c13" size="52" mtime="1642674746"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:27 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '812'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="106" vrev="106" srcmd5="2e0ec40ad9c26c4a3f7e306d4cc7d8e2">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="f67c9b663a1a9d41235337eb104068f6" baserev="f67c9b663a1a9d41235337eb104068f6" xsrcmd5="6d9a9774c0e9b6dae82636b55eccea1c" lsrcmd5="2e0ec40ad9c26c4a3f7e306d4cc7d8e2"/>
-          <serviceinfo code="succeeded" xsrcmd5="3bc103c2ae4b86732e6be3e49a70990a"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="615d521f759cf36885d04e06b92064bf" size="75" mtime="1642674746"/>
-          <entry name="_link" md5="caf84decc0099bc4ee9fb2aed990456e" size="141" mtime="1642674746"/>
-          <entry name="somefile.txt" md5="179de56854b7fdb98a3dab43576c4c13" size="52" mtime="1642674746"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:27 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:42 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_branch_request
@@ -1261,5 +1244,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"object_kind":null,"project":{"http_url":null},"object_attributes":{"source":{"default_branch":"123456789"}}}'
-  recorded_at: Thu, 20 Jan 2022 10:32:27 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:42 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/with_a_push_event_for_a_commit/behaves_like_successful_new_PR_or_MR_event/1_1_2_5_1_4.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/with_a_push_event_for_a_commit/behaves_like_successful_new_PR_or_MR_event/1_1_2_5_1_4.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:43 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_244
+    uri: http://backend:5352/source/foo_project/_meta?user=user_11
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Of Human Bondage</title>
+          <title>The Wind's Twelve Quarters</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '148'
+      - '158'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Of Human Bondage</title>
+          <title>The Wind's Twelve Quarters</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:43 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_245
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_12
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>A Swiftly Tilting Planet</title>
-          <description>Est explicabo non sed.</description>
+          <title>Absalom, Absalom!</title>
+          <description>Eaque consequatur quasi eligendi.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '156'
+      - '160'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>A Swiftly Tilting Planet</title>
-          <description>Est explicabo non sed.</description>
+          <title>Absalom, Absalom!</title>
+          <description>Eaque consequatur quasi eligendi.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:43 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Odio sit architecto. Fugit aliquam harum. Hic est quae.
+      string: Quae aut tempora. Et cumque voluptatem. Eum aut nam.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1625" vrev="1625">
-          <srcmd5>eff09ef7ba421c7b6c4f07c4ab0db4f7</srcmd5>
+        <revision rev="113" vrev="113">
+          <srcmd5>0781377e7c9839cd056da3d40826a7b8</srcmd5>
           <version>unknown</version>
-          <time>1642674745</time>
+          <time>1643641663</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:43 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Voluptates est deleniti. Praesentium incidunt dicta. Vel sint vitae.
+      string: Perspiciatis ut quia. Beatae possimus qui. Enim quos corporis.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +181,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1626" vrev="1626">
-          <srcmd5>af5f94558e1fbf504c48764c0e5bb9ef</srcmd5>
+        <revision rev="114" vrev="114">
+          <srcmd5>512b23cca3329fd1a7c6887396148265</srcmd5>
           <version>unknown</version>
-          <time>1642674745</time>
+          <time>1643641663</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:43 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -227,7 +227,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:32:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:43 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_meta?user=Iggy
@@ -235,8 +235,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>A Swiftly Tilting Planet</title>
-          <description>Est explicabo non sed.</description>
+          <title>Absalom, Absalom!</title>
+          <description>Eaque consequatur quasi eligendi.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -257,15 +257,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '164'
+      - '168'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>A Swiftly Tilting Planet</title>
-          <description>Est explicabo non sed.</description>
+          <title>Absalom, Absalom!</title>
+          <description>Eaque consequatur quasi eligendi.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:43 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=branch&noservice=1&opackage=bar_package&oproject=foo_project&user=Iggy
@@ -293,19 +293,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="103" vrev="103">
-          <srcmd5>2aebac70cd6958069b79dba54a255328</srcmd5>
+        <revision rev="37" vrev="37">
+          <srcmd5>f3f6b80ef7a144c32d4299a454f6ccdc</srcmd5>
           <version>unknown</version>
-          <time>1642674745</time>
+          <time>1643641663</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:43 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_meta?user=Iggy
@@ -313,8 +313,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>A Swiftly Tilting Planet</title>
-          <description>Est explicabo non sed.</description>
+          <title>Absalom, Absalom!</title>
+          <description>Eaque consequatur quasi eligendi.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -335,15 +335,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '164'
+      - '168'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>A Swiftly Tilting Planet</title>
-          <description>Est explicabo non sed.</description>
+          <title>Absalom, Absalom!</title>
+          <description>Eaque consequatur quasi eligendi.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:43 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -369,18 +369,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '735'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="103" vrev="103" srcmd5="2aebac70cd6958069b79dba54a255328">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="af5f94558e1fbf504c48764c0e5bb9ef" baserev="af5f94558e1fbf504c48764c0e5bb9ef" xsrcmd5="a407afbeb8b81bfaabe7866853748db0" lsrcmd5="2aebac70cd6958069b79dba54a255328"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="bfcc340ad6ab85627caa1f67b3c29016" size="55" mtime="1642674745"/>
-          <entry name="_link" md5="208e692b043222ca740527a8b9f5e86b" size="141" mtime="1642674745"/>
-          <entry name="somefile.txt" md5="c40ed9c7a843addd7b18d06bbc6e8400" size="68" mtime="1642674745"/>
+        <directory name="bar_package-123456789" rev="37" vrev="37" srcmd5="f3f6b80ef7a144c32d4299a454f6ccdc">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="512b23cca3329fd1a7c6887396148265" baserev="512b23cca3329fd1a7c6887396148265" xsrcmd5="c7b5524cda48f014dbc44b691cc547d7" lsrcmd5="f3f6b80ef7a144c32d4299a454f6ccdc"/>
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="bf094783ea8d13b36f77ceda1f9ad137" size="52" mtime="1643641663"/>
+          <entry name="_link" md5="f6665d3c45d9b944f873c58b1313add5" size="141" mtime="1643641663"/>
+          <entry name="somefile.txt" md5="81dae88ee7d03a83724f8fe1c1e961fa" size="62" mtime="1643641663"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:43 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?view=info
@@ -406,15 +406,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '343'
+      - '341'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package-123456789" rev="103" vrev="1729" srcmd5="a407afbeb8b81bfaabe7866853748db0" lsrcmd5="2aebac70cd6958069b79dba54a255328" verifymd5="af5f94558e1fbf504c48764c0e5bb9ef">
+        <sourceinfo package="bar_package-123456789" rev="37" vrev="151" srcmd5="c7b5524cda48f014dbc44b691cc547d7" lsrcmd5="f3f6b80ef7a144c32d4299a454f6ccdc" verifymd5="512b23cca3329fd1a7c6887396148265">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:43 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -440,18 +440,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '735'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="103" vrev="103" srcmd5="2aebac70cd6958069b79dba54a255328">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="af5f94558e1fbf504c48764c0e5bb9ef" baserev="af5f94558e1fbf504c48764c0e5bb9ef" xsrcmd5="a407afbeb8b81bfaabe7866853748db0" lsrcmd5="2aebac70cd6958069b79dba54a255328"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="bfcc340ad6ab85627caa1f67b3c29016" size="55" mtime="1642674745"/>
-          <entry name="_link" md5="208e692b043222ca740527a8b9f5e86b" size="141" mtime="1642674745"/>
-          <entry name="somefile.txt" md5="c40ed9c7a843addd7b18d06bbc6e8400" size="68" mtime="1642674745"/>
+        <directory name="bar_package-123456789" rev="37" vrev="37" srcmd5="f3f6b80ef7a144c32d4299a454f6ccdc">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="512b23cca3329fd1a7c6887396148265" baserev="512b23cca3329fd1a7c6887396148265" xsrcmd5="c7b5524cda48f014dbc44b691cc547d7" lsrcmd5="f3f6b80ef7a144c32d4299a454f6ccdc"/>
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="bf094783ea8d13b36f77ceda1f9ad137" size="52" mtime="1643641663"/>
+          <entry name="_link" md5="f6665d3c45d9b944f873c58b1313add5" size="141" mtime="1643641663"/>
+          <entry name="somefile.txt" md5="81dae88ee7d03a83724f8fe1c1e961fa" size="62" mtime="1643641663"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:43 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -479,18 +479,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '324'
+      - '323'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="55206094b118f6ca65ef944f80d01466">
+        <sourcediff key="ab2c19249a313a1aa7ce23ee71202ef0">
           <old project="home:Iggy" package="bar_package-123456789" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="103" srcmd5="2aebac70cd6958069b79dba54a255328"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="37" srcmd5="f3f6b80ef7a144c32d4299a454f6ccdc"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:43 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -522,14 +522,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="2d4258473c5d6c48f8592fdffcea9f81">
-          <old project="foo_project" package="bar_package" rev="af5f94558e1fbf504c48764c0e5bb9ef" srcmd5="af5f94558e1fbf504c48764c0e5bb9ef"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="a407afbeb8b81bfaabe7866853748db0" srcmd5="a407afbeb8b81bfaabe7866853748db0"/>
+        <sourcediff key="be44a9a497c05a217af408af4274770b">
+          <old project="foo_project" package="bar_package" rev="512b23cca3329fd1a7c6887396148265" srcmd5="512b23cca3329fd1a7c6887396148265"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="c7b5524cda48f014dbc44b691cc547d7" srcmd5="c7b5524cda48f014dbc44b691cc547d7"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:43 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/_meta?user=Iggy
@@ -587,7 +587,7 @@ http_interactions:
             <arch>aarch64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:25 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:43 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_branch_request?user=Iggy
@@ -613,19 +613,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="104" vrev="104">
-          <srcmd5>cdb48c08d4553092b0b6a8a9f0bd50f6</srcmd5>
+        <revision rev="38" vrev="38">
+          <srcmd5>f189d31e4d9aa16d81dac2970355fa7e</srcmd5>
           <version>unknown</version>
-          <time>1642674746</time>
+          <time>1643641663</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:26 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:43 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_meta?user=Iggy
@@ -633,8 +633,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>A Swiftly Tilting Planet</title>
-          <description>Est explicabo non sed.</description>
+          <title>Absalom, Absalom!</title>
+          <description>Eaque consequatur quasi eligendi.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -655,15 +655,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '164'
+      - '168'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>A Swiftly Tilting Planet</title>
-          <description>Est explicabo non sed.</description>
+          <title>Absalom, Absalom!</title>
+          <description>Eaque consequatur quasi eligendi.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:26 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:43 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -689,19 +689,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="104" vrev="104" srcmd5="cdb48c08d4553092b0b6a8a9f0bd50f6">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="af5f94558e1fbf504c48764c0e5bb9ef" baserev="af5f94558e1fbf504c48764c0e5bb9ef" xsrcmd5="103b075d5cc0570b9d3685d85bf34b10" lsrcmd5="cdb48c08d4553092b0b6a8a9f0bd50f6"/>
-          <serviceinfo code="succeeded" xsrcmd5="a2a338684d71cfd9b1528f13a5c449f5"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="bfcc340ad6ab85627caa1f67b3c29016" size="55" mtime="1642674745"/>
-          <entry name="_link" md5="208e692b043222ca740527a8b9f5e86b" size="141" mtime="1642674745"/>
-          <entry name="somefile.txt" md5="c40ed9c7a843addd7b18d06bbc6e8400" size="68" mtime="1642674745"/>
+        <directory name="bar_package-123456789" rev="38" vrev="38" srcmd5="f189d31e4d9aa16d81dac2970355fa7e">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="512b23cca3329fd1a7c6887396148265" baserev="512b23cca3329fd1a7c6887396148265" xsrcmd5="c2461d66aca0ab5e4637a1157d621558" lsrcmd5="f189d31e4d9aa16d81dac2970355fa7e"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="bf094783ea8d13b36f77ceda1f9ad137" size="52" mtime="1643641663"/>
+          <entry name="_link" md5="f6665d3c45d9b944f873c58b1313add5" size="141" mtime="1643641663"/>
+          <entry name="somefile.txt" md5="81dae88ee7d03a83724f8fe1c1e961fa" size="62" mtime="1643641663"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:26 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:43 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?view=info
@@ -727,15 +726,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '343'
+      - '341'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package-123456789" rev="104" vrev="1730" srcmd5="6e450fc2c8b2c0c3dbb6ae6d71a98bb1" lsrcmd5="a2a338684d71cfd9b1528f13a5c449f5" verifymd5="aca250f18436f68b1be8c33d26cf5fe6">
+        <sourceinfo package="bar_package-123456789" rev="38" vrev="152" srcmd5="c2461d66aca0ab5e4637a1157d621558" lsrcmd5="f189d31e4d9aa16d81dac2970355fa7e" verifymd5="fc599a9667a0b35c50cd35494e450ca6">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:26 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:43 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -761,19 +760,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="104" vrev="104" srcmd5="cdb48c08d4553092b0b6a8a9f0bd50f6">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="af5f94558e1fbf504c48764c0e5bb9ef" baserev="af5f94558e1fbf504c48764c0e5bb9ef" xsrcmd5="103b075d5cc0570b9d3685d85bf34b10" lsrcmd5="cdb48c08d4553092b0b6a8a9f0bd50f6"/>
-          <serviceinfo code="succeeded" xsrcmd5="a2a338684d71cfd9b1528f13a5c449f5"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="bfcc340ad6ab85627caa1f67b3c29016" size="55" mtime="1642674745"/>
-          <entry name="_link" md5="208e692b043222ca740527a8b9f5e86b" size="141" mtime="1642674745"/>
-          <entry name="somefile.txt" md5="c40ed9c7a843addd7b18d06bbc6e8400" size="68" mtime="1642674745"/>
+        <directory name="bar_package-123456789" rev="38" vrev="38" srcmd5="f189d31e4d9aa16d81dac2970355fa7e">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="512b23cca3329fd1a7c6887396148265" baserev="512b23cca3329fd1a7c6887396148265" xsrcmd5="c2461d66aca0ab5e4637a1157d621558" lsrcmd5="f189d31e4d9aa16d81dac2970355fa7e"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="bf094783ea8d13b36f77ceda1f9ad137" size="52" mtime="1643641663"/>
+          <entry name="_link" md5="f6665d3c45d9b944f873c58b1313add5" size="141" mtime="1643641663"/>
+          <entry name="somefile.txt" md5="81dae88ee7d03a83724f8fe1c1e961fa" size="62" mtime="1643641663"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:26 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:43 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -801,18 +799,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '324'
+      - '323'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="cac1d949410bce8a7bed653ba518243f">
+        <sourcediff key="063a72854bef5d06c1fca79d6eb92057">
           <old project="home:Iggy" package="bar_package-123456789" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="104" srcmd5="cdb48c08d4553092b0b6a8a9f0bd50f6"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="38" srcmd5="f189d31e4d9aa16d81dac2970355fa7e"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:26 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:43 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -844,14 +842,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="1f85d90df5a3e597758d2c4299f757fa">
-          <old project="foo_project" package="bar_package" rev="af5f94558e1fbf504c48764c0e5bb9ef" srcmd5="af5f94558e1fbf504c48764c0e5bb9ef"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="6e450fc2c8b2c0c3dbb6ae6d71a98bb1" srcmd5="6e450fc2c8b2c0c3dbb6ae6d71a98bb1"/>
+        <sourcediff key="400dcf44cbc520eb77b955d6470bf80a">
+          <old project="foo_project" package="bar_package" rev="512b23cca3329fd1a7c6887396148265" srcmd5="512b23cca3329fd1a7c6887396148265"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="c2461d66aca0ab5e4637a1157d621558" srcmd5="c2461d66aca0ab5e4637a1157d621558"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:26 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:43 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -877,19 +875,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="104" vrev="104" srcmd5="cdb48c08d4553092b0b6a8a9f0bd50f6">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="af5f94558e1fbf504c48764c0e5bb9ef" baserev="af5f94558e1fbf504c48764c0e5bb9ef" xsrcmd5="103b075d5cc0570b9d3685d85bf34b10" lsrcmd5="cdb48c08d4553092b0b6a8a9f0bd50f6"/>
-          <serviceinfo code="succeeded" xsrcmd5="a2a338684d71cfd9b1528f13a5c449f5"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="bfcc340ad6ab85627caa1f67b3c29016" size="55" mtime="1642674745"/>
-          <entry name="_link" md5="208e692b043222ca740527a8b9f5e86b" size="141" mtime="1642674745"/>
-          <entry name="somefile.txt" md5="c40ed9c7a843addd7b18d06bbc6e8400" size="68" mtime="1642674745"/>
+        <directory name="bar_package-123456789" rev="38" vrev="38" srcmd5="f189d31e4d9aa16d81dac2970355fa7e">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="512b23cca3329fd1a7c6887396148265" baserev="512b23cca3329fd1a7c6887396148265" xsrcmd5="c2461d66aca0ab5e4637a1157d621558" lsrcmd5="f189d31e4d9aa16d81dac2970355fa7e"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="bf094783ea8d13b36f77ceda1f9ad137" size="52" mtime="1643641663"/>
+          <entry name="_link" md5="f6665d3c45d9b944f873c58b1313add5" size="141" mtime="1643641663"/>
+          <entry name="somefile.txt" md5="81dae88ee7d03a83724f8fe1c1e961fa" size="62" mtime="1643641663"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:26 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:44 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '628'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="c2461d66aca0ab5e4637a1157d621558" vrev="152" srcmd5="c2461d66aca0ab5e4637a1157d621558">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="512b23cca3329fd1a7c6887396148265" baserev="512b23cca3329fd1a7c6887396148265" lsrcmd5="f189d31e4d9aa16d81dac2970355fa7e"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="bf094783ea8d13b36f77ceda1f9ad137" size="52" mtime="1643641663"/>
+          <entry name="somefile.txt" md5="81dae88ee7d03a83724f8fe1c1e961fa" size="62" mtime="1643641663"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:07:44 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -915,19 +948,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="104" vrev="104" srcmd5="cdb48c08d4553092b0b6a8a9f0bd50f6">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="af5f94558e1fbf504c48764c0e5bb9ef" baserev="af5f94558e1fbf504c48764c0e5bb9ef" xsrcmd5="103b075d5cc0570b9d3685d85bf34b10" lsrcmd5="cdb48c08d4553092b0b6a8a9f0bd50f6"/>
-          <serviceinfo code="succeeded" xsrcmd5="a2a338684d71cfd9b1528f13a5c449f5"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="bfcc340ad6ab85627caa1f67b3c29016" size="55" mtime="1642674745"/>
-          <entry name="_link" md5="208e692b043222ca740527a8b9f5e86b" size="141" mtime="1642674745"/>
-          <entry name="somefile.txt" md5="c40ed9c7a843addd7b18d06bbc6e8400" size="68" mtime="1642674745"/>
+        <directory name="bar_package-123456789" rev="38" vrev="38" srcmd5="f189d31e4d9aa16d81dac2970355fa7e">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="512b23cca3329fd1a7c6887396148265" baserev="512b23cca3329fd1a7c6887396148265" xsrcmd5="c2461d66aca0ab5e4637a1157d621558" lsrcmd5="f189d31e4d9aa16d81dac2970355fa7e"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="bf094783ea8d13b36f77ceda1f9ad137" size="52" mtime="1643641663"/>
+          <entry name="_link" md5="f6665d3c45d9b944f873c58b1313add5" size="141" mtime="1643641663"/>
+          <entry name="somefile.txt" md5="81dae88ee7d03a83724f8fe1c1e961fa" size="62" mtime="1643641663"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:26 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:44 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '628'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="c2461d66aca0ab5e4637a1157d621558" vrev="152" srcmd5="c2461d66aca0ab5e4637a1157d621558">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="512b23cca3329fd1a7c6887396148265" baserev="512b23cca3329fd1a7c6887396148265" lsrcmd5="f189d31e4d9aa16d81dac2970355fa7e"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="bf094783ea8d13b36f77ceda1f9ad137" size="52" mtime="1643641663"/>
+          <entry name="somefile.txt" md5="81dae88ee7d03a83724f8fe1c1e961fa" size="62" mtime="1643641663"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:07:44 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -953,19 +1021,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="104" vrev="104" srcmd5="cdb48c08d4553092b0b6a8a9f0bd50f6">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="af5f94558e1fbf504c48764c0e5bb9ef" baserev="af5f94558e1fbf504c48764c0e5bb9ef" xsrcmd5="103b075d5cc0570b9d3685d85bf34b10" lsrcmd5="cdb48c08d4553092b0b6a8a9f0bd50f6"/>
-          <serviceinfo code="succeeded" xsrcmd5="a2a338684d71cfd9b1528f13a5c449f5"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="bfcc340ad6ab85627caa1f67b3c29016" size="55" mtime="1642674745"/>
-          <entry name="_link" md5="208e692b043222ca740527a8b9f5e86b" size="141" mtime="1642674745"/>
-          <entry name="somefile.txt" md5="c40ed9c7a843addd7b18d06bbc6e8400" size="68" mtime="1642674745"/>
+        <directory name="bar_package-123456789" rev="38" vrev="38" srcmd5="f189d31e4d9aa16d81dac2970355fa7e">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="512b23cca3329fd1a7c6887396148265" baserev="512b23cca3329fd1a7c6887396148265" xsrcmd5="c2461d66aca0ab5e4637a1157d621558" lsrcmd5="f189d31e4d9aa16d81dac2970355fa7e"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="bf094783ea8d13b36f77ceda1f9ad137" size="52" mtime="1643641663"/>
+          <entry name="_link" md5="f6665d3c45d9b944f873c58b1313add5" size="141" mtime="1643641663"/>
+          <entry name="somefile.txt" md5="81dae88ee7d03a83724f8fe1c1e961fa" size="62" mtime="1643641663"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:26 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:44 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '628'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="c2461d66aca0ab5e4637a1157d621558" vrev="152" srcmd5="c2461d66aca0ab5e4637a1157d621558">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="512b23cca3329fd1a7c6887396148265" baserev="512b23cca3329fd1a7c6887396148265" lsrcmd5="f189d31e4d9aa16d81dac2970355fa7e"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="bf094783ea8d13b36f77ceda1f9ad137" size="52" mtime="1643641663"/>
+          <entry name="somefile.txt" md5="81dae88ee7d03a83724f8fe1c1e961fa" size="62" mtime="1643641663"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:07:44 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -991,19 +1094,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="104" vrev="104" srcmd5="cdb48c08d4553092b0b6a8a9f0bd50f6">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="af5f94558e1fbf504c48764c0e5bb9ef" baserev="af5f94558e1fbf504c48764c0e5bb9ef" xsrcmd5="103b075d5cc0570b9d3685d85bf34b10" lsrcmd5="cdb48c08d4553092b0b6a8a9f0bd50f6"/>
-          <serviceinfo code="succeeded" xsrcmd5="a2a338684d71cfd9b1528f13a5c449f5"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="bfcc340ad6ab85627caa1f67b3c29016" size="55" mtime="1642674745"/>
-          <entry name="_link" md5="208e692b043222ca740527a8b9f5e86b" size="141" mtime="1642674745"/>
-          <entry name="somefile.txt" md5="c40ed9c7a843addd7b18d06bbc6e8400" size="68" mtime="1642674745"/>
+        <directory name="bar_package-123456789" rev="38" vrev="38" srcmd5="f189d31e4d9aa16d81dac2970355fa7e">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="512b23cca3329fd1a7c6887396148265" baserev="512b23cca3329fd1a7c6887396148265" xsrcmd5="c2461d66aca0ab5e4637a1157d621558" lsrcmd5="f189d31e4d9aa16d81dac2970355fa7e"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="bf094783ea8d13b36f77ceda1f9ad137" size="52" mtime="1643641663"/>
+          <entry name="_link" md5="f6665d3c45d9b944f873c58b1313add5" size="141" mtime="1643641663"/>
+          <entry name="somefile.txt" md5="81dae88ee7d03a83724f8fe1c1e961fa" size="62" mtime="1643641663"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:26 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:44 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '628'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="c2461d66aca0ab5e4637a1157d621558" vrev="152" srcmd5="c2461d66aca0ab5e4637a1157d621558">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="512b23cca3329fd1a7c6887396148265" baserev="512b23cca3329fd1a7c6887396148265" lsrcmd5="f189d31e4d9aa16d81dac2970355fa7e"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="bf094783ea8d13b36f77ceda1f9ad137" size="52" mtime="1643641663"/>
+          <entry name="somefile.txt" md5="81dae88ee7d03a83724f8fe1c1e961fa" size="62" mtime="1643641663"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:07:44 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -1029,22 +1167,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="104" vrev="104" srcmd5="cdb48c08d4553092b0b6a8a9f0bd50f6">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="af5f94558e1fbf504c48764c0e5bb9ef" baserev="af5f94558e1fbf504c48764c0e5bb9ef" xsrcmd5="103b075d5cc0570b9d3685d85bf34b10" lsrcmd5="cdb48c08d4553092b0b6a8a9f0bd50f6"/>
-          <serviceinfo code="succeeded" xsrcmd5="a2a338684d71cfd9b1528f13a5c449f5"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="bfcc340ad6ab85627caa1f67b3c29016" size="55" mtime="1642674745"/>
-          <entry name="_link" md5="208e692b043222ca740527a8b9f5e86b" size="141" mtime="1642674745"/>
-          <entry name="somefile.txt" md5="c40ed9c7a843addd7b18d06bbc6e8400" size="68" mtime="1642674745"/>
+        <directory name="bar_package-123456789" rev="38" vrev="38" srcmd5="f189d31e4d9aa16d81dac2970355fa7e">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="512b23cca3329fd1a7c6887396148265" baserev="512b23cca3329fd1a7c6887396148265" xsrcmd5="c2461d66aca0ab5e4637a1157d621558" lsrcmd5="f189d31e4d9aa16d81dac2970355fa7e"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="bf094783ea8d13b36f77ceda1f9ad137" size="52" mtime="1643641663"/>
+          <entry name="_link" md5="f6665d3c45d9b944f873c58b1313add5" size="141" mtime="1643641663"/>
+          <entry name="somefile.txt" md5="81dae88ee7d03a83724f8fe1c1e961fa" size="62" mtime="1643641663"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:26 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:44 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1067,171 +1204,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '628'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="104" vrev="104" srcmd5="cdb48c08d4553092b0b6a8a9f0bd50f6">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="af5f94558e1fbf504c48764c0e5bb9ef" baserev="af5f94558e1fbf504c48764c0e5bb9ef" xsrcmd5="103b075d5cc0570b9d3685d85bf34b10" lsrcmd5="cdb48c08d4553092b0b6a8a9f0bd50f6"/>
-          <serviceinfo code="succeeded" xsrcmd5="a2a338684d71cfd9b1528f13a5c449f5"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="bfcc340ad6ab85627caa1f67b3c29016" size="55" mtime="1642674745"/>
-          <entry name="_link" md5="208e692b043222ca740527a8b9f5e86b" size="141" mtime="1642674745"/>
-          <entry name="somefile.txt" md5="c40ed9c7a843addd7b18d06bbc6e8400" size="68" mtime="1642674745"/>
+        <directory name="bar_package-123456789" rev="c2461d66aca0ab5e4637a1157d621558" vrev="152" srcmd5="c2461d66aca0ab5e4637a1157d621558">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="512b23cca3329fd1a7c6887396148265" baserev="512b23cca3329fd1a7c6887396148265" lsrcmd5="f189d31e4d9aa16d81dac2970355fa7e"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="bf094783ea8d13b36f77ceda1f9ad137" size="52" mtime="1643641663"/>
+          <entry name="somefile.txt" md5="81dae88ee7d03a83724f8fe1c1e961fa" size="62" mtime="1643641663"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:26 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '812'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="104" vrev="104" srcmd5="cdb48c08d4553092b0b6a8a9f0bd50f6">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="af5f94558e1fbf504c48764c0e5bb9ef" baserev="af5f94558e1fbf504c48764c0e5bb9ef" xsrcmd5="103b075d5cc0570b9d3685d85bf34b10" lsrcmd5="cdb48c08d4553092b0b6a8a9f0bd50f6"/>
-          <serviceinfo code="succeeded" xsrcmd5="a2a338684d71cfd9b1528f13a5c449f5"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="bfcc340ad6ab85627caa1f67b3c29016" size="55" mtime="1642674745"/>
-          <entry name="_link" md5="208e692b043222ca740527a8b9f5e86b" size="141" mtime="1642674745"/>
-          <entry name="somefile.txt" md5="c40ed9c7a843addd7b18d06bbc6e8400" size="68" mtime="1642674745"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:26 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '812'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="104" vrev="104" srcmd5="cdb48c08d4553092b0b6a8a9f0bd50f6">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="af5f94558e1fbf504c48764c0e5bb9ef" baserev="af5f94558e1fbf504c48764c0e5bb9ef" xsrcmd5="103b075d5cc0570b9d3685d85bf34b10" lsrcmd5="cdb48c08d4553092b0b6a8a9f0bd50f6"/>
-          <serviceinfo code="succeeded" xsrcmd5="a2a338684d71cfd9b1528f13a5c449f5"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="bfcc340ad6ab85627caa1f67b3c29016" size="55" mtime="1642674745"/>
-          <entry name="_link" md5="208e692b043222ca740527a8b9f5e86b" size="141" mtime="1642674745"/>
-          <entry name="somefile.txt" md5="c40ed9c7a843addd7b18d06bbc6e8400" size="68" mtime="1642674745"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:26 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '812'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="104" vrev="104" srcmd5="cdb48c08d4553092b0b6a8a9f0bd50f6">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="af5f94558e1fbf504c48764c0e5bb9ef" baserev="af5f94558e1fbf504c48764c0e5bb9ef" xsrcmd5="103b075d5cc0570b9d3685d85bf34b10" lsrcmd5="cdb48c08d4553092b0b6a8a9f0bd50f6"/>
-          <serviceinfo code="succeeded" xsrcmd5="a2a338684d71cfd9b1528f13a5c449f5"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="bfcc340ad6ab85627caa1f67b3c29016" size="55" mtime="1642674745"/>
-          <entry name="_link" md5="208e692b043222ca740527a8b9f5e86b" size="141" mtime="1642674745"/>
-          <entry name="somefile.txt" md5="c40ed9c7a843addd7b18d06bbc6e8400" size="68" mtime="1642674745"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:26 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '812'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="104" vrev="104" srcmd5="cdb48c08d4553092b0b6a8a9f0bd50f6">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="af5f94558e1fbf504c48764c0e5bb9ef" baserev="af5f94558e1fbf504c48764c0e5bb9ef" xsrcmd5="103b075d5cc0570b9d3685d85bf34b10" lsrcmd5="cdb48c08d4553092b0b6a8a9f0bd50f6"/>
-          <serviceinfo code="succeeded" xsrcmd5="a2a338684d71cfd9b1528f13a5c449f5"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="bfcc340ad6ab85627caa1f67b3c29016" size="55" mtime="1642674745"/>
-          <entry name="_link" md5="208e692b043222ca740527a8b9f5e86b" size="141" mtime="1642674745"/>
-          <entry name="somefile.txt" md5="c40ed9c7a843addd7b18d06bbc6e8400" size="68" mtime="1642674745"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:26 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:44 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_branch_request
@@ -1261,5 +1244,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"object_kind":null,"project":{"http_url":null},"object_attributes":{"source":{"default_branch":"123456789"}}}'
-  recorded_at: Thu, 20 Jan 2022 10:32:26 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:44 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/with_a_push_event_for_a_commit/behaves_like_successful_new_PR_or_MR_event/1_1_2_5_1_5.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/with_a_push_event_for_a_commit/behaves_like_successful_new_PR_or_MR_event/1_1_2_5_1_5.yml
@@ -39,18 +39,57 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:37 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_238
+    uri: http://backend:5352/source/foo_project/_meta?user=user_3
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>A Farewell to Arms</title>
+          <title>To a God Unknown</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '148'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="foo_project">
+          <title>To a God Unknown</title>
+          <description></description>
+          <person userid="Iggy" role="maintainer"/>
+        </project>
+  recorded_at: Mon, 31 Jan 2022 15:07:37 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_4
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="bar_package" project="foo_project">
+          <title>Ah, Wilderness!</title>
+          <description>Perspiciatis est animi a.</description>
+        </package>
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -74,56 +113,17 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <project name="foo_project">
-          <title>A Farewell to Arms</title>
-          <description></description>
-          <person userid="Iggy" role="maintainer"/>
-        </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:21 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_239
-    body:
-      encoding: UTF-8
-      string: |
         <package name="bar_package" project="foo_project">
-          <title>The Lathe of Heaven</title>
-          <description>Aut nobis repudiandae vel.</description>
+          <title>Ah, Wilderness!</title>
+          <description>Perspiciatis est animi a.</description>
         </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '155'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="bar_package" project="foo_project">
-          <title>The Lathe of Heaven</title>
-          <description>Aut nobis repudiandae vel.</description>
-        </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:37 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Similique eius voluptatem. Repudiandae porro quia. Culpa qui autem.
+      string: Quis repellat illo. Et doloremque deleniti. Itaque omnis libero.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1619" vrev="1619">
-          <srcmd5>d4c1a564e273db77763766fdb240ea2e</srcmd5>
+        <revision rev="105" vrev="105">
+          <srcmd5>6a3af7b8e518df648796510e69de7684</srcmd5>
           <version>unknown</version>
-          <time>1642674741</time>
+          <time>1643641657</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:37 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Fugit aut et. Asperiores excepturi labore. Nisi quaerat expedita.
+      string: Veniam et quibusdam. Blanditiis et sed. Ipsum est voluptatem.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +181,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1620" vrev="1620">
-          <srcmd5>1622d6ccbda325416967637427d4d6bd</srcmd5>
+        <revision rev="106" vrev="106">
+          <srcmd5>6cfd5db5b89d1320d9d1076ec767ec7f</srcmd5>
           <version>unknown</version>
-          <time>1642674741</time>
+          <time>1643641657</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:21 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:37 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -227,7 +227,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:32:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:37 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_meta?user=Iggy
@@ -235,8 +235,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>The Lathe of Heaven</title>
-          <description>Aut nobis repudiandae vel.</description>
+          <title>Ah, Wilderness!</title>
+          <description>Perspiciatis est animi a.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -257,15 +257,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '163'
+      - '158'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>The Lathe of Heaven</title>
-          <description>Aut nobis repudiandae vel.</description>
+          <title>Ah, Wilderness!</title>
+          <description>Perspiciatis est animi a.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:37 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=branch&noservice=1&opackage=bar_package&oproject=foo_project&user=Iggy
@@ -297,15 +297,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="97" vrev="97">
-          <srcmd5>fc6be67f816ca86cf469d9e814be4f87</srcmd5>
+        <revision rev="29" vrev="29">
+          <srcmd5>ac5384cfe72e35c7929bbc1272be0cf8</srcmd5>
           <version>unknown</version>
-          <time>1642674742</time>
+          <time>1643641657</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:37 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_meta?user=Iggy
@@ -313,8 +313,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>The Lathe of Heaven</title>
-          <description>Aut nobis repudiandae vel.</description>
+          <title>Ah, Wilderness!</title>
+          <description>Perspiciatis est animi a.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -335,15 +335,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '163'
+      - '158'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>The Lathe of Heaven</title>
-          <description>Aut nobis repudiandae vel.</description>
+          <title>Ah, Wilderness!</title>
+          <description>Perspiciatis est animi a.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:37 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -373,14 +373,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="97" vrev="97" srcmd5="fc6be67f816ca86cf469d9e814be4f87">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="1622d6ccbda325416967637427d4d6bd" baserev="1622d6ccbda325416967637427d4d6bd" xsrcmd5="4fdca0ab7b7416c1587b01677110ad95" lsrcmd5="fc6be67f816ca86cf469d9e814be4f87"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="66b208da81182aa499b866bda67d9af1" size="67" mtime="1642674741"/>
-          <entry name="_link" md5="d4fbec01018bf860ce2941667b16d68e" size="141" mtime="1642674742"/>
-          <entry name="somefile.txt" md5="dce390ab6bb6d1b4fba89260358a7287" size="65" mtime="1642674741"/>
+        <directory name="bar_package-123456789" rev="29" vrev="29" srcmd5="ac5384cfe72e35c7929bbc1272be0cf8">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="6cfd5db5b89d1320d9d1076ec767ec7f" baserev="6cfd5db5b89d1320d9d1076ec767ec7f" xsrcmd5="b0ec5ee9e34506b7e06b3c4d5a2fbc7a" lsrcmd5="ac5384cfe72e35c7929bbc1272be0cf8"/>
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="3767312c41729a4d0eff222c58327b90" size="64" mtime="1643641657"/>
+          <entry name="_link" md5="ebfbbadacadc2fa90a688095d27578b5" size="141" mtime="1643641657"/>
+          <entry name="somefile.txt" md5="a8f54344bf72ce7aa4b9657f01e1a8a1" size="61" mtime="1643641657"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:37 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?view=info
@@ -406,15 +406,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '342'
+      - '341'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package-123456789" rev="97" vrev="1717" srcmd5="4fdca0ab7b7416c1587b01677110ad95" lsrcmd5="fc6be67f816ca86cf469d9e814be4f87" verifymd5="1622d6ccbda325416967637427d4d6bd">
+        <sourceinfo package="bar_package-123456789" rev="29" vrev="135" srcmd5="b0ec5ee9e34506b7e06b3c4d5a2fbc7a" lsrcmd5="ac5384cfe72e35c7929bbc1272be0cf8" verifymd5="6cfd5db5b89d1320d9d1076ec767ec7f">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:38 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -444,14 +444,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="97" vrev="97" srcmd5="fc6be67f816ca86cf469d9e814be4f87">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="1622d6ccbda325416967637427d4d6bd" baserev="1622d6ccbda325416967637427d4d6bd" xsrcmd5="4fdca0ab7b7416c1587b01677110ad95" lsrcmd5="fc6be67f816ca86cf469d9e814be4f87"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="66b208da81182aa499b866bda67d9af1" size="67" mtime="1642674741"/>
-          <entry name="_link" md5="d4fbec01018bf860ce2941667b16d68e" size="141" mtime="1642674742"/>
-          <entry name="somefile.txt" md5="dce390ab6bb6d1b4fba89260358a7287" size="65" mtime="1642674741"/>
+        <directory name="bar_package-123456789" rev="29" vrev="29" srcmd5="ac5384cfe72e35c7929bbc1272be0cf8">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="6cfd5db5b89d1320d9d1076ec767ec7f" baserev="6cfd5db5b89d1320d9d1076ec767ec7f" xsrcmd5="b0ec5ee9e34506b7e06b3c4d5a2fbc7a" lsrcmd5="ac5384cfe72e35c7929bbc1272be0cf8"/>
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="3767312c41729a4d0eff222c58327b90" size="64" mtime="1643641657"/>
+          <entry name="_link" md5="ebfbbadacadc2fa90a688095d27578b5" size="141" mtime="1643641657"/>
+          <entry name="somefile.txt" md5="a8f54344bf72ce7aa4b9657f01e1a8a1" size="61" mtime="1643641657"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:38 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -483,14 +483,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="a8aae25e0351cc5cb82f120b869f87f3">
+        <sourcediff key="a0b63d052bc783036ab4c6c807ae91dd">
           <old project="home:Iggy" package="bar_package-123456789" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="97" srcmd5="fc6be67f816ca86cf469d9e814be4f87"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="29" srcmd5="ac5384cfe72e35c7929bbc1272be0cf8"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:38 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -522,14 +522,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="6135e560bf44f11ee8dc8d16c140346d">
-          <old project="foo_project" package="bar_package" rev="1622d6ccbda325416967637427d4d6bd" srcmd5="1622d6ccbda325416967637427d4d6bd"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="4fdca0ab7b7416c1587b01677110ad95" srcmd5="4fdca0ab7b7416c1587b01677110ad95"/>
+        <sourcediff key="641a5423d5498166ba85511d99536920">
+          <old project="foo_project" package="bar_package" rev="6cfd5db5b89d1320d9d1076ec767ec7f" srcmd5="6cfd5db5b89d1320d9d1076ec767ec7f"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="b0ec5ee9e34506b7e06b3c4d5a2fbc7a" srcmd5="b0ec5ee9e34506b7e06b3c4d5a2fbc7a"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:38 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/_meta?user=Iggy
@@ -587,7 +587,7 @@ http_interactions:
             <arch>aarch64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:38 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_branch_request?user=Iggy
@@ -617,15 +617,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="98" vrev="98">
-          <srcmd5>496e98f8fb1727d67dd157570c495b12</srcmd5>
+        <revision rev="30" vrev="30">
+          <srcmd5>56b54482236d0fe02ba793e49bafc699</srcmd5>
           <version>unknown</version>
-          <time>1642674742</time>
+          <time>1643641658</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:38 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_meta?user=Iggy
@@ -633,8 +633,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>The Lathe of Heaven</title>
-          <description>Aut nobis repudiandae vel.</description>
+          <title>Ah, Wilderness!</title>
+          <description>Perspiciatis est animi a.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -655,15 +655,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '163'
+      - '158'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>The Lathe of Heaven</title>
-          <description>Aut nobis repudiandae vel.</description>
+          <title>Ah, Wilderness!</title>
+          <description>Perspiciatis est animi a.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:38 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -689,19 +689,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '810'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="98" vrev="98" srcmd5="496e98f8fb1727d67dd157570c495b12">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="1622d6ccbda325416967637427d4d6bd" baserev="1622d6ccbda325416967637427d4d6bd" xsrcmd5="b2eb3bcabb77ca950a57e839f0762fd5" lsrcmd5="496e98f8fb1727d67dd157570c495b12"/>
-          <serviceinfo code="succeeded" xsrcmd5="06e5937dc525a2ca35ab7ce84f360367"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="66b208da81182aa499b866bda67d9af1" size="67" mtime="1642674741"/>
-          <entry name="_link" md5="d4fbec01018bf860ce2941667b16d68e" size="141" mtime="1642674742"/>
-          <entry name="somefile.txt" md5="dce390ab6bb6d1b4fba89260358a7287" size="65" mtime="1642674741"/>
+        <directory name="bar_package-123456789" rev="30" vrev="30" srcmd5="56b54482236d0fe02ba793e49bafc699">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="6cfd5db5b89d1320d9d1076ec767ec7f" baserev="6cfd5db5b89d1320d9d1076ec767ec7f" xsrcmd5="31e008d285d759d9f5a5b47d05b275e4" lsrcmd5="56b54482236d0fe02ba793e49bafc699"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="3767312c41729a4d0eff222c58327b90" size="64" mtime="1643641657"/>
+          <entry name="_link" md5="ebfbbadacadc2fa90a688095d27578b5" size="141" mtime="1643641657"/>
+          <entry name="somefile.txt" md5="a8f54344bf72ce7aa4b9657f01e1a8a1" size="61" mtime="1643641657"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:38 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?view=info
@@ -727,15 +726,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '342'
+      - '341'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package-123456789" rev="98" vrev="1718" srcmd5="6c10d21d3ef78392811dcdceca5dfe0a" lsrcmd5="06e5937dc525a2ca35ab7ce84f360367" verifymd5="cfd533dd1ebe0b56c009471693e741be">
+        <sourceinfo package="bar_package-123456789" rev="30" vrev="136" srcmd5="31e008d285d759d9f5a5b47d05b275e4" lsrcmd5="56b54482236d0fe02ba793e49bafc699" verifymd5="e57f081bc6cacb5aeae0e7d738b5b17d">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:38 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -761,19 +760,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '810'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="98" vrev="98" srcmd5="496e98f8fb1727d67dd157570c495b12">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="1622d6ccbda325416967637427d4d6bd" baserev="1622d6ccbda325416967637427d4d6bd" xsrcmd5="b2eb3bcabb77ca950a57e839f0762fd5" lsrcmd5="496e98f8fb1727d67dd157570c495b12"/>
-          <serviceinfo code="succeeded" xsrcmd5="06e5937dc525a2ca35ab7ce84f360367"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="66b208da81182aa499b866bda67d9af1" size="67" mtime="1642674741"/>
-          <entry name="_link" md5="d4fbec01018bf860ce2941667b16d68e" size="141" mtime="1642674742"/>
-          <entry name="somefile.txt" md5="dce390ab6bb6d1b4fba89260358a7287" size="65" mtime="1642674741"/>
+        <directory name="bar_package-123456789" rev="30" vrev="30" srcmd5="56b54482236d0fe02ba793e49bafc699">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="6cfd5db5b89d1320d9d1076ec767ec7f" baserev="6cfd5db5b89d1320d9d1076ec767ec7f" xsrcmd5="31e008d285d759d9f5a5b47d05b275e4" lsrcmd5="56b54482236d0fe02ba793e49bafc699"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="3767312c41729a4d0eff222c58327b90" size="64" mtime="1643641657"/>
+          <entry name="_link" md5="ebfbbadacadc2fa90a688095d27578b5" size="141" mtime="1643641657"/>
+          <entry name="somefile.txt" md5="a8f54344bf72ce7aa4b9657f01e1a8a1" size="61" mtime="1643641657"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:38 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -805,14 +803,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="aaa253eb5bba487e45a58c8cbd8adb50">
+        <sourcediff key="10d2697fabcf3a34084535a8da9c7acf">
           <old project="home:Iggy" package="bar_package-123456789" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="98" srcmd5="496e98f8fb1727d67dd157570c495b12"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="30" srcmd5="56b54482236d0fe02ba793e49bafc699"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:38 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -844,14 +842,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="35c883ce47a1be29fe1ca99caf2d50f5">
-          <old project="foo_project" package="bar_package" rev="1622d6ccbda325416967637427d4d6bd" srcmd5="1622d6ccbda325416967637427d4d6bd"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="6c10d21d3ef78392811dcdceca5dfe0a" srcmd5="6c10d21d3ef78392811dcdceca5dfe0a"/>
+        <sourcediff key="104ad7dbb54142df41217d5ad57c6755">
+          <old project="foo_project" package="bar_package" rev="6cfd5db5b89d1320d9d1076ec767ec7f" srcmd5="6cfd5db5b89d1320d9d1076ec767ec7f"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="31e008d285d759d9f5a5b47d05b275e4" srcmd5="31e008d285d759d9f5a5b47d05b275e4"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:38 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -877,19 +875,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '810'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="98" vrev="98" srcmd5="496e98f8fb1727d67dd157570c495b12">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="1622d6ccbda325416967637427d4d6bd" baserev="1622d6ccbda325416967637427d4d6bd" xsrcmd5="b2eb3bcabb77ca950a57e839f0762fd5" lsrcmd5="496e98f8fb1727d67dd157570c495b12"/>
-          <serviceinfo code="succeeded" xsrcmd5="06e5937dc525a2ca35ab7ce84f360367"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="66b208da81182aa499b866bda67d9af1" size="67" mtime="1642674741"/>
-          <entry name="_link" md5="d4fbec01018bf860ce2941667b16d68e" size="141" mtime="1642674742"/>
-          <entry name="somefile.txt" md5="dce390ab6bb6d1b4fba89260358a7287" size="65" mtime="1642674741"/>
+        <directory name="bar_package-123456789" rev="30" vrev="30" srcmd5="56b54482236d0fe02ba793e49bafc699">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="6cfd5db5b89d1320d9d1076ec767ec7f" baserev="6cfd5db5b89d1320d9d1076ec767ec7f" xsrcmd5="31e008d285d759d9f5a5b47d05b275e4" lsrcmd5="56b54482236d0fe02ba793e49bafc699"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="3767312c41729a4d0eff222c58327b90" size="64" mtime="1643641657"/>
+          <entry name="_link" md5="ebfbbadacadc2fa90a688095d27578b5" size="141" mtime="1643641657"/>
+          <entry name="somefile.txt" md5="a8f54344bf72ce7aa4b9657f01e1a8a1" size="61" mtime="1643641657"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:38 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '628'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="31e008d285d759d9f5a5b47d05b275e4" vrev="136" srcmd5="31e008d285d759d9f5a5b47d05b275e4">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="6cfd5db5b89d1320d9d1076ec767ec7f" baserev="6cfd5db5b89d1320d9d1076ec767ec7f" lsrcmd5="56b54482236d0fe02ba793e49bafc699"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="3767312c41729a4d0eff222c58327b90" size="64" mtime="1643641657"/>
+          <entry name="somefile.txt" md5="a8f54344bf72ce7aa4b9657f01e1a8a1" size="61" mtime="1643641657"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:07:38 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -915,19 +948,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '810'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="98" vrev="98" srcmd5="496e98f8fb1727d67dd157570c495b12">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="1622d6ccbda325416967637427d4d6bd" baserev="1622d6ccbda325416967637427d4d6bd" xsrcmd5="b2eb3bcabb77ca950a57e839f0762fd5" lsrcmd5="496e98f8fb1727d67dd157570c495b12"/>
-          <serviceinfo code="succeeded" xsrcmd5="06e5937dc525a2ca35ab7ce84f360367"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="66b208da81182aa499b866bda67d9af1" size="67" mtime="1642674741"/>
-          <entry name="_link" md5="d4fbec01018bf860ce2941667b16d68e" size="141" mtime="1642674742"/>
-          <entry name="somefile.txt" md5="dce390ab6bb6d1b4fba89260358a7287" size="65" mtime="1642674741"/>
+        <directory name="bar_package-123456789" rev="30" vrev="30" srcmd5="56b54482236d0fe02ba793e49bafc699">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="6cfd5db5b89d1320d9d1076ec767ec7f" baserev="6cfd5db5b89d1320d9d1076ec767ec7f" xsrcmd5="31e008d285d759d9f5a5b47d05b275e4" lsrcmd5="56b54482236d0fe02ba793e49bafc699"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="3767312c41729a4d0eff222c58327b90" size="64" mtime="1643641657"/>
+          <entry name="_link" md5="ebfbbadacadc2fa90a688095d27578b5" size="141" mtime="1643641657"/>
+          <entry name="somefile.txt" md5="a8f54344bf72ce7aa4b9657f01e1a8a1" size="61" mtime="1643641657"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:38 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '628'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="31e008d285d759d9f5a5b47d05b275e4" vrev="136" srcmd5="31e008d285d759d9f5a5b47d05b275e4">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="6cfd5db5b89d1320d9d1076ec767ec7f" baserev="6cfd5db5b89d1320d9d1076ec767ec7f" lsrcmd5="56b54482236d0fe02ba793e49bafc699"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="3767312c41729a4d0eff222c58327b90" size="64" mtime="1643641657"/>
+          <entry name="somefile.txt" md5="a8f54344bf72ce7aa4b9657f01e1a8a1" size="61" mtime="1643641657"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:07:38 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -953,19 +1021,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '810'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="98" vrev="98" srcmd5="496e98f8fb1727d67dd157570c495b12">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="1622d6ccbda325416967637427d4d6bd" baserev="1622d6ccbda325416967637427d4d6bd" xsrcmd5="b2eb3bcabb77ca950a57e839f0762fd5" lsrcmd5="496e98f8fb1727d67dd157570c495b12"/>
-          <serviceinfo code="succeeded" xsrcmd5="06e5937dc525a2ca35ab7ce84f360367"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="66b208da81182aa499b866bda67d9af1" size="67" mtime="1642674741"/>
-          <entry name="_link" md5="d4fbec01018bf860ce2941667b16d68e" size="141" mtime="1642674742"/>
-          <entry name="somefile.txt" md5="dce390ab6bb6d1b4fba89260358a7287" size="65" mtime="1642674741"/>
+        <directory name="bar_package-123456789" rev="30" vrev="30" srcmd5="56b54482236d0fe02ba793e49bafc699">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="6cfd5db5b89d1320d9d1076ec767ec7f" baserev="6cfd5db5b89d1320d9d1076ec767ec7f" xsrcmd5="31e008d285d759d9f5a5b47d05b275e4" lsrcmd5="56b54482236d0fe02ba793e49bafc699"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="3767312c41729a4d0eff222c58327b90" size="64" mtime="1643641657"/>
+          <entry name="_link" md5="ebfbbadacadc2fa90a688095d27578b5" size="141" mtime="1643641657"/>
+          <entry name="somefile.txt" md5="a8f54344bf72ce7aa4b9657f01e1a8a1" size="61" mtime="1643641657"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:38 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '628'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="31e008d285d759d9f5a5b47d05b275e4" vrev="136" srcmd5="31e008d285d759d9f5a5b47d05b275e4">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="6cfd5db5b89d1320d9d1076ec767ec7f" baserev="6cfd5db5b89d1320d9d1076ec767ec7f" lsrcmd5="56b54482236d0fe02ba793e49bafc699"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="3767312c41729a4d0eff222c58327b90" size="64" mtime="1643641657"/>
+          <entry name="somefile.txt" md5="a8f54344bf72ce7aa4b9657f01e1a8a1" size="61" mtime="1643641657"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:07:38 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -991,19 +1094,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '810'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="98" vrev="98" srcmd5="496e98f8fb1727d67dd157570c495b12">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="1622d6ccbda325416967637427d4d6bd" baserev="1622d6ccbda325416967637427d4d6bd" xsrcmd5="b2eb3bcabb77ca950a57e839f0762fd5" lsrcmd5="496e98f8fb1727d67dd157570c495b12"/>
-          <serviceinfo code="succeeded" xsrcmd5="06e5937dc525a2ca35ab7ce84f360367"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="66b208da81182aa499b866bda67d9af1" size="67" mtime="1642674741"/>
-          <entry name="_link" md5="d4fbec01018bf860ce2941667b16d68e" size="141" mtime="1642674742"/>
-          <entry name="somefile.txt" md5="dce390ab6bb6d1b4fba89260358a7287" size="65" mtime="1642674741"/>
+        <directory name="bar_package-123456789" rev="30" vrev="30" srcmd5="56b54482236d0fe02ba793e49bafc699">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="6cfd5db5b89d1320d9d1076ec767ec7f" baserev="6cfd5db5b89d1320d9d1076ec767ec7f" xsrcmd5="31e008d285d759d9f5a5b47d05b275e4" lsrcmd5="56b54482236d0fe02ba793e49bafc699"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="3767312c41729a4d0eff222c58327b90" size="64" mtime="1643641657"/>
+          <entry name="_link" md5="ebfbbadacadc2fa90a688095d27578b5" size="141" mtime="1643641657"/>
+          <entry name="somefile.txt" md5="a8f54344bf72ce7aa4b9657f01e1a8a1" size="61" mtime="1643641657"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:38 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '628'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="31e008d285d759d9f5a5b47d05b275e4" vrev="136" srcmd5="31e008d285d759d9f5a5b47d05b275e4">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="6cfd5db5b89d1320d9d1076ec767ec7f" baserev="6cfd5db5b89d1320d9d1076ec767ec7f" lsrcmd5="56b54482236d0fe02ba793e49bafc699"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="3767312c41729a4d0eff222c58327b90" size="64" mtime="1643641657"/>
+          <entry name="somefile.txt" md5="a8f54344bf72ce7aa4b9657f01e1a8a1" size="61" mtime="1643641657"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:07:38 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -1029,22 +1167,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '810'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="98" vrev="98" srcmd5="496e98f8fb1727d67dd157570c495b12">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="1622d6ccbda325416967637427d4d6bd" baserev="1622d6ccbda325416967637427d4d6bd" xsrcmd5="b2eb3bcabb77ca950a57e839f0762fd5" lsrcmd5="496e98f8fb1727d67dd157570c495b12"/>
-          <serviceinfo code="succeeded" xsrcmd5="06e5937dc525a2ca35ab7ce84f360367"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="66b208da81182aa499b866bda67d9af1" size="67" mtime="1642674741"/>
-          <entry name="_link" md5="d4fbec01018bf860ce2941667b16d68e" size="141" mtime="1642674742"/>
-          <entry name="somefile.txt" md5="dce390ab6bb6d1b4fba89260358a7287" size="65" mtime="1642674741"/>
+        <directory name="bar_package-123456789" rev="30" vrev="30" srcmd5="56b54482236d0fe02ba793e49bafc699">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="6cfd5db5b89d1320d9d1076ec767ec7f" baserev="6cfd5db5b89d1320d9d1076ec767ec7f" xsrcmd5="31e008d285d759d9f5a5b47d05b275e4" lsrcmd5="56b54482236d0fe02ba793e49bafc699"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="3767312c41729a4d0eff222c58327b90" size="64" mtime="1643641657"/>
+          <entry name="_link" md5="ebfbbadacadc2fa90a688095d27578b5" size="141" mtime="1643641657"/>
+          <entry name="somefile.txt" md5="a8f54344bf72ce7aa4b9657f01e1a8a1" size="61" mtime="1643641657"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:38 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1067,169 +1204,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '810'
+      - '628'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="98" vrev="98" srcmd5="496e98f8fb1727d67dd157570c495b12">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="1622d6ccbda325416967637427d4d6bd" baserev="1622d6ccbda325416967637427d4d6bd" xsrcmd5="b2eb3bcabb77ca950a57e839f0762fd5" lsrcmd5="496e98f8fb1727d67dd157570c495b12"/>
-          <serviceinfo code="succeeded" xsrcmd5="06e5937dc525a2ca35ab7ce84f360367"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="66b208da81182aa499b866bda67d9af1" size="67" mtime="1642674741"/>
-          <entry name="_link" md5="d4fbec01018bf860ce2941667b16d68e" size="141" mtime="1642674742"/>
-          <entry name="somefile.txt" md5="dce390ab6bb6d1b4fba89260358a7287" size="65" mtime="1642674741"/>
+        <directory name="bar_package-123456789" rev="31e008d285d759d9f5a5b47d05b275e4" vrev="136" srcmd5="31e008d285d759d9f5a5b47d05b275e4">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="6cfd5db5b89d1320d9d1076ec767ec7f" baserev="6cfd5db5b89d1320d9d1076ec767ec7f" lsrcmd5="56b54482236d0fe02ba793e49bafc699"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="3767312c41729a4d0eff222c58327b90" size="64" mtime="1643641657"/>
+          <entry name="somefile.txt" md5="a8f54344bf72ce7aa4b9657f01e1a8a1" size="61" mtime="1643641657"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:22 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '810'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="98" vrev="98" srcmd5="496e98f8fb1727d67dd157570c495b12">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="1622d6ccbda325416967637427d4d6bd" baserev="1622d6ccbda325416967637427d4d6bd" xsrcmd5="b2eb3bcabb77ca950a57e839f0762fd5" lsrcmd5="496e98f8fb1727d67dd157570c495b12"/>
-          <serviceinfo code="succeeded" xsrcmd5="06e5937dc525a2ca35ab7ce84f360367"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="66b208da81182aa499b866bda67d9af1" size="67" mtime="1642674741"/>
-          <entry name="_link" md5="d4fbec01018bf860ce2941667b16d68e" size="141" mtime="1642674742"/>
-          <entry name="somefile.txt" md5="dce390ab6bb6d1b4fba89260358a7287" size="65" mtime="1642674741"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:22 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '810'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="98" vrev="98" srcmd5="496e98f8fb1727d67dd157570c495b12">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="1622d6ccbda325416967637427d4d6bd" baserev="1622d6ccbda325416967637427d4d6bd" xsrcmd5="b2eb3bcabb77ca950a57e839f0762fd5" lsrcmd5="496e98f8fb1727d67dd157570c495b12"/>
-          <serviceinfo code="succeeded" xsrcmd5="06e5937dc525a2ca35ab7ce84f360367"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="66b208da81182aa499b866bda67d9af1" size="67" mtime="1642674741"/>
-          <entry name="_link" md5="d4fbec01018bf860ce2941667b16d68e" size="141" mtime="1642674742"/>
-          <entry name="somefile.txt" md5="dce390ab6bb6d1b4fba89260358a7287" size="65" mtime="1642674741"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:22 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '810'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="98" vrev="98" srcmd5="496e98f8fb1727d67dd157570c495b12">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="1622d6ccbda325416967637427d4d6bd" baserev="1622d6ccbda325416967637427d4d6bd" xsrcmd5="b2eb3bcabb77ca950a57e839f0762fd5" lsrcmd5="496e98f8fb1727d67dd157570c495b12"/>
-          <serviceinfo code="succeeded" xsrcmd5="06e5937dc525a2ca35ab7ce84f360367"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="66b208da81182aa499b866bda67d9af1" size="67" mtime="1642674741"/>
-          <entry name="_link" md5="d4fbec01018bf860ce2941667b16d68e" size="141" mtime="1642674742"/>
-          <entry name="somefile.txt" md5="dce390ab6bb6d1b4fba89260358a7287" size="65" mtime="1642674741"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:22 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '810'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="98" vrev="98" srcmd5="496e98f8fb1727d67dd157570c495b12">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="1622d6ccbda325416967637427d4d6bd" baserev="1622d6ccbda325416967637427d4d6bd" xsrcmd5="b2eb3bcabb77ca950a57e839f0762fd5" lsrcmd5="496e98f8fb1727d67dd157570c495b12"/>
-          <serviceinfo code="succeeded" xsrcmd5="06e5937dc525a2ca35ab7ce84f360367"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="66b208da81182aa499b866bda67d9af1" size="67" mtime="1642674741"/>
-          <entry name="_link" md5="d4fbec01018bf860ce2941667b16d68e" size="141" mtime="1642674742"/>
-          <entry name="somefile.txt" md5="dce390ab6bb6d1b4fba89260358a7287" size="65" mtime="1642674741"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:22 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:38 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/with_a_push_event_for_a_commit/behaves_like_successful_new_PR_or_MR_event/1_1_2_5_1_6.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/with_a_push_event_for_a_commit/behaves_like_successful_new_PR_or_MR_event/1_1_2_5_1_6.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:40 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_250
+    uri: http://backend:5352/source/foo_project/_meta?user=user_7
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Dulce et Decorum Est</title>
+          <title>The Monkey's Raincoat</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '152'
+      - '153'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Dulce et Decorum Est</title>
+          <title>The Monkey's Raincoat</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:40 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_251
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_8
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>That Good Night</title>
-          <description>Eos neque et velit.</description>
+          <title>Fair Stood the Wind for France</title>
+          <description>Iusto beatae repellat suscipit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '144'
+      - '171'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>That Good Night</title>
-          <description>Eos neque et velit.</description>
+          <title>Fair Stood the Wind for France</title>
+          <description>Iusto beatae repellat suscipit.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:40 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Fuga nemo quaerat. Dolorum impedit fugit. Voluptates quod ea.
+      string: Id voluptate minima. Amet sed nemo. Dicta quis placeat.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1631" vrev="1631">
-          <srcmd5>16675a65b2f21c8ada108daf014453a3</srcmd5>
+        <revision rev="109" vrev="109">
+          <srcmd5>ac2eef01cbe58c51bceb4120d7bbd981</srcmd5>
           <version>unknown</version>
-          <time>1642674748</time>
+          <time>1643641660</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:40 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Ea repellat qui. Repudiandae corporis voluptatem. Ea nulla doloremque.
+      string: Veniam eum voluptatum. Nisi sunt modi. Sed corrupti aliquam.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +181,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1632" vrev="1632">
-          <srcmd5>ba72825245160e07e788b47fc2c40b70</srcmd5>
+        <revision rev="110" vrev="110">
+          <srcmd5>03ccff8e1147246a7c2b76b6aee8fd99</srcmd5>
           <version>unknown</version>
-          <time>1642674748</time>
+          <time>1643641660</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:28 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:40 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -227,7 +227,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:32:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:40 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_meta?user=Iggy
@@ -235,8 +235,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>That Good Night</title>
-          <description>Eos neque et velit.</description>
+          <title>Fair Stood the Wind for France</title>
+          <description>Iusto beatae repellat suscipit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -257,15 +257,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '152'
+      - '179'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>That Good Night</title>
-          <description>Eos neque et velit.</description>
+          <title>Fair Stood the Wind for France</title>
+          <description>Iusto beatae repellat suscipit.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:40 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=branch&noservice=1&opackage=bar_package&oproject=foo_project&user=Iggy
@@ -293,19 +293,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="109" vrev="109">
-          <srcmd5>25cc007baa8168bd29efc598875938af</srcmd5>
+        <revision rev="33" vrev="33">
+          <srcmd5>0b77ab9e18903df6822fadc16abefd67</srcmd5>
           <version>unknown</version>
-          <time>1642674749</time>
+          <time>1643641660</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:40 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_meta?user=Iggy
@@ -313,8 +313,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>That Good Night</title>
-          <description>Eos neque et velit.</description>
+          <title>Fair Stood the Wind for France</title>
+          <description>Iusto beatae repellat suscipit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -335,15 +335,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '152'
+      - '179'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>That Good Night</title>
-          <description>Eos neque et velit.</description>
+          <title>Fair Stood the Wind for France</title>
+          <description>Iusto beatae repellat suscipit.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:40 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -369,18 +369,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '735'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="109" vrev="109" srcmd5="25cc007baa8168bd29efc598875938af">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="ba72825245160e07e788b47fc2c40b70" baserev="ba72825245160e07e788b47fc2c40b70" xsrcmd5="d8af3d5ea16b01d9cc1d71d414d929c2" lsrcmd5="25cc007baa8168bd29efc598875938af"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="bc2bc2eb6f373e752156568c3ac92f24" size="61" mtime="1642674748"/>
-          <entry name="_link" md5="fd43b2a6edf30cb561fbde5426fda2cb" size="141" mtime="1642674749"/>
-          <entry name="somefile.txt" md5="9c1bcfc7dad41e8802530a6317b8b1ba" size="70" mtime="1642674748"/>
+        <directory name="bar_package-123456789" rev="33" vrev="33" srcmd5="0b77ab9e18903df6822fadc16abefd67">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="03ccff8e1147246a7c2b76b6aee8fd99" baserev="03ccff8e1147246a7c2b76b6aee8fd99" xsrcmd5="dbb98fc3128f745342fe3945716549fa" lsrcmd5="0b77ab9e18903df6822fadc16abefd67"/>
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="7798b6404cb184c251e3e40412aee285" size="55" mtime="1643641660"/>
+          <entry name="_link" md5="c7d256cc8ddbc63593cd43723acfb5a8" size="141" mtime="1643641660"/>
+          <entry name="somefile.txt" md5="ab85a9dbc6cac797a431922370872afe" size="60" mtime="1643641660"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:40 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?view=info
@@ -406,15 +406,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '343'
+      - '341'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package-123456789" rev="109" vrev="1741" srcmd5="d8af3d5ea16b01d9cc1d71d414d929c2" lsrcmd5="25cc007baa8168bd29efc598875938af" verifymd5="ba72825245160e07e788b47fc2c40b70">
+        <sourceinfo package="bar_package-123456789" rev="33" vrev="143" srcmd5="dbb98fc3128f745342fe3945716549fa" lsrcmd5="0b77ab9e18903df6822fadc16abefd67" verifymd5="03ccff8e1147246a7c2b76b6aee8fd99">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:40 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -440,18 +440,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '735'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="109" vrev="109" srcmd5="25cc007baa8168bd29efc598875938af">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="ba72825245160e07e788b47fc2c40b70" baserev="ba72825245160e07e788b47fc2c40b70" xsrcmd5="d8af3d5ea16b01d9cc1d71d414d929c2" lsrcmd5="25cc007baa8168bd29efc598875938af"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="bc2bc2eb6f373e752156568c3ac92f24" size="61" mtime="1642674748"/>
-          <entry name="_link" md5="fd43b2a6edf30cb561fbde5426fda2cb" size="141" mtime="1642674749"/>
-          <entry name="somefile.txt" md5="9c1bcfc7dad41e8802530a6317b8b1ba" size="70" mtime="1642674748"/>
+        <directory name="bar_package-123456789" rev="33" vrev="33" srcmd5="0b77ab9e18903df6822fadc16abefd67">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="03ccff8e1147246a7c2b76b6aee8fd99" baserev="03ccff8e1147246a7c2b76b6aee8fd99" xsrcmd5="dbb98fc3128f745342fe3945716549fa" lsrcmd5="0b77ab9e18903df6822fadc16abefd67"/>
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="7798b6404cb184c251e3e40412aee285" size="55" mtime="1643641660"/>
+          <entry name="_link" md5="c7d256cc8ddbc63593cd43723acfb5a8" size="141" mtime="1643641660"/>
+          <entry name="somefile.txt" md5="ab85a9dbc6cac797a431922370872afe" size="60" mtime="1643641660"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:40 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -479,18 +479,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '324'
+      - '323'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="cdd861b867e476a6217d174780b72e90">
+        <sourcediff key="8451040ced7c18c50c3e5a230ff64840">
           <old project="home:Iggy" package="bar_package-123456789" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="109" srcmd5="25cc007baa8168bd29efc598875938af"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="33" srcmd5="0b77ab9e18903df6822fadc16abefd67"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:40 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -522,14 +522,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="6d4f5d18476e84b19571abd87214a6e7">
-          <old project="foo_project" package="bar_package" rev="ba72825245160e07e788b47fc2c40b70" srcmd5="ba72825245160e07e788b47fc2c40b70"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="d8af3d5ea16b01d9cc1d71d414d929c2" srcmd5="d8af3d5ea16b01d9cc1d71d414d929c2"/>
+        <sourcediff key="ece65564796d321f4ebd2a0c1fcf4175">
+          <old project="foo_project" package="bar_package" rev="03ccff8e1147246a7c2b76b6aee8fd99" srcmd5="03ccff8e1147246a7c2b76b6aee8fd99"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="dbb98fc3128f745342fe3945716549fa" srcmd5="dbb98fc3128f745342fe3945716549fa"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:40 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/_meta?user=Iggy
@@ -587,7 +587,7 @@ http_interactions:
             <arch>aarch64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:40 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_branch_request?user=Iggy
@@ -613,19 +613,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="110" vrev="110">
-          <srcmd5>fd5aacebc1b5d6a60ed5a898b2625464</srcmd5>
+        <revision rev="34" vrev="34">
+          <srcmd5>bd493d43726a21753fdf135447496e3e</srcmd5>
           <version>unknown</version>
-          <time>1642674749</time>
+          <time>1643641660</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:40 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_meta?user=Iggy
@@ -633,8 +633,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>That Good Night</title>
-          <description>Eos neque et velit.</description>
+          <title>Fair Stood the Wind for France</title>
+          <description>Iusto beatae repellat suscipit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -655,15 +655,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '152'
+      - '179'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>That Good Night</title>
-          <description>Eos neque et velit.</description>
+          <title>Fair Stood the Wind for France</title>
+          <description>Iusto beatae repellat suscipit.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:40 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -689,19 +689,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="110" vrev="110" srcmd5="fd5aacebc1b5d6a60ed5a898b2625464">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="ba72825245160e07e788b47fc2c40b70" baserev="ba72825245160e07e788b47fc2c40b70" xsrcmd5="b1207545bc8efb165489e15884429c72" lsrcmd5="fd5aacebc1b5d6a60ed5a898b2625464"/>
-          <serviceinfo code="succeeded" xsrcmd5="4c771aa19994692133c498c88abd1428"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="bc2bc2eb6f373e752156568c3ac92f24" size="61" mtime="1642674748"/>
-          <entry name="_link" md5="fd43b2a6edf30cb561fbde5426fda2cb" size="141" mtime="1642674749"/>
-          <entry name="somefile.txt" md5="9c1bcfc7dad41e8802530a6317b8b1ba" size="70" mtime="1642674748"/>
+        <directory name="bar_package-123456789" rev="34" vrev="34" srcmd5="bd493d43726a21753fdf135447496e3e">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="03ccff8e1147246a7c2b76b6aee8fd99" baserev="03ccff8e1147246a7c2b76b6aee8fd99" xsrcmd5="15b6f0be93d2c732479514c6fcd0c5b2" lsrcmd5="bd493d43726a21753fdf135447496e3e"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="7798b6404cb184c251e3e40412aee285" size="55" mtime="1643641660"/>
+          <entry name="_link" md5="c7d256cc8ddbc63593cd43723acfb5a8" size="141" mtime="1643641660"/>
+          <entry name="somefile.txt" md5="ab85a9dbc6cac797a431922370872afe" size="60" mtime="1643641660"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:40 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?view=info
@@ -727,15 +726,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '343'
+      - '341'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package-123456789" rev="110" vrev="1742" srcmd5="1d8f60882442a1f4ec8895c157247a21" lsrcmd5="4c771aa19994692133c498c88abd1428" verifymd5="5587ac5267f09e0c54ac3b84ff265642">
+        <sourceinfo package="bar_package-123456789" rev="34" vrev="144" srcmd5="15b6f0be93d2c732479514c6fcd0c5b2" lsrcmd5="bd493d43726a21753fdf135447496e3e" verifymd5="93c47480b951e704220938b76f3c190f">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:40 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -761,19 +760,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="110" vrev="110" srcmd5="fd5aacebc1b5d6a60ed5a898b2625464">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="ba72825245160e07e788b47fc2c40b70" baserev="ba72825245160e07e788b47fc2c40b70" xsrcmd5="b1207545bc8efb165489e15884429c72" lsrcmd5="fd5aacebc1b5d6a60ed5a898b2625464"/>
-          <serviceinfo code="succeeded" xsrcmd5="4c771aa19994692133c498c88abd1428"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="bc2bc2eb6f373e752156568c3ac92f24" size="61" mtime="1642674748"/>
-          <entry name="_link" md5="fd43b2a6edf30cb561fbde5426fda2cb" size="141" mtime="1642674749"/>
-          <entry name="somefile.txt" md5="9c1bcfc7dad41e8802530a6317b8b1ba" size="70" mtime="1642674748"/>
+        <directory name="bar_package-123456789" rev="34" vrev="34" srcmd5="bd493d43726a21753fdf135447496e3e">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="03ccff8e1147246a7c2b76b6aee8fd99" baserev="03ccff8e1147246a7c2b76b6aee8fd99" xsrcmd5="15b6f0be93d2c732479514c6fcd0c5b2" lsrcmd5="bd493d43726a21753fdf135447496e3e"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="7798b6404cb184c251e3e40412aee285" size="55" mtime="1643641660"/>
+          <entry name="_link" md5="c7d256cc8ddbc63593cd43723acfb5a8" size="141" mtime="1643641660"/>
+          <entry name="somefile.txt" md5="ab85a9dbc6cac797a431922370872afe" size="60" mtime="1643641660"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:40 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -801,18 +799,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '324'
+      - '323'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="996321c8667e1f7ea71569aac4144db2">
+        <sourcediff key="d7026f61158feb7ac04b65ea38b2a6fd">
           <old project="home:Iggy" package="bar_package-123456789" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="110" srcmd5="fd5aacebc1b5d6a60ed5a898b2625464"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="34" srcmd5="bd493d43726a21753fdf135447496e3e"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:41 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -844,14 +842,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="0e46961ee5dadc1d4118c0ff34704a11">
-          <old project="foo_project" package="bar_package" rev="ba72825245160e07e788b47fc2c40b70" srcmd5="ba72825245160e07e788b47fc2c40b70"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="1d8f60882442a1f4ec8895c157247a21" srcmd5="1d8f60882442a1f4ec8895c157247a21"/>
+        <sourcediff key="48e05ad68b748c03b3dbfb90791007b1">
+          <old project="foo_project" package="bar_package" rev="03ccff8e1147246a7c2b76b6aee8fd99" srcmd5="03ccff8e1147246a7c2b76b6aee8fd99"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="15b6f0be93d2c732479514c6fcd0c5b2" srcmd5="15b6f0be93d2c732479514c6fcd0c5b2"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:41 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -877,19 +875,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="110" vrev="110" srcmd5="fd5aacebc1b5d6a60ed5a898b2625464">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="ba72825245160e07e788b47fc2c40b70" baserev="ba72825245160e07e788b47fc2c40b70" xsrcmd5="b1207545bc8efb165489e15884429c72" lsrcmd5="fd5aacebc1b5d6a60ed5a898b2625464"/>
-          <serviceinfo code="succeeded" xsrcmd5="4c771aa19994692133c498c88abd1428"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="bc2bc2eb6f373e752156568c3ac92f24" size="61" mtime="1642674748"/>
-          <entry name="_link" md5="fd43b2a6edf30cb561fbde5426fda2cb" size="141" mtime="1642674749"/>
-          <entry name="somefile.txt" md5="9c1bcfc7dad41e8802530a6317b8b1ba" size="70" mtime="1642674748"/>
+        <directory name="bar_package-123456789" rev="34" vrev="34" srcmd5="bd493d43726a21753fdf135447496e3e">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="03ccff8e1147246a7c2b76b6aee8fd99" baserev="03ccff8e1147246a7c2b76b6aee8fd99" xsrcmd5="15b6f0be93d2c732479514c6fcd0c5b2" lsrcmd5="bd493d43726a21753fdf135447496e3e"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="7798b6404cb184c251e3e40412aee285" size="55" mtime="1643641660"/>
+          <entry name="_link" md5="c7d256cc8ddbc63593cd43723acfb5a8" size="141" mtime="1643641660"/>
+          <entry name="somefile.txt" md5="ab85a9dbc6cac797a431922370872afe" size="60" mtime="1643641660"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:41 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '628'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="15b6f0be93d2c732479514c6fcd0c5b2" vrev="144" srcmd5="15b6f0be93d2c732479514c6fcd0c5b2">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="03ccff8e1147246a7c2b76b6aee8fd99" baserev="03ccff8e1147246a7c2b76b6aee8fd99" lsrcmd5="bd493d43726a21753fdf135447496e3e"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="7798b6404cb184c251e3e40412aee285" size="55" mtime="1643641660"/>
+          <entry name="somefile.txt" md5="ab85a9dbc6cac797a431922370872afe" size="60" mtime="1643641660"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:07:41 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -915,19 +948,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="110" vrev="110" srcmd5="fd5aacebc1b5d6a60ed5a898b2625464">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="ba72825245160e07e788b47fc2c40b70" baserev="ba72825245160e07e788b47fc2c40b70" xsrcmd5="b1207545bc8efb165489e15884429c72" lsrcmd5="fd5aacebc1b5d6a60ed5a898b2625464"/>
-          <serviceinfo code="succeeded" xsrcmd5="4c771aa19994692133c498c88abd1428"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="bc2bc2eb6f373e752156568c3ac92f24" size="61" mtime="1642674748"/>
-          <entry name="_link" md5="fd43b2a6edf30cb561fbde5426fda2cb" size="141" mtime="1642674749"/>
-          <entry name="somefile.txt" md5="9c1bcfc7dad41e8802530a6317b8b1ba" size="70" mtime="1642674748"/>
+        <directory name="bar_package-123456789" rev="34" vrev="34" srcmd5="bd493d43726a21753fdf135447496e3e">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="03ccff8e1147246a7c2b76b6aee8fd99" baserev="03ccff8e1147246a7c2b76b6aee8fd99" xsrcmd5="15b6f0be93d2c732479514c6fcd0c5b2" lsrcmd5="bd493d43726a21753fdf135447496e3e"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="7798b6404cb184c251e3e40412aee285" size="55" mtime="1643641660"/>
+          <entry name="_link" md5="c7d256cc8ddbc63593cd43723acfb5a8" size="141" mtime="1643641660"/>
+          <entry name="somefile.txt" md5="ab85a9dbc6cac797a431922370872afe" size="60" mtime="1643641660"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:41 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '628'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="15b6f0be93d2c732479514c6fcd0c5b2" vrev="144" srcmd5="15b6f0be93d2c732479514c6fcd0c5b2">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="03ccff8e1147246a7c2b76b6aee8fd99" baserev="03ccff8e1147246a7c2b76b6aee8fd99" lsrcmd5="bd493d43726a21753fdf135447496e3e"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="7798b6404cb184c251e3e40412aee285" size="55" mtime="1643641660"/>
+          <entry name="somefile.txt" md5="ab85a9dbc6cac797a431922370872afe" size="60" mtime="1643641660"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:07:41 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -953,19 +1021,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="110" vrev="110" srcmd5="fd5aacebc1b5d6a60ed5a898b2625464">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="ba72825245160e07e788b47fc2c40b70" baserev="ba72825245160e07e788b47fc2c40b70" xsrcmd5="b1207545bc8efb165489e15884429c72" lsrcmd5="fd5aacebc1b5d6a60ed5a898b2625464"/>
-          <serviceinfo code="succeeded" xsrcmd5="4c771aa19994692133c498c88abd1428"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="bc2bc2eb6f373e752156568c3ac92f24" size="61" mtime="1642674748"/>
-          <entry name="_link" md5="fd43b2a6edf30cb561fbde5426fda2cb" size="141" mtime="1642674749"/>
-          <entry name="somefile.txt" md5="9c1bcfc7dad41e8802530a6317b8b1ba" size="70" mtime="1642674748"/>
+        <directory name="bar_package-123456789" rev="34" vrev="34" srcmd5="bd493d43726a21753fdf135447496e3e">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="03ccff8e1147246a7c2b76b6aee8fd99" baserev="03ccff8e1147246a7c2b76b6aee8fd99" xsrcmd5="15b6f0be93d2c732479514c6fcd0c5b2" lsrcmd5="bd493d43726a21753fdf135447496e3e"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="7798b6404cb184c251e3e40412aee285" size="55" mtime="1643641660"/>
+          <entry name="_link" md5="c7d256cc8ddbc63593cd43723acfb5a8" size="141" mtime="1643641660"/>
+          <entry name="somefile.txt" md5="ab85a9dbc6cac797a431922370872afe" size="60" mtime="1643641660"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:41 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '628'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="15b6f0be93d2c732479514c6fcd0c5b2" vrev="144" srcmd5="15b6f0be93d2c732479514c6fcd0c5b2">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="03ccff8e1147246a7c2b76b6aee8fd99" baserev="03ccff8e1147246a7c2b76b6aee8fd99" lsrcmd5="bd493d43726a21753fdf135447496e3e"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="7798b6404cb184c251e3e40412aee285" size="55" mtime="1643641660"/>
+          <entry name="somefile.txt" md5="ab85a9dbc6cac797a431922370872afe" size="60" mtime="1643641660"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:07:41 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -991,19 +1094,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="110" vrev="110" srcmd5="fd5aacebc1b5d6a60ed5a898b2625464">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="ba72825245160e07e788b47fc2c40b70" baserev="ba72825245160e07e788b47fc2c40b70" xsrcmd5="b1207545bc8efb165489e15884429c72" lsrcmd5="fd5aacebc1b5d6a60ed5a898b2625464"/>
-          <serviceinfo code="succeeded" xsrcmd5="4c771aa19994692133c498c88abd1428"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="bc2bc2eb6f373e752156568c3ac92f24" size="61" mtime="1642674748"/>
-          <entry name="_link" md5="fd43b2a6edf30cb561fbde5426fda2cb" size="141" mtime="1642674749"/>
-          <entry name="somefile.txt" md5="9c1bcfc7dad41e8802530a6317b8b1ba" size="70" mtime="1642674748"/>
+        <directory name="bar_package-123456789" rev="34" vrev="34" srcmd5="bd493d43726a21753fdf135447496e3e">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="03ccff8e1147246a7c2b76b6aee8fd99" baserev="03ccff8e1147246a7c2b76b6aee8fd99" xsrcmd5="15b6f0be93d2c732479514c6fcd0c5b2" lsrcmd5="bd493d43726a21753fdf135447496e3e"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="7798b6404cb184c251e3e40412aee285" size="55" mtime="1643641660"/>
+          <entry name="_link" md5="c7d256cc8ddbc63593cd43723acfb5a8" size="141" mtime="1643641660"/>
+          <entry name="somefile.txt" md5="ab85a9dbc6cac797a431922370872afe" size="60" mtime="1643641660"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:41 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '628'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="15b6f0be93d2c732479514c6fcd0c5b2" vrev="144" srcmd5="15b6f0be93d2c732479514c6fcd0c5b2">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="03ccff8e1147246a7c2b76b6aee8fd99" baserev="03ccff8e1147246a7c2b76b6aee8fd99" lsrcmd5="bd493d43726a21753fdf135447496e3e"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="7798b6404cb184c251e3e40412aee285" size="55" mtime="1643641660"/>
+          <entry name="somefile.txt" md5="ab85a9dbc6cac797a431922370872afe" size="60" mtime="1643641660"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:07:41 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -1029,22 +1167,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="110" vrev="110" srcmd5="fd5aacebc1b5d6a60ed5a898b2625464">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="ba72825245160e07e788b47fc2c40b70" baserev="ba72825245160e07e788b47fc2c40b70" xsrcmd5="b1207545bc8efb165489e15884429c72" lsrcmd5="fd5aacebc1b5d6a60ed5a898b2625464"/>
-          <serviceinfo code="succeeded" xsrcmd5="4c771aa19994692133c498c88abd1428"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="bc2bc2eb6f373e752156568c3ac92f24" size="61" mtime="1642674748"/>
-          <entry name="_link" md5="fd43b2a6edf30cb561fbde5426fda2cb" size="141" mtime="1642674749"/>
-          <entry name="somefile.txt" md5="9c1bcfc7dad41e8802530a6317b8b1ba" size="70" mtime="1642674748"/>
+        <directory name="bar_package-123456789" rev="34" vrev="34" srcmd5="bd493d43726a21753fdf135447496e3e">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="03ccff8e1147246a7c2b76b6aee8fd99" baserev="03ccff8e1147246a7c2b76b6aee8fd99" xsrcmd5="15b6f0be93d2c732479514c6fcd0c5b2" lsrcmd5="bd493d43726a21753fdf135447496e3e"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="7798b6404cb184c251e3e40412aee285" size="55" mtime="1643641660"/>
+          <entry name="_link" md5="c7d256cc8ddbc63593cd43723acfb5a8" size="141" mtime="1643641660"/>
+          <entry name="somefile.txt" md5="ab85a9dbc6cac797a431922370872afe" size="60" mtime="1643641660"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:41 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1067,169 +1204,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '628'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="110" vrev="110" srcmd5="fd5aacebc1b5d6a60ed5a898b2625464">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="ba72825245160e07e788b47fc2c40b70" baserev="ba72825245160e07e788b47fc2c40b70" xsrcmd5="b1207545bc8efb165489e15884429c72" lsrcmd5="fd5aacebc1b5d6a60ed5a898b2625464"/>
-          <serviceinfo code="succeeded" xsrcmd5="4c771aa19994692133c498c88abd1428"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="bc2bc2eb6f373e752156568c3ac92f24" size="61" mtime="1642674748"/>
-          <entry name="_link" md5="fd43b2a6edf30cb561fbde5426fda2cb" size="141" mtime="1642674749"/>
-          <entry name="somefile.txt" md5="9c1bcfc7dad41e8802530a6317b8b1ba" size="70" mtime="1642674748"/>
+        <directory name="bar_package-123456789" rev="15b6f0be93d2c732479514c6fcd0c5b2" vrev="144" srcmd5="15b6f0be93d2c732479514c6fcd0c5b2">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="03ccff8e1147246a7c2b76b6aee8fd99" baserev="03ccff8e1147246a7c2b76b6aee8fd99" lsrcmd5="bd493d43726a21753fdf135447496e3e"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="7798b6404cb184c251e3e40412aee285" size="55" mtime="1643641660"/>
+          <entry name="somefile.txt" md5="ab85a9dbc6cac797a431922370872afe" size="60" mtime="1643641660"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:29 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '812'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="110" vrev="110" srcmd5="fd5aacebc1b5d6a60ed5a898b2625464">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="ba72825245160e07e788b47fc2c40b70" baserev="ba72825245160e07e788b47fc2c40b70" xsrcmd5="b1207545bc8efb165489e15884429c72" lsrcmd5="fd5aacebc1b5d6a60ed5a898b2625464"/>
-          <serviceinfo code="succeeded" xsrcmd5="4c771aa19994692133c498c88abd1428"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="bc2bc2eb6f373e752156568c3ac92f24" size="61" mtime="1642674748"/>
-          <entry name="_link" md5="fd43b2a6edf30cb561fbde5426fda2cb" size="141" mtime="1642674749"/>
-          <entry name="somefile.txt" md5="9c1bcfc7dad41e8802530a6317b8b1ba" size="70" mtime="1642674748"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:29 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '812'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="110" vrev="110" srcmd5="fd5aacebc1b5d6a60ed5a898b2625464">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="ba72825245160e07e788b47fc2c40b70" baserev="ba72825245160e07e788b47fc2c40b70" xsrcmd5="b1207545bc8efb165489e15884429c72" lsrcmd5="fd5aacebc1b5d6a60ed5a898b2625464"/>
-          <serviceinfo code="succeeded" xsrcmd5="4c771aa19994692133c498c88abd1428"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="bc2bc2eb6f373e752156568c3ac92f24" size="61" mtime="1642674748"/>
-          <entry name="_link" md5="fd43b2a6edf30cb561fbde5426fda2cb" size="141" mtime="1642674749"/>
-          <entry name="somefile.txt" md5="9c1bcfc7dad41e8802530a6317b8b1ba" size="70" mtime="1642674748"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:29 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '812'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="110" vrev="110" srcmd5="fd5aacebc1b5d6a60ed5a898b2625464">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="ba72825245160e07e788b47fc2c40b70" baserev="ba72825245160e07e788b47fc2c40b70" xsrcmd5="b1207545bc8efb165489e15884429c72" lsrcmd5="fd5aacebc1b5d6a60ed5a898b2625464"/>
-          <serviceinfo code="succeeded" xsrcmd5="4c771aa19994692133c498c88abd1428"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="bc2bc2eb6f373e752156568c3ac92f24" size="61" mtime="1642674748"/>
-          <entry name="_link" md5="fd43b2a6edf30cb561fbde5426fda2cb" size="141" mtime="1642674749"/>
-          <entry name="somefile.txt" md5="9c1bcfc7dad41e8802530a6317b8b1ba" size="70" mtime="1642674748"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:29 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '812'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="110" vrev="110" srcmd5="fd5aacebc1b5d6a60ed5a898b2625464">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="ba72825245160e07e788b47fc2c40b70" baserev="ba72825245160e07e788b47fc2c40b70" xsrcmd5="b1207545bc8efb165489e15884429c72" lsrcmd5="fd5aacebc1b5d6a60ed5a898b2625464"/>
-          <serviceinfo code="succeeded" xsrcmd5="4c771aa19994692133c498c88abd1428"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="bc2bc2eb6f373e752156568c3ac92f24" size="61" mtime="1642674748"/>
-          <entry name="_link" md5="fd43b2a6edf30cb561fbde5426fda2cb" size="141" mtime="1642674749"/>
-          <entry name="somefile.txt" md5="9c1bcfc7dad41e8802530a6317b8b1ba" size="70" mtime="1642674748"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:29 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:41 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/with_a_push_event_for_a_commit/behaves_like_successful_new_PR_or_MR_event/only_reports_for_repositories_and_architectures_matching_the_filters.yml
+++ b/src/api/spec/cassettes/Workflow_Step_BranchPackageStep/_call/when_the_SCM_is_GitLab/with_a_push_event_for_a_commit/behaves_like_successful_new_PR_or_MR_event/only_reports_for_repositories_and_architectures_matching_the_filters.yml
@@ -39,15 +39,15 @@ http_interactions:
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:38 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/_meta?user=user_240
+    uri: http://backend:5352/source/foo_project/_meta?user=user_5
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Cover Her Face</title>
+          <title>Specimen Days</title>
           <description/>
           <person userid="Iggy" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '146'
+      - '145'
     body:
       encoding: UTF-8
       string: |
         <project name="foo_project">
-          <title>Cover Her Face</title>
+          <title>Specimen Days</title>
           <description></description>
           <person userid="Iggy" role="maintainer"/>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:39 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_241
+    uri: http://backend:5352/source/foo_project/bar_package/_meta?user=user_6
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Clouds of Witness</title>
-          <description>Impedit eligendi non officiis.</description>
+          <title>The Lathe of Heaven</title>
+          <description>Voluptas reiciendis at nobis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,21 +109,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '157'
+      - '158'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package" project="foo_project">
-          <title>Clouds of Witness</title>
-          <description>Impedit eligendi non officiis.</description>
+          <title>The Lathe of Heaven</title>
+          <description>Voluptas reiciendis at nobis.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:39 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/_config
     body:
       encoding: UTF-8
-      string: Dolor odio nulla. Cum ea provident. Sint tempore possimus.
+      string: Repellendus repellat aperiam. Enim at dolores. Molestiae vel consequatur.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -143,25 +143,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1621" vrev="1621">
-          <srcmd5>1a163ef68e53158e7ef2dc9f4801cb58</srcmd5>
+        <revision rev="107" vrev="107">
+          <srcmd5>9b46632655b1a9509019f0c0f9baefc9</srcmd5>
           <version>unknown</version>
-          <time>1642674743</time>
+          <time>1643641659</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:39 GMT
 - request:
     method: put
     uri: http://backend:5352/source/foo_project/bar_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Cum in laboriosam. Facilis quisquam omnis. Rem eum ea.
+      string: Nulla ex voluptatum. Pariatur beatae voluptas. Inventore soluta minus.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -181,19 +181,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '211'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1622" vrev="1622">
-          <srcmd5>117c0489196d2ee5f4210890f89f257b</srcmd5>
+        <revision rev="108" vrev="108">
+          <srcmd5>1c12e7973807212ca86f80fbcaab3815</srcmd5>
           <version>unknown</version>
-          <time>1642674743</time>
+          <time>1643641659</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:39 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22bar_package%22%20and%20linkinfo/@project=%22foo_project%22%20and%20@project=%22foo_project%22)
@@ -227,7 +227,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 20 Jan 2022 10:32:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:39 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_meta?user=Iggy
@@ -235,8 +235,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>Clouds of Witness</title>
-          <description>Impedit eligendi non officiis.</description>
+          <title>The Lathe of Heaven</title>
+          <description>Voluptas reiciendis at nobis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -257,15 +257,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '165'
+      - '166'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>Clouds of Witness</title>
-          <description>Impedit eligendi non officiis.</description>
+          <title>The Lathe of Heaven</title>
+          <description>Voluptas reiciendis at nobis.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:39 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=branch&noservice=1&opackage=bar_package&oproject=foo_project&user=Iggy
@@ -297,15 +297,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="99" vrev="99">
-          <srcmd5>3450353fb97cb859759c79cb0edbb407</srcmd5>
+        <revision rev="31" vrev="31">
+          <srcmd5>1a5ebc8445d6c50ff28855a9537189b1</srcmd5>
           <version>unknown</version>
-          <time>1642674743</time>
+          <time>1643641659</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:39 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_meta?user=Iggy
@@ -313,8 +313,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>Clouds of Witness</title>
-          <description>Impedit eligendi non officiis.</description>
+          <title>The Lathe of Heaven</title>
+          <description>Voluptas reiciendis at nobis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -335,15 +335,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '165'
+      - '166'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>Clouds of Witness</title>
-          <description>Impedit eligendi non officiis.</description>
+          <title>The Lathe of Heaven</title>
+          <description>Voluptas reiciendis at nobis.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:39 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -373,14 +373,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="99" vrev="99" srcmd5="3450353fb97cb859759c79cb0edbb407">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="117c0489196d2ee5f4210890f89f257b" baserev="117c0489196d2ee5f4210890f89f257b" xsrcmd5="3cb87569bcac89603cae4085093f3d6f" lsrcmd5="3450353fb97cb859759c79cb0edbb407"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="cf69c42cf5f7612108468dba0a44bf11" size="58" mtime="1642674743"/>
-          <entry name="_link" md5="047ca72bd0391793a58f7df00d53a257" size="141" mtime="1642674743"/>
-          <entry name="somefile.txt" md5="9b754aa4cd99b9af180250bb7edf2b64" size="54" mtime="1642674743"/>
+        <directory name="bar_package-123456789" rev="31" vrev="31" srcmd5="1a5ebc8445d6c50ff28855a9537189b1">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="1c12e7973807212ca86f80fbcaab3815" baserev="1c12e7973807212ca86f80fbcaab3815" xsrcmd5="10c0c91bf3a97b23534ab324e63c7785" lsrcmd5="1a5ebc8445d6c50ff28855a9537189b1"/>
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="062037d93c0fd1a6fb35318d11dcd6e6" size="73" mtime="1643641659"/>
+          <entry name="_link" md5="f466f01033e08c5cecd5117e1f073c4f" size="141" mtime="1643641659"/>
+          <entry name="somefile.txt" md5="cdd832786cc3d2b7e6bf5d2eb79a9f19" size="70" mtime="1643641659"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:39 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?view=info
@@ -406,15 +406,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '342'
+      - '341'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package-123456789" rev="99" vrev="1721" srcmd5="3cb87569bcac89603cae4085093f3d6f" lsrcmd5="3450353fb97cb859759c79cb0edbb407" verifymd5="117c0489196d2ee5f4210890f89f257b">
+        <sourceinfo package="bar_package-123456789" rev="31" vrev="139" srcmd5="10c0c91bf3a97b23534ab324e63c7785" lsrcmd5="1a5ebc8445d6c50ff28855a9537189b1" verifymd5="1c12e7973807212ca86f80fbcaab3815">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:39 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -444,14 +444,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="99" vrev="99" srcmd5="3450353fb97cb859759c79cb0edbb407">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="117c0489196d2ee5f4210890f89f257b" baserev="117c0489196d2ee5f4210890f89f257b" xsrcmd5="3cb87569bcac89603cae4085093f3d6f" lsrcmd5="3450353fb97cb859759c79cb0edbb407"/>
-          <entry name="_branch_request" md5="aea524cf047993d430e69b477e07f3df" size="114" mtime="1642597680"/>
-          <entry name="_config" md5="cf69c42cf5f7612108468dba0a44bf11" size="58" mtime="1642674743"/>
-          <entry name="_link" md5="047ca72bd0391793a58f7df00d53a257" size="141" mtime="1642674743"/>
-          <entry name="somefile.txt" md5="9b754aa4cd99b9af180250bb7edf2b64" size="54" mtime="1642674743"/>
+        <directory name="bar_package-123456789" rev="31" vrev="31" srcmd5="1a5ebc8445d6c50ff28855a9537189b1">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="1c12e7973807212ca86f80fbcaab3815" baserev="1c12e7973807212ca86f80fbcaab3815" xsrcmd5="10c0c91bf3a97b23534ab324e63c7785" lsrcmd5="1a5ebc8445d6c50ff28855a9537189b1"/>
+          <entry name="_branch_request" md5="c4321e613d633f87e139ae1201ad0bf8" size="113" mtime="1643641537"/>
+          <entry name="_config" md5="062037d93c0fd1a6fb35318d11dcd6e6" size="73" mtime="1643641659"/>
+          <entry name="_link" md5="f466f01033e08c5cecd5117e1f073c4f" size="141" mtime="1643641659"/>
+          <entry name="somefile.txt" md5="cdd832786cc3d2b7e6bf5d2eb79a9f19" size="70" mtime="1643641659"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:39 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -483,14 +483,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="c3366b64076a8c5f5fafe32d255f5c2e">
+        <sourcediff key="11331b910cfbb9f4c99cf4c1024def9b">
           <old project="home:Iggy" package="bar_package-123456789" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="99" srcmd5="3450353fb97cb859759c79cb0edbb407"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="31" srcmd5="1a5ebc8445d6c50ff28855a9537189b1"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:39 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -522,14 +522,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="0e4e4cf7e8d75787a71bb9b998eff909">
-          <old project="foo_project" package="bar_package" rev="117c0489196d2ee5f4210890f89f257b" srcmd5="117c0489196d2ee5f4210890f89f257b"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="3cb87569bcac89603cae4085093f3d6f" srcmd5="3cb87569bcac89603cae4085093f3d6f"/>
+        <sourcediff key="44364990a040b8fb4b1108a0ab48df6d">
+          <old project="foo_project" package="bar_package" rev="1c12e7973807212ca86f80fbcaab3815" srcmd5="1c12e7973807212ca86f80fbcaab3815"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="10c0c91bf3a97b23534ab324e63c7785" srcmd5="10c0c91bf3a97b23534ab324e63c7785"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:39 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/_meta?user=Iggy
@@ -587,7 +587,7 @@ http_interactions:
             <arch>aarch64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 20 Jan 2022 10:32:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:39 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_branch_request?user=Iggy
@@ -613,19 +613,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '206'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="100" vrev="100">
-          <srcmd5>0ccfe348b1b3883394fd4846a2b098e5</srcmd5>
+        <revision rev="32" vrev="32">
+          <srcmd5>90dd1d093ecd6a719f68881ed42561de</srcmd5>
           <version>unknown</version>
-          <time>1642674743</time>
+          <time>1643641659</time>
           <user>Iggy</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 20 Jan 2022 10:32:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:39 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789/_meta?user=Iggy
@@ -633,8 +633,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>Clouds of Witness</title>
-          <description>Impedit eligendi non officiis.</description>
+          <title>The Lathe of Heaven</title>
+          <description>Voluptas reiciendis at nobis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -655,15 +655,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '165'
+      - '166'
     body:
       encoding: UTF-8
       string: |
         <package name="bar_package-123456789" project="home:Iggy">
-          <title>Clouds of Witness</title>
-          <description>Impedit eligendi non officiis.</description>
+          <title>The Lathe of Heaven</title>
+          <description>Voluptas reiciendis at nobis.</description>
         </package>
-  recorded_at: Thu, 20 Jan 2022 10:32:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:39 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -689,19 +689,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="100" vrev="100" srcmd5="0ccfe348b1b3883394fd4846a2b098e5">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="117c0489196d2ee5f4210890f89f257b" baserev="117c0489196d2ee5f4210890f89f257b" xsrcmd5="8d60cbfa11aae03d0aaa2180114e1bf2" lsrcmd5="0ccfe348b1b3883394fd4846a2b098e5"/>
-          <serviceinfo code="succeeded" xsrcmd5="a0b193e751435f18971396cb134f7121"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="cf69c42cf5f7612108468dba0a44bf11" size="58" mtime="1642674743"/>
-          <entry name="_link" md5="047ca72bd0391793a58f7df00d53a257" size="141" mtime="1642674743"/>
-          <entry name="somefile.txt" md5="9b754aa4cd99b9af180250bb7edf2b64" size="54" mtime="1642674743"/>
+        <directory name="bar_package-123456789" rev="32" vrev="32" srcmd5="90dd1d093ecd6a719f68881ed42561de">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="1c12e7973807212ca86f80fbcaab3815" baserev="1c12e7973807212ca86f80fbcaab3815" xsrcmd5="77652538b003c57bdfb7b5a0e716db26" lsrcmd5="90dd1d093ecd6a719f68881ed42561de"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="062037d93c0fd1a6fb35318d11dcd6e6" size="73" mtime="1643641659"/>
+          <entry name="_link" md5="f466f01033e08c5cecd5117e1f073c4f" size="141" mtime="1643641659"/>
+          <entry name="somefile.txt" md5="cdd832786cc3d2b7e6bf5d2eb79a9f19" size="70" mtime="1643641659"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:39 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?view=info
@@ -727,15 +726,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '343'
+      - '341'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="bar_package-123456789" rev="100" vrev="1722" srcmd5="d08c9e2453d8f5a3b2dc8561e160f38d" lsrcmd5="a0b193e751435f18971396cb134f7121" verifymd5="0d8538823af35d2e92eaaa1930f08491">
+        <sourceinfo package="bar_package-123456789" rev="32" vrev="140" srcmd5="77652538b003c57bdfb7b5a0e716db26" lsrcmd5="90dd1d093ecd6a719f68881ed42561de" verifymd5="dbd2ce25ed2687c414794605ef6a3336">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="foo_project" package="bar_package"/>
         </sourceinfo>
-  recorded_at: Thu, 20 Jan 2022 10:32:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:39 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -761,19 +760,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="100" vrev="100" srcmd5="0ccfe348b1b3883394fd4846a2b098e5">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="117c0489196d2ee5f4210890f89f257b" baserev="117c0489196d2ee5f4210890f89f257b" xsrcmd5="8d60cbfa11aae03d0aaa2180114e1bf2" lsrcmd5="0ccfe348b1b3883394fd4846a2b098e5"/>
-          <serviceinfo code="succeeded" xsrcmd5="a0b193e751435f18971396cb134f7121"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="cf69c42cf5f7612108468dba0a44bf11" size="58" mtime="1642674743"/>
-          <entry name="_link" md5="047ca72bd0391793a58f7df00d53a257" size="141" mtime="1642674743"/>
-          <entry name="somefile.txt" md5="9b754aa4cd99b9af180250bb7edf2b64" size="54" mtime="1642674743"/>
+        <directory name="bar_package-123456789" rev="32" vrev="32" srcmd5="90dd1d093ecd6a719f68881ed42561de">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="1c12e7973807212ca86f80fbcaab3815" baserev="1c12e7973807212ca86f80fbcaab3815" xsrcmd5="77652538b003c57bdfb7b5a0e716db26" lsrcmd5="90dd1d093ecd6a719f68881ed42561de"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="062037d93c0fd1a6fb35318d11dcd6e6" size="73" mtime="1643641659"/>
+          <entry name="_link" md5="f466f01033e08c5cecd5117e1f073c4f" size="141" mtime="1643641659"/>
+          <entry name="somefile.txt" md5="cdd832786cc3d2b7e6bf5d2eb79a9f19" size="70" mtime="1643641659"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:39 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -801,18 +799,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '324'
+      - '323'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="38d15ee6b7c3b69fb60a848e0b0c3182">
+        <sourcediff key="dbbefbbbc2c458f3b471947a8a232a9c">
           <old project="home:Iggy" package="bar_package-123456789" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="100" srcmd5="0ccfe348b1b3883394fd4846a2b098e5"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="32" srcmd5="90dd1d093ecd6a719f68881ed42561de"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:39 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -844,14 +842,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="8e8b989f5ce3a09da16c44683385fd58">
-          <old project="foo_project" package="bar_package" rev="117c0489196d2ee5f4210890f89f257b" srcmd5="117c0489196d2ee5f4210890f89f257b"/>
-          <new project="home:Iggy" package="bar_package-123456789" rev="d08c9e2453d8f5a3b2dc8561e160f38d" srcmd5="d08c9e2453d8f5a3b2dc8561e160f38d"/>
+        <sourcediff key="fd13ab5ebcf408d3d6db4f3370e3102d">
+          <old project="foo_project" package="bar_package" rev="1c12e7973807212ca86f80fbcaab3815" srcmd5="1c12e7973807212ca86f80fbcaab3815"/>
+          <new project="home:Iggy" package="bar_package-123456789" rev="77652538b003c57bdfb7b5a0e716db26" srcmd5="77652538b003c57bdfb7b5a0e716db26"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 20 Jan 2022 10:32:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:39 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -877,19 +875,54 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="100" vrev="100" srcmd5="0ccfe348b1b3883394fd4846a2b098e5">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="117c0489196d2ee5f4210890f89f257b" baserev="117c0489196d2ee5f4210890f89f257b" xsrcmd5="8d60cbfa11aae03d0aaa2180114e1bf2" lsrcmd5="0ccfe348b1b3883394fd4846a2b098e5"/>
-          <serviceinfo code="succeeded" xsrcmd5="a0b193e751435f18971396cb134f7121"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="cf69c42cf5f7612108468dba0a44bf11" size="58" mtime="1642674743"/>
-          <entry name="_link" md5="047ca72bd0391793a58f7df00d53a257" size="141" mtime="1642674743"/>
-          <entry name="somefile.txt" md5="9b754aa4cd99b9af180250bb7edf2b64" size="54" mtime="1642674743"/>
+        <directory name="bar_package-123456789" rev="32" vrev="32" srcmd5="90dd1d093ecd6a719f68881ed42561de">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="1c12e7973807212ca86f80fbcaab3815" baserev="1c12e7973807212ca86f80fbcaab3815" xsrcmd5="77652538b003c57bdfb7b5a0e716db26" lsrcmd5="90dd1d093ecd6a719f68881ed42561de"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="062037d93c0fd1a6fb35318d11dcd6e6" size="73" mtime="1643641659"/>
+          <entry name="_link" md5="f466f01033e08c5cecd5117e1f073c4f" size="141" mtime="1643641659"/>
+          <entry name="somefile.txt" md5="cdd832786cc3d2b7e6bf5d2eb79a9f19" size="70" mtime="1643641659"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:39 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '628'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="bar_package-123456789" rev="77652538b003c57bdfb7b5a0e716db26" vrev="140" srcmd5="77652538b003c57bdfb7b5a0e716db26">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="1c12e7973807212ca86f80fbcaab3815" baserev="1c12e7973807212ca86f80fbcaab3815" lsrcmd5="90dd1d093ecd6a719f68881ed42561de"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="062037d93c0fd1a6fb35318d11dcd6e6" size="73" mtime="1643641659"/>
+          <entry name="somefile.txt" md5="cdd832786cc3d2b7e6bf5d2eb79a9f19" size="70" mtime="1643641659"/>
+        </directory>
+  recorded_at: Mon, 31 Jan 2022 15:07:39 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Iggy/bar_package-123456789
@@ -915,22 +948,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '733'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="100" vrev="100" srcmd5="0ccfe348b1b3883394fd4846a2b098e5">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="117c0489196d2ee5f4210890f89f257b" baserev="117c0489196d2ee5f4210890f89f257b" xsrcmd5="8d60cbfa11aae03d0aaa2180114e1bf2" lsrcmd5="0ccfe348b1b3883394fd4846a2b098e5"/>
-          <serviceinfo code="succeeded" xsrcmd5="a0b193e751435f18971396cb134f7121"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="cf69c42cf5f7612108468dba0a44bf11" size="58" mtime="1642674743"/>
-          <entry name="_link" md5="047ca72bd0391793a58f7df00d53a257" size="141" mtime="1642674743"/>
-          <entry name="somefile.txt" md5="9b754aa4cd99b9af180250bb7edf2b64" size="54" mtime="1642674743"/>
+        <directory name="bar_package-123456789" rev="32" vrev="32" srcmd5="90dd1d093ecd6a719f68881ed42561de">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="1c12e7973807212ca86f80fbcaab3815" baserev="1c12e7973807212ca86f80fbcaab3815" xsrcmd5="77652538b003c57bdfb7b5a0e716db26" lsrcmd5="90dd1d093ecd6a719f68881ed42561de"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="062037d93c0fd1a6fb35318d11dcd6e6" size="73" mtime="1643641659"/>
+          <entry name="_link" md5="f466f01033e08c5cecd5117e1f073c4f" size="141" mtime="1643641659"/>
+          <entry name="somefile.txt" md5="cdd832786cc3d2b7e6bf5d2eb79a9f19" size="70" mtime="1643641659"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:39 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
+    uri: http://backend:5352/source/home:Iggy/bar_package-123456789?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -953,55 +985,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '812'
+      - '628'
     body:
       encoding: UTF-8
       string: |
-        <directory name="bar_package-123456789" rev="100" vrev="100" srcmd5="0ccfe348b1b3883394fd4846a2b098e5">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="117c0489196d2ee5f4210890f89f257b" baserev="117c0489196d2ee5f4210890f89f257b" xsrcmd5="8d60cbfa11aae03d0aaa2180114e1bf2" lsrcmd5="0ccfe348b1b3883394fd4846a2b098e5"/>
-          <serviceinfo code="succeeded" xsrcmd5="a0b193e751435f18971396cb134f7121"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="cf69c42cf5f7612108468dba0a44bf11" size="58" mtime="1642674743"/>
-          <entry name="_link" md5="047ca72bd0391793a58f7df00d53a257" size="141" mtime="1642674743"/>
-          <entry name="somefile.txt" md5="9b754aa4cd99b9af180250bb7edf2b64" size="54" mtime="1642674743"/>
+        <directory name="bar_package-123456789" rev="77652538b003c57bdfb7b5a0e716db26" vrev="140" srcmd5="77652538b003c57bdfb7b5a0e716db26">
+          <linkinfo project="foo_project" package="bar_package" srcmd5="1c12e7973807212ca86f80fbcaab3815" baserev="1c12e7973807212ca86f80fbcaab3815" lsrcmd5="90dd1d093ecd6a719f68881ed42561de"/>
+          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1643641658"/>
+          <entry name="_config" md5="062037d93c0fd1a6fb35318d11dcd6e6" size="73" mtime="1643641659"/>
+          <entry name="somefile.txt" md5="cdd832786cc3d2b7e6bf5d2eb79a9f19" size="70" mtime="1643641659"/>
         </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:23 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Iggy/bar_package-123456789
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '812'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="bar_package-123456789" rev="100" vrev="100" srcmd5="0ccfe348b1b3883394fd4846a2b098e5">
-          <linkinfo project="foo_project" package="bar_package" srcmd5="117c0489196d2ee5f4210890f89f257b" baserev="117c0489196d2ee5f4210890f89f257b" xsrcmd5="8d60cbfa11aae03d0aaa2180114e1bf2" lsrcmd5="0ccfe348b1b3883394fd4846a2b098e5"/>
-          <serviceinfo code="succeeded" xsrcmd5="a0b193e751435f18971396cb134f7121"/>
-          <entry name="_branch_request" md5="1ecf0e682a06f24b71446f85ff3bd803" size="110" mtime="1642597686"/>
-          <entry name="_config" md5="cf69c42cf5f7612108468dba0a44bf11" size="58" mtime="1642674743"/>
-          <entry name="_link" md5="047ca72bd0391793a58f7df00d53a257" size="141" mtime="1642674743"/>
-          <entry name="somefile.txt" md5="9b754aa4cd99b9af180250bb7edf2b64" size="54" mtime="1642674743"/>
-        </directory>
-  recorded_at: Thu, 20 Jan 2022 10:32:23 GMT
+  recorded_at: Mon, 31 Jan 2022 15:07:39 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/models/package_spec.rb
+++ b/src/api/spec/models/package_spec.rb
@@ -145,6 +145,12 @@ RSpec.describe Package, vcr: true do
   end
 
   describe '#file_exists?' do
+    context '_multibuild file should exist' do
+      let!(:multibuild_package) { create(:multibuild_package, name: 'test', project: home_project) }
+
+      it { expect(multibuild_package.file_exists?('_multibuild')).to eq(true) }
+    end
+
     context 'with more than one file' do
       it 'returns true if the file exist' do
         expect(package_with_file.file_exists?('somefile.txt')).to eq(true)


### PR DESCRIPTION
While trying to fix #12121 we found 2 issues:

- `Package#file_exists?` doesn't expand the files on backend and therefore it cannot find the "_multibuild" file

-  ~~When we try to call `report_to_scm` on the `LinkPackageStep` the repositories aren't configured and therefore the call to `workflow_repositories` done inside of `report_to_scm` fails.. We have to call `report_to_scm` inside `ConfigureRepositoriesStep`~~

EDIT: In this PR me and @dmarcoux decided to fix just one issue. The `report_to_scm` problem will be handled differently 