### PR TITLE
Approver cannot be the request creator

### DIFF
--- a/src/api/app/models/bs_request/errors.rb
+++ b/src/api/app/models/bs_request/errors.rb
@@ -58,4 +58,8 @@ module BsRequest::Errors
 
   class ReviewNotSpecified < APIError
   end
+
+  class CreatorCannotAcceptOwnRequests < APIError
+    setup 403, "the creator of the request cannot approve it's own requests"
+  end
 end

--- a/src/api/app/models/bs_request_permission_check.rb
+++ b/src/api/app/models/bs_request_permission_check.rb
@@ -124,6 +124,13 @@ class BsRequestPermissionCheck
 
       check_newstate_action!(action, opts)
 
+      # TODO: Get the relevant project attribute, from the target project or target package. Retrieve the accepter and check if it's the same person than the creator. And fail if true
+      target_package = Package.get_by_project_and_name(action.target_project, action.target_package) if Package.exists_by_project_and_name(action.target_project, action.target_package)
+      target_project = Project.find_by_name(action.target_project) if action.target_project
+      cannot_accept_request = target_package&.find_attribute('OBS', 'CreatorCannotAcceptOwnRequests').present?
+      cannot_accept_request ||= target_project&.find_attribute('OBS', 'CreatorCannotAcceptOwnRequests').present?
+      raise BsRequest::Errors::CreatorCannotAcceptOwnRequests if cannot_accept_request && User.session!.login == req.creator
+
       # abort immediatly if we want to write and can't
       next unless accept_check && !@write_permission_in_this_action
 

--- a/src/api/db/attribute_descriptions.rb
+++ b/src/api/db/attribute_descriptions.rb
@@ -28,7 +28,8 @@ def update_all_attrib_type_descriptions
     'MakeOriginOlder' => 'Initialize packages by making the build results newer then updated ones',
     'DelegateRequestTarget' => 'Delegate the target project of requests even when target_project is specified',
     'AllowSubmitToMaintenanceRelease' => 'Allow submit requests to maintenance release projects',
-    'EnforceRevisionsInRequests' => 'Enforce revisions in request actions'
+    'EnforceRevisionsInRequests' => 'Enforce revisions in request actions',
+    'CreatorCannotAcceptOwnRequests' => 'The creator and the accepter of a request cannot be the same person'
   }
   # rubocop:enable Layout/LineLength
 

--- a/src/api/db/data/20220318123314_add_attribute_to_enforce_request_accepter_and_creator_to_be_a_different_person.rb
+++ b/src/api/db/data/20220318123314_add_attribute_to_enforce_request_accepter_and_creator_to_be_a_different_person.rb
@@ -1,0 +1,11 @@
+class AddAttributeToEnforceRequestAccepterAndCreatorToBeADifferentPerson < ActiveRecord::Migration[6.1]
+  def up
+    ans = AttribNamespace.first_or_create(name: 'OBS')
+    ans.attrib_types.where(name: 'CreatorCannotAcceptOwnRequests').first_or_create(value_count: 0)
+  end
+
+  def down
+    ans = AttribNamespace.first_or_create(name: 'OBS')
+    ans.attrib_types.where(name: 'CreatorCannotAcceptOwnRequests').delete
+  end
+end

--- a/src/api/db/data_schema.rb
+++ b/src/api/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20211027143134)
+DataMigrate::Data.define(version: 20220318123314)

--- a/src/api/db/seeds.rb
+++ b/src/api/db/seeds.rb
@@ -160,6 +160,9 @@ at.attrib_type_modifiable_bies.where(user_id: admin.id).first_or_create
 at.allowed_values << AttribAllowedValue.new(value: 'DisableDevel')
 at.allowed_values << AttribAllowedValue.new(value: 'BugownerOnly')
 
+at = ans.attrib_types.where(name: 'CreatorCannotAcceptOwnRequests').first_or_create(value_count: 0)
+at.attrib_type_modifiable_bies.where(user_id: admin.id).first_or_create
+
 update_all_attrib_type_descriptions
 
 puts 'Seeding issue trackers ...'

--- a/src/api/spec/cassettes/BsRequest/_changestate/when_bs_request_is_staged/when_a_staged_bs_request_is_accepted/1_6_5_2_1.yml
+++ b/src/api/spec/cassettes/BsRequest/_changestate/when_bs_request_is_staged/when_a_staged_bs_request_is_accepted/1_6_5_2_1.yml
@@ -25,15 +25,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '301'
+      - '89'
     body:
       encoding: UTF-8
       string: |
