### PR TITLE
Reset User.session

### DIFF
--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -1122,22 +1122,22 @@ class Project < ApplicationRecord
 
   # called either directly or from delayed job
   def do_project_release(params)
-    User.session ||= User.find_by!(login: params[:user])
+    User.find_by!(login: params[:user]).run_as do
+      # uniq timestring for all targets
+      time_now = Time.now.utc
 
-    # uniq timestring for all targets
-    time_now = Time.now.utc
-
-    packages.each do |pkg|
-      next if pkg.name == '_product' # will be handled via _product:*
-      pkg.project.repositories.each do |repo|
-        next if params[:repository] && params[:repository] != repo.name
-        repo.release_targets.each do |releasetarget|
-          next unless releasetarget.trigger.in?(['manual', 'maintenance'])
-          next if params[:targetproject] && params[:targetproject] != releasetarget.target_repository.project.name
-          next if params[:targetreposiory] && params[:targetreposiory] != releasetarget.target_repository.name
-          # release source and binaries
-          # permission checking happens inside this function
-          release_package(pkg, releasetarget.target_repository, pkg.release_target_name(releasetarget.target_repository, time_now), repo, nil, nil, params[:setrelease], true)
+      packages.each do |pkg|
+        next if pkg.name == '_product' # will be handled via _product:*
+        pkg.project.repositories.each do |repo|
+          next if params[:repository] && params[:repository] != repo.name
+          repo.release_targets.each do |releasetarget|
+            next unless releasetarget.trigger.in?(['manual', 'maintenance'])
+            next if params[:targetproject] && params[:targetproject] != releasetarget.target_repository.project.name
+            next if params[:targetreposiory] && params[:targetreposiory] != releasetarget.target_repository.name
+            # release source and binaries
+            # permission checking happens inside this function
+            release_package(pkg, releasetarget.target_repository, pkg.release_target_name(releasetarget.target_repository, time_now), repo, nil, nil, params[:setrelease], true)
+          end
         end
       end
     end

--- a/src/api/spec/models/project_spec.rb
+++ b/src/api/spec/models/project_spec.rb
@@ -585,7 +585,7 @@ RSpec.describe Project, vcr: true do
     end
 
     it "uses the package's release target name when releasing the package" do
-      project.do_project_release(user: user)
+      project.do_project_release(user: user.login)
       expect(project_release.packages.where(name: 'my_release_target')).to exist
     end
   end


### PR DESCRIPTION
Assigning User.session creates a thread variable. Thread
variables are not reset in delayed jobs. So whoever ran
the first job also ran all the jobs after it...