### PR TITLE
Prevent errors for a BsRequest without a description in NotificationExcerptComponent

### DIFF
--- a/src/api/app/components/notification_excerpt_component.rb
+++ b/src/api/app/components/notification_excerpt_component.rb
@@ -11,7 +11,7 @@ class NotificationExcerptComponent < ApplicationComponent
   def call
     text = case @notification.notifiable_type
            when 'BsRequest'
-             @notification.notifiable.description
+             @notification.notifiable.description.to_s # description can be nil
            when 'Comment'
              helpers.render_without_markdown(@notification.notifiable.body)
            else

--- a/src/api/spec/components/notification_excerpt_component_spec.rb
+++ b/src/api/spec/components/notification_excerpt_component_spec.rb
@@ -2,21 +2,31 @@ require 'rails_helper'
 
 RSpec.describe NotificationExcerptComponent, type: :component do
   let(:user) { create(:user) }
-  let(:notification_for_projects_comment) { create(:web_notification, :comment_for_project, notifiable: comment, subscriber: user) }
 
-  context 'with short excerpt' do
-    let(:comment) { create(:comment_project, body: Faker::Lorem.characters(number: 20)) }
+  context 'notification for a BsRequest without a description' do
+    let(:bs_request) { create(:bs_request_with_submit_action, description: nil) }
+    let(:notification) { create(:web_notification, :request_created, notifiable: bs_request, subscriber: user) }
 
     it do
-      expect(render_inline(described_class.new(notification_for_projects_comment))).not_to have_text('...')
+      expect(render_inline(described_class.new(notification))).to have_selector('p', text: '')
     end
   end
 
-  context 'with long excerpt' do
-    let(:comment) { create(:comment_project, body: Faker::Lorem.characters(number: 120)) }
+  context 'notification for a short comment' do
+    let(:comment) { create(:comment_project, body: 'Nice project!') }
+    let(:notification) { create(:web_notification, :comment_for_project, notifiable: comment, subscriber: user) }
 
     it do
-      expect(render_inline(described_class.new(notification_for_projects_comment))).to have_text('...')
+      expect(render_inline(described_class.new(notification))).to have_selector('p', text: 'Nice project!')
+    end
+  end
+
+  context 'notification for a long comment' do
+    let(:comment) { create(:comment_project, body: Faker::Lorem.characters(number: 120)) }
+    let(:notification) { create(:web_notification, :comment_for_project, notifiable: comment, subscriber: user) }
+
+    it do
+      expect(render_inline(described_class.new(notification))).to have_text('...')
     end
   end
 end


### PR DESCRIPTION
Fixes #12224