### PR TITLE
Create an initial generic status

### DIFF
--- a/src/api/app/models/token/workflow.rb
+++ b/src/api/app/models/token/workflow.rb
@@ -17,7 +17,12 @@ class Token::Workflow < Token
     yaml_file = Workflows::YAMLDownloader.new(@scm_webhook.payload, token: self).call
     @workflows = Workflows::YAMLToWorkflowsService.new(yaml_file: yaml_file, scm_webhook: @scm_webhook, token: self, workflow_run_id: options[:workflow_run].id).call
 
-    @workflows.each(&:call) if validation_errors.none?
+    return validation_errors unless validation_errors.none?
+
+    # This is just an initial generic report to give a feedback asap. Initial status pending
+    ScmInitialStatusReporter.new(@scm_webhook.payload, @scm_webhook.payload, scm_token).call
+    @workflows.each(&:call)
+    ScmInitialStatusReporter.new(@scm_webhook.payload, @scm_webhook.payload, scm_token, 'success').call
 
     # Always returning validation errors to report them back to the SCM in order to help users debug their workflows
     validation_errors

--- a/src/api/app/models/workflow/step/branch_package_step.rb
+++ b/src/api/app/models/workflow/step/branch_package_step.rb
@@ -21,10 +21,7 @@ class Workflow::Step::BranchPackageStep < ::Workflow::Step
     add_branch_request_file(package: target_package)
 
     # SCMs don't support statuses for tags, so we don't need to report back in this case
-    unless scm_webhook.tag_push_event?
-      create_or_update_subscriptions(target_package, workflow_filters)
-      report_to_scm(workflow_filters)
-    end
+    create_or_update_subscriptions(target_package, workflow_filters) unless scm_webhook.tag_push_event?
 
     target_package
   end

--- a/src/api/app/models/workflow/step/link_package_step.rb
+++ b/src/api/app/models/workflow/step/link_package_step.rb
@@ -18,10 +18,7 @@ class Workflow::Step::LinkPackageStep < ::Workflow::Step
     add_branch_request_file(package: target_package)
 
     # SCMs don't support statuses for tags, so we don't need to report back in this case
-    unless scm_webhook.tag_push_event?
-      create_or_update_subscriptions(target_package, workflow_filters)
-      report_to_scm(workflow_filters)
-    end
+    create_or_update_subscriptions(target_package, workflow_filters) unless scm_webhook.tag_push_event?
 
     target_package
   end

--- a/src/api/app/services/scm_initial_status_reporter.rb
+++ b/src/api/app/services/scm_initial_status_reporter.rb
@@ -1,0 +1,14 @@
+class ScmInitialStatusReporter < SCMStatusReporter
+  attr_accessor :state
+
+  def initialize(event_payload, event_subscription_payload, scm_token, event_type = nil)
+    super(event_payload, event_subscription_payload, scm_token)
+    @state = event_type.nil? ? 'pending' : 'success'
+  end
+
+  private
+
+  def status_options
+    { context: 'OBS SCM/CI Workflow Integration started' }
+  end
+end

--- a/src/api/spec/models/token/workflow_spec.rb
+++ b/src/api/spec/models/token/workflow_spec.rb
@@ -72,6 +72,7 @@ RSpec.describe Token::Workflow do
         allow(Workflows::YAMLToWorkflowsService).to receive(:new).with(yaml_file: yaml_file, scm_webhook: scm_webhook, token: workflow_token,
                                                                        workflow_run_id: workflow_run.id).and_return(yaml_to_workflows_service)
         allow(yaml_to_workflows_service).to receive(:call).and_return(workflows)
+        allow(ScmInitialStatusReporter).to receive(:new).and_return(proc { true })
       end
 
       subject { workflow_token.call(workflow_run: workflow_run, scm_webhook: scm_extractor.call) }
@@ -81,6 +82,11 @@ RSpec.describe Token::Workflow do
       end
 
       it { expect { subject }.to change(workflow_token, :triggered_at) & change(workflow_run, :response_url).to('https://api.github.com') }
+
+      it do
+        subject
+        expect(ScmInitialStatusReporter).to have_received(:new).twice
+      end
     end
 
     context 'with validation errors' do

--- a/src/api/spec/models/workflow/step/branch_package_step_spec.rb
+++ b/src/api/spec/models/workflow/step/branch_package_step_spec.rb
@@ -79,24 +79,6 @@ RSpec.describe Workflow::Step::BranchPackageStep, vcr: true do
     it { expect(subject.call.source_file('_branch_request')).to include('123') }
     it { expect { subject.call }.to(change(EventSubscription.where(eventtype: 'Event::BuildFail'), :count).by(1)) }
     it { expect { subject.call }.to(change(EventSubscription.where(eventtype: 'Event::BuildSuccess'), :count).by(1)) }
