### PR TITLE
Update release notes for 2.10.16

### DIFF
--- a/ReleaseNotes-2.10.16
+++ b/ReleaseNotes-2.10.16
@@ -20,4 +20,7 @@ Backend:
 Bugfixes
 ========
 
-
+Frontend:
+ * Update Nokogiri to version 1.13.6 to fix two security issues:
+   - GHSA-xh29-r2w5-wx8m: Improper Handling of Unexpected Data Type.
+   - GHSA-cgx6-hpwq-fhv5: Integer Overflow or Wraparound in libxml2.


### PR DESCRIPTION
Mention the Nokogiri update in the existing _ReleaseNotes-2.10.16_ file, which is not released yet.