### PR TITLE
[backend] add "--filelists_ext" parameter for createrepo

### DIFF
--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -617,6 +617,7 @@ sub createrepo_rpmmd {
   push @createrepoargs, '--content', 'debug' if $data->{'dbgsplit'};
   push @createrepoargs, '--content', 'update' if ($repoinfo->{'projectkind'} || '') eq 'maintenance_incident';
   push @createrepoargs, '--content', 'update' if ($repoinfo->{'projectkind'} || '') eq 'maintenance_release';
+  push @createrepoargs, '--filelists_ext' if $options{'filelists_ext'};
   # createrepo_c 0.20.0 defaults to keep always additional metadata. We must change
   # to old behaviour or old data would stay forever when it got removed actually
   push @createrepoargs, '--discard-additional-metadata';


### PR DESCRIPTION
If "filelists_ext" option is enabled for the rpmmd repository, it will
call createrepo_c with the --filelists_ext parameter.

This parameter will create a new optional variant of filelists.xml,
named filelists_ext.xml.  This will contain, besides the list of files,
the hash (usually SHA256) registered in the RPM header for this file
(only for file types, not for ghost or dir types).

Additionally, a new field "checksum" will register the hash algorithm
used by librpm for those file entries.

Signed-off-by: Alberto Planas <aplanas@suse.com>