### PR TITLE
Rework token name

### DIFF
--- a/src/api/app/components/token_card_component.rb
+++ b/src/api/app/components/token_card_component.rb
@@ -8,7 +8,7 @@ class TokenCardComponent < ApplicationComponent
   end
 
   def operation
-    "Operation: #{@token.class.token_name.capitalize}"
+    "Operation: #{@token.token_name.capitalize}"
   end
 
   def token_package_link

--- a/src/api/app/models/token.rb
+++ b/src/api/app/models/token.rb
@@ -23,6 +23,10 @@ class Token < ApplicationRecord
     self.class.token_name
   end
 
+  def self.token_name
+    name.demodulize.downcase
+  end
+
   def self.token_type(action)
     case action
     when 'rebuild'

--- a/src/api/app/models/token.rb
+++ b/src/api/app/models/token.rb
@@ -20,11 +20,11 @@ class Token < ApplicationRecord
   OPERATIONS = ['Rebuild', 'Release', 'Service', 'Workflow'].freeze
 
   def token_name
-    self.class.token_name
+    self.class.token_name.downcase
   end
 
   def self.token_name
-    name.demodulize.downcase
+    name.demodulize
   end
 
   def self.token_type(action)

--- a/src/api/app/models/token/rebuild.rb
+++ b/src/api/app/models/token/rebuild.rb
@@ -1,8 +1,4 @@
 class Token::Rebuild < Token
-  def self.token_name
-    'rebuild'
-  end
-
   def call(options)
     set_triggered_at
     package_name = options[:package].to_param

--- a/src/api/app/models/token/release.rb
+++ b/src/api/app/models/token/release.rb
@@ -1,10 +1,6 @@
 class Token::Release < Token
   include MaintenanceHelper
 
-  def self.token_name
-    'release'
-  end
-
   def call(options)
     set_triggered_at
     return unless options[:package]

--- a/src/api/app/models/token/rss.rb
+++ b/src/api/app/models/token/rss.rb
@@ -1,7 +1,4 @@
 class Token::Rss < Token
-  def self.token_name
-    'rss'
-  end
 end
 
 # == Schema Information

--- a/src/api/app/models/token/service.rb
+++ b/src/api/app/models/token/service.rb
@@ -1,8 +1,4 @@
 class Token::Service < Token
-  def self.token_name
-    'runservice'
-  end
-
   def call(options)
     set_triggered_at
     Backend::Api::Sources::Package.trigger_services(options[:project].to_param,

--- a/src/api/app/models/token/workflow.rb
+++ b/src/api/app/models/token/workflow.rb
@@ -3,10 +3,6 @@ class Token::Workflow < Token
 
   validates :scm_token, presence: true
 
-  def self.token_name
-    'workflow'
-  end
-
   def call(options)
     set_triggered_at
     @scm_webhook = options[:scm_webhook]

--- a/src/api/app/views/webui/users/token_triggers/show.html.haml
+++ b/src/api/app/views/webui/users/token_triggers/show.html.haml
@@ -13,7 +13,7 @@
             = @token.id
           .form-group
             = f.label(:type, 'Operation:')
-            = @token.class.token_name.capitalize
+            = @token.token_name.capitalize
           - token_package = @token.package
           - if token_package.present?
             = fields_for(:package, token_package) do |token_fields|

--- a/src/api/app/views/webui/users/tokens/edit.html.haml
+++ b/src/api/app/views/webui/users/tokens/edit.html.haml
@@ -22,7 +22,7 @@
                 = @token.id
               .form-group
                 = f.label(:type, 'Operation:')
-                = @token.class.token_name.capitalize
+                = @token.token_name.capitalize
               .form-group
                 = f.label(:name, 'Name:')
                 %span.d-none#original-token-name


### PR DESCRIPTION
Instead of have this class method manually defined in each `Token` class, have it in the parent class in a generic way.

Beside that we standardized the way to access it in the views

From here we have some options:

a) Rename the method to something more useful
b) Move the method `token_name` to the component or transform it in a helper


How to test:

Try to create a new token or edit an existing one