### PR TITLE
[dist] use psmisc (pgrep/pkill) in obsscheduler script

### DIFF
--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -225,6 +225,8 @@ Requires:       user(obsservicerun)
 Requires:       zstd
 # needed for optional sqlite databases, which are default for new installations
 Requires:     perl-DBD-SQLite
+# psmisc for obsscheduler script
+Requires:       psmisc
 
 Obsoletes:      obs-productconverter < 2.9
 Obsoletes:      obs-source_service < 2.9

--- a/dist/obsscheduler
+++ b/dist/obsscheduler
@@ -52,16 +52,16 @@ case "$1" in
 		done
 	;;
 	stop)
-		if checkproc bs_sched; then
+		if pgrep bs_sched >/dev/null ; then
 			for i in $OBS_SCHEDULER_ARCHITECTURES; do
 			 	$obsdir/bs_admin --shutdown-scheduler "$i"
 			done
 			for i in `seq 600`; do
-				checkproc bs_sched || break
+				pgrep bs_sched >/dev/null || break
 			        sleep 1
 			done
-			if checkproc bs_sched ; then
-				killall bs_sched
+			if pgrep bs_sched >/dev/null ; then
+				pkill bs_sched >/dev/null
 			fi
 		fi
 	;;


### PR DESCRIPTION
and add the proper dependency in obs-server package
(before we were silently relying on sysvinit-tools present)