### PR TITLE
Escape whitespace characters correctly for filepaths

### DIFF
--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -430,7 +430,7 @@ class Package < ApplicationRecord
   def self.source_path(project, package, file = nil, opts = {})
     path = "/source/#{project}/#{package}"
     path = Addressable::URI.escape(path)
-    path += "/#{CGI.escape(file)}" if file.present?
+    path += "/#{ERB::Util.url_encode(file)}" if file.present?
     path += '?' + opts.to_query if opts.present?
     path
   end


### PR DESCRIPTION
After the switch from ruby 2.5 to ruby 3.1 we switched from
`URI.escape` to `Addressable::URI.escape` in multiple places
(`URI` is deprecated).
Since anchors are valid parts of URIs, we started using `CGI.escape`
for filenames (see https://github.com/openSUSE/open-build-service/pull/12305#discussion_r826949527).
The problem is that whitespaces are treated differently by `CGI.escape`
compared to the previously used `URI.escape` (they are replaced by `+` signs instead
of using the percent encoding %20).
This clashes now, since files uploaded throught the API are still
'correctly' escaped.
On top of this (not related to the ruby update), files uploaded through
the webui already replaced the whitespace characters with the `+` sign.
Using `ERB::Util.url_encode` reintroduces the previous behaviour.

Example of the different escaping results:

```ruby
2.5.0 :005 > URI.escape('TEST#123.diff')
 => "TEST%23123.diff"
2.5.0 :006 > URI.escape('TEST 123.diff')
 => "TEST%20123.diff"

[11] pry(main)> Addressable::URI.escape('TEST#123.diff')
=> "TEST#123.diff"
[12] pry(main)> Addressable::URI.escape('TEST 123.diff')
=> "TEST%20123.diff"

[13] pry(main)> ERB::Util.url_encode('TEST 123.diff')
=> "TEST%20123.diff"
[14] pry(main)> ERB::Util.url_encode('TEST#123.diff')
=> "TEST%23123.diff"
```

Fixes #12457