### PR TITLE
Rename methods to create/delete relationship events

### DIFF
--- a/src/api/app/mixins/has_relationships.rb
+++ b/src/api/app/mixins/has_relationships.rb
@@ -55,7 +55,7 @@ module HasRelationships
           end
     rel = rel.where(role_id: role.id) if role
     transaction do
-      rel.map(&:create_event_before_delete)
+      rel.map(&:create_relationship_delete_event)
       rel.delete_all
       write_to_backend
     end

--- a/src/api/app/models/relationship.rb
+++ b/src/api/app/models/relationship.rb
@@ -60,7 +60,7 @@ class Relationship < ApplicationRecord
     bugowners.joins(:user).merge(User.with_email)
   }
 
-  after_create :create_event_after_create
+  after_create :create_relationship_create_event
 
   # we only care for project<->user relationships, but the cache is not *that* expensive
   # to recalculate
@@ -127,7 +127,7 @@ class Relationship < ApplicationRecord
     with_groups_and_roles_query.pluck('groups.title', 'roles.title')
   end
 
-  def create_event_before_delete
+  def create_relationship_delete_event
     return unless User.session
 
     Event::RelationshipDelete.create(event_parameters)
@@ -167,7 +167,7 @@ class Relationship < ApplicationRecord
     raise NotFoundError, "Couldn't find user #{user.login}" if user && user.is_nobody?
   end
 
-  def create_event_after_create
+  def create_relationship_create_event
     return unless User.session
 
     Event::RelationshipCreate.create(event_parameters)


### PR DESCRIPTION
The method names `create_event_after_create` and `create_event_before_delete` sound a bit weird to me. Especially in `after_create :create_event_after_create`.

I propose these other names, let me know what you think.