### PR TITLE
Fix empty scm status report

### DIFF
--- a/src/api/app/models/workflow_run.rb
+++ b/src/api/app/models/workflow_run.rb
@@ -46,14 +46,14 @@ class WorkflowRun < ApplicationRecord
   # Stores debug info to help figure out what went wrong when trying to save a Status in the SCM.
   # Marks the workflow run as failed also.
   def save_scm_report_failure(message, options)
-    scm_status_reports.create(response_body: message,
-                              request_parameters: JSON.generate(options.slice(PERMITTED_OPTIONS)))
     update(status: 'fail')
+    scm_status_reports.create(response_body: message,
+                              request_parameters: JSON.generate(options.slice(*PERMITTED_OPTIONS)))
   end
 
   # Stores info from a succesful SCM status report
   def save_scm_report_success(options)
-    scm_status_reports.create(request_parameters: JSON.generate(options.slice(PERMITTED_OPTIONS)))
+    scm_status_reports.create(request_parameters: JSON.generate(options.slice(*PERMITTED_OPTIONS)))
   end
 
   def payload

--- a/src/api/spec/models/workflow_run_spec.rb
+++ b/src/api/spec/models/workflow_run_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe WorkflowRun, vcr: true do
+  let(:workflow_run) { create(:workflow_run) }
+
+  describe '#save_scm_report_success' do
+    subject { workflow_run.save_scm_report_success(options) }
+
+    context 'when providing a permitted key' do
+      let(:options) { { api_endpoint: 'https://api.github.com' } }
+
+      it { expect { subject }.to change(ScmStatusReport, :count).by(1) }
+      it { expect(JSON.parse(subject.request_parameters)).to include('api_endpoint' => 'https://api.github.com') }
+    end
+
+    context 'when providing some other keys' do
+      let(:options) { { non_permitted_key: 'some value' } }
+
+      it { expect { subject }.to change(ScmStatusReport, :count).by(1) }
+      it { expect(JSON.parse(subject.request_parameters)).to be_empty }
+    end
+  end
+
+  describe '#save_scm_report_failure' do
+    subject { workflow_run.save_scm_report_failure('oops it failed', options) }
+
+    context 'when providing a permitted key' do
+      let(:options) { { api_endpoint: 'https://api.github.com' } }
+
+      it { expect { subject }.to change(ScmStatusReport, :count).by(1) }
+      it { expect(JSON.parse(subject.request_parameters)).to include('api_endpoint' => 'https://api.github.com') }
+      it { expect(subject.response_body).to eql('oops it failed') }
+
+      it 'marks the workflow run as failed' do
+        subject
+        expect(workflow_run.reload.status).to eql('fail')
+      end
+    end
+
+    context 'when providing some other keys' do
+      let(:options) { { non_permitted_key: 'some value' } }
+
+      it { expect { subject }.to change(ScmStatusReport, :count).by(1) }
+      it { expect(JSON.parse(subject.request_parameters)).to be_empty }
+      it { expect(subject.response_body).to eql('oops it failed') }
+
+      it 'marks the workflow run as failed' do
+        subject
+        expect(workflow_run.reload.status).to eql('fail')
+      end
+    end
+  end
+end


### PR DESCRIPTION
For the `slice` method to work it needs the `PERMITTED_OPTIONS` array to be unpacked using the `*` operator.