### PR TITLE
Use target_project instead of target_project.name

### DIFF
--- a/src/api/app/components/notification_action_description_component.rb
+++ b/src/api/app/components/notification_action_description_component.rb
@@ -40,7 +40,7 @@ class NotificationActionDescriptionComponent < ApplicationComponent
   end
 
   def target
-    return bs_request_action.target_project.name if number_of_bs_request_actions > 1
+    return bs_request_action.target_project if number_of_bs_request_actions > 1
 
     [bs_request_action.target_project, bs_request_action.target_package].compact.join(' / ')
   end


### PR DESCRIPTION
Closes #12227

`bs_request_action.target_project` already returns a string. It's not an ActiveRecord object that's why we can't use `.name` on it.