### PR TITLE
Parse timezone (and abbreviations) for embargo date

### DIFF
--- a/src/api/app/models/project/embargo_handler.rb
+++ b/src/api/app/models/project/embargo_handler.rb
@@ -16,18 +16,46 @@ class Project
     def embargo_date(embargo_attrib)
       return if embargo_attrib.nil?
 
-      begin
-        embargo = Time.parse(embargo_attrib&.value.to_s).utc
-        # no time specified, allow it next day
-        embargo = embargo.tomorrow if /^\d{4}-\d\d?-\d\d?$/.match?(embargo_attrib.value)
-      rescue ArgumentError
-        raise BsRequest::Errors::InvalidDate, "Unable to parse the date in OBS:EmbargoDate of project #{@project.name}: #{embargo_attrib}"
-      end
+      value = embargo_attrib.value
+
+      embargo = parse_value(value)
+
+      check_timezone_identifier(value)
+
+      # no time specified, allow it next day
+      embargo = embargo.tomorrow if /^\d{4}-\d\d?-\d\d?$/.match?(value)
+
       raise BsRequest::Errors::UnderEmbargo, "The project #{@project.name} is under embargo until #{embargo_attrib}" if embargo > Time.now.utc
     end
 
     def call
       embargo_date(embargo_date_attribute)
+    end
+
+    private
+
+    def check_timezone_identifier(value)
+      # Check for a valid timezone identifier
+      if value =~ /\A\d{4}-\d\d?-\d\d?(\s|T)\d\d?:\d\d?(:\d\d?)?\s(.+)\Z/ &&  # whole string matches 'YYYY-MM-DD HH:MM:SS TZ' and
+         (timezone = Regexp.last_match(3)) !~ /(\+|-)\d\d?(:\d\d?)?/          # timezone part doesn't match '+-HH:MM'
+        begin
+          TZInfo::Timezone.get(timezone)
+        rescue TZInfo::InvalidTimezoneIdentifier
+          raise BsRequest::Errors::InvalidDate, "Unable to parse the timezone in OBS:EmbargoDate of project #{@project.name}: #{value}"
+        end
+      end
+    end
+
+    def parse_value(value)
+      begin
+        parsed_value = Time.zone.parse(value)
+      rescue ArgumentError
+        raise BsRequest::Errors::InvalidDate, "Unable to parse the date in OBS:EmbargoDate of project #{@project.name}: #{value}"
+      end
+
+      raise BsRequest::Errors::InvalidDate, "Unable to parse the date in OBS:EmbargoDate of project #{@project.name}: #{value}" if parsed_value.nil?
+
+      parsed_value
     end
   end
 end

--- a/src/api/spec/models/project/embargo_handler_spec.rb
+++ b/src/api/spec/models/project/embargo_handler_spec.rb
@@ -36,5 +36,23 @@ RSpec.describe 'Project::EmbargoHandler' do
 
       it { expect { embargo_handler.call }.to raise_error(BsRequest::Errors::InvalidDate) }
     end
+
+    context 'Embargo has an invalid timezone' do
+      before do
+        allow(attrib_value).to receive(:value).and_return('2022-01-01 01:01:01 invalid_timezone')
+        allow(embargo_handler).to receive(:embargo_date_attribute).and_return(attrib_value)
+      end
+
+      it { expect { embargo_handler.call }.to raise_error(BsRequest::Errors::InvalidDate) }
+    end
+
+    context 'Embargo is valid (with timezone)' do
+      before do
+        allow(attrib_value).to receive(:value).and_return('2022-01-01 01:01:01 CET')
+        allow(embargo_handler).to receive(:embargo_date_attribute).and_return(attrib_value)
+      end
+
+      it { expect { embargo_handler.call }.not_to raise_error }
+    end
   end
 end


### PR DESCRIPTION
Before this change, the timezone of an embargo date was ignored.

```
> Time.parse('2022-10-10 10:10:10 CEST').utc
=> 2022-10-10 10:10:10 UTC
```

After this change, the timezone of an embargo date is no longer ignored.

```
> Time.zone.parse('2022-10-10 10:10:10 CEST').utc
=> 2022-10-10 08:10:10 UTC
```

Also throw an error in case that the timezone is not recognized. Otherwise it would take the 'UTC' timezone without erroring.

Related to #12649.