### PR TITLE
Show link to add a package to the watchlist for multibuild packages

### DIFF
--- a/src/api/app/components/watchlist_component.rb
+++ b/src/api/app/components/watchlist_component.rb
@@ -15,7 +15,7 @@ class WatchlistComponent < ApplicationComponent
     super
 
     @user = user
-    # NOTE: the order of the array is important, when project and packge are both present we ensure it takes package.
+    # NOTE: the order of the array is important, when project and package are both present we ensure it takes package.
     @object_to_be_watched = [bs_request, package, project].compact.first
   end
 

--- a/src/api/app/mixins/build_log_support.rb
+++ b/src/api/app/mixins/build_log_support.rb
@@ -1,11 +1,11 @@
 module BuildLogSupport
-  def raw_log_chunk(project, package, repo, arch, start, theend)
+  def raw_log_chunk(project, package_name, repo, arch, start, theend)
     logger.debug "get log chunk #{start}-#{theend}"
-    Backend::Api::BuildResults::Status.log_chunk(project.to_s, package.to_s, repo, arch, start, theend)
+    Backend::Api::BuildResults::Status.log_chunk(project.to_s, package_name, repo, arch, start, theend)
   end
 
-  def get_log_chunk(project, package, repo, arch, start, theend)
-    log = raw_log_chunk(project, package, repo, arch, start, theend)
+  def get_log_chunk(project, package_name, repo, arch, start, theend)
+    log = raw_log_chunk(project, package_name, repo, arch, start, theend)
     log.encode!(invalid: :replace, undef: :replace, cr_newline: true)
     log.gsub(%r{([^a-zA-Z0-9&;<>/\n\r \t()])}) do |c|
       if c.ord < 32
@@ -18,9 +18,9 @@ module BuildLogSupport
     end
   end
 
-  def get_size_of_log(project, package, repo, arch)
+  def get_size_of_log(project, package_name, repo, arch)
     logger.debug 'get log entry'
-    data = Backend::Api::BuildResults::Status.build_log_size(project.to_s, package.to_s, repo, arch)
+    data = Backend::Api::BuildResults::Status.build_log_size(project.to_s, package_name, repo, arch)
     return 0 unless data
 
     doc = Xmlhash.parse(data)
@@ -30,12 +30,12 @@ module BuildLogSupport
     0
   end
 
-  def get_job_status(project, package, repo, arch)
-    Backend::Api::BuildResults::Status.job_status(project.to_s, package.to_s, repo, arch)
+  def get_job_status(project, package_name, repo, arch)
+    Backend::Api::BuildResults::Status.job_status(project.to_s, package_name, repo, arch)
   end
 
-  def get_status(project, package, repo, arch)
-    data = Backend::Api::BuildResults::Status.build_result(project.to_s, package.to_s, repo, arch)
+  def get_status(project, package_name, repo, arch)
+    data = Backend::Api::BuildResults::Status.build_result(project.to_s, package_name, repo, arch)
     return '' unless data
 
     doc = Xmlhash.parse(data)

--- a/src/api/app/views/webui/package/_live_build_log_controls.html.haml
+++ b/src/api/app/views/webui/package/_live_build_log_controls.html.haml
@@ -7,26 +7,26 @@
     Stop refresh
 
   - if User.session
