### PR TITLE
Avoid code 500 on packages received through an scmsync for package show

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -68,6 +68,14 @@ class Webui::PackageController < Webui::WebuiController
   end
 
   def show
+    # FIXME: Remove this statement when scmsync is fully supported
+    if @project.scmsync.present?
+      flash[:error] = "Package sources for project #{@project.name} are received through scmsync.
+                       This is not yet fully supported by the OBS frontend"
+      redirect_back(fallback_location: project_show_path(@project))
+      return
+    end
+
     if @spider_bot
       params.delete(:rev)
       params.delete(:srcmd5)


### PR DESCRIPTION
We currently receive exceptions in errbit due to packages
that are received through projects that use scmsync.
Those packages are not known by the OBS frontend and set
to `nil`. This crashes in the package#show view, since the code
tries to access package properties on the the nil object.
This is a temporary fix to avoid exceptions in errbit due to
packages tried being accessed through the webui.

Fixes #12552