### PR TITLE
Rename token's user column to executor

### DIFF
--- a/src/api/app/components/token_card_component.html.haml
+++ b/src/api/app/components/token_card_component.html.haml
@@ -15,7 +15,7 @@
         Package:
         = token_package_link
     %p.card-text
-      Runs as: #{link_to(@token.user.login, user_path(@token.user))}
+      Runs as: #{link_to(@token.executor.login, user_path(@token.executor))}
     - if @token.triggered_at.present?
       %p.card-text
         Last trigger on #{@token.triggered_at}

--- a/src/api/app/controllers/person/token_controller.rb
+++ b/src/api/app/controllers/person/token_controller.rb
@@ -20,7 +20,7 @@ module Person
 
       pkg = (Package.get_by_project_and_name(params[:project], params[:package]) if params[:project] || params[:package])
 
-      @token = Token.token_type(params[:operation]).create(description: params[:description], user: @user, package: pkg, scm_token: params[:scm_token])
+      @token = Token.token_type(params[:operation]).create(description: params[:description], executor: @user, package: pkg, scm_token: params[:scm_token])
       return if @token.valid?
 
       render_error status: 400,

--- a/src/api/app/controllers/trigger_controller.rb
+++ b/src/api/app/controllers/trigger_controller.rb
@@ -28,7 +28,7 @@ class TriggerController < ApplicationController
   def create
     authorize @token, :trigger?
 
-    @token.user.run_as do
+    @token.executor.run_as do
       opts = { project: @project, package: @package, repository: params[:repository], arch: params[:arch] }
       opts[:multibuild_flavor] = @multibuild_container if @multibuild_container.present?
       @token.call(opts)
@@ -59,7 +59,7 @@ class TriggerController < ApplicationController
   end
 
   def pundit_user
-    @token.user
+    @token.executor
   end
 
   def set_project_name

--- a/src/api/app/controllers/trigger_workflow_controller.rb
+++ b/src/api/app/controllers/trigger_workflow_controller.rb
@@ -9,7 +9,7 @@ class TriggerWorkflowController < TriggerController
 
   def create
     authorize @token, :trigger?
-    @token.user.run_as do
+    @token.executor.run_as do
       validation_errors = @token.call(workflow_run: @workflow_run, scm_webhook: @scm_webhook)
 
       unless @workflow_run.status == 'fail' # The SCMStatusReporter might already set the status to 'fail', lets not overwrite it

--- a/src/api/app/controllers/webui/feeds_controller.rb
+++ b/src/api/app/controllers/webui/feeds_controller.rb
@@ -27,8 +27,8 @@ class Webui::FeedsController < Webui::WebuiController
     token = Token::Rss.find_by_string(params[:token])
     if token
       @configuration = ::Configuration.first
-      @user = token.user
-      @notifications = token.user.combined_rss_feed_items
+      @user = token.executor
+      @notifications = token.executor.combined_rss_feed_items
       @host = ::Configuration.obs_url
     else
       flash[:error] = 'Unknown Token for RSS feed'

--- a/src/api/app/controllers/webui/users/rss_tokens_controller.rb
+++ b/src/api/app/controllers/webui/users/rss_tokens_controller.rb
@@ -7,7 +7,7 @@ module Webui
       after_action :verify_authorized
 
       def create
-        token = authorize(::Token::Rss.find_or_initialize_by(user: User.session))
+        token = authorize(::Token::Rss.find_or_initialize_by(executor: User.session))
         if token.persisted?
           flash[:success] = 'Successfully re-generated your RSS feed url'
           token.regenerate_string

--- a/src/api/app/controllers/webui/users/tokens_controller.rb
+++ b/src/api/app/controllers/webui/users/tokens_controller.rb
@@ -44,7 +44,7 @@ class Webui::Users::TokensController < Webui::WebuiController
   end
 
   def create
-    @token = Token.token_type(@params[:type]).new(@params.except(:type).merge(user: User.session, package: @package))
+    @token = Token.token_type(@params[:type]).new(@params.except(:type).merge(executor: User.session, package: @package))
 
     authorize @token
 

--- a/src/api/app/models/token.rb
+++ b/src/api/app/models/token.rb
@@ -1,5 +1,5 @@
 class Token < ApplicationRecord
-  belongs_to :user
+  belongs_to :executor, class_name: 'User'
   has_many :event_subscriptions, dependent: :destroy
   belongs_to :package, inverse_of: :tokens, optional: true
 
@@ -18,7 +18,7 @@ class Token < ApplicationRecord
   include Token::Errors
 
   # TODO: move to Token::Workflow model
-  scope :owned_tokens, ->(user) { where(user: user).where.not(type: ['Token::Rss']) }
+  scope :owned_tokens, ->(user) { where(executor: user).where.not(type: ['Token::Rss']) }
   scope :shared_tokens, ->(user) { user.shared_workflow_tokens }
   scope :group_shared_tokens, ->(user) { user.groups.map(&:shared_workflow_tokens).flatten } # TODO: transform to ActiveRecord_Relation
 
@@ -63,7 +63,7 @@ class Token < ApplicationRecord
   end
 
   def owned_by?(some_user)
-    user == some_user
+    executor == some_user
   end
 end
 
@@ -77,18 +77,18 @@ end
 #  string       :string(255)      indexed
 #  triggered_at :datetime
 #  type         :string(255)
+#  executor_id  :integer          not null, indexed
 #  package_id   :integer          indexed
-#  user_id      :integer          not null, indexed
 #
 # Indexes
 #
 #  index_tokens_on_scm_token  (scm_token)
 #  index_tokens_on_string     (string) UNIQUE
 #  package_id                 (package_id)
-#  user_id                    (user_id)
+#  user_id                    (executor_id)
 #
 # Foreign Keys
 #
-#  tokens_ibfk_1  (user_id => users.id)
+#  tokens_ibfk_1  (executor_id => users.id)
 #  tokens_ibfk_2  (package_id => packages.id)
 #

--- a/src/api/app/models/token/rebuild.rb
+++ b/src/api/app/models/token/rebuild.rb
@@ -23,18 +23,18 @@ end
 #  string       :string(255)      indexed
 #  triggered_at :datetime
 #  type         :string(255)
+#  executor_id  :integer          not null, indexed
 #  package_id   :integer          indexed
-#  user_id      :integer          not null, indexed
 #
 # Indexes
 #
 #  index_tokens_on_scm_token  (scm_token)
 #  index_tokens_on_string     (string) UNIQUE
 #  package_id                 (package_id)
-#  user_id                    (user_id)
+#  user_id                    (executor_id)
 #
 # Foreign Keys
 #
-#  tokens_ibfk_1  (user_id => users.id)
+#  tokens_ibfk_1  (executor_id => users.id)
 #  tokens_ibfk_2  (package_id => packages.id)
 #

--- a/src/api/app/models/token/release.rb
+++ b/src/api/app/models/token/release.rb
@@ -37,18 +37,18 @@ end
 #  string       :string(255)      indexed
 #  triggered_at :datetime
 #  type         :string(255)
+#  executor_id  :integer          not null, indexed
 #  package_id   :integer          indexed
-#  user_id      :integer          not null, indexed
 #
 # Indexes
 #
 #  index_tokens_on_scm_token  (scm_token)
 #  index_tokens_on_string     (string) UNIQUE
 #  package_id                 (package_id)
-#  user_id                    (user_id)
+#  user_id                    (executor_id)
 #
 # Foreign Keys
 #
-#  tokens_ibfk_1  (user_id => users.id)
+#  tokens_ibfk_1  (executor_id => users.id)
 #  tokens_ibfk_2  (package_id => packages.id)
 #

--- a/src/api/app/models/token/rss.rb
+++ b/src/api/app/models/token/rss.rb
@@ -11,18 +11,18 @@ end
 #  string       :string(255)      indexed
 #  triggered_at :datetime
 #  type         :string(255)
