### PR TITLE
Avoid n+1 queries for notification index view

### DIFF
--- a/src/api/app/components/notification_avatars_component.rb
+++ b/src/api/app/components/notification_avatars_component.rb
@@ -13,7 +13,8 @@ class NotificationAvatarsComponent < ApplicationComponent
     @avatar_objects ||= if @notification.notifiable_type == 'Comment'
                           commenters
                         else
-                          @notification.notifiable.reviews.in_state_new.map(&:reviewed_by) + User.where(login: @notification.notifiable.creator)
+                          reviews = @notification.notifiable.reviews
+                          reviews.select(&:new?).map(&:reviewed_by) + User.where(login: @notification.notifiable.creator)
                         end
   end
 
@@ -26,8 +27,8 @@ class NotificationAvatarsComponent < ApplicationComponent
   end
 
   def commenters
-    commentable = @notification.notifiable.commentable
-    commentable.comments.where('updated_at >= ?', @notification.unread_date).map(&:user).uniq
+    comments = @notification.notifiable.commentable.comments
+    comments.select { |comment| comment.updated_at >= @notification.unread_date }.map(&:user).uniq
   end
 
   def package_title(package)

--- a/src/api/app/controllers/person/notifications_controller.rb
+++ b/src/api/app/controllers/person/notifications_controller.rb
@@ -30,12 +30,13 @@ module Person
     end
 
     def fetch_notifications
-      notifications_for_subscribed_user = NotificationsFinder.new(policy_scope(Notification))
+      notifications = policy_scope(Notification)
+      notifications_finder = NotificationsFinder.new(notifications)
 
       filtered_notifications = if params[:project]
-                                 notifications_for_subscribed_user.for_project_name(params[:project])
+                                 notifications_finder.for_project_name(params[:project])
                                else
-                                 notifications_for_subscribed_user.for_subscribed_user
+                                 notifications
                                end
       # We are limiting it just for BsRequests
       NotificationsFinder.new(filtered_notifications).for_notifiable_type(@filter_type)

--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -105,7 +105,10 @@ class Webui::PackageController < Webui::WebuiController
     @comments = @package.comments.includes(:user)
     @comment = Comment.new
 
-    @current_notification = NotificationsFinder.new.for_subscribed_user_by_id(params[:notification_id]) if User.session && params[:notification_id]
+    if User.session && params[:notification_id]
+      @current_notification = Notification.find(params[:notification_id])
+      authorize @current_notification, :update?, policy_class: NotificationPolicy
+    end
 
     @services = @files.any? { |file| file[:name] == '_service' }
 

--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -105,7 +105,7 @@ class Webui::PackageController < Webui::WebuiController
     @comments = @package.comments.includes(:user)
     @comment = Comment.new
 
-    @current_notification = NotificationsFinder.new.for_subscribed_user_by_id(params[:notification_id])
+    @current_notification = NotificationsFinder.new.for_subscribed_user_by_id(params[:notification_id]) if User.session && params[:notification_id]
 
     @services = @files.any? { |file| file[:name] == '_service' }
 

--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -133,7 +133,7 @@ class Webui::ProjectController < Webui::WebuiController
     @comments = @project.comments
     @comment = Comment.new
 
-    @current_notification = NotificationsFinder.new.for_subscribed_user_by_id(params[:notification_id])
+    @current_notification = NotificationsFinder.new.for_subscribed_user_by_id(params[:notification_id]) if User.session && params[:notification_id]
 
     respond_to do |format|
       format.html

--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -133,7 +133,10 @@ class Webui::ProjectController < Webui::WebuiController
     @comments = @project.comments
     @comment = Comment.new
 
-    @current_notification = NotificationsFinder.new.for_subscribed_user_by_id(params[:notification_id]) if User.session && params[:notification_id]
+    if User.session && params[:notification_id]
+      @current_notification = Notification.find(params[:notification_id])
+      authorize @current_notification, :update?, policy_class: NotificationPolicy
+    end
 
     respond_to do |format|
       format.html

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -119,7 +119,10 @@ class Webui::RequestController < Webui::WebuiController
     @comments = @bs_request.comments
     @comment = Comment.new
 
-    @current_notification = NotificationsFinder.new.for_subscribed_user_by_id(params[:notification_id]) if User.session && params[:notification_id]
+    if User.session && params[:notification_id]
+      @current_notification = Notification.find(params[:notification_id])
+      authorize @current_notification, :update?, policy_class: NotificationPolicy
+    end
 
     @actions = @bs_request.webui_actions(filelimit: @diff_limit, tarlimit: @diff_limit, diff_to_superseded: @diff_to_superseded, diffs: false)
     @action = @actions.first

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -119,7 +119,7 @@ class Webui::RequestController < Webui::WebuiController
     @comments = @bs_request.comments
     @comment = Comment.new
 
