### PR TITLE
Pin strscan gem version to 3.0.1

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -105,6 +105,9 @@ gem 'rexml'
 # see https://github.com/prawnpdf/prawn/commit/3658d5125c3b20eb11484c3b039ca6b89dc7d1b7
 gem 'matrix', '~> 0.4'
 
+# until we have a fix for https://github.com/rubygems/rubygems/pull/5529
+gem 'strscan', '3.0.1'
+
 group :development, :production do
   # to have the delayed job daemon
   gem 'daemons'

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -619,6 +619,7 @@ DEPENDENCIES
   simplecov
   single_test
   strong_migrations
+  strscan (= 3.0.1)
   test-unit
   thinking-sphinx
   timecop


### PR DESCRIPTION
In order to avoid conflicts between the by bundler activated
stdlib `strscan` version and the one defined by the Gemfile
until https://github.com/rubygems/rubygems/pull/5529 is merged.