-    = link_to(raw_logfile_path(package: @package, project: @project, arch: @arch, repository: @repo),
+    = link_to(raw_logfile_path(package: @package_name, project: @project, arch: @arch, repository: @repo),
               target: :_blank,
               rel: 'noopener',
               class: 'live-link-action btn-secondary') do
       %i.fas.fa-download
       Download logfile
   - else
-    = link_to(public_build_path(package: @package, project: @project, arch: @arch, repository: @repo, filename: '_log'),
+    = link_to(public_build_path(package: @package_name, project: @project, arch: @arch, repository: @repo, filename: '_log'),
               target: :_blank,
               rel: 'noopener',
               class: 'live-link-action btn-secondary') do
       %i.fas.fa-download
       Download logfile
   - if @can_modify
-    = link_to(package_trigger_rebuild_path(project: @project, package: @package, arch: @arch, repository: @repo),
+    = link_to(package_trigger_rebuild_path(project: @project, package: @package_name, arch: @arch, repository: @repo),
               class: 'link_trigger_rebuild live-link-action btn-warning d-none',
               method: :post) do
       %i.fas.fa-redo
       Trigger Rebuild
-    = link_to(package_abort_build_path(project: @project, package: @package, arch: @arch, repository: @repo),
+    = link_to(package_abort_build_path(project: @project, package: @package_name, arch: @arch, repository: @repo),
               class: 'link_abort_build live-link-action btn-danger d-none') do
       %i.far.fa-times-circle
       Abort Build

--- a/src/api/app/views/webui/package/live_build_log.html.haml
+++ b/src/api/app/views/webui/package/live_build_log.html.haml
@@ -1,9 +1,8 @@
-- @pagetitle = "Build Log for Package #{@package} (Project #{@project})"
+- @pagetitle = "Build Log for Package #{@package_name} (Project #{@project})"
 - @metarobots = 'noindex,nofollow'
 
 .card.mb-3
-  - if @package.is_a?(Package)
-    = render partial: 'tabs', locals: { project: @project, package: @package }
+  = render partial: 'tabs', locals: { project: @project, package: @package }
   .card-body
     %h3= @pagetitle
     %p
@@ -22,7 +21,7 @@
         %strong Packages:
         = @what_depends_on.join(', ')
     = render partial: 'live_build_log_controls'
-    #log-space-wrapper{ data: { url: package_update_build_log_path(package: @package, project: @project,
+    #log-space-wrapper{ data: { url: package_update_build_log_path(package: @package_name, project: @project,
                                                                    status: @status, arch: @arch, repository: @repo) } }
       .d-block.text-center.shadow-sm.position-sticky.w-100#log-info
         .running.stop_refresh.py-2.alert-info

--- a/src/api/spec/cassettes/Webui_PackageController/build_logs/GET_update_build_log/for_multibuild_package/1_10_2_4_5.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/build_logs/GET_update_build_log/for_multibuild_package/1_10_2_4_5.yml
@@ -1,0 +1,115 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '128'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer"/>
+        </project>
+  recorded_at: Wed, 23 Feb 2022 18:19:59 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/my_package/_meta?user=user_2
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="my_package" project="home:tom">
+          <title>Have His Carcase</title>
+          <description>Quaerat incidunt eum maiores.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '151'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="my_package" project="home:tom">
+          <title>Have His Carcase</title>
+          <description>Quaerat incidunt eum maiores.</description>
+        </package>
+  recorded_at: Wed, 23 Feb 2022 18:19:59 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:tom/_result?arch=i586&package=my_package:multibuild-package&repository=leap_42.2&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: unknown repository 'leap_42.2'
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '138'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>unknown repository 'leap_42.2'</summary>
+          <details>404 unknown repository 'leap_42.2'</details>
+        </status>
+  recorded_at: Wed, 23 Feb 2022 18:19:59 GMT
+recorded_with: VCR 6.0.0

--- a/src/api/spec/controllers/webui/package_controller_spec.rb
+++ b/src/api/spec/controllers/webui/package_controller_spec.rb
@@ -784,6 +784,8 @@ RSpec.describe Webui::PackageController, vcr: true do
         it { expect(assigns(:status)).to eq('succeeded') }
         it { expect(assigns(:workerid)).to eq('42') }
         it { expect(assigns(:buildtime)).to eq(1.hour.to_i) }
+        it { expect(assigns(:package)).to eq(source_package) }
+        it { expect(assigns(:package_name)).to eq("#{source_package}:multibuild-package") }
       end
     end
 
@@ -828,7 +830,8 @@ RSpec.describe Webui::PackageController, vcr: true do
         end
 
         it { expect(assigns(:log_chunk)).not_to be_nil }
-        it { expect(assigns(:package)).to eq("#{source_package}:multibuild-package") }
+        it { expect(assigns(:package)).to eq(source_package) }
+        it { expect(assigns(:package_name)).to eq("#{source_package}:multibuild-package") }
         it { expect(assigns(:project)).to eq(source_project) }
         it { expect(assigns(:offset)).to eq(0) }
       end


### PR DESCRIPTION
With the new watchlist implementation, an error was thrown when browsing the live build log for a multibuild package. The guilty was `@package` returning a string instead of an object.

This PR includes the following changes:
- In case of a multibuild package: `@package` used to be a string, now `@package` contains an object.
- `@package_name` is introduced and contains the package string.
- The retrieval of build logs of remote projects was not supported. This code was removed. This means that `@package` is no longer nil.
- Thanks to the previous changes, checking for the permissions is more straight forward, as `@package` is no longer nil.

These changes imply some improvements in the UI for the live build log page for a multibuild package.

**Before:**
- The tabs where not shown
- The breadcrums contained a link to a package with the multibuild flavor. This always redirected to the base package (the package without the flavor).

![Screenshot from 2022-02-25 09-41-49](https://user-images.githubusercontent.com/24919/155686841-4e406b6a-0527-4ea9-8eba-5a8fd1a12668.png)


**Now:**
- The tabs are shown.
- The breadcrums contains a link the the base package.

![Screenshot from 2022-02-25 09-42-10](https://user-images.githubusercontent.com/24919/155686864-40807965-3893-41c8-a3bc-f51dc42fc768.png)

Fixes #12242 .

Co-authored-by: Saray Cabrera Padrón <scabrerapadron@suse.de>

**TODO:**
- [x] Add tests.