### PR TITLE
Be more specific with the naming of the `watcher` receiver role

### DIFF
--- a/src/api/app/models/event/base.rb
+++ b/src/api/app/models/event/base.rb
@@ -247,7 +247,7 @@ module Event
       ret
     end
 
-    def watchers
+    def project_watchers
       project = ::Project.find_by_name(payload['project'])
       return [] if project.blank?
 

--- a/src/api/app/models/event/build_fail.rb
+++ b/src/api/app/models/event/build_fail.rb
@@ -4,7 +4,7 @@ module Event
 
     self.message_bus_routing_key = 'package.build_fail'
     self.description = 'Package has failed to build'
-    receiver_roles :maintainer, :bugowner, :reader, :watcher
+    receiver_roles :maintainer, :bugowner, :reader, :project_watcher
 
     create_jobs :report_to_scm_job
 

--- a/src/api/app/models/event/comment_for_package.rb
+++ b/src/api/app/models/event/comment_for_package.rb
@@ -3,7 +3,7 @@ module Event
     include CommentEvent
     self.message_bus_routing_key = 'package.comment'
     self.description = 'New comment for package created'
-    receiver_roles :maintainer, :bugowner, :watcher
+    receiver_roles :maintainer, :bugowner, :project_watcher
     payload_keys :project, :package, :sender
 
     def subject

--- a/src/api/app/models/event/comment_for_project.rb
+++ b/src/api/app/models/event/comment_for_project.rb
@@ -4,7 +4,7 @@ module Event
     self.message_bus_routing_key = 'project.comment'
     self.description = 'New comment for project created'
     payload_keys :project
-    receiver_roles :maintainer, :bugowner, :watcher
+    receiver_roles :maintainer, :bugowner, :project_watcher
 
     def subject
       "New comment in project #{payload['project']} by #{payload['commenter']}"

--- a/src/api/app/models/event/comment_for_request.rb
+++ b/src/api/app/models/event/comment_for_request.rb
@@ -4,7 +4,7 @@ module Event
     self.message_bus_routing_key = 'request.comment'
     self.description = 'New comment for request created'
     payload_keys :request_number
-    receiver_roles :source_maintainer, :target_maintainer, :creator, :reviewer, :source_watcher, :target_watcher
+    receiver_roles :source_maintainer, :target_maintainer, :creator, :reviewer, :source_project_watcher, :target_project_watcher
 
     def subject
       req = BsRequest.find_by_number(payload['number'])

--- a/src/api/app/models/event/request_create.rb
+++ b/src/api/app/models/event/request_create.rb
@@ -2,7 +2,7 @@ module Event
   class RequestCreate < Request
     self.message_bus_routing_key = 'request.create'
     self.description = 'Request created'
-    receiver_roles :source_maintainer, :target_maintainer, :source_watcher, :target_watcher
+    receiver_roles :source_maintainer, :target_maintainer, :source_project_watcher, :target_project_watcher
 
     def custom_headers
       base = super

--- a/src/api/app/models/event/request_statechange.rb
+++ b/src/api/app/models/event/request_statechange.rb
@@ -3,7 +3,7 @@ module Event
     self.message_bus_routing_key = 'request.state_change'
     self.description = 'Request state was changed'
     payload_keys :oldstate, :duration
-    receiver_roles :source_maintainer, :target_maintainer, :creator, :reviewer, :source_watcher, :target_watcher
+    receiver_roles :source_maintainer, :target_maintainer, :creator, :reviewer, :source_project_watcher, :target_project_watcher
 
     def subject
       "Request #{payload['number']} changed from #{payload['oldstate']} to #{payload['state']} (#{actions_summary})"

--- a/src/api/app/models/event/review_changed.rb
+++ b/src/api/app/models/event/review_changed.rb
@@ -3,7 +3,7 @@ module Event
     self.message_bus_routing_key = 'request.review_changed'
     self.description = 'Request was reviewed'
     payload_keys :reviewers, :by_user, :by_group, :by_project, :by_package
-    receiver_roles :source_maintainer, :target_maintainer, :creator, :source_watcher, :target_watcher
+    receiver_roles :source_maintainer, :target_maintainer, :creator, :source_project_watcher, :target_project_watcher
 
     def subject
       "Request #{payload['number']} was reviewed (#{actions_summary})"

--- a/src/api/app/models/event_subscription.rb
+++ b/src/api/app/models/event_subscription.rb
@@ -8,9 +8,9 @@ class EventSubscription < ApplicationRecord
     reviewer: 'Reviewer',
     commenter: 'Commenter',
     creator: 'Creator',
