### PR TITLE
Add instrumentation to track changes on Notification#delivered

### DIFF
--- a/src/api/app/models/notification.rb
+++ b/src/api/app/models/notification.rb
@@ -14,6 +14,8 @@ class Notification < ApplicationRecord
 
   after_create :track_notification_creation
 
+  after_save :track_notification_delivered, if: :saved_change_to_delivered?
+
   scope :for_web, -> { where(web: true) }
   scope :for_rss, -> { where(rss: true) }
 
@@ -50,6 +52,11 @@ class Notification < ApplicationRecord
   def track_notification_creation
     RabbitmqBus.send_to_bus('metrics',
                             "notification.create,notifiable_type=#{notifiable_type},web=#{web},rss=#{rss} value=1")
+  end
+
+  def track_notification_delivered
+    RabbitmqBus.send_to_bus('metrics',
+                            "notification.delivered,notifiable_type=#{notifiable_type},web=#{web},rss=#{rss} value=1")
   end
 end
 

--- a/src/api/spec/models/notification_spec.rb
+++ b/src/api/spec/models/notification_spec.rb
@@ -65,4 +65,35 @@ RSpec.describe Notification do
       it { expect(subject).to be_truthy }
     end
   end
+
+  describe 'Instrumentation' do
+    let!(:test_user) { create(:confirmed_user, login: 'foo') }
+    let!(:rss_notification) { create(:rss_notification, subscriber: test_user) }
+
+    before do
+      allow(RabbitmqBus).to receive(:send_to_bus).with('metrics', 'notification.delivered,notifiable_type=,web=false,rss=true value=1')
+    end
+
+    context 'if delivered change, we should track it' do
+      before do
+        rss_notification.delivered = true
+      end
+
+      it do
+        rss_notification.save
+        expect(RabbitmqBus).to have_received(:send_to_bus).with('metrics', 'notification.delivered,notifiable_type=,web=false,rss=true value=1')
+      end
+    end
+
+    context 'if delivered doe not change, we should not track it' do
+      before do
+        rss_notification.title = 'FOO FOO'
+      end
+
+      it do
+        rss_notification.save
+        expect(RabbitmqBus).not_to have_received(:send_to_bus).with('metrics', 'notification.delivered,notifiable_type=,web=false,rss=true value=1')
+      end
+    end
+  end
 end


### PR DESCRIPTION
If a Notification is delivered, we want to track it within our SRE stack