### PR TITLE
Use the correct field for the merge request number

### DIFF
--- a/src/api/app/components/workflow_run_row_component.rb
+++ b/src/api/app/components/workflow_run_row_component.rb
@@ -1,7 +1,7 @@
 class WorkflowRunRowComponent < ApplicationComponent
   SOURCE_NAME_PAYLOAD_MAPPING = {
     'pull_request' => ['pull_request', 'number'],
-    'Merge Request Hook' => ['object_attributes', 'id'],
+    'Merge Request Hook' => ['object_attributes', 'iid'],
     'push' => ['head_commit', 'id'],
     'Push Hook' => ['commits', 0, 'id']
   }.freeze

--- a/src/api/spec/components/workflow_run_header_component_spec.rb
+++ b/src/api/spec/components/workflow_run_header_component_spec.rb
@@ -174,7 +174,7 @@ RSpec.describe WorkflowRunHeaderComponent, type: :component do
               "url": "http://example.com/gitlabhq/gitlab-test.git"
             },
             "object_attributes":{
-              "id": 99,
+              "iid": 1,
               "url": "http://example.com/diaspora/merge_requests/1"
             }
           }
@@ -209,7 +209,7 @@ RSpec.describe WorkflowRunHeaderComponent, type: :component do
           <<~END_OF_REQUEST
             {
               "object_attributes":{
-                "id": 99,
+                "iid": 1,
                 "url": "http://example.com/diaspora/merge_requests/1",
                 "action": "unapproved"
               },
@@ -227,7 +227,7 @@ RSpec.describe WorkflowRunHeaderComponent, type: :component do
       end
 
       it 'shows a link to the MR' do
-        expect(rendered_component).to have_link('#99', href: 'http://example.com/diaspora/merge_requests/1')
+        expect(rendered_component).to have_link('#1', href: 'http://example.com/diaspora/merge_requests/1')
       end
     end
 

--- a/src/api/spec/components/workflow_run_row_component_spec.rb
+++ b/src/api/spec/components/workflow_run_row_component_spec.rb
@@ -169,7 +169,7 @@ RSpec.describe WorkflowRunRowComponent, type: :component do
             "url": "http://example.com/gitlabhq/gitlab-test.git"
           },
           "object_attributes": {
-            "id": 99,
+            "iid": 1,
             "url": "http://example.com/diaspora/merge_requests/1",
             "action": "open"
           }
@@ -202,7 +202,7 @@ RSpec.describe WorkflowRunRowComponent, type: :component do
       end
 
       it 'shows a link to the pull request' do
-        expect(rendered_component).to have_link('#99', href: 'http://example.com/diaspora/merge_requests/1')
+        expect(rendered_component).to have_link('#1', href: 'http://example.com/diaspora/merge_requests/1')
       end
 
       ['close', 'merge', 'open', 'reopen', 'update'].each do |action|


### PR DESCRIPTION
In the JSON sent by GitLab for a Merge Request Hook event, the number of the MR is given by the field `iid`, not `id`.

The following is a real example, the Merge Request number in the GitLab UI is `#2`, which corresponds to the `iid` field in the JSON output:

```
  "object_attributes": {
    "id": 147069788,
    "iid": 2,
    ...
    }
```

We were using the correct field in the [ScmExtractor](https://github.com/openSUSE/open-build-service/blob/f75807701d4c317fbb5d0370978cd35d628552ac/src/api/app/services/trigger_controller_service/scm_extractor.rb#L60), so I change it in the workflow run components and their specs.

**Edit**: the use of `id` didn't imply any error for the current use case, but it makes more sense to use the field corresponding to the MR number, as we do with PRs.