+#  executor_id  :integer          not null, indexed
 #  package_id   :integer          indexed
-#  user_id      :integer          not null, indexed
 #
 # Indexes
 #
 #  index_tokens_on_scm_token  (scm_token)
 #  index_tokens_on_string     (string) UNIQUE
 #  package_id                 (package_id)
-#  user_id                    (user_id)
+#  user_id                    (executor_id)
 #
 # Foreign Keys
 #
-#  tokens_ibfk_1  (user_id => users.id)
+#  tokens_ibfk_1  (executor_id => users.id)
 #  tokens_ibfk_2  (package_id => packages.id)
 #

--- a/src/api/app/models/token/service.rb
+++ b/src/api/app/models/token/service.rb
@@ -3,7 +3,7 @@ class Token::Service < Token
     set_triggered_at
     Backend::Api::Sources::Package.trigger_services(options[:project].to_param,
                                                     options[:package].to_param,
-                                                    user.login)
+                                                    executor.login)
   end
 
   def package_find_options
@@ -21,18 +21,18 @@ end
 #  string       :string(255)      indexed
 #  triggered_at :datetime
 #  type         :string(255)
+#  executor_id  :integer          not null, indexed
 #  package_id   :integer          indexed
-#  user_id      :integer          not null, indexed
 #
 # Indexes
 #
 #  index_tokens_on_scm_token  (scm_token)
 #  index_tokens_on_string     (string) UNIQUE
 #  package_id                 (package_id)
-#  user_id                    (user_id)
+#  user_id                    (executor_id)
 #
 # Foreign Keys
 #
-#  tokens_ibfk_1  (user_id => users.id)
+#  tokens_ibfk_1  (executor_id => users.id)
 #  tokens_ibfk_2  (package_id => packages.id)
 #

--- a/src/api/app/models/token/workflow.rb
+++ b/src/api/app/models/token/workflow.rb
@@ -42,8 +42,8 @@ class Token::Workflow < Token
   end
 
   def owned_by?(some_user)
-    # TODO: remove the first condition if we migrate the Token.user to Token.users
-    user == some_user || users.include?(some_user) || groups.map(&:users).flatten.include?(some_user)
+    # TODO: remove the first condition if we migrate, with a data migration, the Token.executor to Token.users
+    executor == some_user || users.include?(some_user) || groups.map(&:users).flatten.include?(some_user)
   end
 
   private
@@ -72,18 +72,18 @@ end
 #  string       :string(255)      indexed
 #  triggered_at :datetime
 #  type         :string(255)
+#  executor_id  :integer          not null, indexed
 #  package_id   :integer          indexed
-#  user_id      :integer          not null, indexed
 #
 # Indexes
 #
 #  index_tokens_on_scm_token  (scm_token)
 #  index_tokens_on_string     (string) UNIQUE
 #  package_id                 (package_id)
-#  user_id                    (user_id)
+#  user_id                    (executor_id)
 #
 # Foreign Keys
 #
-#  tokens_ibfk_1  (user_id => users.id)
+#  tokens_ibfk_1  (executor_id => users.id)
 #  tokens_ibfk_2  (package_id => packages.id)
 #

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -23,7 +23,7 @@ class User < ApplicationRecord
 
   has_many :comments, dependent: :destroy, inverse_of: :user
   has_many :status_messages
-  has_many :tokens, class_name: 'Token', dependent: :destroy, inverse_of: :user
+  has_many :tokens, class_name: 'Token', dependent: :destroy, inverse_of: :executor, foreign_key: :executor_id
 
   has_and_belongs_to_many :shared_workflow_tokens,
                           class_name: 'Token::Workflow',
@@ -32,7 +32,7 @@ class User < ApplicationRecord
                           dependent: :destroy,
                           inverse_of: :token_workflow
 
-  has_one :rss_token, class_name: 'Token::Rss', dependent: :destroy
+  has_one :rss_token, class_name: 'Token::Rss', dependent: :destroy, foreign_key: :executor_id
 
   has_many :reviews, dependent: :nullify
 

--- a/src/api/app/models/workflow.rb
+++ b/src/api/app/models/workflow.rb
@@ -125,7 +125,7 @@ class Workflow
 
   # TODO: Extract this into a service
   def restore_target_projects
-    token_user_login = token.user.login
+    token_user_login = token.executor.login
 
     # Do not process steps for which there's nothing to do
     processable_steps = steps.reject { |step| step.instance_of?(::Workflow::Step::ConfigureRepositories) || step.instance_of?(::Workflow::Step::RebuildPackage) }

--- a/src/api/app/models/workflow/step.rb
+++ b/src/api/app/models/workflow/step.rb
@@ -44,7 +44,7 @@ class Workflow::Step
     ['Event::BuildFail', 'Event::BuildSuccess'].each do |build_event|
       subscription = EventSubscription.find_or_create_by!(eventtype: build_event,
                                                           receiver_role: 'reader', # We pass a valid value, but we don't need this.
-                                                          user: @token.user,
+                                                          user: @token.executor,
                                                           channel: 'scm',
                                                           enabled: true,
                                                           token: @token,

--- a/src/api/app/models/workflow/step/branch_package_step.rb
+++ b/src/api/app/models/workflow/step/branch_package_step.rb
@@ -37,7 +37,7 @@ class Workflow::Step::BranchPackageStep < ::Workflow::Step
       raise BranchPackage::Errors::CanNotBranchPackageNotFound, "Package #{source_project_name}/#{source_package_name} not found, it could not be branched."
     end
 
-    Pundit.authorize(@token.user, src_package, :create_branch?)
+    Pundit.authorize(@token.executor, src_package, :create_branch?)
   end
 
   def create_branched_package
@@ -57,7 +57,7 @@ class Workflow::Step::BranchPackageStep < ::Workflow::Step
     Event::BranchCommand.create(project: source_project_name, package: source_package_name,
                                 targetproject: target_project_name,
                                 targetpackage: target_package_name,
-                                user: @token.user.login)
+                                user: @token.executor.login)
 
     target_package
   end

--- a/src/api/app/models/workflow/step/configure_repositories.rb
+++ b/src/api/app/models/workflow/step/configure_repositories.rb
@@ -12,7 +12,7 @@ class Workflow::Step::ConfigureRepositories < Workflow::Step
     return unless valid?
 
     target_project = Project.get_by_name(target_project_name)
-    Pundit.authorize(@token.user, target_project, :update?)
+    Pundit.authorize(@token.executor, target_project, :update?)
 
     step_instructions[:repositories].each do |repository_instructions|
       repository = Repository.includes(:architectures).find_or_create_by(name: repository_instructions[:name], project: target_project)
@@ -31,7 +31,7 @@ class Workflow::Step::ConfigureRepositories < Workflow::Step
 
     # We have to store the changes on the backend
     target_project.store(comment: "Added the following repositories to the project: #{step_instructions[:repositories].pluck(:name).compact.to_sentence}",
-                         login: @token.user.login)
+                         login: @token.executor.login)
   end
 
   private

--- a/src/api/app/models/workflow/step/link_package_step.rb
+++ b/src/api/app/models/workflow/step/link_package_step.rb
@@ -44,7 +44,7 @@ class Workflow::Step::LinkPackageStep < ::Workflow::Step
 
     if target_project.nil?
       project = Project.new(name: target_project_name)
-      Pundit.authorize(@token.user, project, :create?)
+      Pundit.authorize(@token.executor, project, :create?)
 
       project.save!
       project.commit_user = User.session
@@ -52,7 +52,7 @@ class Workflow::Step::LinkPackageStep < ::Workflow::Step
       project.store
     end
 
-    Pundit.authorize(@token.user, target_project, :update?)
+    Pundit.authorize(@token.executor, target_project, :update?)
     target_project.packages.create(name: target_package_name)
   end
 
