### PR TITLE
Notify if request state change fails because of permission on deleting a project

### DIFF
--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -494,7 +494,7 @@ class Project < ApplicationRecord
           begin
             request.change_state(newstate: 'revoked', comment: "The source project '#{name}' has been removed")
           rescue PostRequestNoPermission
-            logger.debug "#{User.session!.login} tried to revoke request #{request.number} but had no permissions"
+            Airbrake.notify("#{User.session!.login} tried to revoke request #{request.number} but had no permissions")
           end
           break
         end
@@ -503,7 +503,7 @@ class Project < ApplicationRecord
         begin
           request.change_state(newstate: 'declined', comment: "The target project '#{name}' has been removed")
         rescue PostRequestNoPermission
-          logger.debug "#{User.session!.login} tried to decline request #{request.number} but had no permissions"
+          Airbrake.notify("#{User.session!.login} tried to decline request #{request.number} but had no permissions")
         end
         break
       end


### PR DESCRIPTION
Fixes #12250

When a project is deleted we revoke the existing bs_requests for that project. Sometimes the bs_request [state change](https://github.com/openSUSE/open-build-service/blob/8aa082591478ef82b8aae6dd30015f2dc3b91079/src/api/app/models/project.rb#L494) fails silently because of permission issues. This PR tries to address this issue by notifying in this case. 