### PR TITLE
Stop writing to the old workflow runs request payload column

### DIFF
--- a/src/api/app/components/workflow_run_detail_component.rb
+++ b/src/api/app/components/workflow_run_detail_component.rb
@@ -15,8 +15,8 @@ class WorkflowRunDetailComponent < ApplicationComponent
   private
 
   def parse_payload(workflow_run)
-    JSON.pretty_generate(JSON.parse(workflow_run.request_payload))
+    JSON.pretty_generate(JSON.parse(workflow_run.request_json_payload))
   rescue JSON::ParserError
-    workflow_run.request_payload
+    workflow_run.request_json_payload
   end
 end

--- a/src/api/app/components/workflow_run_row_component.rb
+++ b/src/api/app/components/workflow_run_row_component.rb
@@ -83,7 +83,7 @@ class WorkflowRunRowComponent < ApplicationComponent
   private
 
   def payload
-    @payload ||= JSON.parse(workflow_run.request_payload)
+    @payload ||= JSON.parse(workflow_run.request_json_payload)
   rescue JSON::ParserError
     { payload: 'unparseable' }
   end

--- a/src/api/app/controllers/trigger_workflow_controller.rb
+++ b/src/api/app/controllers/trigger_workflow_controller.rb
@@ -71,7 +71,10 @@ class TriggerWorkflowController < TriggerController
     raise Trigger::Errors::InvalidToken, 'Wrong token type. Please use workflow tokens only.' unless @token.is_a?(Token::Workflow)
 
     request_headers = request.headers.to_h.keys.map { |k| "#{k}: #{request.headers[k]}" if k.match?(/^HTTP_/) }.compact.join("\n")
-    @workflow_run = @token.workflow_runs.create(request_headers: request_headers, request_payload: request.body.read)
+    # We need to write the payload into `request_json_payload` too, while the `request_payload` is still around
+    @workflow_run = @token.workflow_runs.create(request_headers: request_headers,
+                                                request_payload: request.body.read,
+                                                request_json_payload: request.body.read)
   end
 
   def abort_trigger_if_ignored_pull_request_action

--- a/src/api/app/controllers/trigger_workflow_controller.rb
+++ b/src/api/app/controllers/trigger_workflow_controller.rb
@@ -73,7 +73,6 @@ class TriggerWorkflowController < TriggerController
     request_headers = request.headers.to_h.keys.map { |k| "#{k}: #{request.headers[k]}" if k.match?(/^HTTP_/) }.compact.join("\n")
     # We need to write the payload into `request_json_payload` too, while the `request_payload` is still around
     @workflow_run = @token.workflow_runs.create(request_headers: request_headers,
-                                                request_payload: request.body.read,
                                                 request_json_payload: request.body.read)
   end
 

--- a/src/api/app/models/workflow_run.rb
+++ b/src/api/app/models/workflow_run.rb
@@ -1,4 +1,6 @@
 class WorkflowRun < ApplicationRecord
+  self.ignored_columns = ['request_payload']
+
   validates :response_url, length: { maximum: 255 }
   validates :request_headers, :status, presence: true
 

--- a/src/api/app/models/workflow_run.rb
+++ b/src/api/app/models/workflow_run.rb
@@ -36,15 +36,16 @@ end
 #
 # Table name: workflow_runs
 #
-#  id              :integer          not null, primary key
-#  request_headers :text(65535)      not null
-#  request_payload :text(65535)      not null
-#  response_body   :text(65535)
-#  response_url    :string(255)
-#  status          :integer          default("running"), not null
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
-#  token_id        :integer          not null, indexed
+#  id                   :integer          not null, primary key
+#  request_headers      :text(65535)      not null
+#  request_json_payload :text(4294967295)
+#  request_payload      :text(65535)      not null
+#  response_body        :text(65535)
+#  response_url         :string(255)
+#  status               :integer          default("running"), not null
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  token_id             :integer          not null, indexed
 #
 # Indexes
 #

--- a/src/api/db/data/20220329152245_backfill_workflow_run_request_json_payload.rb
+++ b/src/api/db/data/20220329152245_backfill_workflow_run_request_json_payload.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class BackfillWorkflowRunRequestJsonPayload < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def up
+    WorkflowRun.unscoped.in_batches do |relation|
+      relation.each { |workflow_run| workflow_run.update(request_json_payload: workflow_run.request_payload) }
+      sleep(0.01)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/src/api/db/data_schema.rb
+++ b/src/api/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20220318123314)
+DataMigrate::Data.define(version: 20220329152245)

--- a/src/api/db/migrate/20220329104414_create_request_json_payload_column_in_workflow_runs.rb
+++ b/src/api/db/migrate/20220329104414_create_request_json_payload_column_in_workflow_runs.rb
@@ -1,0 +1,5 @@
+class CreateRequestJsonPayloadColumnInWorkflowRuns < ActiveRecord::Migration[6.1]
+  def change
+    add_column :workflow_runs, :request_json_payload, :json
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_09_122242) do
+ActiveRecord::Schema.define(version: 2022_03_29_104414) do
 
   create_table "architectures", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false, collation: "utf8_general_ci"
