### PR TITLE
Set wrap-text in confirmation modal texts

### DIFF
--- a/src/api/app/components/confirmation_dialog_component.html.haml
+++ b/src/api/app/components/confirmation_dialog_component.html.haml
@@ -2,9 +2,9 @@
   .modal-dialog.modal-dialog-centered{ role: 'document' }
     .modal-content
       .modal-header
-        %h5.modal-title{ id: "#{modal_id}-label" }= modal_title
+        %h5.wrap-text.modal-title{ id: "#{modal_id}-label" }= modal_title
       .modal-body
-        %p.confirmation-text= confirmation_text
+        %p.wrap-text.confirmation-text= confirmation_text
 
         = form_tag(action, method: method, remote: remote) do
           .modal-footer


### PR DESCRIPTION
Modify ConfirmationDialogComponent to avoid texts going out of the modal like this:

![Screenshot 2022-06-10 at 12-02-19 Open Build Service](https://user-images.githubusercontent.com/2581944/173045150-5df5420b-90b8-439d-a619-d209f63c7876.png)

and to have something like this:

![Screenshot 2022-06-10 at 12-05-55 Open Build Service](https://user-images.githubusercontent.com/2581944/173045205-5fb7d430-25d8-44de-acf0-7bbf72806883.png)
