### PR TITLE
Use patched yajl ruby dependency

### DIFF
--- a/dist/obs-bundled-gems.spec
+++ b/dist/obs-bundled-gems.spec
@@ -66,7 +66,7 @@ Requires:       perl(GD)
 Requires:       rubygem(ruby:2.5.0:bundler)
 Requires:       rubygem(ruby:2.5.0:rake:%{rake_version})
 Requires:       rubygem(ruby:2.5.0:rack:%{rack_version})
-BuildRequires:  rubygem-yajl-ruby
+BuildRequires:  ruby2.5-rubygem-yajl-ruby
 
 %description -n obs-api-deps
 To simplify splitting the test suite packages off the main package,

--- a/dist/obs-bundled-gems.spec
+++ b/dist/obs-bundled-gems.spec
@@ -102,7 +102,7 @@ cp %{_sourcedir}/vendor/cache/*.gem vendor/cache
 # Use packaged yajl ruby gem instead of the one from rubygems.
 # This one is patched and runs on ruby 2.5
 # See https://github.com/brianmario/yajl-ruby/security/advisories/GHSA-jj47-x69x-mxrm
-cp %{_libdir}/ruby/gems/2.5.0/cache/yajl-ruby-1.4.2.gem/vendor/cache/*.gem vendor/cache
+cp %{_libdir}/ruby/gems/2.5.0/cache/yajl-ruby-1.4.2.gem vendor/cache
 
 %build
 # emtpy since bundle does not decouple compile and install

--- a/dist/obs-bundled-gems.spec
+++ b/dist/obs-bundled-gems.spec
@@ -102,7 +102,7 @@ cp %{_sourcedir}/vendor/cache/*.gem vendor/cache
 # Use packaged yajl ruby gem instead of the one from rubygems.
 # This one is patched and runs on ruby 2.5
 # See https://github.com/brianmario/yajl-ruby/security/advisories/GHSA-jj47-x69x-mxrm
-cp %{_libdir}/ruby/gems/2.5.0/cache/yajl-ruby-1.4.2.gemr}/vendor/cache/*.gem vendor/cache
+cp %{_libdir}/ruby/gems/2.5.0/cache/yajl-ruby-1.4.2.gem/vendor/cache/*.gem vendor/cache
 
 %build
 # emtpy since bundle does not decouple compile and install

--- a/dist/obs-bundled-gems.spec
+++ b/dist/obs-bundled-gems.spec
@@ -67,6 +67,7 @@ Requires:       rubygem(ruby:2.5.0:bundler)
 Requires:       rubygem(ruby:2.5.0:rake:%{rake_version})
 Requires:       rubygem(ruby:2.5.0:rack:%{rack_version})
 BuildRequires:  ruby2.5-rubygem-yajl-ruby
+BuildRequires:  ruby2.5-rubygem-nokogiri
 
 %description -n obs-api-deps
 To simplify splitting the test suite packages off the main package,

--- a/dist/obs-bundled-gems.spec
+++ b/dist/obs-bundled-gems.spec
@@ -66,6 +66,7 @@ Requires:       perl(GD)
 Requires:       rubygem(ruby:2.5.0:bundler)
 Requires:       rubygem(ruby:2.5.0:rake:%{rake_version})
 Requires:       rubygem(ruby:2.5.0:rack:%{rack_version})
+BuildRequires:  rubygem-yajl-ruby
 
 %description -n obs-api-deps
 To simplify splitting the test suite packages off the main package,
@@ -98,6 +99,10 @@ cp %{S:0} %{S:1} .
 # copy gem files into cache
 mkdir -p vendor/cache
 cp %{_sourcedir}/vendor/cache/*.gem vendor/cache
+# Use packaged yajl ruby gem instead of the one from rubygems.
+# This one is patched and runs on ruby 2.5
+# See https://github.com/brianmario/yajl-ruby/security/advisories/GHSA-jj47-x69x-mxrm
+cp %{_libdir}/ruby/gems/2.5.0/cache/yajl-ruby-1.4.2.gemr}/vendor/cache/*.gem vendor/cache
 
 %build
 # emtpy since bundle does not decouple compile and install

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -470,7 +470,7 @@ GEM
     xmlrpc (0.3.0)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    yajl-ruby (1.4.1)
+    yajl-ruby (1.4.2)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
There is a security vulnerability on yajl-ruby, but the upstream patch does not work on ruby 2.5. There is a [patched rubygem package](https://build.opensuse.org/package/binaries/OBS:Server:2.10:Staging/rubygem-yajl-ruby), that we use it for 2.10.