### PR TITLE
Prevent shellcheck from following a source file

### DIFF
--- a/dist/t/0000-check_users_and_group.ts
+++ b/dist/t/0000-check_users_and_group.ts
@@ -3,7 +3,7 @@
 BASH_TAP_ROOT=$(dirname "$0")
 
 
-# shellcheck disable=SC1090
+# shellcheck source=/dev/null
 . "$BASH_TAP_ROOT"/bash-tap-bootstrap
 
 


### PR DESCRIPTION
We still don't want the source file to pass the linter. This is fixing a behaviour introduced with a new version of shellcheck.

See: https://github.com/koalaman/shellcheck/wiki/SC1091#correct-code