### PR TITLE
Move writes from tokens user to tokens executor

### DIFF
--- a/src/api/app/components/token_card_component.html.haml
+++ b/src/api/app/components/token_card_component.html.haml
@@ -15,7 +15,7 @@
         Package:
         = token_package_link
     %p.card-text
-      Runs as: #{link_to(@token.user.login, user_path(@token.user))}
+      Runs as: #{link_to(@token.executor.login, user_path(@token.executor))}
     - if @token.triggered_at.present?
       %p.card-text
         Last trigger on #{@token.triggered_at}

--- a/src/api/app/controllers/person/token_controller.rb
+++ b/src/api/app/controllers/person/token_controller.rb
@@ -20,7 +20,7 @@ module Person
 
       pkg = (Package.get_by_project_and_name(params[:project], params[:package]) if params[:project] || params[:package])
 
-      @token = Token.token_type(params[:operation]).create(description: params[:description], user: @user, package: pkg, scm_token: params[:scm_token])
+      @token = Token.token_type(params[:operation]).create(description: params[:description], user: @user, executor_id: @user&.id, package: pkg, scm_token: params[:scm_token])
       return if @token.valid?
 
       render_error status: 400,

--- a/src/api/app/controllers/trigger_controller.rb
+++ b/src/api/app/controllers/trigger_controller.rb
@@ -28,7 +28,7 @@ class TriggerController < ApplicationController
   def create
     authorize @token, :trigger?
 
-    @token.user.run_as do
+    @token.executor.run_as do
       opts = { project: @project, package: @package, repository: params[:repository], arch: params[:arch] }
       opts[:multibuild_flavor] = @multibuild_container if @multibuild_container.present?
       @token.call(opts)
@@ -59,7 +59,7 @@ class TriggerController < ApplicationController
   end
 
   def pundit_user
-    @token.user
+    @token.executor
   end
 
   def set_project_name

--- a/src/api/app/controllers/trigger_workflow_controller.rb
+++ b/src/api/app/controllers/trigger_workflow_controller.rb
@@ -9,7 +9,7 @@ class TriggerWorkflowController < TriggerController
 
   def create
     authorize @token, :trigger?
-    @token.user.run_as do
+    @token.executor.run_as do
       validation_errors = @token.call(workflow_run: @workflow_run, scm_webhook: @scm_webhook)
 
       unless @workflow_run.status == 'fail' # The SCMStatusReporter might already set the status to 'fail', lets not overwrite it

--- a/src/api/app/controllers/webui/feeds_controller.rb
+++ b/src/api/app/controllers/webui/feeds_controller.rb
@@ -27,8 +27,8 @@ class Webui::FeedsController < Webui::WebuiController
     token = Token::Rss.find_by_string(params[:token])
     if token
       @configuration = ::Configuration.first
-      @user = token.user
-      @notifications = token.user.combined_rss_feed_items
+      @user = token.executor
+      @notifications = token.executor.combined_rss_feed_items
       @host = ::Configuration.obs_url
     else
       flash[:error] = 'Unknown Token for RSS feed'

--- a/src/api/app/controllers/webui/users/tokens_controller.rb
+++ b/src/api/app/controllers/webui/users/tokens_controller.rb
@@ -44,7 +44,9 @@ class Webui::Users::TokensController < Webui::WebuiController
   end
 
   def create
-    @token = Token.token_type(@params[:type]).new(@params.except(:type).merge(user: User.session, package: @package))
+    @token = Token.token_type(@params[:type]).new(@params.except(:type).merge(user: User.session,
+                                                                              executor_id: User.session&.id,
+                                                                              package: @package))
 
     authorize @token
 

--- a/src/api/app/models/token.rb
+++ b/src/api/app/models/token.rb
@@ -77,15 +77,17 @@ end
 #  string       :string(255)      indexed
 #  triggered_at :datetime
 #  type         :string(255)
+#  executor_id  :integer          default(0), not null, indexed
 #  package_id   :integer          indexed
 #  user_id      :integer          not null, indexed
 #
 # Indexes
 #
