### PR TITLE
Don't rely on other conditions to stop a live log

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -468,9 +468,7 @@ class Webui::PackageController < Webui::WebuiController
 
       @log_chunk = get_log_chunk(@project, @package_name, @repo, @arch, chunk_start, chunk_end)
       # retry the last chunk again, because build compare overwrites last log lines
-      if @log_chunk.length.zero? && !@first_request && !@finished
-        @log_chunk = get_log_chunk(@project, @package_name, @repo, @arch, chunk_start, chunk_end)
-      end
+      @log_chunk = get_log_chunk(@project, @package_name, @repo, @arch, chunk_start, chunk_end) if @log_chunk.length.zero? && !@first_request && !@finished
 
       old_offset = @offset
       @offset = [chunk_end, @size].min

--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -470,7 +470,6 @@ class Webui::PackageController < Webui::WebuiController
       # retry the last chunk again, because build compare overwrites last log lines
       if @log_chunk.length.zero? && !@first_request && !@finished
         @log_chunk = get_log_chunk(@project, @package_name, @repo, @arch, chunk_start, chunk_end)
-        @finished = true
       end
 
       old_offset = @offset


### PR DESCRIPTION
Whether the log chunk size is zero or the request is not the first, the live log must not stop. Only rely on the list of returning codes recognized as final states to stop the live log.

This prevents the case of stopping the live log when the log chunk size is zero, the request is not the first one, and the code returned by the API is "finished". "finished" is not a final state, and the live log page should keep requesting AJAX calls until the code returned is a final one (like "succeeded", "failed", ...).

References:
- Definition of the state `finished`: https://github.com/openSUSE/open-build-service/blob/97e3faa92a6b090b9b07c94b5102ec14763027de/src/api/app/models/buildresult.rb#L32-L33
- List of final states: https://github.com/openSUSE/open-build-service/blob/97e3faa92a6b090b9b07c94b5102ec14763027de/src/api/app/models/buildresult.rb#L61-L63

**Screenshot 1:** finished build with "Build building" warning message:
![Screenshot from 2022-03-10 14-11-42](https://user-images.githubusercontent.com/24919/157668774-278e6691-5008-454f-bc5e-6b8b1324f697.png)

**Screenshot 2:** finished build with "Build succeeded" green message:
![Screenshot from 2022-03-10 14-16-58](https://user-images.githubusercontent.com/24919/157669721-b24e1f86-dd0b-4bfe-8f70-984f6a4cb868.png)

Currently, the live build log could stop updating the build status. The page gets stucked in the warning message (screenshot 1).

After introducing the changes of this PR, the live build log doesn't stop asking for an update until a final code is reached (screenshot 2 in the case of a succesful build).

