### PR TITLE
Show the scm status request response in the workflow run

### DIFF
--- a/src/api/app/components/workflow_run_detail_component.html.haml
+++ b/src/api/app/components/workflow_run_detail_component.html.haml
@@ -4,6 +4,10 @@
                         role: 'tab', aria: { controls: "incoming-webhook-tab-content#{id}", selected: 'true' } }
       Webhook from #{scm_vendor}
   %li.nav-item{ role: 'presentation' }
+    %a.nav-link{ id: "scm-reports-tab#{id}", data: { toggle: 'tab' }, href: "#scm-reports-tab-content#{id}",
+                role: 'tab', aria: { controls: "scm-reports-tab-content#{id}", selected: 'false' } }
+      Reports to the SCM
+  %li.nav-item{ role: 'presentation' }
     %a.nav-link{ id: "artifacts#{id}", data: { toggle: 'tab' }, href: "#artifacts-tab-content#{id}",
                  role: 'tab', aria: { controls: "artifacts-tab-content#{id}", selected: 'false' } }
       Artifacts
@@ -22,6 +26,24 @@
     %h5 Webhook Request Payload
     %pre.border.p-2#request-payload
       = pretty_request_payload
+  .tab-pane.fade{ id: "scm-reports-tab-content#{id}", role: 'tabpanel',
+                  aria: { labelledby: "scm-reports-tab#{id}" } }
+    - if status_reports.any?
+      .list-group.list-group-flush
+        - status_reports.each do |status_report|
+          .list-group-item
+            %h6 Response body
+            %p
+              %span.badge{ class: status_report.status_class }= status_report.status&.humanize
+            %pre.border.p-2#status-report-response-body
+              = status_report.response_body
+            %h6 Request parameters
+            %pre.border.p-2#status-report-request-parameters
+              = status_report.pretty_request_parameters
+            %small.text-nowrap{ title: l(status_report.created_at.utc) }
+              Sent #{time_ago_in_words(status_report.created_at)} ago
+    - else
+      No status reports
   .tab-pane.fade{ id: "artifacts-tab-content#{id}", role: 'tabpanel',
                   aria: { labelledby: "artifacts#{id}" } }
     %h5 Artifacts

--- a/src/api/app/components/workflow_run_detail_component.rb
+++ b/src/api/app/components/workflow_run_detail_component.rb
@@ -1,7 +1,7 @@
 class WorkflowRunDetailComponent < ApplicationComponent
   attr_reader :id, :request_headers, :pretty_request_payload,
               :response_url, :response_body, :artifacts,
-              :scm_vendor
+              :scm_vendor, :status_reports
 
   def initialize(workflow_run:)
     super
@@ -12,6 +12,7 @@ class WorkflowRunDetailComponent < ApplicationComponent
     @response_body = workflow_run.response_body
     @artifacts = workflow_run.artifacts # collection of WorkflowArtifactsPerStep
     @scm_vendor = workflow_run.scm_vendor.to_s.humanize
+    @status_reports = workflow_run.scm_status_reports
   end
 
   private

--- a/src/api/app/controllers/trigger_workflow_controller.rb
+++ b/src/api/app/controllers/trigger_workflow_controller.rb
@@ -16,11 +16,11 @@ class TriggerWorkflowController < TriggerController
         if validation_errors.none?
           @workflow_run.update(status: 'success', response_body: render_ok)
         else
-          @workflow_run.update_to_fail(render_error(status: 400, message: validation_errors.to_sentence))
+          @workflow_run.update_as_failed(render_error(status: 400, message: validation_errors.to_sentence))
         end
       end
     rescue APIError => e
-      @workflow_run.update_to_fail(render_error(status: e.status, errorcode: e.errorcode, message: e.message))
+      @workflow_run.update_as_failed(render_error(status: e.status, errorcode: e.errorcode, message: e.message))
     end
   end
 
@@ -34,7 +34,7 @@ class TriggerWorkflowController < TriggerController
   def validate_scm_event
     return if @gitlab_event.present? || @github_event.present?
 
