### PR TITLE
Introduce tags for notification counts

### DIFF
--- a/src/api/app/jobs/measurements_job.rb
+++ b/src/api/app/jobs/measurements_job.rb
@@ -6,7 +6,7 @@ class MeasurementsJob < ApplicationJob
 
     RabbitmqBus.send_to_bus('metrics', "group count=#{Group.count}")
     RabbitmqBus.send_to_bus('metrics', "user #{measurements_to_fields(users_measurements)}")
-    RabbitmqBus.send_to_bus('metrics', "notification #{measurements_to_fields(notifications_measurements)}")
+    notifications_measurements
   end
 
   private
@@ -40,14 +40,19 @@ class MeasurementsJob < ApplicationJob
   end
 
   def notifications_measurements
-    {
-      count: Notification.count,
-      for_web: Notification.for_web.count,
-      for_rss: Notification.for_rss.count,
-      read: NotificationsFinder.new.read.count,
-      unread: NotificationsFinder.new.unread.count,
-      about_comments: Notification.where(notifiable_type: 'Comment').count,
-      about_requests: Notification.where(notifiable_type: 'BsRequest').count
-    }
+    RabbitmqBus.send_to_bus('metrics', "notification_count,channel=web value=#{Notification.for_web.count}")
+    RabbitmqBus.send_to_bus('metrics', "notification_count,channel=rss value=#{Notification.for_rss.count}")
+
+    Notification.group(:subscriber_type).count.each do |type|
+      RabbitmqBus.send_to_bus('metrics', "notification_count,subscriber=#{type.first} value=#{type.second}")
+    end
+
+    Notification.group(:delivered).count.each do |type|
+      RabbitmqBus.send_to_bus('metrics', "notification_count,delivered=#{type.first} value=#{type.second}")
+    end
+
+    Notification.group(:notifiable_type).count.each do |type|
+      RabbitmqBus.send_to_bus('metrics', "notification_count,notifiable=#{type.first} value=#{type.second}")
+    end
   end
 end


### PR DESCRIPTION
We only used fields so far which makes it very hard/slow to query.
Tags are also way easier to mix/match in queries.