### PR TITLE
Create migration to create a new workflow payload column

### DIFF
--- a/src/api/app/controllers/trigger_workflow_controller.rb
+++ b/src/api/app/controllers/trigger_workflow_controller.rb
@@ -71,7 +71,10 @@ class TriggerWorkflowController < TriggerController
     raise Trigger::Errors::InvalidToken, 'Wrong token type. Please use workflow tokens only.' unless @token.is_a?(Token::Workflow)
 
     request_headers = request.headers.to_h.keys.map { |k| "#{k}: #{request.headers[k]}" if k.match?(/^HTTP_/) }.compact.join("\n")
-    @workflow_run = @token.workflow_runs.create(request_headers: request_headers, request_payload: request.body.read)
+    # We need to write the payload into `request_json_payload` too, while the `request_payload` is still around
+    @workflow_run = @token.workflow_runs.create(request_headers: request_headers,
+                                                request_payload: request.body.read,
+                                                request_json_payload: request.body.read)
   end
 
   def abort_trigger_if_ignored_pull_request_action

--- a/src/api/app/models/workflow_run.rb
+++ b/src/api/app/models/workflow_run.rb
@@ -36,15 +36,16 @@ end
 #
 # Table name: workflow_runs
 #
-#  id              :integer          not null, primary key
-#  request_headers :text(65535)      not null
-#  request_payload :text(65535)      not null
-#  response_body   :text(65535)
-#  response_url    :string(255)
-#  status          :integer          default("running"), not null
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
-#  token_id        :integer          not null, indexed
+#  id                   :integer          not null, primary key
+#  request_headers      :text(65535)      not null
+#  request_json_payload :text(4294967295)
+#  request_payload      :text(65535)      not null
+#  response_body        :text(65535)
+#  response_url         :string(255)
+#  status               :integer          default("running"), not null
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  token_id             :integer          not null, indexed
 #
 # Indexes
 #

--- a/src/api/db/data/20220329152245_backfill_workflow_run_request_json_payload.rb
+++ b/src/api/db/data/20220329152245_backfill_workflow_run_request_json_payload.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class BackfillWorkflowRunRequestJsonPayload < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def up
+    WorkflowRun.unscoped.in_batches do |relation|
+      relation.each { |workflow_run| workflow_run.update(request_json_payload: workflow_run.request_payload) }
+      sleep(0.01)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/src/api/db/data_schema.rb
+++ b/src/api/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20220318123314)
+DataMigrate::Data.define(version: 20220329152245)

--- a/src/api/db/migrate/20220329104414_create_request_json_payload_column_in_workflow_runs.rb
+++ b/src/api/db/migrate/20220329104414_create_request_json_payload_column_in_workflow_runs.rb
@@ -1,0 +1,5 @@
+class CreateRequestJsonPayloadColumnInWorkflowRuns < ActiveRecord::Migration[6.1]
+  def change
+    add_column :workflow_runs, :request_json_payload, :json
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_09_122242) do
+ActiveRecord::Schema.define(version: 2022_03_29_104414) do
 
   create_table "architectures", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false, collation: "utf8_general_ci"
@@ -1095,7 +1095,9 @@ ActiveRecord::Schema.define(version: 2022_03_09_122242) do
     t.datetime "updated_at", precision: 6, null: false
     t.integer "token_id", null: false
     t.string "response_url"
+    t.text "request_json_payload", size: :long, collation: "utf8mb4_bin"
     t.index ["token_id"], name: "index_workflow_runs_on_token_id"
+    t.check_constraint "json_valid(`request_json_payload`)", name: "request_json_payload"
   end
 
   add_foreign_key "attrib_allowed_values", "attrib_types", name: "attrib_allowed_values_ibfk_1"

--- a/src/api/spec/db/data/backfill_workflow_run_request_json_payload_spec.rb
+++ b/src/api/spec/db/data/backfill_workflow_run_request_json_payload_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+require Rails.root.join('db/data/20220329152245_backfill_workflow_run_request_json_payload.rb')
+
+RSpec.describe BackfillWorkflowRunRequestJsonPayload, type: :migration do
+  describe 'up' do
+    subject { BackfillWorkflowRunRequestJsonPayload.new.up }
+
+    before do
+      create(:workflow_run)
+    end
+
+    it 'fills request_json_payload field with the content of request_payload field' do
+      subject
+      workflow_run = WorkflowRun.last
+      expect(workflow_run.request_json_payload).to eq(workflow_run.request_payload)
+    end
+  end
+end


### PR DESCRIPTION
This PR creates a new column with the proper type to store JSON documents up to 4GB.

To do this [without blocking the table](https://github.com/ankane/strong_migrations#changing-the-type-of-a-column) we have to:
1. Create the new column
2. Write to both columns
3. Backfill data from the old column to the new column

TODO:
- [x] Write a test to check the data migration (the backfilling)

And deploy this before the next changes:

Done in another #12375:
1. Move reads from the old column to the new column
2. Stop writing to the old column

Done in the last PR:
1. Drop the old column