### PR TITLE
Delete `run_service` method from backend lib

### DIFF
--- a/src/api/app/lib/backend/api/sources/package.rb
+++ b/src/api/app/lib/backend/api/sources/package.rb
@@ -77,12 +77,6 @@ module Backend
           http_post(['/source/:project/:package', project_name, package_name], params: { cmd: :mergeservice, user: user_login })
         end
 
-        # Runs the command runservice for that project/package
-        # @return [String]
-        def self.run_service(project_name, package_name, user_login)
-          http_post(['/source/:project/:package', project_name, package_name], params: { cmd: :runservice, user: user_login })
-        end
-
         # Copy a package into another project
         # @option options [String] :keeplink Stay on revision after copying.
         # @option options [String] :comment Comment to attach to this operation.

--- a/src/api/app/models/service.rb
+++ b/src/api/app/models/service.rb
@@ -95,7 +95,7 @@ class Service
                                                         use_source: true, follow_project_links: false)
       return false unless User.session!.can_modify?(service_package)
 
-      Backend::Api::Sources::Package.run_service(service_package.project.name, service_package.name, User.session!.login)
+      Backend::Api::Sources::Package.trigger_services(service_package.project.name, service_package.name, User.session!.login)
       service_package.sources_changed
     end
     true


### PR DESCRIPTION
The `run_service` method is doing exactly the same as the
`trigger_services` method. Lets stick to one and remove the
duplication.