### PR TITLE
Fix error trying to find the target package to be deleted

### DIFF
--- a/src/api/app/models/workflow.rb
+++ b/src/api/app/models/workflow.rb
@@ -112,8 +112,8 @@ class Workflow
   def destroy_target_projects
     # Do not process steps for which there's nothing to do
     processable_steps = steps.reject { |step| step.instance_of?(::Workflow::Step::ConfigureRepositories) || step.instance_of?(::Workflow::Step::RebuildPackage) }
-    target_packages = steps.map(&:target_package).uniq.compact
-    EventSubscription.where(channel: 'scm', token: self, package: target_packages).delete_all
+    target_packages = processable_steps.map(&:target_package).uniq.compact
+    EventSubscription.where(channel: 'scm', token: token, package: target_packages).delete_all
 
     target_project_names = processable_steps.map(&:target_project_name).uniq.compact
     # We want the callbacks to run after destroy, so we can't use delete_all


### PR DESCRIPTION
Fix issue #12122

When a PR is closed/merged, we want to remove the temporary project created by the workflow as well as their event subscriptions. These two removals only make sense for steps like `BranchPackageStep` and `LinkPackageStep`. So we prevent processing other steps like `ConfigureRepositories` or `RebuildPackage` (which don't create any temporary project or event subscriptions).

This PR also fixes the EventSuscription removal, since we were passing an incorrect token, so we always got an empty list.

TODO:

- [X] Specs


