### PR TITLE
Fix metrics for notifications

### DIFF
--- a/src/api/app/models/notification.rb
+++ b/src/api/app/models/notification.rb
@@ -54,9 +54,11 @@ class Notification < ApplicationRecord
                             "notification.create,notifiable_type=#{notifiable_type},web=#{web},rss=#{rss} value=1")
   end
 
+  # This is only called when the request come from the API. The UI performs 'update_all' that does not trigger callbacks.
+  # This metrics complements the same metrics tracked in Webui::Users::NotificationsController#send_notifications_information_rabbitmq
   def track_notification_delivered
     RabbitmqBus.send_to_bus('metrics',
-                            "notification.delivered,notifiable_type=#{notifiable_type},web=#{web},rss=#{rss} value=1")
+                            "notification,action=#{delivered ? 'read' : 'unread'} value=1")
   end
 end
 

--- a/src/api/spec/models/notification_spec.rb
+++ b/src/api/spec/models/notification_spec.rb
@@ -68,31 +68,31 @@ RSpec.describe Notification do
 
   describe 'Instrumentation' do
     let!(:test_user) { create(:confirmed_user, login: 'foo') }
-    let!(:rss_notification) { create(:rss_notification, subscriber: test_user) }
+    let!(:web_notification) { create(:web_notification, subscriber: test_user) }
 
     before do
-      allow(RabbitmqBus).to receive(:send_to_bus).with('metrics', 'notification.delivered,notifiable_type=,web=false,rss=true value=1')
+      allow(RabbitmqBus).to receive(:send_to_bus).with('metrics', 'notification,action=read value=1')
     end
 
     context 'if delivered change, we should track it' do
       before do
-        rss_notification.delivered = true
+        web_notification.delivered = true
       end
 
       it do
-        rss_notification.save
-        expect(RabbitmqBus).to have_received(:send_to_bus).with('metrics', 'notification.delivered,notifiable_type=,web=false,rss=true value=1')
+        web_notification.save
+        expect(RabbitmqBus).to have_received(:send_to_bus).with('metrics', 'notification,action=read value=1')
       end
     end
 
-    context 'if delivered doe not change, we should not track it' do
+    context 'if delivered does not change, we should not track it' do
       before do
-        rss_notification.title = 'FOO FOO'
+        web_notification.title = 'FOO FOO'
       end
 
       it do
-        rss_notification.save
-        expect(RabbitmqBus).not_to have_received(:send_to_bus).with('metrics', 'notification.delivered,notifiable_type=,web=false,rss=true value=1')
+        web_notification.save
+        expect(RabbitmqBus).not_to have_received(:send_to_bus).with('metrics', 'notification,action=read value=1')
       end
     end
   end


### PR DESCRIPTION
We want to track the notifications that were delivered (marked as read), not those that changed the 'delivered' field to any value. That's why the instrumentation needed to be adapted.

We now have to perform two bulk updates to be able to distinguish the notifications that are marked as read and those marked as unread.

Please read the commits descriptions for more details.