### PR TITLE
Replace URI.escape with Addressable::URI.escape 

### DIFF
--- a/src/api/app/helpers/maintenance_helper.rb
+++ b/src/api/app/helpers/maintenance_helper.rb
@@ -97,7 +97,7 @@ module MaintenanceHelper
     link.remove_attribute('project') # its a local link, project name not needed
     link['package'] = link['package'].gsub(/\..*/, '') + target_package_name.gsub(/.*\./, '.') # adapt link target with suffix
     link_xml = link.to_xml
-    Backend::Connection.put "/source/#{URI.escape(target_project.name)}/#{URI.escape(target_package_name)}/_link?rev=repository&user=#{CGI.escape(User.session!.login)}", link_xml
+    Backend::Connection.put Addressable::URI.escape("/source/#{target_project.name}/#{target_package_name}/_link?rev=repository&user=#{User.session!.login}"), link_xml
 
     md5 = Digest::MD5.hexdigest(link_xml)
     # commit with noservice parameter
@@ -108,7 +108,7 @@ module MaintenanceHelper
       comment: "Set local link to #{target_package_name} via maintenance_release request"
     }
     upload_params[:requestid] = action.bs_request.number if action
-    upload_path = "/source/#{URI.escape(target_project.name)}/#{URI.escape(target_package_name)}"
+    upload_path = Addressable::URI.escape("/source/#{target_project.name}/#{target_package_name}")
     upload_path << Backend::Connection.build_query_from_hash(upload_params, [:user, :comment, :cmd, :noservice, :requestid])
     answer = Backend::Connection.post upload_path, "<directory> <entry name=\"_link\" md5=\"#{md5}\" /> </directory>"
     tpkg.sources_changed(dir_xml: answer)
@@ -131,7 +131,7 @@ module MaintenanceHelper
       rev: 'repository',
       comment: "Set link to #{target_package_name} via maintenance_release request"
     }
-    upload_path = "/source/#{URI.escape(target_project.name)}/#{URI.escape(base_package_name)}/_link"
+    upload_path = Addressable::URI.escape("/source/#{target_project.name}/#{base_package_name}/_link")
     upload_path << Backend::Connection.build_query_from_hash(upload_params, [:user, :rev])
     link = "<link package='#{target_package_name}' cicount='copy' />\n"
     md5 = Digest::MD5.hexdigest(link)
@@ -140,7 +140,7 @@ module MaintenanceHelper
     upload_params[:cmd] = 'commitfilelist'
     upload_params[:noservice] = '1'
     upload_params[:requestid] = request.number if request
-    upload_path = "/source/#{URI.escape(target_project.name)}/#{URI.escape(base_package_name)}"
+    upload_path = Addressable::URI.escape("/source/#{target_project.name}/#{base_package_name}")
     upload_path << Backend::Connection.build_query_from_hash(upload_params, [:user, :comment, :cmd, :noservice, :requestid])
     answer = Backend::Connection.post upload_path, "<directory> <entry name=\"_link\" md5=\"#{md5}\" /> </directory>"
     lpkg.sources_changed(dir_xml: answer)
@@ -232,7 +232,7 @@ module MaintenanceHelper
     cp_params[:setupdateinfoid] = update_info_id if update_info_id
     cp_params[:setrelease] = setrelease if setrelease
     cp_params[:multibuild] = '1' unless source_package_name.include?(':')
