### PR TITLE
Do not validate params in TriggerController

### DIFF
--- a/src/api/app/controllers/trigger_controller.rb
+++ b/src/api/app/controllers/trigger_controller.rb
@@ -9,6 +9,9 @@ class TriggerController < ApplicationController
   skip_before_action :extract_user
   # Authentication happens with tokens, so no login is required
   skip_before_action :require_login
+  # SCMs like GitLab/GitHub send data as parameters which are not strings (e.g.: GitHub - PR number is a integer, GitLab - project is a hash)
+  # Other SCMs might also do this, so we're not validating parameters.
+  skip_before_action :validate_params
   after_action :verify_authorized
 
   before_action :validate_gitlab_event, if: :gitlab_webhook?

--- a/src/api/app/controllers/trigger_workflow_controller.rb
+++ b/src/api/app/controllers/trigger_workflow_controller.rb
@@ -1,9 +1,6 @@
 class TriggerWorkflowController < TriggerController
   # We don't need to validate that the body of the request is XML. We receive JSON
   skip_before_action :validate_xml_request, :set_project_name, :set_package_name, :set_project, :set_package, :set_object_to_authorize, :set_multibuild_flavor
-  # GitLab/Github send data as parameters which are not strings
-  # e.g. integer PR number (GitHub) and project hash (GitLab)
-  skip_before_action :validate_params
 
   before_action :set_scm_event
   before_action :abort_trigger_if_ignored_pull_request_action

--- a/src/api/spec/cassettes/TriggerController/_create/when_some_parameters_are_not_strings/still_processes_the_request_without_validating_parameters.yml
+++ b/src/api/spec/cassettes/TriggerController/_create/when_some_parameters_are_not_strings/still_processes_the_request_without_validating_parameters.yml
@@ -1,0 +1,229 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '128'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer"/>
+        </project>
+  recorded_at: Mon, 04 Apr 2022 12:48:28 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/apache2/_meta?user=user_1
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="home:tom">
+          <title>The Wives of Bath</title>
+          <description>Reiciendis sed mollitia sunt.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '149'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="home:tom">
+          <title>The Wives of Bath</title>
+          <description>Reiciendis sed mollitia sunt.</description>
+        </package>
+  recorded_at: Mon, 04 Apr 2022 12:48:28 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/apache2/_service
+    body:
+      encoding: UTF-8
+      string: "<services/>"
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="5" vrev="5">
+          <srcmd5>31f0abf749b8f7db8ce67760ae121a92</srcmd5>
+          <version>unknown</version>
+          <time>1649076508</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Mon, 04 Apr 2022 12:48:28 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_1/_meta?user=user_2
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_1">
+          <title>The Grapes of Wrath</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '105'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_1">
+          <title>The Grapes of Wrath</title>
+          <description></description>
+        </project>
+  recorded_at: Mon, 04 Apr 2022 12:48:28 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_1/package_1/_meta?user=user_3
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_1" project="project_1">
+          <title>Shall not Perish</title>
+          <description>Ad voluptatibus voluptatum veritatis.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '159'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_1" project="project_1">
+          <title>Shall not Perish</title>
+          <description>Ad voluptatibus voluptatum veritatis.</description>
+        </package>
+  recorded_at: Mon, 04 Apr 2022 12:48:28 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/home:tom/apache2?cmd=runservice&user=tom
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+  recorded_at: Mon, 04 Apr 2022 12:48:28 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/controllers/trigger_controller_spec.rb
+++ b/src/api/spec/controllers/trigger_controller_spec.rb
@@ -184,5 +184,18 @@ RSpec.describe TriggerController, vcr: true do
 
       it_behaves_like 'it verifies the signature'
     end
+
+    context 'when some parameters are not strings' do
+      before do
+        request.headers['ACCEPT'] = '*/*'
+        request.headers['CONTENT_TYPE'] = 'application/json'
+        request.headers['HTTP_X_OBS_SIGNATURE'] = signature
+        post :create, body: { a_hash: { integer1: 123 }, integer2: 456 }.to_json
+      end
+
+      it 'still processes the request without validating parameters' do
+        expect(response).to have_http_status(:success)
+      end
+    end
   end
 end


### PR DESCRIPTION
This was removed in the PR #12353 and it was wrong. This controller receives webhooks from SCMs, so skipping this validation is needed.

Specs are also covering what wasn't covered in #12353.