### PR TITLE
Create NotificationExcerptComponent

### DIFF
--- a/src/api/app/components/notification_excerpt_component.rb
+++ b/src/api/app/components/notification_excerpt_component.rb
@@ -1,0 +1,31 @@
+class NotificationExcerptComponent < ApplicationComponent
+  TRUNCATION_LENGTH = 100
+  TRUNCATION_ELLIPSIS_LENGTH = 3 # `...` is the default ellipsis for String#truncate
+
+  def initialize(notification)
+    super
+
+    @notification = notification
+  end
+
+  def call
+    text = case @notification.notifiable_type
+           when 'BsRequest'
+             @notification.notifiable.description
+           when 'Comment'
+             helpers.render_without_markdown(@notification.notifiable.body)
+           else
+             ''
+           end
+
+    tag.p(truncate_to_first_new_line(text), class: ['mt-3', 'mb-0'])
+  end
+
+  private
+
+  def truncate_to_first_new_line(text)
+    first_new_line_index = text.index("\n")
+    truncation_index = !first_new_line_index.nil? && first_new_line_index < TRUNCATION_LENGTH ? first_new_line_index + TRUNCATION_ELLIPSIS_LENGTH : TRUNCATION_LENGTH
+    text.truncate(truncation_index)
+  end
+end

--- a/src/api/app/helpers/webui/markdown_helper.rb
+++ b/src/api/app/helpers/webui/markdown_helper.rb
@@ -1,4 +1,5 @@
 require 'obsapi/markdown_renderer'
+require 'redcarpet/render_strip'
 
 module Webui::MarkdownHelper
   def render_as_markdown(content)
@@ -8,5 +9,10 @@ module Webui::MarkdownHelper
                                            no_intra_emphasis: true,
                                            fenced_code_blocks: true, disable_indented_code_blocks: true)
     ActionController::Base.helpers.sanitize(@md_parser.render(content.dup.to_s))
+  end
+
+  def render_without_markdown(content)
+    @remove_markdown_parser ||= Redcarpet::Markdown.new(Redcarpet::Render::StripDown)
+    ActionController::Base.helpers.sanitize(@remove_markdown_parser.render(content.to_s))
   end
 end

--- a/src/api/app/presenters/notification_presenter.rb
+++ b/src/api/app/presenters/notification_presenter.rb
@@ -1,9 +1,4 @@
-require 'redcarpet/render_strip'
-
 class NotificationPresenter < SimpleDelegator
-  TRUNCATION_LENGTH = 100
-  TRUNCATION_ELLIPSIS_LENGTH = 3 # `...` is the default ellipsis for String#truncate
-
   def initialize(model)
     @model = model
     super(@model)
@@ -37,24 +32,6 @@ class NotificationPresenter < SimpleDelegator
     end
   end
 
-  def truncate_to_first_new_line(text)
-    first_new_line_index = text.index("\n")
-    truncation_index = !first_new_line_index.nil? && first_new_line_index < TRUNCATION_LENGTH ? first_new_line_index + TRUNCATION_ELLIPSIS_LENGTH : TRUNCATION_LENGTH
-    text.truncate(truncation_index)
-  end
-
-  def excerpt
-    text =  case @model.notifiable_type
-            when 'BsRequest'
-              @model.notifiable.description
-            when 'Comment'
-              render_without_markdown(@model.notifiable.body)
-            else
-              ''
-            end
-    truncate_to_first_new_line(text.to_s)
-  end
-
   def commenters
     commentable = @model.notifiable.commentable
     commentable.comments.where('updated_at >= ?', @model.unread_date).map(&:user).uniq
@@ -69,12 +46,6 @@ class NotificationPresenter < SimpleDelegator
   end
 
   private
-
-  def render_without_markdown(content)
-    # Initializes a Markdown parser, if needed
-    @remove_markdown_parser ||= Redcarpet::Markdown.new(Redcarpet::Render::StripDown)
-    ActionController::Base.helpers.sanitize(@remove_markdown_parser.render(content.to_s))
-  end
 
   # Returns strings like "Add Role", "Submit", etc.
   def type_of_action(bs_request)

--- a/src/api/app/views/webui/users/notifications/_notifications_list.html.haml
+++ b/src/api/app/views/webui/users/notifications/_notifications_list.html.haml
@@ -52,7 +52,7 @@
                       = render NotificationActionDescriptionComponent.new(n)
                   .row.d-none.d-md-block.pl-4
                     .col
-                      %p.mt-3.mb-0= notification.excerpt
+                      = render NotificationExcerptComponent.new(n)
   = paginate notifications, views_prefix: 'webui', window: 2, params: { action: 'index', id: nil }
 
 - content_for :ready_function do

--- a/src/api/spec/components/notification_excerpt_component_spec.rb
+++ b/src/api/spec/components/notification_excerpt_component_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe NotificationExcerptComponent, type: :component do
+  let(:user) { create(:user) }
+  let(:notification_for_projects_comment) { create(:web_notification, :comment_for_project, notifiable: comment, subscriber: user) }
+
+  context 'with short excerpt' do
+    let(:comment) { create(:comment_project, body: Faker::Lorem.characters(number: 20)) }
+
+    it do
+      expect(render_inline(described_class.new(notification_for_projects_comment))).not_to have_text('...')
+    end
+  end
+
+  context 'with long excerpt' do
+    let(:comment) { create(:comment_project, body: Faker::Lorem.characters(number: 120)) }
+
+    it do
+      expect(render_inline(described_class.new(notification_for_projects_comment))).to have_text('...')
+    end
+  end
+end

--- a/src/api/spec/components/previews/notification_excerpt_component_preview.rb
+++ b/src/api/spec/components/previews/notification_excerpt_component_preview.rb
@@ -1,0 +1,6 @@
+class NotificationExcerptComponentPreview < ViewComponent::Preview
+  # Preview at http://HOST:PORT/rails/view_components/notification_excerpt_component/preview
+  def preview
+    render(NotificationExcerptComponent.new(Notification.last))
+  end
+end


### PR DESCRIPTION
This can now be covered with unit tests since it's a view component.

Part of #11558

Co-authored-by: Saray Cabrera Padrón <scabrerapadron@suse.de>