### PR TITLE
Use the same bundle path in CI as we use in production

### DIFF
--- a/.circleci/conditional_config.yml
+++ b/.circleci/conditional_config.yml
@@ -52,10 +52,16 @@ images:
   - &frontend_features
     image: registry.opensuse.org/obs/server/unstable/containers/containers/openbuildservice/frontend-features:latest
 aliases:
+  - &setup_bundle_directory
+    name: setup bundle directory
+    command: |
+      sudo mkdir -p /usr/lib64/obs-api/
+      sudo chown frontend:users /usr/lib64/obs-api/
+
   - &restore_bundler_cache
     restore_cache:
       name: Restoring Bundle Cache
-      key: bundle-{{ checksum "src/api/Gemfile.lock" }}
+      key: bundle-v2-{{ checksum "src/api/Gemfile.lock" }}
 
   - &install_dependencies
     name: install dependencies
@@ -66,15 +72,18 @@ aliases:
       bundle config build.nokogiri --use-system-libraries
       bundle config build.sassc --disable-march-tune-native
       bundle config build.nio4r --with-cflags='-Wno-return-type'
-      bundle config set --local path 'vendor/bundle'
+      # Let's bundle into the same directory as our production setup.
+      # Where the bundle resides has influence on the load order!
+      bundle config set --local path '/usr/lib64/obs-api/'
+
       bundle install --jobs=4 --retry=3 --local
 
   - &save_bundler_cache
     save_cache:
       name: Saving Bundle Cache
-      key: bundle-{{ checksum "src/api/Gemfile.lock" }}
+      key: bundle-v2-{{ checksum "src/api/Gemfile.lock" }}
       paths:
-        - "src/api/vendor/bundle"
+        - "/usr/lib64/obs-api/"
 
   - &wait_for_database
     name: Wait for DB
@@ -150,6 +159,7 @@ jobs:
     docker:
       - <<: *frontend_base
     steps:
+      - run: *setup_bundle_directory
       - attach_workspace:
          at: .
       - run:
@@ -196,6 +206,7 @@ jobs:
       - <<: *frontend_base
     steps:
       - checkout
+      - run: *setup_bundle_directory
       - *restore_bundler_cache
       - *restore_rubocop_cache
       - run: *install_dependencies
@@ -208,6 +219,7 @@ jobs:
           root: .
           paths:
             - .
+            - /usr/lib64/obs-api/
 
   rspec:
     parallelism: 3
@@ -215,6 +227,7 @@ jobs:
       - <<: *frontend_base
       - <<: *mariadb
     steps:
+      - run: *setup_bundle_directory
       - attach_workspace:
          at: .
       - run: *wait_for_database
@@ -254,6 +267,7 @@ jobs:
       - <<: *frontend_minitest
       - <<: *mariadb
     steps:
+      - run: *setup_bundle_directory
       - attach_workspace:
          at: .
       - run: *init_git_submodule
@@ -289,8 +303,9 @@ jobs:
       - <<: *frontend_base
       - <<: *mariadb
     steps:
+      - run: *setup_bundle_directory
       - attach_workspace:
-         at: .
+         at: /
       - run: *init_git_submodule
       - run: *wait_for_database
       - run:
@@ -308,6 +323,7 @@ jobs:
       - <<: *frontend_minitest
       - <<: *mariadb
     steps:
+      - run: *setup_bundle_directory
       - attach_workspace:
          at: .
       - run: *init_git_submodule
@@ -335,6 +351,7 @@ jobs:
     docker:
       - <<: *frontend_base
     steps:
+      - run: *setup_bundle_directory
       - attach_workspace:
          at: .
       - run:
@@ -356,6 +373,7 @@ jobs:
       - <<: *frontend_features
       - <<: *mariadb
     steps:
+      - run: *setup_bundle_directory
       - attach_workspace:
          at: .
       - run: *wait_for_database
@@ -393,6 +411,7 @@ jobs:
     environment:
       BUNDLE_GEMFILE: Gemfile.next
     steps:
+      - run: *setup_bundle_directory
       - attach_workspace:
          at: .
       - run: *init_git_submodule
@@ -412,6 +431,7 @@ jobs:
     environment:
       BUNDLE_GEMFILE: Gemfile.next
     steps:
+      - run: *setup_bundle_directory
       - attach_workspace:
          at: .
       - run: *init_git_submodule


### PR DESCRIPTION
Where the bundle resides has an influence on the gem load order.
We have run into several downtimes with this.