### PR TITLE
List read notifications through API

### DIFF
--- a/src/api/app/controllers/person/notifications_controller.rb
+++ b/src/api/app/controllers/person/notifications_controller.rb
@@ -3,7 +3,7 @@ module Person
     include Person::Errors
 
     MAX_PER_PAGE = 300
-    ALLOWED_FILTERS = ['requests', 'incoming_requests', 'outgoing_requests'].freeze
+    ALLOWED_FILTERS = ['requests', 'incoming_requests', 'outgoing_requests', 'read'].freeze
 
     before_action :check_feature_toggle
     before_action :check_filter_type, except: [:update]

--- a/src/api/public/apidocs-new/paths/my_notifications.yaml
+++ b/src/api/public/apidocs-new/paths/my_notifications.yaml
@@ -24,7 +24,7 @@ get:
       name: notifications_type
       schema:
         type: string
-        enum: ['requests', 'incoming_requests', 'outgoing_requests']
+        enum: ['requests', 'incoming_requests', 'outgoing_requests', 'read']
   responses:
     '200':
       description: |

--- a/src/api/spec/controllers/person/notifications_controller_spec.rb
+++ b/src/api/spec/controllers/person/notifications_controller_spec.rb
@@ -63,6 +63,18 @@ RSpec.describe Person::NotificationsController do
       it { expect(response).to have_http_status(:success) }
       it { expect(response.body).to include('<notifications count="2">') }
 
+      context 'filter by notifications_type' do
+        let!(:notifications) { create_list(:web_notification, 2, :request_state_change, subscriber: user, delivered: true) }
+
+        before do
+          login user
+          get :index, params: { format: :xml, notifications_type: 'read' }
+        end
+
+        it { expect(response).to have_http_status(:success) }
+        it { expect(response.body).to include('<notifications count="2">') }
+      end
+
       context 'filter by project finds results' do
         before do
           login user


### PR DESCRIPTION
Currently, we don't have a way to get `read` notifications, we can only get unread notifications through the API. This PR adds a possibility to get read notifications. 