### PR TITLE
Extend task to create workflow runs

### DIFF
--- a/src/api/lib/tasks/dev.rake
+++ b/src/api/lib/tasks/dev.rake
@@ -243,42 +243,6 @@ namespace :dev do
     end
   end
 
-  # Run this task with: rails dev:workflow_runs:data"
-  namespace :workflow_runs do
-    desc 'Creates a workflow token, workflow runs, artifacts and some of their dependencies'
-    task data: :environment do
-      unless Rails.env.development?
-        puts "You are running this rake task in #{Rails.env} environment."
-        puts 'Please only run this task with RAILS_ENV=development'
-        puts 'otherwise it will destroy your database data.'
-        return
-      end
-
-      require 'factory_bot'
-      include FactoryBot::Syntax::Methods
-
-      puts 'Creating workflow token and workflow runs...'
-
-      admin = User.get_default_admin
-      User.session = admin
-      project = find_or_create_project(admin.home_project_name, admin)
-
-      workflow_token = Token::Workflow.find_by(name: 'Testing token') || create(:workflow_token, user: admin, name: 'Testing token')
-
-      create(:running_workflow_run, token: workflow_token)
-      create(:failed_workflow_run, token: workflow_token)
-      succeeded_workflow_run = create(:succeeded_workflow_run, token: workflow_token)
-
-      source_project_name = project.name
-      target_project_name = "#{project.name}:CI:repo:PR-1"
-
-      create(:workflow_artifacts_per_step_branch_package, workflow_run: succeeded_workflow_run, source_project_name: source_project_name, target_project_name: target_project_name)
-      create(:workflow_artifacts_per_step_link_package, workflow_run: succeeded_workflow_run, source_project_name: source_project_name, target_project_name: target_project_name)
-      create(:workflow_artifacts_per_step_rebuild_package, workflow_run: succeeded_workflow_run, source_project_name: source_project_name, target_project_name: target_project_name)
-      create(:workflow_artifacts_per_step_config_repositories, workflow_run: succeeded_workflow_run, source_project_name: source_project_name, target_project_name: target_project_name)
-    end
-  end
-
   # This is automatically run in Review App or manually in development env.
   namespace :development_testdata do
     desc 'Creates test data to play with in dev and CI environments'
@@ -438,7 +402,7 @@ namespace :dev do
       Rake::Task['dev:notifications:data'].invoke(2)
 
       # Create a workflow token, some workflow runs and their related data
-      Rake::Task['dev:workflow_runs:data'].invoke
+      Rake::Task['workflows:create_workflow_runs'].invoke
     end
   end
 end

--- a/src/api/lib/tasks/workflows.rake
+++ b/src/api/lib/tasks/workflows.rake
@@ -1,4 +1,54 @@
 namespace :workflows do
