### PR TITLE
Don't retry requesting the last chunk on live build log

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -485,8 +485,6 @@ class Webui::PackageController < Webui::WebuiController
         @finished = true
       end
     end
-
-    logger.debug 'finished ' + @finished.to_s
   end
 
   def abort_build

--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -467,8 +467,6 @@ class Webui::PackageController < Webui::WebuiController
       end
 
       @log_chunk = get_log_chunk(@project, @package_name, @repo, @arch, chunk_start, chunk_end)
-      # retry the last chunk again, because build compare overwrites last log lines
-      @log_chunk = get_log_chunk(@project, @package_name, @repo, @arch, chunk_start, chunk_end) if @log_chunk.length.zero? && !@first_request && !@finished
 
       old_offset = @offset
       @offset = [chunk_end, @size].min


### PR DESCRIPTION
It is unnecessary to repeat the request of a log chunk after reaching a final state. This is a follow up to fixing the live build log not to stop in a not final state.

Follow up to #12294.