### PR TITLE
Receive notifications for relationships

### DIFF
--- a/src/api/app/components/notification_action_description_component.rb
+++ b/src/api/app/components/notification_action_description_component.rb
@@ -3,6 +3,13 @@ class NotificationActionDescriptionComponent < ApplicationComponent
     super
 
     @notification = notification
+    @role = @notification.event_payload['role']
+    @user = @notification.event_payload['who']
+    @target_object = if @notification.event_payload['package']
+                       "#{@notification.event_payload['project']} / #{@notification.event_payload['package']}"
+                     else
+                       @notification.event_payload['project']
+                     end
   end
 
   def call
@@ -15,6 +22,10 @@ class NotificationActionDescriptionComponent < ApplicationComponent
       when 'Event::CommentForPackage'
         commentable = @notification.notifiable.commentable
         "#{commentable.project.name} / #{commentable.name}"
+      when 'Event::RelationshipCreate'
+        "#{@user} made you #{@role} of #{@target_object}"
+      when 'Event::RelationshipDelete'
+        "#{@user} removed you as #{@role} of #{@target_object}"
       end
     end
   end

--- a/src/api/app/components/notification_avatars_component.rb
+++ b/src/api/app/components/notification_avatars_component.rb
@@ -10,8 +10,11 @@ class NotificationAvatarsComponent < ApplicationComponent
   private
 
   def avatar_objects
-    @avatar_objects ||= if @notification.notifiable_type == 'Comment'
+    @avatar_objects ||= case @notification.notifiable_type
+                        when 'Comment'
                           commenters
+                        when 'Project', 'Package'
+                          [User.find_by(login: @notification.event_payload['who'])]
                         else
                           reviews = @notification.notifiable.reviews
                           reviews.select(&:new?).map(&:reviewed_by) + User.where(login: @notification.notifiable.creator)

--- a/src/api/app/components/notification_component.html.haml
+++ b/src/api/app/components/notification_component.html.haml
@@ -8,15 +8,11 @@
     .col-10
       .row
         .col
+          = notification_icon
+          = render NotificationNotifiableLinkComponent.new(@notification)
+          %small.text-nowrap #{time_ago_in_words(@notification.created_at)} ago
           - if @notification.notifiable_type == 'BsRequest'
-            = image_tag('icons/request-icon.svg', height: 18, title: 'Request notification')
-            = render NotificationNotifiableLinkComponent.new(@notification)
-            %small.text-nowrap #{time_ago_in_words(@notification.created_at)} ago
             = render BsRequestStateBadgeComponent.new(bs_request: @notification.notifiable, css_class: 'ml-1')
-          - else
-            %i.fas.fa-comments{ title: 'Comment notification' }
-            = render NotificationNotifiableLinkComponent.new(@notification)
-            %small.text-nowrap #{time_ago_in_words(@notification.created_at)} ago
         .col-auto.actions.ml-auto.align-self-end.align-self-md-start
           = render NotificationMarkButtonComponent.new(@notification, @selected_filter, params[:page], params[:show_more])
       .row.mt-1.pl-sm-4

--- a/src/api/app/components/notification_component.rb
+++ b/src/api/app/components/notification_component.rb
@@ -5,4 +5,15 @@ class NotificationComponent < ApplicationComponent
     @notification = notification
     @selected_filter = selected_filter
   end
+
+  def notification_icon
+    case @notification.notifiable_type
+    when 'BsRequest'
+      image_tag('icons/request-icon.svg', height: 18, title: 'Request notification')
+    when 'Comment'
+      tag.i(class: ['fas', 'fa-comments'], title: 'Comment notification')
+    else
+      tag.i(class: ['fas', 'fa-user-tag'], title: 'Relationship notification')
+    end
+  end
 end

--- a/src/api/app/models/event/base.rb
+++ b/src/api/app/models/event/base.rb
@@ -30,7 +30,8 @@ module Event
       def notification_events
         ['Event::BuildFail', 'Event::ServiceFail', 'Event::ReviewWanted', 'Event::RequestCreate',
          'Event::RequestStatechange', 'Event::CommentForProject', 'Event::CommentForPackage',
-         'Event::CommentForRequest'].map(&:constantize)
+         'Event::CommentForRequest',
+         'Event::RelationshipCreate', 'Event::RelationshipDelete'].map(&:constantize)
       end
 
       def classnames
