### PR TITLE
[2.10] [backend] support zstd compressed preinstall images

### DIFF
--- a/src/backend/BSSched/BuildJob/PreInstallImage.pm
+++ b/src/backend/BSSched/BuildJob/PreInstallImage.pm
@@ -140,13 +140,15 @@ sub update_preinstallimage {
     $imagedata = $newimagedata;
   }
   my @all;
-  @all = grep {/(?:\.tar\.xz|\.tar\.gz|\.info)$/} grep {!/^\./} sort(ls($jobdir)) if $jobdir;
+  @all = grep {/(?:\.tar\.xz|\.tar\.gz|\.tar\.zst|\.info)$/} grep {!/^\./} sort(ls($jobdir)) if $jobdir;
   my %all = map {$_ => 1} @all;
   my @imgs = grep {s/\.info$//} @all;
   for my $img (@imgs) {
     my $tar;
     next if (-s "$jobdir/$img.info") > 100000;
-    if (-f "$jobdir/$img.tar.xz") {
+    if (-f "$jobdir/$img.tar.zst") {
+      $tar = "$img.tar.zst";
+    } elsif (-f "$jobdir/$img.tar.xz") {
       $tar = "$img.tar.xz";
     } elsif (-f "$jobdir/$img.tar.gz") {
       $tar = "$img.tar.gz";


### PR DESCRIPTION
Backports #12181 to 2.10

(cherry picked from commit 9b5d77b324879942d0ab9021df2aa188fe4e0c20)