### PR TITLE
Move JavaScript part into the ConfirmationDialogComponent

### DIFF
--- a/src/api/app/assets/javascripts/webui/application.js
+++ b/src/api/app/assets/javascripts/webui/application.js
@@ -56,3 +56,4 @@
 //= require webui/user_profile.js
 //= require webui/long_text.js
 //= require webui/new_watchlist/collapsible_tooltip.js
+//= require webui/delete_confirmation_dialog.js

--- a/src/api/app/assets/javascripts/webui/delete_confirmation_dialog.js
+++ b/src/api/app/assets/javascripts/webui/delete_confirmation_dialog.js
@@ -1,4 +1,18 @@
-function setValuesOnDeleteConfirmationDialog(modalId) { // jshint ignore:line
+function collectDeleteConfirmationModalsAndSetValues() { // jshint ignore:line
+  $.each(modalIds(), function( _index, modalId ) {
+    setValuesOnDeleteConfirmationDialog(modalId);
+  });
+}
+
+function modalIds() {
+  var targets = $('a[data-toggle="modal"][data-target^="#delete"]').toArray().map(
+    function(e) { return $(e).data('target');
+  });
+
+  return $.unique(targets);
+}
+
+function setValuesOnDeleteConfirmationDialog(modalId) {
   $(modalId).on('show.bs.modal', function (event) {
     var link = $(event.relatedTarget);
     var modal = $(this);

--- a/src/api/app/assets/javascripts/webui/delete_confirmation_dialog.js
+++ b/src/api/app/assets/javascripts/webui/delete_confirmation_dialog.js
@@ -1,0 +1,26 @@
+function setValuesOnDeleteConfirmationDialog(modalId) { // jshint ignore:line
+  $(modalId).on('show.bs.modal', function (event) {
+    var link = $(event.relatedTarget);
+    var modal = $(this);
+
+    if (typeof(link.data('modal-title')) !== 'undefined') {
+      modal.find('.modal-title').text(link.data('modal-title'));
+    }
+
+    if (typeof(link.data('confirmation-text')) !== 'undefined') {
+      modal.find('.confirmation-text').text(link.data('confirmation-text'));
+    }
+
+    if (typeof(link.data('action')) !== 'undefined') {
+      modal.find('form').attr('action', link.data('action'));
+    }
+
+    if (typeof(link.data('method')) !== 'undefined') {
+      modal.find('form').attr('action', link.data('method'));
+    }
+
+    if (typeof(link.data('remote')) !== 'undefined') {
+      modal.find('form').attr('action', link.data('remote'));
+    }
+  });
+}

--- a/src/api/app/components/delete_confirmation_dialog_component.html.haml
+++ b/src/api/app/components/delete_confirmation_dialog_component.html.haml
@@ -11,3 +11,8 @@
             %a.btn.btn-sm.btn-outline-secondary.px-4{ data: { dismiss: 'modal' } }
               Cancel
             = submit_tag('Remove', class: 'btn btn-sm btn-danger px-4')
+
+:javascript
+  $(document).ready(function() {
+    collectDeleteConfirmationModalsAndSetValues();
+  });

--- a/src/api/app/components/watchlist_component.html.haml
+++ b/src/api/app/components/watchlist_component.html.haml
@@ -23,10 +23,5 @@
   toggleCollapsibleTooltip();
 
   $(document).ready(function() {
-    $('#delete-item-from-watchlist-modal').on('show.bs.modal', function (event) {
-      var link = $(event.relatedTarget);
-      $(this).find('.modal-title').text(link.data('modal-title'));
-      $(this).find('.confirmation-text').text(link.data('confirmation-text'));
-      $(this).find('form').attr('action', link.data('action'));
-    });
+    setValuesOnDeleteConfirmationDialog('#delete-item-from-watchlist-modal');
   });

--- a/src/api/app/components/watchlist_component.html.haml
+++ b/src/api/app/components/watchlist_component.html.haml
@@ -21,7 +21,3 @@
 
 :javascript
   toggleCollapsibleTooltip();
-
-  $(document).ready(function() {
-    setValuesOnDeleteConfirmationDialog('#delete-item-from-watchlist-modal');
-  });

--- a/src/api/app/views/webui/users/tokens/users/index.html.haml
+++ b/src/api/app/views/webui/users/tokens/users/index.html.haml
@@ -75,20 +75,8 @@
           Add Group
 
 :javascript
-  // TODO: move this JS to confirmation_dialog_component.html.haml so this can be reused by any piece of code using the component.
-  //       It has to be generic, taking the modal id from the DOM.
   $(document).ready(function() {
-    $('#delete-user-from-token-modal').on('show.bs.modal', function (event) {
-      var link = $(event.relatedTarget);
-      $(this).find('.confirmation-text').text(link.data('confirmation-text'));
-      $(this).find('form').attr('action', link.data('action'));
-    });
-  });
-  $(document).ready(function() {
-    $('#delete-group-from-token-modal').on('show.bs.modal', function (event) {
-      var link = $(event.relatedTarget);
-      $(this).find('.confirmation-text').text(link.data('confirmation-text'));
-      $(this).find('form').attr('action', link.data('action'));
-    });
+    setValuesOnDeleteConfirmationDialog('#delete-user-from-token-modal');
+    setValuesOnDeleteConfirmationDialog('#delete-group-from-token-modal');
   });
 

--- a/src/api/app/views/webui/users/tokens/users/index.html.haml
+++ b/src/api/app/views/webui/users/tokens/users/index.html.haml
@@ -74,9 +74,3 @@
           %i.fas.fa-plus-circle.text-primary
           Add Group
 
-:javascript
-  $(document).ready(function() {
-    setValuesOnDeleteConfirmationDialog('#delete-user-from-token-modal');
-    setValuesOnDeleteConfirmationDialog('#delete-group-from-token-modal');
-  });
-


### PR DESCRIPTION
Instead of implementing similar pieces of JS code from different views, a generic piece of JS is moved to the component.

TODO:

- [ ] Fix issue in watchlist. When I remove one item, the link "Watch this item/Remove this item" disappears and it shouldn't.
- [ ] Check if having the generic JS affects other existing confirmation dialogs.
- [ ] Rename component from ConfirmationDialogComponent to DeleteConfirmationDialogComponent?