### PR TITLE
Tackle pundit deprecation warning

### DIFF
--- a/src/api/app/controllers/application_controller.rb
+++ b/src/api/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@
 require 'api_error'
 
 class ApplicationController < ActionController::Base
-  include Pundit
+  include Pundit::Authorization
   protect_from_forgery
 
   include ActionController::ImplicitRender

--- a/src/api/app/controllers/trigger_controller.rb
+++ b/src/api/app/controllers/trigger_controller.rb
@@ -3,8 +3,6 @@ class TriggerController < ApplicationController
 
   ALLOWED_GITLAB_EVENTS = ['Push Hook', 'Tag Push Hook', 'Merge Request Hook'].freeze
 
-  include Pundit
-
   # Authentication happens with tokens, so extracting the user is not required
   skip_before_action :extract_user
   # Authentication happens with tokens, so no login is required

--- a/src/api/app/controllers/webui/users/token_triggers_controller.rb
+++ b/src/api/app/controllers/webui/users/token_triggers_controller.rb
@@ -1,5 +1,4 @@
 class Webui::Users::TokenTriggersController < Webui::WebuiController
-  include Pundit
   include Triggerable
 
   before_action :set_token

--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -6,7 +6,7 @@ class Webui::WebuiController < ActionController::Base
 
   Rails.cache.set_domain if Rails.cache.respond_to?(:set_domain)
 
-  include Pundit
+  include Pundit::Authorization
   include FlipperFeature
   include Webui::RescueHandler
   include SetCurrentRequestDetails


### PR DESCRIPTION
Pundit currently throws the following deprecation warning:
`DEPRECATION WARNING: 'include Pundit' is deprecated. Please use
'include Pundit::Authorization' instead.`