### PR TITLE
Add token id to some breadcrumbs

### DIFF
--- a/src/api/app/views/webui/users/tokens/users/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui/users/tokens/users/_breadcrumb_items.html.haml
@@ -2,5 +2,7 @@
   = link_to('Your Profile', user_path(User.session!))
 %li.breadcrumb-item
   = link_to 'Tokens', tokens_path
-  %li.breadcrumb-item.active
-    Users
+%li.breadcrumb-item
+  = link_to @token.id, token_path(@token)
+%li.breadcrumb-item.active
+  Users

--- a/src/api/app/views/webui/workflow_runs/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui/workflow_runs/_breadcrumb_items.html.haml
@@ -2,6 +2,8 @@
   = link_to('Your Profile', user_path(User.session!))
 %li.breadcrumb-item
   = link_to 'Tokens', tokens_path
+%li.breadcrumb-item
+  = link_to @token.id, token_path(@token)
 - if params[:id]
   %li.breadcrumb-item
     = link_to('Workflow Runs', token_workflow_runs_path(@token.id), title: 'Workflow Runs')


### PR DESCRIPTION
To have some reference to the token, we add the token id to the breadcrumbs for the workflow runs page and the token's users page.

**Before (without any reference to the token):**

![Screenshot from 2022-06-14 18-30-59](https://user-images.githubusercontent.com/2581944/173632357-4c5c35f2-df17-4162-9684-30b5db2a8f21.png)

**After:**

![Screenshot from 2022-06-14 18-41-32](https://user-images.githubusercontent.com/2581944/173632338-f2ed490e-ba14-4401-8aef-7c9aa3d5432e.png)

Co-authored-by: Daniel Donisa <daniel.donisa@suse.com>
Co-authored-by: Eduardo Navarro <enavarro@suse.com>