-    watcher: 'Watching the project',
-    source_watcher: 'Watching the source project',
-    target_watcher: 'Watching the target project'
+    project_watcher: 'Watching the project',
+    source_project_watcher: 'Watching the source project',
+    target_project_watcher: 'Watching the target project'
   }.freeze
 
   enum channel: {
@@ -33,7 +33,7 @@ class EventSubscription < ApplicationRecord
 
   validates :receiver_role, inclusion: {
     in: [:maintainer, :bugowner, :reader, :source_maintainer, :target_maintainer,
-         :reviewer, :commenter, :creator, :watcher, :source_watcher, :target_watcher]
+         :reviewer, :commenter, :creator, :project_watcher, :source_project_watcher, :target_project_watcher]
   }
 
   scope :for_eventtype, ->(eventtype) { where(eventtype: eventtype) }

--- a/src/api/spec/db/data/generate_web_notifications_spec.rb
+++ b/src/api/spec/db/data/generate_web_notifications_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe GenerateWebNotifications, type: :migration do
     let!(:event_subscription_3) { create(:event_subscription_comment_for_project, user: owner, receiver_role: 'bugowner') }
     let!(:disabled_event_for_web_and_rss) { create(:event_subscription, eventtype: 'Event::BuildFail', user: owner, receiver_role: 'maintainer') }
     let!(:default_subscription) { create(:event_subscription_comment_for_project_without_subscriber, receiver_role: 'bugowner') }
-    let!(:default_subscription_1) { create(:event_subscription_comment_for_project_without_subscriber, receiver_role: 'watcher') }
+    let!(:default_subscription_1) { create(:event_subscription_comment_for_project_without_subscriber, receiver_role: 'project_watcher') }
     let!(:default_subscription_2) do
       create(:event_subscription_comment_for_project_without_subscriber,
              receiver_role: 'maintainer',

--- a/src/api/spec/features/beta/webui/subscriptions_spec.rb
+++ b/src/api/spec/features/beta/webui/subscriptions_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Subscriptions', type: :feature, js: true do
 
       expect(page).to have_content(title)
       notification_field = find('.card-body h5', text: 'Package has failed to build').sibling('.list-group')
-      ['maintainer', 'bugowner', 'reader', 'watcher'].each do |role|
+      ['maintainer', 'bugowner', 'reader', 'project_watcher'].each do |role|
         subscription_by_role = notification_field.find(".#{role}")
         subscription_by_role.check('email')
         expect(page).to have_css('#flash', text: 'Notifications settings updated')
@@ -18,7 +18,7 @@ RSpec.describe 'Subscriptions', type: :feature, js: true do
       visit path
 
       notification_field = find('.card-body h5', text: 'Package has failed to build').sibling('.list-group')
-      ['maintainer', 'bugowner', 'reader', 'watcher'].each do |role|
+      ['maintainer', 'bugowner', 'reader', 'project_watcher'].each do |role|
         subscription_by_role = notification_field.find(".#{role}")
         expect(subscription_by_role.find_field('email', visible: false)).to be_checked
       end

--- a/src/api/spec/features/webui/subscriptions_spec.rb
+++ b/src/api/spec/features/webui/subscriptions_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Subscriptions', type: :feature, js: true do
 
       expect(page).to have_content(title)
       notification_field = find('.card-body h5', text: 'Package has failed to build').sibling('.list-group')
-      ['maintainer', 'bugowner', 'reader', 'watcher'].each do |role|
+      ['maintainer', 'bugowner', 'reader', 'project_watcher'].each do |role|
         subscription_by_role = notification_field.find(".#{role}")
         subscription_by_role.check('email')
         expect(page).to have_css('#flash', text: 'Notifications settings updated')
@@ -18,7 +18,7 @@ RSpec.describe 'Subscriptions', type: :feature, js: true do
       visit path
 
       notification_field = find('.card-body h5', text: 'Package has failed to build').sibling('.list-group')
-      ['maintainer', 'bugowner', 'reader', 'watcher'].each do |role|
+      ['maintainer', 'bugowner', 'reader', 'project_watcher'].each do |role|
         subscription_by_role = notification_field.find(".#{role}")
         expect(subscription_by_role.find_field('email', visible: false)).to be_checked
       end

--- a/src/api/spec/models/event_subscription/find_for_event_spec.rb
+++ b/src/api/spec/models/event_subscription/find_for_event_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe EventSubscription::FindForEvent do
         create(
           :event_subscription,
           eventtype: 'Event::RequestCreate',
-          receiver_role: 'source_watcher',
+          receiver_role: 'source_project_watcher',
           user: nil,
           group: nil,
           channel: :instant_email
@@ -160,7 +160,7 @@ RSpec.describe EventSubscription::FindForEvent do
         let!(:comment) { create(:comment_project, commentable: project) }
 
         let!(:default_subscription) do
-          create(:event_subscription_comment_for_project, receiver_role: 'watcher', user: nil, group: nil)
+          create(:event_subscription_comment_for_project, receiver_role: 'project_watcher', user: nil, group: nil)
         end
 
         before do


### PR DESCRIPTION
Since we are going to support to receive notifications
for packages and requests followed in the watchlist, we need
to add new receiver roles to the event subscriptions. In order
to add the new watcher roles, we need to rename the existing
watcher roles for projects.

Extracted from PR #12253

Co-authored-by: Daniel Donisa <daniel.donisa@suse.com>