+  # Run this task with: rails workflows:create_workflow_runs
+  desc 'Creates a workflow token, workflow runs, artifacts and some of their dependencies'
+  task create_workflow_runs: :environment do
+    unless Rails.env.development?
+      puts "You are running this rake task in #{Rails.env} environment."
+      puts 'Please only run this task with RAILS_ENV=development'
+      puts 'otherwise it will destroy your database data.'
+      return
+    end
+
+    require 'factory_bot'
+    include FactoryBot::Syntax::Methods
+
+    puts 'Creating workflow token and workflow runs...'
+
+    admin = User.get_default_admin
+    User.session = admin
+    project = find_or_create_project(admin.home_project_name, admin)
+
+    workflow_token = Token::Workflow.find_by(name: 'Testing token') || create(:workflow_token, user: admin, name: 'Testing token')
+
+    # GitHub
+    create(:workflow_run_github_running, token: workflow_token)
+    create(:workflow_run_github_failed, token: workflow_token)
+    create(:workflow_run_github_succeeded, :push, token: workflow_token)
+    create(:workflow_run_github_succeeded, :tag_push, token: workflow_token)
+    create(:workflow_run_github_succeeded, :pull_request_opened, token: workflow_token)
+    create(:workflow_run_github_succeeded, :pull_request_closed, token: workflow_token)
+
+    # GitLab
+    create(:workflow_run_gitlab_running, token: workflow_token)
+    create(:workflow_run_gitlab_failed, token: workflow_token)
+    create(:workflow_run_gitlab_succeeded, :push, token: workflow_token)
+    create(:workflow_run_gitlab_succeeded, :tag_push, token: workflow_token)
+    create(:workflow_run_gitlab_succeeded, :pull_request_opened, token: workflow_token)
+    create(:workflow_run_gitlab_succeeded, :pull_request_closed, token: workflow_token)
+
+    workflow_runs_with_artifacts = WorkflowRun.where(status: 'success')
+
+    source_project_name = project.name
+    target_project_name = "#{project.name}:CI:repo:PR-1"
+
+    workflow_runs_with_artifacts.each do |workflow_run|
+      create(:workflow_artifacts_per_step_branch_package, workflow_run: workflow_run, source_project_name: source_project_name, target_project_name: target_project_name)
+      create(:workflow_artifacts_per_step_link_package, workflow_run: workflow_run, source_project_name: source_project_name, target_project_name: target_project_name)
+      create(:workflow_artifacts_per_step_rebuild_package, workflow_run: workflow_run, source_project_name: source_project_name, target_project_name: target_project_name)
+      create(:workflow_artifacts_per_step_config_repositories, workflow_run: workflow_run, source_project_name: source_project_name, target_project_name: target_project_name)
+    end
+  end
+
   desc 'Remove projects that were not closed as expected and set workflow run status to running'
   task cleanup_non_closed_projects: :environment do
     workflow_runs = WorkflowRun.where(status: 'running')

--- a/src/api/spec/factories/workflow_runs.rb
+++ b/src/api/spec/factories/workflow_runs.rb
@@ -7,23 +7,15 @@ FactoryBot.define do
       END_OF_HEADERS
     end
     request_payload do
-      <<~END_OF_PAYLOAD
-        {
-          "action": "opened",
-          "pull_request": {
-            "number": 1
-          },
-          "repository": {
-            "full_name": "iggy/hello_world",
-            "owner": { "html_url": "https://github.com" }
-          },
-          "foo": "bar"
-        }
-      END_OF_PAYLOAD
+      File.read('spec/support/files/request_payload_github_pull_request_opened.json')
     end
+  end
 
-    factory :succeeded_workflow_run do
+  # GitHub
+  factory :workflow_run_github, parent: :workflow_run do
+    factory :workflow_run_github_succeeded do
       status { 'success' }
+      response_url { 'https://api.github.com' }
       response_body do
         <<~END_OF_RESPONSE_BODY
           <status code="ok">
@@ -31,16 +23,116 @@ FactoryBot.define do
           </status>
         END_OF_RESPONSE_BODY
       end
-      response_url { 'https://api.github.com' }
+      trait :pull_request_opened do
+        request_payload do
+          File.read('spec/support/files/request_payload_github_pull_request_opened.json')
+        end
+      end
+      trait :pull_request_closed do
+        request_payload do
+          File.read('spec/support/files/request_payload_github_pull_request_closed.json')
+        end
+      end
+      trait :push do
+        request_headers do
+          <<~END_OF_HEADERS
+            HTTP_X_GITHUB_EVENT: push
+          END_OF_HEADERS
+        end
+        request_payload do
+          File.read('spec/support/files/request_payload_github_push.json')
+        end
+      end
+      trait :tag_push do
+        request_headers do
+          <<~END_OF_HEADERS
+            HTTP_X_GITHUB_EVENT: push
+          END_OF_HEADERS
+        end
+        request_payload do
+          File.read('spec/support/files/request_payload_github_tag_push.json')
+        end
+      end
     end
 
-    factory :running_workflow_run do
+    factory :workflow_run_github_running do
       status { 'running' }
       response_body { nil }
       response_url { nil }
     end
 
