### PR TITLE
Add Workflow Runs filter by pull/merge request action

### DIFF
--- a/src/api/app/components/workflow_run_request_action_filter_component.html.haml
+++ b/src/api/app/components/workflow_run_request_action_filter_component.html.haml
@@ -1,0 +1,12 @@
+= form_with(url: token_workflow_runs_path(@token_id), method: :get, local: true, class: 'form-inline') do
+  = hidden_field_tag('generic_event_type', @generic_event_type)
+  = label_tag('request_action', 'Action', class: 'sr-only')
+  .input-group.mr-sm-2
+    .input-group-prepend
+      .input-group-text
+        Action
+    = select_tag('request_action',
+                  options_for_select(@filter_options, @request_action),
+                  class: 'form-control custom-select')
+  %button.btn.btn-primary#filter-button{ type: :submit }
+    Apply

--- a/src/api/app/components/workflow_run_request_action_filter_component.rb
+++ b/src/api/app/components/workflow_run_request_action_filter_component.rb
@@ -1,0 +1,10 @@
+class WorkflowRunRequestActionFilterComponent < ApplicationComponent
+  def initialize(token_id:, request_action: '')
+    super
+
+    @request_action = request_action
+    @token_id = token_id
+    @generic_event_type = 'pull_request'
+    @filter_options = ['all'] + ScmWebhook::ALLOWED_PULL_REQUEST_ACTIONS + ScmWebhook::ALLOWED_MERGE_REQUEST_ACTIONS
+  end
+end

--- a/src/api/app/controllers/webui/workflow_runs_controller.rb
+++ b/src/api/app/controllers/webui/workflow_runs_controller.rb
@@ -2,11 +2,11 @@ class Webui::WorkflowRunsController < Webui::WebuiController
   def index
     relation = WorkflowRunPolicy::Scope.new(User.session, WorkflowRun, { token_id: params[:token_id] })
     @workflow_runs_finder = WorkflowRunsFinder.new(relation.resolve)
-
+    @request_action = params[:request_action] if params[:request_action].present? && params[:request_action] != 'all'
     @workflow_runs = if params[:status]
                        @workflow_runs_finder.with_status(params[:status])
                      elsif params[:generic_event_type]
-                       @workflow_runs_finder.with_generic_event_type(params[:generic_event_type])
+                       @workflow_runs_finder.with_generic_event_type(params[:generic_event_type], @request_action)
                      else
                        @workflow_runs_finder.all
                      end

--- a/src/api/app/models/scm_webhook.rb
+++ b/src/api/app/models/scm_webhook.rb
@@ -11,6 +11,8 @@ class ScmWebhook
                                   'edited', 'labeled', 'locked', 'ready_for_review', 'review_request_removed',
                                   'review_requested', 'unassigned', 'unlabeled', 'unlocked'].freeze
   IGNORED_MERGE_REQUEST_ACTIONS = ['approved', 'unapproved'].freeze
+  ALLOWED_PULL_REQUEST_ACTIONS = ['closed', 'opened', 'reopened', 'synchronize'].freeze
+  ALLOWED_MERGE_REQUEST_ACTIONS = ['close', 'merge', 'open', 'reopen', 'update'].freeze
 
   def initialize(attributes = {})
     run_callbacks(:initialize) do

--- a/src/api/app/models/workflow_run.rb
+++ b/src/api/app/models/workflow_run.rb
@@ -78,12 +78,12 @@ class WorkflowRun < ApplicationRecord
 
   def pull_request_with_allowed_action
     hook_event == 'pull_request' &&
-      ScmWebhookEventValidator::ALLOWED_PULL_REQUEST_ACTIONS.include?(payload['action'])
+      ScmWebhook::ALLOWED_PULL_REQUEST_ACTIONS.include?(payload['action'])
   end
 
   def merge_request_with_allowed_action
     hook_event == 'Merge Request Hook' &&
-      ScmWebhookEventValidator::ALLOWED_MERGE_REQUEST_ACTIONS.include?(payload.dig('object_attributes', 'action'))
+      ScmWebhook::ALLOWED_MERGE_REQUEST_ACTIONS.include?(payload.dig('object_attributes', 'action'))
   end
 end
 

--- a/src/api/app/queries/workflow_runs_finder.rb
+++ b/src/api/app/queries/workflow_runs_finder.rb
@@ -22,12 +22,17 @@ class WorkflowRunsFinder
     end
   end
 
-  def with_generic_event_type(generic_event_type)
+  def with_generic_event_type(generic_event_type, request_action = nil)
     query = find_real_event_types(generic_event_type).map do |real_event_type|
       "request_headers LIKE '%#{real_event_type}%'"
     end.join(' OR ')
 
-    @relation.where(query)
+    workflow_runs = @relation.where(query)
+    if request_action
+      workflow_runs = workflow_runs.where("JSON_EXTRACT(request_payload, '$.action') = (?) OR JSON_EXTRACT(request_payload, '$.object_attributes.action') = (?)", request_action,
+                                          request_action)
+    end
+    workflow_runs
   end
 
   def with_status(status)

