### PR TITLE
Set password to opensuse for users generated by dev rake task

### DIFF
--- a/src/api/spec/README.md
+++ b/src/api/spec/README.md
@@ -100,7 +100,7 @@ You can use an inherited factory to add or override attributes.
     email { Faker::Internet.email }
     realname { Faker::Name.name }
     sequence(:login) { |n| "user_#{n}" }
-    password 'buildservice'
+    password 'opensuse'
 
     factory :confirmed_user do
       state 2

--- a/src/api/spec/controllers/webui/session_controller_spec.rb
+++ b/src/api/spec/controllers/webui/session_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Webui::SessionController do
     end
 
     it 'logs in users with correct credentials' do
-      post :create, params: { username: user.login, password: 'buildservice' }
+      post :create, params: { username: user.login, password: 'opensuse' }
       expect(response).to redirect_to search_url
     end
 
@@ -22,13 +22,13 @@ RSpec.describe Webui::SessionController do
 
     it 'tells users about wrong state' do
       user.update(state: :locked)
-      post :create, params: { username: user.login, password: 'buildservice' }
+      post :create, params: { username: user.login, password: 'opensuse' }
       expect(response).to redirect_to root_path
       expect(flash[:error]).to eq('Your account is disabled. Please contact the administrator for details.')
     end
 
     it 'assigns the current user' do
-      post :create, params: { username: user.login, password: 'buildservice' }
+      post :create, params: { username: user.login, password: 'opensuse' }
       expect(User.session!).to eq(user)
       expect(session[:login]).to eq(user.login)
     end
@@ -37,7 +37,7 @@ RSpec.describe Webui::SessionController do
   describe 'POST #create' do
     context 'without referrer' do
       before do
-        post :create, params: { username: user.login, password: 'buildservice' }
+        post :create, params: { username: user.login, password: 'opensuse' }
       end
 
       it 'redirects to root path' do

--- a/src/api/spec/controllers/webui/users_controller_spec.rb
+++ b/src/api/spec/controllers/webui/users_controller_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe Webui::UsersController do
       before do
         already_registered_user = create(:confirmed_user, login: 'previous_user')
         post :create, params: { login: already_registered_user.login,
-                                email: already_registered_user.email, password: 'buildservice' }
+                                email: already_registered_user.email, password: 'opensuse' }
       end
 
       it { expect(flash[:error]).not_to be(nil) }
@@ -129,7 +129,7 @@ RSpec.describe Webui::UsersController do
       before do
         allow(Configuration).to receive(:allow_user_to_create_home_project).and_return(true)
         post :create, params: { login: new_user.login, email: new_user.email,
-                                password: 'buildservice' }
+                                password: 'opensuse' }
       end
 
       it { expect(flash[:success]).to eq("The account '#{new_user.login}' is now active.") }
@@ -140,7 +140,7 @@ RSpec.describe Webui::UsersController do
       before do
         allow(Configuration).to receive(:allow_user_to_create_home_project).and_return(false)
         post :create, params: { login: new_user.login,
-                                email: new_user.email, password: 'buildservice' }
+                                email: new_user.email, password: 'opensuse' }
       end
 
       it { expect(flash[:success]).to eq("The account '#{new_user.login}' is now active.") }
@@ -439,7 +439,7 @@ RSpec.describe Webui::UsersController do
       before do
         login non_admin_user
         stub_const('CONFIG', CONFIG.merge('ldap_mode' => :off))
