### PR TITLE
Show delete requests in status page

### DIFF
--- a/src/api/app/controllers/webui/projects/status_controller.rb
+++ b/src/api/app/controllers/webui/projects/status_controller.rb
@@ -182,9 +182,10 @@ module Webui
         # we do not filter requests for project because we need devel projects too later on and as long as the
         # number of open requests is limited this is the easiest solution
         raw_requests = BsRequest.order(:number).where(state: [:new, :review, :declined]).joins(:bs_request_actions)
-                                .where(bs_request_actions: { type: ['submit', 'delete'] }).pluck('bs_requests.number', 'bs_requests.state',
-                                                                                     'bs_request_actions.target_project',
-                                                                                     'bs_request_actions.target_package')
+                                .where(bs_request_actions: { type: ['submit', 'delete'] }).pluck('bs_requests.number',
+                                                                                                 'bs_requests.state',
+                                                                                                 'bs_request_actions.target_project',
+                                                                                                 'bs_request_actions.target_package')
 
         @declined_requests = {}
         @submits = {}

--- a/src/api/app/controllers/webui/projects/status_controller.rb
+++ b/src/api/app/controllers/webui/projects/status_controller.rb
@@ -182,7 +182,7 @@ module Webui
         # we do not filter requests for project because we need devel projects too later on and as long as the
         # number of open requests is limited this is the easiest solution
         raw_requests = BsRequest.order(:number).where(state: [:new, :review, :declined]).joins(:bs_request_actions)
-                                .where(bs_request_actions: { type: 'submit' }).pluck('bs_requests.number', 'bs_requests.state',
+                                .where(bs_request_actions: { type: ['submit', 'delete'] }).pluck('bs_requests.number', 'bs_requests.state',
                                                                                      'bs_request_actions.target_project',
                                                                                      'bs_request_actions.target_package')
 


### PR DESCRIPTION
Hello,

Fixes #7380.
The status page only listed submit requests so far, it should now also list delete requests.

To verify this, please create a delete requests for any package that has failed, then go to the status page for this project. In the summary tab there should now be a link to this delete request.

**Before**:
![status_before_change](https://user-images.githubusercontent.com/82818782/152599547-e25a3e95-188c-41ab-a27b-ea92d12d266c.png)

**After**:
![status_after_change](https://user-images.githubusercontent.com/82818782/152599581-257222ae-7723-42d9-a65a-89784b9c2d24.png)

