### PR TITLE
Introduce browser notifications for live build logs

### DIFF
--- a/src/api/app/assets/javascripts/webui/live_build_log.js
+++ b/src/api/app/assets/javascripts/webui/live_build_log.js
@@ -21,11 +21,11 @@ $.extend(LiveLog.prototype, {
   initialize: function() {
     this.startButton.click($.proxy(this.start, this));
     this.stopButton.click($.proxy(this.stop, this));
-    if (Notification.permission === 'default') {
+    if (Notification.permission === 'default') { // jshint ignore:line
       this.notificationsButton.click($.proxy(this.askNotificationPermission, this));
     }
     else {
-      this.notificationsButton.html(this.notificationsButton.html().replace('Request Browser Notifications', 'Browser Notifications ' + Notification.permission));
+      this.notificationsButton.html(this.notificationsButton.html().replace('Request Browser Notifications', 'Browser Notifications ' + Notification.permission)); // jshint ignore:line
       this.notificationsButton.addClass('disabled');
     }
     this.start();
@@ -91,7 +91,7 @@ $.extend(LiveLog.prototype, {
     }
   },
 
-  finish: function(status) { // jshint ignore:line
+  finish: function(status) {
     this.finished = true;
     this.stop();
     var statusDetails = this.buildStatusDetails(status);
@@ -103,55 +103,55 @@ $.extend(LiveLog.prototype, {
     this.startButton.addClass('d-none');
   },
 
-  stopAjaxRequest: function() { // jshint ignore:line
+  stopAjaxRequest: function() {
     if (this.ajaxRequest !== 0)
       this.ajaxRequest.abort();
     this.ajaxRequest = 0;
   },
 
-  showAbort: function() { // jshint ignore:line
+  showAbort: function() {
     $(".link_abort_build").removeClass('d-none');
     $(".link_trigger_rebuild").addClass('d-none');
   },
 
-  hideAbort: function() { // jshint ignore:line
+  hideAbort: function() {
     $(".link_abort_build").addClass('d-none');
     $(".link_trigger_rebuild").removeClass('d-none');
   },
 
-  indicatorStatus: function(status) { // jshint ignore:line
+  indicatorStatus: function(status) {
     this.logInfo.children().hide();
     this.logInfo.children('.' + status).show();
   },
 
-  faviconStatus: function(source) { // jshint ignore:line
+  faviconStatus: function(source) {
     if (typeof source !== 'undefined')
       $("link[rel='shortcut icon']").attr("href", source);
   },
 
   browserNotification: function(status) {
-    if (this.notificationSupport() && Notification.permission === "granted") {
+    if (this.notificationSupport() && Notification.permission === "granted") { // jshint ignore:line
       var statusDetails = this.buildStatusDetails(status);
-      new Notification('OBS: ' + statusDetails.content,
+      new Notification('OBS: ' + statusDetails.content, // jshint ignore:line
         { body: 'The status of your Open Build Service build is "' + statusDetails.indicator + '".', icon: statusDetails.favicon }
       );
     }
   },
 
-  askNotificationPermission: function () { // jshint ignore:line
-    if (this.notificationSupport() && Notification.permission === 'default') {
-      Notification.requestPermission().then(function (permission) {
+  askNotificationPermission: function () {
+    if (this.notificationSupport() && Notification.permission === 'default') { // jshint ignore:line
+      Notification.requestPermission().then(function (permission) { // jshint ignore:line
         if (permission === 'granted' || permission === 'denied') {
-          liveLog.notificationsButton.html(liveLog.notificationsButton.html().replace('Request Browser Notifications', 'Browser Notifications ' + Notification.permission));
-          liveLog.notificationsButton.addClass('disabled');
+          liveLog.notificationsButton.html(liveLog.notificationsButton.html().replace('Request Browser Notifications', 'Browser Notifications ' + Notification.permission)); // jshint ignore:line
+          liveLog.notificationsButton.addClass('disabled'); // jshint ignore:line
         }
       });
     }
   },
 
-  notificationSupport: function () { // jshint ignore:line
+  notificationSupport: function () {
     if (!('Notification' in window)) {
-      console.log("This browser does not support notifications.");
+      console.log("This browser does not support notifications."); // jshint ignore:line
       return false;
     } else {
       return true;

--- a/src/api/app/views/webui/package/_live_build_log_controls.html.haml
+++ b/src/api/app/views/webui/package/_live_build_log_controls.html.haml
@@ -1,4 +1,4 @@
-%p
+%p.d-flex
   = link_to('#', class: 'start_refresh d-none live-link-action btn-info') do
     %i.far.fa-play-circle
     Start refresh
@@ -30,3 +30,8 @@
               class: 'link_abort_build live-link-action btn-danger d-none') do
       %i.far.fa-times-circle
       Abort Build
+
+  = link_to('#', class: 'link_notifications live-link-action btn-secondary ml-auto text-capitalize',
+            title: 'Request permission for browser notifications') do
+    %i.far.fa-bell
+    Request Browser Notifications

--- a/src/api/app/views/webui/package/update_build_log.js.haml
+++ b/src/api/app/views/webui/package/update_build_log.js.haml
@@ -1,11 +1,14 @@
 - if @errors
   $('#flash').html("#{escape_javascript(render(partial: 'layouts/webui/flash', locals: { flash: { error: @errors } }))}");
   $("html, body").scrollTop(0);
+  liveLog.browserNotification('#{@status}');
   liveLog.finish("#{@status}");
 - else
   - if @finished
     - if @first_request
       $('#log-space').html('#{escape_javascript(@log_chunk)}');
+    - else
+      liveLog.browserNotification('#{@status}');
     liveLog.finish("#{@status}");
   - else
     $('#log-space').append('#{escape_javascript(@log_chunk)}');


### PR DESCRIPTION
Now it is possible to receive browser notifications from the live build log.

Fixes #7920

Example of a notification of a succeeded build:

![Screenshot from 2022-03-11 14-23-53_browser_notification_succeeded](https://user-images.githubusercontent.com/24919/157877499-9d6d1fcd-b948-4c47-8b1f-e44db73dd36e.png)

Example of a notification of a failed build:

![Screenshot from 2022-03-11 14-25-11_browser_notification_failed](https://user-images.githubusercontent.com/24919/157877523-79f8456c-6946-4d2d-b60f-0f7ecb47faae.png)

A button "Browser Notifications" was added to ask for permission to receive browser notifications:
- It will appear enabled when notifications are not yet allowed or denied.
- It will appear disabled when the permission is already granted or revoked. In this case, the permission could be deleted through the browser configuration.

![Peek 2022-03-11 14-14_Browser_notifications_on_off](https://user-images.githubusercontent.com/24919/157877468-3bd64776-3d05-43e8-b709-da8df5ebfe38.gif)

To test this PR:
- Go to a live log page of a package in the [review app](https://obs-reviewlab.opensuse.org/eduardoj-live_build_log_browser_notifications/package/live_build_log/home:Admin/hello_world/openSUSE_Tumbleweed/x86_64).
- Enable your browser notifications:
  - Click in the button "Browser Notifications".
  - Answer with "Allow".
- Click on "Trigger Rebuild"
- Return to the live build log page.
- Wait until the build finishes. Then, a browser notification should appear in your environment.