### PR TITLE
Add link to remove watchlist items

### DIFF
--- a/src/api/app/components/watched_items_list_component.html.haml
+++ b/src/api/app/components/watched_items_list_component.html.haml
@@ -3,19 +3,29 @@
   - @items.each do |item|
     - case @class_name
       - when 'Package'
-        = link_to(package_show_path(item.project, item), class: 'text-word-break-all') do
-          %i.fas.fa-archive.mr-1
-          #{item.project}/#{item}
+        .d-flex.flex-row.flex-wrap.align-items-baseline
+          = link_to(package_show_path(item.project, item), class: 'text-word-break-all') do
+            %i.fas.fa-archive.mr-1
+            #{item.project}/#{item}
+          = link_to(project_package_toggle_watched_item_path(project_name: item.project.name, package_name: item.name),
+                    method: :put,
+                    class: 'text-light ml-auto') do
+            %i.fa.fa-times-circle
       - when 'Project'
-        = link_to(project_show_path(item), class: 'text-word-break-all') do
-          %i.fas.fa-cubes.mr-1
-          #{item}
+        .d-flex.flex-row.flex-wrap.align-items-baseline
+          = link_to(project_show_path(item), class: 'text-word-break-all') do
+            %i.fas.fa-cubes.mr-1
+            #{item}
+          = link_to(project_toggle_watched_item_path(project_name: item.name), method: :put, class: 'text-light ml-auto') do
+            %i.fa.fa-times-circle
       - when 'BsRequest'
         .d-flex.flex-row.flex-wrap.align-items-baseline.collapsible-tooltip-parent
           = link_to(request_show_path(item.number), class: 'text-word-break-all') do
             = image_tag('icons/request-icon.svg', height: 18, class: 'mr-1 color-inverted')
             = "##{item.number} #{helpers.request_type_of_action(item)}"
           %i.fa.fa-question-circle.text-light.px-2.collapsible-tooltip{ title: 'Click to keep it open' }
+          = link_to(toggle_watched_item_request_path(number: item.number), method: :put, class: 'text-light ml-auto') do
+            %i.fa.fa-times-circle
         .extended-info.mt-2.mb-3.collapsed
           .triangle.left
           .extended-info-content


### PR DESCRIPTION
This allows removing any item in the watchlist without having to visit the item page first.

For now, the removal is working without Ajax and without removal confirmation.

![Screenshot 2022-05-05 at 15-06-44 Open Build Service](https://user-images.githubusercontent.com/2581944/166929261-c98d5f4f-983c-447e-9063-a651c59aa6b3.png)

