### PR TITLE
Set commit sha on target_branch for tag pushes

### DIFF
--- a/src/api/app/services/trigger_controller_service/scm_extractor.rb
+++ b/src/api/app/services/trigger_controller_service/scm_extractor.rb
@@ -109,14 +109,16 @@ module TriggerControllerService
                        # We need this for Workflow::Step#branch_request_content_{github,gitlab}
                        commit_sha: @payload[:after],
                        # We need this for Workflows::YAMLDownloader#download_url
-                       # base_ref is nil when the push event is for commits
-                       target_branch: (@payload[:base_ref] || payload_ref).sub('refs/heads/', '')
+                       # when the push event is for commits, we get the branch name from ref.
+                       target_branch: payload_ref.sub('refs/heads/', '')
                      })
 
       return unless payload_ref.start_with?('refs/tags/')
 
       # We need this for Workflow::Step#target_package_name
-      payload.merge!({ tag_name: payload_ref.sub('refs/tags/', '') })
+      # 'target_branch' will contain a commit SHA
+      payload.merge!({ tag_name: payload_ref.sub('refs/tags/', ''),
+                       target_branch: @payload[:after] })
     end
 
     def gitlab_payload_tag(payload)

--- a/src/api/app/services/workflows/yaml_downloader.rb
+++ b/src/api/app/services/workflows/yaml_downloader.rb
@@ -18,7 +18,7 @@ module Workflows
       Down.download(download_url, max_size: MAX_FILE_SIZE)
     rescue Down::Error => e
       # 'target_branch' can contain a commit sha (when tag push) instead of a branch name
-      raise Token::Errors::NonExistentWorkflowsFile, ".obs/workflows.yml could not be downloaded from the SCM branch or commit #{@scm_payload[:target_branch]}." \
+      raise Token::Errors::NonExistentWorkflowsFile, ".obs/workflows.yml could not be downloaded from the SCM branch/commit #{@scm_payload[:target_branch]}." \
                                                      "\nIs the configuration file in the expected place? Check #{DOCUMENTATION_LINK}\n#{e.message}"
     end
 
@@ -36,7 +36,7 @@ module Workflows
       raise Token::Errors::NonExistentRepository, e.message
     rescue Octokit::NotFound => e
       # 'target_branch' can contain a commit sha (when tag push) instead of a branch name
-      raise Token::Errors::NonExistentWorkflowsFile, ".obs/workflows.yml could not be downloaded from the SCM branch or commit #{@scm_payload[:target_branch]}: #{e.message}"
+      raise Token::Errors::NonExistentWorkflowsFile, ".obs/workflows.yml could not be downloaded from the SCM branch/commit #{@scm_payload[:target_branch]}: #{e.message}"
     end
   end
 end

--- a/src/api/app/services/workflows/yaml_downloader.rb
+++ b/src/api/app/services/workflows/yaml_downloader.rb
@@ -17,7 +17,8 @@ module Workflows
     def download_yaml_file
       Down.download(download_url, max_size: MAX_FILE_SIZE)
     rescue Down::Error => e
-      raise Token::Errors::NonExistentWorkflowsFile, ".obs/workflows.yml could not be downloaded from the SCM branch #{@scm_payload[:target_branch]}." \
+      # 'target_branch' can contain a commit sha (when tag push) instead of a branch name
+      raise Token::Errors::NonExistentWorkflowsFile, ".obs/workflows.yml could not be downloaded from the SCM branch or commit #{@scm_payload[:target_branch]}." \
                                                      "\nIs the configuration file in the expected place? Check #{DOCUMENTATION_LINK}\n#{e.message}"
     end
 
@@ -25,14 +26,17 @@ module Workflows
       case @scm_payload[:scm]
       when 'github'
         client = Octokit::Client.new(access_token: @token.scm_token, api_endpoint: @scm_payload[:api_endpoint])
+        # :ref can be the name of the commit, branch or tag.
         client.content("#{@scm_payload[:target_repository_full_name]}", path: '/.obs/workflows.yml', ref: @scm_payload[:target_branch])[:download_url]
       when 'gitlab'
+        # This GitLab URL admits both a branch name and a commit sha.
         "#{@scm_payload[:api_endpoint]}/#{@scm_payload[:path_with_namespace]}/-/raw/#{@scm_payload[:target_branch]}/.obs/workflows.yml"
       end
     rescue Octokit::InvalidRepository => e
       raise Token::Errors::NonExistentRepository, e.message
     rescue Octokit::NotFound => e
-      raise Token::Errors::NonExistentWorkflowsFile, ".obs/workflows.yml could not be downloaded from the SCM branch #{@scm_payload[:target_branch]}: #{e.message}"
+      # 'target_branch' can contain a commit sha (when tag push) instead of a branch name
+      raise Token::Errors::NonExistentWorkflowsFile, ".obs/workflows.yml could not be downloaded from the SCM branch or commit #{@scm_payload[:target_branch]}: #{e.message}"
     end
   end
 end

