### PR TITLE
Do not check for checks and missing_checks for empty status_reports

### DIFF
--- a/src/api/app/controllers/status/reports_controller.rb
+++ b/src/api/app/controllers/status/reports_controller.rb
@@ -17,7 +17,7 @@ class Status::ReportsController < ApplicationController
                        @checkable.status_reports.find_by!(uuid: params[:report_uuid])
                      else
                        # request reports don't have uuid
-                       @checkable.status_reports.first
+                       @checkable.status_reports.first!
                      end
   end
 end


### PR DESCRIPTION
Most of the times status reports are nil for bs_requests and `GET '/status_reports/requests/<id>/reports'` results in an error 500. This PR avoids the 500 error and returns 404 instead.

```
Server returned an error: HTTP Error 404: Not Found
Couldn't find Status::Report with [WHERE `status_reports`.`checkable_id` = ? AND `status_reports`.`checkable_type` = ?]
```