-#  index_tokens_on_scm_token  (scm_token)
-#  index_tokens_on_string     (string) UNIQUE
-#  package_id                 (package_id)
-#  user_id                    (user_id)
+#  index_tokens_on_executor_id  (executor_id)
+#  index_tokens_on_scm_token    (scm_token)
+#  index_tokens_on_string       (string) UNIQUE
+#  package_id                   (package_id)
+#  user_id                      (user_id)
 #
 # Foreign Keys
 #

--- a/src/api/app/models/token.rb
+++ b/src/api/app/models/token.rb
@@ -1,5 +1,9 @@
 class Token < ApplicationRecord
-  belongs_to :user
+  # We need to ensure ActiveRecord does not try to use the old `user` column before removing it.
+  # Once this change is deployed we can safely drop the column
+  self.ignored_columns = ['user_id']
+
+  belongs_to :executor, class_name: 'User'
   has_many :event_subscriptions, dependent: :destroy
   belongs_to :package, inverse_of: :tokens, optional: true
 

--- a/src/api/app/models/token/rebuild.rb
+++ b/src/api/app/models/token/rebuild.rb
@@ -23,15 +23,17 @@ end
 #  string       :string(255)      indexed
 #  triggered_at :datetime
 #  type         :string(255)
+#  executor_id  :integer          default(0), not null, indexed
 #  package_id   :integer          indexed
 #  user_id      :integer          not null, indexed
 #
 # Indexes
 #
-#  index_tokens_on_scm_token  (scm_token)
-#  index_tokens_on_string     (string) UNIQUE
-#  package_id                 (package_id)
-#  user_id                    (user_id)
+#  index_tokens_on_executor_id  (executor_id)
+#  index_tokens_on_scm_token    (scm_token)
+#  index_tokens_on_string       (string) UNIQUE
+#  package_id                   (package_id)
+#  user_id                      (user_id)
 #
 # Foreign Keys
 #

--- a/src/api/app/models/token/release.rb
+++ b/src/api/app/models/token/release.rb
@@ -37,15 +37,17 @@ end
 #  string       :string(255)      indexed
 #  triggered_at :datetime
 #  type         :string(255)
+#  executor_id  :integer          default(0), not null, indexed
 #  package_id   :integer          indexed
 #  user_id      :integer          not null, indexed
 #
 # Indexes
 #
-#  index_tokens_on_scm_token  (scm_token)
-#  index_tokens_on_string     (string) UNIQUE
-#  package_id                 (package_id)
-#  user_id                    (user_id)
+#  index_tokens_on_executor_id  (executor_id)
+#  index_tokens_on_scm_token    (scm_token)
+#  index_tokens_on_string       (string) UNIQUE
+#  package_id                   (package_id)
+#  user_id                      (user_id)
 #
 # Foreign Keys
 #

--- a/src/api/app/models/token/rss.rb
+++ b/src/api/app/models/token/rss.rb
@@ -11,15 +11,17 @@ end
 #  string       :string(255)      indexed
 #  triggered_at :datetime
 #  type         :string(255)
+#  executor_id  :integer          default(0), not null, indexed
 #  package_id   :integer          indexed
 #  user_id      :integer          not null, indexed
 #
 # Indexes
 #
-#  index_tokens_on_scm_token  (scm_token)
-#  index_tokens_on_string     (string) UNIQUE
-#  package_id                 (package_id)
-#  user_id                    (user_id)
+#  index_tokens_on_executor_id  (executor_id)
+#  index_tokens_on_scm_token    (scm_token)
+#  index_tokens_on_string       (string) UNIQUE
+#  package_id                   (package_id)
+#  user_id                      (user_id)
 #
 # Foreign Keys
 #

--- a/src/api/app/models/token/service.rb
+++ b/src/api/app/models/token/service.rb
@@ -21,15 +21,17 @@ end
 #  string       :string(255)      indexed
 #  triggered_at :datetime
 #  type         :string(255)
