### PR TITLE
Add link to new workflow run in initial reports to SCM

### DIFF
--- a/src/api/app/services/scm_initial_status_reporter.rb
+++ b/src/api/app/services/scm_initial_status_reporter.rb
@@ -1,14 +1,16 @@
 class ScmInitialStatusReporter < SCMStatusReporter
   attr_accessor :state
 
-  def initialize(event_payload, event_subscription_payload, scm_token, event_type = nil)
+  def initialize(event_payload, event_subscription_payload, scm_token, workflow_run, event_type = nil)
     super(event_payload, event_subscription_payload, scm_token)
     @state = event_type.nil? ? 'pending' : 'success'
+    @workflow_run = workflow_run
   end
 
   private
 
   def status_options
-    { context: 'OBS SCM/CI Workflow Integration started' }
+    { context: 'OBS SCM/CI Workflow Integration started',
+      target_url: Rails.application.routes.url_helpers.token_workflow_run_url(@workflow_run.token_id, @workflow_run.id, host: Configuration.obs_url) }
   end
 end


### PR DESCRIPTION
On our OBS instance, the generated link will be like `https://build.opensuse.org/my/tokens/1/workflow_runs/1`