### PR TITLE
Create NotificationActionDescriptionComponent

### DIFF
--- a/src/api/app/components/notification_action_description_component.rb
+++ b/src/api/app/components/notification_action_description_component.rb
@@ -1,0 +1,59 @@
+class NotificationActionDescriptionComponent < ApplicationComponent
+  def initialize(notification)
+    super
+
+    @notification = notification
+  end
+
+  def call
+    tag.div(class: ['smart-overflow']) do
+      case @notification.event_type
+      when 'Event::RequestStatechange', 'Event::RequestCreate', 'Event::ReviewWanted', 'Event::CommentForRequest'
+        source_and_target
+      when 'Event::CommentForProject'
+        "#{@notification.notifiable.commentable.name}"
+      when 'Event::CommentForPackage'
+        commentable = @notification.notifiable.commentable
+        "#{commentable.project.name} / #{commentable.name}"
+      end
+    end
+  end
+
+  private
+
+  def source_and_target
+    capture do
+      if source.present?
+        concat(tag.span(source))
+        concat(tag.i(nil, class: 'fas fa-long-arrow-alt-right text-info mx-2'))
+      end
+      concat(tag.span(target))
+    end
+  end
+
+  def source
+    @source ||= if number_of_bs_request_actions > 1
+                  ''
+                else
+                  [bs_request_action.source_project, bs_request_action.source_package].compact.join(' / ')
+                end
+  end
+
+  def target
+    return bs_request_action.target_project.name if number_of_bs_request_actions > 1
+
+    [bs_request_action.target_project, bs_request_action.target_package].compact.join(' / ')
+  end
+
+  def bs_request
+    @bs_request ||= @notification.notifiable_type == 'BsRequest' ? @notification.notifiable : @notification.notifiable.commentable
+  end
+
+  def bs_request_action
+    @bs_request_action ||= bs_request.bs_request_actions.first
+  end
+
+  def number_of_bs_request_actions
+    @number_of_bs_request_actions ||= bs_request.bs_request_actions.size
+  end
+end

--- a/src/api/app/helpers/webui/notification_helper.rb
+++ b/src/api/app/helpers/webui/notification_helper.rb
@@ -21,28 +21,6 @@ module Webui::NotificationHelper
     end
   end
 
-  def action_description(notification)
-    case notification.event_type
-    when 'Event::RequestStatechange', 'Event::RequestCreate', 'Event::ReviewWanted', 'Event::CommentForRequest'
-      source_and_target(notification)
-    when 'Event::CommentForProject'
-      "#{notification.notifiable.commentable.name}"
-    when 'Event::CommentForPackage'
-      commentable = notification.notifiable.commentable
-      "#{commentable.project.name} / #{commentable.name}"
-    end
-  end
-
-  def source_and_target(notification)
-    capture do
-      if notification.source.present?
-        concat(tag.span(notification.source))
-        concat(tag.i(nil, class: 'fas fa-long-arrow-alt-right text-info mx-2'))
-      end
-      concat(tag.span(notification.target))
-    end
-  end
-
   private
 
   def mark_as_read_or_unread_button(notification)

--- a/src/api/app/presenters/notification_presenter.rb
+++ b/src/api/app/presenters/notification_presenter.rb
@@ -68,22 +68,6 @@ class NotificationPresenter < SimpleDelegator
     end
   end
 
-  def source
-    bs_request = @model.notifiable_type == 'BsRequest' ? @model.notifiable : @model.notifiable.commentable
-    bs_request_action = bs_request.bs_request_actions.first
-    return nil if bs_request.bs_request_actions.size > 1
-
-    [bs_request_action.source_project, bs_request_action.source_package].compact.join(' / ')
-  end
-
-  def target
-    bs_request = @model.notifiable_type == 'BsRequest' ? @model.notifiable : @model.notifiable.commentable
-    bs_request_action = bs_request.bs_request_actions.first
-    return "#{bs_request_action.target_project}" if bs_request.bs_request_actions.size > 1
-
-    [bs_request_action.target_project, bs_request_action.target_package].compact.join(' / ')
-  end
-
   private
 
   def render_without_markdown(content)

--- a/src/api/app/views/webui/users/notifications/_notifications_list.html.haml
+++ b/src/api/app/views/webui/users/notifications/_notifications_list.html.haml
@@ -57,7 +57,7 @@
                     .col-auto.pr-0
                       = render partial: 'notification_avatars', locals: { avatar_objects: notification.avatar_objects }
                     .col-auto.pl-xs-2
-                      .smart-overflow= action_description(notification)
+                      = render NotificationActionDescriptionComponent.new(n)
                   .row.d-none.d-md-block.pl-4
                     .col
                       %p.mt-3.mb-0= notification.excerpt

