### PR TITLE
Rename token_string to input_text in the component

### DIFF
--- a/src/api/app/components/copy_to_clipboard_input_component.html.haml
+++ b/src/api/app/components/copy_to_clipboard_input_component.html.haml
@@ -1,4 +1,4 @@
-= text_field_tag(nil, @token_string, readonly: true, id: 'copy-to-clipboard-readonly', class: 'form-control')
+= text_field_tag(nil, @input_text, readonly: true, id: 'copy-to-clipboard-readonly', class: 'form-control')
 .input-group-append#copy-to-clipboard
   %span.input-group-text
     %i.fas.fa-clipboard

--- a/src/api/app/components/copy_to_clipboard_input_component.rb
+++ b/src/api/app/components/copy_to_clipboard_input_component.rb
@@ -1,6 +1,6 @@
 class CopyToClipboardInputComponent < ApplicationComponent
-  def initialize(token_string:)
+  def initialize(input_text:)
     super
-    @token_string = token_string
+    @input_text = input_text
   end
 end

--- a/src/api/app/views/webui/users/tokens/edit.html.haml
+++ b/src/api/app/views/webui/users/tokens/edit.html.haml
@@ -12,7 +12,7 @@
               %fieldset.form-group
                 = f.label(:string_readonly, 'Your new OBS Personal Access Token Secret', class: 'col-form-label col-form-label-lg')
                 .input-group
-                  = render CopyToClipboardInputComponent.new(token_string: @token.string)
+                  = render CopyToClipboardInputComponent.new(input_text: @token.string)
               %hr
 
           .form-row

--- a/src/api/app/views/webui/users/tokens/show.html.haml
+++ b/src/api/app/views/webui/users/tokens/show.html.haml
@@ -25,7 +25,7 @@
                 %label.col-form-label.font-weight-bold
                   Secret:
                 .input-group
-                  = render CopyToClipboardInputComponent.new(token_string: @token.string)
+                  = render CopyToClipboardInputComponent.new(input_text: @token.string)
               %hr
 
         .form-row
@@ -43,7 +43,7 @@
                 %label.col-form-label.mr-2.font-weight-bold
                   Token trigger url:
                 .input-group
-                  = render CopyToClipboardInputComponent.new(token_string: trigger_workflow_url(id: @token.id))
+                  = render CopyToClipboardInputComponent.new(input_text: trigger_workflow_url(id: @token.id))
 
         - if @token.package
           .form-row


### PR DESCRIPTION
The CopyToClipboardInputComponent is used to copy any kind of string from an input field, not only token strings, so the parameter is renamed.