### PR TITLE
Use 2.10 containers in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,21 +7,25 @@ images:
       NOKOGIRI_USE_SYSTEM_LIBRARIES: 1
 
   - &mariadb
-    image: registry.opensuse.org/obs/server/unstable/containers/containers/openbuildservice/mariadb:latest
+    image: registry.opensuse.org/obs/server/2.10/containers/containers/openbuildservice/mariadb:latest
     command: |
       /bin/bash -c 'echo -e "[mysqld]\ndatadir = /dev/shm" > /etc/my.cnf.d/obs.cnf && cp -a /var/lib/mysql/* /dev/shm && /usr/lib/mysql/mysql-systemd-helper start'
     name: db
 
-  - &backend registry.opensuse.org/obs/server/unstable/containers/containers/openbuildservice/backend:latest
+  - &backend registry.opensuse.org/obs/server/2.10/containers/containers/openbuildservice/backend:latest
 
-  - &frontend_backend
-    image: registry.opensuse.org/obs/server/unstable/containers/containers/openbuildservice/frontend-backend:latest
+  - &frontend_minitest
+    image: registry.opensuse.org/obs/server/2.10/containers/containers/openbuildservice/frontend-minitest:latest
     <<: *common_frontend_config
     environment:
       EAGER_LOAD: 1
 
   - &frontend_base
-    image: registry.opensuse.org/obs/server/unstable/containers/containers/openbuildservice/frontend-base:latest
+    image: registry.opensuse.org/obs/server/2.10/containers/containers/openbuildservice/frontend-base:latest
+    <<: *common_frontend_config
+
+  - &frontend_features
+    image: registry.opensuse.org/obs/server/2.10/containers/containers/openbuildservice/frontend-features:latest
     <<: *common_frontend_config
 
 aliases:
@@ -112,7 +116,7 @@ jobs:
   rspec:
     parallelism: 3
     docker:
-      - <<: *frontend_base
+      - <<: *frontend_features
       - <<: *mariadb
     steps:
       - attach_workspace:
@@ -160,7 +164,7 @@ jobs:
   minitest:
     parallelism: 2
     docker:
-      - <<: *frontend_backend
+      - <<: *frontend_minitest
       - <<: *mariadb
     steps:
       - attach_workspace:
@@ -196,7 +200,7 @@ jobs:
 
   migrations_test:
     docker:
-      - <<: *frontend_backend
+      - <<: *frontend_base
       - <<: *mariadb
     steps:
       - attach_workspace:
@@ -215,7 +219,7 @@ jobs:
 
   spider:
     docker:
-      - <<: *frontend_backend
+      - <<: *frontend_minitest
       - <<: *mariadb
     steps:
       - attach_workspace:
@@ -268,7 +272,7 @@ jobs:
   feature:
     parallelism: 2
     docker:
-      - <<: *frontend_base
+      - <<: *frontend_features
       - <<: *mariadb
     steps:
       - attach_workspace:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/backend/build"]
 	path = src/backend/build
-	url = git://github.com/openSUSE/obs-build.git
+	url = https://github.com/openSUSE/obs-build.git

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,17 @@
 version: "2.1"
 services:
   db:
-    image: registry.opensuse.org/obs/server/unstable/containers/containers/openbuildservice/mariadb
+    image: registry.opensuse.org/obs/server/2.10/containers/containers/openbuildservice/mariadb
     ports:
       - "3306:3306"
     command: /usr/lib/mysql/mysql-systemd-helper start
   cache:
-    image: registry.opensuse.org/obs/server/unstable/containers/containers/openbuildservice/memcached
+    image: registry.opensuse.org/obs/server/2.10/containers/containers/openbuildservice/memcached
     ports:
       - "11211:11211"
     command: /usr/sbin/memcached -u memcached
   backend:
-    image: registry.opensuse.org/obs/server/unstable/containers/containers/openbuildservice/backend
+    image: registry.opensuse.org/obs/server/2.10/containers/containers/openbuildservice/backend
     volumes:
       - .:/obs
       - ./dist/aws_credentials:/etc/obs/cloudupload/.aws/config
