### PR TITLE
[dist] Fix initial presets handling in obsstoragesetup.

### DIFF
--- a/dist/obsstoragesetup
+++ b/dist/obsstoragesetup
@@ -336,10 +336,20 @@ case "$1" in
                 fi
 
 		echo "Setting up OBS Workers according to LVM Volumes"
-		if [ ! -e /etc/buildhost.config.presets ]; then
- 	           mv /etc/buildhost.config /etc/buildhost.config.presets
-                fi
-		
+		if [ ! -e '/etc/buildhost.config.presets' ]; then
+			if [ -e '/etc/buildhost.config' ]; then
+				# If we already have a config file, but no
+				# presets, that means that the user must have
+				# actually provided presets via the config
+				# file, since we couldn't have generated it.
+				mv '/etc/buildhost.config' '/etc/buildhost.config.presets'
+			else
+				# No actual presets specified, so record that
+				# by creating an empty file.
+				touch '/etc/buildhost.config.presets'
+			fi
+		fi
+
 		echo "### autoconfigured values by obsstoragesetup init script"  > /etc/buildhost.config
 		echo "OBS_WORKER_DIRECTORY=\"$OBS_WORKER_DIRECTORY\"" >> /etc/buildhost.config
 		echo "OBS_CACHE_DIR=\"$OBS_WORKER_DIRECTORY/cache\""   >> /etc/buildhost.config


### PR DESCRIPTION
The general idea is that, if a user provided a preset using
`/etc/buildhost.config`, i.e., if this file exists at the start of the
(first) script run, then it should be moved to
`/etc/buildhost.config.presets`, assuming that this file does not exist
already (which is meant as a protection for later runs).

Unfortunately, the logic for doing so was broken for **12 years** and nobody
noticed it.

During the first run, the current code:
  - checks if `buildhost.config.presets` exists, and if it DOES NOT:
  - moves `buildhost.config` to `buildhost.config.presets`
  - creates `buildhost.config` from scratch
  - appends `buildhost.config.presets` to `buildhost.config` (if existent)

This has the unwanted side-effect that if no `buildhost.config` file has
been provided by the user, nothing will be moved in the first run and
the second run will see a `buildhost.config` file, but no
`buildhost.config.presets` file, so it wrongly assumes that the
`buildhost.config` is a user-provided preset and moves it to
`buildhost.config.presets`.

Due to that, the initial, default config will essentially always
override any user-defined value in `/etc/sysconfig/obs-server` or even
when modifying `/etc/buildhost.config` directly.

The fix for that is trivial: if neither files exist, create
`buildhost.conf.presets` as an empty file.

While that will fix the issue for any NEW installations, older ones will
not be affected. Sadly, it's not possible to fix existing installations,
since we lost the information regarding user-provided or auto-generated
config entries long ago due to the initial bug.

See: https://github.com/openSUSE/open-build-service/issues/12520