### PR TITLE
Rename Rubocop auto-correct to autocorrect

### DIFF
--- a/src/api/lib/tasks/dev.rake
+++ b/src/api/lib/tasks/dev.rake
@@ -104,10 +104,10 @@ namespace :dev do
       end
 
       desc 'Autocorrect rubocop offenses in rails and in root'
-      task :auto_correct do
-        sh 'rubocop --auto-correct --ignore_parent_exclusion'
+      task :autocorrect do
+        sh 'rubocop --autocorrect --ignore_parent_exclusion'
         Dir.chdir('../..') do
-          sh 'rubocop --auto-correct'
+          sh 'rubocop --autocorrect'
         end
       end
     end


### PR DESCRIPTION
Rubocop deprecated `auto-correct` in favour of `autocorrect` in PR #12636.
So the rake task is adapted and renamed to: `rake dev:lint:rubocop:autocorrect`.