### PR TITLE
Don't check directly for an unintialized value

### DIFF
--- a/src/backend/BSSched/BuildJob/Patchinfo.pm
+++ b/src/backend/BSSched/BuildJob/Patchinfo.pm
@@ -691,7 +691,7 @@ sub build {
     for my $b (@{$patchinfo->{'issue'} || []}) {
       my $it = (grep {$_->{'name'} eq $b->{'tracker'}} @{$issue_trackers->{'issue-tracker'} || []})[0];
       if ($it && $b->{'id'}) {
-        next if $b->{'publish-issues'} eq 'false';
+        next if defined $b->{'publish-issues'} && $b->{'publish-issues'} eq 'false';
         my $trackerid = $b->{'id'};
         my $referenceid = $b->{'id'};
         if ($b->{'tracker'} eq 'cve') {


### PR DESCRIPTION
Prevent from warnings with the form:

`Use of uninitialized value in string eq at /home/frontend/project/src/api/../backend/BSSched/BuildJob/Patchinfo.pm line 694.`

This can be seen in the logs of minitests:

![Screenshot from 2022-06-29 17-02-21](https://user-images.githubusercontent.com/24919/176469972-7e734c9a-2724-4929-b5da-f28a2eff0bd6.png)
