### PR TITLE
Order watchlist items alphabetically or by number

### DIFF
--- a/src/api/app/components/watchlist_component.rb
+++ b/src/api/app/components/watchlist_component.rb
@@ -62,14 +62,14 @@ class WatchlistComponent < ApplicationComponent
   end
 
   def projects
-    @projects ||= Project.joins(:watched_items).where(watched_items: { user: @user })
+    @projects ||= Project.joins(:watched_items).where(watched_items: { user: @user }).order(:name)
   end
 
   def packages
-    @packages ||= Package.includes(:project).joins(:watched_items).where(watched_items: { user: @user })
+    @packages ||= Package.includes(:project).joins(:watched_items).where(watched_items: { user: @user }).order('projects.name, packages.name')
   end
 
   def bs_requests
-    @bs_requests ||= BsRequest.joins(:watched_items).where(watched_items: { user: @user })
+    @bs_requests ||= BsRequest.joins(:watched_items).where(watched_items: { user: @user }).order('number DESC')
   end
 end


### PR DESCRIPTION
Sort requests by descending number so the most recent ones are on top.

![Screenshot_2022-04-21 Open Build Service(2)](https://user-images.githubusercontent.com/2581944/164432133-7cfb0bf6-758e-4999-8b68-ed9c12aad20d.png)