### PR TITLE
Add new watchable items in the subscription page

### DIFF
--- a/src/api/app/models/event/base.rb
+++ b/src/api/app/models/event/base.rb
@@ -251,7 +251,23 @@ module Event
       project = ::Project.find_by_name(payload['project'])
       return [] if project.blank?
 
-      project.watched_projects.map(&:user)
+      project.watched_projects.map(&:user).concat(project.watched_items.map(&:user)).uniq
+    end
+
+    def package_watchers
+      package = Package.get_by_project_and_name(payload['project'], payload['package'], { follow_multibuild: true, follow_project_links: false, use_source: false })
+      return [] if package.blank?
+
+      package.watched_items.map(&:user)
+    rescue Package::Errors::UnknownObjectError, Project::Errors::UnknownObjectError
+      []
+    end
+
+    def request_watchers
+      bs_request = BsRequest.find_by(number: payload['number'])
+      return [] if bs_request.blank?
+
+      bs_request.watched_items.map(&:user)
     end
 
     def _roles(role, project, package = nil)

--- a/src/api/app/models/event/build_fail.rb
+++ b/src/api/app/models/event/build_fail.rb
@@ -4,7 +4,7 @@ module Event
 
     self.message_bus_routing_key = 'package.build_fail'
     self.description = 'Package has failed to build'
-    receiver_roles :maintainer, :bugowner, :reader, :watcher
+    receiver_roles :maintainer, :bugowner, :reader, :watcher, :package_watcher, :request_watcher
 
     create_jobs :report_to_scm_job
 

--- a/src/api/app/models/event/comment_for_package.rb
+++ b/src/api/app/models/event/comment_for_package.rb
@@ -3,7 +3,7 @@ module Event
     include CommentEvent
     self.message_bus_routing_key = 'package.comment'
     self.description = 'New comment for package created'
-    receiver_roles :maintainer, :bugowner, :watcher
+    receiver_roles :maintainer, :bugowner, :watcher, :package_watcher
     payload_keys :project, :package, :sender
 
     def subject

--- a/src/api/app/models/event/comment_for_request.rb
+++ b/src/api/app/models/event/comment_for_request.rb
@@ -4,7 +4,8 @@ module Event
     self.message_bus_routing_key = 'request.comment'
     self.description = 'New comment for request created'
     payload_keys :request_number
-    receiver_roles :source_maintainer, :target_maintainer, :creator, :reviewer, :source_watcher, :target_watcher
+    receiver_roles :source_maintainer, :target_maintainer, :creator, :reviewer, :source_watcher, :target_watcher,
+                   :source_package_watcher, :target_package_watcher, :request_watcher
 
     def subject
       req = BsRequest.find_by_number(payload['number'])

--- a/src/api/app/models/event/request_create.rb
+++ b/src/api/app/models/event/request_create.rb
@@ -2,7 +2,8 @@ module Event
   class RequestCreate < Request
     self.message_bus_routing_key = 'request.create'
     self.description = 'Request created'
-    receiver_roles :source_maintainer, :target_maintainer, :source_watcher, :target_watcher
+    receiver_roles :source_maintainer, :target_maintainer, :source_watcher, :target_watcher,
+                   :source_package_watcher, :target_package_watcher
 
     def custom_headers
       base = super

--- a/src/api/app/models/event/request_statechange.rb
+++ b/src/api/app/models/event/request_statechange.rb
@@ -3,7 +3,8 @@ module Event
     self.message_bus_routing_key = 'request.state_change'
     self.description = 'Request state was changed'
     payload_keys :oldstate, :duration
-    receiver_roles :source_maintainer, :target_maintainer, :creator, :reviewer, :source_watcher, :target_watcher
+    receiver_roles :source_maintainer, :target_maintainer, :creator, :reviewer, :source_watcher, :target_watcher,
+                   :source_package_watcher, :target_package_watcher, :request_watcher
 
     def subject
       "Request #{payload['number']} changed from #{payload['oldstate']} to #{payload['state']} (#{actions_summary})"

