### PR TITLE
[backend] SLSA: minor meta data fixes

### DIFF
--- a/src/backend/BSSched/BuildJob.pm
+++ b/src/backend/BSSched/BuildJob.pm
@@ -1222,6 +1222,7 @@ sub create {
     }
     $binfo->{'slsaprovenance'} = 1 if $BSConfig::slsaprovenance && grep { $prp =~ /^$_/} @$BSConfig::slsaprovenance;
     if ($binfo->{'slsaprovenance'}) {
+      $binfo->{'slsabuilder'} = $BSConfig::api_url || "obs://".$BSConfig::obsname;
       if ($BSConfig::sourcepublish_downloadurl) {
 	$binfo->{'slsadownloadurl'} = "$BSConfig::sourcepublish_downloadurl/_slsa";
       } elsif ($BSConfig::api_url) {

--- a/src/backend/BSXML.pm
+++ b/src/backend/BSXML.pm
@@ -645,6 +645,7 @@ our $buildinfo = [
 
 	'slsaprovenance',	# internal
 	'slsadownloadurl',	# internal
+	'slsabuilder',   	# internal
 
       [ 'preinstallimage' =>
 	    'project',

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -3286,9 +3286,9 @@ sub generate_slsa_provenance_statement {
     'predicateType' => 'https://slsa.dev/provenance/v0.2',
     'predicate' => {
       'builder' => {
-        'id' => $buildinfo->{'srcserver'}
+        'id' => $buildinfo->{'slsabuilder'}
       },
-      'buildType' => 'https://open-build-server/worker',
+      'buildType' => 'https://open-build-service.org/worker',
       'invocation' => {
         'configSource' => {
           'uri' => $configsourceuri,

--- a/src/backend/t/1000-bs_worker.t
+++ b/src/backend/t/1000-bs_worker.t
@@ -74,6 +74,7 @@ my $buildinfo = {
                 ],
   arch       => 'x86_64',
   slsaprovenance => 1,
+  slsabuilder => "https://my.api",
 };
 
 $Test::Mock::BSRPC::fixtures_map = {
@@ -201,9 +202,9 @@ my $expected_statement = {
   ],
   'predicateType' => 'https://slsa.dev/provenance/v0.2',
   'predicate' => {
-    'buildType' => 'https://open-build-server/worker',
+    'buildType' => 'https://open-build-service.org/worker',
     'builder' => {
-      'id' => 'srcserver',
+      'id' => 'https://my.api',
     },
     'invocation' => {
       'configSource' => {


### PR DESCRIPTION
builder id must not be an internal name, but the configured OBS name instead.

buildType must use a domain registered to us.