### PR TITLE
Get consitent repository name and URL for workflow runs

### DIFF
--- a/src/api/app/models/workflow_run.rb
+++ b/src/api/app/models/workflow_run.rb
@@ -48,13 +48,13 @@ class WorkflowRun < ApplicationRecord
   end
 
   def repository_name
-    payload.dig('repository', 'full_name') || # For GitHub
-      payload.dig('repository', 'name') # For GitLab
+    payload.dig('repository', 'full_name') || # For GitHub on pull_request and push events
+      payload.dig('project', 'path_with_namespace') # For GitLab on merge request and push events
   end
 
   def repository_url
-    payload.dig('repository', 'html_url') || # For GitHub
-      payload.dig('repository', 'git_http_url') || payload.dig('repository', 'url') # For GitLab
+    payload.dig('repository', 'html_url') || # For GitHub on pull_request and push events
+      payload.dig('project', 'web_url') # For GitLab on merge request and push events
   end
 
   def event_source_name

--- a/src/api/spec/components/workflow_run_header_component_spec.rb
+++ b/src/api/spec/components/workflow_run_header_component_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe WorkflowRunHeaderComponent, type: :component do
                 "number": 4330
               },
               "repository": {
-                "full_name": "ZeroMQ",
+                "full_name": "zeromq/libzmq",
                 "html_url": "https://github.com/zeromq/libzmq"
               }
             }
@@ -73,6 +73,10 @@ RSpec.describe WorkflowRunHeaderComponent, type: :component do
         it 'shows a link to the PR' do
           expect(rendered_component).to have_link('#4330', href: 'https://github.com/zeromq/libzmq/pull/4330')
         end
+
+        it 'shows a link to the repository' do
+          expect(rendered_component).to have_link('zeromq/libzmq', href: 'https://github.com/zeromq/libzmq')
+        end
       end
 
       context 'but does not have a supported action' do
@@ -85,7 +89,7 @@ RSpec.describe WorkflowRunHeaderComponent, type: :component do
                 "number": 4330
               },
               "repository": {
-                "full_name": "ZeroMQ",
+                "full_name": "zeromq/libzmq",
                 "html_url": "https://github.com/zeromq/libzmq"
               }
             }
@@ -98,6 +102,10 @@ RSpec.describe WorkflowRunHeaderComponent, type: :component do
 
         it 'shows a link to the PR' do
           expect(rendered_component).to have_link('#4330', href: 'https://github.com/zeromq/libzmq/pull/4330')
+        end
+
+        it 'shows a link to the repository' do
+          expect(rendered_component).to have_link('zeromq/libzmq', href: 'https://github.com/zeromq/libzmq')
         end
       end
     end
@@ -116,7 +124,7 @@ RSpec.describe WorkflowRunHeaderComponent, type: :component do
               "url": "https://example.com/commit/1234"
             },
             "repository": {
-              "full_name": "Example Repository",
+              "full_name": "foo/bar",
               "html_url": "https://example.com"
             }
           }
@@ -139,10 +147,9 @@ RSpec.describe WorkflowRunHeaderComponent, type: :component do
       <<~END_OF_PAYLOAD
         {
           "event_name":"push",
-          "repository":{
-            "name":"hello_world",
-            "url":"git@gitlab.com:vpereira/hello_world.git",
-            "git_http_url":"https://gitlab.com/vpereira/hello_world.git"
+          "project": {
+            "path_with_namespace": "vpereira/hello_world",
+            "web_url":"https://gitlab.com/vpereira/hello_world"
           }
         }
       END_OF_PAYLOAD
@@ -157,7 +164,7 @@ RSpec.describe WorkflowRunHeaderComponent, type: :component do
     end
 
     it 'shows the repository' do
-      expect(rendered_component).to have_link('hello_world', href: 'https://gitlab.com/vpereira/hello_world.git')
+      expect(rendered_component).to have_link('vpereira/hello_world', href: 'https://gitlab.com/vpereira/hello_world')
     end
 
     context 'when the workflow comes from a merge request' do
@@ -169,13 +176,13 @@ RSpec.describe WorkflowRunHeaderComponent, type: :component do
       let(:request_payload) do
         <<~END_OF_REQUEST
           {
-            "repository": {
-              "name": "Gitlab Test",
-              "url": "http://example.com/gitlabhq/gitlab-test.git"
-            },
             "object_attributes":{
               "iid": 1,
               "url": "http://example.com/diaspora/merge_requests/1"
+            },
+            "project": {
+              "path_with_namespace": "gitlabhq/gitlab-test",
+              "web_url":"http://example.com/gitlabhq/gitlab-test"
             }
           }
         END_OF_REQUEST
@@ -190,9 +197,9 @@ RSpec.describe WorkflowRunHeaderComponent, type: :component do
                   "url": "http://example.com/diaspora/merge_requests/1",
                   "action": "#{action}"
                 },