@@ -82,7 +82,7 @@ class Workflow::Step::LinkPackageStep < ::Workflow::Step
   def create_link
     Backend::Api::Sources::Package.write_link(target_project_name,
                                               target_package_name,
-                                              @token.user,
+                                              @token.executor,
                                               link_xml(project: source_project_name, package: source_package_name))
 
     target_package

--- a/src/api/app/models/workflow/step/rebuild_package.rb
+++ b/src/api/app/models/workflow/step/rebuild_package.rb
@@ -18,7 +18,7 @@ class Workflow::Step::RebuildPackage < ::Workflow::Step
     set_object_to_authorize
     set_multibuild_flavor
 
-    Pundit.authorize(@token.user, @token, :rebuild?)
+    Pundit.authorize(@token.executor, @token, :rebuild?)
     rebuild_package
   end
 

--- a/src/api/app/models/workflow/step/set_flags.rb
+++ b/src/api/app/models/workflow/step/set_flags.rb
@@ -39,7 +39,7 @@ class Workflow::Step::SetFlags < ::Workflow::Step
   end
 
   def check_access(object)
-    raise Pundit::NotAuthorizedError unless Pundit.policy(token.user, object).update?
+    raise Pundit::NotAuthorizedError unless Pundit.policy(token.executor, object).update?
   end
 
   def validate_flags

--- a/src/api/app/models/workflow/step/trigger_services.rb
+++ b/src/api/app/models/workflow/step/trigger_services.rb
@@ -15,10 +15,10 @@ class Workflow::Step::TriggerServices < Workflow::Step
     set_object_to_authorize
     set_multibuild_flavor
 
-    Pundit.authorize(@token.user, @token, :trigger_service?)
+    Pundit.authorize(@token.executor, @token, :trigger_service?)
 
     begin
-      Backend::Api::Sources::Package.trigger_services(@project_name, @package_name, @token.user.login, trigger_service_comment)
+      Backend::Api::Sources::Package.trigger_services(@project_name, @package_name, @token.executor.login, trigger_service_comment)
     rescue Backend::NotFoundError => e
       raise NoSourceServiceDefined, "Package #{@project_name}/#{@package_name} does not have a source service defined: #{e.summary}"
     end

--- a/src/api/app/policies/token/rss_policy.rb
+++ b/src/api/app/policies/token/rss_policy.rb
@@ -1,6 +1,6 @@
 class Token::RssPolicy < TokenPolicy
   # TODO: when trigger_workflow is rolled out, remove the create? method
   def create?
-    user == record.user
+    user == record.executor
   end
 end

--- a/src/api/app/policies/token_policy.rb
+++ b/src/api/app/policies/token_policy.rb
@@ -28,7 +28,7 @@ class TokenPolicy < ApplicationPolicy
   end
 
   def update?
-    record.user == user && Flipper.enabled?(:trigger_workflow, user)
+    record.executor == user && Flipper.enabled?(:trigger_workflow, user)
   end
 
   def create?
@@ -36,7 +36,7 @@ class TokenPolicy < ApplicationPolicy
     return false unless Flipper.enabled?(:trigger_workflow, user)
     return false unless record.type != 'Token::Rss'
 
-    record.user == user
+    record.executor == user
   end
 
   def destroy?
@@ -44,10 +44,10 @@ class TokenPolicy < ApplicationPolicy
   end
 
   def webui_trigger?
-    record.user == user && !record.type.in?(['Token::Workflow', 'Token::Rss'])
+    record.executor == user && !record.type.in?(['Token::Workflow', 'Token::Rss'])
   end
 
   def show?
-    record.user == user && !record.type.in?(['Token::Rss'])
+    record.executor == user && !record.type.in?(['Token::Rss'])
   end
 end

--- a/src/api/app/views/webui/users/tokens/show.html.haml
+++ b/src/api/app/views/webui/users/tokens/show.html.haml
@@ -42,7 +42,7 @@
               %label.font-weight-bold
                 Runs as:
               %span
-                = link_to(@token.user.login, user_path(@token.user))
+                = link_to(@token.executor.login, user_path(@token.executor))
 
         - if @token.type == 'Token::Workflow'
           .form-row

--- a/src/api/db/migrate/20220622135133_change_tokens_user_column_to_executor.rb
+++ b/src/api/db/migrate/20220622135133_change_tokens_user_column_to_executor.rb
@@ -1,0 +1,5 @@
+class ChangeTokensUserColumnToExecutor < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured { rename_column :tokens, :user_id, :executor_id }
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_10_114201) do
+ActiveRecord::Schema.define(version: 2022_06_22_135133) do
 
   create_table "architectures", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false, collation: "utf8mb3_general_ci"
@@ -1018,16 +1018,16 @@ ActiveRecord::Schema.define(version: 2022_06_10_114201) do
 
   create_table "tokens", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "string", collation: "utf8mb3_unicode_ci"
-    t.integer "user_id", null: false
+    t.integer "executor_id", null: false
     t.integer "package_id"
     t.string "type", collation: "utf8mb3_unicode_ci"
     t.string "scm_token"
     t.string "description", limit: 64, default: ""
     t.datetime "triggered_at"
+    t.index ["executor_id"], name: "user_id"
     t.index ["package_id"], name: "package_id"
     t.index ["scm_token"], name: "index_tokens_on_scm_token"
     t.index ["string"], name: "index_tokens_on_string", unique: true
-    t.index ["user_id"], name: "user_id"
   end
 
   create_table "updateinfo_counters", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
@@ -1213,7 +1213,7 @@ ActiveRecord::Schema.define(version: 2022_06_10_114201) do
   add_foreign_key "roles_users", "users", name: "roles_users_ibfk_1"
   add_foreign_key "status_checks", "status_reports", column: "status_reports_id"
   add_foreign_key "tokens", "packages", name: "tokens_ibfk_2"
-  add_foreign_key "tokens", "users", name: "tokens_ibfk_1"
+  add_foreign_key "tokens", "users", column: "executor_id", name: "tokens_ibfk_1"
   add_foreign_key "user_registrations", "users", name: "user_registrations_ibfk_1"
   add_foreign_key "watched_projects", "users", name: "watched_projects_ibfk_1"
 end

--- a/src/api/lib/tasks/workflows.rake
+++ b/src/api/lib/tasks/workflows.rake
@@ -18,7 +18,7 @@ namespace :workflows do
     User.session = admin
     project = find_or_create_project(admin.home_project_name, admin)
 
-    workflow_token = Token::Workflow.find_by(description: 'Testing token') || create(:workflow_token, user: admin, description: 'Testing token')
+    workflow_token = Token::Workflow.find_by(description: 'Testing token') || create(:workflow_token, executor: admin, description: 'Testing token')
 
     # GitHub
     create(:workflow_run_github_running, token: workflow_token)

--- a/src/api/spec/components/token_card_component_spec.rb
+++ b/src/api/spec/components/token_card_component_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe TokenCardComponent, type: :component do
   end
 
   context 'token with a description' do
-    let(:token) { build_stubbed(:rebuild_token, user: user, description: 'foo_token') }
+    let(:token) { build_stubbed(:rebuild_token, executor: user, description: 'foo_token') }
 
     it { expect(rendered_content).to have_text('foo_token') }
   end
 
   context 'token without any optional information' do
-    let(:token) { build_stubbed(:rebuild_token, user: user) }
+    let(:token) { build_stubbed(:rebuild_token, executor: user) }
 
     it { expect(rendered_content).to have_text('No description') }
     it { expect(rendered_content).to have_text("Id: #{token.id}") }
@@ -27,7 +27,7 @@ RSpec.describe TokenCardComponent, type: :component do
 
   context 'token with a package assigned' do
     let(:project) { create(:project_with_package) }
-    let(:token) { build_stubbed(:rebuild_token, user: user, package: project.packages.first) }
+    let(:token) { build_stubbed(:rebuild_token, executor: user, package: project.packages.first) }
 
     it { expect(rendered_content).to have_text('Package:') }
     it { expect(rendered_content).to have_link("#{project.name}/#{project.packages.first.name}") }
