### PR TITLE
Add configuration option to prevent adding a maintainer when creating a project

### DIFF
--- a/src/api/app/controllers/source_project_meta_controller.rb
+++ b/src/api/app/controllers/source_project_meta_controller.rb
@@ -70,10 +70,12 @@ class SourceProjectMetaController < SourceController
       else
         project = Project.new(name: @project_name)
         project.update_from_xml!(@request_data)
-        # FIXME3.0: don't modify send data
-        maintainer_role = Role.find_by_title!('maintainer')
-        unless project.relationships.any? { |relationship| relationship.user == User.session! && relationship.role == maintainer_role }
-          project.relationships.find_or_initialize_by(user: User.session!, role: maintainer_role)
+        unless CONFIG['prevent_adding_maintainer_in_project_creation_with_api'].in?([:on, ':on', 'on', 'true', true])
+          # FIXME3.0: don't modify send data
+          maintainer_role = Role.find_by_title!('maintainer')
+          unless project.relationships.any? { |relationship| relationship.user == User.session! && relationship.role == maintainer_role }
+            project.relationships.find_or_initialize_by(user: User.session!, role: maintainer_role)
+          end
         end
       end
       project.store(comment: params[:comment])

--- a/src/api/config/options.yml.example
+++ b/src/api/config/options.yml.example
@@ -208,6 +208,11 @@ default: &default
   # Default: 365 days (1 year).
   notifications_lifetime: 365
 
+  # Prevent adding the user as a maintainer, in project creation, in this API endpoint:
+  # PUT /source/:project/_meta
+  # Former and default value is `false`: the user is added as a maintainer.
+  prevent_adding_maintainer_in_project_creation_with_api: false
+
 production:
   <<: *default
 


### PR DESCRIPTION
Currently, calling the `PUT /source/:project/_meta` API endpoint on a non-existent project adds the user who calls the endpoint as a maintainer of the project. In the future, we want to modify the behavior of this endpoint, by not adding the user as a maintainer. This means that we introduce a backward incompatible change in the API.

To introduce this change smoothly, we add a configuration option that will allow OBS instances administrators to decide when they want to adopt this new behavior.