### PR TITLE
Revoke requests with the permissions of the sender

### DIFF
--- a/src/api/app/models/bs_request_permission_check.rb
+++ b/src/api/app/models/bs_request_permission_check.rb
@@ -109,6 +109,11 @@ class BsRequestPermissionCheck
     if opts[:newstate].in?(['new', 'review', 'revoked', 'superseded']) && req.creator == User.session!.login
       # request creator can reopen, revoke or supersede a request which was declined
       permission_granted = true
+    elsif opts[:newstate] == 'revoked' && req.creator == opts[:override_creator]
+      # NOTE: request should be revoked if project is removed.
+      # override_creator is needed if the logged in user is different than the creator of the request
+      # at the time of removing the project.
+      permission_granted = true
     elsif req.state == :declined && opts[:newstate].in?(['new', 'review']) && (req.commenter == User.session!.login || user_is_staging_manager)
       # people who declined a request shall also be able to reopen it
 

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -492,7 +492,7 @@ class Project < ApplicationRecord
       request.bs_request_actions.each do |action|
         if action.source_project == name
           begin
-            request.change_state(newstate: 'revoked', comment: "The source project '#{name}' has been removed")
+            request.change_state(newstate: 'revoked', comment: "The source project '#{name}' has been removed", override_creator: request.creator)
           rescue PostRequestNoPermission
             Airbrake.notify("#{User.session!.login} tried to revoke request #{request.number} but had no permissions")
           end


### PR DESCRIPTION
It is expected if a project is removed then open requests should transition to the revoked state. When the signed-in user is different than the creator of the request then this is not happening and it fails silently.

Closes #12250 