### PR TITLE
[backend] Allow to configure VM-specific extra args for worker

### DIFF
--- a/dist/obsworker
+++ b/dist/obsworker
@@ -150,6 +150,13 @@ elif [ -e /sys/hypervisor/type ] && [ -x /usr/sbin/xl -o -x /usr/sbin/xm ] && gr
     OBS_VM_TYPE="xen"
 fi
 
+if [ -n "$OBS_VM_ARGS" -a -n "$vmopt" ]; then
+    case "$OBS_VM_ARGS" in
+    -*) OBS_VM_ARGS=" $OBS_VM_ARGS";; # Workaround for build arg parser
+    esac
+    vmopt="$vmopt --vm-args ${OBS_VM_ARGS@Q}"
+fi
+
 if [ "$OBS_VM_TYPE" = "zvm" ]; then
     # for z/VM, the disks are already setup with the workers.
     if [ -n "$OBS_VM_DISK_AUTOSETUP_FILESYSTEM" ]; then

--- a/dist/sysconfig.obs-server
+++ b/dist/sysconfig.obs-server
@@ -223,6 +223,25 @@ OBS_WORKER_NICE_LEVEL=18
 OBS_VM_TYPE="auto"
 
 ## Path:        Applications/OBS
+## Description: Set additional VM argumrnts by worker
+## Type:        string
+## Default:     ""
+## Config:      OBS
+#
+# Use this to pass extra arguments and options specific to VM type.
+#
+# To pass multiple arguments, separate them with spaces.
+# Use regular shell quotes if arguments contain spaces.
+# Example: "--arg1 foo --arg2 'bar baz'"
+#
+# WARNING!
+# Before using this parameter, make sure that build utility on OBS server
+# is new enough to support --vm-args option.
+# Not all VM types can accept extra arguments.
+#
+OBS_VM_ARGS=""
+
+## Path:        Applications/OBS
 ## Description: Set kernel used by worker (kvm)
 ## Type:        ("none" | "/boot/vmlinuz" | "/foo/bar/vmlinuz)
 ## Default:     "none"

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -74,6 +74,7 @@ my $port;
 my $statedir;
 my $hostarch;
 my $vm = '';
+my $vm_args = '';
 my $vm_tmpfs_mode;
 my $vm_root = '';
 my $vm_swap = '';
@@ -652,6 +653,11 @@ while (@ARGV) {
   if ($ARGV[0] eq '--vm-type') {
     shift @ARGV;
     $vm = shift @ARGV;
+    next;
+  }
+  if ($ARGV[0] eq '--vm-args') {
+    shift @ARGV;
+    $vm_args = shift @ARGV;
     next;
   }
   print "OPTION UNKNOWN: $ARGV[0]\n" unless $justbuild;
@@ -3634,6 +3640,7 @@ sub dobuild {
     mkdir("$buildroot/.mount") unless -d "$buildroot/.mount";
     push @args, '--root', "$buildroot/.mount";
     push @args, '--vm-type', $vm;
+    push @args, '--vm-args', $vm_args if $vm_args ne '';
     push @args, '--vm-disk', $vm_root;
     push @args, '--vm-swap', $vm_swap;
     push @args, '--emulator-script', $emulator_script if $vm eq 'emulator' && $emulator_script;
@@ -3660,6 +3667,7 @@ sub dobuild {
     mkdir("$buildroot/.mount") unless -d "$buildroot/.mount";
     push @args, '--root',      "$buildroot/.mount";
     push @args, "--vm-type",   $vm;
+    push @args, '--vm-args', $vm_args if $vm_args ne '';
     push @args, "--vm-disk",   $vm_root;
     push @args, "--vm-swap",   $vm_swap;
     push @args, "--vm-server", $vm_server;
@@ -3674,6 +3682,7 @@ sub dobuild {
     print "VM-TYPE $vm not detected" if $vm;
     push @args, '--root', $buildroot;
     push @args, '--vm-type', $vm if $vm;
+    push @args, '--vm-args', $vm_args if $vm && $vm_args ne '';
   }
   push @args, '--clean';
   push @args, '--changelog';


### PR DESCRIPTION
Sometimes it's necessary to add extra options to a VM running on a specific worker. For example, Oracle Linux 8 runs quite old `systemd-nspawn` that knows nothing about `faccessat2` system call and filters it out using `seccomp` system call filter, breaking newer `glibc`. A workaround is to pass `--system-call-filter=faccessat2` option to `nspawn` VM on OBS workers running on these systems.

This change implements `OBS_VM_ARGS` configuration parameter and passes its value through OBS worker to build process.