### PR TITLE
Avoid database queries in view components

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -163,6 +163,8 @@ group :test do
   gem 'rspec_junit_formatter'
   # to test rabbitmq support
   gem 'bunny-mock'
+  # RSpec matchers to check how many database queries were made by ActiveRecord
+  gem 'db-query-matchers'
 end
 
 group :development, :test do

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -140,6 +140,9 @@ GEM
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0.0)
     database_cleaner-core (2.0.1)
+    db-query-matchers (0.11.0)
+      activesupport (>= 4.0, < 7.1)
+      rspec (>= 3.0)
     deep_cloneable (3.2.0)
       activerecord (>= 3.1.0, < 8)
     delayed_job (4.1.10)
@@ -559,6 +562,7 @@ DEPENDENCIES
   dalli
   data_migrate
   database_cleaner-active_record
+  db-query-matchers
   deep_cloneable
   delayed_job_active_record
   down

--- a/src/api/config/initializers/db_query_matchers.rb
+++ b/src/api/config/initializers/db_query_matchers.rb
@@ -1,0 +1,15 @@
+DBQueryMatchers.configure do |config|
+  config.ignores = [
+    # Executed multiple times when fetching something in the configuration
+    /^SELECT `configurations`.* FROM `configurations`/,
+    # Executed by the schema cache
+    /^SHOW FULL FIELDS FROM/,
+    # TODO: Explain this
+    /^SELECT column_name\nFROM information_schema.statistics/,
+    # Executed when there is a transaction
+    /^SAVEPOINT active_record/,
+    # Executed when there is a transaction
+    /^RELEASE SAVEPOINT active_record/
+  ]
+  config.ignore_cached = true
+end

--- a/src/api/spec/support/view_component.rb
+++ b/src/api/spec/support/view_component.rb
@@ -2,7 +2,18 @@ require 'view_component/test_helpers'
 # To write view component specs with Capybara matchers
 require 'capybara/rspec'
 
+# For context, see https://github.com/github/view_component/issues/1288
+module ViewComponentTestHelpersRenderInline
+  include ViewComponent::TestHelpers
+
+  def render_inline(component, allowed_queries: 0)
+    expect { super(component) }.to make_database_queries(count: allowed_queries)
+
+    rendered_component # from ViewComponent::TestHelpers
+  end
+end
+
 RSpec.configure do |config|
-  config.include ViewComponent::TestHelpers, type: :component
+  config.include ViewComponentTestHelpersRenderInline, type: :component
   config.include Capybara::RSpecMatchers, type: :component
 end


### PR DESCRIPTION
This will help us in having better view components which only handle view code, not fetching data from the database. It also enforces what we wrote in our [developer documentation on view components](https://github.com/openSUSE/open-build-service/wiki/View-Components#avoid-database-queries).