### PR TITLE
Set case-insensitive order for watchlist elements

### DIFF
--- a/src/api/app/components/watchlist_component.rb
+++ b/src/api/app/components/watchlist_component.rb
@@ -61,12 +61,15 @@ class WatchlistComponent < ApplicationComponent
     end
   end
 
+  # Sort projects and packages names in a case-insensitive manner first
+
   def projects
-    @projects ||= Project.joins(:watched_items).where(watched_items: { user: @user }).order(:name)
+    @projects ||= Project.joins(:watched_items).where(watched_items: { user: @user }).order('LOWER(name), name')
   end
 
   def packages
-    @packages ||= Package.includes(:project).joins(:watched_items).where(watched_items: { user: @user }).order('projects.name, packages.name')
+    @packages ||= Package.joins(:project).joins(:watched_items).where(watched_items: { user: @user })
+                         .order('LOWER(projects.name), projects.name, LOWER(packages.name), packages.name')
   end
 
   def bs_requests


### PR DESCRIPTION
The sorting was a bit weird when combining uppercase and lowercase names. This is the explanation:

Performing a simple order query like `Project.all.order('name')` will sort the results on a case-sensitive manner (displaying the uppercase ones first).

![order](https://user-images.githubusercontent.com/2581944/164730344-302a1b5d-5ee5-47c1-bf5d-df43901f00eb.png)

Using `LOWER` like `Project.all.order('LOWER(name)')` we can sort on a case-insensitive manner. It groups the same letters together but the results mix uppercase and lowercase on a messy way.

![order_I](https://user-images.githubusercontent.com/2581944/164730485-ee340b90-4364-4524-9f60-345be5a00f41.png)

The combination of case-insensitive and case-sensitive sorting like `Project.all.order('lower(name), name')` gets exactly what we want.

![order_II](https://user-images.githubusercontent.com/2581944/164730534-a0cec682-71c1-4b26-b851-c61cabee552e.png)

Follw up https://github.com/openSUSE/open-build-service/pull/12460
