### PR TITLE
Change CVE download URL from HTTP to HTTPS

### DIFF
--- a/src/api/app/models/issue_tracker.rb
+++ b/src/api/app/models/issue_tracker.rb
@@ -309,8 +309,8 @@ class IssueTracker < ApplicationRecord
     return unless enable_fetch
 
     # fixed URL of all entries
-    # cveurl = "http://cve.mitre.org/data/downloads/allitems.xml.gz"
-    http = Net::HTTP.start('cve.mitre.org')
+    # cveurl = "https://cve.mitre.org/data/downloads/allitems.xml.gz"
+    http = Net::HTTP.start('cve.mitre.org', use_ssl: true)
     header = http.head('/data/downloads/allitems.xml.gz')
     mtime = Time.parse(header['Last-Modified'])
 

--- a/src/api/test/unit/issue_test.rb
+++ b/src/api/test/unit/issue_test.rb
@@ -70,10 +70,10 @@ class IssueTest < ActiveSupport::TestCase
     end
     cve.issues.create(name: 'CVE-1999-0001')
 
-    stub_request(:head, 'http://cve.mitre.org/data/downloads/allitems.xml.gz')
+    stub_request(:head, 'https://cve.mitre.org/data/downloads/allitems.xml.gz')
       .to_return(status: 200, headers: { 'Last-Modified' => 2.days.ago })
 
-    stub_request(:get, 'http://cve.mitre.org/data/downloads/allitems.xml.gz')
+    stub_request(:get, 'https://cve.mitre.org/data/downloads/allitems.xml.gz')
       .to_return(status: 200, body: load_backend_file('allitems.xml.gz'),
                  headers: { 'Last-Modified' => 2.days.ago })
 


### PR DESCRIPTION
Extracting the CVE issues started failing, and the hardcoded URL became inaccessible. The reason is that it was moved to HTTPS.

I could've also handled the redirection and accessed the URL set in the 'Location' header when the code is '302'. But, as we know the reason and the URL is hardcoded, I prefer to simply fix the URL.

Fixes https://github.com/openSUSE/open-build-service/issues/12747