### PR TITLE
[api] support to limit release source project

### DIFF
--- a/src/api/app/helpers/maintenance_helper.rb
+++ b/src/api/app/helpers/maintenance_helper.rb
@@ -57,6 +57,13 @@ module MaintenanceHelper
                        target
                      end
     target_project.check_write_access!
+
+    # validate possible source limitations
+    attrib = target_project.attribs.find_by(attrib_type: AttribType.find_by_namespace_and_name('OBS', 'LimitReleaseSourceProject'))
+    if attrib.present? && attrib.values.pluck(:value).exclude?(source_package.project.name)
+      raise OutsideLimitReleaseSourceProject, 'Source project is not listed in OBS:LimitReleaseSourceProject attribute'
+    end
+
     # lock the scheduler
     target_project.suspend_scheduler(comment)
 

--- a/src/api/db/attribute_descriptions.rb
+++ b/src/api/db/attribute_descriptions.rb
@@ -32,7 +32,8 @@ def update_all_attrib_type_descriptions
     'EnforceRevisionsInRequests' => 'Enforce revisions in request actions',
     'CreatorCannotAcceptOwnRequests' => 'The creator and the accepter of a request cannot be the same person',
     'SkipChannelBranch' => 'Opt-Out creating channels in maintenance incidents',
-    'RejectBranch' => 'Reject branching of sources'
+    'RejectBranch' => 'Reject branching of sources',
+    'LimitReleaseSourceProject' => 'Limit to listed project names as source for any release operation'
   }
   d.keys.each do |k|
     at = ans.attrib_types.where(name: k).first

--- a/src/api/db/data/20220429123314_add_limit_release_source_project.rb
+++ b/src/api/db/data/20220429123314_add_limit_release_source_project.rb
@@ -1,0 +1,11 @@
+class AddLimitReleaseSourceProject < ActiveRecord::Migration[6.1]
+  def up
+    ans = AttribNamespace.first_or_create(name: 'OBS')
+    ans.attrib_types.where(name: 'LimitReleaseSourceProject').first_or_create
+  end
+
+  def down
+    ans = AttribNamespace.first_or_create(name: 'OBS')
+    ans.attrib_types.where(name: 'LimitReleaseSourceProject').delete
+  end
+end

--- a/src/api/lib/api_error.rb
+++ b/src/api/lib/api_error.rb
@@ -63,6 +63,10 @@ class PostRequestMissingParameter < APIError
   setup 403
 end
 
+class OutsideLimitReleaseSourceProject < APIError
+  setup 403
+end
+
 # 404 errors
 class NotFoundError < APIError
   setup 404

--- a/src/api/test/fixtures/attrib_types.yml
+++ b/src/api/test/fixtures/attrib_types.yml
@@ -149,3 +149,8 @@ OBS_RejectBranch:
   attrib_namespace_id: 9
   value_count: 1
   issue_list: 0
+OBS_LimitReleaseSourceProject:
+  id: 86
+  name: LimitReleaseSourceProject
+  attrib_namespace_id: 9
+  issue_list: 0

--- a/src/api/test/functional/attributes_test.rb
+++ b/src/api/test/functional/attributes_test.rb
@@ -32,7 +32,7 @@ class AttributeControllerTest < ActionDispatch::IntegrationTest
 
     get '/attribute/OBS'
     assert_response :success
-    count = 25
+    count = 26
     assert_xml_tag tag: 'directory', attributes: { count: count }
     assert_xml_tag children: { count: count }
     assert_xml_tag child: { tag: 'entry', attributes: { name: 'Maintained' } }
@@ -276,7 +276,7 @@ ription</description>
 
     get '/attribute/OBS'
     assert_response :success
-    count = 25
+    count = 26
     assert_xml_tag tag: 'directory', attributes: { count: count }
     assert_xml_tag children: { count: count }
     assert_xml_tag child: { tag: 'entry', attributes: { name: 'Maintained' } }

--- a/src/api/test/functional/source_controller_test.rb
+++ b/src/api/test/functional/source_controller_test.rb
@@ -2687,6 +2687,21 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     doc.root.attributes['name'] = 'home:Iggy:TEST'
     put '/source/home:Iggy:TEST/_meta', params: doc.to_s
     assert_response :success
+
+    # limit source via attribute, none allowed
+    post '/source/home:Iggy:TEST/_attribute', params: "
+        <attributes><attribute namespace='OBS' name='LimitReleaseSourceProject'>
+        </attribute></attributes>"
+    assert_response :success
+    post '/source/home:Iggy/TestPack?cmd=release&target_project=home:Iggy:TEST&repository=10.2&target_repository=10.2'
+    assert_response :forbidden
+    assert_xml_tag tag: 'status', attributes: { code: 'outside_limit_release_source_project' }
+    post '/source/home:Iggy:TEST/_attribute', params: "
+        <attributes><attribute namespace='OBS' name='LimitReleaseSourceProject'>
+          <value>home:Iggy</value>
+        </attribute></attributes>"
+    assert_response :success
+
     # but now it works for real
     post '/source/home:Iggy/TestPack?cmd=release&target_project=home:Iggy:TEST&repository=10.2&target_repository=10.2'
     assert_response :success


### PR DESCRIPTION
Introducing the new OBS:LimitReleaseSourceProject attribute which allows to list
accepted source project.

It has only an effect on projects atm.