### PR TITLE
Switch back to rake 13.0.1

### DIFF
--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -324,7 +324,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
     rainbow (3.0.0)
-    rake (13.0.6)
+    rake (13.0.1)
     rantly (2.0.0)
     rbtree (0.4.2)
     rdoc (6.1.1)


### PR DESCRIPTION
The update of rake in https://github.com/openSUSE/open-build-service/pull/12530
was not required. Let stick to the previous version.