@@ -35,13 +35,13 @@ RSpec.describe TokenCardComponent, type: :component do
 
   context 'token that got triggered in the past' do
     let(:time_now) { Time.now.utc }
-    let(:token) { build_stubbed(:rebuild_token, user: user, triggered_at: time_now) }
+    let(:token) { build_stubbed(:rebuild_token, executor: user, triggered_at: time_now) }
 
     it { expect(rendered_content).to have_text("Last trigger on #{time_now}") }
   end
 
   context 'token of type workflow' do
-    let(:token) { build_stubbed(:workflow_token, user: user) }
+    let(:token) { build_stubbed(:workflow_token, executor: user) }
 
     it { expect(rendered_content).to have_link(href: "/my/tokens/#{token.id}/workflow_runs") }
   end

--- a/src/api/spec/controllers/concerns/triggerable_spec.rb
+++ b/src/api/spec/controllers/concerns/triggerable_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Triggerable do
   end
 
   describe '#set_project' do
-    let(:token) { Token::Rebuild.create(user: user) }
+    let(:token) { Token::Rebuild.create(executor: user) }
 
     before do
       allow(Project).to receive(:get_by_name).and_return('some:remote:project')
@@ -42,7 +42,7 @@ RSpec.describe Triggerable do
   end
 
   describe '#set_package' do
-    let(:token) { Token::Service.create(user: user) }
+    let(:token) { Token::Service.create(executor: user) }
     let(:package_name) { 'does-not-exist' }
 
     it 'raises when package does not exist' do
@@ -52,7 +52,7 @@ RSpec.describe Triggerable do
     end
 
     context 'project with project-link and token that follows project-links' do
-      let(:token) { Token::Rebuild.create(user: user) }
+      let(:token) { Token::Rebuild.create(executor: user) }
       let(:package_name) { 'does-not-exist' }
       let(:project_with_a_link) { create(:project, name: 'project_with_a_link', maintainer: user, link_to: project) }
 
@@ -72,7 +72,7 @@ RSpec.describe Triggerable do
     end
 
     context 'project with remote project-link' do
-      let(:token) { Token::Rebuild.create(user: user) }
+      let(:token) { Token::Rebuild.create(executor: user) }
       let(:project_name) { 'project_with_a_link' }
       let(:package_name) { 'remote_package_trigger' }
 
@@ -88,7 +88,7 @@ RSpec.describe Triggerable do
   end
 
   describe '#set_object_to_authorize' do
-    let(:token) { Token::Service.create(user: user) }
+    let(:token) { Token::Service.create(executor: user) }
     let(:local_package) { create(:package, name: 'local_package', project: project_with_a_link) }
 
     it 'assigns associated package' do
@@ -100,7 +100,7 @@ RSpec.describe Triggerable do
     end
 
     context 'project with project-link' do
-      let(:token) { Token::Rebuild.create(user: user) }
+      let(:token) { Token::Rebuild.create(executor: user) }
       let(:project_with_a_link) { create(:project, name: 'project_with_a_link', maintainer: user, link_to: project) }
 
       before do
@@ -117,7 +117,7 @@ RSpec.describe Triggerable do
     end
 
     context 'project with project-link and a local package' do
-      let(:token) { Token::Rebuild.create(user: user) }
+      let(:token) { Token::Rebuild.create(executor: user) }
       let(:project_with_a_link) { create(:project, name: 'project_with_a_link', maintainer: user, link_to: project) }
 
       before do
@@ -135,7 +135,7 @@ RSpec.describe Triggerable do
     end
 
     context 'project with remote project-link' do
-      let(:token) { Token::Rebuild.create(user: user) }
+      let(:token) { Token::Rebuild.create(executor: user) }
       let(:package_name) { 'some-remote-package-that-might-exist' }
       let(:project_with_a_link) { create(:project, name: 'project_with_a_link', maintainer: user, link_to: 'some:remote:project') }
 
@@ -153,7 +153,7 @@ RSpec.describe Triggerable do
     end
 
     context 'project with remote project-link and local package' do
-      let(:token) { Token::Rebuild.create(user: user) }
+      let(:token) { Token::Rebuild.create(executor: user) }
       let(:project_with_a_link) { create(:project, name: 'project_with_a_link', maintainer: user, link_to: 'some:remote:project') }
 
       before do
@@ -176,7 +176,7 @@ RSpec.describe Triggerable do
     let(:multibuild_flavor) { 'libfoo2' }
 
     context 'with a token that allows multibuild' do
-      let(:token) { Token::Rebuild.create(user: user) }
+      let(:token) { Token::Rebuild.create(executor: user) }
 
       before do
         fake_controller_instance.instance_variable_set(:@package_name, "#{multibuild_package.name}:#{multibuild_flavor}")
@@ -201,7 +201,7 @@ RSpec.describe Triggerable do
     end
 
     context 'with a token that does not allow multibuild' do
-      let(:token) { Token::Service.create(user: user) }
+      let(:token) { Token::Service.create(executor: user) }
 
       it 'raises not found' do
         stub_params(project_name: project.name, package_name: multibuild_flavor)

--- a/src/api/spec/controllers/person/token_controller_spec.rb
+++ b/src/api/spec/controllers/person/token_controller_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe Person::TokenController, vcr: false do
   end
 
   describe '#delete' do
-    let!(:token) { create(:service_token, user: user) }
+    let!(:token) { create(:service_token, executor: user) }
 
     context 'requesting deletion of an existent token as an authorized user' do
       subject { delete :delete, params: { login: user.login, id: token.id }, format: :xml }

--- a/src/api/spec/controllers/trigger_controller_spec.rb
+++ b/src/api/spec/controllers/trigger_controller_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe TriggerController, vcr: true do
     end
 
     context 'when token is valid' do
-      let!(:token) { Token::Rebuild.create(user: user, package: package) }
+      let!(:token) { Token::Rebuild.create(executor: user, package: package) }
 
       before do
         allow(Backend::Api::Sources::Package).to receive(:rebuild).and_return("<status code=\"ok\" />\n")
@@ -48,7 +48,7 @@ RSpec.describe TriggerController, vcr: true do
     let(:release_target) { create(:release_target, repository: repository, target_repository: target_repository, trigger: 'manual') }
 
     context 'for inexistent project' do
-      let(:token) { Token::Release.create(user: user, package: package) }
+      let(:token) { Token::Release.create(executor: user, package: package) }
 
       before do
         post :create, params: { project: 'foo', format: :xml }
@@ -58,7 +58,7 @@ RSpec.describe TriggerController, vcr: true do
     end
 
     context 'when token is valid and package exists' do
-      let(:token) { Token::Release.create(user: user, package: package) }
+      let(:token) { Token::Release.create(executor: user, package: package) }
 
       let(:backend_url) do
         "/build/#{target_project.name}/#{target_repository.name}/x86_64/#{package.name}" \
@@ -78,7 +78,7 @@ RSpec.describe TriggerController, vcr: true do
 
     context 'when user has no rights for source' do
       let(:other_user) { create(:confirmed_user, login: 'mrfluffy') }
-      let(:token) { Token::Release.create(user: other_user, package: package) }
+      let(:token) { Token::Release.create(executor: other_user, package: package) }
 
       before do
         release_target
@@ -90,7 +90,7 @@ RSpec.describe TriggerController, vcr: true do
 
     context 'when user has no rights for target' do
       let(:other_user) { create(:confirmed_user, login: 'mrfluffy') }
-      let(:token) { Token::Release.create(user: other_user, package: package) }
+      let(:token) { Token::Release.create(executor: other_user, package: package) }
       let!(:relationship_package_user) { create(:relationship_package_user, user: other_user, package: package) }
 
       before do
@@ -104,7 +104,7 @@ RSpec.describe TriggerController, vcr: true do
 
     context 'when there are no release targets' do
       let(:other_user) { create(:confirmed_user, login: 'mrfluffy') }
