### PR TITLE
Add comment when triggering service from step

### DIFF
--- a/src/api/app/lib/backend/api/sources/package.rb
+++ b/src/api/app/lib/backend/api/sources/package.rb
@@ -53,8 +53,9 @@ module Backend
 
         # It triggers all the services of a package
         # @return [String]
-        def self.trigger_services(project_name, package_name, user_login)
-          http_post(['/source/:project/:package', project_name, package_name], params: { cmd: :runservice, user: user_login })
+        def self.trigger_services(project_name, package_name, user_login, comment = nil)
+          params = { cmd: :runservice, user: user_login, comment: comment }.compact
+          http_post(['/source/:project/:package', project_name, package_name], params: params)
         end
 
         # Writes the patchinfo

--- a/src/api/app/models/workflow/step/trigger_services.rb
+++ b/src/api/app/models/workflow/step/trigger_services.rb
@@ -18,7 +18,7 @@ class Workflow::Step::TriggerServices < Workflow::Step
     Pundit.authorize(@token.user, @token, :trigger_service?)
 
     begin
-      Backend::Api::Sources::Package.trigger_services(@project_name, @package_name, @token.user.login)
+      Backend::Api::Sources::Package.trigger_services(@project_name, @package_name, @token.user.login, trigger_service_comment)
     rescue Backend::NotFoundError => e
       raise NoSourceServiceDefined, "Package #{@project_name}/#{@package_name} does not have a source service defined: #{e.summary}"
     end
@@ -28,5 +28,34 @@ class Workflow::Step::TriggerServices < Workflow::Step
 
   def package_find_options
     { use_source: true, follow_project_links: false, follow_multibuild: false }
+  end
+
+  # Examples of comments:
+  # "Service triggered by a workflow token via $scm PR/MR $number ($event)"
+  # "Service triggered by the '$token' token via $scm push $sha on $tag || $branch"
+  def trigger_service_comment
+    'Service triggered by ' \
+      "#{@token.description.blank? ? 'a workflow token ' : "the '#{@token.description}' token "}" \
+      "via #{@scm_webhook.payload[:scm].titleize} " \
+      "#{details}."
+  end
+
+  def details
+    case @scm_webhook.payload[:event]
+    when 'pull_request', 'Merge Request Hook'
+      "PR/MR ##{@scm_webhook.payload[:pr_number]} (#{@scm_webhook.payload[:event]})"
+    when 'push', 'Push Hook'
+      push_details
+    when 'Tag Push Hook'
+      "push #{@scm_webhook.payload[:commit_sha]&.slice(0, SHORT_COMMIT_SHA_LENGTH)} on #{@scm_webhook.payload[:tag_name]}"
+    end
+  end
+
+  def push_details
+    if @scm_webhook.payload[:scm] == 'github' && @scm_webhook.payload[:ref].start_with?('refs/tags')
+      "push #{@scm_webhook.payload[:commit_sha]&.slice(0, SHORT_COMMIT_SHA_LENGTH)} on #{@scm_webhook.payload[:tag_name]}"
+    else
+      "push #{@scm_webhook.payload[:commit_sha]&.slice(0, SHORT_COMMIT_SHA_LENGTH)} on #{@scm_webhook.payload[:target_branch]}"
+    end
   end
 end

--- a/src/api/spec/models/workflow/step/trigger_services_spec.rb
+++ b/src/api/spec/models/workflow/step/trigger_services_spec.rb
@@ -34,13 +34,15 @@ RSpec.describe Workflow::Step::TriggerServices do
     end
 
     context 'user has permission to trigger the services' do
+      let(:comment) { 'Service triggered by a workflow token via Github PR/MR #1 (pull_request).' }
+
       before do
         allow(Backend::Api::Sources::Package).to receive(:trigger_services).and_return(true)
       end
 
       it 'triggers the service on the backend' do
         subject.call
-        expect(Backend::Api::Sources::Package).to have_received(:trigger_services).with('openSUSE:Factory', 'hello_world', 'Iggy')
+        expect(Backend::Api::Sources::Package).to have_received(:trigger_services).with('openSUSE:Factory', 'hello_world', 'Iggy', comment)
       end
     end
   end


### PR DESCRIPTION
When we trigger a service we can pass a comment. We do so on the trigger_services workflow step, so we will have information about what triggered the service.

Fixes #12400.

This is one possible result:
![Screenshot 2022-06-03 at 18-35-40 The Golden Apples of the Sun](https://user-images.githubusercontent.com/2581944/171907899-ba81a5c8-191c-4b36-873a-8fa191c011d3.png)