--- a/src/api/app/models/event_subscription.rb
+++ b/src/api/app/models/event_subscription.rb
@@ -12,6 +12,12 @@ class EventSubscription < ApplicationRecord
     source_watcher: 'Watching the source project',
     target_watcher: 'Watching the target project'
   }.freeze
+  BETA_RECEIVER_ROLE_TEXTS = {
+    package_watcher: 'Watching the package',
+    source_package_watcher: 'Watching the source package',
+    target_package_watcher: 'Watching the target package',
+    request_watcher: 'Watching the request'
+  }.freeze
 
   enum channel: {
     disabled: 0,
@@ -33,7 +39,8 @@ class EventSubscription < ApplicationRecord
 
   validates :receiver_role, inclusion: {
     in: [:maintainer, :bugowner, :reader, :source_maintainer, :target_maintainer,
-         :reviewer, :commenter, :creator, :watcher, :source_watcher, :target_watcher]
+         :reviewer, :commenter, :creator, :watcher, :source_watcher, :target_watcher,
+         :package_watcher, :target_package_watcher, :source_package_watcher, :request_watcher]
   }
 
   scope :for_eventtype, ->(eventtype) { where(eventtype: eventtype) }
@@ -48,6 +55,14 @@ class EventSubscription < ApplicationRecord
       defaults
     end
   }
+
+  def self.receiver_roles_to_display(user)
+    roles = RECEIVER_ROLE_TEXTS.keys
+    # We have to show the new_watchlist subscription options to the admin in order to allow the global
+    # configuration
+    roles += BETA_RECEIVER_ROLE_TEXTS.keys if Flipper.enabled?(:new_watchlist, user) || User.possibly_nobody.is_admin?
+    roles
+  end
 
   def subscriber
     if user_id.present?

--- a/src/api/app/models/event_subscription/for_event_form.rb
+++ b/src/api/app/models/event_subscription/for_event_form.rb
@@ -9,8 +9,14 @@ class EventSubscription
     end
 
     def call
-      @roles = event_class.receiver_roles.map { |role| EventSubscription::ForRoleForm.new(role, event_class, subscriber).call }
+      @roles = receiver_roles.map { |role| EventSubscription::ForRoleForm.new(role, event_class, subscriber).call }
       self
+    end
+
+    private
+
+    def receiver_roles
+      event_class.receiver_roles & EventSubscription.receiver_roles_to_display(@subscriber)
     end
   end
 end

--- a/src/api/app/views/webui/subscriptions/_subscriptions_form.html.haml
+++ b/src/api/app/views/webui/subscriptions/_subscriptions_form.html.haml
@@ -7,7 +7,7 @@
       .list-group
         - subscription.roles.each do |role|
           .d-flex.flex-column.flex-sm-row.justify-content-sm-between.list-group-item.list-group-item-action
-            %span= EventSubscription::RECEIVER_ROLE_TEXTS[role.name]
+            %span= EventSubscription::RECEIVER_ROLE_TEXTS.merge(EventSubscription::BETA_RECEIVER_ROLE_TEXTS)[role.name]
             .d-flex.flex-column.flex-sm-row{ class: "#{role.name}" }
               - role.channels.each do |channel|
                 .d-flex.flex-nowrap.align-items-baseline.custom-control.custom-checkbox.my-2.my-sm-0.pr-2

