### PR TITLE
Use dom_id for mark_as_read_or_unread_button

### DIFF
--- a/src/api/app/helpers/webui/notification_helper.rb
+++ b/src/api/app/helpers/webui/notification_helper.rb
@@ -48,7 +48,7 @@ module Webui::NotificationHelper
   def mark_as_read_or_unread_button(notification)
     update_path = my_notifications_path(notification_ids: [notification.id])
     title, icon = notification.unread? ? ['Mark as read', 'fa-check'] : ['Mark as unread', 'fa-undo']
-    link_to(update_path, id: "update-notification-#{notification.id}", method: :put,
+    link_to(update_path, id: dom_id(notification, :update), method: :put,
                          class: 'btn btn-sm btn-outline-success', title: title) do
       concat(tag.i(class: "#{icon} fas"))
       concat(" #{title}")


### PR DESCRIPTION
This is what ActionView uses to associate records with DOM elements. Let's use it too!

https://api.rubyonrails.org/classes/ActionView/RecordIdentifier.html#method-i-dom_id

The generated ID is slightly different, `dom_id` uses underscores instead of dashes. So before, it was `update-notification-123`, now it's `update_notification_123`. It's not an issue, as we don't refer to this ID in any code.

Nothing changes visually, but here's the helper in use with the new ID:
![preview](https://user-images.githubusercontent.com/1102934/153903475-cfc8c962-0573-4a80-a183-6541f5ee8d80.png)