-    factory :failed_workflow_run do
+    factory :workflow_run_github_failed do
+      status { 'fail' }
+      response_body do
+        <<~END_OF_RESPONSE_BODY
+          <status code="unknown">
+            <summary>The 'target_project' key is missing</summary>
+          </status>
+        END_OF_RESPONSE_BODY
+      end
+    end
+  end
+
+  # GitLab
+  factory :workflow_run_gitlab, parent: :workflow_run do
+    request_headers do
+      <<~END_OF_HEADERS
+        HTTP_X_GITLAB_EVENT: Merge Request Hook
+      END_OF_HEADERS
+    end
+    request_payload do
+      File.read('spec/support/files/request_payload_gitlab_pull_request_opened.json')
+    end
+
+    factory :workflow_run_gitlab_succeeded do
+      status { 'success' }
+      response_url { 'https://gitlab.com' }
+      response_body do
+        <<~END_OF_RESPONSE_BODY
+          <status code="ok">
+            <summary>Ok</summary>
+          </status>
+        END_OF_RESPONSE_BODY
+      end
+      trait :pull_request_opened do
+        request_payload do
+          File.read('spec/support/files/request_payload_gitlab_pull_request_opened.json')
+        end
+      end
+      trait :pull_request_closed do
+        request_payload do
+          File.read('spec/support/files/request_payload_gitlab_pull_request_closed.json')
+        end
+      end
+      trait :push do
+        request_headers do
+          <<~END_OF_HEADERS
+            HTTP_X_GITLAB_EVENT: Push Hook
+          END_OF_HEADERS
+        end
+        request_payload do
+          File.read('spec/support/files/request_payload_gitlab_push.json')
+        end
+      end
+      trait :tag_push do
+        request_headers do
+          <<~END_OF_HEADERS
+            HTTP_X_GITLAB_EVENT: Tag Push Hook
+          END_OF_HEADERS
+        end
+        request_payload do
+          File.read('spec/support/files/request_payload_gitlab_tag_push.json')
+        end
+      end
+    end
+
+    factory :workflow_run_gitlab_running do
+      status { 'running' }
+      response_body { nil }
+      response_url { nil }
+    end
+
+    factory :workflow_run_gitlab_failed do
       status { 'fail' }
       response_body do
         <<~END_OF_RESPONSE_BODY

--- a/src/api/spec/lib/tasks/workflows_spec.rb
+++ b/src/api/spec/lib/tasks/workflows_spec.rb
@@ -6,24 +6,6 @@ RSpec.describe 'workflows' do
   include_context 'rake'
 
   let!(:admin_user) { create(:admin_user, login: 'Admin') }
