### PR TITLE
WIP: Prevent code 500 on packages received through an scmsync

### DIFF
--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -164,7 +164,10 @@ class Package < ApplicationRecord
     prj = internal_get_project(project)
     return unless prj # remote prjs
 
-    return nil if prj.scmsync.present?
+    if prj.scmsync.present?
+      raise UnknownObjectError, "Package sources for project #{prj.name} are received through scmsync.
+                                 This is not yet supported by the OBS frontend"
+    end
 
     if pkg.nil? && opts[:follow_project_links]
       pkg = prj.find_package(package, opts[:check_update_project])


### PR DESCRIPTION
We currently receive exceptions in errbit due to packages
that are received through projects that use scmsync.
Those packages are not known by the OBS frontend and set
to `nil`. This crashes in the package#show view, since the code
tries to access package properties on the the nil object.
Therefore we should throw an exception instead of setting
the package to nil.

Fixes #12552

WIP: Failing specs, need to check...