### PR TITLE
[api] do not list deleted users

### DIFF
--- a/src/api/app/controllers/person_controller.rb
+++ b/src/api/app/controllers/person_controller.rb
@@ -16,7 +16,7 @@ class PersonController < ApplicationController
     @list = if params[:prefix]
               User.where('login LIKE ?', params[:prefix] + '%')
             else
-              User.all
+              User.not_deleted
             end
   end
 

--- a/src/api/lib/xpath_engine.rb
+++ b/src/api/lib/xpath_engine.rb
@@ -330,7 +330,7 @@ class XpathEngine
                 'LEFT JOIN attrib_values req_order_attrib_value ON req_order_attrib.id = req_order_attrib_value.attrib_id'] << @joins
       order = ['req_order_attrib_value.value DESC', :priority, :created_at]
     when 'users'
-      relation = User.all
+      relation = User.not_deleted
     when 'issues'
       relation = Issue.all
     when 'channels'


### PR DESCRIPTION
The DB entry must remain, as re-creating the same user would cause
a security/trust breach. But personal data got already removed.

However, do not list these accounts anymore

bnc#1106763