### PR TITLE
Remove unused method `webui_infos`

### DIFF
--- a/src/api/app/models/review.rb
+++ b/src/api/app/models/review.rb
@@ -178,16 +178,6 @@ class Review < ApplicationRecord
     end
   end
 
-  def webui_infos
-    ret = _get_attributes
-    # XML has this perl format, don't use that here
-    ret[:when] = created_at
-    ret[:creator] = creator
-    ret[:reason] = reason
-    ret[:id] = id
-    ret
-  end
-
   def reviewers_for_obj(obj)
     return [] unless obj
 


### PR DESCRIPTION
This method could have been removed in 9616040fc5f6f3c9811a9755fede5556263bba44.

I just cherry-picked one commit from #9935.