-        <directory name="source_package" rev="16" vrev="16" srcmd5="48a586f8770e715b0b29cb1803d84528">
-          <entry name="_config" md5="b30a78f507b83c0d96a4028a80e7176f" size="60" mtime="1597244450"/>
-          <entry name="somefile.txt" md5="856af786fd61ce41ce16d2b20c173ee7" size="57" mtime="1597244450"/>
+        <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Wed, 12 Aug 2020 16:02:08 GMT
+  recorded_at: Mon, 21 Mar 2022 12:07:49 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package?expand=1
@@ -59,15 +57,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '301'
+      - '89'
     body:
       encoding: UTF-8
       string: |
-        <directory name="source_package" rev="16" vrev="16" srcmd5="48a586f8770e715b0b29cb1803d84528">
-          <entry name="_config" md5="b30a78f507b83c0d96a4028a80e7176f" size="60" mtime="1597244450"/>
-          <entry name="somefile.txt" md5="856af786fd61ce41ce16d2b20c173ee7" size="57" mtime="1597244450"/>
+        <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Wed, 12 Aug 2020 16:02:08 GMT
+  recorded_at: Mon, 21 Mar 2022 12:07:49 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tux/target_package
@@ -99,7 +95,7 @@ http_interactions:
       string: |
         <directory name="target_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Wed, 12 Aug 2020 16:02:08 GMT
+  recorded_at: Mon, 21 Mar 2022 12:07:49 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tux/target_package?view=info
@@ -132,7 +128,7 @@ http_interactions:
         <sourceinfo package="target_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
           <error>no source uploaded</error>
         </sourceinfo>
-  recorded_at: Wed, 12 Aug 2020 16:02:08 GMT
+  recorded_at: Mon, 21 Mar 2022 12:07:49 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tux/target_package
@@ -164,7 +160,7 @@ http_interactions:
       string: |
         <directory name="target_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Wed, 12 Aug 2020 16:02:08 GMT
+  recorded_at: Mon, 21 Mar 2022 12:07:49 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tux/target_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -201,5 +197,5 @@ http_interactions:
           <new project="home:tux" package="target_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files/>
         </sourcediff>
-  recorded_at: Wed, 12 Aug 2020 16:02:08 GMT
+  recorded_at: Mon, 21 Mar 2022 12:07:49 GMT
 recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/BsRequest/_changestate/when_the_request_is_accepted/and_the_target_package_has_an_attribute_to_disallow_acceptance_by_the_creator/and_the_accepter_is_NOT_the_creator/accepts_the_request.yml