-        post :change_password, params: { login: non_admin_user, password: 'buildservice',
+        post :change_password, params: { login: non_admin_user, password: 'opensuse',
                                          new_password: 'opensuse', repeat_password: 'opensuse' }
       end
 
@@ -452,7 +452,7 @@ RSpec.describe Webui::UsersController do
     context 'unauthenticated' do
       before do
         stub_const('CONFIG', CONFIG.merge('ldap_mode' => :off))
-        post :change_password, params: { login: non_admin_user, password: 'buildservice',
+        post :change_password, params: { login: non_admin_user, password: 'opensuse',
                                          new_password: 'opensuse', repeat_password: 'opensuse' }
       end
 

--- a/src/api/spec/factories/users.rb
+++ b/src/api/spec/factories/users.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     email { Faker::Internet.email }
     realname { Faker::Name.first_name }
     sequence(:login) { |n| "user_#{n}" }
-    password { 'buildservice' }
+    password { 'opensuse' }
 
     transient do
       create_home_project { false }
@@ -68,7 +68,7 @@ FactoryBot.define do
     factory :user_deprecated_password do
       after(:create) do |user|
         user.password_digest = nil
-        user.deprecated_password = 'b6ead59da72f491dd29f84a6579d6dc4' # password: buildservice
+        user.deprecated_password = 'a58e151d3267964feba9066c84afe941' # password: opensuse
         user.deprecated_password_hash_type = 'md5'
         user.deprecated_password_salt = 'm/YVlu5w0M'
 
@@ -93,7 +93,7 @@ FactoryBot.define do
     # This is needed because the salt is random
     # in User.after_validation
     after(:create) do |user|
-      user.password = 'buildservice'
+      user.password = 'opensuse'
       user.save!
     end
   end

--- a/src/api/spec/features/webui/login_spec.rb
+++ b/src/api/spec/features/webui/login_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Login', type: :feature, js: true do
 
     within('#loginform') do
       fill_in 'username', with: user.login
-      fill_in 'password', with: 'buildservice'
+      fill_in 'password', with: 'opensuse'
       click_button('Log In')
     end
 
@@ -37,7 +37,7 @@ RSpec.describe 'Login', type: :feature, js: true do
 
     within('#log-in-modal') do
       fill_in 'username', with: user.login
-      fill_in 'password', with: 'buildservice'
+      fill_in 'password', with: 'opensuse'
       click_button('Log In')
     end
 

--- a/src/api/spec/models/user_spec.rb
+++ b/src/api/spec/models/user_spec.rb
@@ -428,7 +428,7 @@ RSpec.describe User do
 
     context 'with valid credentials' do
       it 'returns a user object for valid credentials' do
-        expect(user.authenticate('buildservice')).to eq(user)
+        expect(user.authenticate('opensuse')).to eq(user)
       end
     end
   end
@@ -439,11 +439,11 @@ RSpec.describe User do
 
       context 'conversation of deprecated password' do
         before do
-          user.authenticate('buildservice')
+          user.authenticate('opensuse')
         end
 
         it 'converts the password to bcrypt' do
-          expect(BCrypt::Password.new(user.password_digest)).to be_is_password('buildservice')
+          expect(BCrypt::Password.new(user.password_digest)).to be_is_password('opensuse')
         end
 
         it 'resets the hash of the deprecated password' do
@@ -486,7 +486,7 @@ RSpec.describe User do
     let(:user) { create(:user, login: 'login_test', login_failure_count: 7, last_logged_in_at: Time.zone.yesterday) }
 
     context 'when user exists' do
-      subject { User.find_with_credentials(user.login, 'buildservice') }
+      subject { User.find_with_credentials(user.login, 'opensuse') }
 
       it { is_expected.to eq(user) }
       it { expect(subject.login_failure_count).to eq(0) }
@@ -494,7 +494,7 @@ RSpec.describe User do
     end
 
     context 'when user does not exist' do
-      it { expect(User.find_with_credentials('unknown', 'buildservice')).to be(nil) }
+      it { expect(User.find_with_credentials('unknown', 'opensuse')).to be(nil) }
     end
 
     context 'when user exist but password was incorrect' do

--- a/src/api/spec/support/features/features_authentication.rb
+++ b/src/api/spec/support/features/features_authentication.rb
@@ -1,5 +1,5 @@
 module FeaturesAuthentication
-  def login(user, password = 'buildservice')
+  def login(user, password = 'opensuse')
     visit new_session_path
     expect(page).to have_text 'Please Log In'
     within('#loginform') do

--- a/src/api/test/functional/build_controller_test.rb
+++ b/src/api/test/functional/build_controller_test.rb
@@ -274,7 +274,7 @@ class BuildControllerTest < ActionDispatch::IntegrationTest
     assert_response 403
     assert_xml_tag(tag: 'status', attributes: { code: 'source_access_no_permission' })
     # retry with maintainer
-    prepare_request_with_user('sourceaccess_homer', 'buildservice')
+    prepare_request_with_user('sourceaccess_homer', 'opensuse')
     get '/build/SourceprotectedProject/repo/i586/pack/_log'
     assert_response :success
   end
@@ -298,7 +298,7 @@ class BuildControllerTest < ActionDispatch::IntegrationTest
     assert_match(/download_binary_no_permission/, @response.body)
     # retry with maintainer
     reset_auth
-    prepare_request_with_user('binary_homer', 'buildservice')
+    prepare_request_with_user('binary_homer', 'opensuse')
     get '/build/BinaryprotectedProject/nada/i586/bdpack/_log'
     assert_response :success
   end
@@ -382,7 +382,7 @@ class BuildControllerTest < ActionDispatch::IntegrationTest
     assert_match(/download_binary_no_permission/, @response.body)
     # success on valid
     reset_auth
-    prepare_request_with_user('binary_homer', 'buildservice')
+    prepare_request_with_user('binary_homer', 'opensuse')
     get '/build/BinaryprotectedProject/nada/i586/bdpack/package?view=fileinfo'
     assert_response 404
     assert_match(/No such file or directory/, @response.body)

--- a/src/api/test/functional/channel_maintenance_test.rb
+++ b/src/api/test/functional/channel_maintenance_test.rb
@@ -30,7 +30,7 @@ class ChannelMaintenanceTests < ActionDispatch::IntegrationTest
     put '/source/BaseDistro3/pack2/file', params: 'NOOP'
     assert_response :success
     # setup maintained attributes
-    prepare_request_with_user('maintenance_coord', 'buildservice')
+    prepare_request_with_user('maintenance_coord', 'opensuse')
     # single packages
     post '/source/BaseDistro2.0/pack2/_attribute', params: "<attributes><attribute namespace='OBS' name='Maintained' /></attributes>"
     assert_response :success
@@ -125,7 +125,7 @@ class ChannelMaintenanceTests < ActionDispatch::IntegrationTest
     assert_xml_tag parent: { tag: 'collection' }, tag: 'request', attributes: { id: id1 }
 
     # accept request
-    prepare_request_with_user('maintenance_coord', 'buildservice')
+    prepare_request_with_user('maintenance_coord', 'opensuse')
     post "/request/#{id1}?cmd=changestate&newstate=accepted"
     assert_response :success
 
@@ -240,7 +240,7 @@ class ChannelMaintenanceTests < ActionDispatch::IntegrationTest
     assert_xml_tag parent: { tag: 'file', attributes: { state: 'added' } }, tag: 'new', attributes: { name: 'new_file' }
 
     # set incident to merge into existing one
-    prepare_request_with_user('maintenance_coord', 'buildservice')
+    prepare_request_with_user('maintenance_coord', 'opensuse')
     post "/request/#{id2}?cmd=setincident&incident=#{incident_project.gsub(/.*:/, '')}"
     assert_response :success
 
@@ -251,13 +251,13 @@ class ChannelMaintenanceTests < ActionDispatch::IntegrationTest
     assert_equal incident_project, maintenance_not_new_project
 
     # try to do it again
-    prepare_request_with_user('maintenance_coord', 'buildservice')
+    prepare_request_with_user('maintenance_coord', 'opensuse')
     post "/request/#{id2}?cmd=setincident&incident=#{incident_project.gsub(/.*:/, '')}"
     assert_response 404
     assert_xml_tag tag: 'status', attributes: { code: 'target_not_maintenance' }
 
     # accept request
-    prepare_request_with_user('maintenance_coord', 'buildservice')
+    prepare_request_with_user('maintenance_coord', 'opensuse')
     post "/request/#{id2}?cmd=changestate&newstate=accepted&force=1" # ignore reviews and accept
     assert_response :success
 
@@ -345,7 +345,7 @@ class ChannelMaintenanceTests < ActionDispatch::IntegrationTest
     login_adrian
     post "/source/#{incident_project}?cmd=addchannels"
     assert_response 403
-    prepare_request_with_user('maintenance_coord', 'buildservice')
+    prepare_request_with_user('maintenance_coord', 'opensuse')
     post "/source/#{incident_project}?cmd=addchannels"
     assert_response :success
     get "/source/#{incident_project}/BaseDistro2.Channel/_meta"
@@ -372,7 +372,7 @@ class ChannelMaintenanceTests < ActionDispatch::IntegrationTest
     assert_response :success
 
     # accept another request to check that addchannel is working automatically
-    prepare_request_with_user('maintenance_coord', 'buildservice')
+    prepare_request_with_user('maintenance_coord', 'opensuse')
     post "/request/#{id3}?cmd=changestate&newstate=accepted&force=1" # ignore reviews and accept
     assert_response :success
     get "/request/#{id3}"
@@ -428,7 +428,7 @@ class ChannelMaintenanceTests < ActionDispatch::IntegrationTest
     login_adrian
     post "/source/#{incident_project}?cmd=addchannels"
     assert_response 403
-    prepare_request_with_user('maintenance_coord', 'buildservice')
+    prepare_request_with_user('maintenance_coord', 'opensuse')
     post "/source/#{incident_project}?cmd=addchannels&mode=skip_disabled"
     assert_response :success
     get "/source/#{incident_project}/BaseDistro2.0.Channel/_meta"
@@ -485,7 +485,7 @@ class ChannelMaintenanceTests < ActionDispatch::IntegrationTest
               File.read("#{Rails.root}/test/fixtures/backend/source/simple_product/#{file}")
       assert_response :success
     end
-    prepare_request_with_user('maintenance_coord', 'buildservice')
+    prepare_request_with_user('maintenance_coord', 'opensuse')
     get "/source/#{incident_project}/BaseDistro2.0.Channel/_meta"
     old_meta = @response.body
     assert_response :success
@@ -520,7 +520,7 @@ class ChannelMaintenanceTests < ActionDispatch::IntegrationTest
     login_king
     delete '/source/BaseDistro2.0/_product'
     assert_response :success
-    prepare_request_with_user('maintenance_coord', 'buildservice')
+    prepare_request_with_user('maintenance_coord', 'opensuse')
 
     # no updateinfo create, so add an issue to the patchinfo
     get "/build/#{incident_project}/BaseDistro3Channel/i586/patchinfo/updateinfo.xml"

--- a/src/api/test/functional/comments_controller_test.rb
+++ b/src/api/test/functional/comments_controller_test.rb
@@ -21,7 +21,7 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     get comments_project_path(project: 'HiddenProject')
     assert_response 404 # huh? Nothing here
 
-    prepare_request_with_user('hidden_homer', 'buildservice')
+    prepare_request_with_user('hidden_homer', 'opensuse')
     get comments_project_path(project: 'HiddenProject')
     assert_response :success
   end

--- a/src/api/test/functional/interconnect_test.rb
+++ b/src/api/test/functional/interconnect_test.rb
@@ -503,7 +503,7 @@ class InterConnectTests < ActionDispatch::IntegrationTest
     get '/source/HiddenRemoteInstance:BaseDistro'
     assert_response 404
     reset_auth
-    prepare_request_with_user('hidden_homer', 'buildservice')
+    prepare_request_with_user('hidden_homer', 'opensuse')
     get '/source/HiddenRemoteInstance'
     assert_response :success
     get '/source/HiddenRemoteInstance:BaseDistro'
@@ -523,7 +523,7 @@ class InterConnectTests < ActionDispatch::IntegrationTest
     get '/build/HiddenRemoteInstance:BaseDistro/BaseDistro_repo/i586/pack1'
     assert_response 404
     reset_auth
-    prepare_request_with_user('hidden_homer', 'buildservice')
+    prepare_request_with_user('hidden_homer', 'opensuse')
     get '/build/HiddenRemoteInstance:BaseDistro/BaseDistro_repo/i586/_repository'
     assert_response :success
     get '/build/HiddenRemoteInstance:BaseDistro/BaseDistro_repo/i586/_repository?view=cache'

--- a/src/api/test/functional/maintenance_test.rb
+++ b/src/api/test/functional/maintenance_test.rb
@@ -242,7 +242,7 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     assert_match(/^\+argl/, @response.body)
 
     # accept request
-    prepare_request_with_user('maintenance_coord', 'buildservice')
+    prepare_request_with_user('maintenance_coord', 'opensuse')
     post "/request/#{id1}?cmd=changestate&newstate=accepted&force=1"
     assert_response :success
 
@@ -300,7 +300,7 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     assert_match(/^\+argl/, @response.body)
 
     # accept request
-    prepare_request_with_user('maintenance_coord', 'buildservice')
+    prepare_request_with_user('maintenance_coord', 'opensuse')
 
     # not allowed to remove project
     delete '/source/home:tom:branches:kde4'
@@ -336,7 +336,7 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     assert_xml_tag(tag: 'patchinfo', attributes: { incident: '1' })
 
     # reopen ...
-    prepare_request_with_user('maintenance_coord', 'buildservice')
+    prepare_request_with_user('maintenance_coord', 'opensuse')
     post "/request/#{id2}?cmd=changestate&newstate=new"
     assert_response 403
 
@@ -551,7 +551,7 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     assert_response :success
 
     # setup maintained attributes
-    prepare_request_with_user('maintenance_coord', 'buildservice')
+    prepare_request_with_user('maintenance_coord', 'opensuse')
     # an entire project
     post '/source/BaseDistro/_attribute', params: "<attributes><attribute namespace='OBS' name='Maintained' /></attributes>"
     assert_response :success
@@ -737,7 +737,7 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     assert_xml_tag(parent: { tag: 'access' }, tag: 'disable', content: nil)
 
     # switch user, still diffable
-    prepare_request_with_user('maintenance_coord', 'buildservice')
+    prepare_request_with_user('maintenance_coord', 'opensuse')
     get '/source/home:tom:branches:OBS_Maintained:pack2/_meta'
     assert_response 404 # due to noaccess
     post "/request/#{id}?cmd=diff&view=xml"
@@ -830,7 +830,7 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     assert_response 400
     assert_xml_tag tag: 'status', attributes: { code: 'incident_has_no_maintenance_project' }
 
-    prepare_request_with_user('maintenance_coord', 'buildservice')
+    prepare_request_with_user('maintenance_coord', 'opensuse')
     # create a public maintenance incident
     post '/source/Temp:Maintenance', params: { cmd: 'createmaintenanceincident' }
     assert_response :success
@@ -919,7 +919,7 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     put '/source/My:Maintenance/_meta', params: maintenance_project_meta.to_s
     assert_response :success
 
-    prepare_request_with_user('maintenance_coord', 'buildservice')
+    prepare_request_with_user('maintenance_coord', 'opensuse')
     raw_post '/source/My:Maintenance/_attribute', "<attributes><attribute namespace='OBS' name='MaintenanceIdTemplate'><value>My-%N-%Y-%C</value></attribute></attributes>"
     assert_response :success
 
@@ -997,7 +997,7 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     post "/source/#{incident_project}/_attribute", params: "<attributes><attribute namespace='OBS' name='EmbargoDate'><value>INVALID_DATE_STRING</value></attribute></attributes>"
     assert_response :success
 
-    prepare_request_with_user('maintenance_coord', 'buildservice')
+    prepare_request_with_user('maintenance_coord', 'opensuse')
 
     # create some changes, including issue tracker references
     Timecop.freeze(1)
@@ -1388,7 +1388,7 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     node = Xmlhash.parse(@response.body)
     assert node['id']
     nreqid = node['id']
-    prepare_request_with_user('maintenance_coord', 'buildservice')
+    prepare_request_with_user('maintenance_coord', 'opensuse')
     post "/request/#{nreqid}?cmd=changestate&newstate=accepted"
     assert_response 403
     post "/request/#{nreqid}?cmd=changestate&newstate=declined"
@@ -1962,7 +1962,7 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     assert_response :success
 
     # Run without server side expansion
-    prepare_request_with_user('maintenance_coord', 'buildservice')
+    prepare_request_with_user('maintenance_coord', 'opensuse')
     rq = '<request>
            <action type="maintenance_release">
              <source project="home:tom:branches:BaseDistro:Update" package="pack1" />
@@ -2001,7 +2001,7 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     assert_response :success
 
     # retry
-    prepare_request_with_user('maintenance_coord', 'buildservice')
+    prepare_request_with_user('maintenance_coord', 'opensuse')
     post '/request?cmd=create', params: rq
     assert_response 400
     assert_xml_tag tag: 'status', attributes: { code: 'missing_patchinfo' }
@@ -2019,13 +2019,13 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     post '/source/home:tom:branches:BaseDistro:Update?cmd=createpatchinfo&force=1'
     assert_response :success
 
-    prepare_request_with_user('maintenance_coord', 'buildservice')
+    prepare_request_with_user('maintenance_coord', 'opensuse')
     post '/request?cmd=create', params: rq
     assert_response 400
     assert_xml_tag tag: 'status', attributes: { code: 'build_not_finished' }
 
     # _patchinfo still incomplete
-    prepare_request_with_user('maintenance_coord', 'buildservice')
+    prepare_request_with_user('maintenance_coord', 'opensuse')
     post '/request?cmd=create&ignore_build_state=1', params: rq
     assert_response 400
     assert_xml_tag tag: 'status', attributes: { code: 'incomplete_patchinfo' }
@@ -2051,7 +2051,7 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
            </action>
            <state name="new" />
          </request>'
-    prepare_request_with_user('maintenance_coord', 'buildservice')
+    prepare_request_with_user('maintenance_coord', 'opensuse')
     post '/request?cmd=create&ignore_build_state=1', params: rq
     assert_response 400
     assert_xml_tag tag: 'status', attributes: { code: 'repository_without_architecture' }
@@ -2063,7 +2063,7 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     put '/source/home:tom:branches:BaseDistro:Update/_meta', params: meta.to_s
     assert_response :success
 
-    prepare_request_with_user('maintenance_coord', 'buildservice')
+    prepare_request_with_user('maintenance_coord', 'opensuse')
     post '/request?cmd=create&ignore_build_state=1', params: rq
     assert_response 400
     assert_xml_tag tag: 'status', attributes: { code: 'architecture_order_missmatch' }

--- a/src/api/test/functional/read_permission_test.rb
+++ b/src/api/test/functional/read_permission_test.rb
@@ -65,7 +65,7 @@ class ReadPermissionTest < ActionDispatch::IntegrationTest
     assert_response 403
 
     # reader access
-    prepare_request_with_user('sourceaccess_homer', 'buildservice')
+    prepare_request_with_user('sourceaccess_homer', 'opensuse')
     get '/source/SourceprotectedProject'
     assert_response :success
     get '/source/SourceprotectedProject/_meta'
@@ -119,7 +119,7 @@ class ReadPermissionTest < ActionDispatch::IntegrationTest
   end
 
   def do_read_access_all_pathes(user, response)
-    prepare_request_with_user(user, 'buildservice')
+    prepare_request_with_user(user, 'opensuse')
     get '/source/HiddenProject/_meta'
     assert_response response
     get '/source/HiddenProject'
@@ -171,7 +171,7 @@ class ReadPermissionTest < ActionDispatch::IntegrationTest
     delresp = 404
     do_branch_package_test(sprj, spkg, tprj, resp, match, testflag, delresp, debug)
     # maintainer
-    prepare_request_with_user('hidden_homer', 'buildservice')
+    prepare_request_with_user('hidden_homer', 'opensuse')
     tprj = 'home:hidden_homer:tmp'
     get "/source/#{tprj}"
     assert_response 404
@@ -208,7 +208,7 @@ class ReadPermissionTest < ActionDispatch::IntegrationTest
     do_branch_package_test(sprj, spkg, tprj, resp, match, testflag, delresp, debug)
     # maintainer
 
-    prepare_request_with_user('hidden_homer', 'buildservice')
+    prepare_request_with_user('hidden_homer', 'opensuse')
     get "/source/#{tprj}/_meta"
     assert :success
     resp = :success
@@ -240,7 +240,7 @@ class ReadPermissionTest < ActionDispatch::IntegrationTest
     delresp = 404
     do_branch_package_test(sprj, spkg, tprj, resp, match, testflag, delresp, debug)
     # maintainer
-    prepare_request_with_user('sourceaccess_homer', 'buildservice')
+    prepare_request_with_user('sourceaccess_homer', 'opensuse')
     tprj = 'home:sourceaccess_homer'
     resp = :success
     match = 'SourceprotectedProject'
@@ -304,7 +304,7 @@ class ReadPermissionTest < ActionDispatch::IntegrationTest
     delresp = 200
     do_test_copy_package(srcprj, srcpkg, destprj, destpkg, resp, flag, delresp)
     # maintainer
-    prepare_request_with_user('hidden_homer', 'buildservice')
+    prepare_request_with_user('hidden_homer', 'opensuse')
     # flag not inherited
     resp = :success
     delresp = :success
@@ -331,7 +331,7 @@ class ReadPermissionTest < ActionDispatch::IntegrationTest
     delresp = 404    # project does not exist, it seems ...
     do_test_copy_package(srcprj, srcpkg, destprj, destpkg, resp, flag, delresp)
     # maintainer
-    prepare_request_with_user('hidden_homer', 'buildservice')
+    prepare_request_with_user('hidden_homer', 'opensuse')
     # flag not inherited - should we inherit in any case to be on the safe side ?
     resp = :success
     delresp = :success
@@ -357,7 +357,7 @@ class ReadPermissionTest < ActionDispatch::IntegrationTest
     delresp = 200
     do_test_copy_package(srcprj, srcpkg, destprj, destpkg, resp, flag, delresp)
     # maintainer
-    prepare_request_with_user('sourceaccess_homer', 'buildservice')
+    prepare_request_with_user('sourceaccess_homer', 'opensuse')
     resp = :success
     delresp = :success
     do_test_copy_package(srcprj, srcpkg, destprj, destpkg, resp, flag, delresp)
@@ -383,7 +383,7 @@ class ReadPermissionTest < ActionDispatch::IntegrationTest
     delresp = 403
     do_test_copy_package(srcprj, srcpkg, destprj, destpkg, resp, flag, delresp)
     # maintainer
-    prepare_request_with_user('sourceaccess_homer', 'buildservice')
+    prepare_request_with_user('sourceaccess_homer', 'opensuse')
     resp = :success
     delresp = :success
     do_test_copy_package(srcprj, srcpkg, destprj, destpkg, resp, flag, delresp)
@@ -784,7 +784,7 @@ class ReadPermissionTest < ActionDispatch::IntegrationTest
   def test_project_paths_to_download_protected_projects
     # NOTE: we documented that binarydownload can be workarounded, it is NO security feature, just convenience.
     # try to access it with a user permitted for binarydownload
-    prepare_request_with_user('binary_homer', 'buildservice')
+    prepare_request_with_user('binary_homer', 'opensuse')
 
     # check if sufficiently protected projects can access protected projects
     put url_for(controller: :source_project_meta, action: :update, project: 'home:binary_homer:ProtectedProject1'),
@@ -854,7 +854,7 @@ class ReadPermissionTest < ActionDispatch::IntegrationTest
     assert_response 404
 
     # check if access protected project has access binarydownload protected project
-    prepare_request_with_user('binary_homer', 'buildservice')
+    prepare_request_with_user('binary_homer', 'opensuse')
     put url_for(controller: :source_project_meta, action: :update, project: 'home:binary_homer:ProtectedProject3'),
         params: '<project name="home:binary_homer:ProtectedProject3"> <title/> <description/> <access><disable/></access> </project>'
     # STDERR.puts(@response.body)

--- a/src/api/test/functional/request_controller_test.rb
+++ b/src/api/test/functional/request_controller_test.rb
@@ -142,7 +142,7 @@ class RequestControllerTest < ActionDispatch::IntegrationTest
   end
 
   def test_submit_request_of_new_package_with_devel_package
-    prepare_request_with_user('Iggy', 'buildservice')
+    prepare_request_with_user('Iggy', 'opensuse')
 
     # we have a devel package definition in source
     get '/source/BaseDistro:Update/pack2/_meta'
@@ -203,7 +203,7 @@ class RequestControllerTest < ActionDispatch::IntegrationTest
   end
 
   def test_submit_with_and_without_revision
-    prepare_request_with_user('Iggy', 'buildservice')
+    prepare_request_with_user('Iggy', 'opensuse')
 
     # we have a devel package definition in source
     get '/source/BaseDistro:Update/pack2/_meta'
@@ -239,7 +239,7 @@ class RequestControllerTest < ActionDispatch::IntegrationTest
   def test_submit_request_of_new_package
     Backend::Test.start(wait_for_scheduler: true)
 
-    prepare_request_with_user('Iggy', 'buildservice')
+    prepare_request_with_user('Iggy', 'opensuse')
     post '/source/home:Iggy/NEW_PACKAGE', params: { cmd: :branch }
     assert_response 404
     assert_xml_tag(tag: 'status', attributes: { code: 'unknown_package' })
@@ -1611,7 +1611,7 @@ class RequestControllerTest < ActionDispatch::IntegrationTest
 
   # osc is still submitting with old style by default
   def test_old_style_submit_request
-    prepare_request_with_user('hidden_homer', 'buildservice')
+    prepare_request_with_user('hidden_homer', 'opensuse')
     post '/request?cmd=create', params: '<request type="submit">
                                    <submit>
                                      <source project="HiddenProject" package="pack" rev="1"/>
@@ -1652,7 +1652,7 @@ class RequestControllerTest < ActionDispatch::IntegrationTest
                                  </request>'
     assert_response 403
 
-    prepare_request_with_user('hidden_homer', 'buildservice')
+    prepare_request_with_user('hidden_homer', 'opensuse')
     post '/request?cmd=create', params: '<request>
                                    <action type="submit">
                                      <source project="HiddenProject" package="pack" rev="1"/>
@@ -1667,7 +1667,7 @@ class RequestControllerTest < ActionDispatch::IntegrationTest
     post "/request/#{id}?cmd=changestate&newstate=revoked"
     assert_response :success
 
-    prepare_request_with_user('sourceaccess_homer', 'buildservice')
+    prepare_request_with_user('sourceaccess_homer', 'opensuse')
     post '/request?cmd=create', params: '<request>
                                    <action type="submit">
                                      <source project="SourceprotectedProject" package="pack" rev="1"/>
@@ -2101,7 +2101,7 @@ class RequestControllerTest < ActionDispatch::IntegrationTest
     post "/request/#{id}?cmd=changestate&newstate=new"
     assert_response 403
     # and reopen it as a non-source-maintainer is not working
-    prepare_request_with_user('fredlibs', 'buildservice')
+    prepare_request_with_user('fredlibs', 'opensuse')
     post "/request/#{id}?cmd=changestate&newstate=new"
     assert_response 403
 
@@ -2139,7 +2139,7 @@ class RequestControllerTest < ActionDispatch::IntegrationTest
     assert_response 403
 
     # and reopen it as a different maintainer from target
-    prepare_request_with_user('fredlibs', 'buildservice')
+    prepare_request_with_user('fredlibs', 'opensuse')
     post "/request/#{id}?cmd=changestate&newstate=new"
     assert_response :success
     get "/request/#{id}"
@@ -3038,7 +3038,7 @@ class RequestControllerTest < ActionDispatch::IntegrationTest
   #
   #
   def test_submit_from_source_protected_project
-    prepare_request_with_user('sourceaccess_homer', 'buildservice')
+    prepare_request_with_user('sourceaccess_homer', 'opensuse')
     post '/request?cmd=create', params: load_backend_file('request/from_source_protected_valid')
     assert_response :success
     assert_xml_tag(tag: 'request')
@@ -3073,7 +3073,7 @@ class RequestControllerTest < ActionDispatch::IntegrationTest
 
   ## create request to hidden package from open place - valid user  - success
   def test_create_request_to_hidden_package_from_open_place_valid_user
-    request_hidden('adrian', 'buildservice', 'request/to_hidden_from_open_valid')
+    request_hidden('adrian', 'opensuse', 'request/to_hidden_from_open_valid')
     assert_response :success
     # assert_xml_tag( :tag => "state", :attributes => { :name => 'new' } )
   end
@@ -3081,7 +3081,7 @@ class RequestControllerTest < ActionDispatch::IntegrationTest
   ## create request to hidden package from open place - invalid user - fail
   # request_controller.rb:178
   def test_create_request_to_hidden_package_from_open_place_invalid_user
-    request_hidden('Iggy', 'buildservice', 'request/to_hidden_from_open_invalid')
+    request_hidden('Iggy', 'opensuse', 'request/to_hidden_from_open_invalid')
     assert_response 404
     assert_xml_tag(tag: 'status', attributes: { code: 'unknown_project' })
   end
@@ -3091,14 +3091,14 @@ class RequestControllerTest < ActionDispatch::IntegrationTest
     login_king
     put '/source/HiddenProject/target/file', params: 'ASD'
     assert_response :success
-    request_hidden('adrian', 'buildservice', 'request/to_hidden_from_hidden_valid')
+    request_hidden('adrian', 'opensuse', 'request/to_hidden_from_hidden_valid')
     assert_response :success
     assert_xml_tag(tag: 'state', attributes: { name: 'new' })
   end
 
   ## create request to hidden package from hidden place - invalid user - fail
   def test_create_request_to_hidden_package_from_hidden_place_invalid_user
-    request_hidden('Iggy', 'buildservice', 'request/to_hidden_from_hidden_invalid')
+    request_hidden('Iggy', 'opensuse', 'request/to_hidden_from_hidden_invalid')
     assert_response 404
     assert_xml_tag(tag: 'status', attributes: { code: 'unknown_project' })
   end
@@ -3106,7 +3106,7 @@ class RequestControllerTest < ActionDispatch::IntegrationTest
   # requests from Hidden to external
   ## create request from hidden package to open place - valid user  - fail ! ?
   def test_create_request_from_hidden_package_to_open_place_valid_user
-    request_hidden('adrian', 'buildservice', 'request/from_hidden_to_open_valid')
+    request_hidden('adrian', 'opensuse', 'request/from_hidden_to_open_valid')
     # FIXME: !!
     # should we really allow this - might be a mistake. qualified procedure could be:
     # sr from hidden to hidden and then make new location visible
@@ -3680,7 +3680,7 @@ class RequestControllerTest < ActionDispatch::IntegrationTest
   end
 
   def test_ordering_of_requests
-    prepare_request_with_user('Iggy', 'buildservice')
+    prepare_request_with_user('Iggy', 'opensuse')
 
     Timecop.freeze(2010, 7, 12)
     post '/request?cmd=create', params: '<request>

--- a/src/api/test/functional/source_controller_test.rb
+++ b/src/api/test/functional/source_controller_test.rb
@@ -203,7 +203,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     assert_xml_tag tag: 'project', attributes: { name: 'SourceprotectedProject' }
     # retry with maintainer
     reset_auth
-    prepare_request_with_user('sourceaccess_homer', 'buildservice')
+    prepare_request_with_user('sourceaccess_homer', 'opensuse')
     get '/source/SourceprotectedProject/_meta'
     assert_response :success
     assert_xml_tag tag: 'project', attributes: { name: 'SourceprotectedProject' }
@@ -246,7 +246,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     assert_response 403
     # retry with maintainer
     reset_auth
-    prepare_request_with_user('sourceaccess_homer', 'buildservice')
+    prepare_request_with_user('sourceaccess_homer', 'opensuse')
     get '/source/SourceprotectedProject/pack'
     assert_response :success
     assert_xml_tag tag: 'directory', child: { tag: 'entry' }
@@ -289,7 +289,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     assert_xml_tag tag: 'package', attributes: { name: 'pack', project: 'SourceprotectedProject' }
     # retry with maintainer
     reset_auth
-    prepare_request_with_user('sourceaccess_homer', 'buildservice')
+    prepare_request_with_user('sourceaccess_homer', 'opensuse')
     get '/source/SourceprotectedProject/pack/_meta'
     assert_response :success
     assert_xml_tag tag: 'package', attributes: { name: 'pack', project: 'SourceprotectedProject' }
@@ -369,7 +369,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
 
   # project_meta does not require auth
   def test_invalid_user
-    prepare_request_with_user('king123', 'buildservice')
+    prepare_request_with_user('king123', 'opensuse')
     get '/source/kde4/_meta'
     assert_response 401
   end
@@ -513,7 +513,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     login_king
     do_change_project_meta_test(prj, resp1, resp2, aresp, match)
     # maintainer
-    prepare_request_with_user('hidden_homer', 'buildservice')
+    prepare_request_with_user('hidden_homer', 'opensuse')
     do_change_project_meta_test(prj, resp1, resp2, aresp, match)
     # FIXME: maintainer via group
   end
@@ -539,7 +539,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     login_king
     do_change_project_meta_test(prj, resp1, resp2, aresp, match)
     # maintainer
-    prepare_request_with_user('sourceaccess_homer', 'buildservice')
+    prepare_request_with_user('sourceaccess_homer', 'opensuse')
     do_change_project_meta_test(prj, resp1, resp2, aresp, match)
   end
 
@@ -679,7 +679,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     assert_select 'project[name=kde5]'
     assert_select 'person[userid=king][role=maintainer]', {}, 'Creator was not added as project maintainer'
 
-    prepare_request_with_user('maintenance_coord', 'buildservice')
+    prepare_request_with_user('maintenance_coord', 'opensuse')
     delete '/source/kde5'
     assert_response 403
     login_fred
@@ -998,7 +998,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     # maintainer via user
     login_fred
     do_change_package_meta_test(prj, pkg, resp1, resp2, aresp, match)
-    prepare_request_with_user('fredlibs', 'buildservice')
+    prepare_request_with_user('fredlibs', 'opensuse')
     do_change_package_meta_test(prj, pkg, resp1, resp2, aresp, match)
     # maintainer via group
     login_adrian
@@ -1029,7 +1029,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     login_king
     do_change_package_meta_test(prj, pkg, resp1, resp2, aresp, match)
     # maintainer
-    prepare_request_with_user('hidden_homer', 'buildservice')
+    prepare_request_with_user('hidden_homer', 'opensuse')
     do_change_package_meta_test(prj, pkg, resp1, resp2, aresp, match)
   end
 
@@ -1051,7 +1051,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     login_king
     do_change_package_meta_test(prj, pkg, resp1, resp2, aresp, match)
     # maintainer
-    prepare_request_with_user('sourceaccess_homer', 'buildservice')
+    prepare_request_with_user('sourceaccess_homer', 'opensuse')
     do_change_package_meta_test(prj, pkg, resp1, resp2, aresp, match)
   end
 
@@ -1423,12 +1423,12 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     atag2 = { tag: 'status', attributes: { code: 'ok' } }
     resp3 = :success
     asel3 = 'package > build > enable'
-    prepare_request_with_user('sourceaccess_homer', 'buildservice')
+    prepare_request_with_user('sourceaccess_homer', 'opensuse')
     do_test_change_package_meta(prj, pkg, resp1, resp2, atag2, resp3, asel3)
   end
 
   def test_put_invalid_package_meta
-    prepare_request_with_user('fredlibs', 'buildservice')
+    prepare_request_with_user('fredlibs', 'opensuse')
     # Get meta file
     get url_for(controller: :source_project_package_meta, action: :show, project: 'kde4', package: 'kdelibs')
     assert_response :success
@@ -1470,7 +1470,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
 
   def test_read_file_hidden_proj
     # nobody
-    prepare_request_with_user('adrian_nobody', 'buildservice')
+    prepare_request_with_user('adrian_nobody', 'opensuse')
     get '/source/HiddenProject/pack/my_file'
 
     assert_response 404
@@ -1483,7 +1483,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     # reader
     # downloader
     # maintainer
-    prepare_request_with_user('hidden_homer', 'buildservice')
+    prepare_request_with_user('hidden_homer', 'opensuse')
     get '/source/HiddenProject/pack/my_file'
     assert_response :success
     assert_equal(@response.body.to_s, 'Protected Content')
@@ -1496,7 +1496,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
 
   def test_read_filelist_sourceaccess_proj
     # nobody
-    prepare_request_with_user('adrian_nobody', 'buildservice')
+    prepare_request_with_user('adrian_nobody', 'opensuse')
     get '/source/SourceprotectedProject/pack'
     assert_response 403
     assert_xml_tag tag: 'status', attributes: { code: 'source_access_no_permission' }
@@ -1508,7 +1508,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     # reader
     # downloader
     # maintainer
-    prepare_request_with_user('sourceaccess_homer', 'buildservice')
+    prepare_request_with_user('sourceaccess_homer', 'opensuse')
     get '/source/SourceprotectedProject/pack'
     assert_response :success
     assert_xml_tag tag: 'directory'
@@ -1529,7 +1529,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     assert_response 401
     assert_xml_tag tag: 'status', attributes: { code: 'anonymous_user' }
     # nobody
-    prepare_request_with_user('adrian_nobody', 'buildservice')
+    prepare_request_with_user('adrian_nobody', 'opensuse')
     get '/source/SourceprotectedProject/pack/my_file'
     assert_response 403
     assert_xml_tag tag: 'status', attributes: { code: 'source_access_no_permission' }
@@ -1541,7 +1541,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     # reader
     # downloader
     # maintainer
-    prepare_request_with_user('sourceaccess_homer', 'buildservice')
+    prepare_request_with_user('sourceaccess_homer', 'opensuse')
     get '/source/SourceprotectedProject/pack/my_file'
     assert_response :success
     assert_equal(@response.body.to_s, 'Protected Content')
@@ -1579,7 +1579,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
 
   def test_add_file_to_package_hidden
     # uninvolved user
-    prepare_request_with_user('fredlibs', 'buildservice')
+    prepare_request_with_user('fredlibs', 'opensuse')
     url1 = '/source/HiddenProject/pack'
     asserttag1 = { tag: 'status', attributes: { code: 'unknown_project' } }
     url2 = '/source/HiddenProject/pack/testfile'
@@ -1593,12 +1593,12 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
                         assertselect2, assertselect2rev,
                         assertresp3, asserteq3, assertresp4)
     # nobody
-    prepare_request_with_user('adrian_nobody', 'buildservice')
+    prepare_request_with_user('adrian_nobody', 'opensuse')
     add_file_to_package(url1, asserttag1, url2, assertresp2,
                         assertselect2, assertselect2rev,
                         assertresp3, asserteq3, assertresp4)
     # maintainer
-    prepare_request_with_user('hidden_homer', 'buildservice')
+    prepare_request_with_user('hidden_homer', 'opensuse')
     asserttag1 = { tag: 'directory', attributes: { srcmd5: 'b47be8b05a188d62b40c9d65cf490618' } }
     assertresp2 = :success
     assertselect2 = 'revision > srcmd5'
@@ -1618,7 +1618,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
 
   def test_add_file_to_package_sourceaccess_protect
     # uninvolved user
-    prepare_request_with_user('fredlibs', 'buildservice')
+    prepare_request_with_user('fredlibs', 'opensuse')
     url1 = '/source/SourceprotectedProject/pack'
     url2 = '/source/SourceprotectedProject/pack/testfile'
     assertresp2 = 403
@@ -1631,12 +1631,12 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
                         assertselect2, assertselect2rev,
                         assertresp3, asserteq3, assertresp4)
     # nobody