--- a/src/api/spec/components/notification_action_description_component_spec.rb
+++ b/src/api/spec/components/notification_action_description_component_spec.rb
@@ -1,0 +1,97 @@
+require 'rails_helper'
+
+RSpec.describe NotificationActionDescriptionComponent, type: :component do
+  context 'when the notification is for a Event::RequestStatechange event with a request having only a target' do
+    let(:target_project) { create(:project, name: 'project_123') }
+    let(:target_package) { create(:package, project: target_project, name: 'package_123') }
+    let(:bs_request) { create(:set_bugowner_request, target_project: target_project, target_package: target_package) }
+    let(:notification) { create(:notification, :request_state_change, notifiable: bs_request) }
+
+    before do
+      render_inline(described_class.new(notification))
+    end
+
+    it 'renders a div containing only the target project and package names' do
+      expect(rendered_component).to have_selector('div.smart-overflow', text: 'project_123 / package_123')
+    end
+  end
+
+  context 'when the notification is for a Event::RequestCreate event with a request having a source and target' do
+    let(:source_project) { create(:project, name: 'source_project_123') }
+    let(:source_package) { create(:package, project: source_project, name: 'source_package_123') }
+    let(:target_project) { create(:project, name: 'project_123') }
+    let(:target_package) { create(:package, project: target_project, name: 'package_123') }
+    let(:bs_request) do
+      create(:bs_request_with_submit_action, source_project: source_project, source_package: source_package, target_project: target_project, target_package: target_package)
+    end
+    let(:notification) { create(:notification, :request_created, notifiable: bs_request) }
+
+    before do
+      render_inline(described_class.new(notification))
+    end
+
+    it 'renders a div containing the source and target project/package names' do
+      expect(rendered_component).to have_selector('div.smart-overflow', text: 'source_project_123 / source_package_123project_123 / package_123')
+    end
+  end
+
+  context 'when the notification is for a Event::ReviewWanted event having only a target' do
+    let(:target_project) { create(:project, name: 'project_123') }
+    let(:target_package) { create(:package, project: target_project, name: 'package_123') }
+    let(:bs_request) { create(:set_bugowner_request, target_project: target_project, target_package: target_package) }
+    let(:notification) { create(:notification, :review_wanted, notifiable: bs_request) }
+
+    before do
+      render_inline(described_class.new(notification))
+    end
+
+    it 'renders a div containing only the target project and package names' do
+      expect(rendered_component).to have_selector('div.smart-overflow', text: 'project_123 / package_123')
+    end
+  end
+
+  context 'when the notification is for a Event::CommentForRequest event' do
+    let(:target_project) { create(:project, name: 'project_123') }
+    let(:target_package) { create(:package, project: target_project, name: 'package_123') }
+    let(:bs_request) { create(:set_bugowner_request, target_project: target_project, target_package: target_package) }
+    let(:comment) { create(:comment, commentable: bs_request) }
+    let(:notification) { create(:notification, :comment_for_request, notifiable: comment) }
+
+    before do
+      render_inline(described_class.new(notification))
+    end
+
+    it 'renders a div containing only the target project and package names' do
+      expect(rendered_component).to have_selector('div.smart-overflow', text: 'project_123 / package_123')
+    end
+  end
+
+  context 'when the notification is for a Event::CommentForProject event' do
+    let(:project) { create(:project, name: 'my_project') }
+    let(:comment) { create(:comment, commentable: project) }
+    let(:notification) { create(:notification, :comment_for_project, notifiable: comment) }
+
+    before do
+      render_inline(described_class.new(notification))
+    end
+
+    it 'renders a div containing the project name' do
+      expect(rendered_component).to have_selector('div.smart-overflow', text: 'my_project')
+    end
+  end
+
+  context 'when the notification is for a Event::CommentForPackage event' do
+    let(:project) { create(:project, name: 'my_project_2') }
+    let(:package) { create(:package, project: project, name: 'my_package_2') }
+    let(:comment) { create(:comment, commentable: package) }
+    let(:notification) { create(:notification, :comment_for_package, notifiable: comment) }
+
+    before do
+      render_inline(described_class.new(notification))
+    end
+
+    it 'renders a div containing the project and package names' do
+      expect(rendered_component).to have_selector('div.smart-overflow', text: 'my_project_2 / my_package_2')
+    end
+  end
+end

--- a/src/api/spec/components/previews/notification_action_description_component_preview.rb
+++ b/src/api/spec/components/previews/notification_action_description_component_preview.rb
@@ -1,0 +1,6 @@
+class NotificationActionDescriptionComponentPreview < ViewComponent::Preview
+  # Preview at http://HOST:PORT/rails/view_components/notification_action_description_component/preview
+  def preview
+    render(NotificationActionDescriptionComponent.new(Notification.last))
+  end
+end


### PR DESCRIPTION
The description of a notification's action is now handled by this component. It's not a mix of a presenter and helpers.

Part of #11558

Co-authored-by: Saray Cabrera Padrón <scabrerapadron@suse.de>