--- a/src/api/spec/models/event/base_spec.rb
+++ b/src/api/spec/models/event/base_spec.rb
@@ -1,0 +1,115 @@
+require 'rails_helper'
+
+RSpec.describe Event::Base, type: :model do
+  describe '#package_watchers' do
+    context 'when the package and project exists' do
+      let(:project) { create(:project_with_repository) }
+      let(:package) { create(:package, name: 'ruby', project: project) }
+      let(:repository) { project.repositories.first }
+      let(:arch) { repository.architectures.first }
+      let(:event) do
+        Event::BuildFail.create(package: package.name,
+                                project: project.name,
+                                repository: repository,
+                                arch: arch,
+                                reason: '')
+      end
+      let(:user) { create(:confirmed_user) }
+
+      subject { event.package_watchers }
+
+      context 'when the package is being watched' do
+        before do
+          WatchedItem.create(watchable: package, user: user)
+        end
+
+        it 'includes the watcher of the package' do
+          expect(subject).to include(user)
+        end
+      end
+
+      context 'when the package is not being watched' do
+        it { expect(subject).to be_empty }
+      end
+    end
+
+    context 'when the project is missing' do
+      let(:package) { create(:package, name: 'ruby') }
+      let(:event) do
+        Event::BuildFail.create(package: package.name,
+                                project: 'nonexistent',
+                                repository: 'openSUSE_Tumbleweed',
+                                arch: 'x86_64',
+                                reason: '')
+      end
+      let(:user) { create(:confirmed_user) }
+
+      subject { event.package_watchers }
+
+      it { expect(subject).to be_empty }
+    end
+
+    context 'when the package is missing' do
+      let(:project) { create(:project_with_repository) }
+      let(:package) { create(:package, name: 'ruby', project: project) }
+      let(:repository) { project.repositories.first }
+      let(:arch) { repository.architectures.first }
+      let(:event) do
+        Event::BuildFail.create(package: 'nonexistent',
+                                project: project.name,
+                                repository: repository.name,
+                                arch: arch.name,
+                                reason: '')
+      end
+      let(:user) { create(:confirmed_user) }
+
+      subject { event.package_watchers }
+
+      it { expect(subject).to be_empty }
+    end
+  end
+
+  describe '#request_watchers' do
+    let(:bs_request) { create(:bs_request_with_submit_action) }
+    let(:event) { Event::RequestStatechange.create(number: bs_request.number) }
+    let(:user) { create(:confirmed_user) }
+
+    subject { event.request_watchers }
+
+    context 'when the request is being watched' do
+      before do
+        WatchedItem.create(watchable: bs_request, user: user)
+      end
+
+      it 'includes the watcher of the request' do
+        expect(subject).to include(user)
+      end
+    end
+
+    context 'when the request is not watched' do
+      it { expect(subject).to be_empty }
+    end
+  end
+
+  describe '#watchers' do
+    let(:project) { create(:project, name: 'openSUSE') }
+    let(:event) { Event::CommentForProject.create(project: project.name) }
+    let(:user) { create(:confirmed_user) }
+
+    subject { event.watchers }
+
+    context 'when the project is being watched' do
+      before do
+        WatchedItem.create(watchable: project, user: user)
+      end
+
+      it 'includes the watcher of the project' do
+        expect(subject).to include(user)
+      end
+    end
+
+    context 'when the project is not watched' do
+      it { expect(subject).to be_empty }
+    end
+  end
+end