--- a/src/api/spec/controllers/trigger_workflow_controller_spec.rb
+++ b/src/api/spec/controllers/trigger_workflow_controller_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe TriggerWorkflowController, type: :controller, beta: true do
       it { expect(response).to have_http_status(:not_found) }
 
       it "displays a user-friendly error message in the response's body" do
-        expect(response.body).to include(".obs/workflows.yml could not be downloaded from the SCM branch main.\nIs the configuration file in the expected place? " \
+        expect(response.body).to include(".obs/workflows.yml could not be downloaded from the SCM branch/commit main.\nIs the configuration file in the expected place? " \
                                          "Check #{Workflows::YAMLDownloader::DOCUMENTATION_LINK}\nBeep Boop, something is wrong")
       end
 

--- a/src/api/spec/models/workflow/step/branch_package_step_spec.rb
+++ b/src/api/spec/models/workflow/step/branch_package_step_spec.rb
@@ -303,7 +303,7 @@ RSpec.describe Workflow::Step::BranchPackageStep, vcr: true do
           ScmWebhook.new(payload: {
                            scm: 'github',
                            event: 'push',
-                           target_branch: 'main',
+                           target_branch: '123456789012345',
                            source_repository_full_name: 'openSUSE/open-build-service',
                            tag_name: 'release_abc',
                            commit_sha: '123456789012345',

--- a/src/api/spec/models/workflow/step/link_package_step_spec.rb
+++ b/src/api/spec/models/workflow/step/link_package_step_spec.rb
@@ -331,7 +331,7 @@ RSpec.describe Workflow::Step::LinkPackageStep, vcr: true do
           ScmWebhook.new(payload: {
                            scm: 'github',
                            event: 'push',
-                           target_branch: 'main',
+                           target_branch: '123456789012345',
                            source_repository_full_name: 'openSUSE/open-build-service',
                            tag_name: 'release_abc',
                            commit_sha: '123456789012345',

--- a/src/api/spec/models/workflow_spec.rb
+++ b/src/api/spec/models/workflow_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe Workflow, type: :model, vcr: true do
           scm: 'github',
           event: 'push',
           ref: 'refs/tags/release_abc',
-          target_branch: 'master'
+          target_branch: '9e0ea1fd99c9000cbb8b8c9d28763d0ddace0b65'
         }
       end
 
@@ -218,7 +218,7 @@ RSpec.describe Workflow, type: :model, vcr: true do
           scm: 'gitlab',
           event: 'Tag Push Hook',
           ref: 'refs/tags/release_abc',
-          target_branch: 'master'
+          target_branch: '9e0ea1fd99c9000cbb8b8c9d28763d0ddace0b65'
         }
       end
 

--- a/src/api/spec/services/trigger_controller_service/scm_extractor_spec.rb
+++ b/src/api/spec/services/trigger_controller_service/scm_extractor_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe TriggerControllerService::ScmExtractor do
             event: 'push',
             api_endpoint: 'https://api.github.com',
             commit_sha: '9e0ea1fd99c9000cbb8b8c9d28763d0ddace0b65',
-            target_branch: 'main',
+            target_branch: '9e0ea1fd99c9000cbb8b8c9d28763d0ddace0b65',
             source_repository_full_name: 'iggy/repo123',
             target_repository_full_name: 'iggy/repo123',
             ref: 'refs/tags/release_abc',

--- a/src/api/spec/services/workflows/artifacts_collector_spec.rb
+++ b/src/api/spec/services/workflows/artifacts_collector_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Workflows::ArtifactsCollector, type: :service do
           ScmWebhook.new(payload: {
                            scm: 'github',
                            event: 'push',
-                           target_branch: 'main',
+                           target_branch: '2a6b530bcdf7a54d881c62333c9f13b6ce16f3fc',
                            source_repository_full_name: 'iggy/hello_world',
                            commit_sha: '2a6b530bcdf7a54d881c62333c9f13b6ce16f3fc',
                            target_repository_full_name: 'iggy/hello_world',
@@ -200,7 +200,7 @@ RSpec.describe Workflows::ArtifactsCollector, type: :service do
           ScmWebhook.new(payload: {
                            scm: 'github',
                            event: 'push',
-                           target_branch: 'main',
+                           target_branch: '2a6b530bcdf7a54d881c62333c9f13b6ce16f3fc',
                            source_repository_full_name: 'iggy/hello_world',
                            commit_sha: '2a6b530bcdf7a54d881c62333c9f13b6ce16f3fc',
                            target_repository_full_name: 'iggy/hello_world',


### PR DESCRIPTION
On tag push events from GitHub, we tried to extract the branch name to set the 'target_branch' field. However, the value was not always correct (sometimes we got the tag name instead of the branch name). So we now extract the commit sha as we do with GitLab.

We use 'target_branch' to download the Yaml file. We can do that using either the branch name or the commit sha. 