### PR TITLE
Respond with an error when the SCM is unsupported

### DIFF
--- a/src/api/app/controllers/trigger_controller.rb
+++ b/src/api/app/controllers/trigger_controller.rb
@@ -9,9 +9,6 @@ class TriggerController < ApplicationController
   skip_before_action :extract_user
   # Authentication happens with tokens, so no login is required
   skip_before_action :require_login
-  # GitLab/Github send data as parameters which are not strings
-  # e.g. integer PR number (GitHub) and project hash (GitLab)
-  skip_before_action :validate_params, if: :scm_webhook?
   after_action :verify_authorized
 
   before_action :validate_gitlab_event, if: :gitlab_webhook?
@@ -48,10 +45,6 @@ class TriggerController < ApplicationController
 
   def github_webhook?
     request.env['HTTP_X_GITHUB_EVENT'].present?
-  end
-
-  def scm_webhook?
-    gitlab_webhook? || github_webhook?
   end
 
   def validate_gitlab_event


### PR DESCRIPTION
Before, validate_params was only skipped when the SCM is supported (GitHub or GitLab). This caused issues whenever a payload from an unsupported SCM didn't pass the checks in validate_params.  For example, Codeberg seems to include `nil` instead of `null` in its JSON payloads. This caused validate_params to raise an exception, preventing us from responding back to the SCM with a helpful error message stating that Codeberg isn't supported.

Fixes #11861