### PR TITLE
Track errors from SCMStatusReporter in WorkflowRuns

### DIFF
--- a/src/api/app/jobs/report_to_scm_job.rb
+++ b/src/api/app/jobs/report_to_scm_job.rb
@@ -11,7 +11,8 @@ class ReportToScmJob < CreateJob
       SCMStatusReporter.new(@event.payload,
                             event_subscription.payload,
                             event_subscription.token.scm_token,
-                            event_subscription.eventtype).call
+                            event_subscription.eventtype,
+                            event_subscription.workflow_run).call
     end
     true
   end

--- a/src/api/app/models/event_subscription.rb
+++ b/src/api/app/models/event_subscription.rb
@@ -105,23 +105,25 @@ end
 #
 # Table name: event_subscriptions
 #
-#  id            :integer          not null, primary key
-#  channel       :integer          default("disabled"), not null
-#  enabled       :boolean          default(FALSE)
-#  eventtype     :string(255)      not null
-#  payload       :text(65535)
-#  receiver_role :string(255)      not null
-#  created_at    :datetime
-#  updated_at    :datetime
-#  group_id      :integer          indexed
-#  package_id    :integer          indexed
-#  token_id      :integer          indexed
-#  user_id       :integer          indexed
+#  id              :integer          not null, primary key
+#  channel         :integer          default("disabled"), not null
+#  enabled         :boolean          default(FALSE)
+#  eventtype       :string(255)      not null
+#  payload         :text(65535)
+#  receiver_role   :string(255)      not null
+#  created_at      :datetime
+#  updated_at      :datetime
+#  group_id        :integer          indexed
+#  package_id      :integer          indexed
+#  token_id        :integer          indexed
+#  user_id         :integer          indexed
+#  workflow_run_id :integer          indexed
 #
 # Indexes
 #
-#  index_event_subscriptions_on_group_id    (group_id)
-#  index_event_subscriptions_on_package_id  (package_id)
-#  index_event_subscriptions_on_token_id    (token_id)
-#  index_event_subscriptions_on_user_id     (user_id)
+#  index_event_subscriptions_on_group_id         (group_id)
+#  index_event_subscriptions_on_package_id       (package_id)
+#  index_event_subscriptions_on_token_id         (token_id)
+#  index_event_subscriptions_on_user_id          (user_id)
+#  index_event_subscriptions_on_workflow_run_id  (workflow_run_id)
 #

--- a/src/api/app/models/event_subscription.rb
+++ b/src/api/app/models/event_subscription.rb
@@ -36,6 +36,7 @@ class EventSubscription < ApplicationRecord
   belongs_to :group, inverse_of: :event_subscriptions, optional: true
   belongs_to :token, inverse_of: :event_subscriptions, optional: true
   belongs_to :package, optional: true
+  belongs_to :workflow_run, optional: true
 
   validates :receiver_role, inclusion: {
     in: [:maintainer, :bugowner, :reader, :source_maintainer, :target_maintainer,

--- a/src/api/app/models/token/workflow.rb
+++ b/src/api/app/models/token/workflow.rb
@@ -10,12 +10,11 @@ class Token::Workflow < Token
     set_triggered_at
     @scm_webhook = options[:scm_webhook]
     workflow_run = options[:workflow_run]
-
     raise Token::Errors::MissingPayload, 'A payload is required' if @scm_webhook.payload.blank?
 
     workflow_run.update(response_url: @scm_webhook.payload[:api_endpoint])
     yaml_file = Workflows::YAMLDownloader.new(@scm_webhook.payload, token: self).call
-    @workflows = Workflows::YAMLToWorkflowsService.new(yaml_file: yaml_file, scm_webhook: @scm_webhook, token: self, workflow_run_id: workflow_run.id).call
+    @workflows = Workflows::YAMLToWorkflowsService.new(yaml_file: yaml_file, scm_webhook: @scm_webhook, token: self, workflow_run: workflow_run).call
 
     return validation_errors unless validation_errors.none?
 

--- a/src/api/app/models/workflow.rb
+++ b/src/api/app/models/workflow.rb
@@ -12,7 +12,7 @@ class Workflow
 
   SUPPORTED_FILTERS = [:architectures, :branches, :event, :repositories].freeze
 
-  attr_accessor :workflow_instructions, :scm_webhook, :token, :workflow_run_id
+  attr_accessor :workflow_instructions, :scm_webhook, :token, :workflow_run
 
   def initialize(attributes = {})
     run_callbacks(:initialize) do
@@ -44,7 +44,7 @@ class Workflow
 
   # ArtifactsCollector can only be called if the step.call doesn't return nil because of a validation error
   def call_step_and_collect_artifacts(step)
-    step.call({ workflow_filters: filters }) && Workflows::ArtifactsCollector.new(step: step, workflow_run_id: workflow_run_id).call
+    step.call({ workflow_filters: filters }) && Workflows::ArtifactsCollector.new(step: step, workflow_run_id: workflow_run.id).call
   end
 
   def steps
@@ -76,7 +76,8 @@ class Workflow
   def initialize_step(step_name, step_instructions)
     SUPPORTED_STEPS[step_name].new(step_instructions: step_instructions,
                                    scm_webhook: scm_webhook,
-                                   token: token)
+                                   token: token,
+                                   workflow_run: workflow_run)
   end
 
   def supported_filters

--- a/src/api/app/models/workflow/step.rb
+++ b/src/api/app/models/workflow/step.rb
@@ -6,7 +6,7 @@ class Workflow::Step
 
   validate :validate_step_instructions
 
-  attr_accessor :scm_webhook, :step_instructions, :token
+  attr_accessor :scm_webhook, :step_instructions, :token, :workflow_run
 
   def initialize(attributes = {})
     run_callbacks(:initialize) do
@@ -48,7 +48,8 @@ class Workflow::Step
                                                           channel: 'scm',
                                                           enabled: true,
                                                           token: @token,
-                                                          package: package)
+                                                          package: package,
+                                                          workflow_run: workflow_run)
       subscription.update!(payload: scm_webhook.payload.merge({ workflow_filters: workflow_filters }))
     end
   end