-    prepare_request_with_user('adrian_nobody', 'buildservice')
+    prepare_request_with_user('adrian_nobody', 'opensuse')
     add_file_to_package(url1, nil, url2, assertresp2,
                         assertselect2, assertselect2rev,
                         assertresp3, asserteq3, assertresp4)
     # maintainer
-    prepare_request_with_user('sourceaccess_homer', 'buildservice')
+    prepare_request_with_user('sourceaccess_homer', 'opensuse')
     asserttag1 = { tag: 'directory', attributes: { srcmd5: 'b47be8b05a188d62b40c9d65cf490618' } }
     assertresp2 = :success
     assertselect2 = 'revision > srcmd5'
@@ -1664,7 +1664,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     assertresp3 = :success
     asserteq3 = true
     assertresp4 = :success
-    prepare_request_with_user('fredlibs', 'buildservice')
+    prepare_request_with_user('fredlibs', 'opensuse')
     add_file_to_package(url1, asserttag1, url2, assertresp2,
                         assertselect2, assertselect2rev,
                         assertresp3, asserteq3, assertresp4)
@@ -1696,7 +1696,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     delete '/source/kde4/kdelibs/my_patch.diff'
     assert_response 401
 
-    prepare_request_with_user('adrian_nobody', 'buildservice')
+    prepare_request_with_user('adrian_nobody', 'opensuse')
     delete '/source/kde4/kdelibs/my_patch.diff'
     assert_response 403
 