-
-    # rubocop:disable RSpec/MultipleExpectations, RSpec/ExampleLength, RSpec/MessageSpies
-    # RSpec/MultipleExpectations, RSpec/ExampleLength - We want to test those expectations together since they depend on each other to be true
-    # RSpec/MesssageSpies - The method `and_call_original` isn't available on `have_received`, so we need to use `receive`
-    it 'only reports for repositories and architectures matching the filters' do
-      expect(SCMStatusReporter).to receive(:new).with({ project: target_project_final_name, package: final_package_name, repository: 'Unicorn_123', arch: 'i586' },
-                                                      scm_webhook.payload, token.scm_token).and_call_original
-      expect(SCMStatusReporter).to receive(:new).with({ project: target_project_final_name, package: final_package_name, repository: 'Unicorn_123', arch: 'x86_64' },
-                                                      scm_webhook.payload, token.scm_token).and_call_original
-      expect(SCMStatusReporter).not_to receive(:new).with({ project: target_project_final_name, package: final_package_name, repository: 'Unicorn_123', arch: 'ppc' },
-                                                          scm_webhook.payload, token.scm_token)
-      expect(SCMStatusReporter).not_to receive(:new).with({ project: target_project_final_name, package: final_package_name, repository: 'Unicorn_123', arch: 'aarch64' },
-                                                          scm_webhook.payload, token.scm_token)
-      expect(SCMStatusReporter).not_to receive(:new).with({ project: target_project_final_name, package: final_package_name, repository: 'openSUSE_Tumbleweed', arch: 'x86_64' },
-                                                          scm_webhook.payload, token.scm_token)
-      subject.call({ workflow_filters: workflow_filters })
-    end
-    # rubocop:enable RSpec/MultipleExpectations, RSpec/ExampleLength, RSpec/MessageSpies
   end
 
   RSpec.shared_context 'successful update event when the branch_package already exists' do
@@ -248,26 +230,6 @@ RSpec.describe Workflow::Step::BranchPackageStep, vcr: true do
         it { expect(subject.call.source_file('_branch_request')).to include('123') }
         it { expect { subject.call }.to(change(EventSubscription.where(eventtype: 'Event::BuildFail'), :count).by(1)) }
         it { expect { subject.call }.to(change(EventSubscription.where(eventtype: 'Event::BuildSuccess'), :count).by(1)) }
-
-        # rubocop:disable RSpec/MultipleExpectations, RSpec/ExampleLength, RSpec/MessageSpies
-        # RSpec/MultipleExpectations, RSpec/ExampleLength - We want to test those expectations together since they depend on each other to be true
-        # RSpec/MesssageSpies - The method `and_call_original` isn't available on `have_received`, so we need to use `receive`
-        it 'only reports for repositories and architectures matching the filters' do
-          [final_package_name, "#{final_package_name}:flavor_a", "#{final_package_name}:flavor_b"].each do |package_or_flavor_name|
-            expect(SCMStatusReporter).to receive(:new).with({ project: target_project_final_name, package: package_or_flavor_name, repository: 'Unicorn_123', arch: 'i586' },
-                                                            scm_webhook.payload, token.scm_token).and_call_original
-            expect(SCMStatusReporter).to receive(:new).with({ project: target_project_final_name, package: package_or_flavor_name, repository: 'Unicorn_123', arch: 'x86_64' },
-                                                            scm_webhook.payload, token.scm_token).and_call_original
-            expect(SCMStatusReporter).not_to receive(:new).with({ project: target_project_final_name, package: package_or_flavor_name, repository: 'Unicorn_123', arch: 'ppc' },
-                                                                scm_webhook.payload, token.scm_token)
-            expect(SCMStatusReporter).not_to receive(:new).with({ project: target_project_final_name, package: package_or_flavor_name, repository: 'Unicorn_123', arch: 'aarch64' },
-                                                                scm_webhook.payload, token.scm_token)
-            expect(SCMStatusReporter).not_to receive(:new).with({ project: target_project_final_name, package: package_or_flavor_name, repository: 'openSUSE_Tumbleweed', arch: 'x86_64' },
-                                                                scm_webhook.payload, token.scm_token)
-          end
-          subject.call({ workflow_filters: workflow_filters })
-        end
-        # rubocop:enable RSpec/MultipleExpectations, RSpec/ExampleLength, RSpec/MessageSpies
       end
 
       context 'for an updated PR event' do


### PR DESCRIPTION
To give a feedback to the users as soon as possible, we are setting initially a generic status to the PR. Package name, multibuild flavors and other details are going to be reported by OBS later with the delayed job `ReportToSCMJob`.

Screenshot when we first create the PR:

![Screenshot_2022-02-02_17-27-10](https://user-images.githubusercontent.com/37418/152195693-58f8e8fb-7107-4e2e-82f9-e5e764e2c62f.png)

Screenshot when the build process reported back:

![Screenshot_2022-02-02_17-32-34](https://user-images.githubusercontent.com/37418/152196000-efa124fb-5683-416f-9c73-f398c1e94a9e.png)

Another thing being changed in this PR is the way that we report back to SCM. Until now we were adding to specific steps, the ability to report back. Now we are trying to come up with a more holistic approach to the problem.

From this card, we have some TODO that should become cards in our backlog:

- [x] For the OBS integration workflow initialization, we would link it to the `workflow_runs` associated with a token (we still have to figure out how to make it public) (card created in the backlog for that)
- [x] Have an event `Event::BuildStarted` coming from backend. Then we could provide the user with more feedback other than "pending" and "done" (card created in the backlog for that)
- ~~[ ] Handle event filtering in the workflow level, not in the steps level. The filters aren't just for reporting~~.