--- a/src/api/app/services/scm_exception_handler.rb
+++ b/src/api/app/services/scm_exception_handler.rb
@@ -26,6 +26,7 @@ class SCMExceptionHandler
               Octokit::InternalServerError do |exception|
     # FIXME: Inform users about the exceptions
     log(exception)
+    log_to_workflow_run(exception, 'GitHub') if @workflow_run.present?
   end
 
   rescue_from Gitlab::Error::Conflict,
@@ -38,12 +39,14 @@ class SCMExceptionHandler
               Gitlab::Error::Unauthorized do |exception|
     # FIXME: Inform users about the exceptions
     log(exception)
+    log_to_workflow_run(exception, 'GitLab') if @workflow_run.present?
   end
 
-  def initialize(event_payload, event_subscription_payload, scm_token)
+  def initialize(event_payload, event_subscription_payload, scm_token, workflow_run = nil)
     @event_payload = event_payload.deep_symbolize_keys
     @event_subscription_payload = event_subscription_payload.deep_symbolize_keys
     @scm_token = scm_token
+    @workflow_run = workflow_run
   end
 
   private
@@ -51,5 +54,9 @@ class SCMExceptionHandler
   def log(exception)
     token = Token::Workflow.find_by(scm_token: @scm_token)
     Rails.logger.error "#{exception.class}: #{exception.message}. TokenID: #{token.id}, User: #{token.user.login}, Event Subscription Payload: #{@event_subscription_payload}"
+  end
+
+  def log_to_workflow_run(exception, scm)
+    @workflow_run.update_to_fail("Failed to report back to #{scm}: #{exception.message}")
   end
 end

--- a/src/api/app/services/scm_exception_handler.rb
+++ b/src/api/app/services/scm_exception_handler.rb
@@ -24,8 +24,6 @@ class SCMExceptionHandler
               Octokit::PathDiffTooLarge,
               Octokit::ServiceUnavailable,
               Octokit::InternalServerError do |exception|
-    # FIXME: Inform users about the exceptions
-    log(exception)
     log_to_workflow_run(exception, 'GitHub') if @workflow_run.present?
   end
 
@@ -37,8 +35,6 @@ class SCMExceptionHandler
               Gitlab::Error::ServiceUnavailable,
               Gitlab::Error::TooManyRequests,
               Gitlab::Error::Unauthorized do |exception|
-    # FIXME: Inform users about the exceptions
-    log(exception)
     log_to_workflow_run(exception, 'GitLab') if @workflow_run.present?
   end
 
@@ -50,11 +46,6 @@ class SCMExceptionHandler
   end
 
   private