@@ -1710,7 +1710,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
   def test_get_package_meta_history
     get '/source/kde4/kdelibs/_history'
     assert_response 401
-    prepare_request_with_user('fredlibs', 'buildservice')
+    prepare_request_with_user('fredlibs', 'opensuse')
     get '/source/kde4/kdelibs/_history'
     assert_response :success
     assert_xml_tag(tag: 'revisionlist')
@@ -1731,7 +1731,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
   def test_get_project_meta_history
     get '/source/kde4/_project/_history'
     assert_response 401
-    prepare_request_with_user('fredlibs', 'buildservice')
+    prepare_request_with_user('fredlibs', 'opensuse')
     get '/source/kde4/_project/_history'
     assert_response :success
     assert_xml_tag(tag: 'revisionlist')
@@ -1778,7 +1778,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
   def test_get_package_meta_file
     get '/source/kde4/kdelibs/_history'
     assert_response 401
-    prepare_request_with_user('fredlibs', 'buildservice')
+    prepare_request_with_user('fredlibs', 'opensuse')
     get '/source/kde4/kdelibs/_meta?meta=1'
     assert_response :success
     assert_xml_tag(tag: 'package')
@@ -1809,7 +1809,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
   end
 
   def test_invalid_package_command
-    prepare_request_with_user('fredlibs', 'buildservice')
+    prepare_request_with_user('fredlibs', 'opensuse')
     post '/source/kde4/kdelibs'
     assert_response 400
     assert_xml_tag(tag: 'status', attributes: { code: 'missing_parameter' })
