### PR TITLE
Support multibuild, do not support project links

### DIFF
--- a/src/api/app/components/watchlist_component.rb
+++ b/src/api/app/components/watchlist_component.rb
@@ -11,15 +11,32 @@ class WatchlistComponent < ApplicationComponent
     'BsRequest' => 'Watch this request'
   }.freeze
 
-  def initialize(user:, project: nil, package: nil, bs_request: nil)
+  def initialize(user:, bs_request: nil, package: nil, project: nil)
     super
 
     @user = user
-    # NOTE: the order of the array is important, when project and package are both present we ensure it takes package.
-    @object_to_be_watched = [bs_request, package, project].compact.first
+    @object_to_be_watched = object_to_be_watched(bs_request, package, project)
   end
 
   private
+
+  def object_to_be_watched(bs_request, package, project)
+    return bs_request if bs_request
+
+    # this is a remote project, don't offer watching.
+    return unless project.is_a?(Project)
+
+    # there is no package, offer watching the project
+    return project unless package
+
+    # maybe package is a multibuild flavor? Try do look up the object of the flavor.
+    package = Package.get_by_project_and_name(project, package, { follow_multibuild: true }) if package.is_a?(String)
+
+    # the package is coming via a project link, don't offer watching it.
+    return if package.project != project
+
+    package
+  end
 
   def object_to_be_watched_in_watchlist?
     @user.watched_items.exists?(watchable: @object_to_be_watched)

--- a/src/api/app/views/layouts/webui/webui.html.haml
+++ b/src/api/app/views/layouts/webui/webui.html.haml
@@ -78,8 +78,9 @@
       - if User.session
         - if feature_enabled?(:new_watchlist)
           = render WatchlistComponent.new(user: User.session!,
-          project: @project,
-          package: @package,
-          bs_request: @bs_request)
+                                          bs_request: @bs_request,
+                                          package: @package,
+                                          project: @project)
+
         - else
           = render partial: 'layouts/webui/watchlist'


### PR DESCRIPTION
Add support in this component handle @package being a multibuild flavor instead
of being a `Package` object.

Do not support adding packages to the watchlist that come in via project links.
EventSubscription based on the watchlist and things like Notifications,
ProjectLogEntry, Mails etc. on top of EventSubscription, do not take project
links into account currently.

Co-authored-by: Eduardo Navarro <enavarro@suse.com>
Co-authored-by: Saray Cabrera Padrón <scabrerapadron@suse.de>