@@ -1095,7 +1095,9 @@ ActiveRecord::Schema.define(version: 2022_03_09_122242) do
     t.datetime "updated_at", precision: 6, null: false
     t.integer "token_id", null: false
     t.string "response_url"
+    t.text "request_json_payload", size: :long, collation: "utf8mb4_bin"
     t.index ["token_id"], name: "index_workflow_runs_on_token_id"
+    t.check_constraint "json_valid(`request_json_payload`)", name: "request_json_payload"
   end
 
   add_foreign_key "attrib_allowed_values", "attrib_types", name: "attrib_allowed_values_ibfk_1"

--- a/src/api/spec/components/workflow_artifacts_per_step_component_spec.rb
+++ b/src/api/spec/components/workflow_artifacts_per_step_component_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe WorkflowArtifactsPerStepComponent, type: :component do
     create(:workflow_run,
            token: workflow_token,
            request_headers: request_headers,
-           request_payload: request_payload)
+           request_json_payload: request_payload)
   end
   let(:scm_webhook) do
     ScmWebhook.new(payload: extractor_payload)

--- a/src/api/spec/components/workflow_run_detail_component_spec.rb
+++ b/src/api/spec/components/workflow_run_detail_component_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe WorkflowRunDetailComponent, type: :component do
     create(:workflow_run,
            token: workflow_token,
            request_headers: request_headers,
-           request_payload: request_payload)
+           request_json_payload: request_payload)
   end
 
   before do

--- a/src/api/spec/components/workflow_run_header_component_spec.rb
+++ b/src/api/spec/components/workflow_run_header_component_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe WorkflowRunHeaderComponent, type: :component do
     create(:workflow_run,
            token: workflow_token,
            request_headers: request_headers,
-           request_payload: request_payload)
+           request_json_payload: request_payload)
   end
 
   before do

--- a/src/api/spec/components/workflow_run_row_component_spec.rb
+++ b/src/api/spec/components/workflow_run_row_component_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe WorkflowRunRowComponent, type: :component do
     create(:workflow_run,
            token: workflow_token,
            request_headers: request_headers,
-           request_payload: request_payload)
+           request_json_payload: request_payload)
   end
 
   before do
@@ -304,7 +304,7 @@ RSpec.describe WorkflowRunRowComponent, type: :component do
                status: 'running',
                token: workflow_token,
                request_headers: request_headers,
-               request_payload: request_payload)
+               request_json_payload: request_payload)
       end
       let(:request_payload) { {} }
 
@@ -319,7 +319,7 @@ RSpec.describe WorkflowRunRowComponent, type: :component do
                status: 'success',
                token: workflow_token,
                request_headers: request_headers,
-               request_payload: request_payload)
+               request_json_payload: request_payload)
       end
       let(:request_payload) { {} }
 
@@ -334,7 +334,7 @@ RSpec.describe WorkflowRunRowComponent, type: :component do
                status: 'fail',
                token: workflow_token,
                request_headers: request_headers,
-               request_payload: request_payload)
+               request_json_payload: request_payload)
       end
       let(:request_payload) { {} }
 
@@ -349,7 +349,7 @@ RSpec.describe WorkflowRunRowComponent, type: :component do
                status: 'fail',
                token: workflow_token,
                request_headers: request_headers,
-               request_payload: request_payload)
+               request_json_payload: request_payload)
       end
       let(:request_payload) { {} }
       let(:request_headers) do

--- a/src/api/spec/db/data/backfill_workflow_run_request_json_payload_spec.rb
+++ b/src/api/spec/db/data/backfill_workflow_run_request_json_payload_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+require Rails.root.join('db/data/20220329152245_backfill_workflow_run_request_json_payload.rb')
+
+RSpec.describe BackfillWorkflowRunRequestJsonPayload, type: :migration do
+  describe 'up' do
+    subject { BackfillWorkflowRunRequestJsonPayload.new.up }
+
+    before do
+      create(:workflow_run)
+    end
+
+    it 'fills request_json_payload field with the content of request_payload field' do
+      subject
+      workflow_run = WorkflowRun.last
+      expect(workflow_run.request_json_payload).to eq(workflow_run.request_payload)
+    end
+  end
+end

--- a/src/api/spec/factories/workflow_runs.rb
+++ b/src/api/spec/factories/workflow_runs.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
         HTTP_X_GITHUB_EVENT: pull_request
       END_OF_HEADERS
     end
-    request_payload do
+    request_json_payload do
       <<~END_OF_PAYLOAD
         {
           "action": "opened",


### PR DESCRIPTION
This PR is a follow-up of #12365.

**NOTE**: That PR has to be already deployed before this one hits production.

This PR shifts the reads from the old `request_payload` to `request_json_payload` so we can stop using that column.

TODO:
- [ ] Deploy #12365 