-    @current_notification = NotificationsFinder.new.for_subscribed_user_by_id(params[:notification_id])
+    @current_notification = NotificationsFinder.new.for_subscribed_user_by_id(params[:notification_id]) if User.session && params[:notification_id]
 
     @actions = @bs_request.webui_actions(filelimit: @diff_limit, tarlimit: @diff_limit, diff_to_superseded: @diff_to_superseded, diffs: false)
     @action = @actions.first

--- a/src/api/app/controllers/webui/users/notifications_controller.rb
+++ b/src/api/app/controllers/webui/users/notifications_controller.rb
@@ -70,13 +70,15 @@ class Webui::Users::NotificationsController < Webui::WebuiController
   end
 
   def fetch_notifications
-    notifications_for_subscribed_user = NotificationsFinder.new(policy_scope(Notification).includes(:notifiable))
+    notifications = policy_scope(Notification).includes(:notifiable)
+    notifications_finder = NotificationsFinder.new(relation = notifications)
+
     if params[:project]
-      notifications_for_subscribed_user.for_project_name(params[:project])
+      notifications_finder.for_project_name(params[:project])
     elsif params[:group]
-      notifications_for_subscribed_user.for_group_title(params[:group])
+      notifications_finder.for_group_title(params[:group])
     else
-      notifications_for_subscribed_user.for_notifiable_type(params[:type])
+      notifications_finder.for_notifiable_type(params[:type])
     end
   end
 

--- a/src/api/app/controllers/webui/users/notifications_controller.rb
+++ b/src/api/app/controllers/webui/users/notifications_controller.rb
@@ -70,8 +70,8 @@ class Webui::Users::NotificationsController < Webui::WebuiController
   end
 
   def fetch_notifications
-    notifications = policy_scope(Notification).includes(:notifiable)
-    notifications_finder = NotificationsFinder.new(relation = notifications)
+    notifications = policy_scope(Notification).includes(notifiable: [{ commentable: [{ comments: :user }, :project, :bs_request_actions] }, :bs_request_actions, :reviews])
+    notifications_finder = NotificationsFinder.new(notifications)
 
     if params[:project]
       notifications_finder.for_project_name(params[:project])

--- a/src/api/app/models/review.rb
+++ b/src/api/app/models/review.rb
@@ -58,7 +58,6 @@ class Review < ApplicationRecord
   scope :bs_request_ids_of_involved_users, ->(user_ids) { where(user_id: user_ids).select(:bs_request_id) }
 
   scope :declined, -> { where(state: :declined) }
-  scope :in_state_new, -> { where(state: :new) }
 
   before_validation(on: :create) do
     self.state = :new if self[:state].nil?
@@ -99,6 +98,10 @@ class Review < ApplicationRecord
 
   def accepted?
     state == :accepted
+  end
+
+  def new?
+    state == :new
   end
 
   def accepted_at

--- a/src/api/app/policies/notification_policy.rb
+++ b/src/api/app/policies/notification_policy.rb
@@ -7,7 +7,9 @@ class NotificationPolicy < ApplicationPolicy
     end
 
     def resolve
-      NotificationsFinder.new(scope).for_subscribed_user(user)
+      # TODO: There are no notifications anymore with subscriber_type 'Group' since we create a notification for every group member instead
+      scope.where("(subscriber_type = 'User' AND subscriber_id = ?) OR (subscriber_type = 'Group' AND subscriber_id IN (?))",
+                  user, user.groups.select(:id))
     end
   end
 

--- a/src/api/app/queries/notifications_finder.rb
+++ b/src/api/app/queries/notifications_finder.rb
@@ -54,10 +54,6 @@ class NotificationsFinder
     unread.joins(:groups).where(groups: { title: group_title })
   end
 
-  def for_subscribed_user_by_id(notification_id)
-    NotificationPolicy::Scope.new(User.session, Notification).resolve.find_by(id: notification_id)
-  end
-
   def stale
     @relation.where('created_at < ?', notifications_lifetime.days.ago)
   end

--- a/src/api/app/queries/notifications_finder.rb
+++ b/src/api/app/queries/notifications_finder.rb
@@ -55,8 +55,6 @@ class NotificationsFinder
   end
 
   def for_subscribed_user_by_id(notification_id)
-    return unless User.session && notification_id
-
     NotificationPolicy::Scope.new(User.session, Notification).resolve.find_by(id: notification_id)
   end
 


### PR DESCRIPTION
The PR removes most of the n+1 queries from the notification index view. The bullet gem now complains about unnecessary eager loads. For me this looks like a false positives. I tested to load some of the associations separate to check if the bullet gem would stop complaining, but ended up with the same result.