+#  executor_id  :integer          default(0), not null, indexed
 #  package_id   :integer          indexed
 #  user_id      :integer          not null, indexed
 #
 # Indexes
 #
-#  index_tokens_on_scm_token  (scm_token)
-#  index_tokens_on_string     (string) UNIQUE
-#  package_id                 (package_id)
-#  user_id                    (user_id)
+#  index_tokens_on_executor_id  (executor_id)
+#  index_tokens_on_scm_token    (scm_token)
+#  index_tokens_on_string       (string) UNIQUE
+#  package_id                   (package_id)
+#  user_id                      (user_id)
 #
 # Foreign Keys
 #

--- a/src/api/app/models/token/workflow.rb
+++ b/src/api/app/models/token/workflow.rb
@@ -74,15 +74,17 @@ end
 #  string       :string(255)      indexed
 #  triggered_at :datetime
 #  type         :string(255)
+#  executor_id  :integer          default(0), not null, indexed
 #  package_id   :integer          indexed
 #  user_id      :integer          not null, indexed
 #
 # Indexes
 #
-#  index_tokens_on_scm_token  (scm_token)
-#  index_tokens_on_string     (string) UNIQUE
-#  package_id                 (package_id)
-#  user_id                    (user_id)
+#  index_tokens_on_executor_id  (executor_id)
+#  index_tokens_on_scm_token    (scm_token)
+#  index_tokens_on_string       (string) UNIQUE
+#  package_id                   (package_id)
+#  user_id                      (user_id)
 #
 # Foreign Keys
 #

--- a/src/api/app/models/workflow.rb
+++ b/src/api/app/models/workflow.rb
@@ -125,7 +125,7 @@ class Workflow
 
   # TODO: Extract this into a service
   def restore_target_projects
-    token_user_login = token.user.login
+    token_user_login = token.executor.login
 
     # Do not process steps for which there's nothing to do
     processable_steps = steps.reject { |step| step.instance_of?(::Workflow::Step::ConfigureRepositories) || step.instance_of?(::Workflow::Step::RebuildPackage) }

--- a/src/api/app/models/workflow/step.rb
+++ b/src/api/app/models/workflow/step.rb
@@ -44,7 +44,7 @@ class Workflow::Step
     ['Event::BuildFail', 'Event::BuildSuccess'].each do |build_event|
       subscription = EventSubscription.find_or_create_by!(eventtype: build_event,
                                                           receiver_role: 'reader', # We pass a valid value, but we don't need this.
-                                                          user: @token.user,
+                                                          user: @token.executor,
                                                           channel: 'scm',
                                                           enabled: true,
                                                           token: @token,

--- a/src/api/app/models/workflow/step/branch_package_step.rb
+++ b/src/api/app/models/workflow/step/branch_package_step.rb
@@ -37,7 +37,7 @@ class Workflow::Step::BranchPackageStep < ::Workflow::Step
       raise BranchPackage::Errors::CanNotBranchPackageNotFound, "Package #{source_project_name}/#{source_package_name} not found, it could not be branched."
     end
 
-    Pundit.authorize(@token.user, src_package, :create_branch?)
+    Pundit.authorize(@token.executor, src_package, :create_branch?)
   end
 
   def create_branched_package
@@ -57,7 +57,7 @@ class Workflow::Step::BranchPackageStep < ::Workflow::Step
     Event::BranchCommand.create(project: source_project_name, package: source_package_name,
                                 targetproject: target_project_name,
                                 targetpackage: target_package_name,
-                                user: @token.user.login)
+                                user: @token.executor.login)
 
     target_package
   end

--- a/src/api/app/models/workflow/step/configure_repositories.rb
+++ b/src/api/app/models/workflow/step/configure_repositories.rb
@@ -12,7 +12,7 @@ class Workflow::Step::ConfigureRepositories < Workflow::Step
     return unless valid?
 
     target_project = Project.get_by_name(target_project_name)
-    Pundit.authorize(@token.user, target_project, :update?)
+    Pundit.authorize(@token.executor, target_project, :update?)
 
     step_instructions[:repositories].each do |repository_instructions|
       repository = Repository.includes(:architectures).find_or_create_by(name: repository_instructions[:name], project: target_project)