-    @workflow_run.update_to_fail(
+    @workflow_run.update_as_failed(
       render_error(
         status: 400,
         errorcode: 'bad_request',

--- a/src/api/app/models/scm_status_report.rb
+++ b/src/api/app/models/scm_status_report.rb
@@ -1,0 +1,43 @@
+# This class represents the communication that took place between OBS and the
+# SCM to render each one of the check marks.
+#
+# Those check marks appear as green, orange and red ticks at the bottom of a
+# PR or next to a commit, on GitHub.
+#
+# The details of the request and the response will be shown in the
+# Reports to the SCM tab in Workflow Runs show page.
+class ScmStatusReport < ApplicationRecord
+  belongs_to :workflow_run
+
+  enum status: {
+    success: 0,
+    fail: 1
+  }
+
+  def pretty_request_parameters
+    return unless request_parameters
+
+    JSON.pretty_generate(JSON.parse(request_parameters))
+  end
+
+  def status_class
+    if success?
+      'badge-primary'
+    else
+      'badge-danger'
+    end
+  end
+end
+
+# == Schema Information
+#
+# Table name: scm_status_reports
+#
+#  id                 :integer          not null, primary key
+#  request_parameters :text(4294967295)
+#  response_body      :text(4294967295)
+#  status             :integer          default("success"), not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  workflow_run_id    :integer
+#

--- a/src/api/app/models/workflow_run.rb
+++ b/src/api/app/models/workflow_run.rb
@@ -18,6 +18,7 @@ class WorkflowRun < ApplicationRecord
 
   belongs_to :token, class_name: 'Token::Workflow', optional: true
   has_many :artifacts, class_name: 'WorkflowArtifactsPerStep', dependent: :destroy
+  has_many :scm_status_reports, dependent: :destroy
 
   paginates_per 20
 
@@ -90,6 +91,10 @@ class WorkflowRun < ApplicationRecord
     else
       :unknown
     end
+  end
+
+  def last_response_body
+    scm_status_reports.last&.response_body
   end
 
   private

--- a/src/api/app/services/scm_exception_handler.rb
+++ b/src/api/app/services/scm_exception_handler.rb
@@ -51,6 +51,21 @@ class SCMExceptionHandler
   private
 
   def log_to_workflow_run(exception, scm)
-    @workflow_run.update_to_fail("Failed to report back to #{scm}: #{ScmExceptionMessage.for(exception: exception, scm: scm)}")
+    if @event_payload[:project] && @event_payload[:package]
+      target_url = Rails.application.routes.url_helpers.package_show_url(@event_payload[:project],
+                                                                         @event_payload[:package],
+                                                                         host: Configuration.obs_url)
+    end
+    @workflow_run.save_scm_report_failure("Failed to report back to #{scm}: #{ScmExceptionMessage.for(exception: exception, scm: scm)}",
+                                          {
+                                            api_endpoint: @event_subscription_payload[:api_endpoint],
+                                            target_repository_full_name: @event_subscription_payload[:target_repository_full_name],
+                                            commit_sha: @event_subscription_payload[:commit_sha],
+                                            state: @state,
+                                            status_options: {
+                                              context: "OBS: #{@event_payload[:package]} - #{@event_payload[:repository]}/#{@event_payload[:arch]}",
+                                              target_url: target_url
+                                            }
+                                          })
   end
 end

--- a/src/api/db/migrate/20220520131205_create_scm_status_reports_table.rb
+++ b/src/api/db/migrate/20220520131205_create_scm_status_reports_table.rb
@@ -1,0 +1,12 @@
+class CreateScmStatusReportsTable < ActiveRecord::Migration[6.1]
+  def change
+    create_table :scm_status_reports, id: :integer do |t|
+      t.integer :workflow_run_id
+      t.text :response_body, size: :long
+      t.text :request_parameters, size: :long
+      t.integer :status, default: 0, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_18_094002) do
+ActiveRecord::Schema.define(version: 2022_05_20_131205) do
 
   create_table "architectures", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false, collation: "utf8mb3_general_ci"
@@ -924,6 +924,15 @@ ActiveRecord::Schema.define(version: 2022_05_18_094002) do
     t.datetime "created_at"
     t.index ["role_id"], name: "role_id"
     t.index ["user_id", "role_id"], name: "roles_users_all_index", unique: true
+  end
+
+  create_table "scm_status_reports", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.integer "workflow_run_id"
+    t.text "response_body", size: :long
+    t.text "request_parameters", size: :long
+    t.integer "status", default: 0, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "sessions", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|

--- a/src/api/spec/factories/workflow_runs.rb
+++ b/src/api/spec/factories/workflow_runs.rb
@@ -53,6 +53,22 @@ FactoryBot.define do
           File.read('spec/support/files/request_payload_github_tag_push.json')
         end
       end
+
+      after(:create) do |workflow_run, _evaluator|
+        ScmStatusReport.create(workflow_run: workflow_run,
+                               response_body: "<status code=\"ok\">\n  <summary>Ok</summary>\n</status>\n",
+                               request_parameters: JSON.generate({
+                                                                   api_endpoint: 'https://api.github.com',
+                                                                   target_repository_full_name: 'danidoni/hello_world',
+                                                                   commit_sha: '6d86fdff6124833e688f93eb3b36c5393fb0e5e5',
+                                                                   state: 'pending',
+                                                                   status_options: {
+                                                                     context: 'OBS:  - /',
+                                                                     target_url: nil
+                                                                   }
+                                                                 }),
+                               status: ScmStatusReport.statuses[:success])
+      end
     end
 
     factory :workflow_run_github_running do
@@ -69,6 +85,22 @@ FactoryBot.define do
             <summary>The 'target_project' key is missing</summary>
           </status>
         END_OF_RESPONSE_BODY
+      end
+
+      after(:create) do |workflow_run, _evaluator|
+        ScmStatusReport.create(workflow_run: workflow_run,
+                               response_body: 'Failed to report back to GitHub: Unauthorized request. Please check your credentials again.',
+                               request_parameters: JSON.generate({
+                                                                   api_endpoint: 'https://api.github.com',
+                                                                   target_repository_full_name: 'danidoni/hello_world',
+                                                                   commit_sha: '6d86fdff6124833e688f93eb3b36c5393fb0e5e5',
+                                                                   state: 'pending',
+                                                                   status_options: {
+                                                                     context: 'OBS:  - /',
+                                                                     target_url: nil
+                                                                   }
+                                                                 }),
+                               status: ScmStatusReport.statuses[:fail])
       end
     end
   end

--- a/src/api/spec/services/scm_status_reporter_spec.rb
+++ b/src/api/spec/services/scm_status_reporter_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe SCMStatusReporter, type: :service do
         it 'tracks the exception in the workflow_run response body and sets the status to fail' do
           subject
           expect(workflow_run.status).to eq('fail')
-          expect(workflow_run.response_body).to eq('Failed to report back to GitHub: Octokit::InvalidRepository')
+          expect(workflow_run.last_response_body).to eq('Failed to report back to GitHub: Octokit::InvalidRepository')
         end
       end
 
@@ -89,7 +89,7 @@ RSpec.describe SCMStatusReporter, type: :service do
 
         it 'tracks the exception in the workflow_run response body and sets the status to fail' do
           expect(workflow_run.status).to eq('fail')
-          expect(workflow_run.response_body).to eq('Failed to report back to GitHub: Sorry. Your account is suspended.')
+          expect(workflow_run.last_response_body).to eq('Failed to report back to GitHub: Sorry. Your account is suspended.')
         end
       end
     end


### PR DESCRIPTION
While running a workflow run, we may have errors when sending the statuses to the SCM.
When that happens we save the response into a new `ScmStatusReport` object so we can debug it later.

**This is how it looks like**
![Screenshot from 2022-05-30 12-52-17](https://user-images.githubusercontent.com/2650/170981318-204ddeb2-5a8a-4319-94d8-e9df3eb51486.png)
![Screenshot from 2022-05-30 13-02-08](https://user-images.githubusercontent.com/2650/170981328-34a95d43-54a7-43c7-a6f9-485f3009f0ef.png)


