### PR TITLE
[backend] unlink old provenance files when spreading new ones

### DIFF
--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -7565,7 +7565,7 @@ my $dispatches = [
 
   # slsa
   'POST:/slsa cmd=addrefs $prpa' => \&slsa_addrefs,
-  '/slsa/$project/$repsitory/$arch/$filename/$digest: view:?' => \&slsa_getfile,
+  '/slsa/$project/$repository/$arch/$filename/$digest: view:?' => \&slsa_getfile,
 
   '/ajaxstatus' => \&getajaxstatus,
   '/serverstatus' => \&BSStdServer::serverstatus,

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -1906,6 +1906,7 @@ sub getbinaries_kiwiproduct {
 	next unless $rpm =~ /(.*)\.rpm$/;
 	next if $rpm =~ /\/::import::/;
 	next if $provenance{"$1.slsa_provenance.json"};
+	unlink("$ddir/$1.slsa_provenance.json");
 	link("$ddir/_slsa_provenance/_slsa_provenance.json", "$ddir/$1.slsa_provenance.json") || die("link $ddir/_slsa_provenance/_slsa_provenance.json $ddir/$1.slsa_provenance.json: $!\n");
 	$kiwiorigins->{"obs://$prp/$1.slsa_provenance.json"} = $prpap;
       }


### PR DESCRIPTION
We may have multiple rpms (like src rpms) going into the same
place, so we need to replace the old provenance files.