@@ -19,7 +19,7 @@ services:
       - ./dist/clouduploader.rb:/usr/bin/clouduploader
     command: /obs/contrib/start_development_backend -d /obs
   worker:
-    image: registry.opensuse.org/obs/server/unstable/containers/containers/openbuildservice/backend
+    image: registry.opensuse.org/obs/server/2.10/containers/containers/openbuildservice/backend
     volumes:
       - .:/obs
     privileged: true
@@ -27,7 +27,7 @@ services:
       - backend
     command: /obs/contrib/start_development_worker
   frontend:
-    image: openbuildservice/frontend
+    image: openbuildservice/frontend:210
     command: foreman start -p 3000
     build:
       dockerfile: docker-files/Dockerfile

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -40,6 +40,7 @@ OBSApi::Application.routes.draw do
     service: %r{\w[^\/]*},
     title: %r{[^\/]*},
     user: %r{[^\/]*},
+    user_login: %r{[^\/]*},
     repository_publish_build_id: %r{[^\/]*}
   }
 

--- a/src/api/docker-files/Dockerfile
+++ b/src/api/docker-files/Dockerfile
@@ -3,13 +3,15 @@
 # contained rails app generating files in the git checkout with
 # some strange user...
 
-FROM registry.opensuse.org/obs/server/unstable/containers/containers/openbuildservice/frontend-base
+FROM registry.opensuse.org/obs/server/2.10/containers/containers/openbuildservice/frontend-features
 ARG CONTAINER_USERID
 
 # for lint task
 RUN npm install -g jshint
 # Same brakeman version is pinned in our CI configuration to have reproducible builds (the license forbids us from shipping the gem in our appliance)
 RUN gem install --no-format-executable brakeman --version 5.0.2
+# install our process manager
+RUN gem install --no-format-executable foreman
 
 # Configure our user
 RUN usermod -u $CONTAINER_USERID frontend
@@ -27,9 +29,14 @@ RUN chown -R frontend /obs/src/api
 USER frontend
 WORKDIR /obs/src/api
 
-ENV BUNDLE_BUILD__SASSC=--disable-march-tune-native
+# Configure our bundle
+RUN bundle config build.ffi --enable-system-libffi; \
+    bundle config build.nokogiri --use-system-libraries; \
+    bundle config build.sassc --disable-march-tune-native; \
+    bundle config build.nio4r --with-cflags='-Wno-return-type'
+
 # Refresh our bundle
-RUN export NOKOGIRI_USE_SYSTEM_LIBRARIES=1; bundle install --jobs=3 --retry=3 || bundle install --jobs=3 --retry=3
+RUN bundle install --jobs=3 --retry=3 || bundle install --jobs=3 --retry=3
 
 # Run our command
 CMD ["foreman", "start", "-f", "Procfile"]

--- a/src/api/docker-files/Dockerfile.minitest
+++ b/src/api/docker-files/Dockerfile.minitest
@@ -2,7 +2,7 @@
 # sure different users can run it without the contained rails app generating
 # files in the git checkout with some strange user...
 
-FROM registry.opensuse.org/obs/server/unstable/containers/containers/openbuildservice/frontend-backend
+FROM registry.opensuse.org/obs/server/2.10/containers/containers/openbuildservice/frontend-minitest
 
 # Configure our user
 ARG CONTAINER_USERID
@@ -21,8 +21,14 @@ RUN chown -R frontend /obs/src/api
 USER frontend
 WORKDIR /obs/src/api
 
+# Configure our bundle
+RUN bundle config build.ffi --enable-system-libffi; \
+    bundle config build.nokogiri --use-system-libraries; \
+    bundle config build.sassc --disable-march-tune-native; \
+    bundle config build.nio4r --with-cflags='-Wno-return-type'
+
 # Refresh our bundle
-RUN export NOKOGIRI_USE_SYSTEM_LIBRARIES=1; bundle install --jobs=3 --retry=3 || bundle install --jobs=3 --retry=3
+RUN bundle install --jobs=3 --retry=3 || bundle install --jobs=3 --retry=3
 
 CMD ["/bin/bash", "-l"]
 


### PR DESCRIPTION
After OSU switched to Ruby 3.1 we need to use 2.10 containers.