@@ -1818,7 +1818,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     assert_xml_tag tag: 'status', attributes: { code: 'illegal_request' }
     assert_xml_tag tag: 'summary', content: 'invalid_command'
 
-    prepare_request_with_user('adrian_nobody', 'buildservice')
+    prepare_request_with_user('adrian_nobody', 'opensuse')
     post '/source/kde4/kdelibs'
     assert_response 400
     assert_xml_tag(tag: 'status', attributes: { code: 'missing_parameter' })
@@ -1829,7 +1829,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
   end
 
   def test_blame_view
-    prepare_request_with_user('fredlibs', 'buildservice')
+    prepare_request_with_user('fredlibs', 'opensuse')
     raw_put '/source/kde4/BLAME/_meta', '<package name="BLAME" project="kde4"><title/><description/></package>'
     assert_response :success
 
@@ -1879,7 +1879,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     assert_response 401
 
     # delete single package in project
-    prepare_request_with_user('fredlibs', 'buildservice')
+    prepare_request_with_user('fredlibs', 'opensuse')
     put '/source/kde4/kdelibs/DUMMYFILE', params: 'dummy'
     assert_response :success
     # to have different revision number in meta and plain files
@@ -1935,7 +1935,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
 
     # admin only operations
-    prepare_request_with_user('fredlibs', 'buildservice')
+    prepare_request_with_user('fredlibs', 'opensuse')
     delete '/source/kde4/kdelibs'
     assert_response :success
     login_king