-      let(:token) { Token::Release.create(user: other_user, package: package) }
+      let(:token) { Token::Release.create(executor: other_user, package: package) }
       let!(:relationship_package_user) { create(:relationship_package_user, user: other_user, package: package) }
 
       before do
@@ -116,7 +116,7 @@ RSpec.describe TriggerController, vcr: true do
   end
 
   describe '#runservice' do
-    let(:token) { Token::Service.create(user: user, package: package) }
+    let(:token) { Token::Service.create(executor: user, package: package) }
     let(:package) { create(:package_with_service, name: 'package_with_service', project: project) }
 
     before do
@@ -128,11 +128,11 @@ RSpec.describe TriggerController, vcr: true do
 
   describe '#create' do
     let(:user) { create(:confirmed_user, :with_home, login: 'tom') }
-    let(:service_token) { create(:service_token, user: user) }
+    let(:service_token) { create(:service_token, executor: user) }
     let(:body) { { hello: :world }.to_json }
     let(:project) { user.home_project }
     let(:package) { create(:package_with_service, name: 'apache2', project: project) }
-    let(:token) { Token::Service.create(user: user, package: package) }
+    let(:token) { Token::Service.create(executor: user, package: package) }
     let(:signature) { 'sha256=' + OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha256'), service_token.string, body) }
 
     shared_examples 'it verifies the signature' do

--- a/src/api/spec/controllers/trigger_workflow_controller_spec.rb
+++ b/src/api/spec/controllers/trigger_workflow_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe TriggerWorkflowController, type: :controller, beta: true do
     context 'workflows.yml do not exist' do
       let(:octokit_client) { instance_double(Octokit::Client) }
       let(:token_extractor_instance) { instance_double(::TriggerControllerService::TokenExtractor) }
-      let(:token) { create(:workflow_token, user: create(:confirmed_user, :in_beta)) }
+      let(:token) { create(:workflow_token, executor: create(:confirmed_user, :in_beta)) }
       let(:github_payload) do
         {
           action: 'opened',
@@ -51,7 +51,7 @@ RSpec.describe TriggerWorkflowController, type: :controller, beta: true do
 
     context 'token different type' do
       let(:token_extractor_instance) { instance_double(::TriggerControllerService::TokenExtractor) }
-      let(:token) { create(:service_token, user: create(:confirmed_user, :in_beta)) }
+      let(:token) { create(:service_token, executor: create(:confirmed_user, :in_beta)) }
 
       let(:github_payload) do
         {
@@ -98,7 +98,7 @@ RSpec.describe TriggerWorkflowController, type: :controller, beta: true do
 
     context 'scm event is invalid' do
       let(:token_extractor_instance) { instance_double(::TriggerControllerService::TokenExtractor) }
-      let(:token) { build_stubbed(:workflow_token, user: build_stubbed(:confirmed_user, :in_beta)) }
+      let(:token) { build_stubbed(:workflow_token, executor: build_stubbed(:confirmed_user, :in_beta)) }
 
       before do
         allow(::TriggerControllerService::TokenExtractor).to receive(:new).and_return(token_extractor_instance)
@@ -114,7 +114,7 @@ RSpec.describe TriggerWorkflowController, type: :controller, beta: true do
     context 'scm action is invalid' do
       let(:octokit_client) { instance_double(Octokit::Client) }
       let(:token_extractor_instance) { instance_double(::TriggerControllerService::TokenExtractor) }
-      let(:token) { build_stubbed(:workflow_token, user: build_stubbed(:confirmed_user, :in_beta)) }
+      let(:token) { build_stubbed(:workflow_token, executor: build_stubbed(:confirmed_user, :in_beta)) }
       let(:github_payload) do
         {
           action: 'assigned',
@@ -150,7 +150,7 @@ RSpec.describe TriggerWorkflowController, type: :controller, beta: true do
 
     context 'scm payload is invalid' do
       let(:token_extractor_instance) { instance_double(::TriggerControllerService::TokenExtractor) }
-      let(:token) { create(:workflow_token, user: create(:confirmed_user, :in_beta)) }
+      let(:token) { create(:workflow_token, executor: create(:confirmed_user, :in_beta)) }
 
       before do
         allow(::TriggerControllerService::TokenExtractor).to receive(:new).and_return(token_extractor_instance)
@@ -179,7 +179,7 @@ RSpec.describe TriggerWorkflowController, type: :controller, beta: true do
 
     context 'validation errors happening when triggering the token' do
       let(:token_extractor_instance) { instance_double(::TriggerControllerService::TokenExtractor) }
-      let(:token) { build_stubbed(:workflow_token, user: build_stubbed(:confirmed_user, :in_beta)) }
+      let(:token) { build_stubbed(:workflow_token, executor: build_stubbed(:confirmed_user, :in_beta)) }
       let(:github_payload) do
         {
           action: 'opened',
@@ -223,7 +223,7 @@ RSpec.describe TriggerWorkflowController, type: :controller, beta: true do
 
     context 'no validation errors' do
       let(:token_extractor_instance) { instance_double(::TriggerControllerService::TokenExtractor) }
-      let(:token) { build_stubbed(:workflow_token, user: build_stubbed(:confirmed_user, :in_beta)) }
+      let(:token) { build_stubbed(:workflow_token, executor: build_stubbed(:confirmed_user, :in_beta)) }
       let(:github_payload) do
         {
           action: 'opened',
@@ -264,7 +264,7 @@ RSpec.describe TriggerWorkflowController, type: :controller, beta: true do
 
     context 'the SCM is unsupported' do
       let(:token_extractor_instance) { instance_double(::TriggerControllerService::TokenExtractor) }
-      let(:token) { build_stubbed(:workflow_token, user: build_stubbed(:confirmed_user, :in_beta)) }
+      let(:token) { build_stubbed(:workflow_token, executor: build_stubbed(:confirmed_user, :in_beta)) }
       let(:scm_payload) do
         { super: 'duper' }
       end

--- a/src/api/spec/controllers/webui/feeds_controller_spec.rb
+++ b/src/api/spec/controllers/webui/feeds_controller_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe Webui::FeedsController do
       render_views
       before do
         ::Configuration.update(obs_url: 'http://localhost')
-        user.create_rss_token
+        user.create_rss_token(executor: user)
         get :notifications, params: { token: user.rss_token.string, format: 'rss' }
       end
 

--- a/src/api/spec/controllers/webui/users/token_triggers_controller_spec.rb
+++ b/src/api/spec/controllers/webui/users/token_triggers_controller_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Webui::Users::TokenTriggersController, vcr: true, type: :controll
       supported_token_classes = [Token::Rebuild, Token::Release, Token::Service]
 
       supported_token_classes.each do |token_class|
-        let(:token) { token_class.create(user: token_user) }
+        let(:token) { token_class.create(executor: token_user) }
 
         it 'flashes error when package param is missing' do
           put :update, params: { id: token.id, project: token_project.name }
@@ -42,7 +42,7 @@ RSpec.describe Webui::Users::TokenTriggersController, vcr: true, type: :controll
 
     context 'rebuild token' do
       context 'when token is valid and associated package exist' do
-        let(:token) { create(:rebuild_token, user: token_user, package: token_package) }
+        let(:token) { create(:rebuild_token, executor: token_user, package: token_package) }
 
         before do
           allow(Backend::Api::Sources::Package).to receive(:rebuild).and_return("<status code=\"ok\" />\n")
@@ -53,7 +53,7 @@ RSpec.describe Webui::Users::TokenTriggersController, vcr: true, type: :controll
       end
 
       context 'when token is valid and package/project provided exist' do
-        let(:token) { create(:rebuild_token, user: token_user, package: nil) }
+        let(:token) { create(:rebuild_token, executor: token_user, package: nil) }
 
         before do
           allow(Backend::Api::Sources::Package).to receive(:rebuild).and_return("<status code=\"ok\" />\n")
@@ -70,7 +70,7 @@ RSpec.describe Webui::Users::TokenTriggersController, vcr: true, type: :controll
       let(:release_target) { create(:release_target, repository: repository, target_repository: target_repository, trigger: 'manual') }
 
       context 'when token is valid and associated package exist' do
-        let(:token) { Token::Release.create(user: token_user, package: token_package) }
+        let(:token) { Token::Release.create(executor: token_user, package: token_package) }
 
         let(:backend_url) do
           "/build/#{target_project.name}/#{target_repository.name}/x86_64/#{token_package.name}" \
@@ -90,7 +90,7 @@ RSpec.describe Webui::Users::TokenTriggersController, vcr: true, type: :controll
 
       context 'when user has no rights for source' do
         let(:other_user) { create(:confirmed_user, login: 'mrfluffy') }
-        let(:token) { Token::Release.create(user: other_user, package: token_package) }
+        let(:token) { Token::Release.create(executor: other_user, package: token_package) }
 
         before do
           login other_user
@@ -107,7 +107,7 @@ RSpec.describe Webui::Users::TokenTriggersController, vcr: true, type: :controll
       context 'when user has no rights for target' do
         let(:other_user) { create(:confirmed_user, login: 'mrfluffy') }
         let!(:relationship_package_user) { create(:relationship_package_user, user: other_user, package: token_package) }
-        let(:token) { Token::Release.create(user: other_user, package: token_package) }
+        let(:token) { Token::Release.create(executor: other_user, package: token_package) }
 
         before do
           login other_user
@@ -123,7 +123,7 @@ RSpec.describe Webui::Users::TokenTriggersController, vcr: true, type: :controll
 
       context 'when there are no release targets' do
         let(:other_user) { create(:confirmed_user, login: 'mrfluffy') }
-        let(:token) { Token::Release.create(user: other_user, package: token_package) }
+        let(:token) { Token::Release.create(executor: other_user, package: token_package) }
         let!(:relationship_package_user) { create(:relationship_package_user, user: other_user, package: token_package) }
 
         before do
@@ -145,13 +145,13 @@ RSpec.describe Webui::Users::TokenTriggersController, vcr: true, type: :controll
 
       context 'when package provides a service' do
         let(:package_with_service) { create(:package_with_service, name: 'package_with_service', project: token_project) }
-        let(:token) { Token::Service.create(user: token_user, package: package_with_service) }
+        let(:token) { Token::Service.create(executor: token_user, package: package_with_service) }
 
         include_examples 'token got triggered'
       end
 
       context 'when package does not provide a service' do
-        let(:token) { Token::Service.create(user: token_user, package: token_package) }
+        let(:token) { Token::Service.create(executor: token_user, package: token_package) }
 
         it 'flashes an error' do
           expect(flash[:error]).to eq('Failed to trigger token: no source service defined!')

--- a/src/api/spec/controllers/webui/users/tokens_controller_spec.rb
+++ b/src/api/spec/controllers/webui/users/tokens_controller_spec.rb
@@ -31,10 +31,10 @@ RSpec.describe Webui::Users::TokensController, type: :controller do
 
   describe 'GET #index' do
     before do
-      create(:service_token, user: user)
-      create(:workflow_token, user: user)
-      create(:rss_token, user: user)
-      create(:release_token, user: other_user)
+      create(:service_token, executor: user)
+      create(:workflow_token, executor: user)
+      create(:rss_token, executor: user)
+      create(:release_token, executor: other_user)
 
       get :index
     end
@@ -102,7 +102,7 @@ RSpec.describe Webui::Users::TokensController, type: :controller do
     subject { put :update, params: update_parameters }
 
     context 'updates a workflow token belonging to the logged-in user' do
-      let(:token) { create(:workflow_token, user: user, scm_token: 'something') }
+      let(:token) { create(:workflow_token, executor: user, scm_token: 'something') }
       let(:update_parameters) { { id: token.id, token: { description: 'My first token', scm_token: 'something_else' } } }
 
       include_examples 'check for flashing a success'
@@ -113,7 +113,7 @@ RSpec.describe Webui::Users::TokensController, type: :controller do
     end
 
     context 'updates the token string of a token belonging to the logged-in user' do
-      let(:token) { create(:service_token, user: user) }
+      let(:token) { create(:service_token, executor: user) }
       let(:update_parameters) { { id: token.id } }
 
       subject { put :update, params: update_parameters, xhr: true }
@@ -133,7 +133,7 @@ RSpec.describe Webui::Users::TokensController, type: :controller do
     end
 
     context 'does not update a token belonging to another user' do
-      let(:token) { create(:service_token, user: other_user) }
+      let(:token) { create(:service_token, executor: other_user) }
       let(:update_parameters) { { id: token.id, token: { scm_token: 'something' } } }
 
       include_examples 'check for flashing an error'
@@ -144,7 +144,7 @@ RSpec.describe Webui::Users::TokensController, type: :controller do
   end
 
   describe 'DELETE #destroy' do
-    let!(:token) { create(:service_token, user: user) }
+    let!(:token) { create(:service_token, executor: user) }
     let(:delete_parameters) { { id: token.id } }
 
     subject { delete :destroy, params: delete_parameters }
@@ -166,7 +166,7 @@ RSpec.describe Webui::Users::TokensController, type: :controller do
     end
 
     context 'token of other user' do
-      let(:token) { create(:service_token, user: other_user) }
+      let(:token) { create(:service_token, executor: other_user) }
 
       include_examples 'check for flashing an error'
 

--- a/src/api/spec/controllers/webui/workflow_runs_controller_spec.rb
+++ b/src/api/spec/controllers/webui/workflow_runs_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Webui::WorkflowRunsController, type: :controller do
   describe 'GET #index' do
     let(:token_user) { create(:confirmed_user) }
-    let(:workflow_token) { create(:workflow_token, user: token_user) }
+    let(:workflow_token) { create(:workflow_token, executor: token_user) }
     let!(:workflow_run) { create(:workflow_run, token: workflow_token) }
 
     before do

--- a/src/api/spec/factories/tokens.rb
+++ b/src/api/spec/factories/tokens.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :token do
     string { Faker::Lorem.characters(number: 32) }
-    user
+    executor { create(:confirmed_user) }
 
     factory :service_token, class: 'Token::Service' do
       package

--- a/src/api/spec/factories/users.rb
+++ b/src/api/spec/factories/users.rb
@@ -53,7 +53,7 @@ FactoryBot.define do
 
       factory :user_with_service_token do
         after(:create) do |user|
-          create(:service_token, user: user)
+          create(:service_token, executor: user)
         end
       end
       factory :dead_user do

--- a/src/api/spec/jobs/report_to_scm_job_spec.rb
+++ b/src/api/spec/jobs/report_to_scm_job_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe ReportToScmJob, vcr: false do
   let(:user) { create(:confirmed_user, login: 'foolano') }
-  let(:token) { Token::Workflow.create(user: user, scm_token: 'fake_token') }
+  let(:token) { Token::Workflow.create(executor: user, scm_token: 'fake_token') }
   let(:project) { create(:project, name: 'project_1', maintainer: user) }
   let(:package) { create(:package, name: 'package_1', project: project) }
   let(:repository) { create(:repository, name: 'repository_1', project: project) }

--- a/src/api/spec/models/token/rebuild_spec.rb
+++ b/src/api/spec/models/token/rebuild_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Token::Rebuild do
   let(:user) { create(:user, login: 'foo') }
-  let(:token) { create(:rebuild_token, user: user) }
+  let(:token) { create(:rebuild_token, executor: user) }
 
   subject { token.call(package: 'bar') }
 

--- a/src/api/spec/models/token/release_spec.rb
+++ b/src/api/spec/models/token/release_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Token::Release, vcr: true do
   let(:repository) { create(:repository, name: 'package_test_repository', architectures: ['x86_64'], project: project_staging) }
   let(:target_repository) { create(:repository, name: 'target_repository', project: target_project) }
 
-  let(:token) { create(:release_token, package: package, user: user) }
+  let(:token) { create(:release_token, package: package, executor: user) }
 
   subject { token.call(package: package) }
 

--- a/src/api/spec/models/token/service_spec.rb
+++ b/src/api/spec/models/token/service_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Token::Service do
   let(:user) { create(:user, login: 'foo') }
-  let(:token) { create(:service_token, user: user) }
+  let(:token) { create(:service_token, executor: user) }
 
   subject { token.call(package: 'bar') }
 

--- a/src/api/spec/models/token/workflow_spec.rb
+++ b/src/api/spec/models/token/workflow_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Token::Workflow do
   describe '#call' do
     let(:token_user) { create(:confirmed_user, :with_home, login: 'Iggy') }
-    let(:workflow_token) { create(:workflow_token, user: token_user) }
+    let(:workflow_token) { create(:workflow_token, executor: token_user) }
     let(:workflow_run) { create(:workflow_run, token: workflow_token) }
 
     context 'without a payload' do

--- a/src/api/spec/models/token_spec.rb
+++ b/src/api/spec/models/token_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Token, type: :model do
 
     it { expect(release_token).to validate_uniqueness_of(:string).case_insensitive }
     it { is_expected.to have_secure_token(:string) }
-    it { is_expected.to belong_to(:user) }
+    it { is_expected.to belong_to(:executor) }
   end
 
   describe '.token_type' do

--- a/src/api/spec/models/workflow/step/branch_package_step_spec.rb
+++ b/src/api/spec/models/workflow/step/branch_package_step_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Workflow::Step::BranchPackageStep, vcr: true do
   let!(:user) { create(:confirmed_user, :with_home, login: 'Iggy') }
-  let(:token) { create(:workflow_token, user: user) }
+  let(:token) { create(:workflow_token, executor: user) }
   let(:target_project_name) { "home:#{user.login}" }
   let(:long_commit_sha) { '123456789' }
   let(:short_commit_sha) { '1234567' }

--- a/src/api/spec/models/workflow/step/configure_repositories_spec.rb
+++ b/src/api/spec/models/workflow/step/configure_repositories_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Workflow::Step::ConfigureRepositories do
   let(:user) { create(:confirmed_user, :with_home, login: 'Iggy') }
-  let(:token) { create(:workflow_token, user: user) }
+  let(:token) { create(:workflow_token, executor: user) }
 
   describe '#call' do
     let(:path_project1) { create(:project, name: 'openSUSE:Factory') }
@@ -52,7 +52,7 @@ RSpec.describe Workflow::Step::ConfigureRepositories do
 
     context 'when the token user does not have enough permissions' do
       let(:another_user) { create(:confirmed_user, :with_home, login: 'Pop') }
-      let(:token) { create(:workflow_token, user: another_user) }
+      let(:token) { create(:workflow_token, executor: another_user) }
       let(:scm_webhook) do
         ScmWebhook.new(payload: {
                          scm: 'github',

--- a/src/api/spec/models/workflow/step/link_package_step_spec.rb
+++ b/src/api/spec/models/workflow/step/link_package_step_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Workflow::Step::LinkPackageStep, vcr: true do
   let!(:user) { create(:confirmed_user, :with_home, login: 'Iggy') }
-  let(:token) { create(:workflow_token, user: user) }
+  let(:token) { create(:workflow_token, executor: user) }
   let(:target_project_name) { "home:#{user.login}" }
 
   subject do

--- a/src/api/spec/models/workflow/step/rebuild_package_step_spec.rb
+++ b/src/api/spec/models/workflow/step/rebuild_package_step_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Workflow::Step::RebuildPackage, vcr: true do
   let!(:user) { create(:confirmed_user, :with_home, login: 'Iggy') }
-  let(:token) { create(:workflow_token, user: user) }
+  let(:token) { create(:workflow_token, executor: user) }
   let(:project) { create(:project, name: 'openSUSE:Factory', maintainer: user) }
   let(:package) { create(:package, name: 'hello_world', project: project) }
 
@@ -35,7 +35,7 @@ RSpec.describe Workflow::Step::RebuildPackage, vcr: true do
 
   context 'user has no permission to trigger rebuild' do
     let(:another_user) { create(:confirmed_user, :with_home, login: 'Oggy') }
-    let!(:token) { create(:workflow_token, user: another_user) }
+    let!(:token) { create(:workflow_token, executor: another_user) }
 
     it { expect { subject.call }.to raise_error(Pundit::NotAuthorizedError) }
   end

--- a/src/api/spec/models/workflow/step/set_flags_step_spec.rb
+++ b/src/api/spec/models/workflow/step/set_flags_step_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Workflow::Step::SetFlags do
   let(:user) { create(:confirmed_user, :with_home, login: 'Iggy') }
-  let(:token) { create(:workflow_token, user: user) }
+  let(:token) { create(:workflow_token, executor: user) }
 
   describe '#call' do
     let(:step_instructions) do
@@ -29,7 +29,7 @@ RSpec.describe Workflow::Step::SetFlags do
 
     context 'when the token user does not have enough permissions' do
       let(:another_user) { create(:confirmed_user, :with_home, login: 'Pop') }
-      let(:token) { create(:workflow_token, user: another_user) }
+      let(:token) { create(:workflow_token, executor: another_user) }
       let!(:project) { create(:project, name: 'home:Iggy') }
       let(:scm_webhook) do
         ScmWebhook.new(payload: {

--- a/src/api/spec/models/workflow/step/trigger_services_spec.rb
+++ b/src/api/spec/models/workflow/step/trigger_services_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Workflow::Step::TriggerServices do
   let!(:user) { create(:confirmed_user, :with_home, login: 'Iggy') }
-  let(:token) { create(:workflow_token, user: user) }
+  let(:token) { create(:workflow_token, executor: user) }
   let(:project) { create(:project, name: 'openSUSE:Factory', maintainer: user) }
   let(:package) { create(:package, name: 'hello_world', project: project) }
 
@@ -28,7 +28,7 @@ RSpec.describe Workflow::Step::TriggerServices do
   describe '#call' do
     context 'user has no permission to trigger the services' do
       let(:another_user) { create(:confirmed_user, :with_home, login: 'Oggy') }
-      let!(:token) { create(:workflow_token, user: another_user) }
+      let!(:token) { create(:workflow_token, executor: another_user) }
 
       it { expect { subject.call }.to raise_error(Pundit::NotAuthorizedError) }
     end

--- a/src/api/spec/models/workflow_spec.rb
+++ b/src/api/spec/models/workflow_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Workflow, type: :model, vcr: true do
   let(:user) { create(:confirmed_user, :with_home, login: 'cameron') }
-  let(:token) { create(:workflow_token, user: user) }
+  let(:token) { create(:workflow_token, executor: user) }
   let!(:workflow_run) { create(:workflow_run, token: token) }
 
   subject do

--- a/src/api/spec/policies/token/rebuild_policy_spec.rb
+++ b/src/api/spec/policies/token/rebuild_policy_spec.rb
@@ -5,14 +5,14 @@ RSpec.describe Token::RebuildPolicy do
 
   describe '#trigger' do
     context 'user inactive' do
-      let(:user_token) { create(:rebuild_token, user: user) }
+      let(:user_token) { create(:rebuild_token, executor: user) }
 
       include_examples 'non-active users cannot trigger a token'
     end
 
     context 'user active' do
-      let(:user_token) { create(:rebuild_token, user: user, package: package) }
-      let(:other_user_token) { create(:rebuild_token, user: other_user) }
+      let(:user_token) { create(:rebuild_token, executor: user, package: package) }
+      let(:other_user_token) { create(:rebuild_token, executor: other_user) }
 
       include_examples 'active users can trigger a token'
     end

--- a/src/api/spec/policies/token/release_policy_spec.rb
+++ b/src/api/spec/policies/token/release_policy_spec.rb
@@ -5,14 +5,14 @@ RSpec.describe Token::ReleasePolicy do
 
   describe '#trigger' do
     context 'user inactive' do
-      let(:user_token) { create(:release_token, user: user) }
+      let(:user_token) { create(:release_token, executor: user) }
 
       include_examples 'non-active users cannot trigger a token'
     end
 
     context 'user active' do
-      let(:user_token) { create(:release_token, user: user, package: package) }
-      let(:other_user_token) { create(:release_token, user: other_user) }
+      let(:user_token) { create(:release_token, executor: user, package: package) }
+      let(:other_user_token) { create(:release_token, executor: other_user) }
 
       include_examples 'active users can trigger a token'
     end

--- a/src/api/spec/policies/token/rss_policy_spec.rb
+++ b/src/api/spec/policies/token/rss_policy_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Token::RssPolicy do
   let(:user) { create(:user) }
   let(:other_user) { build(:user) }
   let(:user_nobody) { build(:user_nobody) }
-  let(:rss_token_user) { create(:rss_token, user: user) }
+  let(:rss_token_user) { create(:rss_token, executor: user) }
 
   subject { described_class }
 

--- a/src/api/spec/policies/token/service_policy_spec.rb
+++ b/src/api/spec/policies/token/service_policy_spec.rb
@@ -5,14 +5,14 @@ RSpec.describe Token::ServicePolicy do
 
   describe '#trigger' do
     context 'user inactive' do
-      let(:user_token) { create(:service_token, user: user) }
+      let(:user_token) { create(:service_token, executor: user) }
 
       include_examples 'non-active users cannot trigger a token'
     end
 
     context 'user active' do
-      let(:user_token) { create(:service_token, user: user, package: package) }
-      let(:other_user_token) { create(:service_token, user: other_user) }
+      let(:user_token) { create(:service_token, executor: user, package: package) }
+      let(:other_user_token) { create(:service_token, executor: other_user) }
 
       include_examples 'active users can trigger a token'
     end

--- a/src/api/spec/policies/token/workflow_policy_spec.rb
+++ b/src/api/spec/policies/token/workflow_policy_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Token::WorkflowPolicy do
   let(:user) { create(:confirmed_user) }
-  let(:user_token) { create(:workflow_token, user: user) }
+  let(:user_token) { create(:workflow_token, executor: user) }
   let(:other_user) { group.users.first }
   let(:group) { create(:group_with_user) }
 
@@ -35,7 +35,7 @@ RSpec.describe Token::WorkflowPolicy do
       end
 
       context 'when the user belongs to a group which owns the token' do
-        let(:group_token) { create(:workflow_token, user: user) }
+        let(:group_token) { create(:workflow_token, executor: user) }
 
         before { group.shared_workflow_tokens << group_token }
 
@@ -79,7 +79,7 @@ RSpec.describe Token::WorkflowPolicy do
       end
 
       context 'when the user belongs to a group which owns the token' do
-        let(:group_token) { create(:workflow_token, user: user) }
+        let(:group_token) { create(:workflow_token, executor: user) }
 
         before { group.shared_workflow_tokens << group_token }
 

--- a/src/api/spec/policies/token_policy_spec.rb
+++ b/src/api/spec/policies/token_policy_spec.rb
@@ -2,12 +2,12 @@ require 'rails_helper'
 
 RSpec.describe TokenPolicy, type: :policy do
   let(:token_user) { create(:confirmed_user) }
-  let(:user_token) { create(:rebuild_token, user: token_user) }
+  let(:user_token) { create(:rebuild_token, executor: token_user) }
   let(:group) { create(:group_with_user) }
   let(:other_user) { group.users.first }
 
-  let(:workflow_token) { create(:workflow_token, user: token_user) }
-  let(:rss_token) { create(:rss_token, user: token_user) }
+  let(:workflow_token) { create(:workflow_token, executor: token_user) }
+  let(:rss_token) { create(:rss_token, executor: token_user) }
 
   subject { described_class }
 
@@ -33,10 +33,10 @@ RSpec.describe TokenPolicy, type: :policy do
       context 'when the user is associated to the token' do
         let!(:token_user) { create(:confirmed_user) }
         let!(:other_user) { create(:confirmed_user) }
-        let!(:rss_token) { create(:rss_token, user: token_user) }
-        let!(:workflow_token) { create(:workflow_token, user: token_user) }
-        let!(:other_users_workflow_token) { create(:workflow_token, user: other_user) }
-        let!(:shared_workflow_token) { create(:workflow_token, user: other_user) }
+        let!(:rss_token) { create(:rss_token, executor: token_user) }
+        let!(:workflow_token) { create(:workflow_token, executor: token_user) }
+        let!(:other_users_workflow_token) { create(:workflow_token, executor: other_user) }
+        let!(:shared_workflow_token) { create(:workflow_token, executor: other_user) }
 
         subject { described_class.new(token_user, scope) }
 
@@ -62,7 +62,7 @@ RSpec.describe TokenPolicy, type: :policy do
       end
 
       context 'when the group is associated to the token' do
-        let!(:group_shared_workflow_token) { create(:workflow_token, user: other_user, string: 'group token') }
+        let!(:group_shared_workflow_token) { create(:workflow_token, executor: other_user, string: 'group token') }
 
         subject { described_class.new(other_user, scope) }
 

--- a/src/api/spec/policies/workflow_run_policy_spec.rb
+++ b/src/api/spec/policies/workflow_run_policy_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe WorkflowRunPolicy do
   let(:token_user) { create(:confirmed_user, login: 'foo') }
-  let(:workflow_token) { create(:workflow_token, user: token_user) }
+  let(:workflow_token) { create(:workflow_token, executor: token_user) }
   let!(:workflow_run) { create(:workflow_run, token: workflow_token) }
 
   describe '#resolve' do
@@ -19,7 +19,7 @@ RSpec.describe WorkflowRunPolicy do
     end
 
     context 'when token type is not of type workflow' do
-      let(:release_token) { create(:release_token, user: token_user) }
+      let(:release_token) { create(:release_token, executor: token_user) }
 
       it 'raise a not authorized error' do
         expect { subject.new(User.session, WorkflowRun, { token_id: release_token.id }).resolve }.to raise_error(Pundit::NotAuthorizedError)

--- a/src/api/spec/services/notification_service/notifier_spec.rb
+++ b/src/api/spec/services/notification_service/notifier_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe NotificationService::Notifier do
         create_relationship_kim
         create_comment_for_project
 
-        user_bob.create_rss_token
-        user_kim.create_rss_token
+        create(:rss_token, executor: user_bob)
+        create(:rss_token, executor: user_kim)
 
         subject
       end

--- a/src/api/spec/services/scm_status_reporter_spec.rb
+++ b/src/api/spec/services/scm_status_reporter_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe SCMStatusReporter, type: :service do
       let!(:user) { create(:confirmed_user, :with_home, login: 'jane_doe') }
       let!(:package) { create(:package, name: 'bye', project: user.home_project) }
 
-      let(:workflow_token) { create(:workflow_token, user: user) }
+      let(:workflow_token) { create(:workflow_token, executor: user) }
       let(:token) { workflow_token.scm_token }
       let(:workflow_run) { create(:workflow_run, token: workflow_token, request_headers: {}, request_payload: {}) }
 

--- a/src/api/spec/services/workflows/artifacts_collector_spec.rb
+++ b/src/api/spec/services/workflows/artifacts_collector_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Workflows::ArtifactsCollector, type: :service do
   let(:user) { create(:confirmed_user) }
-  let(:token) { create(:workflow_token, user: user) }
+  let(:token) { create(:workflow_token, executor: user) }
   let(:workflow_run) { create(:workflow_run, token: token) }
 
   subject { described_class.new(workflow_run_id: workflow_run.id, step: step) }


### PR DESCRIPTION
This change needs to be done during the maintenance window because it is
not a safe operation.