### PR TITLE
[dist] improve error handling for signer cert generation

### DIFF
--- a/dist/functions.setup-appliance.sh
+++ b/dist/functions.setup-appliance.sh
@@ -680,7 +680,7 @@ function create_sign_cert {
   echo "Starting create_sign_cert"
   if [ -f "$backenddir/obs-default-gpg.asc" -a ! -f "$backenddir/obs-default-gpg.cert" ];then
     echo "Creating new signer cert"
-    GNUPGHOME="$backenddir/gnupg" sign --test-sign $SIGND_BIN -C $backenddir/obs-default-gpg.asc > $backenddir/obs-default-gpg.cert
+    GNUPGHOME="$backenddir/gnupg" sign --test-sign $SIGND_BIN -C $backenddir/obs-default-gpg.asc > $backenddir/obs-default-gpg.cert || exit 1
   else
     echo "Skipping new signer cert"
   fi


### PR DESCRIPTION
without this patch /srv/obs/obs-default-gpg.cert is only a empty file if cert generation fails (eg. if the gpg key has no expiry date).

To avoid confusion and make debugging easier, setup-appliance.sh exit with an error if creating the cert fails