### PR TITLE
rubygem packaging only produces semver provides

### DIFF
--- a/dist/obs-bundled-gems.spec
+++ b/dist/obs-bundled-gems.spec
@@ -61,7 +61,7 @@ Requires:       mysql
 Requires:       obs-bundled-gems = %{version}
 Requires:       sphinx >= 2.1.8
 Requires:       perl(GD)
-Requires:       rubygem(ruby:2.7.0:rack:%{rack_version})
+Requires:       rubygem(ruby:2.7.0:rack) = %{rack_version}
 
 %description -n obs-api-deps
 To simplify splitting the test suite packages off the main package,


### PR DESCRIPTION
[ci skip] So only Major|Minor|Patch