@@ -31,7 +31,7 @@ class Workflow::Step::ConfigureRepositories < Workflow::Step
 
     # We have to store the changes on the backend
     target_project.store(comment: "Added the following repositories to the project: #{step_instructions[:repositories].pluck(:name).compact.to_sentence}",
-                         login: @token.user.login)
+                         login: @token.executor.login)
   end
 
   private

--- a/src/api/app/models/workflow/step/link_package_step.rb
+++ b/src/api/app/models/workflow/step/link_package_step.rb
@@ -44,7 +44,7 @@ class Workflow::Step::LinkPackageStep < ::Workflow::Step
 
     if target_project.nil?
       project = Project.new(name: target_project_name)
-      Pundit.authorize(@token.user, project, :create?)
+      Pundit.authorize(@token.executor, project, :create?)
 
       project.save!
       project.commit_user = User.session
@@ -52,7 +52,7 @@ class Workflow::Step::LinkPackageStep < ::Workflow::Step
       project.store
     end
 
-    Pundit.authorize(@token.user, target_project, :update?)
+    Pundit.authorize(@token.executor, target_project, :update?)
     target_project.packages.create(name: target_package_name)
   end
 
@@ -82,7 +82,7 @@ class Workflow::Step::LinkPackageStep < ::Workflow::Step
   def create_link
     Backend::Api::Sources::Package.write_link(target_project_name,
                                               target_package_name,
-                                              @token.user,
+                                              @token.executor,
                                               link_xml(project: source_project_name, package: source_package_name))
 
     target_package

--- a/src/api/app/models/workflow/step/rebuild_package.rb
+++ b/src/api/app/models/workflow/step/rebuild_package.rb
@@ -18,7 +18,7 @@ class Workflow::Step::RebuildPackage < ::Workflow::Step
     set_object_to_authorize
     set_multibuild_flavor
 
-    Pundit.authorize(@token.user, @token, :rebuild?)
+    Pundit.authorize(@token.executor, @token, :rebuild?)
     rebuild_package
   end
 

--- a/src/api/app/models/workflow/step/set_flags.rb
+++ b/src/api/app/models/workflow/step/set_flags.rb
@@ -39,7 +39,7 @@ class Workflow::Step::SetFlags < ::Workflow::Step
   end
 
   def check_access(object)
-    raise Pundit::NotAuthorizedError unless Pundit.policy(token.user, object).update?
+    raise Pundit::NotAuthorizedError unless Pundit.policy(token.executor, object).update?
   end
 
   def validate_flags

--- a/src/api/app/models/workflow/step/trigger_services.rb
+++ b/src/api/app/models/workflow/step/trigger_services.rb
@@ -15,10 +15,10 @@ class Workflow::Step::TriggerServices < Workflow::Step
     set_object_to_authorize
     set_multibuild_flavor
 
-    Pundit.authorize(@token.user, @token, :trigger_service?)
+    Pundit.authorize(@token.executor, @token, :trigger_service?)
 
     begin
-      Backend::Api::Sources::Package.trigger_services(@project_name, @package_name, @token.user.login, trigger_service_comment)
+      Backend::Api::Sources::Package.trigger_services(@project_name, @package_name, @token.executor.login, trigger_service_comment)
     rescue Backend::NotFoundError => e
       raise NoSourceServiceDefined, "Package #{@project_name}/#{@package_name} does not have a source service defined: #{e.summary}"
     end

--- a/src/api/app/policies/token/rss_policy.rb
+++ b/src/api/app/policies/token/rss_policy.rb
@@ -1,6 +1,6 @@
 class Token::RssPolicy < TokenPolicy
   # TODO: when trigger_workflow is rolled out, remove the create? method
   def create?
-    user == record.user
+    user == record.executor
   end
 end

--- a/src/api/app/policies/token_policy.rb
+++ b/src/api/app/policies/token_policy.rb
@@ -28,7 +28,7 @@ class TokenPolicy < ApplicationPolicy
   end
 
   def update?