--- a/src/api/spec/models/event/request_spec.rb
+++ b/src/api/spec/models/event/request_spec.rb
@@ -1,0 +1,94 @@
+require 'rails_helper'
+
+RSpec.describe Event::Request, type: :model do
+  describe '#source_package_watcher' do
+    let(:bs_request) { create(:bs_request_with_submit_action) }
+    let!(:another_source_package) { create(:package, name: 'ruby') }
+    let(:source_package) { create(:package, name: 'ruby') }
+    let(:target_package) { create(:package) }
+    let(:event) do
+      Event::CommentForRequest.create(number: bs_request.number,
+                                      actions: [{ action_id: 1,
+                                                  type: 'submit',
+                                                  sourceproject: source_package.project.name,
+                                                  sourcepackage: source_package.name,
+                                                  targetproject: target_package.project.name,
+                                                  targetpackage: target_package.name }])
+    end
+    let(:user) { create(:confirmed_user) }
+
+    before do
+      bs_request.bs_request_actions.first.update(source_project: target_package.project.name,
+                                                 source_package: source_package.name,
+                                                 target_project: target_package.project.name,
+                                                 target_package: target_package.name)
+    end
+
+    subject { event.source_package_watchers }
+
+    context 'when the request is being watched' do
+      before do
+        WatchedItem.create(watchable: source_package, user: user)
+      end
+
+      it 'includes the watcher of the request' do
+        expect(subject).to include(user)
+      end
+    end
+
+    context 'when the request is not being watched' do
+      it 'does not include any watchers' do
+        expect(subject).to be_empty
+      end
+    end
+  end
+
+  describe '#target_package_watcher' do
+    let(:bs_request) { create(:bs_request_with_submit_action) }
+    let(:source_package) { create(:package) }
+    let!(:another_target_package) { create(:package, name: 'ruby') }
+    let(:target_package) { create(:package, name: 'ruby') }
+    let(:event) do
+      Event::CommentForRequest.create(number: bs_request.number,
+                                      actions: [{ action_id: 1,
+                                                  type: 'submit',
+                                                  sourceproject: source_package.project.name,
+                                                  sourcepackage: source_package.name,
+                                                  targetproject: target_package.project.name,
+                                                  targetpackage: target_package.name },
+                                                # The following action will trigger a Project::Errors::UnknownObjectError
+                                                { action_id: 2,
+                                                  type: 'submit',
+                                                  sourceproject: 'nonexistent',
+                                                  sourcepackage: 'nonexistent',
+                                                  targetproject: 'nonexistent',
+                                                  targetpackage: 'nonexistent' }])
+    end
+    let(:user) { create(:confirmed_user) }
+
+    before do
+      bs_request.bs_request_actions.first.update(source_project: target_package.project.name,
+                                                 source_package: source_package.name,
+                                                 target_project: target_package.project.name,
+                                                 target_package: target_package.name)
+    end
+
+    subject { event.target_package_watchers }
+
+    context 'when the request is being watched' do
+      before do
+        WatchedItem.create(watchable: target_package, user: user)
+      end
+
+      it 'includes the watcher of the request' do
+        expect(subject).to include(user)
+      end
+    end
+
+    context 'when the request is not being watched' do
+      it 'does not include any watchers' do
+        expect(subject).to be_empty
+      end
+    end
+  end
+end

--- a/src/api/spec/models/event_subscription/for_event_form_spec.rb
+++ b/src/api/spec/models/event_subscription/for_event_form_spec.rb
@@ -12,16 +12,24 @@ RSpec.describe EventSubscription::ForEventForm do
 
     context 'for Event::CommentForProject' do
       let(:event_class) { Event::CommentForProject }
+      let(:expected_receiver_roles) do
+        # FIXME: revert it back as `event_class.receiver_roles` when we remove the new_watchlist feature flag
+        event_class.receiver_roles - EventSubscription::BETA_RECEIVER_ROLE_TEXTS.keys
+      end
 
       it { expect(subject.event_class).to eq(event_class) }
-      it { expect(roles.map(&:name)).to match_array(event_class.receiver_roles) }
+      it { expect(roles.map(&:name)).to match_array(expected_receiver_roles) }
     end
 
     context 'for Event::CommentForRequest' do
       let(:event_class) { Event::CommentForRequest }
+      let(:expected_receiver_roles) do
+        # FIXME: revert it back to `event_class.receiver_roles` when we remove the new_watchlist feature flag
+        event_class.receiver_roles - EventSubscription::BETA_RECEIVER_ROLE_TEXTS.keys
+      end
 
       it { expect(subject.event_class).to eq(event_class) }
-      it { expect(roles.map(&:name)).to match_array(event_class.receiver_roles) }
+      it { expect(roles.map(&:name)).to match_array(expected_receiver_roles) }
     end
   end
 end


### PR DESCRIPTION
This PR adds the functionality to subscribe to events triggered for watched packages and request, recently added under the beta program.

*HOW TO TEST:*

1. Navigate to the subscription page http://localhost:3000/my/subscriptions
2. Check some of the new added event subscription like `Watching the request` under the `Request state was changed` section
3. Create a request and add it to your watchlist (make sure your user is part of the beta program)
4. Change the state of the request
5. Enter the rails console and run `SendEventEmailsJob.perform_now` to trigger the creation of the notifications
6. Check in the webui if the notification appears

*TODO:*

- [x] Fix minitests
- [x] Add specs