### PR TITLE
Fix Metrics/ClassLength rubocop offense in workflow model

### DIFF
--- a/src/api/app/models/workflow.rb
+++ b/src/api/app/models/workflow.rb
@@ -2,10 +2,8 @@ class Workflow
   include ActiveModel::Model
 
   SUPPORTED_STEPS = {
-    branch_package: Workflow::Step::BranchPackageStep,
-    link_package: Workflow::Step::LinkPackageStep,
-    configure_repositories: Workflow::Step::ConfigureRepositories,
-    rebuild_package: Workflow::Step::RebuildPackage,
+    branch_package: Workflow::Step::BranchPackageStep, link_package: Workflow::Step::LinkPackageStep,
+    configure_repositories: Workflow::Step::ConfigureRepositories, rebuild_package: Workflow::Step::RebuildPackage,
     set_flags: Workflow::Step::SetFlags
   }.freeze
 


### PR DESCRIPTION
Rubocop started to complain about this on the master branch,
guess because of some PR that got merged without being rebased
before. This is just a quick fix to prevent future PRs failing
in the CI.