### PR TITLE
[backend] fix broken additional metadata with createrepo_c 0.20

### DIFF
--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -172,7 +172,7 @@ Requires:       perl(Date::Parse)
 Requires:       diffutils
 PreReq:         git-core
 Requires:       patch
-Requires:       createrepo_c
+Requires:       createrepo_c >= 0.20
 Recommends:     cron logrotate
 # zsync for appimage signing
 Recommends:     zsync

--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -617,6 +617,9 @@ sub createrepo_rpmmd {
   push @createrepoargs, '--content', 'debug' if $data->{'dbgsplit'};
   push @createrepoargs, '--content', 'update' if ($repoinfo->{'projectkind'} || '') eq 'maintenance_incident';
   push @createrepoargs, '--content', 'update' if ($repoinfo->{'projectkind'} || '') eq 'maintenance_release';
+  # createrepo_c 0.20.0 defaults to keep always additional metadata. We must change
+  # to old behaviour or old data would stay forever when it got removed actually
+  push @createrepoargs, '--discard-additional-metadata';
   my @legacyargs;
   if ($options{'legacy'}) {
     push @legacyargs, '--simple-md-filenames', '--checksum=sha';


### PR DESCRIPTION
createrepo_c changed the default to keep always old metadata.

At the same time modifyrepo_c got changed to fail when the referenced meta data file
got already removed. This leads to the situation that old meta data stays forever.

Not removing the files is not an option as they would stay forever when
actually should not get generated anymore.

Therefore we require the new version of createrepo_c now to be able to switch
back to the old behaviour.