### PR TITLE
Create RuboCop cop to avoid global state in view components

### DIFF
--- a/src/api/.rubocop.yml
+++ b/src/api/.rubocop.yml
@@ -2,6 +2,7 @@ require:
   - rubocop-rails
   - rubocop-rspec
   - rubocop-performance
+  - ./app/lib/rubocop/cop/view_component/avoid_global_state.rb
 
 inherit_from: .rubocop_todo.yml
 

--- a/src/api/app/lib/rubocop/cop/view_component/avoid_global_state.rb
+++ b/src/api/app/lib/rubocop/cop/view_component/avoid_global_state.rb
@@ -1,0 +1,32 @@
+module RuboCop
+  module Cop
+    module ViewComponent
+      class AvoidGlobalState < RuboCop::Cop::Base
+        # https://docs.rubocop.org/rubocop-ast/node_pattern.html#using-node-matcher-macros
+        def_node_search :params, <<~PATTERN
+          (send (send nil? :params) :[] (:sym ...)) # nil? -> https://docs.rubocop.org/rubocop-ast/node_pattern.html#nil-or-nil
+        PATTERN
+
+        MSG = 'View components should not rely on global state by using params. Instead, pass the required data to the initialize method.'.freeze
+
+        # Add an offense for every line using params
+        #
+        # @param [RuboCop::AST::ClassNode]
+        def on_class(node)
+          return unless view_component?(node)
+
+          params(node).each do |param|
+            add_offense(param)
+          end
+        end
+
+        private
+
+        # We can safely assume a class node is a view component if its name ends with Component
+        def view_component?(node)
+          node.identifier.short_name.to_s.end_with?('Component')
+        end
+      end
+    end
+  end
+end

--- a/src/api/config/initializers/zeitwerk.rb
+++ b/src/api/config/initializers/zeitwerk.rb
@@ -13,6 +13,7 @@ Rails.autoloaders.each do |autoloader|
     'scm_status_reporter' => 'SCMStatusReporter',
     'scm_exception_handler' => 'SCMExceptionHandler',
     'yaml_to_workflows_service' => 'YAMLToWorkflowsService',
-    'yaml_downloader' => 'YAMLDownloader'
+    'yaml_downloader' => 'YAMLDownloader',
+    'rubocop' => 'RuboCop'
   )
 end

--- a/src/api/spec/lib/rubocop/cop/view_component/avoid_global_state_spec.rb
+++ b/src/api/spec/lib/rubocop/cop/view_component/avoid_global_state_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe RuboCop::Cop::ViewComponent::AvoidGlobalState, :config do
+  context 'when a view component uses params' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        class MyComponent < ApplicationComponent
+          def initialize
+            @abc = params[:abc]
+                   ^^^^^^^^^^^^ View components should not rely on global state by using params. Instead, pass the required data to the initialize method.
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when a view component does not use params' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        class MyComponent < ApplicationComponent
+          def initialize
+            @abc = 'abc'
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when a class which is not a view component uses params' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        class ClientsController < ApplicationController
+          def show
+            @client = Client.find(params[:id])
+          end
+        end
+      RUBY
+    end
+  end
+end

--- a/src/api/spec/rails_helper.rb
+++ b/src/api/spec/rails_helper.rb
@@ -85,3 +85,6 @@ require 'support/thinking_sphinx'
 
 # support beta
 require 'support/beta'
+
+# custom matchers to test RuboCop custom cops
+require 'support/rubocop'

--- a/src/api/spec/support/rubocop.rb
+++ b/src/api/spec/support/rubocop.rb
@@ -1,0 +1,6 @@
+require 'rubocop/rspec/support'
+
+RSpec.configure do |config|
+  # expect_offense and expect_no_offense matchers
+  config.include RuboCop::RSpec::ExpectOffense
+end


### PR DESCRIPTION
To enforce what we've defined in our developer wiki: https://github.com/openSUSE/open-build-service/wiki/View-Components#avoid-global-state

Two nice articles to understand how custom cops for RuboCop work:
- https://thoughtbot.com/blog/rubocop-custom-cops-for-custom-needs
- https://evilmartians.com/chronicles/custom-cops-for-rubocop-an-emergency-service-for-your-codebase