### PR TITLE
Instrument EventSubscription save operation

### DIFF
--- a/src/api/app/models/event_subscription.rb
+++ b/src/api/app/models/event_subscription.rb
@@ -57,7 +57,7 @@ class EventSubscription < ApplicationRecord
     end
   }
 
-  after_save :track_event_subscription_enabled, if: :saved_change_to_enabled?
+  after_save :track_event_subscription_saved
 
   def self.receiver_roles_to_display(user)
     roles = RECEIVER_ROLE_TEXTS.keys
@@ -103,9 +103,9 @@ class EventSubscription < ApplicationRecord
     channels.keys.reject { |channel| channel == 'disabled' || channel.in?(INTERNAL_ONLY_CHANNELS) }
   end
 
-  def track_event_subscription_enabled
+  def track_event_subscription_saved
     RabbitmqBus.send_to_bus('metrics',
-                            "event_subscription.enabled,event_type=#{eventtype},channel=#{channel} value=1")
+                            "event_subscription.event,event_type=#{eventtype},receiver_role=#{receiver_role},enabled=#{enabled},user=#{user},channel=#{channel} value=1")
   end
 end
 

--- a/src/api/spec/models/event_subscription_spec.rb
+++ b/src/api/spec/models/event_subscription_spec.rb
@@ -5,15 +5,22 @@ RSpec.describe EventSubscription, type: :model do
     let(:user) { create(:confirmed_user, :with_home, login: 'cameron') }
     let(:token) { create(:workflow_token, user: user) }
 
+    let(:channel) { 'scm' }
     let!(:target_project) { create(:project, name: 'test-target-project:openSUSE:open-build-service:PR-4', maintainer: user) }
     let!(:target_package) { create(:package, name: 'test-target-package', project: target_project) }
 
     let(:event_type) { 'Event::BuildFail' }
 
-    let(:event_subscription) { EventSubscription.create!(channel: 'scm', token: token, receiver_role: 'maintainer', eventtype: event_type, package: target_package) }
+    let(:event_enabled) { true }
+
+    let!(:event_subscription) do
+      EventSubscription.create!(channel: channel, token: token, receiver_role: 'maintainer', eventtype: event_type, package: target_package, user: user, enabled: event_enabled)
+    end
+
+    let(:expected_instrumentation) { "event_subscription.event,event_type=#{event_type},receiver_role=maintainer,enabled=#{event_enabled},user=#{user},channel=#{channel} value=1" }
 
     before do
-      allow(RabbitmqBus).to receive(:send_to_bus).with('metrics', "event_subscription.enabled,event_type=#{event_type},channel=scm value=1")
+      allow(RabbitmqBus).to receive(:send_to_bus).with('metrics', expected_instrumentation)
     end
 
     describe '#enabled was changed' do
@@ -23,18 +30,21 @@ RSpec.describe EventSubscription, type: :model do
 
       it do
         event_subscription.save
-        expect(RabbitmqBus).to have_received(:send_to_bus).with('metrics', "event_subscription.enabled,event_type=#{event_type},channel=scm value=1")
+        expect(RabbitmqBus).to have_received(:send_to_bus).with('metrics', expected_instrumentation)
       end
     end
 
     describe '#enabled wasnt changed' do
+      let(:channel) { 'disabled' }
+      let(:event_enabled) { false }
+
       before do
-        event_subscription.channel = 'disabled'
+        event_subscription.channel = channel
       end
 
       it do
         event_subscription.save
-        expect(RabbitmqBus).not_to have_received(:send_to_bus).with('metrics', "event_subscription.enabled,event_type=#{event_type},channel=scm value=1")
+        expect(RabbitmqBus).to have_received(:send_to_bus).with('metrics', expected_instrumentation)
       end
     end
   end


### PR DESCRIPTION
To be able to instrument different fields in the `EventSubscription`, I had to remove the instrumentation done in the PR #12494 and went with a more generic approach. 