-                "repository": {
-                  "name": "Gitlab Test",
-                  "url": "http://example.com/gitlabhq/gitlab-test.git"
+                "project": {
+                  "path_with_namespace": "gitlabhq/gitlab-test",
+                  "web_url":"http://example.com/gitlabhq/gitlab-test"
                 }
               }
             END_OF_REQUEST
@@ -213,9 +220,9 @@ RSpec.describe WorkflowRunHeaderComponent, type: :component do
                 "url": "http://example.com/diaspora/merge_requests/1",
                 "action": "unapproved"
               },
-              "repository": {
-                "name": "Gitlab Test",
-                "url": "http://example.com/gitlabhq/gitlab-test.git"
+              "project": {
+                "path_with_namespace": "gitlabhq/gitlab-test",
+                "web_url":"http://example.com/gitlabhq/gitlab-test"
               }
             }
           END_OF_REQUEST
@@ -228,6 +235,10 @@ RSpec.describe WorkflowRunHeaderComponent, type: :component do
 
       it 'shows a link to the MR' do
         expect(rendered_component).to have_link('#1', href: 'http://example.com/diaspora/merge_requests/1')
+      end
+
+      it 'shows a link to the repository' do
+        expect(rendered_component).to have_link('gitlabhq/gitlab-test', href: 'http://example.com/gitlabhq/gitlab-test')
       end
     end
 
@@ -243,8 +254,8 @@ RSpec.describe WorkflowRunHeaderComponent, type: :component do
             "event_name":"push",
             "project":{
               "id":27158549,
-              "name":"hello_world",
-              "url":"git@gitlab.com:vpereira/hello_world.git"
+              "path_with_namespace":"vpereira/hello_world",
+              "web_url":"http://gitlab.com:vpereira/hello_world"
             },
             "commits":[
               {
@@ -261,12 +272,7 @@ RSpec.describe WorkflowRunHeaderComponent, type: :component do
                 "title":"Update obs project",
                 "url":"https://gitlab.com/vpereira/hello_world/-/commit/cff1dafb4e61f958db8ed8697a8e720d1fe3d3e7"
               }
-            ],
-            "repository":{
-              "name":"hello_world",
-              "url":"git@gitlab.com:vpereira/hello_world.git",
-              "git_http_url":"https://gitlab.com/vpereira/hello_world.git"
-            }
+            ]
           }
         END_OF_PAYLOAD
       end

--- a/src/api/spec/components/workflow_run_row_component_spec.rb
+++ b/src/api/spec/components/workflow_run_row_component_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe WorkflowRunRowComponent, type: :component do
                   "number": 4330
                 },
                 "repository": {
-                  "full_name": "Example Repository",
+                  "full_name": "example/repo",
                   "html_url": "https://example.com"
                 }
               }
@@ -105,7 +105,7 @@ RSpec.describe WorkflowRunRowComponent, type: :component do
                 "number": 4330
               },
               "repository": {
-                "full_name": "Example Repository",
+                "full_name": "example/repo",
                 "html_url": "https://example.com"
               }
             }
@@ -132,7 +132,7 @@ RSpec.describe WorkflowRunRowComponent, type: :component do
               "url": "https://example.com/commit/1234"
             },
             "repository": {
-              "full_name": "Example Repository",
+              "full_name": "example/repo",
               "html_url": "https://example.com"
             }
           }
@@ -142,7 +142,7 @@ RSpec.describe WorkflowRunRowComponent, type: :component do
       it { expect(rendered_component).to have_text 'Push event' }
 
       it 'shows a link to the repository' do
-        expect(rendered_component).to have_link('Example Repository', href: 'https://example.com')
+        expect(rendered_component).to have_link('example/repo', href: 'https://example.com')
       end
 
       it 'shows a link to the pushed commit' do
