### PR TITLE
Catch Octokit::BadGateway and Octokit::UnprocessableEntity exception

### DIFF
--- a/src/api/app/services/scm_exception_handler.rb
+++ b/src/api/app/services/scm_exception_handler.rb
@@ -23,7 +23,9 @@ class SCMExceptionHandler
               Octokit::InvalidRepository,
               Octokit::PathDiffTooLarge,
               Octokit::ServiceUnavailable,
-              Octokit::InternalServerError do |exception|
+              Octokit::InternalServerError,
+              Octokit::UnprocessableEntity,
+              Octokit::BadGateway do |exception|
     log_to_workflow_run(exception, 'GitHub') if @workflow_run.present?
   end
 


### PR DESCRIPTION
Those exception were not catched yet, translating them to something
meaningful will be part of another PR.