### PR TITLE
Improve messages of existing errors in SCM/CI integration

### DIFF
--- a/src/api/app/models/token/workflow.rb
+++ b/src/api/app/models/token/workflow.rb
@@ -1,4 +1,7 @@
 class Token::Workflow < Token
+  AUTHENTICATION_DOCUMENTATION_LINK = (::Workflow::SCM_CI_DOCUMENTATION_URL +
+                                       '#sec.obs.obs_scm_ci_workflow_integration.setup.token_authentication.how_to_authenticate_scm_with_obs').freeze
+
   has_many :workflow_runs, dependent: :destroy, foreign_key: 'token_id', inverse_of: false
 
   validates :scm_token, presence: true
@@ -27,8 +30,8 @@ class Token::Workflow < Token
 
     # Always returning validation errors to report them back to the SCM in order to help users debug their workflows
     validation_errors
-  rescue Octokit::Unauthorized, Gitlab::Error::Unauthorized => e
-    raise Token::Errors::SCMTokenInvalid, e.message
+  rescue Octokit::Unauthorized, Gitlab::Error::Unauthorized
+    raise Token::Errors::SCMTokenInvalid, "Your SCM token secret is not properly set in your OBS workflow token.\nCheck #{AUTHENTICATION_DOCUMENTATION_LINK}"
   end
 
   private

--- a/src/api/app/models/workflow.rb
+++ b/src/api/app/models/workflow.rb
@@ -2,6 +2,8 @@ class Workflow
   include ActiveModel::Model
   include WorkflowInstrumentation # for run_callbacks
 
