### PR TITLE
[api] support request approve in new state

### DIFF
--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -21,6 +21,8 @@ class BsRequest < ApplicationRecord
 
   OBSOLETE_STATES = [:declined, :superseded, :revoked].freeze
 
+  APPROVABLE_STATES = [:new, :review].freeze
+
   ACTION_NOTIFY_LIMIT = 50
 
   scope :to_accept_by_time, -> { where(state: ['new', 'review']).where('accept_at < ?', Time.now) }
@@ -636,7 +638,7 @@ class BsRequest < ApplicationRecord
   end
 
   def approval_handling(new_approver, opts)
-    raise InvalidStateError, 'request is not in review state' unless state == :review
+    raise InvalidStateError, "request is not in an approvable (#{APPROVABLE_STATES.to_sentence}) state" unless APPROVABLE_STATES.include?(state)
 
     # check if User.session! is allowed to potentially accept the request
     # (note: setting the :force key to true will skip some checks but
@@ -648,6 +650,9 @@ class BsRequest < ApplicationRecord
 
     self.approver = new_approver
     save!
+
+    # already all reviews done?
+    auto_accept if state == :new
   end
   private :approval_handling
 


### PR DESCRIPTION
This avoids necessary checking and possible races when doing the final
approve of a request. Accepting an approve and triggering the request
accept in case all reviews are done already directly