-
-  def log(exception)
-    token = Token::Workflow.find_by(scm_token: @scm_token)
-    Rails.logger.error "#{exception.class}: #{exception.message}. TokenID: #{token.id}, User: #{token.user.login}, Event Subscription Payload: #{@event_subscription_payload}"
-  end
 
   def log_to_workflow_run(exception, scm)
     @workflow_run.update_to_fail("Failed to report back to #{scm}: #{exception.message}")

--- a/src/api/app/services/scm_initial_status_reporter.rb
+++ b/src/api/app/services/scm_initial_status_reporter.rb
@@ -2,7 +2,7 @@ class ScmInitialStatusReporter < SCMStatusReporter
   attr_accessor :state
 
   def initialize(event_payload, event_subscription_payload, scm_token, workflow_run, event_type = nil)
-    super(event_payload, event_subscription_payload, scm_token)
+    super(event_payload, event_subscription_payload, scm_token, event_type, workflow_run)
     @state = event_type.nil? ? 'pending' : 'success'
     @workflow_run = workflow_run
   end

--- a/src/api/app/services/workflows/yaml_to_workflows_service.rb
+++ b/src/api/app/services/workflows/yaml_to_workflows_service.rb
@@ -1,10 +1,10 @@
 module Workflows
   class YAMLToWorkflowsService
-    def initialize(yaml_file:, scm_webhook:, token:, workflow_run_id:)
+    def initialize(yaml_file:, scm_webhook:, token:, workflow_run:)
       @yaml_file = yaml_file
       @scm_webhook = scm_webhook
       @token = token
-      @workflow_run_id = workflow_run_id
+      @workflow_run = workflow_run
     end
 
     def call
@@ -23,7 +23,7 @@ module Workflows
       parsed_workflows_yaml
         .map do |_workflow_name, workflow_instructions|
         Workflow.new(workflow_instructions: workflow_instructions, scm_webhook: @scm_webhook, token: @token,
-                     workflow_run_id: @workflow_run_id)
+                     workflow_run: @workflow_run)
       end
     end
   end

--- a/src/api/db/migrate/20220413223300_add_workflow_run_to_event_subscription.rb
+++ b/src/api/db/migrate/20220413223300_add_workflow_run_to_event_subscription.rb
@@ -1,0 +1,6 @@
+class AddWorkflowRunToEventSubscription < ActiveRecord::Migration[6.1]
+  def change
+    add_column :event_subscriptions, :workflow_run_id, :integer
+    add_index :event_subscriptions, :workflow_run_id
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_30_125635) do
+ActiveRecord::Schema.define(version: 2022_04_13_223300) do
 
   create_table "architectures", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false, collation: "utf8_general_ci"
@@ -417,10 +417,12 @@ ActiveRecord::Schema.define(version: 2022_03_30_125635) do
     t.integer "token_id"
     t.text "payload"
     t.integer "package_id"
+    t.integer "workflow_run_id"
     t.index ["group_id"], name: "index_event_subscriptions_on_group_id"
     t.index ["package_id"], name: "index_event_subscriptions_on_package_id"
     t.index ["token_id"], name: "index_event_subscriptions_on_token_id"
     t.index ["user_id"], name: "index_event_subscriptions_on_user_id"
+    t.index ["workflow_run_id"], name: "index_event_subscriptions_on_workflow_run_id"
   end
 
   create_table "events", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|

--- a/src/api/spec/models/token/workflow_spec.rb
+++ b/src/api/spec/models/token/workflow_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Token::Workflow do
       let(:scm_webhook) { ScmWebhook.new(payload: github_extractor_payload) }
       let(:yaml_downloader) { Workflows::YAMLDownloader.new(scm_webhook.payload, token: workflow_token) }
       let(:yaml_file) { File.expand_path(Rails.root.join('spec/support/files/workflows.yml')) }
-      let(:yaml_to_workflows_service) { Workflows::YAMLToWorkflowsService.new(yaml_file: yaml_file, scm_webhook: scm_webhook, token: workflow_token, workflow_run_id: workflow_run.id) }
+      let(:yaml_to_workflows_service) { Workflows::YAMLToWorkflowsService.new(yaml_file: yaml_file, scm_webhook: scm_webhook, token: workflow_token, workflow_run: workflow_run) }
       let(:workflow) do
         Workflow.new(scm_webhook: scm_webhook, token: workflow_token,
                      workflow_instructions: { steps: [branch_package: { source_project: 'home:Admin', source_package: 'ctris', target_project: 'dev:tools' }] })
