### PR TITLE
Handle emails for Relationship events

### DIFF
--- a/src/api/app/views/event_mailer/relationship_create.html.haml
+++ b/src/api/app/views/event_mailer/relationship_create.html.haml
@@ -1,0 +1,7 @@
+:ruby
+  url = if event['package']
+          link_to("#{event['project']}/#{event['package']}", package_users_url(event['project'], event['package'], only_path: false, host: @host))
+        else
+          link_to(event['project'], project_users_url(event['project'], only_path: false, host: @host))
+        end
+#{event['who']} made you #{event['role']} of #{url}.

--- a/src/api/app/views/event_mailer/relationship_create.text.erb
+++ b/src/api/app/views/event_mailer/relationship_create.text.erb
@@ -1,0 +1,10 @@
+<% target_object, url = if event['package']
+    ["#{event['project']}/#{event['package']}",
+     url_for(controller: 'webui/package', action: :users, project: event['project'], package: event['package'], only_path: false, host: @host)]
+  else
+    [event['project'],
+     url_for(controller: 'webui/project', action: :users, project: event['project'], only_path: false, host: @host)]
+  end
+-%>
+<%= "#{event['who']} made you #{event['role']} of #{target_object}" %>
+Visit <%= url %>.

--- a/src/api/app/views/event_mailer/relationship_delete.html.haml
+++ b/src/api/app/views/event_mailer/relationship_delete.html.haml
@@ -1,0 +1,7 @@
+:ruby
+  url = if event['package']
+          link_to("#{event['project']}/#{event['package']}", package_users_url(event['project'], event['package'], only_path: false, host: @host))
+        else
+          link_to(event['project'], project_users_url(event['project'], only_path: false, host: @host))
+        end
+#{event['who']} removed you as #{event['role']} of #{url}.

--- a/src/api/app/views/event_mailer/relationship_delete.text.erb
+++ b/src/api/app/views/event_mailer/relationship_delete.text.erb
@@ -1,0 +1,10 @@
+<% target_object, url = if event['package']
+  ["#{event['project']}/#{event['package']}",
+   url_for(controller: 'webui/package', action: :users, project: event['project'], package: event['package'], only_path: false, host: @host)]
+else
+  [event['project'],
+   url_for(controller: 'webui/project', action: :users, project: event['project'], only_path: false, host: @host)]
+end
+-%>
+<%= "#{event['who']} removed you as #{event['role']} of #{target_object}." %>
+Visit <%= url %>.

--- a/src/api/spec/factories/event_subscriptions.rb
+++ b/src/api/spec/factories/event_subscriptions.rb
@@ -61,5 +61,21 @@ FactoryBot.define do
       user
       group { nil }
     end
+
+    factory :event_subscription_relationship_create do
+      eventtype { 'Event::RelationshipCreate' }
+      receiver_role { 'any_role' }
+      channel { :instant_email }
+      user
+      group { nil }
+    end
+
+    factory :event_subscription_relationship_delete do
+      eventtype { 'Event::RelationshipDelete' }
+      receiver_role { 'any_role' }
+      channel { :instant_email }
+      user
+      group { nil }
+    end
   end
 end


### PR DESCRIPTION
Follow up on #12470 

After introducing a new type of event, we need to make it work for email channel as well.