-  let(:gitlab_request_headers) do
-    <<~END_OF_HEADERS
-      HTTP_X_GITLAB_EVENT: Merge Request Hook
-    END_OF_HEADERS
-  end
-  let(:github_request_payload_opened) do
-    <<~END_OF_REQUEST
-      {
-        "action": "opened",
-        "pull_request": {
-          "number": 1
-        },
-        "repository": {
-          "full_name": "iggy/hello_world"
-        }
-      }
-    END_OF_REQUEST
-  end
   let(:github_request_payload_closed) do
     <<~END_OF_REQUEST
       {
@@ -57,12 +39,12 @@ RSpec.describe 'workflows' do
   let!(:project_iggy_hello_world_pr2) { create(:project, name: 'home:Iggy:iggy:hello_world:PR-2') }
   let!(:project_iggy_test_pr3) { create(:project, name: 'home:Iggy:iggy:test:PR-3') }
 
-  let!(:workflow_run_running_pr_opened) { create(:running_workflow_run, request_payload: github_request_payload_opened) }
-  let!(:workflow_run_succeeded_pr_opened) { create(:succeeded_workflow_run, request_payload: github_request_payload_opened) }
-  let!(:workflow_run_failed_pr_opened) { create(:failed_workflow_run, request_payload: github_request_payload_opened) }
-  let!(:workflow_run_running_pr_closed) { create(:running_workflow_run, request_payload: github_request_payload_closed) }
-  let!(:another_workflow_run_running_pr_closed) { create(:running_workflow_run, request_payload: github_request_payload_closed) }
-  let!(:workflow_run_running_pr_merge) { create(:running_workflow_run, request_headers: gitlab_request_headers, request_payload: gitlab_request_payload_merge) }
+  let!(:workflow_run_running_pr_opened) { create(:workflow_run_github_running) }
+  let!(:workflow_run_succeeded_pr_opened) { create(:workflow_run_github_succeeded, :pull_request_opened) }
+  let!(:workflow_run_failed_pr_opened) { create(:workflow_run_github_failed) }
+  let!(:workflow_run_running_pr_closed) { create(:workflow_run_github_running, request_payload: github_request_payload_closed) }
+  let!(:another_workflow_run_running_pr_closed) { create(:workflow_run_github_running, request_payload: github_request_payload_closed) }
+  let!(:workflow_run_running_pr_merge) { create(:workflow_run_gitlab_running, request_payload: gitlab_request_payload_merge) }
 
   describe 'cleanup_non_closed_projects' do
     let(:task) { 'workflows:cleanup_non_closed_projects' }

--- a/src/api/spec/support/files/request_payload_github_pull_request_closed.json
+++ b/src/api/spec/support/files/request_payload_github_pull_request_closed.json
@@ -1,0 +1,10 @@
+{
+  "action": "closed",
+  "pull_request": {
+    "number": 1
+  },
+  "repository": {
+    "full_name": "iggy/hello_world",
+    "html_url": "https://github.com"
+  }
+}

--- a/src/api/spec/support/files/request_payload_github_pull_request_opened.json
+++ b/src/api/spec/support/files/request_payload_github_pull_request_opened.json
@@ -1,0 +1,10 @@
+{
+  "action": "opened",
+  "pull_request": {
+    "number": 1
+  },
+  "repository": {
+    "full_name": "iggy/hello_world",
+    "html_url": "https://github.com"
+  }
+}

--- a/src/api/spec/support/files/request_payload_github_push.json
+++ b/src/api/spec/support/files/request_payload_github_push.json
@@ -1,0 +1,19 @@
+{
+  "ref": "refs/heads/master",
+  "before": "594440dcbe3eb630a2125ab443f0131c8a16d6d5",
+  "after": "d1b6a25fb371902586974d922ff4789dd4ed7d2e",
+  "base_ref": null,
+  "head_commit": {
+    "id": "d1b6a25fb371902586974d922ff4789dd4ed7d2e",
+    "url": "https://github.com/iggy/hello_world/commit/d1b6a25fb371902586974d922ff4789dd4ed7d2e"
+  },
+  "repository": {
+    "id": 371734220,
+    "name": "hello_world",
+    "full_name": "iggy/hello_world",
+    "html_url": "https://github.com/iggy/hello_world",
+    "url": "https://github.com/iggy/hello_world",
+    "git_url": "git://github.com/iggy/hello_world.git",
+    "master_branch": "master"
+  }
+}

--- a/src/api/spec/support/files/request_payload_github_tag_push.json
+++ b/src/api/spec/support/files/request_payload_github_tag_push.json
@@ -1,0 +1,18 @@
+{
+  "ref": "refs/tags/v1",
+  "before": "594440dcbe3eb630a2125ab443f0131c8a16d6d5",
+  "after": "d1b6a25fb371902586974d922ff4789dd4ed7d2e",
+  "base_ref": "refs/heads/main",
+  "head_commit": {
+    "id": "d1b6a25fb371902586974d922ff4789dd4ed7d2e",
+    "url": "https://github.com/iggy/hello_world/commit/d1b6a25fb371902586974d922ff4789dd4ed7d2e"
+  },
+  "repository": {
+    "id": 371734220,
+    "name": "hello_world",
+    "full_name": "iggy/hello_world",
+    "html_url": "https://github.com/iggy/hello_world",
+    "url": "https://github.com/iggy/hello_world",
+    "git_url": "git://github.com/iggy/hello_world.git"
+  }
+}

--- a/src/api/spec/support/files/request_payload_gitlab_pull_request_closed.json
+++ b/src/api/spec/support/files/request_payload_gitlab_pull_request_closed.json
@@ -1,0 +1,19 @@
+{
+  "object_kind": "merge_request",
+  "event_type": "merge_request",
+  "project": {
+    "name": "hello_world-test",
+    "web_url": "https://gitlab.com/iggy/hello_world",
+    "path_with_namespace": "iggy/hello_world"
+  },
+  "object_attributes": {
+    "id": 49732567,
+    "iid": 1,
+    "action": "close"
+  },
+  "repository": {
+    "name": "hello_world",
+    "url": "git@gitlab.com:iggy/hello_world.git",
+    "homepage": "https://gitlab.com/iggy/hello_world"
+  }
+}

--- a/src/api/spec/support/files/request_payload_gitlab_pull_request_opened.json
+++ b/src/api/spec/support/files/request_payload_gitlab_pull_request_opened.json
@@ -1,0 +1,19 @@
+{
+  "object_kind": "merge_request",
+  "event_type": "merge_request",
+  "project": {
+    "name": "hello_world-test",
+    "web_url": "https://gitlab.com/iggy/hello_world",
+    "path_with_namespace": "iggy/hello_world"
+  },
+  "object_attributes": {
+    "id": 49732567,
+    "iid": 1,
+    "action": "open"
+  },
+  "repository": {
+    "name": "hello_world",
+    "url": "git@gitlab.com:iggy/hello_world.git",
+    "homepage": "https://gitlab.com/iggy/hello_world"
+  }
+}

--- a/src/api/spec/support/files/request_payload_gitlab_push.json
+++ b/src/api/spec/support/files/request_payload_gitlab_push.json
@@ -1,0 +1,25 @@
+{
+  "object_kind": "push",
+  "before": "60cd89df0215ab64cff9b8076a4a3334dce71ba7",
+  "after": "1873d25e0fb0c245e3ad75aadca1f69fdf5fd70b",
+  "ref": "refs/heads/master",
+  "project_id": 16871458,
+  "project": {
+    "id": 16871458,
+    "name": "hello_world",
+    "web_url": "https://gitlab.com/iggy/hello_world",
+    "path_with_namespace": "iggy/hello_world",
+    "http_url": "https://gitlab.com/iggy/hello_world.git"
+  },
+  "commits": [
+    {
+      "id": "1873d25e0fb0c245e3ad75aadca1f69fdf5fd70b",
+      "url": "https://gitlab.com/iggy/hello_world/-/commit/1873d25e0fb0c245e3ad75aadca1f69fdf5fd70b"
+    }
+  ],
+  "repository": {
+    "name": "hello_world",
+    "url": "git@gitlab.com:iggy/hello_world.git",
+    "homepage": "https://gitlab.com/iggy/hello_world"
+  }
+}

--- a/src/api/spec/support/files/request_payload_gitlab_tag_push.json
+++ b/src/api/spec/support/files/request_payload_gitlab_tag_push.json
@@ -1,0 +1,25 @@
+{
+  "object_kind": "tag_push",
+  "before": "60cd89df0215ab64cff9b8076a4a3334dce71ba7",
+  "after": "1873d25e0fb0c245e3ad75aadca1f69fdf5fd70b",
+  "ref": "refs/tags/v1",
+  "project_id": 16871458,
+  "project": {
+    "id": 16871458,
+    "name": "hello_world",
+    "web_url": "https://gitlab.com/iggy/hello_world",
+    "path_with_namespace": "iggy/hello_world",
+    "http_url": "https://gitlab.com/iggy/hello_world.git"
+  },
+  "commits": [
+    {
+      "id": "1873d25e0fb0c245e3ad75aadca1f69fdf5fd70b",
+      "url": "https://gitlab.com/iggy/hello_world/-/commit/1873d25e0fb0c245e3ad75aadca1f69fdf5fd70b"
+    }
+  ],
+  "repository": {
+    "name": "hello_world",
+    "url": "git@gitlab.com:iggy/hello_world.git",
+    "homepage": "https://gitlab.com/iggy/hello_world"
+  }
+}


### PR DESCRIPTION
Create a variety of workflow runs: from both GitHub and GitLab, with different statuses, events and actions.
This task is usually run in development environment and review-app.  