+++ b/src/api/spec/cassettes/BsRequest/_changestate/when_the_request_is_accepted/and_the_target_package_has_an_attribute_to_disallow_acceptance_by_the_creator/and_the_accepter_is_NOT_the_creator/accepts_the_request.yml
@@ -1,0 +1,548 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/source_project_123/_meta?user=user_17
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="source_project_123">
+          <title>The Torment of Others</title>
+          <description/>
+          <person userid="sagan" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '161'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="source_project_123">
+          <title>The Torment of Others</title>
+          <description></description>
+          <person userid="sagan" role="maintainer"/>
+        </project>
+  recorded_at: Mon, 21 Mar 2022 10:17:43 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/source_project_123/source_package_123/_meta?user=user_18
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="source_package_123" project="source_project_123">
+          <title>Recalled to Life</title>
+          <description>Aliquam est rem et.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '159'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="source_package_123" project="source_project_123">
+          <title>Recalled to Life</title>
+          <description>Aliquam est rem et.</description>
+        </package>
+  recorded_at: Mon, 21 Mar 2022 10:17:43 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_123/_meta?user=user_19
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_123">
+          <title>Recalled to Life</title>
+          <description/>
+          <person userid="sagan" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '149'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_123">
+          <title>Recalled to Life</title>
+          <description></description>
+          <person userid="sagan" role="maintainer"/>
+        </project>
+  recorded_at: Mon, 21 Mar 2022 10:17:44 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_123/package_123/_meta?user=user_20
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_123" project="project_123">
+          <title>No Country for Old Men</title>
+          <description>Tempore dolorem dolor dignissimos.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '166'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_123" project="project_123">
+          <title>No Country for Old Men</title>
+          <description>Tempore dolorem dolor dignissimos.</description>
+        </package>
+  recorded_at: Mon, 21 Mar 2022 10:17:44 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/source_project_123/source_package_123
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="source_package_123" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Mon, 21 Mar 2022 10:17:44 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/source_project_123/source_package_123?cmd=diff&expand=1&filelimit=10000&opackage=package_123&oproject=project_123&tarlimit=10000&view=xml&withissues=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '331'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="6bdc6c334f16ef2ea3480f27a675b7c8">
+          <old project="project_123" package="package_123" rev="60" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="source_project_123" package="source_package_123" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <files>
+          </files>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Mon, 21 Mar 2022 10:17:44 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_123/package_123/_attribute?meta=1&user=bujold
+    body:
+      encoding: UTF-8
+      string: |
+        <attributes>
+          <attribute name="CreatorCannotAcceptOwnRequests" namespace="OBS"/>
+        </attributes>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '170'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="140">
+          <srcmd5>66c9c830bf5dae56e8997be26c47a44c</srcmd5>
+          <time>1647857864</time>
+          <user>bujold</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Mon, 21 Mar 2022 10:17:44 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/source_project_123/source_package_123?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="source_package_123" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Mon, 21 Mar 2022 10:17:44 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/source_project_123/source_package_123?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="source_package_123" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Mon, 21 Mar 2022 10:17:44 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/project_123/package_123?cmd=copy&comment=A%20single%20comment&expand=1&keeplink=1&noservice=1&opackage=source_package_123&oproject=source_project_123&requestid=1&user=bujold&withacceptinfo=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '346'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="61" vrev="61">
+          <srcmd5>d41d8cd98f00b204e9800998ecf8427e</srcmd5>
+          <version>unknown</version>
+          <time>1647857864</time>
+          <user>bujold</user>
+          <comment>A single comment</comment>
+          <requestid>1</requestid>
+          <acceptinfo rev="61" srcmd5="d41d8cd98f00b204e9800998ecf8427e" osrcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+        </revision>
+  recorded_at: Mon, 21 Mar 2022 10:17:44 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_123/package_123/_meta?user=bujold
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_123" project="project_123">
+          <title>No Country for Old Men</title>
+          <description>Tempore dolorem dolor dignissimos.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '166'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_123" project="project_123">
+          <title>No Country for Old Men</title>
+          <description>Tempore dolorem dolor dignissimos.</description>
+        </package>
+  recorded_at: Mon, 21 Mar 2022 10:17:44 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/project_123/package_123
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '105'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_123" rev="61" vrev="61" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Mon, 21 Mar 2022 10:17:44 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/project_123/package_123?view=info
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '146'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourceinfo package="package_123" rev="61" vrev="61" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+          <error>no source uploaded</error>
+        </sourceinfo>
+  recorded_at: Mon, 21 Mar 2022 10:17:44 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/project_123/package_123
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '105'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_123" rev="61" vrev="61" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Mon, 21 Mar 2022 10:17:44 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/project_123/package_123?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '284'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="1f4a7c462b391aec08ee338bac308428">
+          <old project="project_123" package="package_123" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="project_123" package="package_123" rev="61" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <files/>
+        </sourcediff>
+  recorded_at: Mon, 21 Mar 2022 10:17:44 GMT
+recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/BsRequest/_changestate/when_the_request_is_accepted/and_the_target_package_has_an_attribute_to_disallow_acceptance_by_the_creator/and_the_accepter_is_the_creator/triggers_an_error.yml
+++ b/src/api/spec/cassettes/BsRequest/_changestate/when_the_request_is_accepted/and_the_target_package_has_an_attribute_to_disallow_acceptance_by_the_creator/and_the_accepter_is_the_creator/triggers_an_error.yml
@@ -1,0 +1,303 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/source_project_123/_meta?user=user_13
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="source_project_123">
+          <title>Down to a Sunless Sea</title>
+          <description/>
+          <person userid="sagan" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '161'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="source_project_123">
+          <title>Down to a Sunless Sea</title>
+          <description></description>
+          <person userid="sagan" role="maintainer"/>
+        </project>
+  recorded_at: Mon, 21 Mar 2022 10:17:42 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/source_project_123/source_package_123/_meta?user=user_14
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="source_package_123" project="source_project_123">
+          <title>Everything is Illuminated</title>
+          <description>Aut est quaerat perferendis.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '177'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="source_package_123" project="source_project_123">
+          <title>Everything is Illuminated</title>
+          <description>Aut est quaerat perferendis.</description>
+        </package>
+  recorded_at: Mon, 21 Mar 2022 10:17:42 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_123/_meta?user=user_15
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_123">
+          <title>Blue Remembered Earth</title>
+          <description/>
+          <person userid="sagan" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '154'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_123">
+          <title>Blue Remembered Earth</title>
+          <description></description>
+          <person userid="sagan" role="maintainer"/>
+        </project>
+  recorded_at: Mon, 21 Mar 2022 10:17:42 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_123/package_123/_meta?user=user_16
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_123" project="project_123">
+          <title>The Golden Bowl</title>
+          <description>Corrupti nihil rem dolorum.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '152'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_123" project="project_123">
+          <title>The Golden Bowl</title>
+          <description>Corrupti nihil rem dolorum.</description>
+        </package>
+  recorded_at: Mon, 21 Mar 2022 10:17:43 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/source_project_123/source_package_123
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="source_package_123" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Mon, 21 Mar 2022 10:17:43 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/source_project_123/source_package_123?cmd=diff&expand=1&filelimit=10000&opackage=package_123&oproject=project_123&tarlimit=10000&view=xml&withissues=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '331'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="6bdc6c334f16ef2ea3480f27a675b7c8">
+          <old project="project_123" package="package_123" rev="60" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="source_project_123" package="source_package_123" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <files>
+          </files>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Mon, 21 Mar 2022 10:17:43 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_123/package_123/_attribute?meta=1&user=sagan
+    body:
+      encoding: UTF-8
+      string: |
+        <attributes>
+          <attribute name="CreatorCannotAcceptOwnRequests" namespace="OBS"/>
+        </attributes>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '169'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="138">
+          <srcmd5>baa17e4a5e1f9d56051b167086f7d857</srcmd5>
+          <time>1647857863</time>
+          <user>sagan</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Mon, 21 Mar 2022 10:17:43 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/source_project_123/source_package_123?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="source_package_123" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Mon, 21 Mar 2022 10:17:43 GMT
+recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/BsRequest/_changestate/when_the_request_is_accepted/and_the_target_package_has_an_attribute_to_disallow_acceptance_by_the_creator/but_the_accepter_is_NOT_the_creator/accepts_the_request.yml
+++ b/src/api/spec/cassettes/BsRequest/_changestate/when_the_request_is_accepted/and_the_target_package_has_an_attribute_to_disallow_acceptance_by_the_creator/but_the_accepter_is_NOT_the_creator/accepts_the_request.yml
@@ -1,0 +1,37 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/source/source_project_123/source_package_123?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'source_project_123' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '164'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'source_project_123' does not exist</summary>
+          <details>404 project 'source_project_123' does not exist</details>
+        </status>
+  recorded_at: Tue, 22 Mar 2022 11:24:23 GMT
+recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/BsRequest/_changestate/when_the_request_is_accepted/and_the_target_project_has_an_attribute_to_disallow_acceptance_by_the_creator/and_the_accepter_is_NOT_the_creator/accepts_the_request.yml
+++ b/src/api/spec/cassettes/BsRequest/_changestate/when_the_request_is_accepted/and_the_target_project_has_an_attribute_to_disallow_acceptance_by_the_creator/and_the_accepter_is_NOT_the_creator/accepts_the_request.yml
@@ -1,0 +1,548 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/source_project_123/_meta?user=user_1
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="source_project_123">
+          <title>For a Breath I Tarry</title>
+          <description/>
+          <person userid="sagan" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '160'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="source_project_123">
+          <title>For a Breath I Tarry</title>
+          <description></description>
+          <person userid="sagan" role="maintainer"/>
+        </project>
+  recorded_at: Mon, 21 Mar 2022 10:17:38 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/source_project_123/source_package_123/_meta?user=user_2
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="source_package_123" project="source_project_123">
+          <title>When the Green Woods Laugh</title>
+          <description>Deserunt tempore suscipit provident.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '186'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="source_package_123" project="source_project_123">
+          <title>When the Green Woods Laugh</title>
+          <description>Deserunt tempore suscipit provident.</description>
+        </package>
+  recorded_at: Mon, 21 Mar 2022 10:17:38 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_123/_meta?user=user_3
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_123">
+          <title>The Last Enemy</title>
+          <description/>
+          <person userid="sagan" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '147'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_123">
+          <title>The Last Enemy</title>
+          <description></description>
+          <person userid="sagan" role="maintainer"/>
+        </project>
+  recorded_at: Mon, 21 Mar 2022 10:17:38 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_123/package_123/_meta?user=user_4
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_123" project="project_123">
+          <title>A Farewell to Arms</title>
+          <description>Et non eveniet et.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '146'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_123" project="project_123">
+          <title>A Farewell to Arms</title>
+          <description>Et non eveniet et.</description>
+        </package>
+  recorded_at: Mon, 21 Mar 2022 10:17:38 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/source_project_123/source_package_123
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="source_package_123" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Mon, 21 Mar 2022 10:17:38 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/source_project_123/source_package_123?cmd=diff&expand=1&filelimit=10000&opackage=package_123&oproject=project_123&tarlimit=10000&view=xml&withissues=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '331'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="1662fb3bd9257906a06477f9c5e576c2">
+          <old project="project_123" package="package_123" rev="58" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="source_project_123" package="source_package_123" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <files>
+          </files>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Mon, 21 Mar 2022 10:17:38 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_123/_project/_attribute?meta=1&user=clarke
+    body:
+      encoding: UTF-8
+      string: |
+        <attributes>
+          <attribute name="CreatorCannotAcceptOwnRequests" namespace="OBS"/>
+        </attributes>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '170'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="116">
+          <srcmd5>955ffa3681de158063a80a86fa76f770</srcmd5>
+          <time>1647857859</time>
+          <user>clarke</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Mon, 21 Mar 2022 10:17:39 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/source_project_123/source_package_123?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="source_package_123" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Mon, 21 Mar 2022 10:17:39 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/source_project_123/source_package_123?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="source_package_123" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Mon, 21 Mar 2022 10:17:39 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/project_123/package_123?cmd=copy&comment=A%20single%20comment&expand=1&keeplink=1&noservice=1&opackage=source_package_123&oproject=source_project_123&requestid=1&user=clarke&withacceptinfo=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '346'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="59" vrev="59">
+          <srcmd5>d41d8cd98f00b204e9800998ecf8427e</srcmd5>
+          <version>unknown</version>
+          <time>1647857859</time>
+          <user>clarke</user>
+          <comment>A single comment</comment>
+          <requestid>1</requestid>
+          <acceptinfo rev="59" srcmd5="d41d8cd98f00b204e9800998ecf8427e" osrcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+        </revision>
+  recorded_at: Mon, 21 Mar 2022 10:17:39 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_123/package_123/_meta?user=clarke
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_123" project="project_123">
+          <title>A Farewell to Arms</title>
+          <description>Et non eveniet et.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '146'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_123" project="project_123">
+          <title>A Farewell to Arms</title>
+          <description>Et non eveniet et.</description>
+        </package>
+  recorded_at: Mon, 21 Mar 2022 10:17:39 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/project_123/package_123
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '105'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_123" rev="59" vrev="59" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Mon, 21 Mar 2022 10:17:39 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/project_123/package_123?view=info
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '146'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourceinfo package="package_123" rev="59" vrev="59" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+          <error>no source uploaded</error>
+        </sourceinfo>
+  recorded_at: Mon, 21 Mar 2022 10:17:39 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/project_123/package_123
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '105'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_123" rev="59" vrev="59" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Mon, 21 Mar 2022 10:17:39 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/project_123/package_123?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '284'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="689739be40229a728273ae73ab2b7444">
+          <old project="project_123" package="package_123" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="project_123" package="package_123" rev="59" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <files/>
+        </sourcediff>
+  recorded_at: Mon, 21 Mar 2022 10:17:39 GMT
+recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/BsRequest/_changestate/when_the_request_is_accepted/and_the_target_project_has_an_attribute_to_disallow_acceptance_by_the_creator/and_the_accepter_is_the_creator/triggers_an_error.yml
+++ b/src/api/spec/cassettes/BsRequest/_changestate/when_the_request_is_accepted/and_the_target_project_has_an_attribute_to_disallow_acceptance_by_the_creator/and_the_accepter_is_the_creator/triggers_an_error.yml
@@ -1,0 +1,303 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/source_project_123/_meta?user=user_5
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="source_project_123">
+          <title>Beneath the Bleeding</title>
+          <description/>
+          <person userid="sagan" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '160'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="source_project_123">
+          <title>Beneath the Bleeding</title>
+          <description></description>
+          <person userid="sagan" role="maintainer"/>
+        </project>
+  recorded_at: Mon, 21 Mar 2022 10:17:40 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/source_project_123/source_package_123/_meta?user=user_6
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="source_package_123" project="source_project_123">
+          <title>Dulce et Decorum Est</title>
+          <description>Dolor maxime incidunt quia.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '171'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="source_package_123" project="source_project_123">
+          <title>Dulce et Decorum Est</title>
+          <description>Dolor maxime incidunt quia.</description>
+        </package>
+  recorded_at: Mon, 21 Mar 2022 10:17:40 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_123/_meta?user=user_7
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_123">
+          <title>Surprised by Joy</title>
+          <description/>
+          <person userid="sagan" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '149'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_123">
+          <title>Surprised by Joy</title>
+          <description></description>
+          <person userid="sagan" role="maintainer"/>
+        </project>
+  recorded_at: Mon, 21 Mar 2022 10:17:40 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_123/package_123/_meta?user=user_8
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_123" project="project_123">
+          <title>No Highway</title>
+          <description>Asperiores dolor odio culpa.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '148'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_123" project="project_123">
+          <title>No Highway</title>
+          <description>Asperiores dolor odio culpa.</description>
+        </package>
+  recorded_at: Mon, 21 Mar 2022 10:17:40 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/source_project_123/source_package_123
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="source_package_123" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Mon, 21 Mar 2022 10:17:40 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/source_project_123/source_package_123?cmd=diff&expand=1&filelimit=10000&opackage=package_123&oproject=project_123&tarlimit=10000&view=xml&withissues=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '331'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="ff65c9ecb7727e5ffa1c7a231e73804a">
+          <old project="project_123" package="package_123" rev="59" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="source_project_123" package="source_package_123" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <files>
+          </files>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Mon, 21 Mar 2022 10:17:40 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_123/_project/_attribute?meta=1&user=sagan
+    body:
+      encoding: UTF-8
+      string: |
+        <attributes>
+          <attribute name="CreatorCannotAcceptOwnRequests" namespace="OBS"/>
+        </attributes>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '169'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="118">
+          <srcmd5>2cd9dffc8e9eece9d06cfa31990cfcd3</srcmd5>
+          <time>1647857860</time>
+          <user>sagan</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Mon, 21 Mar 2022 10:17:40 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/source_project_123/source_package_123?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="source_package_123" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Mon, 21 Mar 2022 10:17:40 GMT
+recorded_with: VCR 6.0.0

