### PR TITLE
Rename event_subscription measurement

### DIFF
--- a/src/api/app/models/event_subscription.rb
+++ b/src/api/app/models/event_subscription.rb
@@ -58,7 +58,7 @@ class EventSubscription < ApplicationRecord
     end
   }
 
-  after_save :track_event_subscription_saved
+  after_save :measure_changes
 
   def self.receiver_roles_to_display(user)
     roles = RECEIVER_ROLE_TEXTS.keys
@@ -104,9 +104,13 @@ class EventSubscription < ApplicationRecord
     channels.keys.reject { |channel| channel == 'disabled' || channel.in?(INTERNAL_ONLY_CHANNELS) }
   end
 
-  def track_event_subscription_saved
+  def measure_changes
     RabbitmqBus.send_to_bus('metrics',
-                            "event_subscription.event,event_type=#{eventtype},receiver_role=#{receiver_role},enabled=#{enabled},user=#{user},channel=#{channel} value=1")
+                            "event_subscription,
+                             event_type=#{eventtype},
+                             enabled=#{enabled},
+                             receiver_role=#{receiver_role},
+                             channel=#{channel} value=1")
   end
 end
 


### PR DESCRIPTION
We are measuring changes to this table, not events.

Also: Stop using user tags.