### PR TITLE
Do not stub constant for NotificationAvatarsComponent specs

### DIFF
--- a/src/api/spec/components/notification_avatars_component_spec.rb
+++ b/src/api/spec/components/notification_avatars_component_spec.rb
@@ -4,28 +4,24 @@ RSpec.describe NotificationAvatarsComponent, type: :component do
   context 'when a notification has more avatars to display than defined in MAXIMUM_DISPLAYED_AVATARS' do
     let(:project) { create(:project) }
     let(:comment_for_project) { create(:comment, commentable: project) }
-    let(:notification) { create(:notification, :comment_for_project, notifiable: comment_for_project) }
+    let(:notification) { create(:notification, :comment_for_project, notifiable: comment_for_project, last_seen_at: 1.day.ago) }
 
     before do
-      # Easier to spec without having to create lots of data
-      # Interpolating described_class to prevent a flaky spec (https://github.com/rspec/rspec-mocks/pull/201#issuecomment-188533226)
-      stub_const("#{described_class}::MAXIMUM_DISPLAYED_AVATARS", 1)
-
       # Comment which was already read (it's older than the notification), so it's not taken into account in the notification
-      create(:comment, commentable: project, updated_at: DateTime.yesterday)
+      create(:comment, commentable: project, updated_at: 2.days.ago)
 
-      # Extra unread comments
-      create_list(:comment, 2, commentable: project)
+      # Extra unread comments (on top of the comment/notifiable for the notification)
+      create_list(:comment, 6, commentable: project)
 
       render_inline(described_class.new(notification))
     end
 
     it 'renders an extra avatar for other users involved' do
-      expect(rendered_component).to have_selector('li.list-inline-item > span[title="2 more users involved"]')
+      expect(rendered_component).to have_selector('li.list-inline-item > span[title="1 more users involved"]')
     end
 
     it 'renders an avatar for each user up to the limit MAXIMUM_DISPLAYED_AVATARS' do
-      expect(rendered_component).to have_selector('li.list-inline-item > img', count: 1)
+      expect(rendered_component).to have_selector('li.list-inline-item > img', count: 6)
     end
   end
 


### PR DESCRIPTION
This is otherwise still flickering, even after the changes from #12249.

Flickering specs are listed in CircleCI:

https://app.circleci.com/insights/github/openSUSE/open-build-service/workflows/test_all/tests