### PR TITLE
Do not link to expanded sources with rev=

### DIFF
--- a/src/api/app/views/webui/package/_commit_item.html.haml
+++ b/src/api/app/views/webui/package/_commit_item.html.haml
@@ -30,6 +30,6 @@
           %i.fas.fa-copy.text-gray-500
           Files Changed
     %li.nav-item
-      = link_to(package_show_path(@project, @package, rev: commit['rev']), class: 'nav-link') do
+      = link_to(package_show_path(@project, @package, rev: commit['rev'], expand: 0), class: 'nav-link') do
         %i.fas.fa-folder-open.text-warning
         Browse Source


### PR DESCRIPTION
Do not link to expanded sources with `rev=`

With default expand=1 it nearly always shows the latest version
from the `_link`, but if a user clicks "Browse Source"
to see an old revision, the user wants to see the old revision.

Fixes #12674

Needs testing.