### PR TITLE
Render modal only once

### DIFF
--- a/src/api/app/views/webui/users/tokens/users/index.html.haml
+++ b/src/api/app/views/webui/users/tokens/users/index.html.haml
@@ -30,10 +30,6 @@
                                            action: token_user_path(token_id: @token.id, id: user.id),
                                            confirmation_text: "Please confirm you want to remove this user #{user.login} from the token." }) do
                       %i.fa.fa-times-circle.text-danger{ title: 'Remove user from token' }
-                    = render DeleteConfirmationDialogComponent.new(modal_id: 'delete-user-from-token-modal',
-                                                                   method: :delete,
-                                                                   options: { remote: false,
-                                                                              modal_title: 'Do you really want to remove this user?' })
       .pt-4
         = render(partial: 'webui/users/tokens/users/add_user_to_token_dialog', locals: { token: @token })
         = link_to('#', data: { toggle: 'modal', target: '#add-user-to-token-modal' }, id: 'add-user-to-token') do
@@ -64,13 +60,17 @@
                                            action: token_group_path(token_id: @token.id, id: group.id),
                                            confirmation_text: "Please confirm you want to remove this group '#{group.title}' from the token." }) do
                       %i.fa.fa-times-circle.text-danger{ title: 'Remove group from token' }
-                    = render DeleteConfirmationDialogComponent.new(modal_id: 'delete-group-from-token-modal',
-                                                                   method: :delete,
-                                                                   options: { remote: false,
-                                                                              modal_title: 'Do you really want to remove this group?' })
       .pt-4
         = render(partial: 'webui/users/tokens/users/add_group_to_token_dialog', locals: { token: @token })
         = link_to('#', data: { toggle: 'modal', target: '#add-group-to-token-modal' }, id: 'add-group-to-token') do
           %i.fas.fa-plus-circle.text-primary
           Add Group
 
+= render DeleteConfirmationDialogComponent.new(modal_id: 'delete-user-from-token-modal',
+                                               method: :delete,
+                                               options: { remote: false,
+                                                          modal_title: 'Do you really want to remove this user?' })
+= render DeleteConfirmationDialogComponent.new(modal_id: 'delete-group-from-token-modal',
+                                               method: :delete,
+                                               options: { remote: false,
+                                                          modal_title: 'Do you really want to remove this group?' })


### PR DESCRIPTION
In the token's users page we were rendering one delete confirmation modal per user and per group. That was wrong for two reasons:

- we didn't concatenated the id of the element to the modal id, so we had many elements in the DOM with the same id.
- it's enough to render one model per type of element, as the id of the element is passed in the `action` data attribute (the form URL).
