### PR TITLE
Test rack/rake gem versions

### DIFF
--- a/.circleci/conditional_config.yml
+++ b/.circleci/conditional_config.yml
@@ -203,7 +203,11 @@ jobs:
       - run: *install_circle_cli
       - run:
           name: Setup application
-          command: cd src/api; bundle exec rake dev:prepare assets:precompile RAILS_ENV=test FORCE_EXAMPLE_FILES=1
+          command: |
+            make -C src/api test_rake
+            make -C src/api test_rack
+            cd src/api
+            bundle exec rake dev:prepare assets:precompile RAILS_ENV=test FORCE_EXAMPLE_FILES=1
       - persist_to_workspace:
           root: .
           paths:

--- a/src/api/Makefile
+++ b/src/api/Makefile
@@ -71,6 +71,17 @@ test_unit:
 	sh -x ./script/prepare_spec_tests.sh
 	sh -x ./script/api_minitest.sh
 	# rspec runs independently
+
+test_rake:
+	$(eval SYSTEM_RAKE_VERSION:=$(shell basename `gem.ruby3.1 which -g rake | sed 's,/lib/rake.rb$$,,'`))
+	$(eval BUNDLE_RAKE_VERSION:=$(shell basename `bundle show rake`))
+	@if [ "$(SYSTEM_RAKE_VERSION)" != "$(BUNDLE_RAKE_VERSION)" ]; then echo "rake version mismatch! System: $(SYSTEM_RAKE_VERSION) / Bundle: $(BUNDLE_RAKE_VERSION)"; exit 1; fi
+
+test_rack:
+	$(eval SYSTEM_RACK_VERSION:=$(shell basename `gem.ruby3.1 which -g rack | sed 's,/lib/rack.rb$$,,'`))
+	$(eval BUNDLE_RACK_VERSION:=$(shell basename `bundle show rack`))
+	@if [ "$(SYSTEM_RACK_VERSION)" != "$(BUNDLE_RACK_VERSION)" ]; then echo "rack version mismatch! System: $(SYSTEM_RACK_VERSION) / Bundle: $(BUNDLE_RACK_VERSION)"; exit 1; fi
+
 clean:
 	rm -rf ../../docs/api/html
 


### PR DESCRIPTION
The system and bundle versions of rake and rack need to match up.
    
The rake and rack gems are dependencies of passenger that it will load, from the
system, during booting itself. If our bundle versions deviate, then booting our app
will try to load those gems again, which will fail. Which makes for an unbootable
app in production. Which will make people 😠 

See #12756 for a failing example

CI now fails like this

![Screenshot from 2022-07-06 16-50-38](https://user-images.githubusercontent.com/514785/177579342-f9519867-af3c-4c33-a24a-15336a452675.png)

Build now fails like this

![Screenshot from 2022-07-06 16-59-20](https://user-images.githubusercontent.com/514785/177581349-cc565161-31bf-41d6-96b4-0f36c640ab27.png)

