### PR TITLE
Catch Gitlab::Error::BadRequest in SCMExceptionHandler

### DIFF
--- a/src/api/app/services/scm_exception_handler.rb
+++ b/src/api/app/services/scm_exception_handler.rb
@@ -34,7 +34,8 @@ class SCMExceptionHandler
               Gitlab::Error::NotFound,
               Gitlab::Error::ServiceUnavailable,
               Gitlab::Error::TooManyRequests,
-              Gitlab::Error::Unauthorized do |exception|
+              Gitlab::Error::Unauthorized,
+              Gitlab::Error::BadRequest do |exception|
     log_to_workflow_run(exception, 'GitLab') if @workflow_run.present?
   end
 


### PR DESCRIPTION
This exception was not catched yet, translating it to something
meaningful will be part of another PR.