### PR TITLE
URI.encode is removed, use Addressable::URI.encode

### DIFF
--- a/src/api/app/models/package_file.rb
+++ b/src/api/app/models/package_file.rb
@@ -6,6 +6,6 @@ class PackageFile < Backend::File
 
   # calculates the real url on the backend to search the file
   def full_path(query = {})
-    URI.encode("/source/#{project_name}/#{package_name}/#{name}") + "?#{query.to_query}"
+    Addressable::URI.encode("/source/#{project_name}/#{package_name}/#{name}") + "?#{query.to_query}"
   end
 end

--- a/src/api/app/models/project_config_file.rb
+++ b/src/api/app/models/project_config_file.rb
@@ -6,7 +6,7 @@ class ProjectConfigFile < ProjectFile
 
   # calculates the real url on the backend to search the file
   def full_path(query = {})
-    URI.encode("/source/#{project_name}/#{name}") + "?#{query.to_query}"
+    Addressable::URI.encode("/source/#{project_name}/#{name}") + "?#{query.to_query}"
   end
 
   # You dont want to change name of _config

--- a/src/api/app/models/project_file.rb
+++ b/src/api/app/models/project_file.rb
@@ -11,6 +11,6 @@ class ProjectFile < Backend::File
 
   # calculates the real url on the backend to search the file
   def full_path(query = {})
-    URI.encode("/source/#{project_name}/_project/#{name}") + "?#{query.to_query}"
+    Addressable::URI.encode("/source/#{project_name}/_project/#{name}") + "?#{query.to_query}"
   end
 end

--- a/src/api/app/models/project_meta_file.rb
+++ b/src/api/app/models/project_meta_file.rb
@@ -6,7 +6,7 @@ class ProjectMetaFile < ProjectFile
 
   # calculates the real url on the backend to search the file
   def full_path(query = {})
-    URI.encode("/source/#{project_name}/#{name}") + "?#{query.to_query}"
+    Addressable::URI.encode("/source/#{project_name}/#{name}") + "?#{query.to_query}"
   end
 
   # You dont want to change name of _meta

--- a/src/api/spec/models/backend/file_spec.rb
+++ b/src/api/spec/models/backend/file_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Backend::File, vcr: true do
       attr_accessor :somefile
 
       def full_path(_query)
-        URI.encode(somefile)
+        Addressable::URI.encode(somefile)
       end
     end
   end

--- a/src/api/test/functional/request_controller_test.rb
+++ b/src/api/test/functional/request_controller_test.rb
@@ -1333,7 +1333,7 @@ class RequestControllerTest < ActionDispatch::IntegrationTest
     assert_xml_tag(tag: 'request', attributes: { id: id })
 
     # via POST
-    post '/search/request', params: URI.encode("match=(state/@name='new' or state/@name='review') and (action/target/@project='kde4' and action/target/@package='wpa_supplicant')")
+    post '/search/request', params: Addressable::URI.encode("match=(state/@name='new' or state/@name='review') and (action/target/@project='kde4' and action/target/@package='wpa_supplicant')")
     assert_response :success
     assert_xml_tag(tag: 'request', attributes: { id: id })
 


### PR DESCRIPTION
See https://github.com/ruby/uri/commit/61c6a47ebf1f2726b60a2bbd70964d64e14b1f98

`URI.escape` is deprecated in Ruby 3.1. This PR helps to reduce the size of the `ruby31` branch, the upcoming changeset to make OBS compatible with Ruby 3.1.

See #12302 