+  SCM_CI_DOCUMENTATION_URL = 'https://openbuildservice.org/help/manuals/obs-user-guide/cha.obs.scm_ci_workflow_integration.html'.freeze
+
   SUPPORTED_STEPS = {
     branch_package: Workflow::Step::BranchPackageStep, link_package: Workflow::Step::LinkPackageStep,
     configure_repositories: Workflow::Step::ConfigureRepositories, rebuild_package: Workflow::Step::RebuildPackage,

--- a/src/api/app/services/workflows/yaml_downloader.rb
+++ b/src/api/app/services/workflows/yaml_downloader.rb
@@ -1,5 +1,6 @@
 module Workflows
   class YAMLDownloader
+    DOCUMENTATION_LINK = "#{::Workflow::SCM_CI_DOCUMENTATION_URL}#sec.obs.obs_scm_ci_workflow_integration.setup.obs_workflows".freeze
     MAX_FILE_SIZE = 1024 * 1024 # 1MB
 
     def initialize(scm_payload, token:)
@@ -16,7 +17,8 @@ module Workflows
     def download_yaml_file
       Down.download(download_url, max_size: MAX_FILE_SIZE)
     rescue Down::Error => e
-      raise Token::Errors::NonExistentWorkflowsFile, ".obs/workflows.yml could not be downloaded from the SCM branch #{@scm_payload[:target_branch]}: #{e.message}"
+      raise Token::Errors::NonExistentWorkflowsFile, ".obs/workflows.yml could not be downloaded from the SCM branch #{@scm_payload[:target_branch]}." \
+                                                     "\nIs the configuration file in the expected place? Check #{DOCUMENTATION_LINK}\n#{e.message}"
     end
 
     def download_url

--- a/src/api/app/validators/workflow_filters_validator.rb
+++ b/src/api/app/validators/workflow_filters_validator.rb
@@ -1,11 +1,18 @@
 class WorkflowFiltersValidator < ActiveModel::Validator
   SUPPORTED_FILTER_VALUES = [:only, :ignore].freeze
+  DOCUMENTATION_LINK = "#{::Workflow::SCM_CI_DOCUMENTATION_URL}#sec.obs.obs_scm_ci_workflow_integration.setup.obs_workflows.filters".freeze
 
   def validate(record)
     @workflow = record
     @workflow_instructions = record.workflow_instructions
 
     validate_filters
+
+    # We use the `:filter` or `:filters` key to have error messages which read better, so we check both.
+    return unless @workflow.errors.include?(:filter) || @workflow.errors.include?(:filters)
+
+    # Guide users by sharing a link whenever there's a validation error
+    @workflow.errors.add(:base, "Documentation for filters: #{DOCUMENTATION_LINK}")
   end
 
   private
@@ -15,14 +22,14 @@ class WorkflowFiltersValidator < ActiveModel::Validator
     return unless @workflow_instructions.key?(:filters)
 
     if unsupported_filters.present?
-      @workflow.errors.add(:base,
-                           "Unsupported filters: #{unsupported_filters.keys.to_sentence}")
+      @workflow.errors.add(:filters,
+                           "#{unsupported_filters.keys.to_sentence} are unsupported")
     end
 
     return if unsupported_filter_values.blank?
 
-    @workflow.errors.add(:base, "Filters #{unsupported_filter_values.to_sentence} have unsupported values, " \
-                                "#{SUPPORTED_FILTER_VALUES.map { |key| "'#{key}'" }.to_sentence} are the only supported values.")
+    @workflow.errors.add(:filters, "#{unsupported_filter_values.to_sentence} have unsupported values, " \
+                                   "#{SUPPORTED_FILTER_VALUES.map { |key| "'#{key}'" }.to_sentence} are the only supported values.")
   end
 
   def unsupported_filters
@@ -35,7 +42,7 @@ class WorkflowFiltersValidator < ActiveModel::Validator
 
       @workflow_instructions[:filters].each do |filter, value|
         if filter == :event
-          @workflow.errors.add(:base, 'Filter event only supports a string value') unless value.is_a?(String)
+          @workflow.errors.add(:filter, 'event only supports a string value') unless value.is_a?(String)
         else
           unsupported_filter_values << filter unless value.keys.all? { |filter_type| SUPPORTED_FILTER_VALUES.include?(filter_type.to_sym) }
         end

--- a/src/api/spec/controllers/trigger_workflow_controller_spec.rb
+++ b/src/api/spec/controllers/trigger_workflow_controller_spec.rb
@@ -40,7 +40,8 @@ RSpec.describe TriggerWorkflowController, type: :controller, beta: true do
       it { expect(response).to have_http_status(:not_found) }
 
       it "displays a user-friendly error message in the response's body" do
-        expect(response.body).to include('.obs/workflows.yml could not be downloaded from the SCM branch main: Beep Boop, something is wrong')
+        expect(response.body).to include(".obs/workflows.yml could not be downloaded from the SCM branch main.\nIs the configuration file in the expected place? " \
+                                         "Check #{Workflows::YAMLDownloader::DOCUMENTATION_LINK}\nBeep Boop, something is wrong")
       end
 
       it { expect(WorkflowRun.count).to eq(1) }

--- a/src/api/spec/models/token/workflow_spec.rb
+++ b/src/api/spec/models/token/workflow_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe Token::Workflow do
       subject { workflow_token.call(workflow_run: workflow_run, scm_webhook: scm_extractor.call) }
 
       it 'returns the validation errors' do
-        expect(subject).to eq(['Event not supported.', 'Workflow steps are not present'])
+        expect(subject).to eq(['Event not supported.', 'Steps are mandatory in a workflow', "Documentation for steps: #{WorkflowStepsValidator::DOCUMENTATION_LINK}"])
       end
 
       it { expect { subject }.to change(workflow_token, :triggered_at) & change(workflow_run, :response_url).to('https://api.github.com') }

--- a/src/api/spec/models/token/workflow_spec.rb
+++ b/src/api/spec/models/token/workflow_spec.rb
@@ -15,6 +15,23 @@ RSpec.describe Token::Workflow do
       end
     end
 
+    context 'with wrong SCM token' do
+      let(:yaml_downloader) { instance_double(Workflows::YAMLDownloader) }
+
+      before do
+        allow(Workflows::YAMLDownloader).to receive(:new).and_return(yaml_downloader)
+        allow(yaml_downloader).to receive(:call).and_raise(Octokit::Unauthorized)
+      end
+
+      it "changes the token's triggered_at field and raises an error with a helpful message" do
+        expect do
+          workflow_token.call({ workflow_run: workflow_run,
+                                scm_webhook: ScmWebhook.new(payload: { something: 123 }) })
+        end.to change(workflow_token, :triggered_at).and(raise_error(Token::Errors::SCMTokenInvalid, 'Your SCM token secret is not properly set in your OBS workflow token.' \
+                                                                                                     "\nCheck #{described_class::AUTHENTICATION_DOCUMENTATION_LINK}"))
+      end
+    end
+
     context 'without validation errors' do
       let(:scm) { 'github' }
       let(:event) { 'pull_request' }

--- a/src/api/spec/validators/workflow_filters_validator_spec.rb
+++ b/src/api/spec/validators/workflow_filters_validator_spec.rb
@@ -5,6 +5,11 @@ RSpec.describe WorkflowFiltersValidator do
     Struct.new(:workflow_instructions) do
       include ActiveModel::Validations
 
+      # To prevent the error "ArgumentError: Class name cannot be blank. You need to supply a name argument when anonymous class given"
+      def self.name
+        'FakeModel'
+      end
+
       validates_with WorkflowFiltersValidator
     end
   end
@@ -29,7 +34,8 @@ RSpec.describe WorkflowFiltersValidator do
 
       it 'is not valid and has an error message' do
         subject.valid?
-        expect(subject.errors.full_messages.to_sentence).to eq('Unsupported filters: something and else')
+        expect(subject.errors.full_messages.to_sentence).to eq('Filters something and else are unsupported and ' \
+                                                               "Documentation for filters: #{described_class::DOCUMENTATION_LINK}")
       end
     end
 
@@ -38,8 +44,9 @@ RSpec.describe WorkflowFiltersValidator do
 
       it 'is not valid and has an error message' do
         subject.valid?
-        expect(subject.errors.full_messages.to_sentence).to eq('Filter event only supports a string value and ' \
-                                                               "Filters repositories and architectures have unsupported values, 'only' and 'ignore' are the only supported values.")
+        expect(subject.errors.full_messages.to_sentence).to eq('Filter event only supports a string value, ' \
+                                                               "Filters repositories and architectures have unsupported values, 'only' and 'ignore' are the only supported values., and " \
+                                                               "Documentation for filters: #{described_class::DOCUMENTATION_LINK}")
       end
     end
 

--- a/src/api/spec/validators/workflow_steps_validator_spec.rb
+++ b/src/api/spec/validators/workflow_steps_validator_spec.rb
@@ -5,6 +5,11 @@ RSpec.describe WorkflowStepsValidator do
     Struct.new(:steps, :workflow_steps) do
       include ActiveModel::Validations
 
+      # To prevent the error "ArgumentError: Class name cannot be blank. You need to supply a name argument when anonymous class given"
+      def self.name
+        'FakeModel'
+      end
+
       validates_with WorkflowStepsValidator
     end
   end
@@ -18,7 +23,8 @@ RSpec.describe WorkflowStepsValidator do
 
       it 'is not valid and has an error message' do
         subject.valid?
-        expect(subject.errors.full_messages.to_sentence).to eq('Workflow steps are not present')
+        expect(subject.errors.full_messages.to_sentence).to eq('Steps are mandatory in a workflow and ' \
+                                                               "Documentation for steps: #{described_class::DOCUMENTATION_LINK}")
       end
     end
 
@@ -28,7 +34,8 @@ RSpec.describe WorkflowStepsValidator do
 
       it 'is not valid and has an error message' do
         subject.valid?
-        expect(subject.errors.full_messages.to_sentence).to eq('The provided workflow steps are unsupported')
+        expect(subject.errors.full_messages.to_sentence).to eq('Steps provided in the workflow are unsupported and ' \
+                                                               "Documentation for steps: #{described_class::DOCUMENTATION_LINK}")
       end
     end
 
@@ -39,7 +46,8 @@ RSpec.describe WorkflowStepsValidator do
 
       it 'is not valid and has an error message' do
         subject.valid?
-        expect(subject.errors.full_messages.to_sentence).to eq("The following workflow steps are unsupported: 'unsupported_step'")
+        expect(subject.errors.full_messages.to_sentence).to eq("Steps 'unsupported_step' are unsupported and " \
+                                                               "Documentation for steps: #{described_class::DOCUMENTATION_LINK}")
       end
     end
 
@@ -50,8 +58,9 @@ RSpec.describe WorkflowStepsValidator do
 
       it 'is not valid and has an error message' do
         subject.valid?
-        expect(subject.errors.full_messages.to_sentence).to eq("The following workflow steps are unsupported: 'unsupported_step' and " \
-                                                               "The 'source_package' key is missing and The 'target_project' key is missing")
+        expect(subject.errors.full_messages.to_sentence).to eq("Steps 'unsupported_step' are unsupported, Steps with errors:\n" \
+                                                               "branch_package - The 'source_package' key is missing and The 'target_project' key is missing, and " \
+                                                               "Documentation for steps: #{described_class::DOCUMENTATION_LINK}")
       end
     end
   end


### PR DESCRIPTION
With the changes in this PR, we can drop some errors from the `Errors` table in the user documentation of the SCM/CI integration. This is happening in the PR https://github.com/openSUSE/obs-docu/pull/235.