### PR TITLE
Fix event_subscription measurements

### DIFF
--- a/src/api/app/models/event_subscription.rb
+++ b/src/api/app/models/event_subscription.rb
@@ -106,11 +106,7 @@ class EventSubscription < ApplicationRecord
 
   def measure_changes
     RabbitmqBus.send_to_bus('metrics',
-                            "event_subscription,
-                             event_type=#{eventtype},
-                             enabled=#{enabled},
-                             receiver_role=#{receiver_role},
-                             channel=#{channel} value=1")
+                            "event_subscription,event_type=#{eventtype},enabled=#{enabled},receiver_role=#{receiver_role},channel=#{channel} value=1")
   end
 end
 


### PR DESCRIPTION
Strings are not hashes. The [influx line protocol](https://docs.influxdata.com/influxdb/v2.2/reference/syntax/line-protocol/) expects a string in a very certain format.