### PR TITLE
Add autorization to token's users index

### DIFF
--- a/src/api/app/controllers/webui/users/tokens/users_controller.rb
+++ b/src/api/app/controllers/webui/users/tokens/users_controller.rb
@@ -4,6 +4,8 @@ class Webui::Users::Tokens::UsersController < Webui::WebuiController
   before_action :set_user, only: :destroy
 
   def index
+    authorize @token
+
     @users = @token.users_shared_among
     @groups = @token.groups_shared_among
   end

--- a/src/api/app/policies/token/workflow_policy.rb
+++ b/src/api/app/policies/token/workflow_policy.rb
@@ -20,6 +20,10 @@ class Token::WorkflowPolicy < TokenPolicy
     record.owned_by?(user)
   end
 
+  def index?
+    create?
+  end
+
   def show?
     create?
   end


### PR DESCRIPTION
When a user tried to access a list of users of a token (because they knew the URL), these two things used to happen:
- if the user was logged in and wasn't associated to the token -> the page was accessible and it shouldn't
- if the user was **nobody** -> it crashed

We added some authorization to avoid the previous behaviour.

To test this:

- Log in as any user not associated with the token
- Go to localhost:3000/my/tokens/1/users (replace 1 with an ID existing on your DB)
- You shouldn't be able to access it.
- Log out (become **nobody**)
- Go to localhost:3000/my/tokens/1/users (replace 1 with an ID existing on your DB)
- It shouldn't crash

Fixes #12695

Co-authored-by: Daniel Donisa <daniel.donisa@suse.com>