@@ -1950,7 +1950,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     assert_xml_tag(tag: 'time', content: mytime)
 
     # delete entire project
-    prepare_request_with_user('fredlibs', 'buildservice')
+    prepare_request_with_user('fredlibs', 'opensuse')
     get '/source/kde4/_meta'
     assert_response :success
     meta_before_delete = @response.body
@@ -1983,7 +1983,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     assert_response 200
     assert_xml_tag(tag: 'entry', attributes: { name: 'kde4' })
 
-    prepare_request_with_user('fredlibs', 'buildservice')
+    prepare_request_with_user('fredlibs', 'opensuse')
     get '/source', params: { deleted: 1 }
     assert_response 403
     assert_match(/only admins can see deleted projects/, @response.body)
@@ -2002,7 +2002,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     revision = node.elements('revision').last['rev']
     assert_equal expected_revision, revision.to_i
 
-    prepare_request_with_user('fredlibs', 'buildservice')
+    prepare_request_with_user('fredlibs', 'opensuse')
     # undelete project
     post '/source/kde4', params: { cmd: :undelete }
     assert_response 403
@@ -2087,7 +2087,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     assert_response 404
     assert_xml_tag tag: 'status', attributes: { code: 'unknown_project' } # was package
 
-    prepare_request_with_user('hidden_homer', 'buildservice')
+    prepare_request_with_user('hidden_homer', 'opensuse')
     post '/source/HiddenProject/pack?oproject=kde4&opackage=kdelibs&cmd=diff'
     assert_response :success
     assert_match(/Minimal rpm package for testing the build controller/, @response.body)
