### PR TITLE
Switch container urls back to OSU

### DIFF
--- a/.circleci/conditional_config.yml
+++ b/.circleci/conditional_config.yml
@@ -40,17 +40,17 @@ images:
   - &backend registry.opensuse.org/obs/server/unstable/containers/containers/openbuildservice/backend:latest
 
   - &frontend_minitest
-    image: registry.opensuse.org/obs/server/unstable/containers/ruby31/containers/openbuildservice/frontend-minitest:latest
+    image: registry.opensuse.org/obs/server/unstable/containers/containers/openbuildservice/frontend-minitest:latest
     <<: *common_frontend_config
     environment:
       EAGER_LOAD: 1
 
   - &frontend_base
-    image: registry.opensuse.org/obs/server/unstable/containers/ruby31/containers/openbuildservice/frontend-base:latest
+    image: registry.opensuse.org/obs/server/unstable/containers/containers/openbuildservice/frontend-base:latest
     <<: *common_frontend_config
 
   - &frontend_features
-    image: registry.opensuse.org/obs/server/unstable/containers/ruby31/containers/openbuildservice/frontend-features:latest
+    image: registry.opensuse.org/obs/server/unstable/containers/containers/openbuildservice/frontend-features:latest
 aliases:
   - &restore_bundler_cache
     restore_cache:

--- a/src/api/docker-files/Dockerfile
+++ b/src/api/docker-files/Dockerfile
@@ -3,7 +3,7 @@
 # contained rails app generating files in the git checkout with
 # some strange user...
 
-FROM registry.opensuse.org/obs/server/unstable/containers/ruby31/containers/openbuildservice/frontend-features:latest
+FROM registry.opensuse.org/obs/server/unstable/containers/containers/openbuildservice/frontend-features:latest
 ARG CONTAINER_USERID
 
 # for lint task


### PR DESCRIPTION
We don't need to point to the ruby31 branch anymore now that the
changes are merged into master.