### PR TITLE
Add new column executor to tokens table

### DIFF
--- a/src/api/app/controllers/person/token_controller.rb
+++ b/src/api/app/controllers/person/token_controller.rb
@@ -20,7 +20,7 @@ module Person
 
       pkg = (Package.get_by_project_and_name(params[:project], params[:package]) if params[:project] || params[:package])
 
-      @token = Token.token_type(params[:operation]).create(description: params[:description], user: @user, package: pkg, scm_token: params[:scm_token])
+      @token = Token.token_type(params[:operation]).create(description: params[:description], user: @user, executor_id: @user&.id, package: pkg, scm_token: params[:scm_token])
       return if @token.valid?
 
       render_error status: 400,

--- a/src/api/app/controllers/webui/users/tokens_controller.rb
+++ b/src/api/app/controllers/webui/users/tokens_controller.rb
@@ -44,7 +44,9 @@ class Webui::Users::TokensController < Webui::WebuiController
   end
 
   def create
-    @token = Token.token_type(@params[:type]).new(@params.except(:type).merge(user: User.session, package: @package))
+    @token = Token.token_type(@params[:type]).new(@params.except(:type).merge(user: User.session,
+                                                                              executor_id: User.session&.id,
+                                                                              package: @package))
 
     authorize @token
 

--- a/src/api/app/models/token.rb
+++ b/src/api/app/models/token.rb
@@ -77,15 +77,17 @@ end
 #  string       :string(255)      indexed
 #  triggered_at :datetime
 #  type         :string(255)
+#  executor_id  :integer          default(0), not null, indexed
 #  package_id   :integer          indexed
 #  user_id      :integer          not null, indexed
 #
 # Indexes
 #
-#  index_tokens_on_scm_token  (scm_token)
-#  index_tokens_on_string     (string) UNIQUE
-#  package_id                 (package_id)
-#  user_id                    (user_id)
+#  index_tokens_on_executor_id  (executor_id)
+#  index_tokens_on_scm_token    (scm_token)
+#  index_tokens_on_string       (string) UNIQUE
+#  package_id                   (package_id)
+#  user_id                      (user_id)
 #
 # Foreign Keys
 #

--- a/src/api/app/models/token/rebuild.rb
+++ b/src/api/app/models/token/rebuild.rb
@@ -23,15 +23,17 @@ end
 #  string       :string(255)      indexed
 #  triggered_at :datetime
 #  type         :string(255)
+#  executor_id  :integer          default(0), not null, indexed
 #  package_id   :integer          indexed
 #  user_id      :integer          not null, indexed
 #
 # Indexes
 #
-#  index_tokens_on_scm_token  (scm_token)
-#  index_tokens_on_string     (string) UNIQUE
-#  package_id                 (package_id)
-#  user_id                    (user_id)
+#  index_tokens_on_executor_id  (executor_id)
+#  index_tokens_on_scm_token    (scm_token)
+#  index_tokens_on_string       (string) UNIQUE
+#  package_id                   (package_id)
+#  user_id                      (user_id)
 #
 # Foreign Keys
 #

--- a/src/api/app/models/token/release.rb
+++ b/src/api/app/models/token/release.rb
@@ -37,15 +37,17 @@ end
 #  string       :string(255)      indexed
 #  triggered_at :datetime
 #  type         :string(255)
+#  executor_id  :integer          default(0), not null, indexed
 #  package_id   :integer          indexed
 #  user_id      :integer          not null, indexed
 #
 # Indexes
 #
-#  index_tokens_on_scm_token  (scm_token)
-#  index_tokens_on_string     (string) UNIQUE
-#  package_id                 (package_id)
-#  user_id                    (user_id)
+#  index_tokens_on_executor_id  (executor_id)
+#  index_tokens_on_scm_token    (scm_token)
+#  index_tokens_on_string       (string) UNIQUE
+#  package_id                   (package_id)
+#  user_id                      (user_id)
 #
 # Foreign Keys
 #

--- a/src/api/app/models/token/rss.rb
+++ b/src/api/app/models/token/rss.rb
@@ -11,15 +11,17 @@ end
 #  string       :string(255)      indexed
 #  triggered_at :datetime
 #  type         :string(255)
+#  executor_id  :integer          default(0), not null, indexed
 #  package_id   :integer          indexed
 #  user_id      :integer          not null, indexed
 #
 # Indexes
 #
