### PR TITLE
Show correct amount in workflow run filter badge

### DIFF
--- a/src/api/app/components/workflow_run_filter_component.rb
+++ b/src/api/app/components/workflow_run_filter_component.rb
@@ -1,5 +1,5 @@
 class WorkflowRunFilterComponent < ApplicationComponent
-  def initialize(token:, selected_filter:, finder: WorkflowRunsFinder.new)
+  def initialize(token:, selected_filter:, finder:)
     super
 
     @count = workflow_runs_count(finder)

--- a/src/api/app/controllers/webui/workflow_runs_controller.rb
+++ b/src/api/app/controllers/webui/workflow_runs_controller.rb
@@ -1,14 +1,14 @@
 class Webui::WorkflowRunsController < Webui::WebuiController
   def index
     relation = WorkflowRunPolicy::Scope.new(User.session, WorkflowRun, { token_id: params[:token_id] })
-    workflow_runs_finder = WorkflowRunsFinder.new(relation.resolve)
+    @workflow_runs_finder = WorkflowRunsFinder.new(relation.resolve)
 
     @workflow_runs = if params[:status]
-                       workflow_runs_finder.with_status(params[:status])
+                       @workflow_runs_finder.with_status(params[:status])
                      elsif params[:event_type]
-                       workflow_runs_finder.with_event_type(params[:event_type])
+                       @workflow_runs_finder.with_event_type(params[:event_type])
                      else
-                       workflow_runs_finder.all
+                       @workflow_runs_finder.all
                      end
 
     @workflow_runs = @workflow_runs.page(params[:page])

--- a/src/api/app/views/webui/workflow_runs/index.html.haml
+++ b/src/api/app/views/webui/workflow_runs/index.html.haml
@@ -8,7 +8,7 @@
         Filtered by: #{params[:status]&.humanize}
         %i.float-right.mt-1.fa.fa-chevron-down#workflow-runs-dropdown-trigger
       .card-body.collapse#filters
-        = render WorkflowRunFilterComponent.new(token: @token, selected_filter: @selected_filter)
+        = render WorkflowRunFilterComponent.new(token: @token, selected_filter: @selected_filter, finder: @workflow_runs_finder)
   .col-md-8.col-lg-9.px-0.px-md-3#workflow-run-list
     .card
       - if @workflow_runs.blank?


### PR DESCRIPTION
The workflow run filter viewcomponent didnt received
the workflow runs from the in the workflow runs controller
initialized finder class. It used the default parameter which
points to all existing workflow runs.
Since there is no usecase where the view component should
use all existing workflow runs, I also removed the default
parameter from the initializer.