### PR TITLE
Remove unneeded `@extend .alert-success`

### DIFF
--- a/src/api/app/assets/stylesheets/webui/flash.scss
+++ b/src/api/app/assets/stylesheets/webui/flash.scss
@@ -6,12 +6,8 @@
   }
 }
 
-.alert-success {
-  @extend .alert-success;
-
-  i.fas {
-    @extend .fa-check-circle;
-  }
+.alert-success i.fas {
+  @extend .fa-check-circle;
 }
 
 .alert-error {


### PR DESCRIPTION
Extending a class with the same class has no effect if nothing else is changed.