### PR TITLE
Increase request payload column capacity

### DIFF
--- a/src/api/app/models/workflow_run.rb
+++ b/src/api/app/models/workflow_run.rb
@@ -93,7 +93,7 @@ end
 #
 #  id              :integer          not null, primary key
 #  request_headers :text(65535)      not null
-#  request_payload :text(65535)      not null
+#  request_payload :text(4294967295) not null
 #  response_body   :text(65535)
 #  response_url    :string(255)
 #  status          :integer          default("running"), not null

--- a/src/api/db/migrate/20220330125635_increase_workflow_runs_request_payload_capacity.rb
+++ b/src/api/db/migrate/20220330125635_increase_workflow_runs_request_payload_capacity.rb
@@ -1,0 +1,5 @@
+class IncreaseWorkflowRunsRequestPayloadCapacity < ActiveRecord::Migration[6.1]
+  def up
+    safety_assured { change_column :workflow_runs, :request_payload, :longtext }
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_09_122242) do
+ActiveRecord::Schema.define(version: 2022_03_30_125635) do
 
   create_table "architectures", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false, collation: "utf8_general_ci"
@@ -1088,7 +1088,7 @@ ActiveRecord::Schema.define(version: 2022_03_09_122242) do
 
   create_table "workflow_runs", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.text "request_headers", null: false
-    t.text "request_payload", null: false
+    t.text "request_payload", size: :long, null: false
     t.integer "status", limit: 1, default: 0, null: false
     t.text "response_body"
     t.datetime "created_at", precision: 6, null: false


### PR DESCRIPTION
When storing large jsons, we've been hitting the column's capacity
limit, so we change the column's type to allow for up to 4GB of data in
the `request_payload` column.

Fixes #11891

**NOTE:** This PR should be merged and deployed during the next maintenance window, as the migration will block the `workflow_runs` table.
**NOTE2**: Looks like the migration takes half a minute more or less against a production database dump
**NOTE3**: Looks like the `json` datatype [triggers some errors](https://app.circleci.com/pipelines/github/openSUSE/open-build-service/6206/workflows/3a596494-d368-4bbd-926e-a4723069e065/jobs/81106) so we go with plain LONGTEXT column data type