### PR TITLE
Add new filter for tag push events

### DIFF
--- a/src/api/app/components/workflow_run_filter_component.html.haml
+++ b/src/api/app/components/workflow_run_filter_component.html.haml
@@ -27,3 +27,5 @@
                                               filter_item: { generic_event_type: 'pull_request' }, selected_filter: @selected_filter)
   = render WorkflowRunFilterLinkComponent.new(token: @token, text: 'Push', amount: @count['push'],
                                               filter_item: { generic_event_type: 'push' }, selected_filter: @selected_filter)
+  = render WorkflowRunFilterLinkComponent.new(token: @token, text: 'Tag Push', amount: @count['tag_push'],
+                                              filter_item: { generic_event_type: 'tag_push' }, selected_filter: @selected_filter)

--- a/src/api/app/models/workflow_run.rb
+++ b/src/api/app/models/workflow_run.rb
@@ -67,6 +67,17 @@ class WorkflowRun < ApplicationRecord
     payload.dig(*mapped_source_url) if mapped_source_url
   end
 
+  def generic_event_type
+    # We only have filters for push, tag_push, and pull_request
+    if hook_event == 'Push Hook' || payload.fetch('ref', '').match('refs/heads')
+      'push'
+    elsif hook_event == 'Tag Push Hook' || payload.fetch('ref', '').match('refs/tag')
+      'tag_push'
+    elsif hook_event.in?(['pull_request', 'Merge Request Hook'])
+      'pull_request'
+    end
+  end
+
   private
 
   def parsed_request_headers

--- a/src/api/app/queries/workflow_runs_finder.rb
+++ b/src/api/app/queries/workflow_runs_finder.rb
@@ -1,10 +1,8 @@
 class WorkflowRunsFinder
   EVENT_TYPE_MAPPING = {
-    'pull_request' => 'pull_request',
-    'Merge Request Hook' => 'pull_request',
-    'push' => 'push',
-    'Push Hook' => 'push',
-    'Tag Push Hook' => 'push'
+    'pull_request' => ['pull_request', 'Merge Request Hook'],
+    'push' => ['push', 'Push Hook'],
+    'tag_push' => ['push', 'Tag Push Hook']
   }.freeze
 
   def initialize(relation = WorkflowRun.all)
@@ -17,18 +15,24 @@ class WorkflowRunsFinder
 
   def group_by_generic_event_type
     @relation.all.each_with_object(Hash.new(0)) do |workflow_run, grouped_workflows|
-      key = find_generic_event_type(workflow_run.hook_event)
-      grouped_workflows[key] += 1
+      grouped_workflows[workflow_run.generic_event_type] += 1
     end
   end
 
   def with_generic_event_type(generic_event_type, request_action = nil)
-    query = find_real_event_types(generic_event_type).map do |real_event_type|
-      "request_headers LIKE '%#{real_event_type}%'"
-    end.join(' OR ')
+    query = case generic_event_type
+            when 'tag_push'
+              "request_headers LIKE '%: Tag Push Hook%' OR JSON_EXTRACT(request_payload, '$.ref') LIKE '%refs/tags/%'"
+            when 'push'
+              "request_headers LIKE '%: Push Hook%' OR JSON_EXTRACT(request_payload, '$.ref') LIKE '%refs/heads/%'"
+            else
+              EVENT_TYPE_MAPPING[generic_event_type].map do |event_type|
+                "request_headers LIKE '%: #{event_type}%'"
+              end.join(' OR ')
+            end
 
     workflow_runs = @relation.where(query)
-    if request_action
+    if request_action && generic_event_type == 'pull_request'
       workflow_runs = workflow_runs.where("JSON_EXTRACT(request_payload, '$.action') = (?) OR JSON_EXTRACT(request_payload, '$.object_attributes.action') = (?)", request_action,
                                           request_action)
     end
@@ -49,15 +53,5 @@ class WorkflowRunsFinder
 
   def failed
     with_status('fail')
-  end
-
-  private
-
-  def find_real_event_types(generic_event_type)
-    EVENT_TYPE_MAPPING.filter_map { |key, value| key if value == generic_event_type }
-  end
-
-  def find_generic_event_type(real_event_type)
-    EVENT_TYPE_MAPPING[real_event_type]
   end
 end

