### PR TITLE
Make the smoke tests pass in openQA for the 2.10 branch

### DIFF
--- a/dist/t/0060-check_required_services.ts
+++ b/dist/t/0060-check_required_services.ts
@@ -69,7 +69,7 @@ sub get_distribution {
   my $line;
   while ($line = <$fh>) {
     $os = 'suse' if ($line =~ /^ID_LIKE=.*suse.*/);
-    $os = 'rh' if ($line =~ /^ID_LIKE=.*fedora.*/);
+    $os = 'rh' if ($line =~ /^ID(_LIKE)?=.*fedora.*/);
   }
   close $fh;
   return $os

--- a/dist/t/0060-check_required_services.ts
+++ b/dist/t/0060-check_required_services.ts
@@ -8,13 +8,13 @@ my $tests    = 14;
 my $max_wait = 300;
 
 my @daemons = qw/obsdispatcher.service  obspublisher.service    obsrepserver.service
-                 obsscheduler.service   obssrcserver.service    /;
+                 obsscheduler.service   obssrcserver.service    mariadb.service/;
 
 my $os = get_distribution();
 if ($os eq "suse") {
-  push @daemons, "apache2.service", "mysql.service";
+  push @daemons, "apache2.service";
 } elsif ($os eq 'rh') {
-  push @daemons, "httpd.service", "mariadb.service";
+  push @daemons, "httpd.service";
 } else {
   die "Could not determine distribution!\n";
 }

--- a/dist/t/0060-check_required_services.ts
+++ b/dist/t/0060-check_required_services.ts
@@ -8,7 +8,16 @@ my $tests    = 14;
 my $max_wait = 300;
 
 my @daemons = qw/obsdispatcher.service  obspublisher.service    obsrepserver.service
-                 obsscheduler.service   obssrcserver.service    apache2.service         mysql.service/;
+                 obsscheduler.service   obssrcserver.service    /;
+
+my $os = get_distribution();
+if ($os eq "suse") {
+  push @daemons, "apache2.service", "mysql.service";
+} elsif ($os eq 'rh') {
+  push @daemons, "httpd.service", "mariadb.service";
+} else {
+  die "Could not determine distribution!\n";
+}
 
 my $version = `rpm -q --queryformat %{Version} obs-server`;
 
@@ -52,3 +61,16 @@ foreach my $srv ( @daemons ) {
 
 
 exit 0;
+
+sub get_distribution {
+  my $fh;
+  my $os = "";
+  open $fh, '<', '/etc/os-release' || die "Could not open /etc/os-release: $!";
+  my $line;
+  while ($line = <$fh>) {
+    $os = 'suse' if ($line =~ /^ID_LIKE=.*suse.*/);
+    $os = 'rh' if ($line =~ /^ID_LIKE=.*fedora.*/);
+  }
+  close $fh;
+  return $os
+}

--- a/dist/t/0060-check_required_services.ts
+++ b/dist/t/0060-check_required_services.ts
@@ -8,7 +8,17 @@ my $tests    = 14;
 my $max_wait = 300;
 
 my @daemons = qw/obsdispatcher.service  obspublisher.service    obsrepserver.service
-                 obsscheduler.service   obssrcserver.service    mariadb.service/;
+                 obsscheduler.service   obssrcserver.service/;
+
+my $out=`systemctl list-units`;
+my $mariadb;
+foreach my $unit (split(/\n/, $out)) {
+  $mariadb = $1 if $unit =~ /^((mysql|mariadb)\.service)/
+}
+
+die "could not find mariadb or mysql" if ! $mariadb;
+
+push @daemons, $mariadb;
 
 my $os = get_distribution();
 if ($os eq "suse") {

--- a/dist/t/0060-check_required_services.ts
+++ b/dist/t/0060-check_required_services.ts
@@ -13,7 +13,10 @@ my @active_daemons = qw/obsdispatcher.service  obspublisher.service    obsrepser
 my $out=`systemctl list-units`;
 my $mariadb;
 foreach my $unit (split(/\n/, $out)) {
-  $mariadb = $1 if $unit =~ /^\s*((mysql|mariadb)\.service)\s+/
+  if $unit =~ /^\s*((mysql|mariadb)\.service)\s+/ {
+    $mariadb = $1;
+    last;
+  }
 }
 
 die "could not find mariadb or mysql" if ! $mariadb;

--- a/dist/t/0060-check_required_services.ts
+++ b/dist/t/0060-check_required_services.ts
@@ -34,8 +34,13 @@ my $version = `rpm -q --queryformat %{Version} obs-server`;
 my @enabled_daemons = @active_daemons;
 
 if ($version !~ /^2\.[89]\./) {
-  push @active_daemons, 'obs-clockwork.service', 'obs-delayedjob-queue-consistency_check.service', 'obs-delayedjob-queue-default.service', 'obs-delayedjob-queue-issuetracking.service', 'obs-delayedjob-queue-mailers.service', 'obs-delayedjob-queue-project_log_rotate.service', 'obs-delayedjob-queue-quick@0.service', 'obs-delayedjob-queue-quick@1.service', 'obs-delayedjob-queue-quick@2.service', 'obs-delayedjob-queue-releasetracking.service', 'obs-delayedjob-queue-staging.service', 'obs-delayedjob-queue-scm.service', 'obs-sphinx.service';
-  $tests = $tests + 13;
+  push @active_daemons, 'obs-clockwork.service', 'obs-delayedjob-queue-consistency_check.service', 'obs-delayedjob-queue-default.service', 'obs-delayedjob-queue-issuetracking.service', 'obs-delayedjob-queue-mailers.service', 'obs-delayedjob-queue-project_log_rotate.service', 'obs-delayedjob-queue-quick@0.service', 'obs-delayedjob-queue-quick@1.service', 'obs-delayedjob-queue-quick@2.service', 'obs-delayedjob-queue-releasetracking.service', 'obs-delayedjob-queue-staging.service', 'obs-sphinx.service';
+  $tests += 12;
+  my @out=`systemctl show --property=LoadError obs-delayedjob-queue-scm.service`;
+  if ($out[0] !~ /^LoadError=org.freedesktop.systemd1.NoSuchUnit/) {
+    push @active_daemons, 'obs-delayedjob-queue-scm.service';
+    $tests += 1;
+  }
 }
 
 plan tests => $tests;

--- a/dist/t/0060-check_required_services.ts
+++ b/dist/t/0060-check_required_services.ts
@@ -62,7 +62,6 @@ while ($max_wait > 0) {
 	foreach my $srv (@active_daemons) {
 		my @state=`systemctl is-active $srv 2>/dev/null`;
 		chomp($state[0]);
-		print "$srv $state[0]\n";
 		if ( $state[0] eq 'active') {
 			$srv_state{$srv} = $state[0];
 		} elsif ( $state[0] eq 'failed') {

--- a/dist/t/0060-check_required_services.ts
+++ b/dist/t/0060-check_required_services.ts
@@ -13,7 +13,7 @@ my @active_daemons = qw/obsdispatcher.service  obspublisher.service    obsrepser
 my $out=`systemctl list-units`;
 my $mariadb;
 foreach my $unit (split(/\n/, $out)) {
-  if $unit =~ /^\s*((mysql|mariadb)\.service)\s+/ {
+  if ($unit =~ /^\s*((mysql|mariadb)\.service)\s+/) {
     $mariadb = $1;
     last;
   }

--- a/dist/t/0090-check_database.ts
+++ b/dist/t/0090-check_database.ts
@@ -14,8 +14,8 @@ TABLES_IN_DB=$(mysql -e "show tables" $DB_NAME)
 [[ $TABLES_IN_DB ]]
 is "$?" 0 "Checking if tables in database $DB_NAME"
 
-D=`ps -ef|grep "mysqld .* --datadir=/srv/obs/MySQL"|wc -l`
+D=$(mysql -e 'SHOW VARIABLES WHERE Variable_Name LIKE "datadir"'|grep datadir |awk '{ print $2 }')
 
-[ $D -gt 1 -o -f /srv/obs/MySQL/*.pid ]
+[ $D == '/srv/obs/MySQL/' -o -f /srv/obs/MySQL/*.pid ]
 
 is "$?" 0 "Checking if database is started under /srv/obs/MySQL"

--- a/dist/t/spec/features/0030_project_spec.rb
+++ b/dist/t/spec/features/0030_project_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Project" do
     end
     click_link('Repositories')
     click_link('Add from a Distribution')
-    check('repo_openSUSE_Leap_15_3', allow_label_click: true)
-    expect(page).to have_content("Successfully added repository 'openSUSE_Leap_15.3'")
+    check('openSUSE Leap 15.3', allow_label_click: true)
+    expect(page).to have_content("Successfully added repository '15.3'")
   end
 end


### PR DESCRIPTION
Cherry pick the commits in master that have adapted the smoke tests, and apply them to the 2.10 branch.

Only two kind of tests where involved in these changes:
- testing for mysql or mariadb service
- selecting the correct repository to add to a package

To review this pull request, follow the steps described in [Run OpenQAthe smoketests locally](https://github.com/openSUSE/open-build-service/wiki/Run-OpenQA-smoketest-locally). Just pick up the last OBS 2.10.12 image. And also, when doing the `git clone` command change it to retrieve this branch:

```
git clone --single-branch --branch add_tests_fixes --depth 1 https://github.com/eduardoj/open-build-service.git /tmp/open-build-service
```