-    cp_path = "/build/#{CGI.escape(target_repository.project.name)}/#{URI.escape(target_repository.name)}/#{URI.escape(arch.name)}/#{URI.escape(target_package_name)}"
+    cp_path = Addressable::URI.escape("/build/#{target_repository.project.name}/#{target_repository.name}/#{arch.name}/#{target_package_name}")
 
     cp_path << Backend::Connection.build_query_from_hash(cp_params, [:cmd, :oproject, :opackage,
                                                                      :orepository, :setupdateinfoid,

--- a/src/api/app/helpers/webui/webui_helper.rb
+++ b/src/api/app/helpers/webui/webui_helper.rb
@@ -13,7 +13,7 @@ module Webui::WebuiHelper
       cc = ('&cc=' + email_list[1..-1].join('&cc=')) if email_list
     end
 
-    URI.escape(
+    Addressable::URI.escape(
       "#{@configuration['bugzilla_url']}/enter_bug.cgi?classification=7340&product=openSUSE.org" \
       "&component=3rd party software&assigned_to=#{assignee}#{cc}&short_desc=#{desc}"
     )

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -428,8 +428,9 @@ class Package < ApplicationRecord
   end
 
   def self.source_path(project, package, file = nil, opts = {})
-    path = "/source/#{URI.escape(project)}/#{URI.escape(package)}"
-    path += "/#{URI.escape(file)}" if file.present?
+    path = "/source/#{project}/#{package}"
+    path = Addressable::URI.escape(path)
+    path += "/#{CGI.escape(file)}" if file.present?
     path += '?' + opts.to_query if opts.present?
     path
   end
@@ -1324,7 +1325,7 @@ class Package < ApplicationRecord
       permitted_params = params.permit(:repository, :arch, :package, :code, :wipe)
 
       # do not use project.name because we missuse the package source container for build container operations
-      Backend::Connection.post("/build/#{URI.escape(build_project)}?cmd=#{command}&#{permitted_params.to_h.to_query}")
+      Backend::Connection.post(Addressable::URI.escape("/build/#{build_project}?cmd=#{command}&#{permitted_params.to_h.to_query}"))
     rescue Backend::Error, Timeout::Error, Project::WritePermissionError => e
       errors.add(:base, e.message)
       return false

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -309,8 +309,9 @@ class Project < ApplicationRecord
     end
 
     def source_path(project, file = nil, opts = {})
-      path = "/source/#{URI.escape(project)}"
-      path += "/#{URI.escape(file)}" if file.present?
+      path = "/source/#{project}"
+      path = Addressable::URI.escape(path)
+      path += "/#{CGI.escape(file)}" if file.present?
       path += '?' + opts.to_query if opts.present?
       path
     end

--- a/src/api/spec/factories/packages.rb
+++ b/src/api/spec/factories/packages.rb
@@ -108,7 +108,10 @@ FactoryBot.define do
       after(:create) do |package|
         # NOTE: Enable global write through when writing new VCR cassetes.
         # ensure the backend knows the project
-        Backend::Connection.put("/source/#{URI.escape(package.project.name)}/#{URI.escape(package.name)}/_service", '<services/>') if CONFIG['global_write_through']
+        if CONFIG['global_write_through']
+          Backend::Connection.put(Addressable::URI.escape("/source/#{package.project.name}/#{package.name}/_service"),
+                                  '<services/>')
+        end
       end
     end
 
@@ -116,7 +119,10 @@ FactoryBot.define do
       after(:create) do |package|
         # NOTE: Enable global write through when writing new VCR cassetes.
         # ensure the backend knows the project
-        Backend::Connection.put("/source/#{URI.escape(package.project.name)}/#{URI.escape(package.name)}/_service", '<service>broken</service>') if CONFIG['global_write_through']
+        if CONFIG['global_write_through']
+          Backend::Connection.put(Addressable::URI.escape("/source/#{package.project.name}/#{package.name}/_service"),
+                                  '<service>broken</service>')
+        end
       end
     end
 
@@ -131,7 +137,7 @@ FactoryBot.define do
         # ensure the backend knows the project
         if CONFIG['global_write_through']
           full_path = "/source/#{package.project.name}/#{package.name}/#{evaluator.changes_file_name}"
-          Backend::Connection.put(URI.escape(full_path), evaluator.changes_file_content)
+          Backend::Connection.put(Addressable::URI.escape(full_path), evaluator.changes_file_content)
         end
       end
     end
@@ -160,7 +166,7 @@ FactoryBot.define do
         # ensure the backend knows the project
         if CONFIG['global_write_through']
           full_path = "/source/#{package.project.name}/#{package.name}/#{evaluator.kiwi_file_name}"
-          Backend::Connection.put(URI.escape(full_path), evaluator.kiwi_file_content)
+          Backend::Connection.put(Addressable::URI.escape(full_path), evaluator.kiwi_file_content)
         end
       end
     end

--- a/src/api/spec/models/package_spec.rb
+++ b/src/api/spec/models/package_spec.rb
@@ -652,7 +652,7 @@ RSpec.describe Package, vcr: true do
       before do
         if CONFIG['global_write_through']
           full_path = "/source/#{package.project.name}/#{package.name}/lorem.changes"
-          Backend::Connection.put(URI.escape(full_path), 'Lorem ipsum dolorem')
+          Backend::Connection.put(Addressable::URI.escape(full_path), 'Lorem ipsum dolorem')
         end
       end
 


### PR DESCRIPTION
In order to prepare for the update of Ruby 3.1, we're extracting as many changes as possible and pushing them to master. 

`URI.escape` will be deprecated in Ruby 3.1 (see #12304)