### PR TITLE
Introduce validation for EmbargoDate attribute

### DIFF
--- a/src/api/app/controllers/source_attribute_controller.rb
+++ b/src/api/app/controllers/source_attribute_controller.rb
@@ -68,7 +68,10 @@ class SourceAttributeController < SourceController
 
       attrib.container = @attribute_container
 
-      raise APIError, message: attrib.errors.full_messages.join('\n'), status: 400 unless attrib.valid?
+      unless attrib.valid?
+        render_error(message: attrib.errors.full_messages.join('\n'), status: 400, errorcode: attrib.errors.filter_map(&:type).first&.to_s)
+        return false
+      end
 
       authorize attrib, :create?
     end

--- a/src/api/spec/models/attrib_spec.rb
+++ b/src/api/spec/models/attrib_spec.rb
@@ -144,6 +144,26 @@ RSpec.describe Attrib, type: :model do
       }
     end
 
+    describe '#validate_embargo_date_value' do
+      subject { build(:embargo_date_attrib, project: project, values: [attrib_value]) }
+
+      context 'wrong date' do
+        let(:attrib_value) { build(:attrib_value, value: '2022-01-50') }
+
+        it {
+          expect(subject.errors.full_messages).to match_array(["Value '2022-01-50' couldn't be parsed: 'argument out of range'"])
+        }
+      end
+
+      context 'wrong timezone' do
+        let(:attrib_value) { build(:attrib_value, value: '2022-01-01 12:10 wrong_timezone') }
+
+        it {
+          expect(subject.errors.full_messages).to match_array(["Value '2022-01-01 12:10 wrong_timezone' contains a non-valid timezone"])
+        }
+      end
+    end
+
     describe '#validate_issues' do
       let(:issue) { create(:issue_with_tracker) }
       let(:attrib_type) { create(:attrib_type, issue_list: false) }

--- a/src/api/spec/models/project/embargo_handler_spec.rb
+++ b/src/api/spec/models/project/embargo_handler_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe 'Project::EmbargoHandler' do
-  let!(:user) { create(:confirmed_user, login: 'bar') }
-  let!(:project) { create(:project, name: 'foo', maintainer: user) }
-  let(:attrib) { create(:embargo_date_attrib, project: project) }
+  let(:user) { create(:confirmed_user, login: 'bar') }
+  let(:project) { create(:project, name: 'foo', maintainer: user) }
+  let(:attrib) { create(:embargo_date_attrib, project: project, values: [attrib_value]) }
 
-  let(:embargo_handler) { Project::EmbargoHandler.new(project) }
+  subject { Project::EmbargoHandler.new(project).call }
 
   before do
     login user
@@ -13,46 +13,42 @@ RSpec.describe 'Project::EmbargoHandler' do
   end
 
   describe '#call' do
-    let(:attrib_value) { instance_double(AttribValue) }
-
     context 'Project is embargoed' do
-      it { expect { embargo_handler.call }.to raise_error BsRequest::Errors::UnderEmbargo }
+      let(:attrib) { create(:embargo_date_attrib, project: project) }
+
+      it { expect { subject }.to raise_error BsRequest::Errors::UnderEmbargo }
+    end
+
+    context 'Embargo is an empty string' do
+      let(:attrib_value) { create(:attrib_value, value: '') }
+
+      it { expect { subject }.to raise_error(BsRequest::Errors::InvalidDate) }
     end
 
     context 'Embargo is in the past' do
-      before do
-        allow(attrib_value).to receive(:value).and_return((Time.now.utc - 2.days).to_s)
-        allow(embargo_handler).to receive(:embargo_date_attribute).and_return(attrib_value)
-      end
+      let(:attrib_value) { create(:attrib_value, value: (Time.now.utc - 2.days).to_s) }
 
-      it { expect { embargo_handler.call }.not_to raise_error }
+      it { expect { subject }.not_to raise_error }
     end
 
     context 'Embargo is invalid' do
-      before do
-        allow(attrib_value).to receive(:value).and_return('batatinha')
-        allow(embargo_handler).to receive(:embargo_date_attribute).and_return(attrib_value)
-      end
+      let(:attrib_value) { create(:attrib_value, value: 'batatinha') }
+      let(:attrib) { build(:embargo_date_attrib, project: project, values: [attrib_value]).save(validate: false) }
 
-      it { expect { embargo_handler.call }.to raise_error(BsRequest::Errors::InvalidDate) }
+      it { expect { subject }.to raise_error(BsRequest::Errors::InvalidDate) }
     end
 
     context 'Embargo has an invalid timezone' do
-      before do
-        allow(attrib_value).to receive(:value).and_return('2022-01-01 01:01:01 invalid_timezone')
-        allow(embargo_handler).to receive(:embargo_date_attribute).and_return(attrib_value)
-      end
+      let(:attrib_value) { create(:attrib_value, value: '2022-01-01 01:01:01 invalid_timezone') }
+      let(:attrib) { build(:embargo_date_attrib, project: project, values: [attrib_value]).save(validate: false) }
 
-      it { expect { embargo_handler.call }.to raise_error(BsRequest::Errors::InvalidDate) }
+      it { expect { subject }.to raise_error(BsRequest::Errors::InvalidDate) }
     end
 
     context 'Embargo is valid (with timezone)' do
-      before do
-        allow(attrib_value).to receive(:value).and_return('2022-01-01 01:01:01 CET')
-        allow(embargo_handler).to receive(:embargo_date_attribute).and_return(attrib_value)
-      end
+      let(:attrib_value) { create(:attrib_value, value: '2022-01-01 01:01:01 CET') }
 
-      it { expect { embargo_handler.call }.not_to raise_error }
+      it { expect { subject }.not_to raise_error }
     end
   end
 end


### PR DESCRIPTION
This PR introduces validation for the EmbargoDate attribute.

This means it will be no longer possible to introduce an invalid EmbargoDate attribute.

Anyway, the step of checking for an embargo date when releasing packages still handles the case of invalid embargo dates, which were stored previously in the database. This PR doesn't contain any data migration to modify embargo dates according to the new validation rules.

As a consequence of introducing this validation in the `Attrib` model, some specs were modified to make use of invalid `Attrib` objects. Regarding maintenance minitests, as the case of invalid EmbargoDate attributes is already tested in specs, the minitests were adapted to handle the case of valid EmbargoDate attributes.

To test this PR:
- open the review-app
- go to a project
- click on the "Attributes" tab
- click on the "Add Attribute" link
- select "OBS:EmbargoDate" and click in the "Add" button
- fill the "Value:" text box with an embargo date (valid or invalid)
- click on "Save" and expect to see a success message, or an error message

Fixes #12649.