### PR TITLE
resourceful routes for watched items

### DIFF
--- a/src/api/app/components/watchlist_component.rb
+++ b/src/api/app/components/watchlist_component.rb
@@ -36,11 +36,11 @@ class WatchlistComponent < ApplicationComponent
   def toggle_watchable_path
     case @object_to_be_watched
     when Package
-      toggle_package_watched_items_path(project: @object_to_be_watched.project.name, package: @object_to_be_watched.name)
+      project_package_toggle_watched_item_path(project_name: @object_to_be_watched.project.name, package_name: @object_to_be_watched.name)
     when Project
-      toggle_project_watched_items_path(project: @object_to_be_watched.name)
+      project_toggle_watched_item_path(project_name: @object_to_be_watched.name)
     when BsRequest
-      toggle_request_watched_items_path(number: @object_to_be_watched.number)
+      toggle_watched_item_request_path(number: @object_to_be_watched.number)
     end
   end
 

--- a/src/api/app/controllers/webui/watched_items_controller.rb
+++ b/src/api/app/controllers/webui/watched_items_controller.rb
@@ -9,7 +9,7 @@ class Webui::WatchedItemsController < Webui::WebuiController
     BsRequest => 'request'
   }.freeze
 
-  def toggle
+  def toggle_watched_item
     watched_item = User.session!.watched_items.find_by(watchable: @item)
 
     if watched_item
@@ -26,10 +26,10 @@ class Webui::WatchedItemsController < Webui::WebuiController
   private
 
   def set_item
-    @item = if params[:package]
-              Package.find_by_project_and_name(params[:project], params[:package])
-            elsif params[:project]
-              Project.find_by(name: params[:project])
+    @item = if params[:project_name] && params[:package_name]
+              Package.find_by_project_and_name(params[:project_name], params[:package_name])
+            elsif params[:project_name]
+              Project.find_by(name: params[:project_name])
             elsif params[:number]
               BsRequest.find_by(number: params[:number])
             end

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -272,6 +272,7 @@ OBSApi::Application.routes.draw do
         resources :devel_project_changes, controller: 'webui/requests/devel_project_changes', only: [:new, :create], constraints: cons
         resources :submissions, controller: 'webui/requests/submissions', only: [:new, :create], constraints: cons
         resource :files, controller: 'webui/packages/files', only: [:new, :create], constraints: cons
+        put 'toggle_watched_item', controller: 'webui/watched_items', constraints: cons
       end
 
       resources :role_additions, controller: 'webui/requests/role_additions', only: [:new, :create], constraints: cons
@@ -281,6 +282,7 @@ OBSApi::Application.routes.draw do
           post :toggle
         end
       end
+      put 'toggle_watched_item', controller: 'webui/watched_items', constraints: cons
     end
 
     controller 'webui/request' do
@@ -293,6 +295,12 @@ OBSApi::Application.routes.draw do
       get 'request/list_small' => :list_small, as: 'request_list_small'
       post 'request/set_bugowner_request' => :set_bugowner_request
       get 'request/:number/request_action/:id' => :request_action, as: 'request_action'
+    end
+
+    resources :requests, only: [], param: :number, controller: 'webui/bs_requests' do
+      member do
+        put :toggle_watched_item, controller: 'webui/watched_items'
+      end
     end
 
     controller 'webui/search' do
@@ -340,12 +348,6 @@ OBSApi::Application.routes.draw do
         resources :workflow_runs, only: [:index, :show], controller: 'webui/workflow_runs'
       end
       resources :token_triggers, only: [:show, :update], controller: 'webui/users/token_triggers'
-
-      resource :watched_items, controller: 'webui/watched_items', only: [:toggle], constraints: cons do
-        put '/package/:project/:package/toggle' => :toggle, as: :toggle_package
-        put '/project/:project/toggle' => :toggle, as: :toggle_project
-        put '/request/:number/toggle' => :toggle, as: :toggle_request
-      end
     end
 
     get 'home', to: 'webui/webui#home', as: :home

--- a/src/api/spec/controllers/webui/watched_items_controller_spec.rb
+++ b/src/api/spec/controllers/webui/watched_items_controller_spec.rb
@@ -1,39 +1,52 @@
 require 'rails_helper'
 
 RSpec.describe Webui::WatchedItemsController, type: :controller do
-  describe '#toggle' do
+  describe '#toggle_watched_item' do
     context 'when the user belongs to the beta group' do
       before do
         Flipper.enable(:new_watchlist, user)
       end
 
-      context 'when the watched item is not already watched' do
+      context 'when the package is not already watched' do
         let(:user) { create(:confirmed_user) }
         let(:package) { create(:package) }
 
         before do
           login user
-          put :toggle, params: { package: package, project: package.project }
+          put :toggle_watched_item, params: { package_name: package, project_name: package.project }
         end
 
-        it 'adds the watched item to the watchlist' do
-          expect(user.watched_items.map(&:watchable)).to include(package)
+        it 'adds the package to the watchlist' do
+          expect(user.watched_items).to exist(watchable: package)
         end
       end
 
-      context 'when the watched item is already watched' do
+      context 'when the request is not already watched' do
+        let(:user) { create(:confirmed_user) }
+        let(:bs_request) { create(:bs_request_with_submit_action) }
+
+        before do
+          login user
+          put :toggle_watched_item, params: { number: bs_request.number }
+        end
+
+        it 'adds the request to the watchlist' do
+          expect(user.watched_items).to exist(watchable: bs_request)
+        end
+      end
+
+      context 'when the item is already watched' do
         let(:user) { create(:confirmed_user) }
         let(:package) { create(:package) }
 
         before do
           login user
           user.watched_items.create(watchable: package)
-
-          put :toggle, params: { package: package, project: package.project }
+          put :toggle_watched_item, params: { package_name: package, project_name: package.project }
         end
 
-        it 'removes the watched item from the watchlist' do
-          expect(user.reload.watched_items.map(&:watchable)).to be_empty
+        it 'removes the item from the watchlist' do
+          expect(user.watched_items).not_to exist(watchable: package)
         end
       end
     end
@@ -43,13 +56,13 @@ RSpec.describe Webui::WatchedItemsController, type: :controller do
         Flipper.disable(:new_watchlist, user)
       end
 
-      context 'when the watched item is not already watched' do
+      context 'when the item is not already watched' do
         let(:user) { create(:confirmed_user) }
         let(:package) { create(:package) }
 
         before { login user }
 
-        subject { put :toggle, params: { package: package, project: package.project } }
+        subject { put :toggle_watched_item, params: { package_name: package, project_name: package.project } }
 
         it 'raises an exception' do
           expect { subject }.to raise_error(NotFoundError)


### PR DESCRIPTION
Right now we use custom routes for creating/deleting watched items. Following Rails conventions for routing, we should update the custom routes for watched items toggle to resourceful routes.

We can't use `member` for some of these new routes because we have `param: :name` for both projects and package nested routes and it's not possible to distinguish if the name is for `project` or `package`. 

The [last paragraph of this article](https://guides.rubyonrails.org/v6.1/routing.html#adding-member-routes) describes that we can ommit `member` to obtain the same result but using the param names we need.