### PR TITLE
[dist] fixed missing end of if (fi)

### DIFF
--- a/dist/obsworker
+++ b/dist/obsworker
@@ -381,6 +381,7 @@ case "$1" in
 	elif [ "--lxc" == "$vmopt" ]; then echo "LXC container"
 	elif [ "openstack" == "$OBS_VM_TYPE" ]; then echo "OpenStack virtual machine"
 	else  echo "chroot"
+	fi
 
         # find SLP announced OBS servers
         if [ "$OBS_USE_SLP" == "yes" ]; then


### PR DESCRIPTION
without this patch the obsworker script is breaking with the following
error message:

/usr/sbin/obsworker: line 488: syntax error near unexpected token `;;'
/usr/sbin/obsworker: line 488: `    ;;'