--- a/src/api/spec/cassettes/BsRequest/_changestate/when_the_request_is_accepted/and_the_target_project_has_an_attribute_to_disallow_acceptance_by_the_creator/but_the_accepter_is_NOT_the_creator/accepts_the_request.yml
+++ b/src/api/spec/cassettes/BsRequest/_changestate/when_the_request_is_accepted/and_the_target_project_has_an_attribute_to_disallow_acceptance_by_the_creator/but_the_accepter_is_NOT_the_creator/accepts_the_request.yml
@@ -1,0 +1,37 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/source/source_project_123/source_package_123?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'source_project_123' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '164'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'source_project_123' does not exist</summary>
+          <details>404 project 'source_project_123' does not exist</details>
+        </status>
+  recorded_at: Tue, 22 Mar 2022 11:24:22 GMT
+recorded_with: VCR 6.0.0

--- a/src/api/spec/support/database_cleaner.rb
+++ b/src/api/spec/support/database_cleaner.rb
@@ -39,6 +39,7 @@ RSpec.configure do |config|
     create(:obs_attrib_type, name: 'VeryImportantProject')
     create(:obs_attrib_type, name: 'DelegateRequestTarget')
     create(:obs_attrib_type, name: 'EmbargoDate', value_count: 1)
+    create(:obs_attrib_type, name: 'CreatorCannotAcceptOwnRequests', value_count: 0)
     Configuration.first_or_create(name: 'private', title: 'Open Build Service').update(allow_user_to_create_home_project: false)
   end
 


### PR DESCRIPTION
In order to enforce two different reviewers, the approver cannot be the same person than the creator of a request, if the proper attribute is enabled at target project or target package.

## How to test this
1. In the review-app, go to your home project
2. Add an `CreatorCannotAcceptOwnRequests` attribute there.
3. Go to the project's hello-world package
4. Branch it and change the sources so you can submit a request back
5. Go to the request and accept it.

### Expected result
As you have the `CreatorCannotAcceptOwnRequests` attribute set and you are the same approver user as the request's creator user, an error will popup preventing you to approve the request.

If you go now and remove the attribute from the project, you'll be allowed to approve your own request.

You could also approve it with or without the attribute set if you log in with another user with proper permissions in the project (as it's not the same person as the request creator).

## TODO
- [x] Implementation of the validation
- [x] Specs
- [x] Data migration to create the new Attribute
- [x] Testing in API