### PR TITLE
Send metrics about ScmStatusReport#status

### DIFF
--- a/src/api/app/models/workflow_run.rb
+++ b/src/api/app/models/workflow_run.rb
@@ -50,11 +50,15 @@ class WorkflowRun < ApplicationRecord
     scm_status_reports.create(response_body: message,
                               request_parameters: JSON.generate(options.slice(*PERMITTED_OPTIONS)),
                               status: 'fail') # set ScmStatusReport status
+
+    RabbitmqBus.send_to_bus('metrics', 'scm_status_report,status=fail value=1')
   end
 
   # Stores info from a succesful SCM status report. The default value for 'status' is 'success'.
   def save_scm_report_success(options)
     scm_status_reports.create(request_parameters: JSON.generate(options.slice(*PERMITTED_OPTIONS)))
+
+    RabbitmqBus.send_to_bus('metrics', 'scm_status_report,status=success value=1')
   end
 
   def payload

--- a/src/api/spec/models/workflow_run_spec.rb
+++ b/src/api/spec/models/workflow_run_spec.rb
@@ -10,16 +10,32 @@ RSpec.describe WorkflowRun, vcr: true do
       let(:options) { { api_endpoint: 'https://api.github.com' } }
 
       it { expect { subject }.to change(ScmStatusReport, :count).by(1) }
-      it { expect(JSON.parse(subject.request_parameters)).to include('api_endpoint' => 'https://api.github.com') }
-      it { expect(subject.status).to eq('success') }
+
+      it 'stores the correct parameters in request_parameters' do
+        subject
+        expect(JSON.parse(ScmStatusReport.last.request_parameters)).to include('api_endpoint' => 'https://api.github.com')
+      end
+
+      it 'stores correct status value' do
+        subject
+        expect(ScmStatusReport.last.status).to eq('success')
+      end
     end
 
     context 'when providing some other keys' do
       let(:options) { { non_permitted_key: 'some value' } }
 
       it { expect { subject }.to change(ScmStatusReport, :count).by(1) }
-      it { expect(JSON.parse(subject.request_parameters)).to be_empty }
-      it { expect(subject.status).to eq('success') }
+
+      it 'stores empty request_parameters' do
+        subject
+        expect(JSON.parse(ScmStatusReport.last.request_parameters)).to be_empty
+      end
+
+      it 'stores correct status value' do
+        subject
+        expect(ScmStatusReport.last.status).to eq('success')
+      end
     end
   end
 
@@ -30,9 +46,17 @@ RSpec.describe WorkflowRun, vcr: true do
       let(:options) { { api_endpoint: 'https://api.github.com' } }
 
       it { expect { subject }.to change(ScmStatusReport, :count).by(1) }
-      it { expect(JSON.parse(subject.request_parameters)).to include('api_endpoint' => 'https://api.github.com') }
-      it { expect(subject.response_body).to eql('oops it failed') }
-      it { expect(subject.status).to eq('fail') }
+
+      it 'stores the correct parameters in request_parameters' do
+        subject
+        expect(JSON.parse(ScmStatusReport.last.request_parameters)).to include('api_endpoint' => 'https://api.github.com')
+      end
+
+      it 'stores correct values for failure' do
+        subject
+        expect(ScmStatusReport.last.response_body).to eql('oops it failed')
+        expect(ScmStatusReport.last.status).to eq('fail')
+      end
 
       it 'marks the workflow run as failed' do
         subject
@@ -44,9 +68,17 @@ RSpec.describe WorkflowRun, vcr: true do
       let(:options) { { non_permitted_key: 'some value' } }
 
       it { expect { subject }.to change(ScmStatusReport, :count).by(1) }
-      it { expect(JSON.parse(subject.request_parameters)).to be_empty }
-      it { expect(subject.response_body).to eql('oops it failed') }
-      it { expect(subject.status).to eq('fail') }
+
+      it 'stores empty request_parameters' do
+        subject
+        expect(JSON.parse(ScmStatusReport.last.request_parameters)).to be_empty
+      end
+
+      it 'stores correct values for failure' do
+        subject
+        expect(ScmStatusReport.last.response_body).to eql('oops it failed')
+        expect(ScmStatusReport.last.status).to eq('fail')
+      end
 
       it 'marks the workflow run as failed' do
         subject


### PR DESCRIPTION
The status can be `success` or `fail` and represents whether OBS was able to send the report back or not.

Co-authored-by: Eduardo Navarro <enavarro@suse.com>