-    record.user == user && Flipper.enabled?(:trigger_workflow, user)
+    record.executor == user && Flipper.enabled?(:trigger_workflow, user)
   end
 
   def create?
@@ -36,7 +36,7 @@ class TokenPolicy < ApplicationPolicy
     return false unless Flipper.enabled?(:trigger_workflow, user)
     return false unless record.type != 'Token::Rss'
 
-    record.user == user
+    record.executor == user
   end
 
   def destroy?
@@ -44,10 +44,10 @@ class TokenPolicy < ApplicationPolicy
   end
 
   def webui_trigger?
-    record.user == user && !record.type.in?(['Token::Workflow', 'Token::Rss'])
+    record.executor == user && !record.type.in?(['Token::Workflow', 'Token::Rss'])
   end
 
   def show?
-    record.user == user && !record.type.in?(['Token::Rss'])
+    record.executor == user && !record.type.in?(['Token::Rss'])
   end
 end

--- a/src/api/app/views/webui/users/tokens/show.html.haml
+++ b/src/api/app/views/webui/users/tokens/show.html.haml
@@ -42,7 +42,7 @@
               %label.font-weight-bold
                 Runs as:
               %span
-                = link_to(@token.user.login, user_path(@token.user))
+                = link_to(@token.executor.login, user_path(@token.executor))
 
         - if @token.type == 'Token::Workflow'
           .form-row

--- a/src/api/db/migrate/20220621075514_add_executor_column_to_tokens_table.rb
+++ b/src/api/db/migrate/20220621075514_add_executor_column_to_tokens_table.rb
@@ -1,0 +1,6 @@
+class AddExecutorColumnToTokensTable < ActiveRecord::Migration[6.1]
+  def change
+    add_column :tokens, :executor_id, :integer, null: false, default: 0
+    add_index :tokens, :executor_id
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_10_114201) do
+ActiveRecord::Schema.define(version: 2022_06_21_075514) do
 
   create_table "architectures", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false, collation: "utf8mb3_general_ci"
@@ -1024,6 +1024,8 @@ ActiveRecord::Schema.define(version: 2022_06_10_114201) do
     t.string "scm_token"
     t.string "description", limit: 64, default: ""
     t.datetime "triggered_at"
+    t.integer "executor_id", default: 0, null: false
+    t.index ["executor_id"], name: "index_tokens_on_executor_id"
     t.index ["package_id"], name: "package_id"
     t.index ["scm_token"], name: "index_tokens_on_scm_token"
     t.index ["string"], name: "index_tokens_on_string", unique: true

--- a/src/api/lib/tasks/databases.rake
+++ b/src/api/lib/tasks/databases.rake
@@ -6,16 +6,4 @@ namespace :db do
     puts 'warning for migrating your data run data:migrate'
     puts ''
   end
-
-  namespace :backfill do
-    desc 'Backfill the tokens executor_id column with the user_id'
-    task token_executor: :environment do
-      Token.unscoped.in_batches do |relation|
-        relation.each do |token|
-          token.update(executor_id: token.user.id)
-        end
-        sleep(0.01) # throttle
-      end
-    end
-  end
 end

--- a/src/api/lib/tasks/databases.rake
+++ b/src/api/lib/tasks/databases.rake
@@ -6,4 +6,16 @@ namespace :db do
     puts 'warning for migrating your data run data:migrate'
     puts ''
   end
+
+  namespace :backfill do
+    desc 'Backfill the tokens executor_id column with the user_id'
+    task token_executor: :environment do
+      Token.unscoped.in_batches do |relation|
+        relation.each do |token|
+          token.update(executor_id: token.user.id)
+        end
+        sleep(0.01) # throttle
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is the second of several PRs to rename the existing Token.user relationship to Token.executor in a safe manner.

This is a follow-up to  #12708

In this PR, we:

1. Move reads from the new column
2. Disable the old column so ActiveRecord forgets it

In the last PR following this one, we'll delete the old user column.