-#  index_tokens_on_scm_token  (scm_token)
-#  index_tokens_on_string     (string) UNIQUE
-#  package_id                 (package_id)
-#  user_id                    (user_id)
+#  index_tokens_on_executor_id  (executor_id)
+#  index_tokens_on_scm_token    (scm_token)
+#  index_tokens_on_string       (string) UNIQUE
+#  package_id                   (package_id)
+#  user_id                      (user_id)
 #
 # Foreign Keys
 #

--- a/src/api/app/models/token/service.rb
+++ b/src/api/app/models/token/service.rb
@@ -21,15 +21,17 @@ end
 #  string       :string(255)      indexed
 #  triggered_at :datetime
 #  type         :string(255)
+#  executor_id  :integer          default(0), not null, indexed
 #  package_id   :integer          indexed
 #  user_id      :integer          not null, indexed
 #
 # Indexes
 #
-#  index_tokens_on_scm_token  (scm_token)
-#  index_tokens_on_string     (string) UNIQUE
-#  package_id                 (package_id)
-#  user_id                    (user_id)
+#  index_tokens_on_executor_id  (executor_id)
+#  index_tokens_on_scm_token    (scm_token)
+#  index_tokens_on_string       (string) UNIQUE
+#  package_id                   (package_id)
+#  user_id                      (user_id)
 #
 # Foreign Keys
 #

--- a/src/api/app/models/token/workflow.rb
+++ b/src/api/app/models/token/workflow.rb
@@ -74,15 +74,17 @@ end
 #  string       :string(255)      indexed
 #  triggered_at :datetime
 #  type         :string(255)
+#  executor_id  :integer          default(0), not null, indexed
 #  package_id   :integer          indexed
 #  user_id      :integer          not null, indexed
 #
 # Indexes
 #
-#  index_tokens_on_scm_token  (scm_token)
-#  index_tokens_on_string     (string) UNIQUE
-#  package_id                 (package_id)
-#  user_id                    (user_id)
+#  index_tokens_on_executor_id  (executor_id)
+#  index_tokens_on_scm_token    (scm_token)
+#  index_tokens_on_string       (string) UNIQUE
+#  package_id                   (package_id)
+#  user_id                      (user_id)
 #
 # Foreign Keys
 #

--- a/src/api/db/migrate/20220621075514_add_executor_column_to_tokens_table.rb
+++ b/src/api/db/migrate/20220621075514_add_executor_column_to_tokens_table.rb
@@ -1,0 +1,6 @@
+class AddExecutorColumnToTokensTable < ActiveRecord::Migration[6.1]
+  def change
+    add_column :tokens, :executor_id, :integer, null: false, default: 0
+    add_index :tokens, :executor_id
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_10_114201) do
+ActiveRecord::Schema.define(version: 2022_06_21_075514) do
 
   create_table "architectures", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false, collation: "utf8mb3_general_ci"
@@ -1024,6 +1024,8 @@ ActiveRecord::Schema.define(version: 2022_06_10_114201) do
     t.string "scm_token"
     t.string "description", limit: 64, default: ""
     t.datetime "triggered_at"
+    t.integer "executor_id", default: 0, null: false
+    t.index ["executor_id"], name: "index_tokens_on_executor_id"
     t.index ["package_id"], name: "package_id"
     t.index ["scm_token"], name: "index_tokens_on_scm_token"
     t.index ["string"], name: "index_tokens_on_string", unique: true

--- a/src/api/lib/tasks/databases.rake
+++ b/src/api/lib/tasks/databases.rake
@@ -6,4 +6,16 @@ namespace :db do
     puts 'warning for migrating your data run data:migrate'
     puts ''
   end
+
+  namespace :backfill do
+    desc 'Backfill the tokens executor_id column with the user_id'
+    task token_executor: :environment do
+      Token.unscoped.in_batches do |relation|
+        relation.each do |token|
+          token.update(executor_id: token.user.id)
+        end
+        sleep(0.01) # throttle
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is the first of several PRs to rename the existing `Token.user` relationship to `Token.executor` in a safe manner.

In this PR, we:
1. Create the new column
2. Move writes to the new column
3. Backfill data

Then, in PRs following this one, we'll move reads to the new column (#12714), and finally, delete the old `user` column.