### PR TITLE
Prevent from updating architectures when retrieving workers' status

### DIFF
--- a/src/api/app/models/worker_status.rb
+++ b/src/api/app/models/worker_status.rb
@@ -68,8 +68,6 @@ class WorkerStatus
 
     architecture_name = daemon.attributes['arch'].value
 
-    daemon_architecture(architecture_name)
-
     ['high', 'next', 'med', 'low'].each do |key|
       s_key = squeue_key([key, architecture_name])
       add_squeue(s_key, queue.attributes[key].value)
@@ -82,10 +80,6 @@ class WorkerStatus
 
   def generic_key_generation(key_parts)
     key_parts.join('_')
-  end
-
-  def daemon_architecture(arch_name)
-    Architecture.unavailable.find_by(name: arch_name).try(:update, available: true)
   end
 
   def parse_worker_infos(wdata)

--- a/src/api/spec/models/worker_status_spec.rb
+++ b/src/api/spec/models/worker_status_spec.rb
@@ -113,15 +113,5 @@ RSpec.describe WorkerStatus do
     subject { WorkerStatus.new.save }
 
     it { expect { subject }.to change(StatusHistory, :count).from(0).to(23) }
-
-    context 'it change the Architecture to active' do
-      before do
-        Architecture.available.update(available: false)
-      end
-
-      it { expect(Architecture.available).to be_empty }
-      it { expect(Architecture.unavailable).not_to be_empty }
-      it { expect { subject }.to change { Architecture.available.count }.by(3) }
-    end
   end
 end


### PR DESCRIPTION
For modifying the availability of architectures we could use instead the `PUT /configuration` endpoint, or the Web UI page under `Configuration -> Architectures`.

Fixes #9523, fixes #10358, and fixes #11660.