### PR TITLE
[backend] write build config into _slsa_provenance.config

### DIFF
--- a/src/backend/bs_signer
+++ b/src/backend/bs_signer
@@ -506,10 +506,14 @@ sub signslaprovenance {
   }
   if ($signfile =~ /\/_slsa_provenance.json$/) {
     # also send the config if we have one
-    my $buildinfo = readxml("$jobdir/_buildenv", $BSXML::buildinfo, 1) || {};
-    if ($buildinfo->{'config'}) {
-      my $digest = Digest::SHA::sha256_hex($buildinfo->{'config'});
-      $todo{'_config'}->{$digest} = $buildinfo->{'config'};
+    my $config = readstr("$jobdir/_slsa_provenance.config", 1);
+    if (!defined $config) {
+      my $buildinfo = readxml("$jobdir/_buildenv", $BSXML::buildinfo, 1) || {};
+      $config = $buildinfo->{'config'};
+    }
+    if (defined($config)) {
+      my $digest = Digest::SHA::sha256_hex($config);
+      $todo{'_config'}->{$digest} = $config;
     }
   }
   

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -3482,6 +3482,7 @@ sub dobuild {
     $config = BSRPC::rpc("$server/getconfig", undef, "project=$projid", "repository=$repoid", @configpath);
     $config = Build::combine_configs($config, "Macros:\n$buildinfo->{'modularity_macros'}") if $buildinfo->{'modularity_macros'};
   }
+  $buildinfo->{'slsa_provenance_config'} = $config if $buildinfo->{'slsaprovenance'};
   $buildinfo->{'outbuildinfo'}->{'config'} = $config;
   writestr("$buildroot/.build.config", undef, $config);
   add_slsa_materials_config($buildinfo, "$projid/$repoid", $config);
@@ -4454,10 +4455,11 @@ if ($ex == 0) {
   @send = map {{name => (split('/', $_))[-1], filename => $_}} @send;
   @send = grep {$_->{'name'} ne '_generated_buildreqs'} @send;
 
-  @send = grep {$_->{'name'} !~ /slsa_provenance.json$/} @send;
+  @send = grep {$_->{'name'} !~ /slsa_provenance.(?:json|config)$/} @send;
   if ($buildinfo->{'slsaprovenance'}) {
     my $slsa_provenance = generate_slsa_provenance_statement($buildinfo, \@send);
     push @send, { 'name' => '_slsa_provenance.json', 'data' => $slsa_provenance };
+    push @send, { 'name' => '_slsa_provenance.config', 'data' => $buildinfo->{'slsa_provenance_config'}} if $buildinfo->{'slsa_provenance_config'};
   }
   
   if ($kiwitree) {


### PR DESCRIPTION
Getting the config from the _buildenv is too flaky. We currently
do not write a buildenv file for some build types and the
xml roundtrip makes me nervous.