@@ -87,7 +87,7 @@ RSpec.describe Token::Workflow do
         allow(Workflows::YAMLDownloader).to receive(:new).with(scm_webhook.payload, token: workflow_token).and_return(yaml_downloader)
         allow(yaml_downloader).to receive(:call).and_return(yaml_file)
         allow(Workflows::YAMLToWorkflowsService).to receive(:new).with(yaml_file: yaml_file, scm_webhook: scm_webhook, token: workflow_token,
-                                                                       workflow_run_id: workflow_run.id).and_return(yaml_to_workflows_service)
+                                                                       workflow_run: workflow_run).and_return(yaml_to_workflows_service)
         allow(yaml_to_workflows_service).to receive(:call).and_return(workflows)
         allow(ScmInitialStatusReporter).to receive(:new).and_return(proc { true })
       end
@@ -138,7 +138,7 @@ RSpec.describe Token::Workflow do
       let(:scm_webhook) { ScmWebhook.new(payload: github_extractor_payload) }
       let(:yaml_downloader) { Workflows::YAMLDownloader.new(scm_webhook.payload, token: workflow_token) }
       let(:yaml_file) { File.expand_path(Rails.root.join('spec/support/files/workflows.yml')) }
-      let(:yaml_to_workflows_service) { Workflows::YAMLToWorkflowsService.new(yaml_file: yaml_file, scm_webhook: scm_webhook, token: workflow_token, workflow_run_id: workflow_run.id) }
+      let(:yaml_to_workflows_service) { Workflows::YAMLToWorkflowsService.new(yaml_file: yaml_file, scm_webhook: scm_webhook, token: workflow_token, workflow_run: workflow_run) }
       let(:workflows) { [Workflow.new(scm_webhook: scm_webhook, token: workflow_token, workflow_instructions: {})] }
 
       before do
@@ -147,7 +147,7 @@ RSpec.describe Token::Workflow do
         allow(Workflows::YAMLDownloader).to receive(:new).with(scm_webhook.payload, token: workflow_token).and_return(yaml_downloader)
         allow(yaml_downloader).to receive(:call).and_return(yaml_file)
         allow(Workflows::YAMLToWorkflowsService).to receive(:new).with(yaml_file: yaml_file, scm_webhook: scm_webhook, token: workflow_token,
-                                                                       workflow_run_id: workflow_run.id).and_return(yaml_to_workflows_service)
+                                                                       workflow_run: workflow_run).and_return(yaml_to_workflows_service)
         allow(yaml_to_workflows_service).to receive(:call).and_return(workflows)
       end
 

--- a/src/api/spec/models/workflow_spec.rb
+++ b/src/api/spec/models/workflow_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Workflow, type: :model, vcr: true do
   let!(:workflow_run) { create(:workflow_run, token: token) }
 
   subject do
-    described_class.new(workflow_instructions: yaml, scm_webhook: ScmWebhook.new(payload: extractor_payload), token: token, workflow_run_id: workflow_run.id)
+    described_class.new(workflow_instructions: yaml, scm_webhook: ScmWebhook.new(payload: extractor_payload), token: token, workflow_run: workflow_run)
   end
 
   describe '#call' do

--- a/src/api/spec/services/workflows/yaml_to_workflows_service_spec.rb
+++ b/src/api/spec/services/workflows/yaml_to_workflows_service_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Workflows::YAMLToWorkflowsService, type: :service do
 
   describe '#call' do
     subject do
-      Workflows::YAMLToWorkflowsService.new(yaml_file: workflows_yml_file, scm_webhook: ScmWebhook.new(payload: payload), token: token, workflow_run_id: workflow_run.id).call
+      Workflows::YAMLToWorkflowsService.new(yaml_file: workflows_yml_file, scm_webhook: ScmWebhook.new(payload: payload), token: token, workflow_run: workflow_run).call
     end
 
     context 'it supports many workflows' do


### PR DESCRIPTION
In the past we only wrote the exception raised in the scm status reporter to the logfiles, which are not accessible for the users. In order to help the users to debug, we want to show the errors in the workflow runs UI. For now simply by writing it to the response body. 

*How to test:*

Easiest way to test this is by simply setting up a workflow with a `branch_package` step and to mock the code by raising one of the `Octokit` exceptions if the `SCMStatusReporter#call` or somehow let the reporter fail by for example cutting network connection... 

*TODO:*

- [x] Add testcase to `scm_status_reporter_spec.rb` to check that workflow_run tracks error
- [x] Make sure migration can be run without downtime, adjust when necessary @krauselukas 
~- [ ] "Translate" exception message from Octokit to something meaningful~ (follow up PR)