@@ -292,7 +293,7 @@ module Event
       { event_type: eventtype,
         event_payload: payload,
         notifiable_id: payload['id'],
-        created_at: payload['when'].to_datetime,
+        created_at: payload['when']&.to_datetime,
         title: subject_to_title }
     end
 

--- a/src/api/app/models/event/relationship.rb
+++ b/src/api/app/models/event/relationship.rb
@@ -1,7 +1,29 @@
 module Event
   class Relationship < Base
     self.abstract_class = true
-    payload_keys :description, :who, :user, :group, :project, :package, :role
+    payload_keys :description, :who, :user, :group, :project, :package, :role, :notifiable_id
     shortenable_key :description
+
+    def parameters_for_notification
+      super.merge({ notifiable_type: notifiable_type, notifiable_id: notifiable_id })
+    end
+
+    def any_roles
+      [User.find_by(login: payload['user']) || Group.find_by(title: payload['group'])]
+    end
+
+    def notifiable_type
+      return 'Package' if payload['package']
+
+      'Project'
+    end
+
+    def notifiable_id
+      # FIXME: Inherited package coming from a project link via attribute link resolves to the upstream package. This is confusing at least. We need to think about this behaviour later.
+      return Package.get_by_project_and_name(payload['project'], payload['package']).id if payload['package']
+      return Project.get_by_name(payload['project']).id if Project.exists_by_name(payload['project'])
+
+      nil
+    end
   end
 end

--- a/src/api/app/models/event/relationship_create.rb
+++ b/src/api/app/models/event/relationship_create.rb
@@ -2,6 +2,8 @@ module Event
   class RelationshipCreate < Relationship
     self.message_bus_routing_key = 'relationship.create'
     self.description = 'Relationship was created'
+
+    receiver_roles :any_role
   end
 end
 

--- a/src/api/app/models/event/relationship_delete.rb
+++ b/src/api/app/models/event/relationship_delete.rb
@@ -2,6 +2,8 @@ module Event
   class RelationshipDelete < Relationship
     self.message_bus_routing_key = 'relationship.delete'
     self.description = 'Relationship was deleted'
+
+    receiver_roles :any_role
   end
 end
 

--- a/src/api/app/models/event_subscription.rb
+++ b/src/api/app/models/event_subscription.rb
@@ -10,7 +10,8 @@ class EventSubscription < ApplicationRecord
     creator: 'Creator',
     watcher: 'Watching the project',
     source_watcher: 'Watching the source project',
-    target_watcher: 'Watching the target project'
+    target_watcher: 'Watching the target project',
+    any_role: 'Any role'
   }.freeze
   BETA_RECEIVER_ROLE_TEXTS = {
     package_watcher: 'Watching the package',
@@ -41,7 +42,7 @@ class EventSubscription < ApplicationRecord
   validates :receiver_role, inclusion: {
     in: [:maintainer, :bugowner, :reader, :source_maintainer, :target_maintainer,
          :reviewer, :commenter, :creator, :watcher, :source_watcher, :target_watcher,
-         :package_watcher, :target_package_watcher, :source_package_watcher, :request_watcher]
+         :package_watcher, :target_package_watcher, :source_package_watcher, :request_watcher, :any_role]
   }
 
   scope :for_eventtype, ->(eventtype) { where(eventtype: eventtype) }

--- a/src/api/app/models/relationship.rb
+++ b/src/api/app/models/relationship.rb
@@ -177,7 +177,8 @@ class Relationship < ApplicationRecord
     parameters = { who: User.session.login,
                    user: user&.login,
                    group: group&.title,
-                   role: role.title }
+                   role: role.title,
+                   notifiable_id: id }
     if package
       parameters[:project] = package.project.name
       parameters[:package] = package.name