@@ -162,11 +162,8 @@ RSpec.describe WorkflowRunRowComponent, type: :component do
         {
           "object_kind": "merge_request",
           "project": {
-            "name":"Gitlab Test"
-          },
-          "repository": {
-            "name": "Gitlab Test",
-            "url": "http://example.com/gitlabhq/gitlab-test.git"
+            "path_with_namespace": "gitlabhq/gitlab-test",
+            "web_url":"http://example.com/gitlabhq/gitlab-test"
           },
           "object_attributes": {
             "iid": 1,
@@ -185,7 +182,7 @@ RSpec.describe WorkflowRunRowComponent, type: :component do
       end
 
       it { expect(rendered_component).to have_text('Unknown source') }
-      it { expect(rendered_component).not_to have_link('Gitlab Test', href: 'http://example.com/gitlabhq/gitlab-test.git') }
+      it { expect(rendered_component).not_to have_link('gitlabhq/gitlab-test', href: 'http://example.com/gitlabhq/gitlab-test') }
     end
 
     context 'and comes from a merge request event' do
@@ -198,7 +195,7 @@ RSpec.describe WorkflowRunRowComponent, type: :component do
       it { expect(rendered_component).to have_text('Merge request hook event') }
 
       it 'shows a link to the repository' do
-        expect(rendered_component).to have_link('Gitlab Test', href: 'http://example.com/gitlabhq/gitlab-test.git')
+        expect(rendered_component).to have_link('gitlabhq/gitlab-test', href: 'http://example.com/gitlabhq/gitlab-test')
       end
 
       it 'shows a link to the pull request' do
@@ -249,8 +246,8 @@ RSpec.describe WorkflowRunRowComponent, type: :component do
             "event_name":"push",
             "project":{
               "id":27158549,
-              "name":"hello_world",
-              "url":"git@gitlab.com:vpereira/hello_world.git"
+              "path_with_namespace":"vpereira/hello_world",
+              "web_url":"https://gitlab.com/vpereira/hello_world"
             },
             "commits":[
               {
@@ -267,18 +264,13 @@ RSpec.describe WorkflowRunRowComponent, type: :component do
                 "title":"Update obs project",
                 "url":"https://gitlab.com/vpereira/hello_world/-/commit/cff1dafb4e61f958db8ed8697a8e720d1fe3d3e7"
               }
-            ],
-            "repository":{
-              "name":"hello_world",
-              "url":"git@gitlab.com:vpereira/hello_world.git",
-              "git_http_url":"https://gitlab.com/vpereira/hello_world.git"
-            }
+            ]
           }
         END_OF_PAYLOAD
       end
 
       it 'shows a link to the repository' do
-        expect(rendered_component).to have_link('hello_world', href: 'https://gitlab.com/vpereira/hello_world.git')
+        expect(rendered_component).to have_link('vpereira/hello_world', href: 'https://gitlab.com/vpereira/hello_world')
       end
 
       it 'is expected to have text "Push Event"' do

--- a/src/api/spec/lib/tasks/workflows_spec.rb
+++ b/src/api/spec/lib/tasks/workflows_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe 'workflows' do
         "pull_request": {
           "number": 2
         },
-        "repository": {
-          "full_name": "iggy/hello_world"
+        "project": {
+          "path_with_namespace": "iggy/hello_world"
         }
       }
     END_OF_REQUEST
@@ -46,8 +46,8 @@ RSpec.describe 'workflows' do
           "iid": 3,
           "action": "merge"
         },
-        "repository": {
-          "name": "iggy/test"
+        "project": {
+          "path_with_namespace": "iggy/test"
         }
       }
     END_OF_REQUEST


### PR DESCRIPTION
The workflow run details contain a link to the SCM's repository. Compare these two screenshots of workflow runs with real incoming payloads:

![Screenshot from 2022-03-28 19-06-32](https://user-images.githubusercontent.com/2581944/160621925-14477be0-1b80-41c1-a505-ad4a05e93a3b.png)

![Screenshot from 2022-03-28 19-06-49](https://user-images.githubusercontent.com/2581944/160621978-d17db929-6d95-4fc0-8c5d-dae43bf45b87.png)

For GitHub-related workflow runs, we are displaying repository names like `foo/bar`.
For GitLab-related workflow runs, we were displaying repository names like `bar`. For consistency, I have decided to get the information from another payload field, so we can also have `foo/bar`.

Apart from the names, if we compare the links (at the bottom of the screenshots), we see that GitLab-related workflow runs used to point to a wrong URL because we were getting the information from a payload field that could contain `git@gitlab.com:foo/bar.git` instead of an HTTP(s) URL. So I'm now using another payload field to get the correct URL.

~**NOTE:** I'll need to adapt this PR after PR #12354 is merged as part of this code is refactored there.~