### PR TITLE
Revert "Notify if request state change fails because of permission on deleting a project"

### DIFF
--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -494,7 +494,7 @@ class Project < ApplicationRecord
           begin
             request.change_state(newstate: 'revoked', comment: "The source project '#{name}' has been removed", override_creator: request.creator)
           rescue PostRequestNoPermission
-            Airbrake.notify("#{User.session!.login} tried to revoke request #{request.number} but had no permissions")
+            logger.debug "#{User.session!.login} tried to revoke request #{request.number} but had no permissions"
           end
           break
         end
@@ -503,7 +503,7 @@ class Project < ApplicationRecord
         begin
           request.change_state(newstate: 'declined', comment: "The target project '#{name}' has been removed")
         rescue PostRequestNoPermission
-          Airbrake.notify("#{User.session!.login} tried to decline request #{request.number} but had no permissions")
+          logger.debug "#{User.session!.login} tried to decline request #{request.number} but had no permissions"
         end
         break
       end


### PR DESCRIPTION
Reverts openSUSE/open-build-service#12328

This was for debugging purposes. Developers can't do anything about the permissions, no need to notify them.