### PR TITLE
[backend] BSSched::DoD.pm: do nothing in dodcheck if called from the …

### DIFF
--- a/src/backend/BSSched/DoD.pm
+++ b/src/backend/BSSched/DoD.pm
@@ -190,6 +190,7 @@ sub dodcheck {
   my ($ctx, $pool, $arch, @pkgs) = @_;
   return unless @pkgs;
   $ctx = $ctx->{'realctx'} if $ctx->{'realctx'};	# we need the real one to add entries
+  return if $ctx->{'isreposerver'};			# the reposerver does not check for dods
   my %names;
   if (defined &BSSolv::repo::dodcookie) {
     %names = (%names, $_->pkgnames()) for grep {$_->dodurl() || $_->dodcookie()} $pool->repos();


### PR DESCRIPTION
…repo server

We added a dodcheck call to Docker/Kiwi, but that broke buildinfo
generation if a DoD package was not available.