--- a/src/api/app/queries/outdated_notifications_finder/package.rb
+++ b/src/api/app/queries/outdated_notifications_finder/package.rb
@@ -1,0 +1,10 @@
+class OutdatedNotificationsFinder::Package
+  def initialize(scope, parameters)
+    @scope = scope
+    @parameters = parameters
+  end
+
+  def call
+    @scope.where(notifiable_type: 'Package', notifiable_id: @parameters['notifiable_id'])
+  end
+end

--- a/src/api/app/queries/outdated_notifications_finder/project.rb
+++ b/src/api/app/queries/outdated_notifications_finder/project.rb
@@ -1,0 +1,10 @@
+class OutdatedNotificationsFinder::Project
+  def initialize(scope, parameters)
+    @scope = scope
+    @parameters = parameters
+  end
+
+  def call
+    @scope.where(notifiable_type: 'Project', notifiable_id: @parameters['notifiable_id'])
+  end
+end

--- a/src/api/app/services/notification_service/notifier.rb
+++ b/src/api/app/services/notification_service/notifier.rb
@@ -5,11 +5,15 @@ module NotificationService
                         'Event::ReviewWanted',
                         'Event::CommentForProject',
                         'Event::CommentForPackage',
-                        'Event::CommentForRequest'].freeze
+                        'Event::CommentForRequest',
+                        'Event::RelationshipCreate',
+                        'Event::RelationshipDelete'].freeze
     CHANNELS = [:web, :rss].freeze
     ALLOWED_NOTIFIABLE_TYPES = {
       'BsRequest' => ::BsRequest,
-      'Comment' => ::Comment
+      'Comment' => ::Comment,
+      'Project' => ::Project,
+      'Package' => ::Package
     }.freeze
     ALLOWED_CHANNELS = {
       web: NotificationService::WebChannel,

--- a/src/api/app/services/notification_service/web_channel.rb
+++ b/src/api/app/services/notification_service/web_channel.rb
@@ -3,7 +3,9 @@ module NotificationService
   class WebChannel
     ALLOWED_FINDERS = {
       'BsRequest' => OutdatedNotificationsFinder::BsRequest,
-      'Comment' => OutdatedNotificationsFinder::Comment
+      'Comment' => OutdatedNotificationsFinder::Comment,
+      'Project' => OutdatedNotificationsFinder::Project,
+      'Package' => OutdatedNotificationsFinder::Package
     }.freeze
 
     def initialize(subscription, event)

--- a/src/api/app/services/notified_projects.rb
+++ b/src/api/app/services/notified_projects.rb
@@ -4,6 +4,7 @@ class NotifiedProjects
     @notifiable = @notification.notifiable
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def call
     return Project.none if @notifiable.blank?
 
@@ -19,6 +20,11 @@ class NotifiedProjects
       when 'BsRequest'
         @notifiable.commentable.target_project_objects.distinct
       end
+    when 'Package'
+      @notifiable.project
+    when 'Project'
+      @notifiable
     end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 end

--- a/src/api/spec/models/event_subscription/find_for_event_spec.rb
+++ b/src/api/spec/models/event_subscription/find_for_event_spec.rb
@@ -275,5 +275,267 @@ RSpec.describe EventSubscription::FindForEvent do
         end
       end
     end
+
+    context 'with an added relationship' do
+      let(:owner) { create(:confirmed_user) }
+      let(:group) { create(:group_with_user) }
+      let(:user) { create(:confirmed_user) }
+      let(:project) { create(:project_with_package) }
+      let(:package) { project.packages.first }
+
+      subject do
+        EventSubscription::FindForEvent.new(event).subscriptions(:web)
+      end
+
+      context 'when dealing with projects' do
+        context 'and there is a subscription for the target user' do
+          let(:event) { Event::RelationshipCreate.create!(who: owner, user: user.login, project: project.name) }
+
+          before do
+            event_subscription = create(
+              :event_subscription,
+              eventtype: 'Event::RelationshipCreate',
+              receiver_role: 'any_role',
+              user: user,
+              group: nil,
+              channel: :web
+            )
+            event_subscription.payload = { project: project.name }
+          end
+
+          it 'includes the target user' do
+            expect(subject.map(&:subscriber)).to include(user)
+          end
+        end
+
+        context 'and there is no subscription for the target user' do
+          let(:event) { Event::RelationshipCreate.create!(who: owner, user: user.login, project: project.name) }
+
+          it 'does not include the target user' do
+            expect(subject.map(&:subscriber)).not_to include(user)
+          end
+        end
+
+        context 'and there is a subscription for the group' do
+          let(:user) { group.users.first }
+          let(:event) { Event::RelationshipCreate.create!(who: owner, group: group.title, project: project.name) }
+
+          before do
+            event_subscription = create(
+              :event_subscription,
+              eventtype: 'Event::RelationshipCreate',
+              receiver_role: 'any_role',
+              user: user,
+              group: nil,
+              channel: :web
+            )
+            event_subscription.payload = { project: project.name }
+          end
+
+          it 'includes the target user' do
+            expect(subject.map(&:subscriber)).to include(user)
+          end
+        end
+
+        context 'and there is no subscription for the target group' do
+          let(:event) { Event::RelationshipCreate.create!(who: owner, group: group.title, project: project.name) }
+
+          it 'does not include the target user' do
+            expect(subject.map(&:subscriber)).not_to include(user)
+          end
+        end
+      end
+
+      context 'when dealing with packages' do
+        context 'and there is a subscription for the target user' do
+          let(:event) { Event::RelationshipCreate.create!(who: owner, user: user.login, package: package.name) }
+
+          before do
+            event_subscription = create(
+              :event_subscription,
+              eventtype: 'Event::RelationshipCreate',
+              receiver_role: 'any_role',
+              user: user,
+              group: nil,
+              channel: :web
+            )
+            event_subscription.payload = { package: package.name }
+          end
+
+          it 'includes the target user' do
+            expect(subject.map(&:subscriber)).to include(user)
+          end
+        end
+
+        context 'and there is no subscription for the target user' do
+          let(:event) { Event::RelationshipCreate.create!(who: owner, user: user.login, package: package.name) }
+
+          it 'does not include the target user' do
+            expect(subject.map(&:subscriber)).not_to include(user)
+          end
+        end
+
+        context 'and there is a subscription for the group' do
+          let(:user) { group.users.first }
+          let(:event) { Event::RelationshipCreate.create!(who: owner, group: group.title, package: package.name) }
+
+          before do
+            event_subscription = create(
+              :event_subscription,
+              eventtype: 'Event::RelationshipCreate',
+              receiver_role: 'any_role',
+              user: user,
+              group: nil,
+              channel: :web
+            )
+            event_subscription.payload = { package: package.name }
+          end
+
+          it 'includes the target user' do
+            expect(subject.map(&:subscriber)).to include(user)
+          end
+        end
+
+        context 'and there is no subscription for the target group' do
+          let(:event) { Event::RelationshipCreate.create!(who: owner, group: group.title, package: package.name) }
+
+          it 'does not include the target user' do
+            expect(subject.map(&:subscriber)).not_to include(user)
+          end
+        end
+      end
+    end
+
+    context 'with a removed relationship' do
+      let(:owner) { create(:confirmed_user) }
+      let(:user) { create(:confirmed_user) }
+      let(:group) { create(:group_with_user) }
+      let(:project) { create(:project_with_package) }
+      let(:package) { project.packages.first }
+
+      subject do
+        EventSubscription::FindForEvent.new(event).subscriptions(:web)
+      end
+
+      context 'when dealing with projects' do
+        context 'and there is a subscription for the target user' do
+          let(:event) { Event::RelationshipDelete.create!(who: owner, user: user.login, project: project.name) }
+
+          before do
+            event_subscription = create(
+              :event_subscription,
+              eventtype: 'Event::RelationshipDelete',
+              receiver_role: 'any_role',
+              user: user,
+              group: nil,
+              channel: :web
+            )
+            event_subscription.payload = { project: project.name }
+          end
+
+          it 'includes the target user' do
+            expect(subject.map(&:subscriber)).to include(user)
+          end
+        end
+
+        context 'and there is no subscription for the target user' do
+          let(:event) { Event::RelationshipDelete.create!(who: owner, user: user.login, project: project.name) }
+
+          it 'does not include the target user' do
+            expect(subject.map(&:subscriber)).not_to include(user)
+          end
+        end
+
+        context 'and there is a subscription for the group' do
+          let(:user) { group.users.first }
+          let(:event) { Event::RelationshipDelete.create!(who: owner, group: group.title, project: project.name) }
+
+          before do
+            event_subscription = create(
+              :event_subscription,
+              eventtype: 'Event::RelationshipDelete',
+              receiver_role: 'any_role',
+              user: user,
+              group: nil,
+              channel: :web
+            )
+            event_subscription.payload = { project: project.name }
+          end
+
+          it 'includes the target user' do
+            expect(subject.map(&:subscriber)).to include(user)
+          end
+        end
+
+        context 'and there is no subscription for the target group' do
+          let(:user) { group.users.first }
+          let(:event) { Event::RelationshipDelete.create!(who: owner, group: group.title, project: project.name) }
+
+          it 'does not include the target user' do
+            expect(subject.map(&:subscriber)).not_to include(user)
+          end
+        end
+      end
+
+      context 'when dealing with packages' do
+        context 'and there is a subscription for the target user' do
+          let(:event) { Event::RelationshipDelete.create!(who: owner, user: user.login, package: package.name) }
+
+          before do
+            event_subscription = create(
+              :event_subscription,
+              eventtype: 'Event::RelationshipDelete',
+              receiver_role: 'any_role',
+              user: user,
+              group: nil,
+              channel: :web
+            )
+            event_subscription.payload = { package: package.name }
+          end
+
+          it 'includes the target user' do
+            expect(subject.map(&:subscriber)).to include(user)
+          end
+        end
+
+        context 'and there is no subscription for the target user' do
+          let(:event) { Event::RelationshipDelete.create!(who: owner, user: user.login, package: package.name) }
+
+          it 'does not include the target user' do
+            expect(subject.map(&:subscriber)).not_to include(user)
+          end
+        end
+
+        context 'and there is a subscription for the group' do
+          let(:user) { group.users.first }
+          let(:event) { Event::RelationshipDelete.create!(who: owner, group: group.title, package: package.name) }
+
+          before do
+            event_subscription = create(
+              :event_subscription,
+              eventtype: 'Event::RelationshipDelete',
+              receiver_role: 'any_role',
+              user: user,
+              group: nil,
+              channel: :web
+            )
+            event_subscription.payload = { package: package.name }
+          end
+
+          it 'includes the target user' do
+            expect(subject.map(&:subscriber)).to include(user)
+          end
+        end
+
+        context 'and there is no subscription for the target group' do
+          let(:user) { group.users.first }
+          let(:event) { Event::RelationshipDelete.create!(who: owner, group: group.title, package: package.name) }
+
+          it 'does not include the target user' do
+            expect(subject.map(&:subscriber)).not_to include(user)
+          end
+        end
+      end
+    end
   end
 end

--- a/src/api/spec/services/notification_service/notifier_spec.rb
+++ b/src/api/spec/services/notification_service/notifier_spec.rb
@@ -75,5 +75,268 @@ RSpec.describe NotificationService::Notifier do
       it { expect(Notification.first).to be_web }
       it { expect(Notification.first).not_to be_rss }
     end
+
+    context 'and I have an event for a relationship create' do
+      let(:owner) { create(:confirmed_user) }
+
+      context 'and I am dealing with projects' do
+        let(:project) { create(:project_with_package) }
+
+        context 'and the event triggers for a user' do
+          let(:user) { create(:confirmed_user) }
+          let(:event) { Event::RelationshipCreate.create!(who: owner, user: user.login, project: project.name, notifiable_id: project.id) }
+
+          context 'and a user is subscribed to the event' do
+            before do
+              event_subscription = create(
+                :event_subscription,
+                eventtype: 'Event::RelationshipCreate',
+                receiver_role: 'any_role',
+                user: user,
+                group: nil,
+                channel: :web
+              )
+              event_subscription.payload = { project: project.name }
+            end
+
+            it 'creates a new notification for the target user' do
+              expect { NotificationService::Notifier.new(event).call }.to change(Notification, :count).to(1)
+            end
+          end
+
+          context 'and no user is subscribed to the event' do
+            it 'does not create a new notification for the target user' do
+              expect { NotificationService::Notifier.new(event).call }.not_to change(Notification, :count)
+            end
+          end
+        end
+
+        context 'and the event triggers for a group' do
+          let(:group) { create(:group_with_user) }
+          let(:user) { group.users.first }
+          let(:event) { Event::RelationshipCreate.create!(who: owner, group: group.title, project: project.name, notifiable_id: project.id) }
+
+          context 'and a group member is subscribed to the event' do
+            before do
+              event_subscription = create(
+                :event_subscription,
+                eventtype: 'Event::RelationshipCreate',
+                receiver_role: 'any_role',
+                user: user,
+                group: nil,
+                channel: :web
+              )
+              event_subscription.payload = { project: project.name }
+              group.groups_users.first.update(email: false)
+            end
+
+            it 'creates a new notification for the subscribed group members' do
+              expect { NotificationService::Notifier.new(event).call }.to change(Notification, :count).to(1)
+            end
+          end
+
+          context 'and no group is subscribed to the event' do
+            it 'does not create a new notification for the target user' do
+              expect { NotificationService::Notifier.new(event).call }.not_to change(Notification, :count)
+            end
+          end
+        end
+      end
+
+      context 'and I am dealing with packages' do
+        let(:project) { create(:project_with_package) }
+        let(:package) { project.packages.first }
+
+        context 'and the event triggers for a user' do
+          let(:user) { create(:confirmed_user) }
+          let(:event) { Event::RelationshipCreate.create!(who: owner, user: user.login, package: package.name, project: project.name, notifiable_id: package.id) }
+
+          context 'and a user is subscribed to the event' do
+            before do
+              event_subscription = create(
+                :event_subscription,
+                eventtype: 'Event::RelationshipCreate',
+                receiver_role: 'any_role',
+                user: user,
+                group: nil,
+                channel: :web
+              )
+              event_subscription.payload = { package: package.name }
+            end
+
+            it 'creates a new notification for the target user' do
+              expect { NotificationService::Notifier.new(event).call }.to change(Notification, :count).to(1)
+            end
+          end
+
+          context 'and no user is subscribed to the event' do
+            it 'does not create a new notification for the target user' do
+              expect { NotificationService::Notifier.new(event).call }.not_to change(Notification, :count)
+            end
+          end
+        end
+
+        context 'and the event triggers for a group' do
+          let(:group) { create(:group_with_user) }
+          let(:user) { group.users.first }
+          let(:event) { Event::RelationshipCreate.create!(who: owner, group: group.title, package: package.name, project: project.name, notifiable_id: package.id) }
+
+          context 'and a group is subscribed to the event' do
+            before do
+              event_subscription = create(
+                :event_subscription,
+                eventtype: 'Event::RelationshipCreate',
+                receiver_role: 'any_role',
+                user: user,
+                group: nil,
+                channel: :web
+              )
+              event_subscription.payload = { package: package.name }
+            end
+
+            it 'creates a new notification for the target user' do
+              expect { NotificationService::Notifier.new(event).call }.to change(Notification, :count).to(1)
+            end
+          end
+
+          context 'and no group is subscribed to the event' do
+            it 'does not create a new notification for the target user' do
+              expect { NotificationService::Notifier.new(event).call }.not_to change(Notification, :count)
+            end
+          end
+        end
+      end
+    end
+
+    context 'and I have an event for a relationship delete' do
+      let(:owner) { create(:confirmed_user) }
+
+      context 'and I am dealing with projects' do
+        let(:project) { create(:project_with_package) }
+
+        context 'and the event triggers for a user' do
+          let(:user) { create(:confirmed_user) }
+          let(:event) { Event::RelationshipDelete.create!(who: owner, user: user.login, project: project.name, notifiable_id: project.id) }
+
+          context 'and a user is subscribed to the event' do
+            before do
+              event_subscription = create(
+                :event_subscription,
+                eventtype: 'Event::RelationshipDelete',
+                receiver_role: 'any_role',
+                user: user,
+                group: nil,
+                channel: :web
+              )
+              event_subscription.payload = { project: project.name }
+            end
+
+            it 'creates a new notification for the target user' do
+              expect { NotificationService::Notifier.new(event).call }.to change(Notification, :count).to(1)
+            end
+          end
+
+          context 'and no user is subscribed to the event' do
+            it 'does not create a new notification for the target user' do
+              expect { NotificationService::Notifier.new(event).call }.not_to change(Notification, :count)
+            end
+          end
+        end
+
+        context 'and the event triggers for a group' do
+          let(:group) { create(:group_with_user) }
+          let(:user) { group.users.first }
+          let(:event) { Event::RelationshipDelete.create!(who: owner, group: group.title, project: project.name, notifiable_id: project.id) }
+
+          context 'and a group member is subscribed to the event' do
+            before do
+              event_subscription = create(
+                :event_subscription,
+                eventtype: 'Event::RelationshipDelete',
+                receiver_role: 'any_role',
+                user: user,
+                group: nil,
+                channel: :web
+              )
+              event_subscription.payload = { project: project.name }
+            end
+
+            it 'creates a new notification for the subscribed group members' do
+              expect { NotificationService::Notifier.new(event).call }.to change(Notification, :count).to(1)
+            end
+          end
+
+          context 'and no group is subscribed to the event' do
+            it 'does not create a new notification for the target user' do
+              expect { NotificationService::Notifier.new(event).call }.not_to change(Notification, :count)
+            end
+          end
+        end
+      end
+
+      context 'and I am dealing with packages' do
+        let(:project) { create(:project_with_package) }
+        let(:package) { project.packages.first }
+
+        context 'and the event triggers for a user' do
+          let(:user) { create(:confirmed_user) }
+          let(:event) { Event::RelationshipDelete.create!(who: owner, user: user.login, package: package.name, project: project.name, notifiable_id: package.id) }
+
+          context 'and a user is subscribed to the event' do
+            before do
+              event_subscription = create(
+                :event_subscription,
+                eventtype: 'Event::RelationshipDelete',
+                receiver_role: 'any_role',
+                user: user,
+                group: nil,
+                channel: :web
+              )
+              event_subscription.payload = { package: package.name }
+            end
+
+            it 'creates a new notification for the target user' do
+              expect { NotificationService::Notifier.new(event).call }.to change(Notification, :count).to(1)
+            end
+          end
+
+          context 'and no user is subscribed to the event' do
+            it 'does not create a new notification for the target user' do
+              expect { NotificationService::Notifier.new(event).call }.not_to change(Notification, :count)
+            end
+          end
+        end
+
+        context 'and the event triggers for a group' do
+          let(:group) { create(:group_with_user) }
+          let(:user) { group.users.first }
+          let(:event) { Event::RelationshipDelete.create!(who: owner, group: group.title, package: package.name, project: project.name, notifiable_id: package.id) }
+
+          context 'and a group is subscribed to the event' do
+            before do
+              event_subscription = create(
+                :event_subscription,
+                eventtype: 'Event::RelationshipDelete',
+                receiver_role: 'any_role',
+                user: user,
+                group: nil,
+                channel: :web
+              )
+              event_subscription.payload = { package: package.name }
+            end
+
+            it 'creates a new notification for the target user' do
+              expect { NotificationService::Notifier.new(event).call }.to change(Notification, :count).to(1)
+            end
+          end
+
+          context 'and no group is subscribed to the event' do
+            it 'does not create a new notification for the target user' do
+              expect { NotificationService::Notifier.new(event).call }.not_to change(Notification, :count)
+            end
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Receive notifications when a relationship is created or deleted. It is available for any kind of role if the user subscribed to the relationship events.

## This is how it looks like:

![Screenshot 2022-04-29 at 12-25-36 Open Build Service](https://user-images.githubusercontent.com/2581944/165927792-9535f982-805b-4369-a2fb-c1e0d00086bd.png)



## How to test this PR
- Given you have two users ready, `Admin` and `Iggy` for example, with home projects.
- Iggy should enable the notifications for the "Relationship  was created" and "Relationship was deleted" event types.
- Admin should go to its home project and add Iggy as maintainer, for example.
- Iggy should get a notification saying it's been added as maintainer into `home:Admin` project.