### PR TITLE
Remove obsoleted parameter `IgnoredPatterns` (for `Layout/LineLength`) found in .rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -80,7 +80,6 @@ Metrics/ClassLength:
 
 Layout/LineLength:
   Max: 150
-  IgnoredPatterns: ['\A#']
 
 Metrics/ModuleLength:
   Severity: refactor


### PR DESCRIPTION
Prevent from showing this warning message when running RuboCop:

```
Warning: obsolete parameter `IgnoredPatterns` (for `Layout/LineLength`) found in .rubocop.yml
`IgnoredPatterns` has been renamed to `AllowedPatterns`.
```

`IgnoredPatterns` was deprecated in favour of `AllowedPatterns` in [RuboCop 1.28](https://github.com/rubocop/rubocop/releases/tag/v1.28.0).