### PR TITLE
Inform user when the provided token is wrong 

### DIFF
--- a/src/api/app/controllers/concerns/rescue_handler.rb
+++ b/src/api/app/controllers/concerns/rescue_handler.rb
@@ -31,6 +31,10 @@ module RescueHandler
       render plain: text, status: http_status
     end
 
+    rescue_from Trigger::Errors::InvalidToken do |exception|
+      render_error status: 403, errorcode: 'invalid_token', message: exception.message
+    end
+
     rescue_from Project::WritePermissionError do |exception|
       render_error status: 403, errorcode: 'modify_project_no_permission', message: exception.message
     end

--- a/src/api/app/controllers/trigger_controller.rb
+++ b/src/api/app/controllers/trigger_controller.rb
@@ -54,7 +54,7 @@ class TriggerController < ApplicationController
   # AUTHENTICATION
   def set_token
     @token = ::TriggerControllerService::TokenExtractor.new(request).call
-    raise InvalidToken unless @token
+    raise InvalidToken, 'No valid token found' unless @token
   end
 
   def pundit_user

--- a/src/api/app/controllers/trigger_workflow_controller.rb
+++ b/src/api/app/controllers/trigger_workflow_controller.rb
@@ -68,6 +68,8 @@ class TriggerWorkflowController < TriggerController
   end
 
   def create_workflow_run
+    raise Trigger::Errors::InvalidToken, 'Wrong token type. Please use workflow tokens only.' unless @token.is_a?(Token::Workflow)
+
     request_headers = request.headers.to_h.keys.map { |k| "#{k}: #{request.headers[k]}" if k.match?(/^HTTP_/) }.compact.join("\n")
     @workflow_run = @token.workflow_runs.create(request_headers: request_headers, request_payload: request.body.read)
   end

--- a/src/api/spec/controllers/trigger_controller_spec.rb
+++ b/src/api/spec/controllers/trigger_controller_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe TriggerController, vcr: true do
       end
 
       it { expect(response).to have_http_status(:forbidden) }
+      it { expect(response.body).to include('No valid token') }
     end
 
     context 'when token is valid' do

--- a/src/api/spec/controllers/trigger_workflow_controller_spec.rb
+++ b/src/api/spec/controllers/trigger_workflow_controller_spec.rb
@@ -48,6 +48,18 @@ RSpec.describe TriggerWorkflowController, type: :controller, beta: true do
       it { expect(response.body).to include(WorkflowRun.last.response_body) }
     end
 
+    context 'token is invalid' do
+      let(:token_extractor_instance) { instance_double(::TriggerControllerService::TokenExtractor) }
+
+      before do
+        allow(::TriggerControllerService::TokenExtractor).to receive(:new).and_return(token_extractor_instance)
+        allow(token_extractor_instance).to receive(:call).and_return(nil)
+        post :create, params: { format: :json }
+      end
+
+      it { expect(response).to have_http_status(:forbidden) }
+    end
+
     context 'scm event is invalid' do
       let(:token_extractor_instance) { instance_double(::TriggerControllerService::TokenExtractor) }
       let(:token) { build_stubbed(:workflow_token, user: build_stubbed(:confirmed_user, :in_beta)) }

--- a/src/api/test/functional/source_services_test.rb
+++ b/src/api/test/functional/source_services_test.rb
@@ -561,7 +561,7 @@ class SourceServicesTest < ActionDispatch::IntegrationTest
     assert_response 401
     post '/trigger/runservice'
     assert_response 403
-    assert_xml_tag tag: 'status', attributes: { code: 'permission_denied' }
+    assert_xml_tag tag: 'status', attributes: { code: 'invalid_token' }
     assert_match(/No valid token found/, @response.body)
 
     # with wrong token

--- a/src/api/test/functional/trigger_controller_test.rb
+++ b/src/api/test/functional/trigger_controller_test.rb
@@ -27,7 +27,7 @@ class TriggerControllerTest < ActionDispatch::IntegrationTest
     reset_auth
     post '/trigger/rebuild'
     assert_response 403
-    assert_xml_tag tag: 'status', attributes: { code: 'permission_denied' }
+    assert_xml_tag tag: 'status', attributes: { code: 'invalid_token' }
     assert_match(/No valid token found/, @response.body)
 
     # with wrong token


### PR DESCRIPTION
Fixes #12176

In this PR I'm fixing two issues:

- When user has two valid work flow tokens, but then assigns the wrong ID on the github side
- When user has two valid tokens, but for different types and then assign the wrong ID on the github side