--- a/src/api/spec/queries/workflow_runs_finder_spec.rb
+++ b/src/api/spec/queries/workflow_runs_finder_spec.rb
@@ -2,16 +2,18 @@ require 'rails_helper'
 
 RSpec.describe WorkflowRunsFinder do
   let(:workflow_token) { create(:workflow_token) }
+  # GitHub
+  let!(:workflow_run_github_push) { create(:workflow_run_github_succeeded, :push, token: workflow_token) }
+  let!(:workflow_run_github_tag_push) { create(:workflow_run_github_succeeded, :tag_push, token: workflow_token) }
+  let!(:workflow_run_github_pull_request_opened) { create(:workflow_run_github_succeeded, :pull_request_opened, token: workflow_token) }
+  let!(:workflow_run_github_pull_request_closed) { create(:workflow_run_github_succeeded, :pull_request_closed, token: workflow_token) }
+  # GitLab
+  let!(:workflow_run_gitlab_push) { create(:workflow_run_gitlab_succeeded, :push, token: workflow_token) }
+  let!(:workflow_run_gitlab_tag_push) { create(:workflow_run_gitlab_succeeded, :tag_push, token: workflow_token) }
+  let!(:workflow_run_gitlab_pull_request_opened) { create(:workflow_run_gitlab_succeeded, :pull_request_opened, token: workflow_token) }
+  let!(:workflow_run_gitlab_pull_request_closed) { create(:workflow_run_gitlab_succeeded, :pull_request_closed, token: workflow_token) }
 
   before do
-    ScmWebhookEventValidator::ALLOWED_GITHUB_EVENTS.each do |event|
-      create(:workflow_run, token: workflow_token, status: 'running', request_headers: "HTTP_X_GITHUB_EVENT: #{event}\n")
-    end
-
-    ScmWebhookEventValidator::ALLOWED_GITLAB_EVENTS.each do |event|
-      create(:workflow_run, token: workflow_token, status: 'running', request_headers: "HTTP_X_GITLAB_EVENT: #{event}\n")
-    end
-
     ['success', 'running', 'fail'].each do |status|
       create(:workflow_run, token: workflow_token, status: status, request_headers: "HTTP_X_GITHUB_EVENT: pull_request\n")
     end
@@ -21,35 +23,39 @@ RSpec.describe WorkflowRunsFinder do
 
   describe '#all' do
     it 'returns all workflow runs' do
-      expect(subject.all.count).to eq(8)
+      expect(subject.all.count).to eq(11)
     end
   end
 
   describe '#group_by_generic_event_type' do
     it 'returns a hash with the amount of workflow runs grouped by event' do
-      expect(subject.group_by_generic_event_type).to include({ 'pull_request' => 5, 'push' => 3 })
+      expect(subject.group_by_generic_event_type).to include({ 'pull_request' => 7, 'push' => 2, 'tag_push' => 2 })
     end
   end
 
   describe '#with_generic_event_type' do
     it 'returns workflows for pull_request generic event' do
-      expect(subject.with_generic_event_type('pull_request').count).to eq(5)
+      expect(subject.with_generic_event_type('pull_request').count).to eq(7)
     end
 
     it 'returns workflows for push generic event' do
-      expect(subject.with_generic_event_type('push').count).to eq(3)
+      expect(subject.with_generic_event_type('push').count).to eq(2)
+    end
+
+    it 'returns workflows for tag push generic event' do
+      expect(subject.with_generic_event_type('tag_push').count).to eq(2)
     end
   end
 
   describe '#succeeded' do
     it 'returns all workflow runs with status success' do
-      expect(subject.succeeded.count).to eq(1)
+      expect(subject.succeeded.count).to eq(9)
     end
   end
 
   describe '#running' do
     it 'returns all workflow runs with status running' do
-      expect(subject.running.count).to eq(6)
+      expect(subject.running.count).to eq(1)
     end
   end
 


### PR DESCRIPTION
Workflow runs can be filtered now by tag push events (from GitHub and GitLab).

Keep in mind that, for GitHub, push events for tags are in the same event type as push events for commits (it's simply "push"). For GitLab, it's a separate event ("Tag Push Hook").