### PR TITLE
Describe what the "Share Token" page is for

### DIFF
--- a/src/api/app/components/token_card_component.html.haml
+++ b/src/api/app/components/token_card_component.html.haml
@@ -31,7 +31,7 @@
           data: { toggle: 'modal', target: '#delete-token-modal', token_id: @token.id, action: token_path(@token) } do
           %i.fas.fa-times-circle.text-danger
         - if @token.type == 'Token::Workflow'
-          = link_to(token_users_path(@token.id), title: 'Users') do
+          = link_to(token_users_path(@token.id), title: 'Share Token') do
             %i.fas.fa-users
           = link_to(token_workflow_runs_path(@token.id), title: 'Workflow Runs') do
             %i.fas.fa-book-open

--- a/src/api/app/views/webui/users/tokens/show.html.haml
+++ b/src/api/app/views/webui/users/tokens/show.html.haml
@@ -80,9 +80,9 @@
               %i.fas.fa-project-diagram
               %span.nav-item-name Trigger Token
           - if @token.type == 'Token::Workflow'
-            = link_to(token_users_path(@token.id), class: 'pl-2', title: 'Users') do
+            = link_to(token_users_path(@token.id), class: 'pl-2', title: 'Share') do
               %i.fas.fa-users
-              %span.nav-item-name Users
+              %span.nav-item-name Share
             = link_to(token_workflow_runs_path(@token.id), class: 'pl-2', title: 'Workflow Runs') do
               %i.fas.fa-book-open
               %span.nav-item-name Workflow Runs

--- a/src/api/app/views/webui/users/tokens/users/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui/users/tokens/users/_breadcrumb_items.html.haml
@@ -5,4 +5,4 @@
 %li.breadcrumb-item
   = link_to @token.id, token_path(@token)
 %li.breadcrumb-item.active
-  Users
+  Share Token

--- a/src/api/app/views/webui/users/tokens/users/index.html.haml
+++ b/src/api/app/views/webui/users/tokens/users/index.html.haml
@@ -1,14 +1,26 @@
 :ruby
   @pagetitle = if @token.description.blank?
-                 'Users of the token'
+                 'Share token'
                else
-                 "Users of the '#{@token.description}' token"
+                 "Share '#{@token.description}' token"
                end
 
 .card.mb-3
   .card-body
+    %h3 Token Sharing
+
+    %p The users and groups you share this token with will have complete access to the token.
+
+    %p
+      They will be able to trigger the token in their SCM/CI integrations as if they were you.
+      But they will also be able to modify, regenerate and even delete the token.
+
+    %p
+      %i.fa.fa-exclamation-triangle.text-warning{ title: 'Warning' }
+      %span Please don't share your token with others if you don't understand what that implies.
+
     #involved-users
-      %h3 Users
+      %h4 Share with Users
       - if @users.present?
         %table.responsive.table.table-sm.table-bordered.table-hover.w-100#user-table
           %thead
@@ -38,7 +50,7 @@
 
   .card-body
     #involved-groups
-      %h3 Groups
+      %h4 Share with Groups
       - if @groups.present?
         %table.responsive.table.table-sm.table-bordered.table-hover.w-100#group-table
           %thead


### PR DESCRIPTION
The page "Share Token" missed user documentation. This PR adds documentation explaining what is to "Share a token", and how can it be used.

Replace the literal "Users" with "Share". The literal "Users" is not so accurate since the introduction of sharing a token with groups.

Co-authored-by: Saray Cabrera Padrón <scabrerapadron@suse.de>