### PR TITLE
Add rails task to create workflow token and runs

### DIFF
--- a/src/api/spec/factories/workflow_artifacts_per_step.rb
+++ b/src/api/spec/factories/workflow_artifacts_per_step.rb
@@ -1,0 +1,65 @@
+FactoryBot.define do
+  factory :workflow_artifacts_per_step, aliases: [:workflow_artifacts_per_step_branch_package] do
+    workflow_run { create(:workflow_run) }
+    step { 'Workflow::Step::BranchPackageStep' }
+
+    transient do
+      source_project_name { Faker::Lorem.word }
+      target_project_name { Faker::Lorem.word }
+      source_package_name { Faker::Lorem.word }
+      target_package_name { source_package_name }
+    end
+
+    before(:create) do |workflow_artifacts_per_step, evaluator|
+      source_project = Project.find_by(name: evaluator.source_project_name) || create(:project, name: evaluator.source_project_name)
+      target_project = Project.find_by(name: evaluator.target_project_name) || create(:project, name: evaluator.target_project_name)
+
+      create(:package, name: evaluator.source_package_name, project: source_project) unless Package.find_by_project_and_name(evaluator.source_project_name, evaluator.source_package_name)
+      create(:package, name: evaluator.target_package_name, project: target_project) unless Package.find_by_project_and_name(evaluator.target_project_name, evaluator.target_package_name)
+
+      workflow_artifacts_per_step.artifacts = { source_project: evaluator.source_project_name,
+                                                source_package: evaluator.source_package_name,
+                                                target_project: evaluator.target_project_name,
+                                                target_package: evaluator.target_package_name }.to_json
+    end
+
+    factory :workflow_artifacts_per_step_link_package do
+      step { 'Workflow::Step::LinkPackageStep' }
+
+      before(:create) do |workflow_artifacts_per_step, evaluator|
+        workflow_artifacts_per_step.artifacts = { source_project: evaluator.source_project_name,
+                                                  source_package: evaluator.source_package_name,
+                                                  target_project: evaluator.target_project_name,
+                                                  target_package: evaluator.target_package_name }.to_json
+      end
+    end
+    factory :workflow_artifacts_per_step_rebuild_package do
+      step { 'Workflow::Step::RebuildPackage' }
+
+      before(:create) do |workflow_artifacts_per_step, evaluator|
+        workflow_artifacts_per_step.artifacts = { project: evaluator.source_project_name,
+                                                  package: evaluator.source_package_name }.to_json
+      end
+    end
+    factory :workflow_artifacts_per_step_config_repositories do
+      step { 'Workflow::Step::ConfigureRepositories' }
+      before(:create) do |workflow_artifacts_per_step, evaluator|
+        workflow_artifacts_per_step.artifacts = {
+          project: evaluator.target_project_name,
+          repositories: [
+            {
+              name: 'openSUSE_Tumbleweed',
+              paths: [
+                {
+                  target_project: 'openSUSE:Factory',
+                  target_repository: 'snapshot'
+                }
+              ],
+              architectures: ['x86_64']
+            }
+          ]
+        }.to_json
+      end
+    end
+  end
+end

--- a/src/api/spec/factories/workflow_runs.rb
+++ b/src/api/spec/factories/workflow_runs.rb
@@ -1,7 +1,54 @@
 FactoryBot.define do
   factory :workflow_run do
-    request_headers  { Faker::Lorem.characters(number: 32) }
-    request_payload  { Faker::Lorem.characters(number: 32) }
-    token
+    token { create(:workflow_token) }
+    request_headers do
+      <<~END_OF_HEADERS
+        HTTP_X_GITHUB_EVENT: pull_request
+      END_OF_HEADERS
+    end
+    request_payload do
+      <<~END_OF_PAYLOAD
+        {
+          "action": "opened",
+          "pull_request": {
+            "number": 1
+          },
+          "repository": {
+            "full_name": "iggy/hello_world",
+            "owner": { "html_url": "https://github.com" }
+          },
+          "foo": "bar"
+        }
+      END_OF_PAYLOAD
+    end
+
+    factory :succeeded_workflow_run do
+      status { 'success' }
+      response_body do
+        <<~END_OF_RESPONSE_BODY
+          <status code="ok">
+            <summary>Ok</summary>
+          </status>
+        END_OF_RESPONSE_BODY
+      end
+      response_url { 'https://api.github.com' }
+    end
+
+    factory :running_workflow_run do
+      status { 'running' }
+      response_body { nil }
+      response_url { nil }
+    end
+
+    factory :failed_workflow_run do
+      status { 'fail' }
+      response_body do
+        <<~END_OF_RESPONSE_BODY
+          <status code="unknown">
+            <summary>The 'target_project' key is missing</summary>
+          </status>
+        END_OF_RESPONSE_BODY
+      end
+    end
   end
 end


### PR DESCRIPTION
With this task, we can easily fill in our development database with a workflow token and some workflow runs.
Data that helps us to try out things during development and in review-app.