### PR TITLE
Move JavaScript part into the ConfirmationDialogComponent

### DIFF
--- a/src/api/app/assets/javascripts/webui/delete_confirmation_dialog.js
+++ b/src/api/app/assets/javascripts/webui/delete_confirmation_dialog.js
@@ -1,4 +1,18 @@
-function setValuesOnDeleteConfirmationDialog(modalId) { // jshint ignore:line
+function collectDeleteConfirmationModalsAndSetValues() { // jshint ignore:line
+  $.each(modalIds(), function( _index, modalId ) {
+    setValuesOnDeleteConfirmationDialog(modalId);
+  });
+}
+
+function modalIds() {
+  var targets = $('a[data-toggle="modal"][data-target^="#delete"]').toArray().map(
+    function(e) { return $(e).data('target');
+  });
+
+  return $.unique(targets);
+}
+
+function setValuesOnDeleteConfirmationDialog(modalId) {
   $(modalId).on('show.bs.modal', function (event) {
     var link = $(event.relatedTarget);
     var modal = $(this);

--- a/src/api/app/components/delete_confirmation_dialog_component.html.haml
+++ b/src/api/app/components/delete_confirmation_dialog_component.html.haml
@@ -11,3 +11,8 @@
             %a.btn.btn-sm.btn-outline-secondary.px-4{ data: { dismiss: 'modal' } }
               Cancel
             = submit_tag('Remove', class: 'btn btn-sm btn-danger px-4')
+
+:javascript
+  $(document).ready(function() {
+    collectDeleteConfirmationModalsAndSetValues();
+  });

--- a/src/api/app/components/watchlist_component.html.haml
+++ b/src/api/app/components/watchlist_component.html.haml
@@ -21,7 +21,3 @@
 
 :javascript
   toggleCollapsibleTooltip();
-
-  $(document).ready(function() {
-    setValuesOnDeleteConfirmationDialog('#delete-item-from-watchlist-modal');
-  });

--- a/src/api/app/views/webui/users/tokens/users/index.html.haml
+++ b/src/api/app/views/webui/users/tokens/users/index.html.haml
@@ -74,9 +74,3 @@
           %i.fas.fa-plus-circle.text-primary
           Add Group
 
-:javascript
-  $(document).ready(function() {
-    setValuesOnDeleteConfirmationDialog('#delete-user-from-token-modal');
-    setValuesOnDeleteConfirmationDialog('#delete-group-from-token-modal');
-  });
-


### PR DESCRIPTION
Instead of calling the same JS function from different views, we call the JS from the component. It iterates over all the modals in the DOM whose id starts with `#delete`, takes the expected data attributes, if any, and sets those values in the modal content. 

**How to test?**

As this code iterates over all deletion modals in the DOM, I would test
- **deleting elements that already call the component**
  - add a project to the watchlist
  - remove the project from the watchlist using the deletion icon next to the project name
  - this should open a modal containing the project name
  - click the "Remove" button, and the project should disappear from the list.
- **deleting elements that don't call the component yet**
  - go to the same project page
  - add a few comments
  - delete a comment
  - this should open a modal, even if we are not using the component for the deletion of the comments yet
  - the comment should be removed