### PR TITLE
Fix ambiguity of OpenOffice issue tracker

### DIFF
--- a/docs/api/api/issue_trackers.xml
+++ b/docs/api/api/issue_trackers.xml
@@ -165,7 +165,7 @@
     <description>OpenOffice.org Bugzilla</description>
     <url>http://openoffice.org/bugzilla/</url>
     <show-url>http://openoffice.org/bugzilla/show_bug.cgi?id=@@@</show-url>
-    <regex>i#(\d+)</regex>
+    <regex>[(\s]i#(\d+)</regex>
     <label>i#@@@</label>
     <enable-fetch>false</enable-fetch>
   </issue-tracker>

--- a/src/api/db/seeds.rb
+++ b/src/api/db/seeds.rb
@@ -272,7 +272,7 @@ IssueTracker.where(name: 'ITS').first_or_create(description: 'OpenLDAP Issue Tra
                                                 show_url: 'http://www.openldap.org/its/index.cgi/Contrib?id=@@@')
 IssueTracker.where(name: 'i').first_or_create(description: 'OpenOffice.org Bugzilla',
                                               kind: 'bugzilla',
-                                              regex: 'i#(\d+)',
+                                              regex: '[(\s]i#(\d+)',
                                               url: 'http://openoffice.org/bugzilla/',
                                               label: 'boost#@@@',
                                               show_url: 'http://openoffice.org/bugzilla/show_bug.cgi?id=@@@')

--- a/src/api/test/fixtures/issue_trackers.yml
+++ b/src/api/test/fixtures/issue_trackers.yml
@@ -159,7 +159,7 @@ issue_trackers_39:
   description: OpenOffice.org Bugzilla
   url: http://openoffice.org/bugzilla/
   show_url: http://openoffice.org/bugzilla/show_bug.cgi?id=@@@
-  regex: [(\s]i#(\d+)
+  regex: '[(\s]i#(\d+)'
   label: '@@@'
   issues_updated: 2011-07-29 14:00:21.000000000 Z
   enable_fetch: 0

--- a/src/api/test/fixtures/issue_trackers.yml
+++ b/src/api/test/fixtures/issue_trackers.yml
@@ -159,7 +159,7 @@ issue_trackers_39:
   description: OpenOffice.org Bugzilla
   url: http://openoffice.org/bugzilla/
   show_url: http://openoffice.org/bugzilla/show_bug.cgi?id=@@@
-  regex: i#(\d+)
+  regex: [(\s]i#(\d+)
   label: '@@@'
   issues_updated: 2011-07-29 14:00:21.000000000 Z
   enable_fetch: 0


### PR DESCRIPTION
The actual OpenOffice issue tracer label must be proceeded by round
bracket `(` or whitespace. Otherwise it can be confused with GitHub
isseu like here:

https://build.opensuse.org/request/show/976545

`gh#uyuni-project/uyuni#5418` gets resolved to:

[gh#uyuni-project/uyuni#5418](https://github.com/uyuni-project/uyuni/issues/5418)
[i#5418](http://openoffice.org/bugzilla/show_bug.cgi?id=5418)