### PR TITLE
Fix flickering spec in features/webui/projects_spec.rb

### DIFF
--- a/src/api/spec/features/webui/projects_spec.rb
+++ b/src/api/spec/features/webui/projects_spec.rb
@@ -172,7 +172,6 @@ RSpec.describe 'Projects', type: :feature, js: true do
   describe 'maintenance incidents', vcr: true do
     let(:maintenance_project) { create(:maintenance_project, name: "#{project.name}:maintenance_project") }
     let(:target_repository) { create(:repository, name: 'theone') }
-    let(:elided_maintenance_project_name) { 'home:Jane...roject:0' }
 
     it 'visiting the maintenance overview' do
       login user
@@ -181,7 +180,7 @@ RSpec.describe 'Projects', type: :feature, js: true do
       click_link('Incidents')
       page.execute_script('window.scrollBy(0,50)')
       click_link('Create Maintenance Incident')
-      expect(page).to have_css('#flash', text: "Created maintenance incident project #{elided_maintenance_project_name}")
+      expect(page).to have_css('#project-title', text: "#{maintenance_project}:0")
 
       # We can not create this via the Bootstrap UI, except by adding plain XML to the meta editor
       repository = create(:repository, project: Project.find_by(name: "#{project.name}:maintenance_project:0"), name: 'target')


### PR DESCRIPTION
According to the CircleCI insights about flickering specs, this spec was failing in about 3% of the last 100 CI runs. It failed when, for an obscure reason, the flash wasn't set. I have no idea why, but checking for the project's title on the project#show page of the newly created maintenance incident is sufficient to test the whole workflow.

Link to the CircleCI insights:
https://app.circleci.com/insights/github/openSUSE/open-build-service/workflows/test_all/tests

Fixes #10233