--- a/src/api/app/validators/scm_webhook_event_validator.rb
+++ b/src/api/app/validators/scm_webhook_event_validator.rb
@@ -2,9 +2,6 @@ class ScmWebhookEventValidator < ActiveModel::Validator
   ALLOWED_GITHUB_EVENTS = ['pull_request', 'push'].freeze
   ALLOWED_GITLAB_EVENTS = ['Merge Request Hook', 'Push Hook', 'Tag Push Hook'].freeze
 
-  ALLOWED_PULL_REQUEST_ACTIONS = ['closed', 'opened', 'reopened', 'synchronize'].freeze
-  ALLOWED_MERGE_REQUEST_ACTIONS = ['close', 'merge', 'open', 'reopen', 'update'].freeze
-
   def validate(record)
     @record = record
 
@@ -22,7 +19,7 @@ class ScmWebhookEventValidator < ActiveModel::Validator
 
     case @record.payload[:event]
     when 'pull_request'
-      return true if ALLOWED_PULL_REQUEST_ACTIONS.include?(@record.payload[:action])
+      return true if ScmWebhook::ALLOWED_PULL_REQUEST_ACTIONS.include?(@record.payload[:action])
 
       @record.errors.add(:base, 'Pull request action not supported.')
     when 'push'
@@ -38,7 +35,7 @@ class ScmWebhookEventValidator < ActiveModel::Validator
 
     case @record.payload[:event]
     when 'Merge Request Hook'
-      return true if ALLOWED_MERGE_REQUEST_ACTIONS.include?(@record.payload[:action])
+      return true if ScmWebhook::ALLOWED_MERGE_REQUEST_ACTIONS.include?(@record.payload[:action])
 
       @record.errors.add(:base, 'Merge request action not supported.')
     when 'Push Hook', 'Tag Push Hook'

--- a/src/api/app/views/webui/workflow_runs/index.html.haml
+++ b/src/api/app/views/webui/workflow_runs/index.html.haml
@@ -11,11 +11,13 @@
         = render WorkflowRunFilterComponent.new(token: @token, selected_filter: @selected_filter, finder: @workflow_runs_finder)
   .col-md-8.col-lg-9.px-0.px-md-3#workflow-run-list
     .card
-      - if @workflow_runs.blank?
-        .card-body
-          %p There are no workflow runs for this token yet
-      - else
-        .card-body
+      .card-body
+        - if @selected_filter[:generic_event_type] == 'pull_request'
+          = render WorkflowRunRequestActionFilterComponent.new(token_id: @token.id, request_action: @request_action)
+        - if @workflow_runs.blank?
+          .text-center
+            %p There are no workflow runs available
+        - else
           .text-center
             %span.ml-3= page_entries_info(@workflow_runs)
           .accordion.pt-3#workflow-runs-accordion

--- a/src/api/spec/components/workflow_run_request_action_filter_component_spec.rb
+++ b/src/api/spec/components/workflow_run_request_action_filter_component_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe WorkflowRunRequestActionFilterComponent, type: :component do
+  let(:workflow_token) { create(:workflow_token) }
+
+  it 'shows correct filter options' do
+    render_inline(described_class.new(token_id: workflow_token.id))
+    filters = ['all'] + ScmWebhook::ALLOWED_PULL_REQUEST_ACTIONS + ScmWebhook::ALLOWED_MERGE_REQUEST_ACTIONS
+
+    filters.each do |filter|
+      expect(rendered_component).to have_text(filter)
+    end
+  end
+end

--- a/src/api/spec/controllers/webui/workflow_runs_controller_spec.rb
+++ b/src/api/spec/controllers/webui/workflow_runs_controller_spec.rb
@@ -8,9 +8,30 @@ RSpec.describe Webui::WorkflowRunsController, type: :controller do
 
     before do
       login token_user
-      get :index, params: { token_id: workflow_token.id }
     end
 
-    it { expect(assigns(:workflow_runs).count).to eq(1) }
+    context 'when action_filter is not available' do
+      before do
+        get :index, params: { token_id: workflow_token.id }
+      end
+
+      it { expect(assigns(:workflow_runs).count).to eq(1) }
+    end
+
+    context 'when action_filter is available' do
+      it 'finds workflow runs when the action is available' do
+        get :index, params: { token_id: workflow_token.id, request_action: 'opened', generic_event_type: 'pull_request' }
+
+        expect(assigns(:workflow_runs).count).to eq(1)
+        expect(assigns(:request_action)).to eq('opened')
+      end
+
+      it 'does not find workflow runs when action is not available' do
+        get :index, params: { token_id: workflow_token.id, request_action: 'closed', generic_event_type: 'pull_request' }
+
+        expect(assigns(:workflow_runs).count).to eq(0)
+        expect(assigns(:request_action)).to eq('closed')
+      end
+    end
   end
 end


### PR DESCRIPTION
Currently, it is not possible to filter workflow runs by action type i.e., we can not filter workflow runs for `pull_requests/merge requests` by actions like `opened`, `closed`, etc. This PR allows us to filter `pull_requests/merge requests` by actions.

![filter option](https://user-images.githubusercontent.com/12820609/162733611-3bf4e7ab-74ad-44e7-823d-16b303574ec3.png)
