### PR TITLE
Fix backend tests backport

### DIFF
--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -32,6 +32,7 @@
 
 %define secret_key_file /srv/www/obs/api/config/secret.key
 %define obs_backend_data_dir /srv/obs
+%define obs_backend_dir /usr/lib/obs/server
 
 %if ! %{defined _restart_on_update_reload}
 %define _restart_on_update_reload() (\
@@ -462,8 +463,8 @@ rm -rf %{buildroot}/srv/www/obs/api/spec
 rm %{buildroot}/srv/www/obs/api/config/brakeman.ignore
 
 # fail when Makefiles created a directory
-if ! test -L %{buildroot}/usr/lib/obs/server/build; then
-  echo "/usr/lib/obs/server/build is not a symlink!"
+if ! test -L %{buildroot}%{obs_backend_dir}/build; then
+  echo "%{obs_backend_dir}/build is not a symlink!"
   exit 1
 fi
 
@@ -497,7 +498,7 @@ exit 0
 
 export DESTDIR=$RPM_BUILD_ROOT
 # check installed backend
-pushd $RPM_BUILD_ROOT/usr/lib/obs/server/
+pushd $RPM_BUILD_ROOT%{obs_backend_dir}/
 rm -rf build
 ln -sf /usr/lib/build build # just for %%check, it is a %%ghost
 popd
@@ -510,7 +511,7 @@ popd
 
 ####
 # start backend testing
-pushd $RPM_BUILD_ROOT/usr/lib/obs/server/
+pushd $RPM_BUILD_ROOT%{obs_backend_dir}/
 %if 0%{?disable_obs_backend_test_suite:1} < 1
 # TODO: move syntax check to backend test suite
 for i in bs_*; do
@@ -633,11 +634,11 @@ exit 0
 %posttrans
 [ -d /srv/obs ] || install -d -o obsrun -g obsrun /srv/obs
 # this changes from directory to symlink. rpm can not handle this itself.
-if [ -e /usr/lib/obs/server/build -a ! -L /usr/lib/obs/server/build ]; then
-  rm -rf /usr/lib/obs/server/build
+if [ -e %{obs_backend_dir}/build -a ! -L %{obs_backend_dir}/build ]; then
+  rm -rf %{obs_backend_dir}/build
 fi
-if [ ! -e /usr/lib/obs/server/build ]; then
-  ln -sf ../../build /usr/lib/obs/server/build
+if [ ! -e %{obs_backend_dir}/build ]; then
+  ln -sf ../../build %{obs_backend_dir}/build
 fi
 
 %postun
@@ -747,7 +748,7 @@ fi
 %doc dist/{README.UPDATERS,README.SETUP} docs/openSUSE.org.xml ReleaseNotes-* README.md COPYING AUTHORS
 %dir /etc/slp.reg.d
 %dir /usr/lib/obs
-%dir /usr/lib/obs/server
+%dir %{obs_backend_dir}
 %config(noreplace) /etc/logrotate.d/obs-server
 %{_unitdir}/obsscheduler.service
 %{_unitdir}/obssrcserver.service
@@ -778,48 +779,48 @@ fi
 /usr/sbin/rcobssigner
 /usr/sbin/rcobsnotifyforward
 /usr/sbin/rcobsredis
-/usr/lib/obs/server/plugins
-/usr/lib/obs/server/BSDispatcher
-/usr/lib/obs/server/BSRepServer
-/usr/lib/obs/server/BSSched
-/usr/lib/obs/server/BSSrcServer
-/usr/lib/obs/server/BSPublisher
-/usr/lib/obs/server/XML
-/usr/lib/obs/server/*.pm
-/usr/lib/obs/server/BSConfig.pm.template
-/usr/lib/obs/server/DESIGN
-/usr/lib/obs/server/License
-/usr/lib/obs/server/README
-/usr/lib/obs/server/bs_admin
-/usr/lib/obs/server/bs_cleanup
-/usr/lib/obs/server/bs_archivereq
-/usr/lib/obs/server/bs_check_consistency
-/usr/lib/obs/server/bs_deltastore
-/usr/lib/obs/server/bs_servicedispatch
-/usr/lib/obs/server/bs_dodup
-/usr/lib/obs/server/bs_getbinariesproxy
-/usr/lib/obs/server/bs_mergechanges
-/usr/lib/obs/server/bs_mkarchrepo
-/usr/lib/obs/server/bs_notar
-/usr/lib/obs/server/bs_regpush
-/usr/lib/obs/server/bs_dispatch
-/usr/lib/obs/server/bs_publish
-/usr/lib/obs/server/bs_repserver
-/usr/lib/obs/server/bs_sched
-/usr/lib/obs/server/bs_serverstatus
-/usr/lib/obs/server/bs_srcserver
-/usr/lib/obs/server/bs_worker
-/usr/lib/obs/server/bs_signer
-/usr/lib/obs/server/bs_warden
-/usr/lib/obs/server/bs_redis
-/usr/lib/obs/server/bs_notifyforward
-/usr/lib/obs/server/worker
-/usr/lib/obs/server/worker-deltagen.spec
-%config(noreplace) /usr/lib/obs/server/BSConfig.pm
+%{obs_backend_dir}/plugins
+%{obs_backend_dir}/BSDispatcher
+%{obs_backend_dir}/BSRepServer
+%{obs_backend_dir}/BSSched
+%{obs_backend_dir}/BSSrcServer
+%{obs_backend_dir}/BSPublisher
+%{obs_backend_dir}/XML
+%{obs_backend_dir}/*.pm
+%{obs_backend_dir}/BSConfig.pm.template
+%{obs_backend_dir}/DESIGN
+%{obs_backend_dir}/License
+%{obs_backend_dir}/README
+%{obs_backend_dir}/bs_admin
+%{obs_backend_dir}/bs_cleanup
+%{obs_backend_dir}/bs_archivereq
+%{obs_backend_dir}/bs_check_consistency
+%{obs_backend_dir}/bs_deltastore
+%{obs_backend_dir}/bs_servicedispatch
+%{obs_backend_dir}/bs_dodup
+%{obs_backend_dir}/bs_getbinariesproxy
+%{obs_backend_dir}/bs_mergechanges
+%{obs_backend_dir}/bs_mkarchrepo
+%{obs_backend_dir}/bs_notar
+%{obs_backend_dir}/bs_regpush
+%{obs_backend_dir}/bs_dispatch
+%{obs_backend_dir}/bs_publish
+%{obs_backend_dir}/bs_repserver
+%{obs_backend_dir}/bs_sched
+%{obs_backend_dir}/bs_serverstatus
+%{obs_backend_dir}/bs_srcserver
+%{obs_backend_dir}/bs_worker
+%{obs_backend_dir}/bs_signer
+%{obs_backend_dir}/bs_warden
+%{obs_backend_dir}/bs_redis
+%{obs_backend_dir}/bs_notifyforward
+%{obs_backend_dir}/worker
+%{obs_backend_dir}/worker-deltagen.spec
+%config(noreplace) %{obs_backend_dir}/BSConfig.pm
 %config(noreplace) /etc/slp.reg.d/*
 # created via %%post, since rpm fails otherwise while switching from
 # directory to symlink
-%ghost /usr/lib/obs/server/build
+%ghost %{obs_backend_dir}/build
 %attr(0775, obsrun, obsrun) %dir %{obs_backend_data_dir}
 %attr(0755, obsrun, obsrun) %dir %{obs_backend_data_dir}/build
 %attr(0755, obsrun, obsrun) %dir %{obs_backend_data_dir}/events
@@ -838,14 +839,14 @@ fi
 %config(noreplace) /etc/logrotate.d/obs-source_service
 %config(noreplace) /etc/cron.d/cleanup_scm_cache
 /usr/sbin/rcobsservice
-/usr/lib/obs/server/bs_service
-/usr/lib/obs/server/call-service-in-docker.sh
-/usr/lib/obs/server/run-service-containerized
-/usr/lib/obs/server/cleanup_scm_cache
+%{obs_backend_dir}/bs_service
+%{obs_backend_dir}/call-service-in-docker.sh
+%{obs_backend_dir}/run-service-containerized
+%{obs_backend_dir}/cleanup_scm_cache
 
 # formerly obs-productconverter
 /usr/bin/obs_productconvert
-/usr/lib/obs/server/bs_productconvert
+%{obs_backend_dir}/bs_productconvert
 
 # add obsservicerun user into docker group if docker
 # gets installed
@@ -973,7 +974,7 @@ usermod -a -G docker obsservicerun
 %files -n obs-common
 %defattr(-,root,root)
 %{_fillupdir}/sysconfig.obs-server
-/usr/lib/obs/server/setup-appliance.sh
+%{obs_backend_dir}/setup-appliance.sh
 %{_unitdir}/obsstoragesetup.service
 /usr/sbin/obsstoragesetup
 /usr/sbin/rcobsstoragesetup
@@ -994,8 +995,8 @@ usermod -a -G docker obsservicerun
 %{_unitdir}/obsclouduploadserver.service
 /usr/sbin/rcobsclouduploadworker
 /usr/sbin/rcobsclouduploadserver
-/usr/lib/obs/server/bs_clouduploadserver
-/usr/lib/obs/server/bs_clouduploadworker
+%{obs_backend_dir}/bs_clouduploadserver
+%{obs_backend_dir}/bs_clouduploadworker
 %{_bindir}/clouduploader
 %dir /etc/obs
 %dir /etc/obs/cloudupload

--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -397,6 +397,17 @@ getent passwd obsapidelayed >/dev/null || \
 %files -n system-user-obsservicerun
 %endif
 
+%package -n obs-backend-testsuite
+Summary:        The Open Build Service -- Backend Testsuite
+Group:          Productivity/Networking/Web/Utilities
+Requires:       obs-server
+
+%description  -n obs-backend-testsuite
+This package contains the backend unit tests
+
+%files  -n obs-backend-testsuite
+%{obs_backend_dir}/t
+
 #--------------------------------------------------------------------------------
 %prep
 %setup -q -n open-build-service-%version

--- a/dist/t/osc/fixtures/obs-testpackage-2.8._service
+++ b/dist/t/osc/fixtures/obs-testpackage-2.8._service
@@ -1,7 +1,7 @@
 <services>
   <service name="tar_scm">
     <param name="versionformat">%ad</param>
-    <param name="url">git://github.com/M0ses/obs-testpackage.git</param>
+    <param name="url">https://github.com/M0ses/obs-testpackage.git</param>
     <param name="scm">git</param>
     <param name="extract">dist/obs-testpackage.spec</param>
   </service>

--- a/dist/t/osc/fixtures/obs-testpackage._service
+++ b/dist/t/osc/fixtures/obs-testpackage._service
@@ -1,7 +1,7 @@
 <services>
   <service name="obs_scm">
     <param name="versionformat">%ad</param>
-    <param name="url">git://github.com/M0ses/obs-testpackage.git</param>
+    <param name="url">https://github.com/M0ses/obs-testpackage.git</param>
     <param name="scm">git</param>
     <param name="extract">dist/obs-testpackage.spec</param>
   </service>

--- a/src/backend/Makefile
+++ b/src/backend/Makefile
@@ -17,7 +17,6 @@ install: prepare_dirs install_data_dirs bs_config
 	cp -a ./* $(DESTDIR)$(OBS_BACKEND_PREFIX)
 	rm -rf $(DESTDIR)$(OBS_BACKEND_PREFIX)/build
 	rm -rf $(DESTDIR)$(OBS_BACKEND_PREFIX)/Makefile
-	rm -rf $(DESTDIR)$(OBS_BACKEND_PREFIX)/t
 	rm -rf $(DESTDIR)$(OBS_BACKEND_PREFIX)/testdata
 	rm -rf $(DESTDIR)$(OBS_BACKEND_PREFIX)/examples
 	# just for check section, it is a %%ghost

--- a/src/backend/Makefile
+++ b/src/backend/Makefile
@@ -31,7 +31,7 @@ install_data_dirs: prepare_dirs
 
 test_unit: bs_config
 	rm -rf t/tmp/*
-	LANG=C prove -Ibuild -I. -v t/*.t
+	LANG=C prove -Ibuild -I. -I/usr/lib/build -v t/*.t
 
 cover: bs_config clean_cover
 	rm -rf t/tmp/*

--- a/src/backend/t/0015-BSSched-EventSource-Directory.t
+++ b/src/backend/t/0015-BSSched-EventSource-Directory.t
@@ -78,24 +78,24 @@ my $stdout_content;
   @ev = BSSched::EventSource::Directory::readevents($gctx,$eventdir->{$arch});
   $expected = [
 	    {
-	      'evfilename' => 't/data/0015/events/x86_64/finished:devel:languages:perl:CPAN-P::openSUSE_Tumbleweed::perl-perlbench-1c7e973409998f482ce9dba10304e653',
+	      'evfilename' => $eventdir->{$arch}.'/finished:devel:languages:perl:CPAN-P::openSUSE_Tumbleweed::perl-perlbench-1c7e973409998f482ce9dba10304e653',
 	      'type' => 'built',
 	      'job' => 'devel:languages:perl:CPAN-P::openSUSE_Tumbleweed::perl-perlbench-1c7e973409998f482ce9dba10304e653'
 	    },
 	    {
 	      'project' => 'devel:languages:perl:CPAN-S',
-	      'evfilename' => 't/data/0015/events/x86_64/package:devel:languages:perl::perl-Unknown-Type',
+	      'evfilename' => $eventdir->{$arch}.'/package:devel:languages:perl::perl-Unknown-Type',
 	      'type' => 'unknown',
 	      'package' => 'perl-SWISH'
 	    },
 	    {
 	      'project' => 'devel:languages:perl:CPAN-S',
-	      'evfilename' => 't/data/0015/events/x86_64/package:devel:languages:perl:CPAN-S::perl-SWISH',
+	      'evfilename' => $eventdir->{$arch}.'/package:devel:languages:perl:CPAN-S::perl-SWISH',
 	      'type' => 'package',
 	      'package' => 'perl-SWISH'
 	    },
 	    {
-	      'evfilename' => 't/data/0015/events/x86_64/package:devel:languages:perl:CPAN-S::perl-Scalar-Boolean',
+	      'evfilename' => $eventdir->{$arch}.'/package:devel:languages:perl:CPAN-S::perl-Scalar-Boolean',
 	      'project' => 'devel:languages:perl:CPAN-S',
 	      'package' => 'perl-Scalar-Boolean',
 	      'type' => 'package'
@@ -104,10 +104,10 @@ my $stdout_content;
 	      'type' => 'package',
 	      'package' => 'perl-ScatterPlot',
 	      'project' => 'devel:languages:perl:CPAN-S',
-	      'evfilename' => 't/data/0015/events/x86_64/package:devel:languages:perl:CPAN-S::perl-ScatterPlot'
+	      'evfilename' => $eventdir->{$arch}.'/package:devel:languages:perl:CPAN-S::perl-ScatterPlot'
 	    },
 	    {
-	      'evfilename' => 't/data/0015/events/x86_64/package:project-name::test-package-name',
+	      'evfilename' => $eventdir->{$arch}.'/package:project-name::test-package-name',
 	      'package' => 'test-package-name',
 	      'type' => 'package'
 	    }
@@ -125,7 +125,7 @@ $expected = [
           {
             'package' => 'test-package-name',
             'type' => 'package',
-            'evfilename' => 't/data/0015/events/i586/package:project-name::test-package-name'
+            'evfilename' => $eventdir->{$arch}.'/package:project-name::test-package-name'
           }
         ];
 


### PR DESCRIPTION
* added %{obs_backend_dir} macro
* added obs-backend-testsuite rpm
* changed deprecated git:// url in test cases to https://
* added perl include path "/usr/lib/build" in "src/backend/Makefile"
* fixed expected path in "0015-BSSched-EventSource-Directory.t"