### PR TITLE
allow kiwi versions not strictly x.y.z scheme

### DIFF
--- a/src/api/app/models/kiwi/preference.rb
+++ b/src/api/app/models/kiwi/preference.rb
@@ -24,7 +24,7 @@ class Kiwi::Preference < ApplicationRecord
   }, _prefix: :image_type
 
   validates :type_image, inclusion: { in: type_images.keys }, allow_nil: true
-  validates :version, format: { with: /\A\d+\.\d+\.\d+\z/ }
+  validates :version, format: { with: /\A[\d.]+\z/ }
 
   def containerconfig_xml
     builder = Nokogiri::XML::Builder.new do |xml|

--- a/src/api/spec/models/kiwi/preference_spec.rb
+++ b/src/api/spec/models/kiwi/preference_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Kiwi::Preference, type: :model do
   describe 'validations' do
     it { is_expected.to allow_value('12.3.456').for(:version) }
     it { is_expected.not_to allow_value('1.2.a').for(:version) }
-    it { is_expected.not_to allow_value('1.2').for(:version) }
+    it { is_expected.not_to allow_value('1/2').for(:version) }
   end
 
   describe '#containerconfig_xml' do


### PR DESCRIPTION
Kiwi just allows numbers and dots. This fixes errors when working on our
official templates for Leap, using just "15.3" as version for example.