### PR TITLE
Introduces 210 label for 2.10 images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,25 +7,26 @@ images:
       NOKOGIRI_USE_SYSTEM_LIBRARIES: 1
 
   - &mariadb
-    image: registry.opensuse.org/obs/server/2.10/containers/containers/openbuildservice/mariadb:latest
+    image: registry.opensuse.org/obs/server/2.10/containers/containers/openbuildservice/mariadb:210
     command: |
       /bin/bash -c 'echo -e "[mysqld]\ndatadir = /dev/shm" > /etc/my.cnf.d/obs.cnf && cp -a /var/lib/mysql/* /dev/shm && /usr/lib/mysql/mysql-systemd-helper start'
     name: db
 
-  - &backend registry.opensuse.org/obs/server/2.10/containers/containers/openbuildservice/backend:latest
+  - &backend
+    image: registry.opensuse.org/obs/server/2.10/containers/containers/openbuildservice/backend:210
 
   - &frontend_minitest
-    image: registry.opensuse.org/obs/server/2.10/containers/containers/openbuildservice/frontend-minitest:latest
+    image: registry.opensuse.org/obs/server/2.10/containers/containers/openbuildservice/frontend-minitest:210
     <<: *common_frontend_config
     environment:
       EAGER_LOAD: 1
 
   - &frontend_base
-    image: registry.opensuse.org/obs/server/2.10/containers/containers/openbuildservice/frontend-base:latest
+    image: registry.opensuse.org/obs/server/2.10/containers/containers/openbuildservice/frontend-base:210
     <<: *common_frontend_config
 
   - &frontend_features
-    image: registry.opensuse.org/obs/server/2.10/containers/containers/openbuildservice/frontend-features:latest
+    image: registry.opensuse.org/obs/server/2.10/containers/containers/openbuildservice/frontend-features:210
     <<: *common_frontend_config
 
 aliases:
@@ -238,7 +239,7 @@ jobs:
 
   backend_test:
     docker:
-      - image: *backend
+      - *backend
     working_directory: /home/frontend/project
     steps:
       - attach_workspace:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,17 @@
 version: "2.1"
 services:
   db:
-    image: registry.opensuse.org/obs/server/2.10/containers/containers/openbuildservice/mariadb
+    image: registry.opensuse.org/obs/server/2.10/containers/containers/openbuildservice/mariadb:210
     ports:
       - "3306:3306"
     command: /usr/lib/mysql/mysql-systemd-helper start
   cache:
-    image: registry.opensuse.org/obs/server/2.10/containers/containers/openbuildservice/memcached
+    image: registry.opensuse.org/obs/server/2.10/containers/containers/openbuildservice/memcached:210
     ports:
       - "11211:11211"
     command: /usr/sbin/memcached -u memcached
   backend:
-    image: registry.opensuse.org/obs/server/2.10/containers/containers/openbuildservice/backend
+    image: registry.opensuse.org/obs/server/2.10/containers/containers/openbuildservice/backend:210
     volumes:
       - .:/obs
       - ./dist/aws_credentials:/etc/obs/cloudupload/.aws/config
@@ -19,7 +19,7 @@ services:
       - ./dist/clouduploader.rb:/usr/bin/clouduploader
     command: /obs/contrib/start_development_backend -d /obs
   worker:
-    image: registry.opensuse.org/obs/server/2.10/containers/containers/openbuildservice/backend
+    image: registry.opensuse.org/obs/server/2.10/containers/containers/openbuildservice/backend:210
     volumes:
       - .:/obs
     privileged: true

--- a/src/api/docker-files/Dockerfile
+++ b/src/api/docker-files/Dockerfile
@@ -3,7 +3,7 @@
 # contained rails app generating files in the git checkout with
 # some strange user...
 
-FROM registry.opensuse.org/obs/server/2.10/containers/containers/openbuildservice/frontend-features
+FROM registry.opensuse.org/obs/server/2.10/containers/containers/openbuildservice/frontend-features:210
 ARG CONTAINER_USERID
 
 # for lint task

--- a/src/api/docker-files/Dockerfile.minitest
+++ b/src/api/docker-files/Dockerfile.minitest
@@ -2,7 +2,7 @@
 # sure different users can run it without the contained rails app generating
 # files in the git checkout with some strange user...
 
-FROM registry.opensuse.org/obs/server/2.10/containers/containers/openbuildservice/frontend-minitest
+FROM registry.opensuse.org/obs/server/2.10/containers/containers/openbuildservice/frontend-minitest:210
 
 # Configure our user
 ARG CONTAINER_USERID


### PR DESCRIPTION
For docker those two images are the same:

registry.opensuse.org/obs/server/2.10/containers/containers/openbuildservice/backend
registry.opensuse.org/obs/server/unstable/containers/containers/openbuildservice/backend

The are both openbuildservice/backend:latest. So whatever image it finds first, it's going to use.
This lead to strange problems with the dev-env when switching between 2.10 and master branches.