@@ -2117,7 +2117,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     assert_response 403
     assert_xml_tag tag: 'status', attributes: { code: 'source_access_no_permission' }
 
-    prepare_request_with_user('sourceaccess_homer', 'buildservice')
+    prepare_request_with_user('sourceaccess_homer', 'opensuse')
     post '/source/SourceprotectedProject/pack?oproject=kde4&opackage=kdelibs&cmd=diff'
     assert_response :success
     assert_match(/Protected Content/, @response.body)
@@ -2162,7 +2162,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     put '/source/kde4/_pattern/mypattern', params: load_backend_file('pattern/digiKam.xml')
     assert_response 401
 
-    prepare_request_with_user('adrian_nobody', 'buildservice')
+    prepare_request_with_user('adrian_nobody', 'opensuse')
     get '/source/DoesNotExist/_pattern'
     assert_response 404
     get '/source/kde4/_pattern'
@@ -2193,7 +2193,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     assert_response 400
 
     # delete failure
-    prepare_request_with_user('adrian_nobody', 'buildservice')
+    prepare_request_with_user('adrian_nobody', 'opensuse')
     delete '/source/home:coolo:test/_pattern/mypattern'
     assert_response 403
 
@@ -2212,7 +2212,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
   def test_prjconf
     get url_for(controller: :source_project_config, action: :show, project: 'DoesNotExist')
     assert_response 401
