### PR TITLE
Fix artifacts for configure_repositories

### DIFF
--- a/src/api/app/services/workflows/artifacts_collector.rb
+++ b/src/api/app/services/workflows/artifacts_collector.rb
@@ -14,10 +14,14 @@ module Workflows
                       target_project: @step.target_project_name,
                       target_package: @step.target_package_name
                     }
-                  when 'Workflow::Step::RebuildPackage', 'Workflow::Step::ConfigureRepositories'
+                  when 'Workflow::Step::RebuildPackage'
                     @step.step_instructions
+                  when 'Workflow::Step::ConfigureRepositories'
+                    {
+                      project: @step.target_project_name,
+                      repositories: @step.step_instructions[:repositories]
+                    }
                   end
-
       WorkflowArtifactsPerStep.find_or_create_by(workflow_run_id: @workflow_run_id, step: @step.class.name, artifacts: artifacts.to_json)
     end
   end

--- a/src/api/spec/components/previews/workflow_artifacts_per_step_component_preview.rb
+++ b/src/api/spec/components/previews/workflow_artifacts_per_step_component_preview.rb
@@ -85,7 +85,10 @@ class WorkflowArtifactsPerStepComponentPreview < ViewComponent::Preview
                                                        token: token
                                                      })
 
-    artifacts = step.step_instructions.to_json
+    artifacts = {
+      project: step.target_project_name,
+      repositories: step.step_instructions[:repositories]
+    }.to_json
 
     artifacts_per_step = WorkflowArtifactsPerStep.new(workflow_run: workflow_run, artifacts: artifacts, step: step.class.name)
     render(WorkflowArtifactsPerStepComponent.new(artifacts_per_step: artifacts_per_step))

--- a/src/api/spec/services/workflows/artifacts_collector_spec.rb
+++ b/src/api/spec/services/workflows/artifacts_collector_spec.rb
@@ -274,7 +274,7 @@ RSpec.describe Workflows::ArtifactsCollector, type: :service do
 
       let(:step_instructions) do
         {
-          project: 'home:Iggy',
+          project: 'home:Iggy:sandbox',
           repositories:
             [
               {
@@ -316,7 +316,12 @@ RSpec.describe Workflows::ArtifactsCollector, type: :service do
                        })
       end
 
-      let(:artifacts) { step_instructions }
+      let(:artifacts) do
+        {
+          project: 'home:Iggy:sandbox:iggy:hello_world:PR-1',
+          repositories: step_instructions[:repositories]
+        }
+      end
 
       it { expect { subject.call }.to change(WorkflowArtifactsPerStep, :count).by(1) }
 


### PR DESCRIPTION
We were collecting the wrong project as artifact of a `configure_repositories` step.

Caught by @dmarcoux in this PR: https://github.com/openSUSE/open-build-service/pull/12157#pullrequestreview-871906406

![Workflow-Run-46-Open-Build-Service](https://user-images.githubusercontent.com/2581944/152499209-42a575d3-c80b-4427-890a-72ab52c19b14.png)

