### PR TITLE
Rename method

### DIFF
--- a/src/api/app/services/scm_status_reporter.rb
+++ b/src/api/app/services/scm_status_reporter.rb
@@ -43,7 +43,7 @@ class SCMStatusReporter < SCMExceptionHandler
   rescue Octokit::Error, Gitlab::Error::Error => e
     rescue_with_handler(e) || raise(e)
   rescue Faraday::ConnectionFailed => e
-    @workflow_run.update_to_fail("Failed to report back to GitHub: #{e.message}")
+    @workflow_run.update_as_failed("Failed to report back to GitHub: #{e.message}")
   end
   # rubocop:enable Metrics/PerceivedComplexity
   # rubocop:enable Metrics/CyclomaticComplexity


### PR DESCRIPTION
Since this [PR](https://github.com/openSUSE/open-build-service/pull/12625/files#diff-88f9213e07b60452bc1fd66352eff85d02e49d095cad9e6a0052d7cc918e2d57) `update_to_fail` was renamed as `update_as_failed`, but looks like not all occurrences were renamed.