### PR TITLE
Show the token trigger url in token details page

### DIFF
--- a/src/api/app/views/webui/users/tokens/show.html.haml
+++ b/src/api/app/views/webui/users/tokens/show.html.haml
@@ -36,6 +36,15 @@
               %span
                 = @token.token_name
 
+        - if @token.type == 'Token::Workflow'
+          .form-row
+            .col
+              .form-group
+                %label.col-form-label.mr-2.font-weight-bold
+                  Token trigger url:
+                .input-group
+                  = render CopyToClipboardInputComponent.new(token_string: trigger_workflow_url(id: @token.id))
+
         - if @token.package
           .form-row
             .col-sm


### PR DESCRIPTION
Show the url to trigger the token workflow for easy copying. 

![image](https://user-images.githubusercontent.com/2650/171612937-eed8266d-45eb-4ec6-9929-a88569750932.png)
