### PR TITLE
Provide debug symbol packages for Debian based builds

### DIFF
--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -975,6 +975,20 @@ sub createrepo_debian {
   } else {
     rmdir($udebs);
   }
+
+  my $ddebs = "$extrep/debian-debug";
+  mkdir_p($ddebs) unless -d $ddebs;
+  if (qsystem('chdir', $ddebs, 'stdout', 'Packages.new', 'dpkg-scanpackages', '-t', 'ddeb', '-m', '..', '/dev/null')) {
+    die("    dpkg-scanpackages for ddebs failed: $?\n");
+  }
+  compress_and_rename("$ddebs/Packages.new", "$ddebs/Packages");
+
+  if ( -e "$ddebs/Packages") {
+    createrelease_debian($ddebs, $projid, $repoid, $data, $options);
+  } else {
+    rmdir($ddebs);
+  }
+
 }
 
 sub createrelease_debian {
@@ -1062,6 +1076,10 @@ sub deleterepo_debian {
   if (-d "$extrep/debian-installer") {
     BSUtil::cleandir("$extrep/debian-installer");
     rmdir("$extrep/debian-installer");
+  }
+  if (-d "$extrep/debian-debug") {
+    BSUtil::cleandir("$extrep/debian-debug");
+    rmdir("$extrep/debian-debug");
   }
 }
 


### PR DESCRIPTION
The Open Build Service can be used to create binary packages for various Linux distributions. In case of Debian based Distributions (e.g. Ubuntu) the automatically generated repositories, miss additional packages with debug symbols (provided as *.ddeb files). While the *.ddeb files are available, they are not referenced by the repositories meta data/Package files.

The provided contribution generates additional repositories on the web server, referencing the *.ddeb files. The corresponding repository files are placed in a debian-debug sub-directory. The implementation is more or less a simple copy of the code, already used to provide the additional debian-installer repo. Adding the debian-debug repository to an actual .deb based Linux Distribution makes it possible to simply install debug symbol packages via apt.