### PR TITLE
Fix flickering spec in features/webui/maintenance_workflow_spec.rb

### DIFF
--- a/src/api/spec/features/webui/maintenance_workflow_spec.rb
+++ b/src/api/spec/features/webui/maintenance_workflow_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe 'MaintenanceWorkflow', type: :feature, js: true, vcr: true do
            create_patchinfo: true,
            maintainer: maintenance_coord_user)
   end
+  let(:bs_request) { BsRequest.last }
 
   before do
     User.session = admin_user
@@ -65,12 +66,12 @@ RSpec.describe 'MaintenanceWorkflow', type: :feature, js: true, vcr: true do
     #########################################################
     login(maintenance_coord_user)
 
-    visit request_show_path(BsRequest.last)
+    visit request_show_path(bs_request)
 
     fill_in('reason', with: 'really? ok')
 
     click_button('Accept request')
-    expect(page).to have_css('#flash', text: "Request #{BsRequest.last.number} accepted")
+    expect(page).to have_css('#overview h3', text: "Request #{bs_request.number} accepted")
 
     # Step 4: The maintenance coordinator edits the patchinfo file
     ##############################################################


### PR DESCRIPTION
According to the CircleCI insights about flickering specs, this spec was failing in about 2% of the last 100 CI runs. It failed when, for an obscure reason, the flash wasn't set. I have no idea why, but checking for the request's number and state on the request#show page of the newly accepted BsRequest is sufficient to test the whole workflow.

Link to the CircleCI insights:
https://app.circleci.com/insights/github/openSUSE/open-build-service/workflows/test_all/tests