### PR TITLE
Avoid watchlist to crash with special cases

### DIFF
--- a/src/api/app/views/layouts/webui/webui.html.haml
+++ b/src/api/app/views/layouts/webui/webui.html.haml
@@ -78,8 +78,9 @@
       - if User.session
         - if feature_enabled?(:new_watchlist)
           = render WatchlistComponent.new(user: User.session!,
-          project: @project,
-          package: @package,
-          bs_request: @bs_request)
+                                          bs_request: @bs_request,
+                                          package: @package,
+                                          project: @project)
+
         - else
           = render partial: 'layouts/webui/watchlist'


### PR DESCRIPTION
Right now, the new watchlist implementation fails when `@project` or `@package` don't contain an object but a string or nil. 
This happens when we have links and multibuild packages.

With the introduced code, we make sure we always get an object when this is possible. Otherwise, we assume they are nil, so we don't offer an item to add to the watchlist. We decided to add that logic inside the `WatchlistComponent` because it would be too much ruby code for the layout view.

In the case of inherited packages belonging to project links, we decided not to provide the link to add the package to the watchlist. It's not straightforward to keep track of the linked project.

After this is merged, we can enable back the `new_watchlist` feature flag in production. First for the `staff` group and then for the `beta` group.