-    prepare_request_with_user('adrian_nobody', 'buildservice')
+    prepare_request_with_user('adrian_nobody', 'opensuse')
     get url_for(controller: :source_project_config, action: :show, project: 'DoesNotExist')
     assert_response 404
     get url_for(controller: :source_project_config, action: :show, project: 'kde4')
@@ -2223,7 +2223,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     put url_for(controller: :source_project_config, action: :update, project: 'RemoteInstance:BaseDistro'), params: 'Substitute: nix da'
     assert_response 403
 
-    prepare_request_with_user('adrian_nobody', 'buildservice')
+    prepare_request_with_user('adrian_nobody', 'opensuse')
     put url_for(controller: :source_project_config, action: :update, project: 'kde4'), params: 'Substitute: nix da'
     assert_response 403
 
@@ -3614,7 +3614,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     assert_response 401
     assert_xml_tag tag: 'status', attributes: { code: 'authentication_required' }
 
-    prepare_request_with_user('fredlibs', 'buildservice')
+    prepare_request_with_user('fredlibs', 'opensuse')
     # ensure he has no home project
     get '/source/home:fredlibs'
     assert_response 404
@@ -3632,7 +3632,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     put '/source/home:fredlibs/_meta', params: "<project name='home:fredlibs'><title/><description/> <person role='maintainer' userid='fredlibs'/> </project>"
     assert_response :success
 
-    prepare_request_with_user('fredlibs', 'buildservice')
+    prepare_request_with_user('fredlibs', 'opensuse')
     post '/source/home:Iggy/TestPack', params: { cmd: :branch }
     assert_response :success
 
@@ -3678,7 +3678,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     post '/source/home:Iggy/TestPack', params: { cmd: :branch, target_project: 'home:coolo:test' }
     assert_response 401
     assert_xml_tag tag: 'status', attributes: { code: 'authentication_required' }
-    prepare_request_with_user('fredlibs', 'buildservice')
+    prepare_request_with_user('fredlibs', 'opensuse')
     post '/source/home:Iggy/TestPack', params: { cmd: :branch, target_project: 'NotExisting' }
     assert_response 403
     assert_match(/no permission to create project/, @response.body)

--- a/src/api/test/functional/statistics_controller_test.rb
+++ b/src/api/test/functional/statistics_controller_test.rb
@@ -170,7 +170,7 @@ class StatisticsControllerTest < ActionDispatch::IntegrationTest
     assert_no_xml_tag tag: 'project', attributes: { name: 'HiddenProject' }
 
     # redo as user, seeing the hidden project
-    prepare_request_with_user('hidden_homer', 'buildservice')
+    prepare_request_with_user('hidden_homer', 'opensuse')
     # get most active packages
     get url_for(controller: :statistics, action: :most_active_packages, limit: 0)
     assert_response :success

--- a/src/api/test/test_helper.rb
+++ b/src/api/test/test_helper.rb
@@ -276,7 +276,7 @@ module ActionDispatch
 
     # will provide a user without special permissions
     def prepare_request_valid_user
-      prepare_request_with_user('tom', 'buildservice')
+      prepare_request_with_user('tom', 'opensuse')
     end
 
     def prepare_request_invalid_user
@@ -320,27 +320,27 @@ module ActionDispatch
     end
 
     def login_Iggy
-      prepare_request_with_user('Iggy', 'buildservice')
+      prepare_request_with_user('Iggy', 'opensuse')
     end
 
     def login_adrian
-      prepare_request_with_user('adrian', 'buildservice')
+      prepare_request_with_user('adrian', 'opensuse')
     end
 
     def login_adrian_downloader
-      prepare_request_with_user('adrian_downloader', 'buildservice')
+      prepare_request_with_user('adrian_downloader', 'opensuse')
     end
 
     def login_fred
-      prepare_request_with_user('fred', 'buildservice')
+      prepare_request_with_user('fred', 'opensuse')
     end
 
     def login_tom
-      prepare_request_with_user('tom', 'buildservice')
+      prepare_request_with_user('tom', 'opensuse')
     end
 
     def login_dmayr
-      prepare_request_with_user('dmayr', 'buildservice')
+      prepare_request_with_user('dmayr', 'opensuse')
     end
   end
 end


### PR DESCRIPTION
Just like we do for the Admin user. This is convenient when testing things in the development environment.