### PR TITLE
Fix LDAP groups

### DIFF
--- a/src/api/app/models/user_ldap_strategy.rb
+++ b/src/api/app/models/user_ldap_strategy.rb
@@ -288,7 +288,7 @@ class UserLdapStrategy
     group = (group.is_a?(String) ? Group.find_by_title(group) : group)
 
     begin
-      render_grouplist_ldap([group], user).any?
+      UserLdapStrategy.render_grouplist_ldap([group], user).any?
     rescue Exception
       Rails.logger.info 'Error occurred in searching user_group in ldap.'
       false
@@ -367,7 +367,7 @@ class UserLdapStrategy
     relationships.each do |relationship|
       return false if relationship.group.nil?
       # check whether current user is in this group
-      return true if user_in_group_ldap?(login, relationship.group)
+      return true if user_in_group_ldap?(User.session, relationship.group)
     end
 
     Rails.logger.info "Failed with #{method_name}"

--- a/src/api/app/models/user_ldap_strategy.rb
+++ b/src/api/app/models/user_ldap_strategy.rb
@@ -83,7 +83,7 @@ class UserLdapStrategy
       end
       user_dn = ''
       user_memberof_attr = ''
-      ldap_con.search(CONFIG['ldap_search_base'], LDAP::LDAP_SCOPE_SUBTREE, filter) do |entry|
+      ldap_con.search(CONFIG['ldap_search_base'], LDAP::LDAP_SCOPE_SUBTREE, filter, [CONFIG['ldap_user_memberof_attr']]) do |entry|
         user_dn = entry.dn
         if CONFIG['ldap_user_memberof_attr'].in?(entry.attrs)
           user_memberof_attr = entry.vals(CONFIG['ldap_user_memberof_attr'])


### PR DESCRIPTION
It seems the LDAP group feature is not heavily used, for me at least it always produced exceptions and I had to tinker with `api/app/models/user_ldap_strategy.rb` a bit to get it working. Note that I have absolutely no Ruby experience, so feel free to take this PR as a mere suggestion on how to potentially fix that feature.


Commit db20774368 fixes what seems to be actual errors with Ruby's scoping rules, but I am of course not sure. Without those, I at least always got errors of this kind:
```
[2022-05-18T11:56:15.549185 #17847] FATAL -- : [690f9afb-ffeb-470b-80ed-4e70254f4820] [17847:2752.05] ActionView::Template::Error (undefined local variable or method `login' for #<UserLdapStrategy:0x0000557bc522e9d0>
```
due to the missing `@` sigil for the (instance?) variable `login`, apparently.

Also,
```
E, [2022-05-10T13:13:57.737533 #3434] ERROR -- : [3434:29.02] Exception: undefined method `render_grouplist_ldap' for #<UserLdapStrategy:0x0000558e51f26450>
```
for the missing `UserLdapStrategy.`. Let me know if this is in any way the proper way to fix those.


The other commit, 865ae51e6d, fixes an issue when interacting with OpenLDAP, where some "operational" attributes are apparently not returned for an unqualified query for all attributes. You have to explicitly ask for them. The fix is to always ask for the configured `CONFIG['ldap_user_memberof_attr']` attribute, I believe this should be harmless and possible for all LDAP backends (but I have not tested this with an AD setup, for example).

Let me know if these suggestions help you, kind regards,
  Lorenz