### PR TITLE
[api] support staging without write access in GA projects

### DIFF
--- a/src/api/app/controllers/concerns/rescue_authorization_handler.rb
+++ b/src/api/app/controllers/concerns/rescue_authorization_handler.rb
@@ -52,7 +52,7 @@ module RescueAuthorizationHandler
       when :anonymous_user
         'Please login to access the resource'
       when :request_state_change
-        "Request #{exception.record.number} is not acceptable"
+        "Request #{exception.record.number} would not be acceptable by you"
       else
         "Sorry, you are not authorized to #{action_for_exception(exception)} this #{ActiveSupport::Inflector.underscore(exception.record.class.to_s).humanize(capitalize: false)}."
       end

--- a/src/api/app/controllers/concerns/rescue_authorization_handler.rb
+++ b/src/api/app/controllers/concerns/rescue_authorization_handler.rb
@@ -51,6 +51,8 @@ module RescueAuthorizationHandler
       case exception.reason
       when :anonymous_user
         'Please login to access the resource'
+      when :request_state_change
+        "Request #{exception.record.number} is not acceptable"
       else
         "Sorry, you are not authorized to #{action_for_exception(exception)} this #{ActiveSupport::Inflector.underscore(exception.record.class.to_s).humanize(capitalize: false)}."
       end

--- a/src/api/app/controllers/staging/staging_projects_controller.rb
+++ b/src/api/app/controllers/staging/staging_projects_controller.rb
@@ -48,7 +48,6 @@ class Staging::StagingProjectsController < Staging::StagingController
 
   def accept
     authorize @staging_project, :accept?
-    authorize @project, :update?
 
     # check general state
     raise StagingProjectNotAcceptable, 'Staging project is not in state acceptable.' unless can_accept?

--- a/src/api/app/controllers/staging/staging_projects_controller.rb
+++ b/src/api/app/controllers/staging/staging_projects_controller.rb
@@ -49,19 +49,31 @@ class Staging::StagingProjectsController < Staging::StagingController
   def accept
     authorize @staging_project, :accept?
 
-    # check general state
-    raise StagingProjectNotAcceptable, 'Staging project is not in state acceptable.' unless can_accept?
-
-    StagingProjectAcceptJob.perform_later(project_id: @staging_project.id, user_login: User.session!.login)
-    render_ok
+    if acceptable?(force: params[:force].present?)
+      StagingProjectAcceptJob.perform_later(project_id: @staging_project.id, user_login: User.session!.login)
+      render_ok
+    else
+      render_error(
+        status: 400,
+        errorcode: 'staging_project_not_in_acceptable_state',
+        message: "Staging Project is not acceptable: #{@acceptable_error}"
+      )
+    end
   end
 
   private
 
-  def can_accept?
-    return true if @staging_project.overall_state == :acceptable
+  def acceptable?(force: false)
+    @acceptable_error = 'has reviews open' unless @staging_project.missing_reviews.empty?
 
-    params[:force].present? && @staging_project.force_acceptable?
+    if force
+      unless @staging_project.overall_state.in?(StagingProject::FORCEABLE_STATES)
+        @acceptable_error = "is not in state #{StagingProject::FORCEABLE_STATES.to_sentence(last_word_connector: ' or ')}"
+      end
+    else
+      @acceptable_error = "#{@staging_project.overall_state} is not an acceptable state" unless @staging_project.overall_state == :acceptable
+    end
+    @acceptable_error.blank?
   end
 
   def set_options

--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -495,6 +495,15 @@ class BsRequest < ApplicationRecord
     check_bs_request_actions!(skip_source: true)
   end
 
+  def permission_check_change_state(opts)
+    begin
+      permission_check_change_state!(opts)
+    rescue PostRequestNoPermission
+      return false
+    end
+    true
+  end
+
   def changestate_accepted(opts)
     # all maintenance_incident actions go into the same incident project
     incident_project = nil # .where(type: 'maintenance_incident')

--- a/src/api/app/models/concerns/staging_project.rb
+++ b/src/api/app/models/concerns/staging_project.rb
@@ -37,7 +37,6 @@ module StagingProject
 
     # Reset history
     project_log_entries.staging_history.delete_all
-    clear_memoized_data
 
     true
   end
@@ -174,14 +173,6 @@ module StagingProject
   end
 
   private
-
-  def clear_memoized_data
-    @broken_packages = []
-    @building_repositories = []
-    @requests_to_review = nil
-    @problems = nil
-    @overall_state = nil
-  end
 
   def state
     # FIXME: We should use a better way to check if we are in :accepting state. Could be a state machine or storing the state locally.

--- a/src/api/app/models/concerns/staging_project.rb
+++ b/src/api/app/models/concerns/staging_project.rb
@@ -15,6 +15,7 @@ module StagingProject
   end
 
   HISTORY_EVENT_TYPES = [:staging_project_created, :staged_request, :unstaged_request].freeze
+  FORCEABLE_STATES = [:building, :failed, :testing].freeze
 
   def accept
     # Disabling build for all repositories and architectures.
@@ -170,14 +171,6 @@ module StagingProject
 
     project_log_entry.datetime = Time.now
     project_log_entry.save!
-  end
-
-  def force_acceptable?
-    return false if overall_state.in?([:empty, :unacceptable, :accepting])
-
-    # won't force accept missing reviews, but we can skip
-    # building, testing and failing projects
-    missing_reviews.empty?
   end
 
   private

--- a/src/api/app/policies/project_policy.rb
+++ b/src/api/app/policies/project_policy.rb
@@ -46,10 +46,12 @@ class ProjectPolicy < ApplicationPolicy
   def accept?
     return false unless update?
 
-    record.staged_requests.each do |request|
-      # we pretend the user asked for force, we only want to check permissions
-      # not if it makes sense
-      request.permission_check_change_state!(newstate: 'accepted', force: true)
+    user.run_as do
+      record.staged_requests.each do |request|
+        # we pretend the user asked for force, we only want to check permissions
+        # not if it would makes sense to accept the request
+        raise Pundit::NotAuthorizedError, query: :accept?, record: request, reason: :request_state_change unless request.permission_check_change_state(newstate: 'accepted', force: true)
+      end
     end
   end
 

--- a/src/api/spec/cassettes/Project/Staging_Project/_accept/when_the_staging_project_has_missing_reviews/1_1_7_2_1.yml
+++ b/src/api/spec/cassettes/Project/Staging_Project/_accept/when_the_staging_project_has_missing_reviews/1_1_7_2_1.yml
@@ -39,14 +39,14 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:39 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:57 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_67
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_81
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_27">
+        <workflow project="home:tom" managers="group_35">
           <staging_project name="home:tom:Staging:A"/>
         </workflow>
     headers:
@@ -68,28 +68,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="296">
-          <srcmd5>18c421127255f8651943e9d01db8c02e</srcmd5>
-          <time>1658422059</time>
-          <user>user_67</user>
+        <revision rev="98">
+          <srcmd5>14d916d63685873e75945590d01b8a4a</srcmd5>
+          <time>1658762217</time>
+          <user>user_81</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:39 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:57 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_67
+    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_81
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_27" role="maintainer"/>
+          <group groupid="group_35" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -117,16 +117,16 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_27" role="maintainer"/>
+          <group groupid="group_35" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:39 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:57 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_67
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_81
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_27">
+        <workflow project="home:tom" managers="group_35">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -149,28 +149,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="297">
-          <srcmd5>3fc84c8e3e92a59e00d8704cd916ac09</srcmd5>
-          <time>1658422059</time>
-          <user>user_67</user>
+        <revision rev="99">
+          <srcmd5>cf67cc78742b19163f3d8bc069207874</srcmd5>
+          <time>1658762217</time>
+          <user>user_81</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:39 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:57 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_67
+    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_81
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:B">
           <title/>
           <description/>
-          <group groupid="group_27" role="maintainer"/>
+          <group groupid="group_35" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -198,12 +198,12 @@ http_interactions:
         <project name="home:tom:Staging:B">
           <title></title>
           <description></description>
-          <group groupid="group_27" role="maintainer"/>
+          <group groupid="group_35" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:39 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:57 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_meta?user=user_67
+    uri: http://backend:5352/source/home:tom/_meta?user=user_81
     body:
       encoding: UTF-8
       string: |
@@ -211,7 +211,7 @@ http_interactions:
           <title/>
           <description/>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_27" role="reviewer"/>
+          <group groupid="group_35" role="reviewer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -240,18 +240,18 @@ http_interactions:
           <title></title>
           <description></description>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_27" role="reviewer"/>
+          <group groupid="group_35" role="reviewer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:39 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:57 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_68
+    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_82
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>Precious Bane</title>
-          <description>Assumenda nihil est omnis.</description>
+          <title>Absalom, Absalom!</title>
+          <description>Molestiae rerum labore iste.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -272,21 +272,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '162'
+      - '168'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>Precious Bane</title>
-          <description>Assumenda nihil est omnis.</description>
+          <title>Absalom, Absalom!</title>
+          <description>Molestiae rerum labore iste.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:39 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:57 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_config
     body:
       encoding: UTF-8
-      string: Explicabo autem illum. Ut eius est. Alias qui sapiente.
+      string: Quis assumenda voluptas. Neque fugiat et. Possimus unde dicta.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -306,25 +306,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="145" vrev="145">
-          <srcmd5>f01f5265c1941903f7f4258ecc7216ca</srcmd5>
+        <revision rev="63" vrev="63">
+          <srcmd5>d295e80671166c9f32828d0595044d31</srcmd5>
           <version>unknown</version>
-          <time>1658422059</time>
+          <time>1658762217</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:39 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:57 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/somefile.txt
     body:
       encoding: UTF-8
-      string: Ducimus nostrum tempore. Dolores dolor rem. Facilis et iste.
+      string: Ex quaerat commodi. Iure omnis non. Et sit asperiores.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -344,19 +344,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="146" vrev="146">
-          <srcmd5>a7dafb6923eba21d16e314879472b8f5</srcmd5>
+        <revision rev="64" vrev="64">
+          <srcmd5>cfa9bc09b8474d63026789661ee898d3</srcmd5>
           <version>unknown</version>
-          <time>1658422059</time>
+          <time>1658762217</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:39 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:57 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/_meta?user=tom
@@ -364,7 +364,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>Death Be Not Proud</title>
+          <title>Ego Dominus Tuus</title>
           <description/>
         </project>
     headers:
@@ -386,15 +386,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '109'
+      - '107'
     body:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>Death Be Not Proud</title>
+          <title>Ego Dominus Tuus</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:40 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:57 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package_2/_meta?user=tom
@@ -402,8 +402,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="target_project">
-          <title>Great Work of Time</title>
-          <description>Qui sit voluptas ea.</description>
+          <title>If Not Now, When?</title>
+          <description>Omnis aperiam magni aliquam.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -424,15 +424,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '156'
+      - '163'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="target_project">
-          <title>Great Work of Time</title>
-          <description>Qui sit voluptas ea.</description>
+          <title>If Not Now, When?</title>
+          <description>Omnis aperiam magni aliquam.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:40 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:57 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_meta?user=tom
@@ -440,7 +440,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Dying of the Light</title>
+          <title>Blithe Spirit</title>
           <description/>
         </project>
     headers:
@@ -462,15 +462,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '109'
+      - '104'
     body:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Dying of the Light</title>
+          <title>Blithe Spirit</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:40 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:57 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_project/_attribute?meta=1&user=tom
@@ -499,18 +499,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '166'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="146">
-          <srcmd5>61c8b70794865fad4ebf6417a03bdf72</srcmd5>
-          <time>1658422060</time>
+        <revision rev="62">
+          <srcmd5>fc9f6bb9762f7501386ec1668721dfed</srcmd5>
+          <time>1658762217</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:40 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:57 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/source_package/_meta?user=tom
@@ -518,8 +518,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>A Handful of Dust</title>
-          <description>Ea soluta facilis reiciendis.</description>
+          <title>A Scanner Darkly</title>
+          <description>Magni voluptatem modi deleniti.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -540,15 +540,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '162'
+      - '163'
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>A Handful of Dust</title>
-          <description>Ea soluta facilis reiciendis.</description>
+          <title>A Scanner Darkly</title>
+          <description>Magni voluptatem modi deleniti.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:40 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:57 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package
@@ -580,7 +580,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:40 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:57 GMT
 - request:
     method: post
     uri: http://backend:5352/source/source_project/source_package?cmd=diff&expand=1&filelimit=10000&opackage=target_package_2&oproject=target_project&tarlimit=10000&view=xml&withissues=1
@@ -603,24 +603,24 @@ http_interactions:
     headers:
       Content-Type:
       - text/xml
-      Content-Length:
-      - '331'
       Cache-Control:
       - no-cache
       Connection:
       - close
+      Content-Length:
+      - '331'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="7155e225942a839c793fb9287cc86a7a">
-          <old project="target_project" package="target_package_2" rev="51" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+        <sourcediff key="44c50c734bc05b4f7c54186e249274b9">
+          <old project="target_project" package="target_package_2" rev="13" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <new project="source_project" package="source_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files>
           </files>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:40 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:57 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22source_package%22%20and%20linkinfo/@project=%22source_project%22%20and%20@project=%22source_project%22)
@@ -654,7 +654,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 21 Jul 2022 16:47:40 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:57 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2/_meta?user=tom
@@ -662,8 +662,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>A Handful of Dust</title>
-          <description>Ea soluta facilis reiciendis.</description>
+          <title>A Scanner Darkly</title>
+          <description>Magni voluptatem modi deleniti.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -684,15 +684,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '168'
+      - '169'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>A Handful of Dust</title>
-          <description>Ea soluta facilis reiciendis.</description>
+          <title>A Scanner Darkly</title>
+          <description>Magni voluptatem modi deleniti.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:40 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:57 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?cmd=branch&noservice=1&opackage=source_package&oproject=source_project&user=tom
@@ -724,15 +724,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2" vrev="2">
+        <revision rev="1" vrev="1">
           <srcmd5>8e451641a827df5f4f409d1d543fdb7b</srcmd5>
           <version>unknown</version>
-          <time>1658422060</time>
+          <time>1658762217</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:40 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:57 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2/_meta?user=tom
@@ -740,8 +740,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>A Handful of Dust</title>
-          <description>Ea soluta facilis reiciendis.</description>
+          <title>A Scanner Darkly</title>
+          <description>Magni voluptatem modi deleniti.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -762,15 +762,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '168'
+      - '169'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>A Handful of Dust</title>
-          <description>Ea soluta facilis reiciendis.</description>
+          <title>A Scanner Darkly</title>
+          <description>Magni voluptatem modi deleniti.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:40 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:58 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2
@@ -800,11 +800,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="target_package_2" rev="2" vrev="2" srcmd5="8e451641a827df5f4f409d1d543fdb7b">
+        <directory name="target_package_2" rev="1" vrev="1" srcmd5="8e451641a827df5f4f409d1d543fdb7b">
           <linkinfo project="source_project" package="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
-          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658419299"/>
+          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658762120"/>
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:40 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:58 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?view=info
@@ -834,11 +834,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="target_package_2" rev="2" vrev="2" srcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
+        <sourceinfo package="target_package_2" rev="1" vrev="1" srcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="source_project" package="source_package"/>
         </sourceinfo>
-  recorded_at: Thu, 21 Jul 2022 16:47:40 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:58 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2
@@ -868,11 +868,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="target_package_2" rev="2" vrev="2" srcmd5="8e451641a827df5f4f409d1d543fdb7b">
+        <directory name="target_package_2" rev="1" vrev="1" srcmd5="8e451641a827df5f4f409d1d543fdb7b">
           <linkinfo project="source_project" package="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
-          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658419299"/>
+          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658762120"/>
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:40 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:58 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -904,14 +904,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="51ab6419dbab29188144344061334586">
+        <sourcediff key="a38f4b4e228bc555381cec0d7cc141f9">
           <old project="home:tom:Staging:A" package="target_package_2" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:tom:Staging:A" package="target_package_2" rev="2" srcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
+          <new project="home:tom:Staging:A" package="target_package_2" rev="1" srcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:40 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:58 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -950,14 +950,14 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:40 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:58 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=tom
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_27">
+        <workflow project="home:tom" managers="group_35">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -984,14 +984,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="298">
-          <srcmd5>3fc84c8e3e92a59e00d8704cd916ac09</srcmd5>
-          <time>1658422060</time>
+        <revision rev="100">
+          <srcmd5>cf67cc78742b19163f3d8bc069207874</srcmd5>
+          <time>1658762218</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:40 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:58 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=tom
@@ -1001,7 +1001,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_27" role="maintainer"/>
+          <group groupid="group_35" role="maintainer"/>
           <repository name="staging_repository">
             <arch>x86_64</arch>
           </repository>
@@ -1032,12 +1032,12 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_27" role="maintainer"/>
+          <group groupid="group_35" role="maintainer"/>
           <repository name="staging_repository">
             <arch>x86_64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:40 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:58 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package_3/_meta?user=tom
@@ -1045,8 +1045,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_3" project="target_project">
-          <title>Clouds of Witness</title>
-          <description>Quam est ad exercitationem.</description>
+          <title>Cabbages and Kings</title>
+          <description>Consequatur iste voluptatem deserunt.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1067,15 +1067,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '162'
+      - '173'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package_3" project="target_project">
-          <title>Clouds of Witness</title>
-          <description>Quam est ad exercitationem.</description>
+          <title>Cabbages and Kings</title>
+          <description>Consequatur iste voluptatem deserunt.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:40 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:58 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package
@@ -1107,7 +1107,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:40 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:58 GMT
 - request:
     method: post
     uri: http://backend:5352/source/source_project/source_package?cmd=diff&expand=1&filelimit=10000&opackage=target_package_3&oproject=target_project&tarlimit=10000&view=xml&withissues=1
@@ -1130,12 +1130,12 @@ http_interactions:
     headers:
       Content-Type:
       - text/xml
-      Content-Length:
-      - '330'
       Cache-Control:
       - no-cache
       Connection:
       - close
+      Content-Length:
+      - '330'
     body:
       encoding: UTF-8
       string: |
@@ -1147,7 +1147,7 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:40 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:58 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22source_package%22%20and%20linkinfo/@project=%22source_project%22%20and%20@project=%22source_project%22)
@@ -1181,7 +1181,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 21 Jul 2022 16:47:40 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:58 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_3/_meta?user=tom
@@ -1189,8 +1189,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_3" project="home:tom:Staging:A">
-          <title>A Handful of Dust</title>
-          <description>Ea soluta facilis reiciendis.</description>
+          <title>A Scanner Darkly</title>
+          <description>Magni voluptatem modi deleniti.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1211,15 +1211,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '168'
+      - '169'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package_3" project="home:tom:Staging:A">
-          <title>A Handful of Dust</title>
-          <description>Ea soluta facilis reiciendis.</description>
+          <title>A Scanner Darkly</title>
+          <description>Magni voluptatem modi deleniti.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:40 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:58 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_3?cmd=branch&noservice=1&opackage=source_package&oproject=source_project&user=tom
@@ -1251,15 +1251,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="5" vrev="5">
+        <revision rev="1" vrev="1">
           <srcmd5>8e451641a827df5f4f409d1d543fdb7b</srcmd5>
           <version>unknown</version>
-          <time>1658422060</time>
+          <time>1658762218</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:40 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:58 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_3/_meta?user=tom
@@ -1267,8 +1267,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_3" project="home:tom:Staging:A">
-          <title>A Handful of Dust</title>
-          <description>Ea soluta facilis reiciendis.</description>
+          <title>A Scanner Darkly</title>
+          <description>Magni voluptatem modi deleniti.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1289,15 +1289,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '168'
+      - '169'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package_3" project="home:tom:Staging:A">
-          <title>A Handful of Dust</title>
-          <description>Ea soluta facilis reiciendis.</description>
+          <title>A Scanner Darkly</title>
+          <description>Magni voluptatem modi deleniti.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:40 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:58 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_3
@@ -1327,11 +1327,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="target_package_3" rev="5" vrev="5" srcmd5="8e451641a827df5f4f409d1d543fdb7b">
+        <directory name="target_package_3" rev="1" vrev="1" srcmd5="8e451641a827df5f4f409d1d543fdb7b">
           <linkinfo project="source_project" package="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
-          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658419307"/>
+          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658762218"/>
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:40 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:58 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_3?view=info
@@ -1361,11 +1361,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="target_package_3" rev="5" vrev="5" srcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
+        <sourceinfo package="target_package_3" rev="1" vrev="1" srcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="source_project" package="source_package"/>
         </sourceinfo>
-  recorded_at: Thu, 21 Jul 2022 16:47:40 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:58 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_3
@@ -1395,11 +1395,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="target_package_3" rev="5" vrev="5" srcmd5="8e451641a827df5f4f409d1d543fdb7b">
+        <directory name="target_package_3" rev="1" vrev="1" srcmd5="8e451641a827df5f4f409d1d543fdb7b">
           <linkinfo project="source_project" package="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
-          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658419307"/>
+          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658762218"/>
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:40 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:58 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_3?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -1431,14 +1431,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="b693b5c0a50daf53f8755da14531ccb8">
+        <sourcediff key="d4f5f6bc9b6c05f30ca2ba2f7e10d6b8">
           <old project="home:tom:Staging:A" package="target_package_3" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:tom:Staging:A" package="target_package_3" rev="5" srcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
+          <new project="home:tom:Staging:A" package="target_package_3" rev="1" srcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:40 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:58 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_3?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -1461,12 +1461,12 @@ http_interactions:
     headers:
       Content-Type:
       - text/xml
-      Content-Length:
-      - '386'
       Cache-Control:
       - no-cache
       Connection:
       - close
+      Content-Length:
+      - '386'
     body:
       encoding: UTF-8
       string: |
@@ -1477,14 +1477,14 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:40 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:58 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=tom
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_27">
+        <workflow project="home:tom" managers="group_35">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -1511,14 +1511,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="299">
-          <srcmd5>3fc84c8e3e92a59e00d8704cd916ac09</srcmd5>
-          <time>1658422060</time>
+        <revision rev="101">
+          <srcmd5>cf67cc78742b19163f3d8bc069207874</srcmd5>
+          <time>1658762218</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:40 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:58 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=tom
@@ -1528,7 +1528,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_27" role="maintainer"/>
+          <group groupid="group_35" role="maintainer"/>
           <repository name="staging_repository">
             <arch>x86_64</arch>
           </repository>
@@ -1559,19 +1559,19 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_27" role="maintainer"/>
+          <group groupid="group_35" role="maintainer"/>
           <repository name="staging_repository">
             <arch>x86_64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:40 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:58 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_67
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_81
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_27">
+        <workflow project="home:tom" managers="group_35">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -1598,14 +1598,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="300">
-          <srcmd5>3fc84c8e3e92a59e00d8704cd916ac09</srcmd5>
-          <time>1658422060</time>
-          <user>user_67</user>
+        <revision rev="102">
+          <srcmd5>cf67cc78742b19163f3d8bc069207874</srcmd5>
+          <time>1658762218</time>
+          <user>user_81</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:40 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:58 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=tom
@@ -1615,7 +1615,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_27" role="maintainer"/>
+          <group groupid="group_35" role="maintainer"/>
           <build>
             <disable/>
           </build>
@@ -1649,7 +1649,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_27" role="maintainer"/>
+          <group groupid="group_35" role="maintainer"/>
           <build>
             <disable/>
           </build>
@@ -1657,7 +1657,7 @@ http_interactions:
             <arch>x86_64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:40 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:58 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package?expand=1
@@ -1689,7 +1689,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:41 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:58 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package?expand=1
@@ -1721,7 +1721,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:41 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:58 GMT
 - request:
     method: post
     uri: http://backend:5352/source/target_project/target_package_2?cmd=copy&comment=Request%20for%20package%20target_package_2&expand=1&keeplink=1&noservice=1&opackage=source_package&oproject=source_project&requestid=1&user=tom&withacceptinfo=1
@@ -1753,16 +1753,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="52" vrev="52">
+        <revision rev="14" vrev="14">
           <srcmd5>d41d8cd98f00b204e9800998ecf8427e</srcmd5>
           <version>unknown</version>
-          <time>1658422061</time>
+          <time>1658762218</time>
           <user>tom</user>
           <comment>Request for package target_package_2</comment>
           <requestid>1</requestid>
-          <acceptinfo rev="52" srcmd5="d41d8cd98f00b204e9800998ecf8427e" osrcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <acceptinfo rev="14" srcmd5="d41d8cd98f00b204e9800998ecf8427e" osrcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:41 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:58 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package_2/_meta?user=tom
@@ -1770,8 +1770,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="target_project">
-          <title>Great Work of Time</title>
-          <description>Qui sit voluptas ea.</description>
+          <title>If Not Now, When?</title>
+          <description>Omnis aperiam magni aliquam.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1792,15 +1792,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '156'
+      - '163'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="target_project">
-          <title>Great Work of Time</title>
-          <description>Qui sit voluptas ea.</description>
+          <title>If Not Now, When?</title>
+          <description>Omnis aperiam magni aliquam.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:41 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package_2
@@ -1830,9 +1830,9 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="target_package_2" rev="52" vrev="52" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <directory name="target_package_2" rev="14" vrev="14" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:41 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package_2?view=info
@@ -1862,10 +1862,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="target_package_2" rev="52" vrev="52" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <sourceinfo package="target_package_2" rev="14" vrev="14" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
           <error>no source uploaded</error>
         </sourceinfo>
-  recorded_at: Thu, 21 Jul 2022 16:47:41 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package_2
@@ -1895,9 +1895,9 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="target_package_2" rev="52" vrev="52" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <directory name="target_package_2" rev="14" vrev="14" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:41 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
 - request:
     method: post
     uri: http://backend:5352/source/target_project/target_package_2?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -1929,12 +1929,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="e0bc3a5adfca11f45511291bdb7edc9a">
+        <sourcediff key="3c4f498fe75bc34d80f6d4625ec41da6">
           <old project="target_project" package="target_package_2" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="target_project" package="target_package_2" rev="52" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="target_project" package="target_package_2" rev="14" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files/>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:41 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
 - request:
     method: delete
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?comment&user=tom
@@ -1966,5 +1966,5 @@ http_interactions:
       string: '<status code="ok" />
 
 '
-  recorded_at: Thu, 21 Jul 2022 16:47:41 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Project/Staging_Project/_accept/when_the_staging_project_is_in_acceptable_state/should_remove_staging_project_log_entries/1_1_7_1_2_1.yml
+++ b/src/api/spec/cassettes/Project/Staging_Project/_accept/when_the_staging_project_is_in_acceptable_state/should_remove_staging_project_log_entries/1_1_7_1_2_1.yml
@@ -39,14 +39,14 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:36 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:36 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_63
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_57
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_25">
+        <workflow project="home:tom" managers="group_23">
           <staging_project name="home:tom:Staging:A"/>
         </workflow>
     headers:
@@ -68,28 +68,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="287">
-          <srcmd5>265f95387ce128dadc92b57f6247935d</srcmd5>
-          <time>1658422056</time>
-          <user>user_63</user>
+        <revision rev="44">
+          <srcmd5>0ff1578d6f49d4d4d3b3b784f5bbfdd7</srcmd5>
+          <time>1658762196</time>
+          <user>user_57</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:36 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:36 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_63
+    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_57
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_25" role="maintainer"/>
+          <group groupid="group_23" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -117,16 +117,16 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_25" role="maintainer"/>
+          <group groupid="group_23" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:36 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:36 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_63
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_57
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_25">
+        <workflow project="home:tom" managers="group_23">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -149,28 +149,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="288">
-          <srcmd5>a53eb95f49c1fee041f0168343a2ff33</srcmd5>
-          <time>1658422056</time>
-          <user>user_63</user>
+        <revision rev="45">
+          <srcmd5>6bf67b537ff325279c5ed00a43e87a94</srcmd5>
+          <time>1658762196</time>
+          <user>user_57</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:36 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:36 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_63
+    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_57
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:B">
           <title/>
           <description/>
-          <group groupid="group_25" role="maintainer"/>
+          <group groupid="group_23" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -198,12 +198,12 @@ http_interactions:
         <project name="home:tom:Staging:B">
           <title></title>
           <description></description>
-          <group groupid="group_25" role="maintainer"/>
+          <group groupid="group_23" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:36 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:36 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_meta?user=user_63
+    uri: http://backend:5352/source/home:tom/_meta?user=user_57
     body:
       encoding: UTF-8
       string: |
@@ -211,7 +211,7 @@ http_interactions:
           <title/>
           <description/>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_25" role="reviewer"/>
+          <group groupid="group_23" role="reviewer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -240,18 +240,18 @@ http_interactions:
           <title></title>
           <description></description>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_25" role="reviewer"/>
+          <group groupid="group_23" role="reviewer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:36 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:36 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_64
+    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_58
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>For a Breath I Tarry</title>
-          <description>Voluptatem esse deserunt et.</description>
+          <title>The Line of Beauty</title>
+          <description>Temporibus dolores eligendi non.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -272,21 +272,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '173'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>For a Breath I Tarry</title>
-          <description>Voluptatem esse deserunt et.</description>
+          <title>The Line of Beauty</title>
+          <description>Temporibus dolores eligendi non.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:36 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:36 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_config
     body:
       encoding: UTF-8
-      string: Aut doloribus est. Libero rerum et. Tempora amet laudantium.
+      string: Velit maxime quis. Odio voluptatum dolor. Amet consequatur officiis.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -306,25 +306,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="141" vrev="141">
-          <srcmd5>4fede992b11eb42f5ef4c4b63ebd80f4</srcmd5>
+        <revision rev="39" vrev="39">
+          <srcmd5>f296acb8bad0754f3a851e5be2235a0b</srcmd5>
           <version>unknown</version>
-          <time>1658422056</time>
+          <time>1658762196</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:36 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:36 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/somefile.txt
     body:
       encoding: UTF-8
-      string: Deleniti voluptates eum. Ducimus est eligendi. Quisquam maiores ea.
+      string: Facilis et rerum. Ea voluptas dolorem. Voluptas sit aut.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -344,19 +344,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="142" vrev="142">
-          <srcmd5>70cfb2559b34877d20fda47023dc14fb</srcmd5>
+        <revision rev="40" vrev="40">
+          <srcmd5>8b40475c29355ac27b09219ec476f73b</srcmd5>
           <version>unknown</version>
-          <time>1658422056</time>
+          <time>1658762196</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:36 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:36 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/_meta?user=tom
@@ -364,7 +364,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>Postern of Fate</title>
+          <title>Now Sleeps the Crimson Petal</title>
           <description/>
         </project>
     headers:
@@ -386,15 +386,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '106'
+      - '119'
     body:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>Postern of Fate</title>
+          <title>Now Sleeps the Crimson Petal</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:36 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:36 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package_2/_meta?user=tom
@@ -402,8 +402,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="target_project">
-          <title>The Monkey's Raincoat</title>
-          <description>Minima eaque ea quo.</description>
+          <title>Unweaving the Rainbow</title>
+          <description>Praesentium quia voluptatem dolore.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -424,15 +424,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '159'
+      - '174'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="target_project">
-          <title>The Monkey's Raincoat</title>
-          <description>Minima eaque ea quo.</description>
+          <title>Unweaving the Rainbow</title>
+          <description>Praesentium quia voluptatem dolore.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:36 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:36 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_meta?user=tom
@@ -440,7 +440,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>A Handful of Dust</title>
+          <title>It's a Battlefield</title>
           <description/>
         </project>
     headers:
@@ -462,15 +462,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '108'
+      - '109'
     body:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>A Handful of Dust</title>
+          <title>It's a Battlefield</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:36 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:36 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_project/_attribute?meta=1&user=tom
@@ -499,18 +499,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '166'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="142">
-          <srcmd5>2e2f8fc153bb63ce38f45d1edb2ecf12</srcmd5>
-          <time>1658422056</time>
+        <revision rev="38">
+          <srcmd5>1442f47387628d375f6980c1563b843b</srcmd5>
+          <time>1658762196</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:36 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:36 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/source_package/_meta?user=tom
@@ -518,8 +518,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>The Wives of Bath</title>
-          <description>Non pariatur eligendi enim.</description>
+          <title>By Grand Central Station I Sat Down and Wept</title>
+          <description>Cum occaecati qui perspiciatis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -540,15 +540,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '160'
+      - '191'
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>The Wives of Bath</title>
-          <description>Non pariatur eligendi enim.</description>
+          <title>By Grand Central Station I Sat Down and Wept</title>
+          <description>Cum occaecati qui perspiciatis.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:36 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:36 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package
@@ -580,7 +580,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:37 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:36 GMT
 - request:
     method: post
     uri: http://backend:5352/source/source_project/source_package?cmd=diff&expand=1&filelimit=10000&opackage=target_package_2&oproject=target_project&tarlimit=10000&view=xml&withissues=1
@@ -608,19 +608,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '331'
+      - '330'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="d23af11241f7852203711f9bed72045e">
-          <old project="target_project" package="target_package_2" rev="50" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+        <sourcediff key="bf2529527f2b74387b2a4047c35bb5b0">
+          <old project="target_project" package="target_package_2" rev="1" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <new project="source_project" package="source_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files>
           </files>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:37 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:36 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22source_package%22%20and%20linkinfo/@project=%22source_project%22%20and%20@project=%22source_project%22)
@@ -654,7 +654,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 21 Jul 2022 16:47:37 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:36 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2/_meta?user=tom
@@ -662,8 +662,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>The Wives of Bath</title>
-          <description>Non pariatur eligendi enim.</description>
+          <title>By Grand Central Station I Sat Down and Wept</title>
+          <description>Cum occaecati qui perspiciatis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -684,15 +684,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '166'
+      - '197'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>The Wives of Bath</title>
-          <description>Non pariatur eligendi enim.</description>
+          <title>By Grand Central Station I Sat Down and Wept</title>
+          <description>Cum occaecati qui perspiciatis.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:37 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:37 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?cmd=branch&noservice=1&opackage=source_package&oproject=source_project&user=tom
@@ -727,12 +727,12 @@ http_interactions:
         <revision rev="1" vrev="1">
           <srcmd5>8e451641a827df5f4f409d1d543fdb7b</srcmd5>
           <version>unknown</version>
-          <time>1658422057</time>
+          <time>1658762197</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:37 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:37 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2/_meta?user=tom
@@ -740,8 +740,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>The Wives of Bath</title>
-          <description>Non pariatur eligendi enim.</description>
+          <title>By Grand Central Station I Sat Down and Wept</title>
+          <description>Cum occaecati qui perspiciatis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -762,15 +762,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '166'
+      - '197'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>The Wives of Bath</title>
-          <description>Non pariatur eligendi enim.</description>
+          <title>By Grand Central Station I Sat Down and Wept</title>
+          <description>Cum occaecati qui perspiciatis.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:37 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:37 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2
@@ -802,9 +802,9 @@ http_interactions:
       string: |
         <directory name="target_package_2" rev="1" vrev="1" srcmd5="8e451641a827df5f4f409d1d543fdb7b">
           <linkinfo project="source_project" package="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
-          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658419299"/>
+          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658762120"/>
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:37 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:37 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?view=info
@@ -838,7 +838,7 @@ http_interactions:
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="source_project" package="source_package"/>
         </sourceinfo>
-  recorded_at: Thu, 21 Jul 2022 16:47:37 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:37 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2
@@ -870,9 +870,9 @@ http_interactions:
       string: |
         <directory name="target_package_2" rev="1" vrev="1" srcmd5="8e451641a827df5f4f409d1d543fdb7b">
           <linkinfo project="source_project" package="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
-          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658419299"/>
+          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658762120"/>
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:37 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:37 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -911,7 +911,7 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:37 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:37 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -950,14 +950,14 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:37 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:37 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=tom
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_25">
+        <workflow project="home:tom" managers="group_23">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -980,18 +980,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '166'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="289">
-          <srcmd5>a53eb95f49c1fee041f0168343a2ff33</srcmd5>
-          <time>1658422057</time>
+        <revision rev="46">
+          <srcmd5>6bf67b537ff325279c5ed00a43e87a94</srcmd5>
+          <time>1658762197</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:37 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:37 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=tom
@@ -1001,7 +1001,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_25" role="maintainer"/>
+          <group groupid="group_23" role="maintainer"/>
           <repository name="staging_repository">
             <arch>x86_64</arch>
           </repository>
@@ -1032,12 +1032,12 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_25" role="maintainer"/>
+          <group groupid="group_23" role="maintainer"/>
           <repository name="staging_repository">
             <arch>x86_64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:37 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:37 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package/_meta?user=tom
@@ -1045,8 +1045,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>The Violent Bear It Away</title>
-          <description>Iste sint magni praesentium.</description>
+          <title>A Confederacy of Dunces</title>
+          <description>Adipisci porro et amet.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1067,15 +1067,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '168'
+      - '162'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>The Violent Bear It Away</title>
-          <description>Iste sint magni praesentium.</description>
+          <title>A Confederacy of Dunces</title>
+          <description>Adipisci porro et amet.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:37 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:37 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package
@@ -1107,7 +1107,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:37 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:37 GMT
 - request:
     method: post
     uri: http://backend:5352/source/source_project/source_package?cmd=diff&expand=1&filelimit=10000&opackage=target_package&oproject=target_project&tarlimit=10000&view=xml&withissues=1
@@ -1135,19 +1135,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '329'
+      - '328'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="ab8b566c184cffd354b181327999a079">
-          <old project="target_project" package="target_package" rev="34" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+        <sourcediff key="3360c5bc4c9400d7929cfe967dc18e4f">
+          <old project="target_project" package="target_package" rev="2" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <new project="source_project" package="source_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files>
           </files>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:37 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:37 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22source_package%22%20and%20linkinfo/@project=%22source_project%22%20and%20@project=%22source_project%22)
@@ -1181,7 +1181,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 21 Jul 2022 16:47:37 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:37 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/target_package/_meta?user=tom
@@ -1189,8 +1189,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="home:tom:Staging:A">
-          <title>The Wives of Bath</title>
-          <description>Non pariatur eligendi enim.</description>
+          <title>By Grand Central Station I Sat Down and Wept</title>
+          <description>Cum occaecati qui perspiciatis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1211,15 +1211,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '164'
+      - '195'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="home:tom:Staging:A">
-          <title>The Wives of Bath</title>
-          <description>Non pariatur eligendi enim.</description>
+          <title>By Grand Central Station I Sat Down and Wept</title>
+          <description>Cum occaecati qui perspiciatis.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:37 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:37 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package?cmd=branch&noservice=1&opackage=source_package&oproject=source_project&user=tom
@@ -1254,12 +1254,12 @@ http_interactions:
         <revision rev="1" vrev="1">
           <srcmd5>8e451641a827df5f4f409d1d543fdb7b</srcmd5>
           <version>unknown</version>
-          <time>1658422057</time>
+          <time>1658762197</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:37 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:37 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/target_package/_meta?user=tom
@@ -1267,8 +1267,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="home:tom:Staging:A">
-          <title>The Wives of Bath</title>
-          <description>Non pariatur eligendi enim.</description>
+          <title>By Grand Central Station I Sat Down and Wept</title>
+          <description>Cum occaecati qui perspiciatis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1289,15 +1289,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '164'
+      - '195'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="home:tom:Staging:A">
-          <title>The Wives of Bath</title>
-          <description>Non pariatur eligendi enim.</description>
+          <title>By Grand Central Station I Sat Down and Wept</title>
+          <description>Cum occaecati qui perspiciatis.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:37 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:37 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package
@@ -1329,9 +1329,9 @@ http_interactions:
       string: |
         <directory name="target_package" rev="1" vrev="1" srcmd5="8e451641a827df5f4f409d1d543fdb7b">
           <linkinfo project="source_project" package="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
-          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658419310"/>
+          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658490907"/>
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:37 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:37 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package?view=info
@@ -1365,7 +1365,7 @@ http_interactions:
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="source_project" package="source_package"/>
         </sourceinfo>
-  recorded_at: Thu, 21 Jul 2022 16:47:37 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:37 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package
@@ -1397,9 +1397,9 @@ http_interactions:
       string: |
         <directory name="target_package" rev="1" vrev="1" srcmd5="8e451641a827df5f4f409d1d543fdb7b">
           <linkinfo project="source_project" package="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
-          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658419310"/>
+          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658490907"/>
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:37 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:37 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -1438,7 +1438,7 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:37 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:37 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -1477,14 +1477,14 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:37 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:37 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=tom
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_25">
+        <workflow project="home:tom" managers="group_23">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -1507,18 +1507,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '166'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="290">
-          <srcmd5>a53eb95f49c1fee041f0168343a2ff33</srcmd5>
-          <time>1658422057</time>
+        <revision rev="47">
+          <srcmd5>6bf67b537ff325279c5ed00a43e87a94</srcmd5>
+          <time>1658762197</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:37 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:37 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=tom
@@ -1528,7 +1528,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_25" role="maintainer"/>
+          <group groupid="group_23" role="maintainer"/>
           <repository name="staging_repository">
             <arch>x86_64</arch>
           </repository>
@@ -1559,19 +1559,19 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_25" role="maintainer"/>
+          <group groupid="group_23" role="maintainer"/>
           <repository name="staging_repository">
             <arch>x86_64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:37 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:37 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_63
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_57
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_25">
+        <workflow project="home:tom" managers="group_23">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -1594,18 +1594,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="291">
-          <srcmd5>a53eb95f49c1fee041f0168343a2ff33</srcmd5>
-          <time>1658422057</time>
-          <user>user_63</user>
+        <revision rev="48">
+          <srcmd5>6bf67b537ff325279c5ed00a43e87a94</srcmd5>
+          <time>1658762197</time>
+          <user>user_57</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:37 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:37 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=tom
@@ -1615,7 +1615,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_25" role="maintainer"/>
+          <group groupid="group_23" role="maintainer"/>
           <build>
             <disable/>
           </build>
@@ -1649,7 +1649,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_25" role="maintainer"/>
+          <group groupid="group_23" role="maintainer"/>
           <build>
             <disable/>
           </build>
@@ -1657,7 +1657,7 @@ http_interactions:
             <arch>x86_64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:37 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:37 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package?expand=1
@@ -1689,7 +1689,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:37 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:37 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package?expand=1
@@ -1721,7 +1721,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:38 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:37 GMT
 - request:
     method: post
     uri: http://backend:5352/source/target_project/target_package_2?cmd=copy&comment=Request%20for%20package%20target_package_2&expand=1&keeplink=1&noservice=1&opackage=source_package&oproject=source_project&requestid=1&user=tom&withacceptinfo=1
@@ -1749,20 +1749,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '363'
+      - '360'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="51" vrev="51">
+        <revision rev="2" vrev="2">
           <srcmd5>d41d8cd98f00b204e9800998ecf8427e</srcmd5>
           <version>unknown</version>
-          <time>1658422058</time>
+          <time>1658762197</time>
           <user>tom</user>
           <comment>Request for package target_package_2</comment>
           <requestid>1</requestid>
-          <acceptinfo rev="51" srcmd5="d41d8cd98f00b204e9800998ecf8427e" osrcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <acceptinfo rev="2" srcmd5="d41d8cd98f00b204e9800998ecf8427e" osrcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:38 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:37 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package_2/_meta?user=tom
@@ -1770,8 +1770,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="target_project">
-          <title>The Monkey's Raincoat</title>
-          <description>Minima eaque ea quo.</description>
+          <title>Unweaving the Rainbow</title>
+          <description>Praesentium quia voluptatem dolore.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1792,15 +1792,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '159'
+      - '174'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="target_project">
-          <title>The Monkey's Raincoat</title>
-          <description>Minima eaque ea quo.</description>
+          <title>Unweaving the Rainbow</title>
+          <description>Praesentium quia voluptatem dolore.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:38 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:37 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package_2
@@ -1826,13 +1826,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '110'
+      - '108'
     body:
       encoding: UTF-8
       string: |
-        <directory name="target_package_2" rev="51" vrev="51" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <directory name="target_package_2" rev="2" vrev="2" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:38 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:37 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package_2?view=info
@@ -1858,14 +1858,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '151'
+      - '149'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="target_package_2" rev="51" vrev="51" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <sourceinfo package="target_package_2" rev="2" vrev="2" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
           <error>no source uploaded</error>
         </sourceinfo>
-  recorded_at: Thu, 21 Jul 2022 16:47:38 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:37 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package_2
@@ -1891,13 +1891,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '110'
+      - '108'
     body:
       encoding: UTF-8
       string: |
-        <directory name="target_package_2" rev="51" vrev="51" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <directory name="target_package_2" rev="2" vrev="2" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:38 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:37 GMT
 - request:
     method: post
     uri: http://backend:5352/source/target_project/target_package_2?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -1925,16 +1925,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '300'
+      - '299'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="968826088788e49a5943295500570a53">
+        <sourcediff key="5e7bc532566aca4e942d6e7b418a9140">
           <old project="target_project" package="target_package_2" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="target_project" package="target_package_2" rev="51" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="target_project" package="target_package_2" rev="2" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files/>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:38 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:37 GMT
 - request:
     method: delete
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?comment&user=tom
@@ -1966,7 +1966,7 @@ http_interactions:
       string: '<status code="ok" />
 
 '
-  recorded_at: Thu, 21 Jul 2022 16:47:38 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:38 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package?expand=1
@@ -1998,7 +1998,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:38 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:38 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package?expand=1
@@ -2030,7 +2030,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:38 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:38 GMT
 - request:
     method: post
     uri: http://backend:5352/source/target_project/target_package?cmd=copy&comment=Request%20for%20package%20target_package&expand=1&keeplink=1&noservice=1&opackage=source_package&oproject=source_project&requestid=2&user=tom&withacceptinfo=1
@@ -2058,20 +2058,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '361'
+      - '358'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="35" vrev="35">
+        <revision rev="3" vrev="3">
           <srcmd5>d41d8cd98f00b204e9800998ecf8427e</srcmd5>
           <version>unknown</version>
-          <time>1658422058</time>
+          <time>1658762198</time>
           <user>tom</user>
           <comment>Request for package target_package</comment>
           <requestid>2</requestid>
-          <acceptinfo rev="35" srcmd5="d41d8cd98f00b204e9800998ecf8427e" osrcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <acceptinfo rev="3" srcmd5="d41d8cd98f00b204e9800998ecf8427e" osrcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:38 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:38 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package/_meta?user=tom
@@ -2079,8 +2079,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>The Violent Bear It Away</title>
-          <description>Iste sint magni praesentium.</description>
+          <title>A Confederacy of Dunces</title>
+          <description>Adipisci porro et amet.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -2101,15 +2101,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '168'
+      - '162'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>The Violent Bear It Away</title>
-          <description>Iste sint magni praesentium.</description>
+          <title>A Confederacy of Dunces</title>
+          <description>Adipisci porro et amet.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:38 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:38 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package
@@ -2135,13 +2135,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '108'
+      - '106'
     body:
       encoding: UTF-8
       string: |
-        <directory name="target_package" rev="35" vrev="35" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <directory name="target_package" rev="3" vrev="3" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:38 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:38 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package?view=info
@@ -2167,14 +2167,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '149'
+      - '147'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="target_package" rev="35" vrev="35" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <sourceinfo package="target_package" rev="3" vrev="3" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
           <error>no source uploaded</error>
         </sourceinfo>
-  recorded_at: Thu, 21 Jul 2022 16:47:38 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:38 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package
@@ -2200,13 +2200,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '108'
+      - '106'
     body:
       encoding: UTF-8
       string: |
-        <directory name="target_package" rev="35" vrev="35" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <directory name="target_package" rev="3" vrev="3" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:38 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:38 GMT
 - request:
     method: post
     uri: http://backend:5352/source/target_project/target_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -2234,16 +2234,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '296'
+      - '295'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="28c111f4198b710c87dfe2ca556ede83">
+        <sourcediff key="227d490c998bf9739f64a6d731d2d473">
           <old project="target_project" package="target_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="target_project" package="target_package" rev="35" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="target_project" package="target_package" rev="3" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files/>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:38 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:38 GMT
 - request:
     method: delete
     uri: http://backend:5352/source/home:tom:Staging:A/target_package?comment&user=tom
@@ -2275,5 +2275,5 @@ http_interactions:
       string: '<status code="ok" />
 
 '
-  recorded_at: Thu, 21 Jul 2022 16:47:38 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:38 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Project/Staging_Project/_accept/when_the_staging_project_is_in_acceptable_state/should_remove_staging_project_log_entries/1_1_7_1_2_2.yml
+++ b/src/api/spec/cassettes/Project/Staging_Project/_accept/when_the_staging_project_is_in_acceptable_state/should_remove_staging_project_log_entries/1_1_7_1_2_2.yml
@@ -39,14 +39,14 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:34 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:34 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_61
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_55
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_24">
+        <workflow project="home:tom" managers="group_22">
           <staging_project name="home:tom:Staging:A"/>
         </workflow>
     headers:
@@ -68,28 +68,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="282">
-          <srcmd5>11bcef28377dcffa433dbc8b53841314</srcmd5>
-          <time>1658422054</time>
-          <user>user_61</user>
+        <revision rev="39">
+          <srcmd5>6278c0ea067a3f9eb1e6bd0ef14be298</srcmd5>
+          <time>1658762194</time>
+          <user>user_55</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:34 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:34 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_61
+    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_55
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_24" role="maintainer"/>
+          <group groupid="group_22" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -117,16 +117,16 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_24" role="maintainer"/>
+          <group groupid="group_22" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:34 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:34 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_61
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_55
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_24">
+        <workflow project="home:tom" managers="group_22">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -149,28 +149,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="283">
-          <srcmd5>71637360387d7e3a1cbb5390fb5c1060</srcmd5>
-          <time>1658422054</time>
-          <user>user_61</user>
+        <revision rev="40">
+          <srcmd5>0b4dd9a7406126f7ab8ab4b1a6abfb17</srcmd5>
+          <time>1658762194</time>
+          <user>user_55</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:34 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:34 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_61
+    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_55
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:B">
           <title/>
           <description/>
-          <group groupid="group_24" role="maintainer"/>
+          <group groupid="group_22" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -198,12 +198,12 @@ http_interactions:
         <project name="home:tom:Staging:B">
           <title></title>
           <description></description>
-          <group groupid="group_24" role="maintainer"/>
+          <group groupid="group_22" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:34 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:34 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_meta?user=user_61
+    uri: http://backend:5352/source/home:tom/_meta?user=user_55
     body:
       encoding: UTF-8
       string: |
@@ -211,7 +211,7 @@ http_interactions:
           <title/>
           <description/>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_24" role="reviewer"/>
+          <group groupid="group_22" role="reviewer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -240,18 +240,18 @@ http_interactions:
           <title></title>
           <description></description>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_24" role="reviewer"/>
+          <group groupid="group_22" role="reviewer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:34 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:34 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_62
+    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_56
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>The Cricket on the Hearth</title>
-          <description>Natus reprehenderit nobis amet.</description>
+          <title>Dying of the Light</title>
+          <description>Eaque sit reprehenderit earum.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -272,21 +272,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '179'
+      - '171'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>The Cricket on the Hearth</title>
-          <description>Natus reprehenderit nobis amet.</description>
+          <title>Dying of the Light</title>
+          <description>Eaque sit reprehenderit earum.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:34 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:34 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_config
     body:
       encoding: UTF-8
-      string: Vero et harum. Aliquid aliquam id. Necessitatibus dolores corrupti.
+      string: Laboriosam nobis in. Aspernatur enim unde. Perferendis et molestiae.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -306,25 +306,26 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="139" vrev="139">
-          <srcmd5>c6f4918b1eeb3cbb2e2f1ebd83fbb8a9</srcmd5>
+        <revision rev="37" vrev="37">
+          <srcmd5>b9012502df5c0089475f591d81c0fb55</srcmd5>
           <version>unknown</version>
-          <time>1658422054</time>
+          <time>1658762194</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:34 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:34 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/somefile.txt
     body:
       encoding: UTF-8
-      string: Quo accusantium est. Fuga suscipit aspernatur. Ipsam aut aliquam.
+      string: Consequatur temporibus dolor. Est corporis placeat. Velit inventore
+        mollitia.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -344,19 +345,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="140" vrev="140">
-          <srcmd5>916f4a531b149d6a0b98031074589981</srcmd5>
+        <revision rev="38" vrev="38">
+          <srcmd5>c0a3805fadd8baea5b2141c0d1f11d97</srcmd5>
           <version>unknown</version>
-          <time>1658422054</time>
+          <time>1658762194</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:34 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:34 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/_meta?user=tom
@@ -364,7 +365,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>A Confederacy of Dunces</title>
+          <title>Mother Night</title>
           <description/>
         </project>
     headers:
@@ -386,15 +387,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '114'
+      - '103'
     body:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>A Confederacy of Dunces</title>
+          <title>Mother Night</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:34 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:34 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package_2/_meta?user=tom
@@ -402,8 +403,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="target_project">
-          <title>That Hideous Strength</title>
-          <description>In rem quia qui.</description>
+          <title>Jacob Have I Loved</title>
+          <description>Quasi sit deleniti harum.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -424,15 +425,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '155'
+      - '161'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="target_project">
-          <title>That Hideous Strength</title>
-          <description>In rem quia qui.</description>
+          <title>Jacob Have I Loved</title>
+          <description>Quasi sit deleniti harum.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:34 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:34 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_meta?user=tom
@@ -440,7 +441,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Look to Windward</title>
+          <title>That Hideous Strength</title>
           <description/>
         </project>
     headers:
@@ -462,15 +463,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '107'
+      - '112'
     body:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Look to Windward</title>
+          <title>That Hideous Strength</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:34 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:34 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_project/_attribute?meta=1&user=tom
@@ -499,18 +500,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '166'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="140">
-          <srcmd5>ecf8b5cc603beac9eb902567d93b3cbe</srcmd5>
-          <time>1658422054</time>
+        <revision rev="36">
+          <srcmd5>fb78dfd8810371d265ea97e80a96247f</srcmd5>
+          <time>1658762194</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:34 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:34 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/source_package/_meta?user=tom
@@ -518,8 +519,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>Of Mice and Men</title>
-          <description>Quod occaecati sunt et.</description>
+          <title>The Torment of Others</title>
+          <description>Animi rerum esse consequatur.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -540,15 +541,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '154'
+      - '166'
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>Of Mice and Men</title>
-          <description>Quod occaecati sunt et.</description>
+          <title>The Torment of Others</title>
+          <description>Animi rerum esse consequatur.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:34 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:34 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package
@@ -580,7 +581,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:34 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:34 GMT
 - request:
     method: post
     uri: http://backend:5352/source/source_project/source_package?cmd=diff&expand=1&filelimit=10000&opackage=target_package_2&oproject=target_project&tarlimit=10000&view=xml&withissues=1
@@ -608,19 +609,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '331'
+      - '330'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="ef510a2f20a402a9383b5f0bd82eee37">
-          <old project="target_project" package="target_package_2" rev="49" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+        <sourcediff key="580805f12ba74a4130f37fd117de1377">
+          <old project="target_project" package="target_package_2" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <new project="source_project" package="source_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files>
           </files>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:35 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:34 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22source_package%22%20and%20linkinfo/@project=%22source_project%22%20and%20@project=%22source_project%22)
@@ -654,7 +655,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 21 Jul 2022 16:47:35 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:34 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2/_meta?user=tom
@@ -662,8 +663,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>Of Mice and Men</title>
-          <description>Quod occaecati sunt et.</description>
+          <title>The Torment of Others</title>
+          <description>Animi rerum esse consequatur.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -684,15 +685,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '160'
+      - '172'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>Of Mice and Men</title>
-          <description>Quod occaecati sunt et.</description>
+          <title>The Torment of Others</title>
+          <description>Animi rerum esse consequatur.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:35 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:34 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?cmd=branch&noservice=1&opackage=source_package&oproject=source_project&user=tom
@@ -727,12 +728,12 @@ http_interactions:
         <revision rev="1" vrev="1">
           <srcmd5>8e451641a827df5f4f409d1d543fdb7b</srcmd5>
           <version>unknown</version>
-          <time>1658422055</time>
+          <time>1658762194</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:35 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:34 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2/_meta?user=tom
@@ -740,8 +741,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>Of Mice and Men</title>
-          <description>Quod occaecati sunt et.</description>
+          <title>The Torment of Others</title>
+          <description>Animi rerum esse consequatur.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -762,15 +763,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '160'
+      - '172'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>Of Mice and Men</title>
-          <description>Quod occaecati sunt et.</description>
+          <title>The Torment of Others</title>
+          <description>Animi rerum esse consequatur.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:35 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:34 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2
@@ -802,9 +803,9 @@ http_interactions:
       string: |
         <directory name="target_package_2" rev="1" vrev="1" srcmd5="8e451641a827df5f4f409d1d543fdb7b">
           <linkinfo project="source_project" package="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
-          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658419299"/>
+          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658762120"/>
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:35 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:34 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?view=info
@@ -838,7 +839,7 @@ http_interactions:
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="source_project" package="source_package"/>
         </sourceinfo>
-  recorded_at: Thu, 21 Jul 2022 16:47:35 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:34 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2
@@ -870,9 +871,9 @@ http_interactions:
       string: |
         <directory name="target_package_2" rev="1" vrev="1" srcmd5="8e451641a827df5f4f409d1d543fdb7b">
           <linkinfo project="source_project" package="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
-          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658419299"/>
+          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658762120"/>
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:35 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:35 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -895,12 +896,12 @@ http_interactions:
     headers:
       Content-Type:
       - text/xml
-      Content-Length:
-      - '330'
       Cache-Control:
       - no-cache
       Connection:
       - close
+      Content-Length:
+      - '330'
     body:
       encoding: UTF-8
       string: |
@@ -911,7 +912,7 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:35 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:35 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -934,12 +935,12 @@ http_interactions:
     headers:
       Content-Type:
       - text/xml
-      Content-Length:
-      - '386'
       Cache-Control:
       - no-cache
       Connection:
       - close
+      Content-Length:
+      - '386'
     body:
       encoding: UTF-8
       string: |
@@ -950,14 +951,14 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:35 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:35 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=tom
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_24">
+        <workflow project="home:tom" managers="group_22">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -980,18 +981,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '166'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="284">
-          <srcmd5>71637360387d7e3a1cbb5390fb5c1060</srcmd5>
-          <time>1658422055</time>
+        <revision rev="41">
+          <srcmd5>0b4dd9a7406126f7ab8ab4b1a6abfb17</srcmd5>
+          <time>1658762195</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:35 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:35 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=tom
@@ -1001,7 +1002,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_24" role="maintainer"/>
+          <group groupid="group_22" role="maintainer"/>
           <repository name="staging_repository">
             <arch>x86_64</arch>
           </repository>
@@ -1032,12 +1033,12 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_24" role="maintainer"/>
+          <group groupid="group_22" role="maintainer"/>
           <repository name="staging_repository">
             <arch>x86_64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:35 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:35 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package/_meta?user=tom
@@ -1045,8 +1046,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>Now Sleeps the Crimson Petal</title>
-          <description>Vel magni eos similique.</description>
+          <title>Precious Bane</title>
+          <description>Asperiores mollitia sed labore.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1067,15 +1068,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '168'
+      - '160'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>Now Sleeps the Crimson Petal</title>
-          <description>Vel magni eos similique.</description>
+          <title>Precious Bane</title>
+          <description>Asperiores mollitia sed labore.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:35 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:35 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package
@@ -1107,7 +1108,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:35 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:35 GMT
 - request:
     method: post
     uri: http://backend:5352/source/source_project/source_package?cmd=diff&expand=1&filelimit=10000&opackage=target_package&oproject=target_project&tarlimit=10000&view=xml&withissues=1
@@ -1130,24 +1131,24 @@ http_interactions:
     headers:
       Content-Type:
       - text/xml
+      Content-Length:
+      - '328'
       Cache-Control:
       - no-cache
       Connection:
       - close
-      Content-Length:
-      - '329'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="3190ac7e56242e2ac4c5133d594036c1">
-          <old project="target_project" package="target_package" rev="33" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+        <sourcediff key="22bfb82bf1c9f9c9dd66ba87930cd41c">
+          <old project="target_project" package="target_package" rev="1" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <new project="source_project" package="source_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files>
           </files>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:35 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:35 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22source_package%22%20and%20linkinfo/@project=%22source_project%22%20and%20@project=%22source_project%22)
@@ -1181,7 +1182,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 21 Jul 2022 16:47:35 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:35 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/target_package/_meta?user=tom
@@ -1189,8 +1190,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="home:tom:Staging:A">
-          <title>Of Mice and Men</title>
-          <description>Quod occaecati sunt et.</description>
+          <title>The Torment of Others</title>
+          <description>Animi rerum esse consequatur.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1211,15 +1212,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '158'
+      - '170'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="home:tom:Staging:A">
-          <title>Of Mice and Men</title>
-          <description>Quod occaecati sunt et.</description>
+          <title>The Torment of Others</title>
+          <description>Animi rerum esse consequatur.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:35 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:35 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package?cmd=branch&noservice=1&opackage=source_package&oproject=source_project&user=tom
@@ -1254,12 +1255,12 @@ http_interactions:
         <revision rev="1" vrev="1">
           <srcmd5>8e451641a827df5f4f409d1d543fdb7b</srcmd5>
           <version>unknown</version>
-          <time>1658422055</time>
+          <time>1658762195</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:35 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:35 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/target_package/_meta?user=tom
@@ -1267,8 +1268,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="home:tom:Staging:A">
-          <title>Of Mice and Men</title>
-          <description>Quod occaecati sunt et.</description>
+          <title>The Torment of Others</title>
+          <description>Animi rerum esse consequatur.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1289,15 +1290,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '158'
+      - '170'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="home:tom:Staging:A">
-          <title>Of Mice and Men</title>
-          <description>Quod occaecati sunt et.</description>
+          <title>The Torment of Others</title>
+          <description>Animi rerum esse consequatur.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:35 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:35 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package
@@ -1329,9 +1330,9 @@ http_interactions:
       string: |
         <directory name="target_package" rev="1" vrev="1" srcmd5="8e451641a827df5f4f409d1d543fdb7b">
           <linkinfo project="source_project" package="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
-          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658419310"/>
+          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658490907"/>
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:35 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:35 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package?view=info
@@ -1365,7 +1366,7 @@ http_interactions:
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="source_project" package="source_package"/>
         </sourceinfo>
-  recorded_at: Thu, 21 Jul 2022 16:47:35 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:35 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package
@@ -1397,9 +1398,9 @@ http_interactions:
       string: |
         <directory name="target_package" rev="1" vrev="1" srcmd5="8e451641a827df5f4f409d1d543fdb7b">
           <linkinfo project="source_project" package="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
-          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658419310"/>
+          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658490907"/>
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:35 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:35 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -1422,12 +1423,12 @@ http_interactions:
     headers:
       Content-Type:
       - text/xml
-      Content-Length:
-      - '326'
       Cache-Control:
       - no-cache
       Connection:
       - close
+      Content-Length:
+      - '326'
     body:
       encoding: UTF-8
       string: |
@@ -1438,7 +1439,7 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:35 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:35 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -1461,12 +1462,12 @@ http_interactions:
     headers:
       Content-Type:
       - text/xml
-      Content-Length:
-      - '384'
       Cache-Control:
       - no-cache
       Connection:
       - close
+      Content-Length:
+      - '384'
     body:
       encoding: UTF-8
       string: |
@@ -1477,14 +1478,14 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:35 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:35 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=tom
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_24">
+        <workflow project="home:tom" managers="group_22">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -1507,18 +1508,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '166'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="285">
-          <srcmd5>71637360387d7e3a1cbb5390fb5c1060</srcmd5>
-          <time>1658422055</time>
+        <revision rev="42">
+          <srcmd5>0b4dd9a7406126f7ab8ab4b1a6abfb17</srcmd5>
+          <time>1658762195</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:35 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:35 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=tom
@@ -1528,7 +1529,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_24" role="maintainer"/>
+          <group groupid="group_22" role="maintainer"/>
           <repository name="staging_repository">
             <arch>x86_64</arch>
           </repository>
@@ -1559,19 +1560,19 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_24" role="maintainer"/>
+          <group groupid="group_22" role="maintainer"/>
           <repository name="staging_repository">
             <arch>x86_64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:35 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:35 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_61
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_55
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_24">
+        <workflow project="home:tom" managers="group_22">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -1594,18 +1595,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="286">
-          <srcmd5>71637360387d7e3a1cbb5390fb5c1060</srcmd5>
-          <time>1658422055</time>
-          <user>user_61</user>
+        <revision rev="43">
+          <srcmd5>0b4dd9a7406126f7ab8ab4b1a6abfb17</srcmd5>
+          <time>1658762195</time>
+          <user>user_55</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:35 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:35 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=tom
@@ -1615,7 +1616,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_24" role="maintainer"/>
+          <group groupid="group_22" role="maintainer"/>
           <build>
             <disable/>
           </build>
@@ -1649,7 +1650,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_24" role="maintainer"/>
+          <group groupid="group_22" role="maintainer"/>
           <build>
             <disable/>
           </build>
@@ -1657,7 +1658,7 @@ http_interactions:
             <arch>x86_64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:35 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:35 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package?expand=1
@@ -1689,7 +1690,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:35 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:35 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package?expand=1
@@ -1721,7 +1722,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:35 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:35 GMT
 - request:
     method: post
     uri: http://backend:5352/source/target_project/target_package_2?cmd=copy&comment=Request%20for%20package%20target_package_2&expand=1&keeplink=1&noservice=1&opackage=source_package&oproject=source_project&requestid=1&user=tom&withacceptinfo=1
@@ -1749,20 +1750,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '363'
+      - '360'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="50" vrev="50">
+        <revision rev="1" vrev="1">
           <srcmd5>d41d8cd98f00b204e9800998ecf8427e</srcmd5>
           <version>unknown</version>
-          <time>1658422055</time>
+          <time>1658762195</time>
           <user>tom</user>
           <comment>Request for package target_package_2</comment>
           <requestid>1</requestid>
-          <acceptinfo rev="50" srcmd5="d41d8cd98f00b204e9800998ecf8427e" osrcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <acceptinfo rev="1" srcmd5="d41d8cd98f00b204e9800998ecf8427e" osrcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:35 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:35 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package_2/_meta?user=tom
@@ -1770,8 +1771,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="target_project">
-          <title>That Hideous Strength</title>
-          <description>In rem quia qui.</description>
+          <title>Jacob Have I Loved</title>
+          <description>Quasi sit deleniti harum.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1792,15 +1793,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '155'
+      - '161'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="target_project">
-          <title>That Hideous Strength</title>
-          <description>In rem quia qui.</description>
+          <title>Jacob Have I Loved</title>
+          <description>Quasi sit deleniti harum.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:35 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:35 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package_2
@@ -1826,13 +1827,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '110'
+      - '108'
     body:
       encoding: UTF-8
       string: |
-        <directory name="target_package_2" rev="50" vrev="50" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <directory name="target_package_2" rev="1" vrev="1" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:35 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:35 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package_2?view=info
@@ -1858,14 +1859,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '151'
+      - '149'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="target_package_2" rev="50" vrev="50" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <sourceinfo package="target_package_2" rev="1" vrev="1" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
           <error>no source uploaded</error>
         </sourceinfo>
-  recorded_at: Thu, 21 Jul 2022 16:47:35 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:35 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package_2
@@ -1891,13 +1892,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '110'
+      - '108'
     body:
       encoding: UTF-8
       string: |
-        <directory name="target_package_2" rev="50" vrev="50" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <directory name="target_package_2" rev="1" vrev="1" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:35 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:35 GMT
 - request:
     method: post
     uri: http://backend:5352/source/target_project/target_package_2?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -1925,16 +1926,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '300'
+      - '299'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="cef989b6a52f1aac8ffb14e190ee1386">
+        <sourcediff key="0d0c6c09e3a2dd2c1d4f29a090cfcfbf">
           <old project="target_project" package="target_package_2" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="target_project" package="target_package_2" rev="50" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="target_project" package="target_package_2" rev="1" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files/>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:36 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:35 GMT
 - request:
     method: delete
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?comment&user=tom
@@ -1966,7 +1967,7 @@ http_interactions:
       string: '<status code="ok" />
 
 '
-  recorded_at: Thu, 21 Jul 2022 16:47:36 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:35 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package?expand=1
@@ -1998,7 +1999,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:36 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:36 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package?expand=1
@@ -2030,7 +2031,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:36 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:36 GMT
 - request:
     method: post
     uri: http://backend:5352/source/target_project/target_package?cmd=copy&comment=Request%20for%20package%20target_package&expand=1&keeplink=1&noservice=1&opackage=source_package&oproject=source_project&requestid=2&user=tom&withacceptinfo=1
@@ -2058,20 +2059,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '361'
+      - '358'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="34" vrev="34">
+        <revision rev="2" vrev="2">
           <srcmd5>d41d8cd98f00b204e9800998ecf8427e</srcmd5>
           <version>unknown</version>
-          <time>1658422056</time>
+          <time>1658762196</time>
           <user>tom</user>
           <comment>Request for package target_package</comment>
           <requestid>2</requestid>
-          <acceptinfo rev="34" srcmd5="d41d8cd98f00b204e9800998ecf8427e" osrcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <acceptinfo rev="2" srcmd5="d41d8cd98f00b204e9800998ecf8427e" osrcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:36 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:36 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package/_meta?user=tom
@@ -2079,8 +2080,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>Now Sleeps the Crimson Petal</title>
-          <description>Vel magni eos similique.</description>
+          <title>Precious Bane</title>
+          <description>Asperiores mollitia sed labore.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -2101,15 +2102,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '168'
+      - '160'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>Now Sleeps the Crimson Petal</title>
-          <description>Vel magni eos similique.</description>
+          <title>Precious Bane</title>
+          <description>Asperiores mollitia sed labore.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:36 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:36 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package
@@ -2135,13 +2136,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '108'
+      - '106'
     body:
       encoding: UTF-8
       string: |
-        <directory name="target_package" rev="34" vrev="34" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <directory name="target_package" rev="2" vrev="2" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:36 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:36 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package?view=info
@@ -2167,14 +2168,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '149'
+      - '147'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="target_package" rev="34" vrev="34" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <sourceinfo package="target_package" rev="2" vrev="2" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
           <error>no source uploaded</error>
         </sourceinfo>
-  recorded_at: Thu, 21 Jul 2022 16:47:36 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:36 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package
@@ -2200,13 +2201,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '108'
+      - '106'
     body:
       encoding: UTF-8
       string: |
-        <directory name="target_package" rev="34" vrev="34" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <directory name="target_package" rev="2" vrev="2" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:36 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:36 GMT
 - request:
     method: post
     uri: http://backend:5352/source/target_project/target_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -2234,16 +2235,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '296'
+      - '295'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="9537c4f5b6010146730f68e37be9e94c">
+        <sourcediff key="fde9adb5c560326a887fb736be54bb29">
           <old project="target_project" package="target_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="target_project" package="target_package" rev="34" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="target_project" package="target_package" rev="2" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files/>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:36 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:36 GMT
 - request:
     method: delete
     uri: http://backend:5352/source/home:tom:Staging:A/target_package?comment&user=tom
@@ -2275,5 +2276,5 @@ http_interactions:
       string: '<status code="ok" />
 
 '
-  recorded_at: Thu, 21 Jul 2022 16:47:36 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:36 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Project/Staging_Project/_accept/when_the_staging_project_is_in_acceptable_state/staging_project_should_be_accepted/1_1_7_1_1_1.yml
+++ b/src/api/spec/cassettes/Project/Staging_Project/_accept/when_the_staging_project_is_in_acceptable_state/staging_project_should_be_accepted/1_1_7_1_1_1.yml
@@ -39,14 +39,14 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:28 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:44 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_55
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_65
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_21">
+        <workflow project="home:tom" managers="group_27">
           <staging_project name="home:tom:Staging:A"/>
         </workflow>
     headers:
@@ -68,28 +68,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="267">
-          <srcmd5>cb1fd1b7713d953d8e3695874e145cba</srcmd5>
-          <time>1658422048</time>
-          <user>user_55</user>
+        <revision rev="64">
+          <srcmd5>18c421127255f8651943e9d01db8c02e</srcmd5>
+          <time>1658762204</time>
+          <user>user_65</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:28 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:44 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_55
+    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_65
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_21" role="maintainer"/>
+          <group groupid="group_27" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -117,16 +117,16 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_21" role="maintainer"/>
+          <group groupid="group_27" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:28 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:44 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_55
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_65
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_21">
+        <workflow project="home:tom" managers="group_27">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -149,28 +149,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="268">
-          <srcmd5>43915dfb0725f5f94cb4d5aa1902f64c</srcmd5>
-          <time>1658422048</time>
-          <user>user_55</user>
+        <revision rev="65">
+          <srcmd5>3fc84c8e3e92a59e00d8704cd916ac09</srcmd5>
+          <time>1658762204</time>
+          <user>user_65</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:28 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:44 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_55
+    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_65
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:B">
           <title/>
           <description/>
-          <group groupid="group_21" role="maintainer"/>
+          <group groupid="group_27" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -198,12 +198,12 @@ http_interactions:
         <project name="home:tom:Staging:B">
           <title></title>
           <description></description>
-          <group groupid="group_21" role="maintainer"/>
+          <group groupid="group_27" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:28 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:44 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_meta?user=user_55
+    uri: http://backend:5352/source/home:tom/_meta?user=user_65
     body:
       encoding: UTF-8
       string: |
@@ -211,7 +211,7 @@ http_interactions:
           <title/>
           <description/>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_21" role="reviewer"/>
+          <group groupid="group_27" role="reviewer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -240,18 +240,18 @@ http_interactions:
           <title></title>
           <description></description>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_21" role="reviewer"/>
+          <group groupid="group_27" role="reviewer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:28 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:44 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_56
+    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_66
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>The Last Enemy</title>
-          <description>Vel et error mollitia.</description>
+          <title>Blue Remembered Earth</title>
+          <description>Voluptas a voluptatibus vitae.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -272,21 +272,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '159'
+      - '174'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>The Last Enemy</title>
-          <description>Vel et error mollitia.</description>
+          <title>Blue Remembered Earth</title>
+          <description>Voluptas a voluptatibus vitae.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:28 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:45 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_config
     body:
       encoding: UTF-8
-      string: Nemo ullam nihil. Corporis ullam quia. Et unde nemo.
+      string: Et optio modi. Voluptatem id corrupti. Quo expedita voluptatem.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -306,25 +306,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="133" vrev="133">
-          <srcmd5>133e4a8945b6fd7b938fa6bbb22eccad</srcmd5>
+        <revision rev="47" vrev="47">
+          <srcmd5>cc16d8407248c318127f95a06bca0d10</srcmd5>
           <version>unknown</version>
-          <time>1658422048</time>
+          <time>1658762205</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:28 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:45 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/somefile.txt
     body:
       encoding: UTF-8
-      string: Eaque ipsum nulla. Minus omnis nisi. Voluptate nihil tempore.
+      string: Omnis earum et. Rerum labore in. Omnis et quis.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -344,19 +344,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="134" vrev="134">
-          <srcmd5>a162c61527a0a2f4c82bad43cf6039e0</srcmd5>
+        <revision rev="48" vrev="48">
+          <srcmd5>f0480630a9ae8ad8aaa501b8918217c6</srcmd5>
           <version>unknown</version>
-          <time>1658422048</time>
+          <time>1658762205</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:28 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:45 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/_meta?user=tom
@@ -364,7 +364,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>The Heart Is a Lonely Hunter</title>
+          <title>From Here to Eternity</title>
           <description/>
         </project>
     headers:
@@ -386,15 +386,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '119'
+      - '112'
     body:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>The Heart Is a Lonely Hunter</title>
+          <title>From Here to Eternity</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:28 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:45 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package_2/_meta?user=tom
@@ -402,8 +402,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="target_project">
-          <title>A Many-Splendoured Thing</title>
-          <description>Nostrum quaerat et minus.</description>
+          <title>The Way of All Flesh</title>
+          <description>Tenetur quibusdam voluptas cupiditate.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -424,15 +424,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '176'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="target_project">
-          <title>A Many-Splendoured Thing</title>
-          <description>Nostrum quaerat et minus.</description>
+          <title>The Way of All Flesh</title>
+          <description>Tenetur quibusdam voluptas cupiditate.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:28 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:45 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_meta?user=tom
@@ -440,7 +440,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Let Us Now Praise Famous Men</title>
+          <title>The Green Bay Tree</title>
           <description/>
         </project>
     headers:
@@ -462,15 +462,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '119'
+      - '109'
     body:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Let Us Now Praise Famous Men</title>
+          <title>The Green Bay Tree</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:28 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:45 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_project/_attribute?meta=1&user=tom
@@ -499,18 +499,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '166'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="134">
-          <srcmd5>deb1758b7b57b04b2585c1c5cb7427ca</srcmd5>
-          <time>1658422048</time>
+        <revision rev="46">
+          <srcmd5>bb0aab35e64c3fab23b4e132f3bbab7c</srcmd5>
+          <time>1658762205</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:28 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:45 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/source_package/_meta?user=tom
@@ -518,8 +518,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>Endless Night</title>
-          <description>Quasi velit accusantium sunt.</description>
+          <title>The Golden Bowl</title>
+          <description>Est debitis quos qui.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -540,15 +540,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '158'
+      - '152'
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>Endless Night</title>
-          <description>Quasi velit accusantium sunt.</description>
+          <title>The Golden Bowl</title>
+          <description>Est debitis quos qui.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:28 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:45 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package
@@ -580,7 +580,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:28 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:45 GMT
 - request:
     method: post
     uri: http://backend:5352/source/source_project/source_package?cmd=diff&expand=1&filelimit=10000&opackage=target_package_2&oproject=target_project&tarlimit=10000&view=xml&withissues=1
@@ -608,19 +608,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '331'
+      - '330'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="b9360c621b072bbbde2fb69953bf2ffb">
-          <old project="target_project" package="target_package_2" rev="46" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+        <sourcediff key="76bd0383252378a2ebd1904ecf5dcf56">
+          <old project="target_project" package="target_package_2" rev="5" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <new project="source_project" package="source_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files>
           </files>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:28 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:45 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22source_package%22%20and%20linkinfo/@project=%22source_project%22%20and%20@project=%22source_project%22)
@@ -654,7 +654,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 21 Jul 2022 16:47:28 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:45 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2/_meta?user=tom
@@ -662,8 +662,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>Endless Night</title>
-          <description>Quasi velit accusantium sunt.</description>
+          <title>The Golden Bowl</title>
+          <description>Est debitis quos qui.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -684,15 +684,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '164'
+      - '158'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>Endless Night</title>
-          <description>Quasi velit accusantium sunt.</description>
+          <title>The Golden Bowl</title>
+          <description>Est debitis quos qui.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:28 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:45 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?cmd=branch&noservice=1&opackage=source_package&oproject=source_project&user=tom
@@ -727,12 +727,12 @@ http_interactions:
         <revision rev="1" vrev="1">
           <srcmd5>8e451641a827df5f4f409d1d543fdb7b</srcmd5>
           <version>unknown</version>
-          <time>1658422048</time>
+          <time>1658762205</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:28 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:45 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2/_meta?user=tom
@@ -740,8 +740,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>Endless Night</title>
-          <description>Quasi velit accusantium sunt.</description>
+          <title>The Golden Bowl</title>
+          <description>Est debitis quos qui.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -762,15 +762,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '164'
+      - '158'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>Endless Night</title>
-          <description>Quasi velit accusantium sunt.</description>
+          <title>The Golden Bowl</title>
+          <description>Est debitis quos qui.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:28 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:45 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2
@@ -802,9 +802,9 @@ http_interactions:
       string: |
         <directory name="target_package_2" rev="1" vrev="1" srcmd5="8e451641a827df5f4f409d1d543fdb7b">
           <linkinfo project="source_project" package="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
-          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658419299"/>
+          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658762120"/>
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:28 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:45 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?view=info
@@ -838,7 +838,7 @@ http_interactions:
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="source_project" package="source_package"/>
         </sourceinfo>
-  recorded_at: Thu, 21 Jul 2022 16:47:28 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:45 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2
@@ -870,9 +870,9 @@ http_interactions:
       string: |
         <directory name="target_package_2" rev="1" vrev="1" srcmd5="8e451641a827df5f4f409d1d543fdb7b">
           <linkinfo project="source_project" package="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
-          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658419299"/>
+          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658762120"/>
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:28 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:45 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -911,7 +911,7 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:28 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:45 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -950,14 +950,14 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:28 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:45 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=tom
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_21">
+        <workflow project="home:tom" managers="group_27">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -980,18 +980,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '166'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="269">
-          <srcmd5>43915dfb0725f5f94cb4d5aa1902f64c</srcmd5>
-          <time>1658422048</time>
+        <revision rev="66">
+          <srcmd5>3fc84c8e3e92a59e00d8704cd916ac09</srcmd5>
+          <time>1658762205</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:28 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:45 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=tom
@@ -1001,7 +1001,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_21" role="maintainer"/>
+          <group groupid="group_27" role="maintainer"/>
           <repository name="staging_repository">
             <arch>x86_64</arch>
           </repository>
@@ -1032,12 +1032,12 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_21" role="maintainer"/>
+          <group groupid="group_27" role="maintainer"/>
           <repository name="staging_repository">
             <arch>x86_64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:28 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:45 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package/_meta?user=tom
@@ -1045,8 +1045,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>Antic Hay</title>
-          <description>Aut sint iure consectetur.</description>
+          <title>Many Waters</title>
+          <description>Quia totam ut architecto.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1067,15 +1067,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '151'
+      - '152'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>Antic Hay</title>
-          <description>Aut sint iure consectetur.</description>
+          <title>Many Waters</title>
+          <description>Quia totam ut architecto.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:28 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:45 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package
@@ -1107,7 +1107,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:28 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:45 GMT
 - request:
     method: post
     uri: http://backend:5352/source/source_project/source_package?cmd=diff&expand=1&filelimit=10000&opackage=target_package&oproject=target_project&tarlimit=10000&view=xml&withissues=1
@@ -1135,19 +1135,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '329'
+      - '328'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="56112c360cbd3d1626ec2896f6daaf6a">
-          <old project="target_project" package="target_package" rev="30" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+        <sourcediff key="c73b85d06f06148d5de25ab803fdfd98">
+          <old project="target_project" package="target_package" rev="6" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <new project="source_project" package="source_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files>
           </files>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:29 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:45 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22source_package%22%20and%20linkinfo/@project=%22source_project%22%20and%20@project=%22source_project%22)
@@ -1181,7 +1181,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 21 Jul 2022 16:47:29 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:45 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/target_package/_meta?user=tom
@@ -1189,8 +1189,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="home:tom:Staging:A">
-          <title>Endless Night</title>
-          <description>Quasi velit accusantium sunt.</description>
+          <title>The Golden Bowl</title>
+          <description>Est debitis quos qui.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1211,15 +1211,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '162'
+      - '156'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="home:tom:Staging:A">
-          <title>Endless Night</title>
-          <description>Quasi velit accusantium sunt.</description>
+          <title>The Golden Bowl</title>
+          <description>Est debitis quos qui.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:29 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:45 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package?cmd=branch&noservice=1&opackage=source_package&oproject=source_project&user=tom
@@ -1254,12 +1254,12 @@ http_interactions:
         <revision rev="1" vrev="1">
           <srcmd5>8e451641a827df5f4f409d1d543fdb7b</srcmd5>
           <version>unknown</version>
-          <time>1658422049</time>
+          <time>1658762205</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:29 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:45 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/target_package/_meta?user=tom
@@ -1267,8 +1267,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="home:tom:Staging:A">
-          <title>Endless Night</title>
-          <description>Quasi velit accusantium sunt.</description>
+          <title>The Golden Bowl</title>
+          <description>Est debitis quos qui.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1289,15 +1289,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '162'
+      - '156'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="home:tom:Staging:A">
-          <title>Endless Night</title>
-          <description>Quasi velit accusantium sunt.</description>
+          <title>The Golden Bowl</title>
+          <description>Est debitis quos qui.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:29 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:45 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package
@@ -1329,9 +1329,9 @@ http_interactions:
       string: |
         <directory name="target_package" rev="1" vrev="1" srcmd5="8e451641a827df5f4f409d1d543fdb7b">
           <linkinfo project="source_project" package="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
-          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658419310"/>
+          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658490907"/>
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:29 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:45 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package?view=info
@@ -1365,7 +1365,7 @@ http_interactions:
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="source_project" package="source_package"/>
         </sourceinfo>
-  recorded_at: Thu, 21 Jul 2022 16:47:29 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:45 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package
@@ -1397,9 +1397,9 @@ http_interactions:
       string: |
         <directory name="target_package" rev="1" vrev="1" srcmd5="8e451641a827df5f4f409d1d543fdb7b">
           <linkinfo project="source_project" package="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
-          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658419310"/>
+          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658490907"/>
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:29 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:45 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -1438,7 +1438,7 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:29 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:45 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -1477,14 +1477,14 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:29 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=tom
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_21">
+        <workflow project="home:tom" managers="group_27">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -1507,18 +1507,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '166'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="270">
-          <srcmd5>43915dfb0725f5f94cb4d5aa1902f64c</srcmd5>
-          <time>1658422049</time>
+        <revision rev="67">
+          <srcmd5>3fc84c8e3e92a59e00d8704cd916ac09</srcmd5>
+          <time>1658762206</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:29 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=tom
@@ -1528,7 +1528,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_21" role="maintainer"/>
+          <group groupid="group_27" role="maintainer"/>
           <repository name="staging_repository">
             <arch>x86_64</arch>
           </repository>
@@ -1559,19 +1559,19 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_21" role="maintainer"/>
+          <group groupid="group_27" role="maintainer"/>
           <repository name="staging_repository">
             <arch>x86_64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:29 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:46 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_55
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_65
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_21">
+        <workflow project="home:tom" managers="group_27">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -1594,18 +1594,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="271">
-          <srcmd5>43915dfb0725f5f94cb4d5aa1902f64c</srcmd5>
-          <time>1658422049</time>
-          <user>user_55</user>
+        <revision rev="68">
+          <srcmd5>3fc84c8e3e92a59e00d8704cd916ac09</srcmd5>
+          <time>1658762206</time>
+          <user>user_65</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:29 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=tom
@@ -1615,7 +1615,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_21" role="maintainer"/>
+          <group groupid="group_27" role="maintainer"/>
           <build>
             <disable/>
           </build>
@@ -1649,7 +1649,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_21" role="maintainer"/>
+          <group groupid="group_27" role="maintainer"/>
           <build>
             <disable/>
           </build>
@@ -1657,7 +1657,7 @@ http_interactions:
             <arch>x86_64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:29 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:46 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package?expand=1
@@ -1689,7 +1689,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:29 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:46 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package?expand=1
@@ -1721,7 +1721,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:29 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:46 GMT
 - request:
     method: post
     uri: http://backend:5352/source/target_project/target_package_2?cmd=copy&comment=Request%20for%20package%20target_package_2&expand=1&keeplink=1&noservice=1&opackage=source_package&oproject=source_project&requestid=1&user=tom&withacceptinfo=1
@@ -1749,20 +1749,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '363'
+      - '360'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="47" vrev="47">
+        <revision rev="6" vrev="6">
           <srcmd5>d41d8cd98f00b204e9800998ecf8427e</srcmd5>
           <version>unknown</version>
-          <time>1658422049</time>
+          <time>1658762206</time>
           <user>tom</user>
           <comment>Request for package target_package_2</comment>
           <requestid>1</requestid>
-          <acceptinfo rev="47" srcmd5="d41d8cd98f00b204e9800998ecf8427e" osrcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <acceptinfo rev="6" srcmd5="d41d8cd98f00b204e9800998ecf8427e" osrcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:29 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package_2/_meta?user=tom
@@ -1770,8 +1770,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="target_project">
-          <title>A Many-Splendoured Thing</title>
-          <description>Nostrum quaerat et minus.</description>
+          <title>The Way of All Flesh</title>
+          <description>Tenetur quibusdam voluptas cupiditate.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1792,15 +1792,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '176'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="target_project">
-          <title>A Many-Splendoured Thing</title>
-          <description>Nostrum quaerat et minus.</description>
+          <title>The Way of All Flesh</title>
+          <description>Tenetur quibusdam voluptas cupiditate.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:29 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:46 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package_2
@@ -1826,13 +1826,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '110'
+      - '108'
     body:
       encoding: UTF-8
       string: |
-        <directory name="target_package_2" rev="47" vrev="47" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <directory name="target_package_2" rev="6" vrev="6" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:29 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:46 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package_2?view=info
@@ -1858,14 +1858,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '151'
+      - '149'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="target_package_2" rev="47" vrev="47" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <sourceinfo package="target_package_2" rev="6" vrev="6" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
           <error>no source uploaded</error>
         </sourceinfo>
-  recorded_at: Thu, 21 Jul 2022 16:47:29 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:46 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package_2
@@ -1891,13 +1891,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '110'
+      - '108'
     body:
       encoding: UTF-8
       string: |
-        <directory name="target_package_2" rev="47" vrev="47" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <directory name="target_package_2" rev="6" vrev="6" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:29 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:46 GMT
 - request:
     method: post
     uri: http://backend:5352/source/target_project/target_package_2?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -1925,16 +1925,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '300'
+      - '299'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="edfaff47238b85695523e9319c5d3f30">
+        <sourcediff key="184d236b62eb7f06549b023f838522ca">
           <old project="target_project" package="target_package_2" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="target_project" package="target_package_2" rev="47" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="target_project" package="target_package_2" rev="6" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files/>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:29 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:46 GMT
 - request:
     method: delete
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?comment&user=tom
@@ -1966,7 +1966,7 @@ http_interactions:
       string: '<status code="ok" />
 
 '
-  recorded_at: Thu, 21 Jul 2022 16:47:29 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:46 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package?expand=1
@@ -1998,7 +1998,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:29 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:46 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package?expand=1
@@ -2030,7 +2030,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:29 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:46 GMT
 - request:
     method: post
     uri: http://backend:5352/source/target_project/target_package?cmd=copy&comment=Request%20for%20package%20target_package&expand=1&keeplink=1&noservice=1&opackage=source_package&oproject=source_project&requestid=2&user=tom&withacceptinfo=1
@@ -2058,20 +2058,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '361'
+      - '358'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="31" vrev="31">
+        <revision rev="7" vrev="7">
           <srcmd5>d41d8cd98f00b204e9800998ecf8427e</srcmd5>
           <version>unknown</version>
-          <time>1658422049</time>
+          <time>1658762206</time>
           <user>tom</user>
           <comment>Request for package target_package</comment>
           <requestid>2</requestid>
-          <acceptinfo rev="31" srcmd5="d41d8cd98f00b204e9800998ecf8427e" osrcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <acceptinfo rev="7" srcmd5="d41d8cd98f00b204e9800998ecf8427e" osrcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:29 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package/_meta?user=tom
@@ -2079,8 +2079,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>Antic Hay</title>
-          <description>Aut sint iure consectetur.</description>
+          <title>Many Waters</title>
+          <description>Quia totam ut architecto.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -2101,15 +2101,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '151'
+      - '152'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>Antic Hay</title>
-          <description>Aut sint iure consectetur.</description>
+          <title>Many Waters</title>
+          <description>Quia totam ut architecto.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:29 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:46 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package
@@ -2135,13 +2135,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '108'
+      - '106'
     body:
       encoding: UTF-8
       string: |
-        <directory name="target_package" rev="31" vrev="31" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <directory name="target_package" rev="7" vrev="7" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:29 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:46 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package?view=info
@@ -2167,14 +2167,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '149'
+      - '147'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="target_package" rev="31" vrev="31" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <sourceinfo package="target_package" rev="7" vrev="7" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
           <error>no source uploaded</error>
         </sourceinfo>
-  recorded_at: Thu, 21 Jul 2022 16:47:29 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:46 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package
@@ -2200,13 +2200,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '108'
+      - '106'
     body:
       encoding: UTF-8
       string: |
-        <directory name="target_package" rev="31" vrev="31" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <directory name="target_package" rev="7" vrev="7" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:29 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:46 GMT
 - request:
     method: post
     uri: http://backend:5352/source/target_project/target_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -2234,16 +2234,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '296'
+      - '295'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="a94e8be040b6ef6d47f8a9ced4154329">
+        <sourcediff key="3eff0ab6b19ba932fbd4d87f35fdfc60">
           <old project="target_project" package="target_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="target_project" package="target_package" rev="31" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="target_project" package="target_package" rev="7" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files/>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:29 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:46 GMT
 - request:
     method: delete
     uri: http://backend:5352/source/home:tom:Staging:A/target_package?comment&user=tom
@@ -2275,5 +2275,5 @@ http_interactions:
       string: '<status code="ok" />
 
 '
-  recorded_at: Thu, 21 Jul 2022 16:47:29 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:46 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Project/Staging_Project/_accept/when_the_staging_project_is_in_acceptable_state/staging_project_should_be_accepted/1_1_7_1_1_2.yml
+++ b/src/api/spec/cassettes/Project/Staging_Project/_accept/when_the_staging_project_is_in_acceptable_state/staging_project_should_be_accepted/1_1_7_1_1_2.yml
@@ -39,14 +39,14 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:26 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:47 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_53
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_67
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_20">
+        <workflow project="home:tom" managers="group_28">
           <staging_project name="home:tom:Staging:A"/>
         </workflow>
     headers:
@@ -68,28 +68,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="262">
-          <srcmd5>9a93e226d354e8c0b628b3cce0ea7b2c</srcmd5>
-          <time>1658422046</time>
-          <user>user_53</user>
+        <revision rev="69">
+          <srcmd5>71d78a3c9c2792b3438fd55addd93dea</srcmd5>
+          <time>1658762207</time>
+          <user>user_67</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:26 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:47 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_53
+    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_67
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_20" role="maintainer"/>
+          <group groupid="group_28" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -117,16 +117,16 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_20" role="maintainer"/>
+          <group groupid="group_28" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:26 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:47 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_53
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_67
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_20">
+        <workflow project="home:tom" managers="group_28">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -149,28 +149,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="263">
-          <srcmd5>8da317e26168b4639bbbf4172477283b</srcmd5>
-          <time>1658422046</time>
-          <user>user_53</user>
+        <revision rev="70">
+          <srcmd5>b885dd2550e612cb2b37ef62d0ecfbfe</srcmd5>
+          <time>1658762207</time>
+          <user>user_67</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:26 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:47 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_53
+    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_67
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:B">
           <title/>
           <description/>
-          <group groupid="group_20" role="maintainer"/>
+          <group groupid="group_28" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -198,12 +198,12 @@ http_interactions:
         <project name="home:tom:Staging:B">
           <title></title>
           <description></description>
-          <group groupid="group_20" role="maintainer"/>
+          <group groupid="group_28" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:26 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:47 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_meta?user=user_53
+    uri: http://backend:5352/source/home:tom/_meta?user=user_67
     body:
       encoding: UTF-8
       string: |
@@ -211,7 +211,7 @@ http_interactions:
           <title/>
           <description/>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_20" role="reviewer"/>
+          <group groupid="group_28" role="reviewer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -240,18 +240,18 @@ http_interactions:
           <title></title>
           <description></description>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_20" role="reviewer"/>
+          <group groupid="group_28" role="reviewer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:26 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:47 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_54
+    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_68
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>Vile Bodies</title>
-          <description>Cupiditate reprehenderit quia eos.</description>
+          <title>Of Human Bondage</title>
+          <description>Quasi qui voluptatibus consequuntur.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -272,22 +272,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '168'
+      - '175'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>Vile Bodies</title>
-          <description>Cupiditate reprehenderit quia eos.</description>
+          <title>Of Human Bondage</title>
+          <description>Quasi qui voluptatibus consequuntur.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:26 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_config
     body:
       encoding: UTF-8
-      string: Nam voluptatum molestias. Optio temporibus exercitationem. Libero sed
-        maiores.
+      string: Enim praesentium quos. Animi aspernatur illo. Et quae facere.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -307,25 +306,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="131" vrev="131">
-          <srcmd5>5c3c00c1226ff218a4f7449211508081</srcmd5>
+        <revision rev="49" vrev="49">
+          <srcmd5>19efbf211aea3ab4a4171dbfc27577a6</srcmd5>
           <version>unknown</version>
-          <time>1658422046</time>
+          <time>1658762207</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:26 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/somefile.txt
     body:
       encoding: UTF-8
-      string: Quisquam tempore quas. Voluptate quas qui. Quisquam eum et.
+      string: Non consequatur voluptatem. Molestiae sed aliquam. Et praesentium libero.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -345,19 +344,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="132" vrev="132">
-          <srcmd5>d20fdc505f45ca1149eea38e15dc836d</srcmd5>
+        <revision rev="50" vrev="50">
+          <srcmd5>7541b962a72cddce8404337097ba942b</srcmd5>
           <version>unknown</version>
-          <time>1658422046</time>
+          <time>1658762207</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:26 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/_meta?user=tom
@@ -365,7 +364,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>Consider the Lilies</title>
+          <title>Waiting for the Barbarians</title>
           <description/>
         </project>
     headers:
@@ -387,15 +386,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '110'
+      - '117'
     body:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>Consider the Lilies</title>
+          <title>Waiting for the Barbarians</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:26 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package_2/_meta?user=tom
@@ -403,8 +402,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="target_project">
-          <title>Fame Is the Spur</title>
-          <description>Sunt nihil recusandae et.</description>
+          <title>A Time to Kill</title>
+          <description>Itaque repudiandae officiis quae.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -425,15 +424,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '159'
+      - '165'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="target_project">
-          <title>Fame Is the Spur</title>
-          <description>Sunt nihil recusandae et.</description>
+          <title>A Time to Kill</title>
+          <description>Itaque repudiandae officiis quae.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:26 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_meta?user=tom
@@ -441,7 +440,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>The Green Bay Tree</title>
+          <title>This Lime Tree Bower</title>
           <description/>
         </project>
     headers:
@@ -463,15 +462,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '109'
+      - '111'
     body:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>The Green Bay Tree</title>
+          <title>This Lime Tree Bower</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:26 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_project/_attribute?meta=1&user=tom
@@ -500,18 +499,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '166'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="132">
-          <srcmd5>bb0aab35e64c3fab23b4e132f3bbab7c</srcmd5>
-          <time>1658422046</time>
+        <revision rev="48">
+          <srcmd5>3aa5ec7c4c4108bedcce9c3f56cdafb1</srcmd5>
+          <time>1658762207</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:26 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/source_package/_meta?user=tom
@@ -519,8 +518,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>For Whom the Bell Tolls</title>
-          <description>Nemo et enim atque.</description>
+          <title>The Far-Distant Oxus</title>
+          <description>Hic impedit nisi sunt.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -546,10 +545,10 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>For Whom the Bell Tolls</title>
-          <description>Nemo et enim atque.</description>
+          <title>The Far-Distant Oxus</title>
+          <description>Hic impedit nisi sunt.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:26 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:47 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package
@@ -581,7 +580,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:26 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:47 GMT
 - request:
     method: post
     uri: http://backend:5352/source/source_project/source_package?cmd=diff&expand=1&filelimit=10000&opackage=target_package_2&oproject=target_project&tarlimit=10000&view=xml&withissues=1
@@ -609,19 +608,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '331'
+      - '330'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="ac569ba52da33c910f5ad1b4904b45e8">
-          <old project="target_project" package="target_package_2" rev="45" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+        <sourcediff key="3f2de7980c55a78d4eae7a941529468b">
+          <old project="target_project" package="target_package_2" rev="6" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <new project="source_project" package="source_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files>
           </files>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:26 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:47 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22source_package%22%20and%20linkinfo/@project=%22source_project%22%20and%20@project=%22source_project%22)
@@ -655,7 +654,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 21 Jul 2022 16:47:26 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2/_meta?user=tom
@@ -663,8 +662,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>For Whom the Bell Tolls</title>
-          <description>Nemo et enim atque.</description>
+          <title>The Far-Distant Oxus</title>
+          <description>Hic impedit nisi sunt.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -690,10 +689,10 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>For Whom the Bell Tolls</title>
-          <description>Nemo et enim atque.</description>
+          <title>The Far-Distant Oxus</title>
+          <description>Hic impedit nisi sunt.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:26 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:47 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?cmd=branch&noservice=1&opackage=source_package&oproject=source_project&user=tom
@@ -728,12 +727,12 @@ http_interactions:
         <revision rev="1" vrev="1">
           <srcmd5>8e451641a827df5f4f409d1d543fdb7b</srcmd5>
           <version>unknown</version>
-          <time>1658422046</time>
+          <time>1658762207</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:26 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2/_meta?user=tom
@@ -741,8 +740,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>For Whom the Bell Tolls</title>
-          <description>Nemo et enim atque.</description>
+          <title>The Far-Distant Oxus</title>
+          <description>Hic impedit nisi sunt.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -768,10 +767,10 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>For Whom the Bell Tolls</title>
-          <description>Nemo et enim atque.</description>
+          <title>The Far-Distant Oxus</title>
+          <description>Hic impedit nisi sunt.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:26 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:47 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2
@@ -803,9 +802,9 @@ http_interactions:
       string: |
         <directory name="target_package_2" rev="1" vrev="1" srcmd5="8e451641a827df5f4f409d1d543fdb7b">
           <linkinfo project="source_project" package="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
-          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658419299"/>
+          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658762120"/>
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:26 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:47 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?view=info
@@ -839,7 +838,7 @@ http_interactions:
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="source_project" package="source_package"/>
         </sourceinfo>
-  recorded_at: Thu, 21 Jul 2022 16:47:26 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:47 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2
@@ -871,9 +870,9 @@ http_interactions:
       string: |
         <directory name="target_package_2" rev="1" vrev="1" srcmd5="8e451641a827df5f4f409d1d543fdb7b">
           <linkinfo project="source_project" package="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
-          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658419299"/>
+          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658762120"/>
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:26 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:47 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -912,7 +911,7 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:26 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:47 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -951,14 +950,14 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:26 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=tom
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_20">
+        <workflow project="home:tom" managers="group_28">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -981,18 +980,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '166'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="264">
-          <srcmd5>8da317e26168b4639bbbf4172477283b</srcmd5>
-          <time>1658422046</time>
+        <revision rev="71">
+          <srcmd5>b885dd2550e612cb2b37ef62d0ecfbfe</srcmd5>
+          <time>1658762207</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:26 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=tom
@@ -1002,7 +1001,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_20" role="maintainer"/>
+          <group groupid="group_28" role="maintainer"/>
           <repository name="staging_repository">
             <arch>x86_64</arch>
           </repository>
@@ -1033,12 +1032,12 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_20" role="maintainer"/>
+          <group groupid="group_28" role="maintainer"/>
           <repository name="staging_repository">
             <arch>x86_64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:26 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package/_meta?user=tom
@@ -1046,8 +1045,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>Look to Windward</title>
-          <description>Aut aut quia autem.</description>
+          <title>The House of Mirth</title>
+          <description>Vitae ut et ut.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1068,15 +1067,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '151'
+      - '149'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>Look to Windward</title>
-          <description>Aut aut quia autem.</description>
+          <title>The House of Mirth</title>
+          <description>Vitae ut et ut.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:26 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:47 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package
@@ -1108,7 +1107,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:26 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:48 GMT
 - request:
     method: post
     uri: http://backend:5352/source/source_project/source_package?cmd=diff&expand=1&filelimit=10000&opackage=target_package&oproject=target_project&tarlimit=10000&view=xml&withissues=1
@@ -1136,19 +1135,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '329'
+      - '328'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="6d5a5b99c00d08991345ac5f1f529fa2">
-          <old project="target_project" package="target_package" rev="29" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+        <sourcediff key="1fe34ee08ce58cb8836a9b3027838846">
+          <old project="target_project" package="target_package" rev="7" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <new project="source_project" package="source_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files>
           </files>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:27 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:48 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22source_package%22%20and%20linkinfo/@project=%22source_project%22%20and%20@project=%22source_project%22)
@@ -1182,7 +1181,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 21 Jul 2022 16:47:27 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:48 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/target_package/_meta?user=tom
@@ -1190,8 +1189,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="home:tom:Staging:A">
-          <title>For Whom the Bell Tolls</title>
-          <description>Nemo et enim atque.</description>
+          <title>The Far-Distant Oxus</title>
+          <description>Hic impedit nisi sunt.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1217,10 +1216,10 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="home:tom:Staging:A">
-          <title>For Whom the Bell Tolls</title>
-          <description>Nemo et enim atque.</description>
+          <title>The Far-Distant Oxus</title>
+          <description>Hic impedit nisi sunt.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:27 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:48 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package?cmd=branch&noservice=1&opackage=source_package&oproject=source_project&user=tom
@@ -1255,12 +1254,12 @@ http_interactions:
         <revision rev="1" vrev="1">
           <srcmd5>8e451641a827df5f4f409d1d543fdb7b</srcmd5>
           <version>unknown</version>
-          <time>1658422047</time>
+          <time>1658762208</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:27 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:48 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/target_package/_meta?user=tom
@@ -1268,8 +1267,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="home:tom:Staging:A">
-          <title>For Whom the Bell Tolls</title>
-          <description>Nemo et enim atque.</description>
+          <title>The Far-Distant Oxus</title>
+          <description>Hic impedit nisi sunt.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1295,10 +1294,10 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="home:tom:Staging:A">
-          <title>For Whom the Bell Tolls</title>
-          <description>Nemo et enim atque.</description>
+          <title>The Far-Distant Oxus</title>
+          <description>Hic impedit nisi sunt.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:27 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:48 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package
@@ -1330,9 +1329,9 @@ http_interactions:
       string: |
         <directory name="target_package" rev="1" vrev="1" srcmd5="8e451641a827df5f4f409d1d543fdb7b">
           <linkinfo project="source_project" package="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
-          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658419310"/>
+          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658490907"/>
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:27 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:48 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package?view=info
@@ -1366,7 +1365,7 @@ http_interactions:
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="source_project" package="source_package"/>
         </sourceinfo>
-  recorded_at: Thu, 21 Jul 2022 16:47:27 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:48 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package
@@ -1398,9 +1397,9 @@ http_interactions:
       string: |
         <directory name="target_package" rev="1" vrev="1" srcmd5="8e451641a827df5f4f409d1d543fdb7b">
           <linkinfo project="source_project" package="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
-          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658419310"/>
+          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658490907"/>
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:27 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:48 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -1439,7 +1438,7 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:27 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:48 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -1478,14 +1477,14 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:27 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:48 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=tom
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_20">
+        <workflow project="home:tom" managers="group_28">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -1508,18 +1507,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '166'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="265">
-          <srcmd5>8da317e26168b4639bbbf4172477283b</srcmd5>
-          <time>1658422047</time>
+        <revision rev="72">
+          <srcmd5>b885dd2550e612cb2b37ef62d0ecfbfe</srcmd5>
+          <time>1658762208</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:27 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:48 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=tom
@@ -1529,7 +1528,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_20" role="maintainer"/>
+          <group groupid="group_28" role="maintainer"/>
           <repository name="staging_repository">
             <arch>x86_64</arch>
           </repository>
@@ -1560,19 +1559,19 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_20" role="maintainer"/>
+          <group groupid="group_28" role="maintainer"/>
           <repository name="staging_repository">
             <arch>x86_64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:27 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:48 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_53
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_67
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_20">
+        <workflow project="home:tom" managers="group_28">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -1595,18 +1594,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="266">
-          <srcmd5>8da317e26168b4639bbbf4172477283b</srcmd5>
-          <time>1658422047</time>
-          <user>user_53</user>
+        <revision rev="73">
+          <srcmd5>b885dd2550e612cb2b37ef62d0ecfbfe</srcmd5>
+          <time>1658762208</time>
+          <user>user_67</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:27 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:48 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=tom
@@ -1616,7 +1615,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_20" role="maintainer"/>
+          <group groupid="group_28" role="maintainer"/>
           <build>
             <disable/>
           </build>
@@ -1650,7 +1649,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_20" role="maintainer"/>
+          <group groupid="group_28" role="maintainer"/>
           <build>
             <disable/>
           </build>
@@ -1658,7 +1657,7 @@ http_interactions:
             <arch>x86_64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:27 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:48 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package?expand=1
@@ -1690,7 +1689,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:27 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:48 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package?expand=1
@@ -1722,7 +1721,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:27 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:48 GMT
 - request:
     method: post
     uri: http://backend:5352/source/target_project/target_package_2?cmd=copy&comment=Request%20for%20package%20target_package_2&expand=1&keeplink=1&noservice=1&opackage=source_package&oproject=source_project&requestid=1&user=tom&withacceptinfo=1
@@ -1750,20 +1749,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '363'
+      - '360'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="46" vrev="46">
+        <revision rev="7" vrev="7">
           <srcmd5>d41d8cd98f00b204e9800998ecf8427e</srcmd5>
           <version>unknown</version>
-          <time>1658422047</time>
+          <time>1658762208</time>
           <user>tom</user>
           <comment>Request for package target_package_2</comment>
           <requestid>1</requestid>
-          <acceptinfo rev="46" srcmd5="d41d8cd98f00b204e9800998ecf8427e" osrcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <acceptinfo rev="7" srcmd5="d41d8cd98f00b204e9800998ecf8427e" osrcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:27 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:48 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package_2/_meta?user=tom
@@ -1771,8 +1770,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="target_project">
-          <title>Fame Is the Spur</title>
-          <description>Sunt nihil recusandae et.</description>
+          <title>A Time to Kill</title>
+          <description>Itaque repudiandae officiis quae.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1793,15 +1792,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '159'
+      - '165'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="target_project">
-          <title>Fame Is the Spur</title>
-          <description>Sunt nihil recusandae et.</description>
+          <title>A Time to Kill</title>
+          <description>Itaque repudiandae officiis quae.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:27 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:48 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package_2
@@ -1827,13 +1826,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '110'
+      - '108'
     body:
       encoding: UTF-8
       string: |
-        <directory name="target_package_2" rev="46" vrev="46" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <directory name="target_package_2" rev="7" vrev="7" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:27 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:48 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package_2?view=info
@@ -1859,14 +1858,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '151'
+      - '149'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="target_package_2" rev="46" vrev="46" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <sourceinfo package="target_package_2" rev="7" vrev="7" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
           <error>no source uploaded</error>
         </sourceinfo>
-  recorded_at: Thu, 21 Jul 2022 16:47:27 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:48 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package_2
@@ -1892,13 +1891,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '110'
+      - '108'
     body:
       encoding: UTF-8
       string: |
-        <directory name="target_package_2" rev="46" vrev="46" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <directory name="target_package_2" rev="7" vrev="7" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:27 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:48 GMT
 - request:
     method: post
     uri: http://backend:5352/source/target_project/target_package_2?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -1926,16 +1925,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '300'
+      - '299'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="a6c28f3e40a0fccb07488be9f7a5dcf0">
+        <sourcediff key="645ac2496a0cf34be9e1234ba45e548e">
           <old project="target_project" package="target_package_2" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="target_project" package="target_package_2" rev="46" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="target_project" package="target_package_2" rev="7" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files/>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:27 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:48 GMT
 - request:
     method: delete
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?comment&user=tom
@@ -1967,7 +1966,7 @@ http_interactions:
       string: '<status code="ok" />
 
 '
-  recorded_at: Thu, 21 Jul 2022 16:47:27 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:48 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package?expand=1
@@ -1999,7 +1998,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:27 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:48 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package?expand=1
@@ -2031,7 +2030,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:27 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:48 GMT
 - request:
     method: post
     uri: http://backend:5352/source/target_project/target_package?cmd=copy&comment=Request%20for%20package%20target_package&expand=1&keeplink=1&noservice=1&opackage=source_package&oproject=source_project&requestid=2&user=tom&withacceptinfo=1
@@ -2059,20 +2058,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '361'
+      - '358'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="30" vrev="30">
+        <revision rev="8" vrev="8">
           <srcmd5>d41d8cd98f00b204e9800998ecf8427e</srcmd5>
           <version>unknown</version>
-          <time>1658422047</time>
+          <time>1658762208</time>
           <user>tom</user>
           <comment>Request for package target_package</comment>
           <requestid>2</requestid>
-          <acceptinfo rev="30" srcmd5="d41d8cd98f00b204e9800998ecf8427e" osrcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <acceptinfo rev="8" srcmd5="d41d8cd98f00b204e9800998ecf8427e" osrcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:27 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:48 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package/_meta?user=tom
@@ -2080,8 +2079,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>Look to Windward</title>
-          <description>Aut aut quia autem.</description>
+          <title>The House of Mirth</title>
+          <description>Vitae ut et ut.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -2102,15 +2101,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '151'
+      - '149'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>Look to Windward</title>
-          <description>Aut aut quia autem.</description>
+          <title>The House of Mirth</title>
+          <description>Vitae ut et ut.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:27 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:48 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package
@@ -2136,13 +2135,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '108'
+      - '106'
     body:
       encoding: UTF-8
       string: |
-        <directory name="target_package" rev="30" vrev="30" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <directory name="target_package" rev="8" vrev="8" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:27 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:48 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package?view=info
@@ -2168,14 +2167,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '149'
+      - '147'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="target_package" rev="30" vrev="30" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <sourceinfo package="target_package" rev="8" vrev="8" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
           <error>no source uploaded</error>
         </sourceinfo>
-  recorded_at: Thu, 21 Jul 2022 16:47:27 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:48 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package
@@ -2201,13 +2200,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '108'
+      - '106'
     body:
       encoding: UTF-8
       string: |
-        <directory name="target_package" rev="30" vrev="30" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <directory name="target_package" rev="8" vrev="8" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:27 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:48 GMT
 - request:
     method: post
     uri: http://backend:5352/source/target_project/target_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -2235,16 +2234,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '296'
+      - '295'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="edce7c9cebff215429f195812a6986de">
+        <sourcediff key="fce418211376413a269401a5bf8435d6">
           <old project="target_project" package="target_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="target_project" package="target_package" rev="30" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="target_project" package="target_package" rev="8" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files/>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:27 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:48 GMT
 - request:
     method: delete
     uri: http://backend:5352/source/home:tom:Staging:A/target_package?comment&user=tom
@@ -2276,5 +2275,5 @@ http_interactions:
       string: '<status code="ok" />
 
 '
-  recorded_at: Thu, 21 Jul 2022 16:47:27 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:48 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Project/Staging_Project/_accept/when_the_staging_project_is_in_acceptable_state/staging_project_should_be_accepted/1_1_7_1_1_3.yml
+++ b/src/api/spec/cassettes/Project/Staging_Project/_accept/when_the_staging_project_is_in_acceptable_state/staging_project_should_be_accepted/1_1_7_1_1_3.yml
@@ -39,14 +39,14 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:30 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:38 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_57
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_59
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_22">
+        <workflow project="home:tom" managers="group_24">
           <staging_project name="home:tom:Staging:A"/>
         </workflow>
     headers:
@@ -68,28 +68,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="272">
-          <srcmd5>6278c0ea067a3f9eb1e6bd0ef14be298</srcmd5>
-          <time>1658422050</time>
-          <user>user_57</user>
+        <revision rev="49">
+          <srcmd5>11bcef28377dcffa433dbc8b53841314</srcmd5>
+          <time>1658762198</time>
+          <user>user_59</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:30 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:38 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_57
+    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_59
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_22" role="maintainer"/>
+          <group groupid="group_24" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -117,16 +117,16 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_22" role="maintainer"/>
+          <group groupid="group_24" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:30 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:38 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_57
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_59
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_22">
+        <workflow project="home:tom" managers="group_24">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -149,28 +149,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="273">
-          <srcmd5>0b4dd9a7406126f7ab8ab4b1a6abfb17</srcmd5>
-          <time>1658422050</time>
-          <user>user_57</user>
+        <revision rev="50">
+          <srcmd5>71637360387d7e3a1cbb5390fb5c1060</srcmd5>
+          <time>1658762198</time>
+          <user>user_59</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:30 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:38 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_57
+    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_59
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:B">
           <title/>
           <description/>
-          <group groupid="group_22" role="maintainer"/>
+          <group groupid="group_24" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -198,12 +198,12 @@ http_interactions:
         <project name="home:tom:Staging:B">
           <title></title>
           <description></description>
-          <group groupid="group_22" role="maintainer"/>
+          <group groupid="group_24" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:30 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:38 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_meta?user=user_57
+    uri: http://backend:5352/source/home:tom/_meta?user=user_59
     body:
       encoding: UTF-8
       string: |
@@ -211,7 +211,7 @@ http_interactions:
           <title/>
           <description/>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_22" role="reviewer"/>
+          <group groupid="group_24" role="reviewer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -240,18 +240,18 @@ http_interactions:
           <title></title>
           <description></description>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_22" role="reviewer"/>
+          <group groupid="group_24" role="reviewer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:30 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:38 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_58
+    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_60
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>A Farewell to Arms</title>
-          <description>Aut voluptatum est voluptatibus.</description>
+          <title>Wildfire at Midnight</title>
+          <description>Totam fugiat officia perferendis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -272,21 +272,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '173'
+      - '176'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>A Farewell to Arms</title>
-          <description>Aut voluptatum est voluptatibus.</description>
+          <title>Wildfire at Midnight</title>
+          <description>Totam fugiat officia perferendis.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:30 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:38 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_config
     body:
       encoding: UTF-8
-      string: Sit soluta provident. Dignissimos quia illo. Similique cum hic.
+      string: Quia enim dicta. Ipsum quos molestias. Officiis sunt dignissimos.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -306,25 +306,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="135" vrev="135">
-          <srcmd5>d7c555d6eddd941386a88a04ad59a4ad</srcmd5>
+        <revision rev="41" vrev="41">
+          <srcmd5>28dc3e81cea6d550be989a4d5a4b1382</srcmd5>
           <version>unknown</version>
-          <time>1658422050</time>
+          <time>1658762198</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:30 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:38 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/somefile.txt
     body:
       encoding: UTF-8
-      string: Sequi et nihil. Praesentium odio voluptates. Iusto rerum iste.
+      string: Minima labore ipsa. Beatae optio ea. Beatae tempora eum.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -344,19 +344,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="136" vrev="136">
-          <srcmd5>d91486ad58eeab46f5ccd5e3a0efc383</srcmd5>
+        <revision rev="42" vrev="42">
+          <srcmd5>90f1a2553cbe0cb1710dd7b1ea2e80ee</srcmd5>
           <version>unknown</version>
-          <time>1658422050</time>
+          <time>1658762198</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:30 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:38 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/_meta?user=tom
@@ -364,7 +364,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>A Glass of Blessings</title>
+          <title>Mr Standfast</title>
           <description/>
         </project>
     headers:
@@ -386,15 +386,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '111'
+      - '103'
     body:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>A Glass of Blessings</title>
+          <title>Mr Standfast</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:30 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:38 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package_2/_meta?user=tom
@@ -402,8 +402,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="target_project">
-          <title>Things Fall Apart</title>
-          <description>Et non molestias reprehenderit.</description>
+          <title>Taming a Sea Horse</title>
+          <description>Sint qui voluptas sunt.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -424,15 +424,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '166'
+      - '159'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="target_project">
-          <title>Things Fall Apart</title>
-          <description>Et non molestias reprehenderit.</description>
+          <title>Taming a Sea Horse</title>
+          <description>Sint qui voluptas sunt.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:30 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:38 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_meta?user=tom
@@ -440,7 +440,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Butter In a Lordly Dish</title>
+          <title>Pale Kings and Princes</title>
           <description/>
         </project>
     headers:
@@ -462,15 +462,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '114'
+      - '113'
     body:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Butter In a Lordly Dish</title>
+          <title>Pale Kings and Princes</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:30 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:38 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_project/_attribute?meta=1&user=tom
@@ -499,18 +499,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '166'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="136">
-          <srcmd5>7bdf3c9dc4d25ba2a1407f3bc142ca95</srcmd5>
-          <time>1658422050</time>
+        <revision rev="40">
+          <srcmd5>a01db2e2a46621786c1426ba7c000814</srcmd5>
+          <time>1658762198</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:30 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:38 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/source_package/_meta?user=tom
@@ -518,8 +518,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>To Say Nothing of the Dog</title>
-          <description>Nobis vel vero eum.</description>
+          <title>Some Buried Caesar</title>
+          <description>Ea eos ut tenetur.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -540,15 +540,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '160'
+      - '152'
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>To Say Nothing of the Dog</title>
-          <description>Nobis vel vero eum.</description>
+          <title>Some Buried Caesar</title>
+          <description>Ea eos ut tenetur.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:30 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:38 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package
@@ -580,7 +580,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:30 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:38 GMT
 - request:
     method: post
     uri: http://backend:5352/source/source_project/source_package?cmd=diff&expand=1&filelimit=10000&opackage=target_package_2&oproject=target_project&tarlimit=10000&view=xml&withissues=1
@@ -608,19 +608,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '331'
+      - '330'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="87e1e6a20a7cdde715251884384c8372">
-          <old project="target_project" package="target_package_2" rev="47" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+        <sourcediff key="bc54e20e225eaab5c4d602c0ab976b87">
+          <old project="target_project" package="target_package_2" rev="2" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <new project="source_project" package="source_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files>
           </files>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:30 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:39 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22source_package%22%20and%20linkinfo/@project=%22source_project%22%20and%20@project=%22source_project%22)
@@ -654,7 +654,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 21 Jul 2022 16:47:30 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:39 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2/_meta?user=tom
@@ -662,8 +662,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>To Say Nothing of the Dog</title>
-          <description>Nobis vel vero eum.</description>
+          <title>Some Buried Caesar</title>
+          <description>Ea eos ut tenetur.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -684,15 +684,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '166'
+      - '158'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>To Say Nothing of the Dog</title>
-          <description>Nobis vel vero eum.</description>
+          <title>Some Buried Caesar</title>
+          <description>Ea eos ut tenetur.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:30 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:39 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?cmd=branch&noservice=1&opackage=source_package&oproject=source_project&user=tom
@@ -727,12 +727,12 @@ http_interactions:
         <revision rev="1" vrev="1">
           <srcmd5>8e451641a827df5f4f409d1d543fdb7b</srcmd5>
           <version>unknown</version>
-          <time>1658422050</time>
+          <time>1658762199</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:30 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:39 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2/_meta?user=tom
@@ -740,8 +740,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>To Say Nothing of the Dog</title>
-          <description>Nobis vel vero eum.</description>
+          <title>Some Buried Caesar</title>
+          <description>Ea eos ut tenetur.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -762,15 +762,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '166'
+      - '158'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>To Say Nothing of the Dog</title>
-          <description>Nobis vel vero eum.</description>
+          <title>Some Buried Caesar</title>
+          <description>Ea eos ut tenetur.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:30 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:39 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2
@@ -802,9 +802,9 @@ http_interactions:
       string: |
         <directory name="target_package_2" rev="1" vrev="1" srcmd5="8e451641a827df5f4f409d1d543fdb7b">
           <linkinfo project="source_project" package="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
-          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658419299"/>
+          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658762120"/>
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:30 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:39 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?view=info
@@ -838,7 +838,7 @@ http_interactions:
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="source_project" package="source_package"/>
         </sourceinfo>
-  recorded_at: Thu, 21 Jul 2022 16:47:30 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:39 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2
@@ -870,9 +870,9 @@ http_interactions:
       string: |
         <directory name="target_package_2" rev="1" vrev="1" srcmd5="8e451641a827df5f4f409d1d543fdb7b">
           <linkinfo project="source_project" package="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
-          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658419299"/>
+          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658762120"/>
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:30 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:39 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -911,7 +911,7 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:30 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:39 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -950,14 +950,14 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:30 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:39 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=tom
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_22">
+        <workflow project="home:tom" managers="group_24">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -980,18 +980,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '166'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="274">
-          <srcmd5>0b4dd9a7406126f7ab8ab4b1a6abfb17</srcmd5>
-          <time>1658422050</time>
+        <revision rev="51">
+          <srcmd5>71637360387d7e3a1cbb5390fb5c1060</srcmd5>
+          <time>1658762199</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:30 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:39 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=tom
@@ -1001,7 +1001,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_22" role="maintainer"/>
+          <group groupid="group_24" role="maintainer"/>
           <repository name="staging_repository">
             <arch>x86_64</arch>
           </repository>
@@ -1032,12 +1032,12 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_22" role="maintainer"/>
+          <group groupid="group_24" role="maintainer"/>
           <repository name="staging_repository">
             <arch>x86_64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:30 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:39 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package/_meta?user=tom
@@ -1045,8 +1045,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>The Sun Also Rises</title>
-          <description>Ducimus voluptas ea ipsum.</description>
+          <title>Tirra Lirra by the River</title>
+          <description>Enim quidem laborum laudantium.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1067,15 +1067,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '160'
+      - '171'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>The Sun Also Rises</title>
-          <description>Ducimus voluptas ea ipsum.</description>
+          <title>Tirra Lirra by the River</title>
+          <description>Enim quidem laborum laudantium.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:30 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:39 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package
@@ -1107,7 +1107,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:31 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:39 GMT
 - request:
     method: post
     uri: http://backend:5352/source/source_project/source_package?cmd=diff&expand=1&filelimit=10000&opackage=target_package&oproject=target_project&tarlimit=10000&view=xml&withissues=1
@@ -1135,19 +1135,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '329'
+      - '328'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="05d1cb4687b584bab1983aefb1d0aedd">
-          <old project="target_project" package="target_package" rev="31" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+        <sourcediff key="90c2818903ec79ac4d2d2c85b08f3eba">
+          <old project="target_project" package="target_package" rev="3" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <new project="source_project" package="source_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files>
           </files>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:31 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:39 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22source_package%22%20and%20linkinfo/@project=%22source_project%22%20and%20@project=%22source_project%22)
@@ -1181,7 +1181,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 21 Jul 2022 16:47:31 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:39 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/target_package/_meta?user=tom
@@ -1189,8 +1189,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="home:tom:Staging:A">
-          <title>To Say Nothing of the Dog</title>
-          <description>Nobis vel vero eum.</description>
+          <title>Some Buried Caesar</title>
+          <description>Ea eos ut tenetur.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1211,15 +1211,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '164'
+      - '156'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="home:tom:Staging:A">
-          <title>To Say Nothing of the Dog</title>
-          <description>Nobis vel vero eum.</description>
+          <title>Some Buried Caesar</title>
+          <description>Ea eos ut tenetur.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:31 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:39 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package?cmd=branch&noservice=1&opackage=source_package&oproject=source_project&user=tom
@@ -1254,12 +1254,12 @@ http_interactions:
         <revision rev="1" vrev="1">
           <srcmd5>8e451641a827df5f4f409d1d543fdb7b</srcmd5>
           <version>unknown</version>
-          <time>1658422051</time>
+          <time>1658762199</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:31 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:39 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/target_package/_meta?user=tom
@@ -1267,8 +1267,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="home:tom:Staging:A">
-          <title>To Say Nothing of the Dog</title>
-          <description>Nobis vel vero eum.</description>
+          <title>Some Buried Caesar</title>
+          <description>Ea eos ut tenetur.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1289,15 +1289,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '164'
+      - '156'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="home:tom:Staging:A">
-          <title>To Say Nothing of the Dog</title>
-          <description>Nobis vel vero eum.</description>
+          <title>Some Buried Caesar</title>
+          <description>Ea eos ut tenetur.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:31 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:39 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package
@@ -1329,9 +1329,9 @@ http_interactions:
       string: |
         <directory name="target_package" rev="1" vrev="1" srcmd5="8e451641a827df5f4f409d1d543fdb7b">
           <linkinfo project="source_project" package="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
-          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658419310"/>
+          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658490907"/>
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:31 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:39 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package?view=info
@@ -1365,7 +1365,7 @@ http_interactions:
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="source_project" package="source_package"/>
         </sourceinfo>
-  recorded_at: Thu, 21 Jul 2022 16:47:31 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:39 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package
@@ -1397,9 +1397,9 @@ http_interactions:
       string: |
         <directory name="target_package" rev="1" vrev="1" srcmd5="8e451641a827df5f4f409d1d543fdb7b">
           <linkinfo project="source_project" package="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
-          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658419310"/>
+          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658490907"/>
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:31 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:39 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -1438,7 +1438,7 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:31 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:39 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -1477,14 +1477,14 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:31 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:39 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=tom
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_22">
+        <workflow project="home:tom" managers="group_24">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -1507,18 +1507,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '166'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="275">
-          <srcmd5>0b4dd9a7406126f7ab8ab4b1a6abfb17</srcmd5>
-          <time>1658422051</time>
+        <revision rev="52">
+          <srcmd5>71637360387d7e3a1cbb5390fb5c1060</srcmd5>
+          <time>1658762199</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:31 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:39 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=tom
@@ -1528,7 +1528,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_22" role="maintainer"/>
+          <group groupid="group_24" role="maintainer"/>
           <repository name="staging_repository">
             <arch>x86_64</arch>
           </repository>
@@ -1559,19 +1559,19 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_22" role="maintainer"/>
+          <group groupid="group_24" role="maintainer"/>
           <repository name="staging_repository">
             <arch>x86_64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:31 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:39 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_57
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_59
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_22">
+        <workflow project="home:tom" managers="group_24">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -1594,18 +1594,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="276">
-          <srcmd5>0b4dd9a7406126f7ab8ab4b1a6abfb17</srcmd5>
-          <time>1658422051</time>
-          <user>user_57</user>
+        <revision rev="53">
+          <srcmd5>71637360387d7e3a1cbb5390fb5c1060</srcmd5>
+          <time>1658762199</time>
+          <user>user_59</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:31 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:39 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=tom
@@ -1615,7 +1615,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_22" role="maintainer"/>
+          <group groupid="group_24" role="maintainer"/>
           <build>
             <disable/>
           </build>
@@ -1649,7 +1649,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_22" role="maintainer"/>
+          <group groupid="group_24" role="maintainer"/>
           <build>
             <disable/>
           </build>
@@ -1657,7 +1657,7 @@ http_interactions:
             <arch>x86_64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:31 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:39 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package?expand=1
@@ -1689,7 +1689,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:31 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:39 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package?expand=1
@@ -1721,7 +1721,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:31 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:39 GMT
 - request:
     method: post
     uri: http://backend:5352/source/target_project/target_package_2?cmd=copy&comment=Request%20for%20package%20target_package_2&expand=1&keeplink=1&noservice=1&opackage=source_package&oproject=source_project&requestid=1&user=tom&withacceptinfo=1
@@ -1749,20 +1749,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '363'
+      - '360'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="48" vrev="48">
+        <revision rev="3" vrev="3">
           <srcmd5>d41d8cd98f00b204e9800998ecf8427e</srcmd5>
           <version>unknown</version>
-          <time>1658422051</time>
+          <time>1658762199</time>
           <user>tom</user>
           <comment>Request for package target_package_2</comment>
           <requestid>1</requestid>
-          <acceptinfo rev="48" srcmd5="d41d8cd98f00b204e9800998ecf8427e" osrcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <acceptinfo rev="3" srcmd5="d41d8cd98f00b204e9800998ecf8427e" osrcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:31 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:39 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package_2/_meta?user=tom
@@ -1770,8 +1770,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="target_project">
-          <title>Things Fall Apart</title>
-          <description>Et non molestias reprehenderit.</description>
+          <title>Taming a Sea Horse</title>
+          <description>Sint qui voluptas sunt.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1792,15 +1792,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '166'
+      - '159'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="target_project">
-          <title>Things Fall Apart</title>
-          <description>Et non molestias reprehenderit.</description>
+          <title>Taming a Sea Horse</title>
+          <description>Sint qui voluptas sunt.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:31 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:39 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package_2
@@ -1826,13 +1826,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '110'
+      - '108'
     body:
       encoding: UTF-8
       string: |
-        <directory name="target_package_2" rev="48" vrev="48" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <directory name="target_package_2" rev="3" vrev="3" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:31 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:39 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package_2?view=info
@@ -1858,14 +1858,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '151'
+      - '149'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="target_package_2" rev="48" vrev="48" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <sourceinfo package="target_package_2" rev="3" vrev="3" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
           <error>no source uploaded</error>
         </sourceinfo>
-  recorded_at: Thu, 21 Jul 2022 16:47:31 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:39 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package_2
@@ -1891,13 +1891,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '110'
+      - '108'
     body:
       encoding: UTF-8
       string: |
-        <directory name="target_package_2" rev="48" vrev="48" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <directory name="target_package_2" rev="3" vrev="3" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:31 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:39 GMT
 - request:
     method: post
     uri: http://backend:5352/source/target_project/target_package_2?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -1925,16 +1925,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '300'
+      - '299'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="8edde7cd138855a3d5d06410f9db679d">
+        <sourcediff key="5be59e44e9eaef38cd1f31195e3cfcce">
           <old project="target_project" package="target_package_2" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="target_project" package="target_package_2" rev="48" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="target_project" package="target_package_2" rev="3" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files/>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:31 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:40 GMT
 - request:
     method: delete
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?comment&user=tom
@@ -1966,7 +1966,7 @@ http_interactions:
       string: '<status code="ok" />
 
 '
-  recorded_at: Thu, 21 Jul 2022 16:47:31 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:40 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package?expand=1
@@ -1998,7 +1998,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:31 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:40 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package?expand=1
@@ -2030,7 +2030,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:31 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:40 GMT
 - request:
     method: post
     uri: http://backend:5352/source/target_project/target_package?cmd=copy&comment=Request%20for%20package%20target_package&expand=1&keeplink=1&noservice=1&opackage=source_package&oproject=source_project&requestid=2&user=tom&withacceptinfo=1
@@ -2058,20 +2058,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '361'
+      - '358'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="32" vrev="32">
+        <revision rev="4" vrev="4">
           <srcmd5>d41d8cd98f00b204e9800998ecf8427e</srcmd5>
           <version>unknown</version>
-          <time>1658422051</time>
+          <time>1658762200</time>
           <user>tom</user>
           <comment>Request for package target_package</comment>
           <requestid>2</requestid>
-          <acceptinfo rev="32" srcmd5="d41d8cd98f00b204e9800998ecf8427e" osrcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <acceptinfo rev="4" srcmd5="d41d8cd98f00b204e9800998ecf8427e" osrcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:31 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:40 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package/_meta?user=tom
@@ -2079,8 +2079,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>The Sun Also Rises</title>
-          <description>Ducimus voluptas ea ipsum.</description>
+          <title>Tirra Lirra by the River</title>
+          <description>Enim quidem laborum laudantium.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -2101,15 +2101,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '160'
+      - '171'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>The Sun Also Rises</title>
-          <description>Ducimus voluptas ea ipsum.</description>
+          <title>Tirra Lirra by the River</title>
+          <description>Enim quidem laborum laudantium.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:31 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:40 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package
@@ -2135,13 +2135,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '108'
+      - '106'
     body:
       encoding: UTF-8
       string: |
-        <directory name="target_package" rev="32" vrev="32" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <directory name="target_package" rev="4" vrev="4" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:31 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:40 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package?view=info
@@ -2167,14 +2167,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '149'
+      - '147'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="target_package" rev="32" vrev="32" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <sourceinfo package="target_package" rev="4" vrev="4" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
           <error>no source uploaded</error>
         </sourceinfo>
-  recorded_at: Thu, 21 Jul 2022 16:47:31 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:40 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package
@@ -2200,13 +2200,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '108'
+      - '106'
     body:
       encoding: UTF-8
       string: |
-        <directory name="target_package" rev="32" vrev="32" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <directory name="target_package" rev="4" vrev="4" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:31 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:40 GMT
 - request:
     method: post
     uri: http://backend:5352/source/target_project/target_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -2234,16 +2234,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '296'
+      - '295'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="803c49ef88304ca4b53c4f4b2a283294">
+        <sourcediff key="85635bd52082081a63fe3a348a498059">
           <old project="target_project" package="target_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="target_project" package="target_package" rev="32" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="target_project" package="target_package" rev="4" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files/>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:31 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:40 GMT
 - request:
     method: delete
     uri: http://backend:5352/source/home:tom:Staging:A/target_package?comment&user=tom
@@ -2275,5 +2275,5 @@ http_interactions:
       string: '<status code="ok" />
 
 '
-  recorded_at: Thu, 21 Jul 2022 16:47:32 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:40 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Project/Staging_Project/_accept/when_the_staging_project_is_in_acceptable_state/staging_project_should_be_accepted/1_1_7_1_1_4.yml
+++ b/src/api/spec/cassettes/Project/Staging_Project/_accept/when_the_staging_project_is_in_acceptable_state/staging_project_should_be_accepted/1_1_7_1_1_4.yml
@@ -39,14 +39,14 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:23 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:42 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_51
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_63
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_19">
+        <workflow project="home:tom" managers="group_26">
           <staging_project name="home:tom:Staging:A"/>
         </workflow>
     headers:
@@ -68,28 +68,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="257">
-          <srcmd5>0158be7ff9287d1012ab1e250d38306d</srcmd5>
-          <time>1658422043</time>
-          <user>user_51</user>
+        <revision rev="59">
+          <srcmd5>f472b730ea06cc771fc8864e0967704b</srcmd5>
+          <time>1658762202</time>
+          <user>user_63</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:23 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:42 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_51
+    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_63
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_19" role="maintainer"/>
+          <group groupid="group_26" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -117,16 +117,16 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_19" role="maintainer"/>
+          <group groupid="group_26" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:23 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:42 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_51
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_63
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_19">
+        <workflow project="home:tom" managers="group_26">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -149,28 +149,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="258">
-          <srcmd5>dd6419dc39db4a141b5218ebf157c8bc</srcmd5>
-          <time>1658422043</time>
-          <user>user_51</user>
+        <revision rev="60">
+          <srcmd5>66ca9a1c412076cae43ea2451e893738</srcmd5>
+          <time>1658762202</time>
+          <user>user_63</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:23 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:42 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_51
+    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_63
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:B">
           <title/>
           <description/>
-          <group groupid="group_19" role="maintainer"/>
+          <group groupid="group_26" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -198,12 +198,12 @@ http_interactions:
         <project name="home:tom:Staging:B">
           <title></title>
           <description></description>
-          <group groupid="group_19" role="maintainer"/>
+          <group groupid="group_26" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:24 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:42 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_meta?user=user_51
+    uri: http://backend:5352/source/home:tom/_meta?user=user_63
     body:
       encoding: UTF-8
       string: |
@@ -211,7 +211,7 @@ http_interactions:
           <title/>
           <description/>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_19" role="reviewer"/>
+          <group groupid="group_26" role="reviewer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -240,18 +240,18 @@ http_interactions:
           <title></title>
           <description></description>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_19" role="reviewer"/>
+          <group groupid="group_26" role="reviewer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:24 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:42 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_52
+    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_64
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>The Stars' Tennis Balls</title>
-          <description>Voluptatum ut cupiditate ullam.</description>
+          <title>O Pioneers!</title>
+          <description>Delectus nulla saepe qui.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -272,21 +272,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '177'
+      - '159'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>The Stars' Tennis Balls</title>
-          <description>Voluptatum ut cupiditate ullam.</description>
+          <title>O Pioneers!</title>
+          <description>Delectus nulla saepe qui.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:24 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:42 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_config
     body:
       encoding: UTF-8
-      string: Molestiae ex amet. Iusto accusantium fugiat. Eius quia earum.
+      string: Eum maiores in. Amet quos qui. Esse dolores laborum.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -306,25 +306,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="129" vrev="129">
-          <srcmd5>c4a82b07a43c968a96164da7ff9045fd</srcmd5>
+        <revision rev="45" vrev="45">
+          <srcmd5>2445a90c89b93a0e8e1fb04910ca1766</srcmd5>
           <version>unknown</version>
-          <time>1658422044</time>
+          <time>1658762202</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:24 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:42 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/somefile.txt
     body:
       encoding: UTF-8
-      string: Perferendis esse optio. Unde necessitatibus quibusdam. Beatae et reprehenderit.
+      string: Officia esse libero. A fugiat modi. Earum quia totam.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -344,19 +344,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="130" vrev="130">
-          <srcmd5>3f6adc5a58d5b95b085f625dec02097f</srcmd5>
+        <revision rev="46" vrev="46">
+          <srcmd5>28c661d7b3ddb73dc80cceca2fbc375e</srcmd5>
           <version>unknown</version>
-          <time>1658422044</time>
+          <time>1658762202</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:24 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:43 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/_meta?user=tom
@@ -394,7 +394,7 @@ http_interactions:
           <title>Eyeless in Gaza</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:24 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:43 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package_2/_meta?user=tom
@@ -402,8 +402,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="target_project">
-          <title>That Good Night</title>
-          <description>Doloribus voluptatibus voluptate rerum.</description>
+          <title>A Scanner Darkly</title>
+          <description>Tenetur saepe ut sit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -424,15 +424,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '172'
+      - '155'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="target_project">
-          <title>That Good Night</title>
-          <description>Doloribus voluptatibus voluptate rerum.</description>
+          <title>A Scanner Darkly</title>
+          <description>Tenetur saepe ut sit.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:24 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:43 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_meta?user=tom
@@ -440,7 +440,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Infinite Jest</title>
+          <title>Specimen Days</title>
           <description/>
         </project>
     headers:
@@ -467,10 +467,10 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Infinite Jest</title>
+          <title>Specimen Days</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:24 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:43 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_project/_attribute?meta=1&user=tom
@@ -499,18 +499,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '166'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="130">
-          <srcmd5>4f7457935a88a6625d8cddd1155f7655</srcmd5>
-          <time>1658422044</time>
+        <revision rev="44">
+          <srcmd5>d8523d4c15ced44c620bd129fd142044</srcmd5>
+          <time>1658762203</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:24 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:43 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/source_package/_meta?user=tom
@@ -518,8 +518,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>The Way Through the Woods</title>
-          <description>Aut nisi sed est.</description>
+          <title>Fair Stood the Wind for France</title>
+          <description>Enim sit quas accusantium.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -540,15 +540,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '158'
+      - '172'
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>The Way Through the Woods</title>
-          <description>Aut nisi sed est.</description>
+          <title>Fair Stood the Wind for France</title>
+          <description>Enim sit quas accusantium.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:24 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:43 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package
@@ -580,7 +580,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:24 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:43 GMT
 - request:
     method: post
     uri: http://backend:5352/source/source_project/source_package?cmd=diff&expand=1&filelimit=10000&opackage=target_package_2&oproject=target_project&tarlimit=10000&view=xml&withissues=1
@@ -608,19 +608,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '331'
+      - '330'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="0c08609e1347f5523c30b1b64814e6ee">
-          <old project="target_project" package="target_package_2" rev="44" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+        <sourcediff key="bb3fbda2038200985c60a57f46ab5e71">
+          <old project="target_project" package="target_package_2" rev="4" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <new project="source_project" package="source_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files>
           </files>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:24 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:43 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22source_package%22%20and%20linkinfo/@project=%22source_project%22%20and%20@project=%22source_project%22)
@@ -654,7 +654,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 21 Jul 2022 16:47:24 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:43 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2/_meta?user=tom
@@ -662,8 +662,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>The Way Through the Woods</title>
-          <description>Aut nisi sed est.</description>
+          <title>Fair Stood the Wind for France</title>
+          <description>Enim sit quas accusantium.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -684,15 +684,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '164'
+      - '178'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>The Way Through the Woods</title>
-          <description>Aut nisi sed est.</description>
+          <title>Fair Stood the Wind for France</title>
+          <description>Enim sit quas accusantium.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:24 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:43 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?cmd=branch&noservice=1&opackage=source_package&oproject=source_project&user=tom
@@ -727,12 +727,12 @@ http_interactions:
         <revision rev="1" vrev="1">
           <srcmd5>8e451641a827df5f4f409d1d543fdb7b</srcmd5>
           <version>unknown</version>
-          <time>1658422044</time>
+          <time>1658762203</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:24 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:43 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2/_meta?user=tom
@@ -740,8 +740,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>The Way Through the Woods</title>
-          <description>Aut nisi sed est.</description>
+          <title>Fair Stood the Wind for France</title>
+          <description>Enim sit quas accusantium.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -762,15 +762,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '164'
+      - '178'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>The Way Through the Woods</title>
-          <description>Aut nisi sed est.</description>
+          <title>Fair Stood the Wind for France</title>
+          <description>Enim sit quas accusantium.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:24 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:43 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2
@@ -802,9 +802,9 @@ http_interactions:
       string: |
         <directory name="target_package_2" rev="1" vrev="1" srcmd5="8e451641a827df5f4f409d1d543fdb7b">
           <linkinfo project="source_project" package="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
-          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658419299"/>
+          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658762120"/>
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:24 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:43 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?view=info
@@ -838,7 +838,7 @@ http_interactions:
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="source_project" package="source_package"/>
         </sourceinfo>
-  recorded_at: Thu, 21 Jul 2022 16:47:24 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:43 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2
@@ -870,9 +870,9 @@ http_interactions:
       string: |
         <directory name="target_package_2" rev="1" vrev="1" srcmd5="8e451641a827df5f4f409d1d543fdb7b">
           <linkinfo project="source_project" package="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
-          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658419299"/>
+          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658762120"/>
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:24 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:43 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -911,7 +911,7 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:24 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:43 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -950,14 +950,14 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:24 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:43 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=tom
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_19">
+        <workflow project="home:tom" managers="group_26">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -980,18 +980,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '166'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="259">
-          <srcmd5>dd6419dc39db4a141b5218ebf157c8bc</srcmd5>
-          <time>1658422044</time>
+        <revision rev="61">
+          <srcmd5>66ca9a1c412076cae43ea2451e893738</srcmd5>
+          <time>1658762203</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:24 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:43 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=tom
@@ -1001,7 +1001,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_19" role="maintainer"/>
+          <group groupid="group_26" role="maintainer"/>
           <repository name="staging_repository">
             <arch>x86_64</arch>
           </repository>
@@ -1032,12 +1032,12 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_19" role="maintainer"/>
+          <group groupid="group_26" role="maintainer"/>
           <repository name="staging_repository">
             <arch>x86_64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:24 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:43 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package/_meta?user=tom
@@ -1045,8 +1045,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>The Wealth of Nations</title>
-          <description>Totam aspernatur et aut.</description>
+          <title>The Doors of Perception</title>
+          <description>Ratione sit ipsam qui.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1072,10 +1072,10 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>The Wealth of Nations</title>
-          <description>Totam aspernatur et aut.</description>
+          <title>The Doors of Perception</title>
+          <description>Ratione sit ipsam qui.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:24 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:43 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package
@@ -1107,7 +1107,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:24 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:43 GMT
 - request:
     method: post
     uri: http://backend:5352/source/source_project/source_package?cmd=diff&expand=1&filelimit=10000&opackage=target_package&oproject=target_project&tarlimit=10000&view=xml&withissues=1
@@ -1130,24 +1130,24 @@ http_interactions:
     headers:
       Content-Type:
       - text/xml
-      Content-Length:
-      - '329'
       Cache-Control:
       - no-cache
       Connection:
       - close
+      Content-Length:
+      - '328'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="f0ade37f19a7eee38b40dd0309766ea1">
-          <old project="target_project" package="target_package" rev="28" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+        <sourcediff key="ba3c52d930727cd52f6ff2e6843575f7">
+          <old project="target_project" package="target_package" rev="5" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <new project="source_project" package="source_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files>
           </files>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:24 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:43 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22source_package%22%20and%20linkinfo/@project=%22source_project%22%20and%20@project=%22source_project%22)
@@ -1181,7 +1181,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 21 Jul 2022 16:47:24 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:43 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/target_package/_meta?user=tom
@@ -1189,8 +1189,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="home:tom:Staging:A">
-          <title>The Way Through the Woods</title>
-          <description>Aut nisi sed est.</description>
+          <title>Fair Stood the Wind for France</title>
+          <description>Enim sit quas accusantium.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1211,15 +1211,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '162'
+      - '176'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="home:tom:Staging:A">
-          <title>The Way Through the Woods</title>
-          <description>Aut nisi sed est.</description>
+          <title>Fair Stood the Wind for France</title>
+          <description>Enim sit quas accusantium.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:24 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:43 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package?cmd=branch&noservice=1&opackage=source_package&oproject=source_project&user=tom
@@ -1254,12 +1254,12 @@ http_interactions:
         <revision rev="1" vrev="1">
           <srcmd5>8e451641a827df5f4f409d1d543fdb7b</srcmd5>
           <version>unknown</version>
-          <time>1658422044</time>
+          <time>1658762203</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:25 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:43 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/target_package/_meta?user=tom
@@ -1267,8 +1267,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="home:tom:Staging:A">
-          <title>The Way Through the Woods</title>
-          <description>Aut nisi sed est.</description>
+          <title>Fair Stood the Wind for France</title>
+          <description>Enim sit quas accusantium.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1289,15 +1289,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '162'
+      - '176'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="home:tom:Staging:A">
-          <title>The Way Through the Woods</title>
-          <description>Aut nisi sed est.</description>
+          <title>Fair Stood the Wind for France</title>
+          <description>Enim sit quas accusantium.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:25 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:43 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package
@@ -1329,9 +1329,9 @@ http_interactions:
       string: |
         <directory name="target_package" rev="1" vrev="1" srcmd5="8e451641a827df5f4f409d1d543fdb7b">
           <linkinfo project="source_project" package="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
-          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658419310"/>
+          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658490907"/>
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:25 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:43 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package?view=info
@@ -1365,7 +1365,7 @@ http_interactions:
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="source_project" package="source_package"/>
         </sourceinfo>
-  recorded_at: Thu, 21 Jul 2022 16:47:25 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:43 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package
@@ -1397,9 +1397,9 @@ http_interactions:
       string: |
         <directory name="target_package" rev="1" vrev="1" srcmd5="8e451641a827df5f4f409d1d543fdb7b">
           <linkinfo project="source_project" package="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
-          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658419310"/>
+          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658490907"/>
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:25 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:43 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -1438,7 +1438,7 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:25 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:43 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -1477,14 +1477,14 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:25 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:43 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=tom
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_19">
+        <workflow project="home:tom" managers="group_26">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -1507,18 +1507,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '166'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="260">
-          <srcmd5>dd6419dc39db4a141b5218ebf157c8bc</srcmd5>
-          <time>1658422045</time>
+        <revision rev="62">
+          <srcmd5>66ca9a1c412076cae43ea2451e893738</srcmd5>
+          <time>1658762203</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:25 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:43 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=tom
@@ -1528,7 +1528,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_19" role="maintainer"/>
+          <group groupid="group_26" role="maintainer"/>
           <repository name="staging_repository">
             <arch>x86_64</arch>
           </repository>
@@ -1559,19 +1559,19 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_19" role="maintainer"/>
+          <group groupid="group_26" role="maintainer"/>
           <repository name="staging_repository">
             <arch>x86_64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:25 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:43 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_51
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_63
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_19">
+        <workflow project="home:tom" managers="group_26">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -1594,18 +1594,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="261">
-          <srcmd5>dd6419dc39db4a141b5218ebf157c8bc</srcmd5>
-          <time>1658422045</time>
-          <user>user_51</user>
+        <revision rev="63">
+          <srcmd5>66ca9a1c412076cae43ea2451e893738</srcmd5>
+          <time>1658762204</time>
+          <user>user_63</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:25 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:44 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=tom
@@ -1615,7 +1615,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_19" role="maintainer"/>
+          <group groupid="group_26" role="maintainer"/>
           <build>
             <disable/>
           </build>
@@ -1649,7 +1649,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_19" role="maintainer"/>
+          <group groupid="group_26" role="maintainer"/>
           <build>
             <disable/>
           </build>
@@ -1657,7 +1657,7 @@ http_interactions:
             <arch>x86_64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:25 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:44 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package?expand=1
@@ -1689,7 +1689,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:25 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:44 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package?expand=1
@@ -1721,7 +1721,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:25 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:44 GMT
 - request:
     method: post
     uri: http://backend:5352/source/target_project/target_package_2?cmd=copy&comment=Request%20for%20package%20target_package_2&expand=1&keeplink=1&noservice=1&opackage=source_package&oproject=source_project&requestid=1&user=tom&withacceptinfo=1
@@ -1749,20 +1749,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '363'
+      - '360'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="45" vrev="45">
+        <revision rev="5" vrev="5">
           <srcmd5>d41d8cd98f00b204e9800998ecf8427e</srcmd5>
           <version>unknown</version>
-          <time>1658422045</time>
+          <time>1658762204</time>
           <user>tom</user>
           <comment>Request for package target_package_2</comment>
           <requestid>1</requestid>
-          <acceptinfo rev="45" srcmd5="d41d8cd98f00b204e9800998ecf8427e" osrcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <acceptinfo rev="5" srcmd5="d41d8cd98f00b204e9800998ecf8427e" osrcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:25 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:44 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package_2/_meta?user=tom
@@ -1770,8 +1770,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="target_project">
-          <title>That Good Night</title>
-          <description>Doloribus voluptatibus voluptate rerum.</description>
+          <title>A Scanner Darkly</title>
+          <description>Tenetur saepe ut sit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1792,15 +1792,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '172'
+      - '155'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="target_project">
-          <title>That Good Night</title>
-          <description>Doloribus voluptatibus voluptate rerum.</description>
+          <title>A Scanner Darkly</title>
+          <description>Tenetur saepe ut sit.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:25 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:44 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package_2
@@ -1826,13 +1826,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '110'
+      - '108'
     body:
       encoding: UTF-8
       string: |
-        <directory name="target_package_2" rev="45" vrev="45" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <directory name="target_package_2" rev="5" vrev="5" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:25 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:44 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package_2?view=info
@@ -1858,14 +1858,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '151'
+      - '149'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="target_package_2" rev="45" vrev="45" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <sourceinfo package="target_package_2" rev="5" vrev="5" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
           <error>no source uploaded</error>
         </sourceinfo>
-  recorded_at: Thu, 21 Jul 2022 16:47:25 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:44 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package_2
@@ -1891,13 +1891,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '110'
+      - '108'
     body:
       encoding: UTF-8
       string: |
-        <directory name="target_package_2" rev="45" vrev="45" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <directory name="target_package_2" rev="5" vrev="5" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:25 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:44 GMT
 - request:
     method: post
     uri: http://backend:5352/source/target_project/target_package_2?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -1925,16 +1925,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '300'
+      - '299'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="0f156e61d6ce5c89dee3fa6cef4b01bf">
+        <sourcediff key="996713bb68e79d1409ec4b3e5b9d431b">
           <old project="target_project" package="target_package_2" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="target_project" package="target_package_2" rev="45" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="target_project" package="target_package_2" rev="5" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files/>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:25 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:44 GMT
 - request:
     method: delete
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?comment&user=tom
@@ -1966,7 +1966,7 @@ http_interactions:
       string: '<status code="ok" />
 
 '
-  recorded_at: Thu, 21 Jul 2022 16:47:25 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:44 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package?expand=1
@@ -1998,7 +1998,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:25 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:44 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package?expand=1
@@ -2030,7 +2030,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:25 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:44 GMT
 - request:
     method: post
     uri: http://backend:5352/source/target_project/target_package?cmd=copy&comment=Request%20for%20package%20target_package&expand=1&keeplink=1&noservice=1&opackage=source_package&oproject=source_project&requestid=2&user=tom&withacceptinfo=1
@@ -2058,20 +2058,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '361'
+      - '358'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="29" vrev="29">
+        <revision rev="6" vrev="6">
           <srcmd5>d41d8cd98f00b204e9800998ecf8427e</srcmd5>
           <version>unknown</version>
-          <time>1658422045</time>
+          <time>1658762204</time>
           <user>tom</user>
           <comment>Request for package target_package</comment>
           <requestid>2</requestid>
-          <acceptinfo rev="29" srcmd5="d41d8cd98f00b204e9800998ecf8427e" osrcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <acceptinfo rev="6" srcmd5="d41d8cd98f00b204e9800998ecf8427e" osrcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:25 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:44 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package/_meta?user=tom
@@ -2079,8 +2079,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>The Wealth of Nations</title>
-          <description>Totam aspernatur et aut.</description>
+          <title>The Doors of Perception</title>
+          <description>Ratione sit ipsam qui.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -2106,10 +2106,10 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>The Wealth of Nations</title>
-          <description>Totam aspernatur et aut.</description>
+          <title>The Doors of Perception</title>
+          <description>Ratione sit ipsam qui.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:25 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:44 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package
@@ -2135,13 +2135,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '108'
+      - '106'
     body:
       encoding: UTF-8
       string: |
-        <directory name="target_package" rev="29" vrev="29" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <directory name="target_package" rev="6" vrev="6" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:25 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:44 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package?view=info
@@ -2167,14 +2167,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '149'
+      - '147'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="target_package" rev="29" vrev="29" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <sourceinfo package="target_package" rev="6" vrev="6" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
           <error>no source uploaded</error>
         </sourceinfo>
-  recorded_at: Thu, 21 Jul 2022 16:47:25 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:44 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package
@@ -2200,13 +2200,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '108'
+      - '106'
     body:
       encoding: UTF-8
       string: |
-        <directory name="target_package" rev="29" vrev="29" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <directory name="target_package" rev="6" vrev="6" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:25 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:44 GMT
 - request:
     method: post
     uri: http://backend:5352/source/target_project/target_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -2234,16 +2234,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '296'
+      - '295'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="87ec12ee56d1da71ba1cf117e6c21352">
+        <sourcediff key="d7e348a6d4af2552ac06382cc1d5ec45">
           <old project="target_project" package="target_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="target_project" package="target_package" rev="29" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="target_project" package="target_package" rev="6" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files/>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:25 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:44 GMT
 - request:
     method: delete
     uri: http://backend:5352/source/home:tom:Staging:A/target_package?comment&user=tom
@@ -2275,5 +2275,5 @@ http_interactions:
       string: '<status code="ok" />
 
 '
-  recorded_at: Thu, 21 Jul 2022 16:47:25 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:44 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Project/Staging_Project/_accept/when_the_staging_project_is_in_acceptable_state/staging_project_should_be_accepted/1_1_7_1_1_5.yml
+++ b/src/api/spec/cassettes/Project/Staging_Project/_accept/when_the_staging_project_is_in_acceptable_state/staging_project_should_be_accepted/1_1_7_1_1_5.yml
@@ -39,14 +39,14 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:32 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:40 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_59
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_61
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_23">
+        <workflow project="home:tom" managers="group_25">
           <staging_project name="home:tom:Staging:A"/>
         </workflow>
     headers:
@@ -68,28 +68,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="277">
-          <srcmd5>0ff1578d6f49d4d4d3b3b784f5bbfdd7</srcmd5>
-          <time>1658422052</time>
-          <user>user_59</user>
+        <revision rev="54">
+          <srcmd5>265f95387ce128dadc92b57f6247935d</srcmd5>
+          <time>1658762200</time>
+          <user>user_61</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:32 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:40 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_59
+    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_61
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_23" role="maintainer"/>
+          <group groupid="group_25" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -117,16 +117,16 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_23" role="maintainer"/>
+          <group groupid="group_25" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:32 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:40 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_59
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_61
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_23">
+        <workflow project="home:tom" managers="group_25">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -149,28 +149,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="278">
-          <srcmd5>6bf67b537ff325279c5ed00a43e87a94</srcmd5>
-          <time>1658422052</time>
-          <user>user_59</user>
+        <revision rev="55">
+          <srcmd5>a53eb95f49c1fee041f0168343a2ff33</srcmd5>
+          <time>1658762200</time>
+          <user>user_61</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:32 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:40 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_59
+    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_61
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:B">
           <title/>
           <description/>
-          <group groupid="group_23" role="maintainer"/>
+          <group groupid="group_25" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -198,12 +198,12 @@ http_interactions:
         <project name="home:tom:Staging:B">
           <title></title>
           <description></description>
-          <group groupid="group_23" role="maintainer"/>
+          <group groupid="group_25" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:32 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:40 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_meta?user=user_59
+    uri: http://backend:5352/source/home:tom/_meta?user=user_61
     body:
       encoding: UTF-8
       string: |
@@ -211,7 +211,7 @@ http_interactions:
           <title/>
           <description/>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_23" role="reviewer"/>
+          <group groupid="group_25" role="reviewer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -240,18 +240,18 @@ http_interactions:
           <title></title>
           <description></description>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_23" role="reviewer"/>
+          <group groupid="group_25" role="reviewer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:32 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:40 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_60
+    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_62
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>A Catskill Eagle</title>
-          <description>Consequuntur ab quaerat mollitia.</description>
+          <title>The Moving Toyshop</title>
+          <description>Quis ut adipisci necessitatibus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -272,21 +272,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '172'
+      - '173'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>A Catskill Eagle</title>
-          <description>Consequuntur ab quaerat mollitia.</description>
+          <title>The Moving Toyshop</title>
+          <description>Quis ut adipisci necessitatibus.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:32 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:40 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_config
     body:
       encoding: UTF-8
-      string: Saepe quibusdam accusamus. Deserunt labore id. Rem non in.
+      string: Inventore perferendis dicta. Blanditiis molestiae tempore. Ut et molestiae.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -306,25 +306,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="137" vrev="137">
-          <srcmd5>1159d0690f1df9af9e4df6d46c636541</srcmd5>
+        <revision rev="43" vrev="43">
+          <srcmd5>145d3f723696990554c344aa414bf3c7</srcmd5>
           <version>unknown</version>
-          <time>1658422052</time>
+          <time>1658762200</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:32 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:40 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/somefile.txt
     body:
       encoding: UTF-8
-      string: Ut culpa temporibus. Fugit sint earum. Sed qui aliquam.
+      string: Quibusdam eos molestiae. Sit fugiat veniam. Est alias rem.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -344,19 +344,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="138" vrev="138">
-          <srcmd5>18a664f2b6adf71aa138bc12c93576b1</srcmd5>
+        <revision rev="44" vrev="44">
+          <srcmd5>5fc6d5de08d81d2e49bcbf1172059252</srcmd5>
           <version>unknown</version>
-          <time>1658422052</time>
+          <time>1658762200</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:32 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:40 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/_meta?user=tom
@@ -364,7 +364,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>The Cricket on the Hearth</title>
+          <title>Of Mice and Men</title>
           <description/>
         </project>
     headers:
@@ -386,15 +386,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '116'
+      - '106'
     body:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>The Cricket on the Hearth</title>
+          <title>Of Mice and Men</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:32 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:40 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package_2/_meta?user=tom
@@ -402,8 +402,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="target_project">
-          <title>Wildfire at Midnight</title>
-          <description>Dolore ea quia accusantium.</description>
+          <title>Stranger in a Strange Land</title>
+          <description>Aut ut sit ducimus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -424,15 +424,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '165'
+      - '163'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="target_project">
-          <title>Wildfire at Midnight</title>
-          <description>Dolore ea quia accusantium.</description>
+          <title>Stranger in a Strange Land</title>
+          <description>Aut ut sit ducimus.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:32 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:40 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_meta?user=tom
@@ -440,7 +440,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>The Skull Beneath the Skin</title>
+          <title>The Moon by Night</title>
           <description/>
         </project>
     headers:
@@ -462,15 +462,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '117'
+      - '108'
     body:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>The Skull Beneath the Skin</title>
+          <title>The Moon by Night</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:32 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:40 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_project/_attribute?meta=1&user=tom
@@ -499,18 +499,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '166'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="138">
-          <srcmd5>edb75f38f012b08609b1ff7ebef360d9</srcmd5>
-          <time>1658422052</time>
+        <revision rev="42">
+          <srcmd5>6688d5ce2de5e1ad9dfcf4dd81602c66</srcmd5>
+          <time>1658762200</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:32 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:40 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/source_package/_meta?user=tom
@@ -518,8 +518,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>Wildfire at Midnight</title>
-          <description>Hic minus commodi est.</description>
+          <title>Carrion Comfort</title>
+          <description>Amet in ab possimus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -540,15 +540,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '158'
+      - '151'
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>Wildfire at Midnight</title>
-          <description>Hic minus commodi est.</description>
+          <title>Carrion Comfort</title>
+          <description>Amet in ab possimus.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:32 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:40 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package
@@ -580,7 +580,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:32 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:41 GMT
 - request:
     method: post
     uri: http://backend:5352/source/source_project/source_package?cmd=diff&expand=1&filelimit=10000&opackage=target_package_2&oproject=target_project&tarlimit=10000&view=xml&withissues=1
@@ -608,19 +608,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '331'
+      - '330'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="749da541036a6c3ac942022781ffbdc1">
-          <old project="target_project" package="target_package_2" rev="48" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+        <sourcediff key="5075e62412b3317ec9d84dbba0bd4038">
+          <old project="target_project" package="target_package_2" rev="3" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <new project="source_project" package="source_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files>
           </files>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:32 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:41 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22source_package%22%20and%20linkinfo/@project=%22source_project%22%20and%20@project=%22source_project%22)
@@ -654,7 +654,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 21 Jul 2022 16:47:32 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:41 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2/_meta?user=tom
@@ -662,8 +662,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>Wildfire at Midnight</title>
-          <description>Hic minus commodi est.</description>
+          <title>Carrion Comfort</title>
+          <description>Amet in ab possimus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -684,15 +684,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '164'
+      - '157'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>Wildfire at Midnight</title>
-          <description>Hic minus commodi est.</description>
+          <title>Carrion Comfort</title>
+          <description>Amet in ab possimus.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:32 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:41 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?cmd=branch&noservice=1&opackage=source_package&oproject=source_project&user=tom
@@ -727,12 +727,12 @@ http_interactions:
         <revision rev="1" vrev="1">
           <srcmd5>8e451641a827df5f4f409d1d543fdb7b</srcmd5>
           <version>unknown</version>
-          <time>1658422052</time>
+          <time>1658762201</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:32 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:41 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2/_meta?user=tom
@@ -740,8 +740,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>Wildfire at Midnight</title>
-          <description>Hic minus commodi est.</description>
+          <title>Carrion Comfort</title>
+          <description>Amet in ab possimus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -762,15 +762,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '164'
+      - '157'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>Wildfire at Midnight</title>
-          <description>Hic minus commodi est.</description>
+          <title>Carrion Comfort</title>
+          <description>Amet in ab possimus.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:32 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:41 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2
@@ -802,9 +802,9 @@ http_interactions:
       string: |
         <directory name="target_package_2" rev="1" vrev="1" srcmd5="8e451641a827df5f4f409d1d543fdb7b">
           <linkinfo project="source_project" package="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
-          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658419299"/>
+          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658762120"/>
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:32 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:41 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?view=info
@@ -838,7 +838,7 @@ http_interactions:
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="source_project" package="source_package"/>
         </sourceinfo>
-  recorded_at: Thu, 21 Jul 2022 16:47:32 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:41 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2
@@ -870,9 +870,9 @@ http_interactions:
       string: |
         <directory name="target_package_2" rev="1" vrev="1" srcmd5="8e451641a827df5f4f409d1d543fdb7b">
           <linkinfo project="source_project" package="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
-          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658419299"/>
+          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658762120"/>
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:32 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:41 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -911,7 +911,7 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:32 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:41 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -950,14 +950,14 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:32 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:41 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=tom
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_23">
+        <workflow project="home:tom" managers="group_25">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -980,18 +980,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '166'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="279">
-          <srcmd5>6bf67b537ff325279c5ed00a43e87a94</srcmd5>
-          <time>1658422052</time>
+        <revision rev="56">
+          <srcmd5>a53eb95f49c1fee041f0168343a2ff33</srcmd5>
+          <time>1658762201</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:32 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:41 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=tom
@@ -1001,7 +1001,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_23" role="maintainer"/>
+          <group groupid="group_25" role="maintainer"/>
           <repository name="staging_repository">
             <arch>x86_64</arch>
           </repository>
@@ -1032,12 +1032,12 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_23" role="maintainer"/>
+          <group groupid="group_25" role="maintainer"/>
           <repository name="staging_repository">
             <arch>x86_64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:32 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:41 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package/_meta?user=tom
@@ -1045,8 +1045,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>The Green Bay Tree</title>
-          <description>Voluptas architecto consectetur quo.</description>
+          <title>O Pioneers!</title>
+          <description>Quidem numquam officiis reiciendis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1067,15 +1067,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '170'
+      - '162'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>The Green Bay Tree</title>
-          <description>Voluptas architecto consectetur quo.</description>
+          <title>O Pioneers!</title>
+          <description>Quidem numquam officiis reiciendis.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:33 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:41 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package
@@ -1107,7 +1107,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:33 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:41 GMT
 - request:
     method: post
     uri: http://backend:5352/source/source_project/source_package?cmd=diff&expand=1&filelimit=10000&opackage=target_package&oproject=target_project&tarlimit=10000&view=xml&withissues=1
@@ -1135,19 +1135,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '329'
+      - '328'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="cececee5347cc5df16c3cb7bb1db2e55">
-          <old project="target_project" package="target_package" rev="32" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+        <sourcediff key="2fa4a76be6f30ddb86232ac15304c986">
+          <old project="target_project" package="target_package" rev="4" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <new project="source_project" package="source_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files>
           </files>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:33 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:41 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22source_package%22%20and%20linkinfo/@project=%22source_project%22%20and%20@project=%22source_project%22)
@@ -1181,7 +1181,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 21 Jul 2022 16:47:33 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:41 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/target_package/_meta?user=tom
@@ -1189,8 +1189,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="home:tom:Staging:A">
-          <title>Wildfire at Midnight</title>
-          <description>Hic minus commodi est.</description>
+          <title>Carrion Comfort</title>
+          <description>Amet in ab possimus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1211,15 +1211,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '162'
+      - '155'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="home:tom:Staging:A">
-          <title>Wildfire at Midnight</title>
-          <description>Hic minus commodi est.</description>
+          <title>Carrion Comfort</title>
+          <description>Amet in ab possimus.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:33 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:41 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package?cmd=branch&noservice=1&opackage=source_package&oproject=source_project&user=tom
@@ -1254,12 +1254,12 @@ http_interactions:
         <revision rev="1" vrev="1">
           <srcmd5>8e451641a827df5f4f409d1d543fdb7b</srcmd5>
           <version>unknown</version>
-          <time>1658422053</time>
+          <time>1658762201</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:33 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:41 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/target_package/_meta?user=tom
@@ -1267,8 +1267,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="home:tom:Staging:A">
-          <title>Wildfire at Midnight</title>
-          <description>Hic minus commodi est.</description>
+          <title>Carrion Comfort</title>
+          <description>Amet in ab possimus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1289,15 +1289,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '162'
+      - '155'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="home:tom:Staging:A">
-          <title>Wildfire at Midnight</title>
-          <description>Hic minus commodi est.</description>
+          <title>Carrion Comfort</title>
+          <description>Amet in ab possimus.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:33 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:41 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package
@@ -1329,9 +1329,9 @@ http_interactions:
       string: |
         <directory name="target_package" rev="1" vrev="1" srcmd5="8e451641a827df5f4f409d1d543fdb7b">
           <linkinfo project="source_project" package="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
-          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658419310"/>
+          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658490907"/>
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:33 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:41 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package?view=info
@@ -1365,7 +1365,7 @@ http_interactions:
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="source_project" package="source_package"/>
         </sourceinfo>
-  recorded_at: Thu, 21 Jul 2022 16:47:33 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:41 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package
@@ -1397,9 +1397,9 @@ http_interactions:
       string: |
         <directory name="target_package" rev="1" vrev="1" srcmd5="8e451641a827df5f4f409d1d543fdb7b">
           <linkinfo project="source_project" package="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
-          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658419310"/>
+          <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658490907"/>
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:33 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:41 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -1438,7 +1438,7 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:33 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:41 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -1477,14 +1477,14 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:33 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:41 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=tom
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_23">
+        <workflow project="home:tom" managers="group_25">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -1507,18 +1507,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '166'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="280">
-          <srcmd5>6bf67b537ff325279c5ed00a43e87a94</srcmd5>
-          <time>1658422053</time>
+        <revision rev="57">
+          <srcmd5>a53eb95f49c1fee041f0168343a2ff33</srcmd5>
+          <time>1658762201</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:33 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:41 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=tom
@@ -1528,7 +1528,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_23" role="maintainer"/>
+          <group groupid="group_25" role="maintainer"/>
           <repository name="staging_repository">
             <arch>x86_64</arch>
           </repository>
@@ -1559,19 +1559,19 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_23" role="maintainer"/>
+          <group groupid="group_25" role="maintainer"/>
           <repository name="staging_repository">
             <arch>x86_64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:33 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:41 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_59
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_61
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_23">
+        <workflow project="home:tom" managers="group_25">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -1594,18 +1594,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="281">
-          <srcmd5>6bf67b537ff325279c5ed00a43e87a94</srcmd5>
-          <time>1658422053</time>
-          <user>user_59</user>
+        <revision rev="58">
+          <srcmd5>a53eb95f49c1fee041f0168343a2ff33</srcmd5>
+          <time>1658762201</time>
+          <user>user_61</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:33 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:41 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=tom
@@ -1615,7 +1615,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_23" role="maintainer"/>
+          <group groupid="group_25" role="maintainer"/>
           <build>
             <disable/>
           </build>
@@ -1649,7 +1649,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_23" role="maintainer"/>
+          <group groupid="group_25" role="maintainer"/>
           <build>
             <disable/>
           </build>
@@ -1657,7 +1657,7 @@ http_interactions:
             <arch>x86_64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:33 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:41 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package?expand=1
@@ -1689,7 +1689,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:33 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:42 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package?expand=1
@@ -1721,7 +1721,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:33 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:42 GMT
 - request:
     method: post
     uri: http://backend:5352/source/target_project/target_package_2?cmd=copy&comment=Request%20for%20package%20target_package_2&expand=1&keeplink=1&noservice=1&opackage=source_package&oproject=source_project&requestid=1&user=tom&withacceptinfo=1
@@ -1749,20 +1749,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '363'
+      - '360'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="49" vrev="49">
+        <revision rev="4" vrev="4">
           <srcmd5>d41d8cd98f00b204e9800998ecf8427e</srcmd5>
           <version>unknown</version>
-          <time>1658422053</time>
+          <time>1658762202</time>
           <user>tom</user>
           <comment>Request for package target_package_2</comment>
           <requestid>1</requestid>
-          <acceptinfo rev="49" srcmd5="d41d8cd98f00b204e9800998ecf8427e" osrcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <acceptinfo rev="4" srcmd5="d41d8cd98f00b204e9800998ecf8427e" osrcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:33 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:42 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package_2/_meta?user=tom
@@ -1770,8 +1770,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="target_project">
-          <title>Wildfire at Midnight</title>
-          <description>Dolore ea quia accusantium.</description>
+          <title>Stranger in a Strange Land</title>
+          <description>Aut ut sit ducimus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1792,15 +1792,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '165'
+      - '163'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="target_project">
-          <title>Wildfire at Midnight</title>
-          <description>Dolore ea quia accusantium.</description>
+          <title>Stranger in a Strange Land</title>
+          <description>Aut ut sit ducimus.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:33 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:42 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package_2
@@ -1826,13 +1826,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '110'
+      - '108'
     body:
       encoding: UTF-8
       string: |
-        <directory name="target_package_2" rev="49" vrev="49" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <directory name="target_package_2" rev="4" vrev="4" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:33 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:42 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package_2?view=info
@@ -1858,14 +1858,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '151'
+      - '149'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="target_package_2" rev="49" vrev="49" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <sourceinfo package="target_package_2" rev="4" vrev="4" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
           <error>no source uploaded</error>
         </sourceinfo>
-  recorded_at: Thu, 21 Jul 2022 16:47:33 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:42 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package_2
@@ -1891,13 +1891,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '110'
+      - '108'
     body:
       encoding: UTF-8
       string: |
-        <directory name="target_package_2" rev="49" vrev="49" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <directory name="target_package_2" rev="4" vrev="4" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:33 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:42 GMT
 - request:
     method: post
     uri: http://backend:5352/source/target_project/target_package_2?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -1925,16 +1925,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '300'
+      - '299'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="cad4dd154fe59e6559cc7e171a7e62fd">
+        <sourcediff key="23f93726f1df0496da03d4a764d3901f">
           <old project="target_project" package="target_package_2" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="target_project" package="target_package_2" rev="49" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="target_project" package="target_package_2" rev="4" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files/>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:33 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:42 GMT
 - request:
     method: delete
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?comment&user=tom
@@ -1966,7 +1966,7 @@ http_interactions:
       string: '<status code="ok" />
 
 '
-  recorded_at: Thu, 21 Jul 2022 16:47:34 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:42 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package?expand=1
@@ -1998,7 +1998,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:34 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:42 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package?expand=1
@@ -2030,7 +2030,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:34 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:42 GMT
 - request:
     method: post
     uri: http://backend:5352/source/target_project/target_package?cmd=copy&comment=Request%20for%20package%20target_package&expand=1&keeplink=1&noservice=1&opackage=source_package&oproject=source_project&requestid=2&user=tom&withacceptinfo=1
@@ -2058,20 +2058,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '361'
+      - '358'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="33" vrev="33">
+        <revision rev="5" vrev="5">
           <srcmd5>d41d8cd98f00b204e9800998ecf8427e</srcmd5>
           <version>unknown</version>
-          <time>1658422054</time>
+          <time>1658762202</time>
           <user>tom</user>
           <comment>Request for package target_package</comment>
           <requestid>2</requestid>
-          <acceptinfo rev="33" srcmd5="d41d8cd98f00b204e9800998ecf8427e" osrcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <acceptinfo rev="5" srcmd5="d41d8cd98f00b204e9800998ecf8427e" osrcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:34 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:42 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package/_meta?user=tom
@@ -2079,8 +2079,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>The Green Bay Tree</title>
-          <description>Voluptas architecto consectetur quo.</description>
+          <title>O Pioneers!</title>
+          <description>Quidem numquam officiis reiciendis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -2101,15 +2101,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '170'
+      - '162'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>The Green Bay Tree</title>
-          <description>Voluptas architecto consectetur quo.</description>
+          <title>O Pioneers!</title>
+          <description>Quidem numquam officiis reiciendis.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:34 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:42 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package
@@ -2135,13 +2135,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '108'
+      - '106'
     body:
       encoding: UTF-8
       string: |
-        <directory name="target_package" rev="33" vrev="33" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <directory name="target_package" rev="5" vrev="5" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:34 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:42 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package?view=info
@@ -2167,14 +2167,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '149'
+      - '147'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="target_package" rev="33" vrev="33" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <sourceinfo package="target_package" rev="5" vrev="5" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
           <error>no source uploaded</error>
         </sourceinfo>
-  recorded_at: Thu, 21 Jul 2022 16:47:34 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:42 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package
@@ -2200,13 +2200,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '108'
+      - '106'
     body:
       encoding: UTF-8
       string: |
-        <directory name="target_package" rev="33" vrev="33" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <directory name="target_package" rev="5" vrev="5" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:34 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:42 GMT
 - request:
     method: post
     uri: http://backend:5352/source/target_project/target_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -2234,16 +2234,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '296'
+      - '295'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="facf8c76e51d9f9d994c58c916b3f688">
+        <sourcediff key="df7b2feed5b756a2c22fc6e3615d0b67">
           <old project="target_project" package="target_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="target_project" package="target_package" rev="33" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="target_project" package="target_package" rev="5" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files/>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:34 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:42 GMT
 - request:
     method: delete
     uri: http://backend:5352/source/home:tom:Staging:A/target_package?comment&user=tom
@@ -2275,5 +2275,5 @@ http_interactions:
       string: '<status code="ok" />
 
 '
-  recorded_at: Thu, 21 Jul 2022 16:47:34 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:42 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Project/Staging_Project/_accept/when_the_staging_project_is_using_pre-approved_requests/staged_requests_should_be_accepted_by_approver/1_1_7_4_1_1.yml
+++ b/src/api/spec/cassettes/Project/Staging_Project/_accept/when_the_staging_project_is_using_pre-approved_requests/staged_requests_should_be_accepted_by_approver/1_1_7_4_1_1.yml
@@ -39,14 +39,14 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:49 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_83
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_69
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_36">
+        <workflow project="home:tom" managers="group_29">
           <staging_project name="home:tom:Staging:A"/>
         </workflow>
     headers:
@@ -68,28 +68,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="103">
-          <srcmd5>b2986a92cbef7d6cfa4b5c41cfaeaba0</srcmd5>
-          <time>1658762219</time>
-          <user>user_83</user>
+        <revision rev="74">
+          <srcmd5>2ca2b0d9b433bd3073e8911bb20511df</srcmd5>
+          <time>1658762209</time>
+          <user>user_69</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:49 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_83
+    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_69
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_29" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -117,16 +117,16 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_29" role="maintainer"/>
         </project>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:49 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_83
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_69
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_36">
+        <workflow project="home:tom" managers="group_29">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -149,28 +149,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="104">
-          <srcmd5>d3dc403b3bbd9c1401b638e11d486c21</srcmd5>
-          <time>1658762219</time>
-          <user>user_83</user>
+        <revision rev="75">
+          <srcmd5>ab3d588934c4da97d06949614800b96a</srcmd5>
+          <time>1658762209</time>
+          <user>user_69</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:49 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_83
+    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_69
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:B">
           <title/>
           <description/>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_29" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -198,12 +198,12 @@ http_interactions:
         <project name="home:tom:Staging:B">
           <title></title>
           <description></description>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_29" role="maintainer"/>
         </project>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:49 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_meta?user=user_83
+    uri: http://backend:5352/source/home:tom/_meta?user=user_69
     body:
       encoding: UTF-8
       string: |
@@ -211,7 +211,7 @@ http_interactions:
           <title/>
           <description/>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_36" role="reviewer"/>
+          <group groupid="group_29" role="reviewer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -240,18 +240,18 @@ http_interactions:
           <title></title>
           <description></description>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_36" role="reviewer"/>
+          <group groupid="group_29" role="reviewer"/>
         </project>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:49 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_84
+    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_70
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>The Waste Land</title>
-          <description>Aliquam adipisci velit asperiores.</description>
+          <title>Have His Carcase</title>
+          <description>Dolores alias minus veritatis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -272,21 +272,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '169'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>The Waste Land</title>
-          <description>Aliquam adipisci velit asperiores.</description>
+          <title>Have His Carcase</title>
+          <description>Dolores alias minus veritatis.</description>
         </package>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_config
     body:
       encoding: UTF-8
-      string: Maxime omnis possimus. Odit qui consequatur. Qui quis vitae.
+      string: Sed possimus neque. Consequatur optio occaecati. Illo quaerat qui.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -310,21 +310,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="65" vrev="65">
-          <srcmd5>67f21c7ddab0e207e94e032f6732e1d4</srcmd5>
+        <revision rev="51" vrev="51">
+          <srcmd5>7ff31e1f2671db96c6313fc1dc83617e</srcmd5>
           <version>unknown</version>
-          <time>1658762219</time>
+          <time>1658762209</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/somefile.txt
     body:
       encoding: UTF-8
-      string: Voluptatum est nihil. Distinctio accusamus sint. Accusantium enim id.
+      string: Rerum consequatur nihil. Sunt dolore a. Nam dolor tempore.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -348,15 +348,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="66" vrev="66">
-          <srcmd5>2a22e138fc0ef9d6981816e3997ba427</srcmd5>
+        <revision rev="52" vrev="52">
+          <srcmd5>758b16bcd89072d7766c06f447eec36d</srcmd5>
           <version>unknown</version>
-          <time>1658762219</time>
+          <time>1658762209</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/_meta?user=tom
@@ -364,7 +364,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>The Mermaids Singing</title>
+          <title>Ring of Bright Water</title>
           <description/>
         </project>
     headers:
@@ -391,10 +391,10 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>The Mermaids Singing</title>
+          <title>Ring of Bright Water</title>
           <description></description>
         </project>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package_2/_meta?user=tom
@@ -402,8 +402,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="target_project">
-          <title>The Sun Also Rises</title>
-          <description>Odit debitis sit excepturi.</description>
+          <title>The Torment of Others</title>
+          <description>Qui molestias enim nisi.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -429,10 +429,10 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="target_project">
-          <title>The Sun Also Rises</title>
-          <description>Odit debitis sit excepturi.</description>
+          <title>The Torment of Others</title>
+          <description>Qui molestias enim nisi.</description>
         </package>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_meta?user=tom
@@ -440,7 +440,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Many Waters</title>
+          <title>The Monkey's Raincoat</title>
           <description/>
         </project>
     headers:
@@ -462,15 +462,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '102'
+      - '112'
     body:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Many Waters</title>
+          <title>The Monkey's Raincoat</title>
           <description></description>
         </project>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_project/_attribute?meta=1&user=tom
@@ -503,14 +503,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="64">
-          <srcmd5>b3df56152978fa66e2e250b475619d6d</srcmd5>
-          <time>1658762219</time>
+        <revision rev="50">
+          <srcmd5>97bc06985a5bad8a7a386d381ebca646</srcmd5>
+          <time>1658762209</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/source_package/_meta?user=tom
@@ -518,8 +518,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>Death Be Not Proud</title>
-          <description>Recusandae provident earum ex.</description>
+          <title>A Confederacy of Dunces</title>
+          <description>Et maxime optio quia.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -540,15 +540,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '164'
+      - '160'
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>Death Be Not Proud</title>
-          <description>Recusandae provident earum ex.</description>
+          <title>A Confederacy of Dunces</title>
+          <description>Et maxime optio quia.</description>
         </package>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:49 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package
@@ -580,7 +580,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:49 GMT
 - request:
     method: post
     uri: http://backend:5352/source/source_project/source_package?cmd=diff&expand=1&filelimit=10000&opackage=target_package_2&oproject=target_project&tarlimit=10000&view=xml&withissues=1
@@ -608,19 +608,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '331'
+      - '330'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="34e57069b586e7ab724b16f19bcd0dcb">
-          <old project="target_project" package="target_package_2" rev="14" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+        <sourcediff key="e558857a2c1966d9439afa345f818bfc">
+          <old project="target_project" package="target_package_2" rev="7" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <new project="source_project" package="source_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files>
           </files>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:49 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22source_package%22%20and%20linkinfo/@project=%22source_project%22%20and%20@project=%22source_project%22)
@@ -654,7 +654,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2/_meta?user=tom
@@ -662,8 +662,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>Death Be Not Proud</title>
-          <description>Recusandae provident earum ex.</description>
+          <title>A Confederacy of Dunces</title>
+          <description>Et maxime optio quia.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -684,15 +684,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '170'
+      - '166'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>Death Be Not Proud</title>
-          <description>Recusandae provident earum ex.</description>
+          <title>A Confederacy of Dunces</title>
+          <description>Et maxime optio quia.</description>
         </package>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:49 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?cmd=branch&noservice=1&opackage=source_package&oproject=source_project&user=tom
@@ -727,12 +727,12 @@ http_interactions:
         <revision rev="1" vrev="1">
           <srcmd5>8e451641a827df5f4f409d1d543fdb7b</srcmd5>
           <version>unknown</version>
-          <time>1658762219</time>
+          <time>1658762209</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2/_meta?user=tom
@@ -740,8 +740,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>Death Be Not Proud</title>
-          <description>Recusandae provident earum ex.</description>
+          <title>A Confederacy of Dunces</title>
+          <description>Et maxime optio quia.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -762,15 +762,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '170'
+      - '166'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>Death Be Not Proud</title>
-          <description>Recusandae provident earum ex.</description>
+          <title>A Confederacy of Dunces</title>
+          <description>Et maxime optio quia.</description>
         </package>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:49 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2
@@ -804,7 +804,7 @@ http_interactions:
           <linkinfo project="source_project" package="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
           <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658762120"/>
         </directory>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:49 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?view=info
@@ -838,7 +838,7 @@ http_interactions:
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="source_project" package="source_package"/>
         </sourceinfo>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:49 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2
@@ -872,7 +872,7 @@ http_interactions:
           <linkinfo project="source_project" package="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
           <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658762120"/>
         </directory>
-  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:49 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -911,7 +911,7 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:49 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -950,14 +950,14 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=tom
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_36">
+        <workflow project="home:tom" managers="group_29">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -980,18 +980,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '166'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="105">
-          <srcmd5>d3dc403b3bbd9c1401b638e11d486c21</srcmd5>
-          <time>1658762220</time>
+        <revision rev="76">
+          <srcmd5>ab3d588934c4da97d06949614800b96a</srcmd5>
+          <time>1658762209</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=tom
@@ -1001,7 +1001,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_29" role="maintainer"/>
           <repository name="staging_repository">
             <arch>x86_64</arch>
           </repository>
@@ -1032,19 +1032,19 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_29" role="maintainer"/>
           <repository name="staging_repository">
             <arch>x86_64</arch>
           </repository>
         </project>
-  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:49 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_83
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_69
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_36">
+        <workflow project="home:tom" managers="group_29">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -1067,18 +1067,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="106">
-          <srcmd5>d3dc403b3bbd9c1401b638e11d486c21</srcmd5>
-          <time>1658762220</time>
-          <user>user_83</user>
+        <revision rev="77">
+          <srcmd5>ab3d588934c4da97d06949614800b96a</srcmd5>
+          <time>1658762209</time>
+          <user>user_69</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=tom
@@ -1088,7 +1088,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_29" role="maintainer"/>
           <build>
             <disable/>
           </build>
@@ -1122,7 +1122,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_29" role="maintainer"/>
           <build>
             <disable/>
           </build>
@@ -1130,7 +1130,7 @@ http_interactions:
             <arch>x86_64</arch>
           </repository>
         </project>
-  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:50 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package?expand=1
@@ -1162,5 +1162,282 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:50 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/source_project/source_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '89'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Mon, 25 Jul 2022 15:16:50 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/target_project/target_package_2?cmd=copy&comment=Request%20for%20package%20target_package_2&expand=1&keeplink=1&noservice=1&opackage=source_package&oproject=source_project&requestid=1&user=autobuild&withacceptinfo=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '366'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="8" vrev="8">
+          <srcmd5>d41d8cd98f00b204e9800998ecf8427e</srcmd5>
+          <version>unknown</version>
+          <time>1658762210</time>
+          <user>autobuild</user>
+          <comment>Request for package target_package_2</comment>
+          <requestid>1</requestid>
+          <acceptinfo rev="8" srcmd5="d41d8cd98f00b204e9800998ecf8427e" osrcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+        </revision>
+  recorded_at: Mon, 25 Jul 2022 15:16:50 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/target_project/target_package_2/_meta?user=autobuild
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package_2" project="target_project">
+          <title>The Torment of Others</title>
+          <description>Qui molestias enim nisi.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '163'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package_2" project="target_project">
+          <title>The Torment of Others</title>
+          <description>Qui molestias enim nisi.</description>
+        </package>
+  recorded_at: Mon, 25 Jul 2022 15:16:50 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/target_project/target_package_2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '108'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="target_package_2" rev="8" vrev="8" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Mon, 25 Jul 2022 15:16:50 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/target_project/target_package_2?view=info
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '149'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourceinfo package="target_package_2" rev="8" vrev="8" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+          <error>no source uploaded</error>
+        </sourceinfo>
+  recorded_at: Mon, 25 Jul 2022 15:16:50 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/target_project/target_package_2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '108'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="target_package_2" rev="8" vrev="8" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Mon, 25 Jul 2022 15:16:50 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/target_project/target_package_2?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '299'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="521442dbefb663651cdc3913e10e7a32">
+          <old project="target_project" package="target_package_2" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="target_project" package="target_package_2" rev="8" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <files/>
+        </sourcediff>
+  recorded_at: Mon, 25 Jul 2022 15:16:50 GMT
+- request:
+    method: delete
+    uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?comment&user=autobuild
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+  recorded_at: Mon, 25 Jul 2022 15:16:50 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Project/Staging_Project/_accept/when_the_staging_project_is_using_pre-approved_requests/staged_requests_should_be_accepted_by_approver/1_1_7_4_1_2.yml
+++ b/src/api/spec/cassettes/Project/Staging_Project/_accept/when_the_staging_project_is_using_pre-approved_requests/staged_requests_should_be_accepted_by_approver/1_1_7_4_1_2.yml
@@ -39,14 +39,14 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:51 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_83
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_73
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_36">
+        <workflow project="home:tom" managers="group_31">
           <staging_project name="home:tom:Staging:A"/>
         </workflow>
     headers:
@@ -68,28 +68,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="103">
-          <srcmd5>b2986a92cbef7d6cfa4b5c41cfaeaba0</srcmd5>
-          <time>1658762219</time>
-          <user>user_83</user>
+        <revision rev="82">
+          <srcmd5>858fc5aa02396f412c38ebd9715591bf</srcmd5>
+          <time>1658762211</time>
+          <user>user_73</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:51 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_83
+    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_73
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_31" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -117,16 +117,16 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_31" role="maintainer"/>
         </project>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:52 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_83
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_73
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_36">
+        <workflow project="home:tom" managers="group_31">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -149,28 +149,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="104">
-          <srcmd5>d3dc403b3bbd9c1401b638e11d486c21</srcmd5>
-          <time>1658762219</time>
-          <user>user_83</user>
+        <revision rev="83">
+          <srcmd5>3a14b8118683a8f6a6e01e0236b83bb2</srcmd5>
+          <time>1658762212</time>
+          <user>user_73</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:52 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_83
+    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_73
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:B">
           <title/>
           <description/>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_31" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -198,12 +198,12 @@ http_interactions:
         <project name="home:tom:Staging:B">
           <title></title>
           <description></description>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_31" role="maintainer"/>
         </project>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:52 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_meta?user=user_83
+    uri: http://backend:5352/source/home:tom/_meta?user=user_73
     body:
       encoding: UTF-8
       string: |
@@ -211,7 +211,7 @@ http_interactions:
           <title/>
           <description/>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_36" role="reviewer"/>
+          <group groupid="group_31" role="reviewer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -240,18 +240,18 @@ http_interactions:
           <title></title>
           <description></description>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_36" role="reviewer"/>
+          <group groupid="group_31" role="reviewer"/>
         </project>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:52 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_84
+    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_74
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>The Waste Land</title>
-          <description>Aliquam adipisci velit asperiores.</description>
+          <title>A Farewell to Arms</title>
+          <description>Ipsam et in qui.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -272,21 +272,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '157'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>The Waste Land</title>
-          <description>Aliquam adipisci velit asperiores.</description>
+          <title>A Farewell to Arms</title>
+          <description>Ipsam et in qui.</description>
         </package>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:52 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_config
     body:
       encoding: UTF-8
-      string: Maxime omnis possimus. Odit qui consequatur. Qui quis vitae.
+      string: Magnam id aperiam. Est alias et. Aut sed placeat.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -310,21 +310,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="65" vrev="65">
-          <srcmd5>67f21c7ddab0e207e94e032f6732e1d4</srcmd5>
+        <revision rev="55" vrev="55">
+          <srcmd5>d10eeff8fc3c83c9fc287cc6dab14c93</srcmd5>
           <version>unknown</version>
-          <time>1658762219</time>
+          <time>1658762212</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:52 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/somefile.txt
     body:
       encoding: UTF-8
-      string: Voluptatum est nihil. Distinctio accusamus sint. Accusantium enim id.
+      string: Dolorem consequatur iusto. Itaque totam et. Eveniet sit ea.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -348,15 +348,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="66" vrev="66">
-          <srcmd5>2a22e138fc0ef9d6981816e3997ba427</srcmd5>
+        <revision rev="56" vrev="56">
+          <srcmd5>35cd4c0f18ae2308ff987edb86e32ade</srcmd5>
           <version>unknown</version>
-          <time>1658762219</time>
+          <time>1658762212</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:52 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/_meta?user=tom
@@ -364,7 +364,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>The Mermaids Singing</title>
+          <title>Now Sleeps the Crimson Petal</title>
           <description/>
         </project>
     headers:
@@ -386,15 +386,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '111'
+      - '119'
     body:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>The Mermaids Singing</title>
+          <title>Now Sleeps the Crimson Petal</title>
           <description></description>
         </project>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:52 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package_2/_meta?user=tom
@@ -402,8 +402,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="target_project">
-          <title>The Sun Also Rises</title>
-          <description>Odit debitis sit excepturi.</description>
+          <title>After Many a Summer Dies the Swan</title>
+          <description>Enim perspiciatis fuga magni.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -424,15 +424,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '163'
+      - '180'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="target_project">
-          <title>The Sun Also Rises</title>
-          <description>Odit debitis sit excepturi.</description>
+          <title>After Many a Summer Dies the Swan</title>
+          <description>Enim perspiciatis fuga magni.</description>
         </package>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:52 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_meta?user=tom
@@ -440,7 +440,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Many Waters</title>
+          <title>To a God Unknown</title>
           <description/>
         </project>
     headers:
@@ -462,15 +462,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '102'
+      - '107'
     body:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Many Waters</title>
+          <title>To a God Unknown</title>
           <description></description>
         </project>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:52 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_project/_attribute?meta=1&user=tom
@@ -503,14 +503,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="64">
-          <srcmd5>b3df56152978fa66e2e250b475619d6d</srcmd5>
-          <time>1658762219</time>
+        <revision rev="54">
+          <srcmd5>b6a07fca0cbf8c1a08164765aa471f9b</srcmd5>
+          <time>1658762212</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:52 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/source_package/_meta?user=tom
@@ -518,8 +518,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>Death Be Not Proud</title>
-          <description>Recusandae provident earum ex.</description>
+          <title>The Other Side of Silence</title>
+          <description>Mollitia facere eaque optio.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -540,15 +540,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '164'
+      - '169'
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>Death Be Not Proud</title>
-          <description>Recusandae provident earum ex.</description>
+          <title>The Other Side of Silence</title>
+          <description>Mollitia facere eaque optio.</description>
         </package>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:52 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package
@@ -580,7 +580,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:52 GMT
 - request:
     method: post
     uri: http://backend:5352/source/source_project/source_package?cmd=diff&expand=1&filelimit=10000&opackage=target_package_2&oproject=target_project&tarlimit=10000&view=xml&withissues=1
@@ -608,19 +608,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '331'
+      - '330'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="34e57069b586e7ab724b16f19bcd0dcb">
-          <old project="target_project" package="target_package_2" rev="14" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+        <sourcediff key="4f22e8b5f98a753475a38f4b4aa43d26">
+          <old project="target_project" package="target_package_2" rev="9" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <new project="source_project" package="source_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files>
           </files>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:52 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22source_package%22%20and%20linkinfo/@project=%22source_project%22%20and%20@project=%22source_project%22)
@@ -654,7 +654,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:52 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2/_meta?user=tom
@@ -662,8 +662,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>Death Be Not Proud</title>
-          <description>Recusandae provident earum ex.</description>
+          <title>The Other Side of Silence</title>
+          <description>Mollitia facere eaque optio.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -684,15 +684,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '170'
+      - '175'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>Death Be Not Proud</title>
-          <description>Recusandae provident earum ex.</description>
+          <title>The Other Side of Silence</title>
+          <description>Mollitia facere eaque optio.</description>
         </package>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:52 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?cmd=branch&noservice=1&opackage=source_package&oproject=source_project&user=tom
@@ -727,12 +727,12 @@ http_interactions:
         <revision rev="1" vrev="1">
           <srcmd5>8e451641a827df5f4f409d1d543fdb7b</srcmd5>
           <version>unknown</version>
-          <time>1658762219</time>
+          <time>1658762212</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:52 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2/_meta?user=tom
@@ -740,8 +740,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>Death Be Not Proud</title>
-          <description>Recusandae provident earum ex.</description>
+          <title>The Other Side of Silence</title>
+          <description>Mollitia facere eaque optio.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -762,15 +762,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '170'
+      - '175'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>Death Be Not Proud</title>
-          <description>Recusandae provident earum ex.</description>
+          <title>The Other Side of Silence</title>
+          <description>Mollitia facere eaque optio.</description>
         </package>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:52 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2
@@ -804,7 +804,7 @@ http_interactions:
           <linkinfo project="source_project" package="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
           <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658762120"/>
         </directory>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:52 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?view=info
@@ -838,7 +838,7 @@ http_interactions:
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="source_project" package="source_package"/>
         </sourceinfo>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:52 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2
@@ -872,7 +872,7 @@ http_interactions:
           <linkinfo project="source_project" package="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
           <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658762120"/>
         </directory>
-  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:52 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -911,7 +911,7 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:52 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -950,14 +950,14 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:52 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=tom
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_36">
+        <workflow project="home:tom" managers="group_31">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -980,18 +980,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '166'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="105">
-          <srcmd5>d3dc403b3bbd9c1401b638e11d486c21</srcmd5>
-          <time>1658762220</time>
+        <revision rev="84">
+          <srcmd5>3a14b8118683a8f6a6e01e0236b83bb2</srcmd5>
+          <time>1658762212</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:52 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=tom
@@ -1001,7 +1001,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_31" role="maintainer"/>
           <repository name="staging_repository">
             <arch>x86_64</arch>
           </repository>
@@ -1032,19 +1032,19 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_31" role="maintainer"/>
           <repository name="staging_repository">
             <arch>x86_64</arch>
           </repository>
         </project>
-  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:52 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_83
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_73
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_36">
+        <workflow project="home:tom" managers="group_31">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -1067,18 +1067,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="106">
-          <srcmd5>d3dc403b3bbd9c1401b638e11d486c21</srcmd5>
-          <time>1658762220</time>
-          <user>user_83</user>
+        <revision rev="85">
+          <srcmd5>3a14b8118683a8f6a6e01e0236b83bb2</srcmd5>
+          <time>1658762212</time>
+          <user>user_73</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:52 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=tom
@@ -1088,7 +1088,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_31" role="maintainer"/>
           <build>
             <disable/>
           </build>
@@ -1122,7 +1122,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_31" role="maintainer"/>
           <build>
             <disable/>
           </build>
@@ -1130,7 +1130,7 @@ http_interactions:
             <arch>x86_64</arch>
           </repository>
         </project>
-  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:52 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package?expand=1
@@ -1162,5 +1162,282 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:52 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/source_project/source_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '89'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Mon, 25 Jul 2022 15:16:52 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/target_project/target_package_2?cmd=copy&comment=Request%20for%20package%20target_package_2&expand=1&keeplink=1&noservice=1&opackage=source_package&oproject=source_project&requestid=1&user=autobuild&withacceptinfo=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '369'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="10" vrev="10">
+          <srcmd5>d41d8cd98f00b204e9800998ecf8427e</srcmd5>
+          <version>unknown</version>
+          <time>1658762212</time>
+          <user>autobuild</user>
+          <comment>Request for package target_package_2</comment>
+          <requestid>1</requestid>
+          <acceptinfo rev="10" srcmd5="d41d8cd98f00b204e9800998ecf8427e" osrcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+        </revision>
+  recorded_at: Mon, 25 Jul 2022 15:16:52 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/target_project/target_package_2/_meta?user=autobuild
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package_2" project="target_project">
+          <title>After Many a Summer Dies the Swan</title>
+          <description>Enim perspiciatis fuga magni.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '180'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package_2" project="target_project">
+          <title>After Many a Summer Dies the Swan</title>
+          <description>Enim perspiciatis fuga magni.</description>
+        </package>
+  recorded_at: Mon, 25 Jul 2022 15:16:53 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/target_project/target_package_2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '110'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="target_package_2" rev="10" vrev="10" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Mon, 25 Jul 2022 15:16:53 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/target_project/target_package_2?view=info
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '151'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourceinfo package="target_package_2" rev="10" vrev="10" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+          <error>no source uploaded</error>
+        </sourceinfo>
+  recorded_at: Mon, 25 Jul 2022 15:16:53 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/target_project/target_package_2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '110'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="target_package_2" rev="10" vrev="10" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Mon, 25 Jul 2022 15:16:53 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/target_project/target_package_2?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '300'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="788fdbd3adf5df9d87d5aafb7c165d47">
+          <old project="target_project" package="target_package_2" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="target_project" package="target_package_2" rev="10" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <files/>
+        </sourcediff>
+  recorded_at: Mon, 25 Jul 2022 15:16:53 GMT
+- request:
+    method: delete
+    uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?comment&user=autobuild
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+  recorded_at: Mon, 25 Jul 2022 15:16:53 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Project/Staging_Project/_accept/when_the_staging_project_is_using_pre-approved_requests/staged_requests_should_be_accepted_by_approver/1_1_7_4_1_3.yml
+++ b/src/api/spec/cassettes/Project/Staging_Project/_accept/when_the_staging_project_is_using_pre-approved_requests/staged_requests_should_be_accepted_by_approver/1_1_7_4_1_3.yml
@@ -39,14 +39,14 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:50 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_83
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_71
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_36">
+        <workflow project="home:tom" managers="group_30">
           <staging_project name="home:tom:Staging:A"/>
         </workflow>
     headers:
@@ -68,28 +68,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="103">
-          <srcmd5>b2986a92cbef7d6cfa4b5c41cfaeaba0</srcmd5>
-          <time>1658762219</time>
-          <user>user_83</user>
+        <revision rev="78">
+          <srcmd5>edca7846ce939228f9dfa2309e5dc0a7</srcmd5>
+          <time>1658762210</time>
+          <user>user_71</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:50 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_83
+    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_71
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_30" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -117,16 +117,16 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_30" role="maintainer"/>
         </project>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:50 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_83
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_71
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_36">
+        <workflow project="home:tom" managers="group_30">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -149,28 +149,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="104">
-          <srcmd5>d3dc403b3bbd9c1401b638e11d486c21</srcmd5>
-          <time>1658762219</time>
-          <user>user_83</user>
+        <revision rev="79">
+          <srcmd5>e370d324b55f0c43b5b9a75b8c36792a</srcmd5>
+          <time>1658762210</time>
+          <user>user_71</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:50 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_83
+    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_71
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:B">
           <title/>
           <description/>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_30" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -198,12 +198,12 @@ http_interactions:
         <project name="home:tom:Staging:B">
           <title></title>
           <description></description>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_30" role="maintainer"/>
         </project>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:50 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_meta?user=user_83
+    uri: http://backend:5352/source/home:tom/_meta?user=user_71
     body:
       encoding: UTF-8
       string: |
@@ -211,7 +211,7 @@ http_interactions:
           <title/>
           <description/>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_36" role="reviewer"/>
+          <group groupid="group_30" role="reviewer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -240,18 +240,18 @@ http_interactions:
           <title></title>
           <description></description>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_36" role="reviewer"/>
+          <group groupid="group_30" role="reviewer"/>
         </project>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:50 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_84
+    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_72
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>The Waste Land</title>
-          <description>Aliquam adipisci velit asperiores.</description>
+          <title>Those Barren Leaves, Thrones, Dominations</title>
+          <description>A fuga et ut.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -272,21 +272,22 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '177'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>The Waste Land</title>
-          <description>Aliquam adipisci velit asperiores.</description>
+          <title>Those Barren Leaves, Thrones, Dominations</title>
+          <description>A fuga et ut.</description>
         </package>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:50 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_config
     body:
       encoding: UTF-8
-      string: Maxime omnis possimus. Odit qui consequatur. Qui quis vitae.
+      string: Perspiciatis voluptas voluptatem. Voluptates velit debitis. Delectus
+        ut fugiat.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -310,21 +311,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="65" vrev="65">
-          <srcmd5>67f21c7ddab0e207e94e032f6732e1d4</srcmd5>
+        <revision rev="53" vrev="53">
+          <srcmd5>f524e87fb0e5e0607e2a3a681fcff587</srcmd5>
           <version>unknown</version>
-          <time>1658762219</time>
+          <time>1658762210</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:50 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/somefile.txt
     body:
       encoding: UTF-8
-      string: Voluptatum est nihil. Distinctio accusamus sint. Accusantium enim id.
+      string: Vel voluptas beatae. Et voluptatem cum. Dignissimos possimus et.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -348,15 +349,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="66" vrev="66">
-          <srcmd5>2a22e138fc0ef9d6981816e3997ba427</srcmd5>
+        <revision rev="54" vrev="54">
+          <srcmd5>1489fd13ed8d5a395889772d0ea6d4af</srcmd5>
           <version>unknown</version>
-          <time>1658762219</time>
+          <time>1658762210</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:50 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/_meta?user=tom
@@ -364,7 +365,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>The Mermaids Singing</title>
+          <title>Ego Dominus Tuus</title>
           <description/>
         </project>
     headers:
@@ -386,15 +387,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '111'
+      - '107'
     body:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>The Mermaids Singing</title>
+          <title>Ego Dominus Tuus</title>
           <description></description>
         </project>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:50 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package_2/_meta?user=tom
@@ -402,8 +403,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="target_project">
-          <title>The Sun Also Rises</title>
-          <description>Odit debitis sit excepturi.</description>
+          <title>To Say Nothing of the Dog</title>
+          <description>Et quo ab magni.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -424,15 +425,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '163'
+      - '159'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="target_project">
-          <title>The Sun Also Rises</title>
-          <description>Odit debitis sit excepturi.</description>
+          <title>To Say Nothing of the Dog</title>
+          <description>Et quo ab magni.</description>
         </package>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:50 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_meta?user=tom
@@ -440,7 +441,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Many Waters</title>
+          <title>Consider the Lilies</title>
           <description/>
         </project>
     headers:
@@ -462,15 +463,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '102'
+      - '110'
     body:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Many Waters</title>
+          <title>Consider the Lilies</title>
           <description></description>
         </project>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:50 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_project/_attribute?meta=1&user=tom
@@ -503,14 +504,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="64">
-          <srcmd5>b3df56152978fa66e2e250b475619d6d</srcmd5>
-          <time>1658762219</time>
+        <revision rev="52">
+          <srcmd5>646eaa9aa0a6906008bc7b10b73a9e04</srcmd5>
+          <time>1658762210</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:50 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/source_package/_meta?user=tom
@@ -518,8 +519,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>Death Be Not Proud</title>
-          <description>Recusandae provident earum ex.</description>
+          <title>The Doors of Perception</title>
+          <description>Quas dolorem amet cupiditate.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -540,15 +541,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '164'
+      - '168'
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>Death Be Not Proud</title>
-          <description>Recusandae provident earum ex.</description>
+          <title>The Doors of Perception</title>
+          <description>Quas dolorem amet cupiditate.</description>
         </package>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:50 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package
@@ -580,7 +581,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:51 GMT
 - request:
     method: post
     uri: http://backend:5352/source/source_project/source_package?cmd=diff&expand=1&filelimit=10000&opackage=target_package_2&oproject=target_project&tarlimit=10000&view=xml&withissues=1
@@ -608,19 +609,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '331'
+      - '330'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="34e57069b586e7ab724b16f19bcd0dcb">
-          <old project="target_project" package="target_package_2" rev="14" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+        <sourcediff key="ac8cde01b7c3fc9d17b73e51970538f2">
+          <old project="target_project" package="target_package_2" rev="8" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <new project="source_project" package="source_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files>
           </files>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:51 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22source_package%22%20and%20linkinfo/@project=%22source_project%22%20and%20@project=%22source_project%22)
@@ -654,7 +655,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:51 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2/_meta?user=tom
@@ -662,8 +663,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>Death Be Not Proud</title>
-          <description>Recusandae provident earum ex.</description>
+          <title>The Doors of Perception</title>
+          <description>Quas dolorem amet cupiditate.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -684,15 +685,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '170'
+      - '174'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>Death Be Not Proud</title>
-          <description>Recusandae provident earum ex.</description>
+          <title>The Doors of Perception</title>
+          <description>Quas dolorem amet cupiditate.</description>
         </package>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:51 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?cmd=branch&noservice=1&opackage=source_package&oproject=source_project&user=tom
@@ -727,12 +728,12 @@ http_interactions:
         <revision rev="1" vrev="1">
           <srcmd5>8e451641a827df5f4f409d1d543fdb7b</srcmd5>
           <version>unknown</version>
-          <time>1658762219</time>
+          <time>1658762211</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:51 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2/_meta?user=tom
@@ -740,8 +741,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>Death Be Not Proud</title>
-          <description>Recusandae provident earum ex.</description>
+          <title>The Doors of Perception</title>
+          <description>Quas dolorem amet cupiditate.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -762,15 +763,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '170'
+      - '174'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>Death Be Not Proud</title>
-          <description>Recusandae provident earum ex.</description>
+          <title>The Doors of Perception</title>
+          <description>Quas dolorem amet cupiditate.</description>
         </package>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:51 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2
@@ -804,7 +805,7 @@ http_interactions:
           <linkinfo project="source_project" package="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
           <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658762120"/>
         </directory>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:51 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?view=info
@@ -838,7 +839,7 @@ http_interactions:
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="source_project" package="source_package"/>
         </sourceinfo>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:51 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2
@@ -872,7 +873,7 @@ http_interactions:
           <linkinfo project="source_project" package="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
           <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658762120"/>
         </directory>
-  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:51 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -911,7 +912,7 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:51 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -950,14 +951,14 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:51 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=tom
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_36">
+        <workflow project="home:tom" managers="group_30">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -980,18 +981,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '166'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="105">
-          <srcmd5>d3dc403b3bbd9c1401b638e11d486c21</srcmd5>
-          <time>1658762220</time>
+        <revision rev="80">
+          <srcmd5>e370d324b55f0c43b5b9a75b8c36792a</srcmd5>
+          <time>1658762211</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:51 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=tom
@@ -1001,7 +1002,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_30" role="maintainer"/>
           <repository name="staging_repository">
             <arch>x86_64</arch>
           </repository>
@@ -1032,19 +1033,19 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_30" role="maintainer"/>
           <repository name="staging_repository">
             <arch>x86_64</arch>
           </repository>
         </project>
-  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:51 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_83
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_71
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_36">
+        <workflow project="home:tom" managers="group_30">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -1067,18 +1068,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="106">
-          <srcmd5>d3dc403b3bbd9c1401b638e11d486c21</srcmd5>
-          <time>1658762220</time>
-          <user>user_83</user>
+        <revision rev="81">
+          <srcmd5>e370d324b55f0c43b5b9a75b8c36792a</srcmd5>
+          <time>1658762211</time>
+          <user>user_71</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:51 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=tom
@@ -1088,7 +1089,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_30" role="maintainer"/>
           <build>
             <disable/>
           </build>
@@ -1122,7 +1123,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_30" role="maintainer"/>
           <build>
             <disable/>
           </build>
@@ -1130,7 +1131,7 @@ http_interactions:
             <arch>x86_64</arch>
           </repository>
         </project>
-  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:51 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package?expand=1
@@ -1162,5 +1163,282 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:51 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/source_project/source_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '89'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Mon, 25 Jul 2022 15:16:51 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/target_project/target_package_2?cmd=copy&comment=Request%20for%20package%20target_package_2&expand=1&keeplink=1&noservice=1&opackage=source_package&oproject=source_project&requestid=1&user=autobuild&withacceptinfo=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '366'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="9" vrev="9">
+          <srcmd5>d41d8cd98f00b204e9800998ecf8427e</srcmd5>
+          <version>unknown</version>
+          <time>1658762211</time>
+          <user>autobuild</user>
+          <comment>Request for package target_package_2</comment>
+          <requestid>1</requestid>
+          <acceptinfo rev="9" srcmd5="d41d8cd98f00b204e9800998ecf8427e" osrcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+        </revision>
+  recorded_at: Mon, 25 Jul 2022 15:16:51 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/target_project/target_package_2/_meta?user=autobuild
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package_2" project="target_project">
+          <title>To Say Nothing of the Dog</title>
+          <description>Et quo ab magni.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '159'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package_2" project="target_project">
+          <title>To Say Nothing of the Dog</title>
+          <description>Et quo ab magni.</description>
+        </package>
+  recorded_at: Mon, 25 Jul 2022 15:16:51 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/target_project/target_package_2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '108'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="target_package_2" rev="9" vrev="9" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Mon, 25 Jul 2022 15:16:51 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/target_project/target_package_2?view=info
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '149'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourceinfo package="target_package_2" rev="9" vrev="9" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+          <error>no source uploaded</error>
+        </sourceinfo>
+  recorded_at: Mon, 25 Jul 2022 15:16:51 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/target_project/target_package_2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '108'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="target_package_2" rev="9" vrev="9" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Mon, 25 Jul 2022 15:16:51 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/target_project/target_package_2?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '299'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="47bdfd53c5d46ed946fa558812a025dd">
+          <old project="target_project" package="target_package_2" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="target_project" package="target_package_2" rev="9" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <files/>
+        </sourcediff>
+  recorded_at: Mon, 25 Jul 2022 15:16:51 GMT
+- request:
+    method: delete
+    uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?comment&user=autobuild
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+  recorded_at: Mon, 25 Jul 2022 15:16:51 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Project/Staging_Project/_accept/when_the_staging_project_is_using_pre-approved_requests/staged_requests_should_be_accepted_by_approver/1_1_7_4_1_4.yml
+++ b/src/api/spec/cassettes/Project/Staging_Project/_accept/when_the_staging_project_is_using_pre-approved_requests/staged_requests_should_be_accepted_by_approver/1_1_7_4_1_4.yml
@@ -39,14 +39,14 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:53 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_83
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_75
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_36">
+        <workflow project="home:tom" managers="group_32">
           <staging_project name="home:tom:Staging:A"/>
         </workflow>
     headers:
@@ -68,28 +68,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="103">
-          <srcmd5>b2986a92cbef7d6cfa4b5c41cfaeaba0</srcmd5>
-          <time>1658762219</time>
-          <user>user_83</user>
+        <revision rev="86">
+          <srcmd5>b7ffeab3caa6206fe9442e7269046544</srcmd5>
+          <time>1658762213</time>
+          <user>user_75</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:53 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_83
+    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_75
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_32" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -117,16 +117,16 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_32" role="maintainer"/>
         </project>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:53 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_83
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_75
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_36">
+        <workflow project="home:tom" managers="group_32">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -149,28 +149,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="104">
-          <srcmd5>d3dc403b3bbd9c1401b638e11d486c21</srcmd5>
-          <time>1658762219</time>
-          <user>user_83</user>
+        <revision rev="87">
+          <srcmd5>0481fbadf19cc95a40fb41c271230f7e</srcmd5>
+          <time>1658762213</time>
+          <user>user_75</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:53 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_83
+    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_75
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:B">
           <title/>
           <description/>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_32" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -198,12 +198,12 @@ http_interactions:
         <project name="home:tom:Staging:B">
           <title></title>
           <description></description>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_32" role="maintainer"/>
         </project>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:53 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_meta?user=user_83
+    uri: http://backend:5352/source/home:tom/_meta?user=user_75
     body:
       encoding: UTF-8
       string: |
@@ -211,7 +211,7 @@ http_interactions:
           <title/>
           <description/>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_36" role="reviewer"/>
+          <group groupid="group_32" role="reviewer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -240,18 +240,18 @@ http_interactions:
           <title></title>
           <description></description>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_36" role="reviewer"/>
+          <group groupid="group_32" role="reviewer"/>
         </project>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:53 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_84
+    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_76
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>The Waste Land</title>
-          <description>Aliquam adipisci velit asperiores.</description>
+          <title>To a God Unknown</title>
+          <description>Voluptas sequi culpa quis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -272,21 +272,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '165'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>The Waste Land</title>
-          <description>Aliquam adipisci velit asperiores.</description>
+          <title>To a God Unknown</title>
+          <description>Voluptas sequi culpa quis.</description>
         </package>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_config
     body:
       encoding: UTF-8
-      string: Maxime omnis possimus. Odit qui consequatur. Qui quis vitae.
+      string: Soluta at officia. Fuga soluta id. In est consequatur.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -310,21 +310,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="65" vrev="65">
-          <srcmd5>67f21c7ddab0e207e94e032f6732e1d4</srcmd5>
+        <revision rev="57" vrev="57">
+          <srcmd5>cd60db090b570c828b1a02d5d5deea76</srcmd5>
           <version>unknown</version>
-          <time>1658762219</time>
+          <time>1658762213</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/somefile.txt
     body:
       encoding: UTF-8
-      string: Voluptatum est nihil. Distinctio accusamus sint. Accusantium enim id.
+      string: Voluptatibus tenetur ea. Deleniti exercitationem et. Qui esse est.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -348,15 +348,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="66" vrev="66">
-          <srcmd5>2a22e138fc0ef9d6981816e3997ba427</srcmd5>
+        <revision rev="58" vrev="58">
+          <srcmd5>dc6f74f54c0f6f4bc06a04af0a8c9adb</srcmd5>
           <version>unknown</version>
-          <time>1658762219</time>
+          <time>1658762213</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/_meta?user=tom
@@ -364,7 +364,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>The Mermaids Singing</title>
+          <title>The Lathe of Heaven</title>
           <description/>
         </project>
     headers:
@@ -386,15 +386,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '111'
+      - '110'
     body:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>The Mermaids Singing</title>
+          <title>The Lathe of Heaven</title>
           <description></description>
         </project>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package_2/_meta?user=tom
@@ -402,8 +402,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="target_project">
-          <title>The Sun Also Rises</title>
-          <description>Odit debitis sit excepturi.</description>
+          <title>A Scanner Darkly</title>
+          <description>Aspernatur ipsam quidem deserunt.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -424,15 +424,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '163'
+      - '167'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="target_project">
-          <title>The Sun Also Rises</title>
-          <description>Odit debitis sit excepturi.</description>
+          <title>A Scanner Darkly</title>
+          <description>Aspernatur ipsam quidem deserunt.</description>
         </package>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_meta?user=tom
@@ -440,7 +440,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Many Waters</title>
+          <title>Little Hands Clapping</title>
           <description/>
         </project>
     headers:
@@ -462,15 +462,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '102'
+      - '112'
     body:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Many Waters</title>
+          <title>Little Hands Clapping</title>
           <description></description>
         </project>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_project/_attribute?meta=1&user=tom
@@ -503,14 +503,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="64">
-          <srcmd5>b3df56152978fa66e2e250b475619d6d</srcmd5>
-          <time>1658762219</time>
+        <revision rev="56">
+          <srcmd5>30c0a395d0b225d092e0c58d5fde7a18</srcmd5>
+          <time>1658762213</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/source_package/_meta?user=tom
@@ -518,8 +518,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>Death Be Not Proud</title>
-          <description>Recusandae provident earum ex.</description>
+          <title>The Waste Land</title>
+          <description>Voluptates tempora odit excepturi.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -545,10 +545,10 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>Death Be Not Proud</title>
-          <description>Recusandae provident earum ex.</description>
+          <title>The Waste Land</title>
+          <description>Voluptates tempora odit excepturi.</description>
         </package>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:53 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package
@@ -580,7 +580,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:53 GMT
 - request:
     method: post
     uri: http://backend:5352/source/source_project/source_package?cmd=diff&expand=1&filelimit=10000&opackage=target_package_2&oproject=target_project&tarlimit=10000&view=xml&withissues=1
@@ -612,15 +612,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="34e57069b586e7ab724b16f19bcd0dcb">
-          <old project="target_project" package="target_package_2" rev="14" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+        <sourcediff key="b56a5419769707c9cbf039bd623891aa">
+          <old project="target_project" package="target_package_2" rev="10" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <new project="source_project" package="source_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files>
           </files>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:53 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22source_package%22%20and%20linkinfo/@project=%22source_project%22%20and%20@project=%22source_project%22)
@@ -654,7 +654,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2/_meta?user=tom
@@ -662,8 +662,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>Death Be Not Proud</title>
-          <description>Recusandae provident earum ex.</description>
+          <title>The Waste Land</title>
+          <description>Voluptates tempora odit excepturi.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -689,10 +689,10 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>Death Be Not Proud</title>
-          <description>Recusandae provident earum ex.</description>
+          <title>The Waste Land</title>
+          <description>Voluptates tempora odit excepturi.</description>
         </package>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:53 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?cmd=branch&noservice=1&opackage=source_package&oproject=source_project&user=tom
@@ -727,12 +727,12 @@ http_interactions:
         <revision rev="1" vrev="1">
           <srcmd5>8e451641a827df5f4f409d1d543fdb7b</srcmd5>
           <version>unknown</version>
-          <time>1658762219</time>
+          <time>1658762213</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2/_meta?user=tom
@@ -740,8 +740,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>Death Be Not Proud</title>
-          <description>Recusandae provident earum ex.</description>
+          <title>The Waste Land</title>
+          <description>Voluptates tempora odit excepturi.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -767,10 +767,10 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>Death Be Not Proud</title>
-          <description>Recusandae provident earum ex.</description>
+          <title>The Waste Land</title>
+          <description>Voluptates tempora odit excepturi.</description>
         </package>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:53 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2
@@ -804,7 +804,7 @@ http_interactions:
           <linkinfo project="source_project" package="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
           <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658762120"/>
         </directory>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:53 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?view=info
@@ -838,7 +838,7 @@ http_interactions:
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="source_project" package="source_package"/>
         </sourceinfo>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:53 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2
@@ -872,7 +872,7 @@ http_interactions:
           <linkinfo project="source_project" package="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
           <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658762120"/>
         </directory>
-  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:53 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -911,7 +911,7 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:53 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -950,14 +950,14 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:54 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=tom
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_36">
+        <workflow project="home:tom" managers="group_32">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -980,18 +980,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '166'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="105">
-          <srcmd5>d3dc403b3bbd9c1401b638e11d486c21</srcmd5>
-          <time>1658762220</time>
+        <revision rev="88">
+          <srcmd5>0481fbadf19cc95a40fb41c271230f7e</srcmd5>
+          <time>1658762214</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:54 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=tom
@@ -1001,7 +1001,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_32" role="maintainer"/>
           <repository name="staging_repository">
             <arch>x86_64</arch>
           </repository>
@@ -1032,19 +1032,19 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_32" role="maintainer"/>
           <repository name="staging_repository">
             <arch>x86_64</arch>
           </repository>
         </project>
-  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:54 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_83
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_75
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_36">
+        <workflow project="home:tom" managers="group_32">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -1067,18 +1067,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="106">
-          <srcmd5>d3dc403b3bbd9c1401b638e11d486c21</srcmd5>
-          <time>1658762220</time>
-          <user>user_83</user>
+        <revision rev="89">
+          <srcmd5>0481fbadf19cc95a40fb41c271230f7e</srcmd5>
+          <time>1658762214</time>
+          <user>user_75</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:54 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=tom
@@ -1088,7 +1088,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_32" role="maintainer"/>
           <build>
             <disable/>
           </build>
@@ -1122,7 +1122,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_32" role="maintainer"/>
           <build>
             <disable/>
           </build>
@@ -1130,7 +1130,7 @@ http_interactions:
             <arch>x86_64</arch>
           </repository>
         </project>
-  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:54 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package?expand=1
@@ -1162,5 +1162,282 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:54 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/source_project/source_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '89'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Mon, 25 Jul 2022 15:16:54 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/target_project/target_package_2?cmd=copy&comment=Request%20for%20package%20target_package_2&expand=1&keeplink=1&noservice=1&opackage=source_package&oproject=source_project&requestid=1&user=autobuild&withacceptinfo=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '369'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="11" vrev="11">
+          <srcmd5>d41d8cd98f00b204e9800998ecf8427e</srcmd5>
+          <version>unknown</version>
+          <time>1658762214</time>
+          <user>autobuild</user>
+          <comment>Request for package target_package_2</comment>
+          <requestid>1</requestid>
+          <acceptinfo rev="11" srcmd5="d41d8cd98f00b204e9800998ecf8427e" osrcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+        </revision>
+  recorded_at: Mon, 25 Jul 2022 15:16:54 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/target_project/target_package_2/_meta?user=autobuild
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package_2" project="target_project">
+          <title>A Scanner Darkly</title>
+          <description>Aspernatur ipsam quidem deserunt.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '167'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package_2" project="target_project">
+          <title>A Scanner Darkly</title>
+          <description>Aspernatur ipsam quidem deserunt.</description>
+        </package>
+  recorded_at: Mon, 25 Jul 2022 15:16:54 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/target_project/target_package_2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '110'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="target_package_2" rev="11" vrev="11" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Mon, 25 Jul 2022 15:16:54 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/target_project/target_package_2?view=info
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '151'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourceinfo package="target_package_2" rev="11" vrev="11" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+          <error>no source uploaded</error>
+        </sourceinfo>
+  recorded_at: Mon, 25 Jul 2022 15:16:54 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/target_project/target_package_2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '110'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="target_package_2" rev="11" vrev="11" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Mon, 25 Jul 2022 15:16:54 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/target_project/target_package_2?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '300'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="a3c505e79ac465a45d21a0ad042b6274">
+          <old project="target_project" package="target_package_2" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="target_project" package="target_package_2" rev="11" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <files/>
+        </sourcediff>
+  recorded_at: Mon, 25 Jul 2022 15:16:54 GMT
+- request:
+    method: delete
+    uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?comment&user=autobuild
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+  recorded_at: Mon, 25 Jul 2022 15:16:54 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Project/Staging_Project/_accept/when_the_staging_project_is_using_pre-approved_requests/staged_requests_should_be_accepted_by_approver/1_1_7_4_1_5.yml
+++ b/src/api/spec/cassettes/Project/Staging_Project/_accept/when_the_staging_project_is_using_pre-approved_requests/staged_requests_should_be_accepted_by_approver/1_1_7_4_1_5.yml
@@ -39,14 +39,14 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:55 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_83
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_79
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_36">
+        <workflow project="home:tom" managers="group_34">
           <staging_project name="home:tom:Staging:A"/>
         </workflow>
     headers:
@@ -68,28 +68,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="103">
-          <srcmd5>b2986a92cbef7d6cfa4b5c41cfaeaba0</srcmd5>
-          <time>1658762219</time>
-          <user>user_83</user>
+        <revision rev="94">
+          <srcmd5>a2a6b97bb52dea86f0621cf493197d54</srcmd5>
+          <time>1658762216</time>
+          <user>user_79</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:56 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_83
+    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_79
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_34" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -117,16 +117,16 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_34" role="maintainer"/>
         </project>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:56 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_83
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_79
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_36">
+        <workflow project="home:tom" managers="group_34">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -149,28 +149,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="104">
-          <srcmd5>d3dc403b3bbd9c1401b638e11d486c21</srcmd5>
-          <time>1658762219</time>
-          <user>user_83</user>
+        <revision rev="95">
+          <srcmd5>a552ee983f053fa9227951658e6a6565</srcmd5>
+          <time>1658762216</time>
+          <user>user_79</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:56 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_83
+    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_79
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:B">
           <title/>
           <description/>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_34" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -198,12 +198,12 @@ http_interactions:
         <project name="home:tom:Staging:B">
           <title></title>
           <description></description>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_34" role="maintainer"/>
         </project>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:56 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_meta?user=user_83
+    uri: http://backend:5352/source/home:tom/_meta?user=user_79
     body:
       encoding: UTF-8
       string: |
@@ -211,7 +211,7 @@ http_interactions:
           <title/>
           <description/>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_36" role="reviewer"/>
+          <group groupid="group_34" role="reviewer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -240,18 +240,18 @@ http_interactions:
           <title></title>
           <description></description>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_36" role="reviewer"/>
+          <group groupid="group_34" role="reviewer"/>
         </project>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:56 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_84
+    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_80
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>The Waste Land</title>
-          <description>Aliquam adipisci velit asperiores.</description>
+          <title>The Way Through the Woods</title>
+          <description>Rerum qui consectetur non.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -272,21 +272,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '174'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>The Waste Land</title>
-          <description>Aliquam adipisci velit asperiores.</description>
+          <title>The Way Through the Woods</title>
+          <description>Rerum qui consectetur non.</description>
         </package>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:56 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_config
     body:
       encoding: UTF-8
-      string: Maxime omnis possimus. Odit qui consequatur. Qui quis vitae.
+      string: Numquam ut est. Distinctio error suscipit. Qui id ut.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -310,21 +310,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="65" vrev="65">
-          <srcmd5>67f21c7ddab0e207e94e032f6732e1d4</srcmd5>
+        <revision rev="61" vrev="61">
+          <srcmd5>05f8b33273bee227dd11fc851554c073</srcmd5>
           <version>unknown</version>
-          <time>1658762219</time>
+          <time>1658762216</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:56 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/somefile.txt
     body:
       encoding: UTF-8
-      string: Voluptatum est nihil. Distinctio accusamus sint. Accusantium enim id.
+      string: Totam temporibus cumque. Quod et repudiandae. Eveniet et saepe.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -348,15 +348,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="66" vrev="66">
-          <srcmd5>2a22e138fc0ef9d6981816e3997ba427</srcmd5>
+        <revision rev="62" vrev="62">
+          <srcmd5>0cef3371a98011c4b2cc7e8b97b4e53e</srcmd5>
           <version>unknown</version>
-          <time>1658762219</time>
+          <time>1658762216</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:56 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/_meta?user=tom
@@ -364,7 +364,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>The Mermaids Singing</title>
+          <title>In Death Ground</title>
           <description/>
         </project>
     headers:
@@ -386,15 +386,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '111'
+      - '106'
     body:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>The Mermaids Singing</title>
+          <title>In Death Ground</title>
           <description></description>
         </project>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:56 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package_2/_meta?user=tom
@@ -402,8 +402,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="target_project">
-          <title>The Sun Also Rises</title>
-          <description>Odit debitis sit excepturi.</description>
+          <title>Ego Dominus Tuus</title>
+          <description>Fugiat rerum voluptatem quis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -429,10 +429,10 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="target_project">
-          <title>The Sun Also Rises</title>
-          <description>Odit debitis sit excepturi.</description>
+          <title>Ego Dominus Tuus</title>
+          <description>Fugiat rerum voluptatem quis.</description>
         </package>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:56 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_meta?user=tom
@@ -440,7 +440,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Many Waters</title>
+          <title>The Curious Incident of the Dog in the Night-Time</title>
           <description/>
         </project>
     headers:
@@ -462,15 +462,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '102'
+      - '140'
     body:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Many Waters</title>
+          <title>The Curious Incident of the Dog in the Night-Time</title>
           <description></description>
         </project>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:56 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_project/_attribute?meta=1&user=tom
@@ -503,14 +503,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="64">
-          <srcmd5>b3df56152978fa66e2e250b475619d6d</srcmd5>
-          <time>1658762219</time>
+        <revision rev="60">
+          <srcmd5>fbf1cd34828a2199b43039429fd6ed36</srcmd5>
+          <time>1658762216</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:56 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/source_package/_meta?user=tom
@@ -518,8 +518,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>Death Be Not Proud</title>
-          <description>Recusandae provident earum ex.</description>
+          <title>Carrion Comfort</title>
+          <description>Ducimus molestiae temporibus possimus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -540,15 +540,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '164'
+      - '169'
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>Death Be Not Proud</title>
-          <description>Recusandae provident earum ex.</description>
+          <title>Carrion Comfort</title>
+          <description>Ducimus molestiae temporibus possimus.</description>
         </package>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:56 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package
@@ -580,7 +580,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:56 GMT
 - request:
     method: post
     uri: http://backend:5352/source/source_project/source_package?cmd=diff&expand=1&filelimit=10000&opackage=target_package_2&oproject=target_project&tarlimit=10000&view=xml&withissues=1
@@ -612,15 +612,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="34e57069b586e7ab724b16f19bcd0dcb">
-          <old project="target_project" package="target_package_2" rev="14" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+        <sourcediff key="9914975ba95dfab56f2ff35d3fb36c94">
+          <old project="target_project" package="target_package_2" rev="12" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <new project="source_project" package="source_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files>
           </files>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:56 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22source_package%22%20and%20linkinfo/@project=%22source_project%22%20and%20@project=%22source_project%22)
@@ -654,7 +654,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:56 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2/_meta?user=tom
@@ -662,8 +662,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>Death Be Not Proud</title>
-          <description>Recusandae provident earum ex.</description>
+          <title>Carrion Comfort</title>
+          <description>Ducimus molestiae temporibus possimus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -684,15 +684,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '170'
+      - '175'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>Death Be Not Proud</title>
-          <description>Recusandae provident earum ex.</description>
+          <title>Carrion Comfort</title>
+          <description>Ducimus molestiae temporibus possimus.</description>
         </package>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:56 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?cmd=branch&noservice=1&opackage=source_package&oproject=source_project&user=tom
@@ -727,12 +727,12 @@ http_interactions:
         <revision rev="1" vrev="1">
           <srcmd5>8e451641a827df5f4f409d1d543fdb7b</srcmd5>
           <version>unknown</version>
-          <time>1658762219</time>
+          <time>1658762216</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:56 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2/_meta?user=tom
@@ -740,8 +740,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>Death Be Not Proud</title>
-          <description>Recusandae provident earum ex.</description>
+          <title>Carrion Comfort</title>
+          <description>Ducimus molestiae temporibus possimus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -762,15 +762,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '170'
+      - '175'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>Death Be Not Proud</title>
-          <description>Recusandae provident earum ex.</description>
+          <title>Carrion Comfort</title>
+          <description>Ducimus molestiae temporibus possimus.</description>
         </package>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:56 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2
@@ -804,7 +804,7 @@ http_interactions:
           <linkinfo project="source_project" package="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
           <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658762120"/>
         </directory>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:56 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?view=info
@@ -838,7 +838,7 @@ http_interactions:
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="source_project" package="source_package"/>
         </sourceinfo>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:56 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2
@@ -872,7 +872,7 @@ http_interactions:
           <linkinfo project="source_project" package="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
           <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658762120"/>
         </directory>
-  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:56 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -911,7 +911,7 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:56 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -950,14 +950,14 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:56 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=tom
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_36">
+        <workflow project="home:tom" managers="group_34">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -980,18 +980,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '166'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="105">
-          <srcmd5>d3dc403b3bbd9c1401b638e11d486c21</srcmd5>
-          <time>1658762220</time>
+        <revision rev="96">
+          <srcmd5>a552ee983f053fa9227951658e6a6565</srcmd5>
+          <time>1658762216</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:56 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=tom
@@ -1001,7 +1001,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_34" role="maintainer"/>
           <repository name="staging_repository">
             <arch>x86_64</arch>
           </repository>
@@ -1032,19 +1032,19 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_34" role="maintainer"/>
           <repository name="staging_repository">
             <arch>x86_64</arch>
           </repository>
         </project>
-  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:56 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_83
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_79
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_36">
+        <workflow project="home:tom" managers="group_34">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -1067,18 +1067,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="106">
-          <srcmd5>d3dc403b3bbd9c1401b638e11d486c21</srcmd5>
-          <time>1658762220</time>
-          <user>user_83</user>
+        <revision rev="97">
+          <srcmd5>a552ee983f053fa9227951658e6a6565</srcmd5>
+          <time>1658762216</time>
+          <user>user_79</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:56 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=tom
@@ -1088,7 +1088,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_34" role="maintainer"/>
           <build>
             <disable/>
           </build>
@@ -1122,7 +1122,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_34" role="maintainer"/>
           <build>
             <disable/>
           </build>
@@ -1130,7 +1130,7 @@ http_interactions:
             <arch>x86_64</arch>
           </repository>
         </project>
-  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:56 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package?expand=1
@@ -1162,5 +1162,282 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:56 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/source_project/source_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '89'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Mon, 25 Jul 2022 15:16:57 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/target_project/target_package_2?cmd=copy&comment=Request%20for%20package%20target_package_2&expand=1&keeplink=1&noservice=1&opackage=source_package&oproject=source_project&requestid=1&user=autobuild&withacceptinfo=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '369'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="13" vrev="13">
+          <srcmd5>d41d8cd98f00b204e9800998ecf8427e</srcmd5>
+          <version>unknown</version>
+          <time>1658762217</time>
+          <user>autobuild</user>
+          <comment>Request for package target_package_2</comment>
+          <requestid>1</requestid>
+          <acceptinfo rev="13" srcmd5="d41d8cd98f00b204e9800998ecf8427e" osrcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+        </revision>
+  recorded_at: Mon, 25 Jul 2022 15:16:57 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/target_project/target_package_2/_meta?user=autobuild
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package_2" project="target_project">
+          <title>Ego Dominus Tuus</title>
+          <description>Fugiat rerum voluptatem quis.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '163'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package_2" project="target_project">
+          <title>Ego Dominus Tuus</title>
+          <description>Fugiat rerum voluptatem quis.</description>
+        </package>
+  recorded_at: Mon, 25 Jul 2022 15:16:57 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/target_project/target_package_2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '110'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="target_package_2" rev="13" vrev="13" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Mon, 25 Jul 2022 15:16:57 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/target_project/target_package_2?view=info
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '151'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourceinfo package="target_package_2" rev="13" vrev="13" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+          <error>no source uploaded</error>
+        </sourceinfo>
+  recorded_at: Mon, 25 Jul 2022 15:16:57 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/target_project/target_package_2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '110'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="target_package_2" rev="13" vrev="13" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Mon, 25 Jul 2022 15:16:57 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/target_project/target_package_2?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '300'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="a4cb2d85c29acdd10516cc0661b9852d">
+          <old project="target_project" package="target_package_2" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="target_project" package="target_package_2" rev="13" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <files/>
+        </sourcediff>
+  recorded_at: Mon, 25 Jul 2022 15:16:57 GMT
+- request:
+    method: delete
+    uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?comment&user=autobuild
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+  recorded_at: Mon, 25 Jul 2022 15:16:57 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Project/Staging_Project/_accept/when_the_staging_project_is_using_pre-approved_requests/staged_requests_should_be_accepted_by_approver/1_1_7_4_1_6.yml
+++ b/src/api/spec/cassettes/Project/Staging_Project/_accept/when_the_staging_project_is_using_pre-approved_requests/staged_requests_should_be_accepted_by_approver/1_1_7_4_1_6.yml
@@ -39,14 +39,14 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:54 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_83
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_77
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_36">
+        <workflow project="home:tom" managers="group_33">
           <staging_project name="home:tom:Staging:A"/>
         </workflow>
     headers:
@@ -68,28 +68,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="103">
-          <srcmd5>b2986a92cbef7d6cfa4b5c41cfaeaba0</srcmd5>
-          <time>1658762219</time>
-          <user>user_83</user>
+        <revision rev="90">
+          <srcmd5>b353acc82ce0ac5c1f049c2ce941ba01</srcmd5>
+          <time>1658762214</time>
+          <user>user_77</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:54 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_83
+    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_77
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_33" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -117,16 +117,16 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_33" role="maintainer"/>
         </project>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:54 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_83
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_77
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_36">
+        <workflow project="home:tom" managers="group_33">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -149,28 +149,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="104">
-          <srcmd5>d3dc403b3bbd9c1401b638e11d486c21</srcmd5>
-          <time>1658762219</time>
-          <user>user_83</user>
+        <revision rev="91">
+          <srcmd5>41c5f9c8b91d52c863df323ce747999c</srcmd5>
+          <time>1658762214</time>
+          <user>user_77</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:54 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_83
+    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_77
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:B">
           <title/>
           <description/>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_33" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -198,12 +198,12 @@ http_interactions:
         <project name="home:tom:Staging:B">
           <title></title>
           <description></description>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_33" role="maintainer"/>
         </project>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:54 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_meta?user=user_83
+    uri: http://backend:5352/source/home:tom/_meta?user=user_77
     body:
       encoding: UTF-8
       string: |
@@ -211,7 +211,7 @@ http_interactions:
           <title/>
           <description/>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_36" role="reviewer"/>
+          <group groupid="group_33" role="reviewer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -240,170 +240,18 @@ http_interactions:
           <title></title>
           <description></description>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_36" role="reviewer"/>
+          <group groupid="group_33" role="reviewer"/>
         </project>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:54 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_84
+    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_78
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>The Waste Land</title>
-          <description>Aliquam adipisci velit asperiores.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '171'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="package_with_file" project="home:tom:Staging:A">
-          <title>The Waste Land</title>
-          <description>Aliquam adipisci velit asperiores.</description>
-        </package>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_config
-    body:
-      encoding: UTF-8
-      string: Maxime omnis possimus. Odit qui consequatur. Qui quis vitae.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '209'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="65" vrev="65">
-          <srcmd5>67f21c7ddab0e207e94e032f6732e1d4</srcmd5>
-          <version>unknown</version>
-          <time>1658762219</time>
-          <user>unknown</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/somefile.txt
-    body:
-      encoding: UTF-8
-      string: Voluptatum est nihil. Distinctio accusamus sint. Accusantium enim id.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '209'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="66" vrev="66">
-          <srcmd5>2a22e138fc0ef9d6981816e3997ba427</srcmd5>
-          <version>unknown</version>
-          <time>1658762219</time>
-          <user>unknown</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/target_project/_meta?user=tom
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="target_project">
-          <title>The Mermaids Singing</title>
-          <description/>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '111'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="target_project">
-          <title>The Mermaids Singing</title>
-          <description></description>
-        </project>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/target_project/target_package_2/_meta?user=tom
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="target_package_2" project="target_project">
-          <title>The Sun Also Rises</title>
-          <description>Odit debitis sit excepturi.</description>
+          <title>The Moon by Night</title>
+          <description>Hic ea assumenda saepe.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -428,19 +276,95 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <package name="target_package_2" project="target_project">
-          <title>The Sun Also Rises</title>
-          <description>Odit debitis sit excepturi.</description>
+        <package name="package_with_file" project="home:tom:Staging:A">
+          <title>The Moon by Night</title>
+          <description>Hic ea assumenda saepe.</description>
         </package>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:54 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/source_project/_meta?user=tom
+    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_config
+    body:
+      encoding: UTF-8
+      string: Qui et rerum. Cum ea eos. Perspiciatis numquam dolor.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <project name="source_project">
-          <title>Many Waters</title>
+        <revision rev="59" vrev="59">
+          <srcmd5>ced1986b73cdb400df1a6d6fbd65ac72</srcmd5>
+          <version>unknown</version>
+          <time>1658762214</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Mon, 25 Jul 2022 15:16:54 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Adipisci pariatur tempore. Explicabo et dolore. Et molestiae incidunt.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="60" vrev="60">
+          <srcmd5>c7537357bb7f650476eb7cd0cf9138f0</srcmd5>
+          <version>unknown</version>
+          <time>1658762214</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Mon, 25 Jul 2022 15:16:54 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/target_project/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="target_project">
+          <title>In a Glass Darkly</title>
           <description/>
         </project>
     headers:
@@ -462,15 +386,91 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '102'
+      - '108'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="target_project">
+          <title>In a Glass Darkly</title>
+          <description></description>
+        </project>
+  recorded_at: Mon, 25 Jul 2022 15:16:54 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/target_project/target_package_2/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package_2" project="target_project">
+          <title>Consider Phlebas</title>
+          <description>Animi distinctio pariatur alias.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '166'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package_2" project="target_project">
+          <title>Consider Phlebas</title>
+          <description>Animi distinctio pariatur alias.</description>
+        </package>
+  recorded_at: Mon, 25 Jul 2022 15:16:54 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/source_project/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Many Waters</title>
+          <title>The Heart Is Deceitful Above All Things</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '130'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="source_project">
+          <title>The Heart Is Deceitful Above All Things</title>
           <description></description>
         </project>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:54 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_project/_attribute?meta=1&user=tom
@@ -503,14 +503,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="64">
-          <srcmd5>b3df56152978fa66e2e250b475619d6d</srcmd5>
-          <time>1658762219</time>
+        <revision rev="58">
+          <srcmd5>d7b10c55454363c98b42c55c72a53fe5</srcmd5>
+          <time>1658762215</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:55 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/source_package/_meta?user=tom
@@ -518,8 +518,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>Death Be Not Proud</title>
-          <description>Recusandae provident earum ex.</description>
+          <title>The Little Foxes</title>
+          <description>Quod officiis occaecati eius.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -540,15 +540,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '164'
+      - '161'
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>Death Be Not Proud</title>
-          <description>Recusandae provident earum ex.</description>
+          <title>The Little Foxes</title>
+          <description>Quod officiis occaecati eius.</description>
         </package>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:55 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package
@@ -580,7 +580,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:55 GMT
 - request:
     method: post
     uri: http://backend:5352/source/source_project/source_package?cmd=diff&expand=1&filelimit=10000&opackage=target_package_2&oproject=target_project&tarlimit=10000&view=xml&withissues=1
@@ -612,15 +612,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="34e57069b586e7ab724b16f19bcd0dcb">
-          <old project="target_project" package="target_package_2" rev="14" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+        <sourcediff key="44afb6ef83a5d48fb995c5daf791ff81">
+          <old project="target_project" package="target_package_2" rev="11" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <new project="source_project" package="source_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files>
           </files>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:55 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22source_package%22%20and%20linkinfo/@project=%22source_project%22%20and%20@project=%22source_project%22)
@@ -654,7 +654,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:55 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2/_meta?user=tom
@@ -662,8 +662,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>Death Be Not Proud</title>
-          <description>Recusandae provident earum ex.</description>
+          <title>The Little Foxes</title>
+          <description>Quod officiis occaecati eius.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -684,15 +684,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '170'
+      - '167'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>Death Be Not Proud</title>
-          <description>Recusandae provident earum ex.</description>
+          <title>The Little Foxes</title>
+          <description>Quod officiis occaecati eius.</description>
         </package>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:55 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?cmd=branch&noservice=1&opackage=source_package&oproject=source_project&user=tom
@@ -727,12 +727,12 @@ http_interactions:
         <revision rev="1" vrev="1">
           <srcmd5>8e451641a827df5f4f409d1d543fdb7b</srcmd5>
           <version>unknown</version>
-          <time>1658762219</time>
+          <time>1658762215</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:55 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2/_meta?user=tom
@@ -740,8 +740,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>Death Be Not Proud</title>
-          <description>Recusandae provident earum ex.</description>
+          <title>The Little Foxes</title>
+          <description>Quod officiis occaecati eius.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -762,15 +762,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '170'
+      - '167'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package_2" project="home:tom:Staging:A">
-          <title>Death Be Not Proud</title>
-          <description>Recusandae provident earum ex.</description>
+          <title>The Little Foxes</title>
+          <description>Quod officiis occaecati eius.</description>
         </package>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:55 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2
@@ -804,7 +804,7 @@ http_interactions:
           <linkinfo project="source_project" package="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
           <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658762120"/>
         </directory>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:55 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?view=info
@@ -838,7 +838,7 @@ http_interactions:
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="source_project" package="source_package"/>
         </sourceinfo>
-  recorded_at: Mon, 25 Jul 2022 15:16:59 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:55 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2
@@ -872,7 +872,7 @@ http_interactions:
           <linkinfo project="source_project" package="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
           <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658762120"/>
         </directory>
-  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:55 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -911,7 +911,7 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:55 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -950,14 +950,14 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:55 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=tom
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_36">
+        <workflow project="home:tom" managers="group_33">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -980,18 +980,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '166'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="105">
-          <srcmd5>d3dc403b3bbd9c1401b638e11d486c21</srcmd5>
-          <time>1658762220</time>
+        <revision rev="92">
+          <srcmd5>41c5f9c8b91d52c863df323ce747999c</srcmd5>
+          <time>1658762215</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:55 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=tom
@@ -1001,7 +1001,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_33" role="maintainer"/>
           <repository name="staging_repository">
             <arch>x86_64</arch>
           </repository>
@@ -1032,19 +1032,19 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_33" role="maintainer"/>
           <repository name="staging_repository">
             <arch>x86_64</arch>
           </repository>
         </project>
-  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:55 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_83
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_77
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_36">
+        <workflow project="home:tom" managers="group_33">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -1067,18 +1067,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="106">
-          <srcmd5>d3dc403b3bbd9c1401b638e11d486c21</srcmd5>
-          <time>1658762220</time>
-          <user>user_83</user>
+        <revision rev="93">
+          <srcmd5>41c5f9c8b91d52c863df323ce747999c</srcmd5>
+          <time>1658762215</time>
+          <user>user_77</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:55 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=tom
@@ -1088,7 +1088,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_33" role="maintainer"/>
           <build>
             <disable/>
           </build>
@@ -1122,7 +1122,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_33" role="maintainer"/>
           <build>
             <disable/>
           </build>
@@ -1130,7 +1130,7 @@ http_interactions:
             <arch>x86_64</arch>
           </repository>
         </project>
-  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:55 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package?expand=1
@@ -1162,5 +1162,282 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:55 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/source_project/source_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '89'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Mon, 25 Jul 2022 15:16:55 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/target_project/target_package_2?cmd=copy&comment=Request%20for%20package%20target_package_2&expand=1&keeplink=1&noservice=1&opackage=source_package&oproject=source_project&requestid=1&user=autobuild&withacceptinfo=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '369'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="12" vrev="12">
+          <srcmd5>d41d8cd98f00b204e9800998ecf8427e</srcmd5>
+          <version>unknown</version>
+          <time>1658762215</time>
+          <user>autobuild</user>
+          <comment>Request for package target_package_2</comment>
+          <requestid>1</requestid>
+          <acceptinfo rev="12" srcmd5="d41d8cd98f00b204e9800998ecf8427e" osrcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+        </revision>
+  recorded_at: Mon, 25 Jul 2022 15:16:55 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/target_project/target_package_2/_meta?user=autobuild
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package_2" project="target_project">
+          <title>Consider Phlebas</title>
+          <description>Animi distinctio pariatur alias.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '166'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package_2" project="target_project">
+          <title>Consider Phlebas</title>
+          <description>Animi distinctio pariatur alias.</description>
+        </package>
+  recorded_at: Mon, 25 Jul 2022 15:16:55 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/target_project/target_package_2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '110'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="target_package_2" rev="12" vrev="12" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Mon, 25 Jul 2022 15:16:55 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/target_project/target_package_2?view=info
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '151'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourceinfo package="target_package_2" rev="12" vrev="12" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+          <error>no source uploaded</error>
+        </sourceinfo>
+  recorded_at: Mon, 25 Jul 2022 15:16:55 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/target_project/target_package_2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '110'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="target_package_2" rev="12" vrev="12" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Mon, 25 Jul 2022 15:16:55 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/target_project/target_package_2?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '300'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="c6be42fd37b74d5d4c24325d3fd52be9">
+          <old project="target_project" package="target_package_2" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="target_project" package="target_package_2" rev="12" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <files/>
+        </sourcediff>
+  recorded_at: Mon, 25 Jul 2022 15:16:55 GMT
+- request:
+    method: delete
+    uri: http://backend:5352/source/home:tom:Staging:A/target_package_2?comment&user=autobuild
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+  recorded_at: Mon, 25 Jul 2022 15:16:55 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Project/Staging_Project/_assign_managers_group/when_the_group_was_already_assigned/1_1_4_2_1.yml
+++ b/src/api/spec/cassettes/Project/Staging_Project/_assign_managers_group/when_the_group_was_already_assigned/1_1_4_2_1.yml
@@ -39,14 +39,14 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:42 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:31 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_73
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_43
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_31">
+        <workflow project="home:tom" managers="group_15">
           <staging_project name="home:tom:Staging:A"/>
         </workflow>
     headers:
@@ -68,28 +68,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="307">
-          <srcmd5>858fc5aa02396f412c38ebd9715591bf</srcmd5>
-          <time>1658422062</time>
-          <user>user_73</user>
+        <revision rev="29">
+          <srcmd5>2e4fd7acfe7e7c1f399a1329f38a7407</srcmd5>
+          <time>1658762191</time>
+          <user>user_43</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:42 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:31 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_73
+    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_43
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_31" role="maintainer"/>
+          <group groupid="group_15" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -117,16 +117,16 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_31" role="maintainer"/>
+          <group groupid="group_15" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:42 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:31 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_73
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_43
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_31">
+        <workflow project="home:tom" managers="group_15">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -149,28 +149,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="308">
-          <srcmd5>3a14b8118683a8f6a6e01e0236b83bb2</srcmd5>
-          <time>1658422062</time>
-          <user>user_73</user>
+        <revision rev="30">
+          <srcmd5>9baea94f04f89a4aef426e3f265e78df</srcmd5>
+          <time>1658762191</time>
+          <user>user_43</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:42 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:31 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_73
+    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_43
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:B">
           <title/>
           <description/>
-          <group groupid="group_31" role="maintainer"/>
+          <group groupid="group_15" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -198,12 +198,12 @@ http_interactions:
         <project name="home:tom:Staging:B">
           <title></title>
           <description></description>
-          <group groupid="group_31" role="maintainer"/>
+          <group groupid="group_15" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:42 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:31 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_meta?user=user_73
+    uri: http://backend:5352/source/home:tom/_meta?user=user_43
     body:
       encoding: UTF-8
       string: |
@@ -211,7 +211,7 @@ http_interactions:
           <title/>
           <description/>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_31" role="reviewer"/>
+          <group groupid="group_15" role="reviewer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -240,18 +240,18 @@ http_interactions:
           <title></title>
           <description></description>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_31" role="reviewer"/>
+          <group groupid="group_15" role="reviewer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:42 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:31 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_74
+    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_44
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>Consider Phlebas</title>
-          <description>Hic dignissimos aut pariatur.</description>
+          <title>Tender Is the Night</title>
+          <description>Est ea odio sed.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -272,21 +272,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '168'
+      - '158'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>Consider Phlebas</title>
-          <description>Hic dignissimos aut pariatur.</description>
+          <title>Tender Is the Night</title>
+          <description>Est ea odio sed.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:42 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:31 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_config
     body:
       encoding: UTF-8
-      string: Sint omnis fugiat. Asperiores autem aut. Ipsam qui architecto.
+      string: Enim consectetur eius. Ut sequi dolor. Alias qui sed.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -306,25 +306,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="151" vrev="151">
-          <srcmd5>17c4922bdda5d4a252de30e3ebbf05c8</srcmd5>
+        <revision rev="29" vrev="29">
+          <srcmd5>178e68fc54cb58c7d1435b4a93c560d3</srcmd5>
           <version>unknown</version>
-          <time>1658422062</time>
+          <time>1658762191</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:42 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:31 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/somefile.txt
     body:
       encoding: UTF-8
-      string: Doloremque qui aut. Laboriosam eius non. Ea et omnis.
+      string: At possimus et. Iusto tenetur illo. Iste sit unde.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -344,26 +344,26 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="152" vrev="152">
-          <srcmd5>4953616d03788da687d1eb7c5cb2539a</srcmd5>
+        <revision rev="30" vrev="30">
+          <srcmd5>4741ddd46c2c0faabf963afc520d195a</srcmd5>
           <version>unknown</version>
-          <time>1658422062</time>
+          <time>1658762191</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:42 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:31 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_73
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_43
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_31">
+        <workflow project="home:tom" managers="group_15">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -386,18 +386,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="309">
-          <srcmd5>3a14b8118683a8f6a6e01e0236b83bb2</srcmd5>
-          <time>1658422062</time>
-          <user>user_73</user>
+        <revision rev="31">
+          <srcmd5>9baea94f04f89a4aef426e3f265e78df</srcmd5>
+          <time>1658762191</time>
+          <user>user_43</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:42 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:31 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=tom
@@ -407,7 +407,7 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_31" role="maintainer"/>
+          <group groupid="group_15" role="maintainer"/>
           <repository name="staging_repository">
             <arch>x86_64</arch>
           </repository>
@@ -438,10 +438,10 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_31" role="maintainer"/>
+          <group groupid="group_15" role="maintainer"/>
           <repository name="staging_repository">
             <arch>x86_64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:42 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:31 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Project/Staging_Project/_assign_managers_group/when_the_group_wasn_t_assigned_before/1_1_4_1_1.yml
+++ b/src/api/spec/cassettes/Project/Staging_Project/_assign_managers_group/when_the_group_wasn_t_assigned_before/1_1_4_1_1.yml
@@ -39,14 +39,14 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:41 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:32 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_71
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_45
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_29">
+        <workflow project="home:tom" managers="group_16">
           <staging_project name="home:tom:Staging:A"/>
         </workflow>
     headers:
@@ -68,28 +68,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="304">
-          <srcmd5>2ca2b0d9b433bd3073e8911bb20511df</srcmd5>
-          <time>1658422062</time>
-          <user>user_71</user>
+        <revision rev="32">
+          <srcmd5>6efef63c33531a03717eb30200b211e1</srcmd5>
+          <time>1658762192</time>
+          <user>user_45</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:42 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:32 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_71
+    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_45
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_29" role="maintainer"/>
+          <group groupid="group_16" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -117,16 +117,16 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_29" role="maintainer"/>
+          <group groupid="group_16" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:42 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:32 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_71
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_45
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_29">
+        <workflow project="home:tom" managers="group_16">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -149,28 +149,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="305">
-          <srcmd5>ab3d588934c4da97d06949614800b96a</srcmd5>
-          <time>1658422062</time>
-          <user>user_71</user>
+        <revision rev="33">
+          <srcmd5>f9d865f06b672417cef33acd1c3cd4e3</srcmd5>
+          <time>1658762192</time>
+          <user>user_45</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:42 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:32 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_71
+    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_45
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:B">
           <title/>
           <description/>
-          <group groupid="group_29" role="maintainer"/>
+          <group groupid="group_16" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -198,12 +198,12 @@ http_interactions:
         <project name="home:tom:Staging:B">
           <title></title>
           <description></description>
-          <group groupid="group_29" role="maintainer"/>
+          <group groupid="group_16" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:42 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:32 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_meta?user=user_71
+    uri: http://backend:5352/source/home:tom/_meta?user=user_45
     body:
       encoding: UTF-8
       string: |
@@ -211,7 +211,7 @@ http_interactions:
           <title/>
           <description/>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_29" role="reviewer"/>
+          <group groupid="group_16" role="reviewer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -240,18 +240,18 @@ http_interactions:
           <title></title>
           <description></description>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_29" role="reviewer"/>
+          <group groupid="group_16" role="reviewer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:42 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:32 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_72
+    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_46
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>Stranger in a Strange Land</title>
-          <description>Et sed sit rerum.</description>
+          <title>Brandy of the Damned</title>
+          <description>Praesentium dolor nemo corporis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -272,22 +272,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '166'
+      - '175'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>Stranger in a Strange Land</title>
-          <description>Et sed sit rerum.</description>
+          <title>Brandy of the Damned</title>
+          <description>Praesentium dolor nemo corporis.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:42 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:32 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_config
     body:
       encoding: UTF-8
-      string: Dolorum beatae repellat. Repellat accusantium voluptatum. Voluptatum
-        quas enim.
+      string: Distinctio sequi quae. Architecto voluptas repellendus. Est totam voluptatem.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -307,25 +306,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="149" vrev="149">
-          <srcmd5>3e46e7668a13731c683967a797d1592f</srcmd5>
+        <revision rev="31" vrev="31">
+          <srcmd5>46fdb912f35884134b032f690764a511</srcmd5>
           <version>unknown</version>
-          <time>1658422062</time>
+          <time>1658762192</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:42 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:32 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/somefile.txt
     body:
       encoding: UTF-8
-      string: Commodi et et. Recusandae voluptas modi. Non odit dolorem.
+      string: Sit vel incidunt. Facilis id fugit. Quos porro voluptates.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -345,26 +344,26 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="150" vrev="150">
-          <srcmd5>ab57db0aff34aa290f830dee465e4514</srcmd5>
+        <revision rev="32" vrev="32">
+          <srcmd5>5c647015177ecc5fdd9f053f1f1be661</srcmd5>
           <version>unknown</version>
-          <time>1658422062</time>
+          <time>1658762192</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:42 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:32 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_71
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_45
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_29">
+        <workflow project="home:tom" managers="group_16">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -387,18 +386,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="306">
-          <srcmd5>ab3d588934c4da97d06949614800b96a</srcmd5>
-          <time>1658422062</time>
-          <user>user_71</user>
+        <revision rev="34">
+          <srcmd5>f9d865f06b672417cef33acd1c3cd4e3</srcmd5>
+          <time>1658762192</time>
+          <user>user_45</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:42 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:32 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=tom
@@ -408,8 +407,8 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_29" role="maintainer"/>
-          <group groupid="group_30" role="maintainer"/>
+          <group groupid="group_16" role="maintainer"/>
+          <group groupid="group_17" role="maintainer"/>
           <repository name="staging_repository">
             <arch>x86_64</arch>
           </repository>
@@ -440,11 +439,11 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_29" role="maintainer"/>
-          <group groupid="group_30" role="maintainer"/>
+          <group groupid="group_16" role="maintainer"/>
+          <group groupid="group_17" role="maintainer"/>
           <repository name="staging_repository">
             <arch>x86_64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:42 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:32 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Project/Staging_Project/_copy/1_1_6_2.yml
+++ b/src/api/spec/cassettes/Project/Staging_Project/_copy/1_1_6_2.yml
@@ -39,14 +39,14 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:43 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:02 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_79
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_95
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_34">
+        <workflow project="home:tom" managers="group_42">
           <staging_project name="home:tom:Staging:A"/>
         </workflow>
     headers:
@@ -72,24 +72,24 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="315">
-          <srcmd5>a2a6b97bb52dea86f0621cf493197d54</srcmd5>
-          <time>1658422063</time>
-          <user>user_79</user>
+        <revision rev="120">
+          <srcmd5>d084873351cbb99443a1831eed2fb8b7</srcmd5>
+          <time>1658762222</time>
+          <user>user_95</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:43 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:02 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_79
+    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_95
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_34" role="maintainer"/>
+          <group groupid="group_42" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -117,16 +117,16 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_34" role="maintainer"/>
+          <group groupid="group_42" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:43 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:02 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_79
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_95
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_34">
+        <workflow project="home:tom" managers="group_42">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -153,24 +153,24 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="316">
-          <srcmd5>a552ee983f053fa9227951658e6a6565</srcmd5>
-          <time>1658422063</time>
-          <user>user_79</user>
+        <revision rev="121">
+          <srcmd5>b11b8a091b868c430167d82991588166</srcmd5>
+          <time>1658762222</time>
+          <user>user_95</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:43 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:02 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_79
+    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_95
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:B">
           <title/>
           <description/>
-          <group groupid="group_34" role="maintainer"/>
+          <group groupid="group_42" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -198,12 +198,12 @@ http_interactions:
         <project name="home:tom:Staging:B">
           <title></title>
           <description></description>
-          <group groupid="group_34" role="maintainer"/>
+          <group groupid="group_42" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:44 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:02 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_meta?user=user_79
+    uri: http://backend:5352/source/home:tom/_meta?user=user_95
     body:
       encoding: UTF-8
       string: |
@@ -211,7 +211,7 @@ http_interactions:
           <title/>
           <description/>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_34" role="reviewer"/>
+          <group groupid="group_42" role="reviewer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -240,16 +240,16 @@ http_interactions:
           <title></title>
           <description></description>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_34" role="reviewer"/>
+          <group groupid="group_42" role="reviewer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:44 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:02 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_79
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_95
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_34">
+        <workflow project="home:tom" managers="group_42">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
           <staging_project name="home:tom:Staging:XYZ"/>
@@ -277,14 +277,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="317">
-          <srcmd5>166857ec3393f0e6ad750a77ed2c43f6</srcmd5>
-          <time>1658422064</time>
-          <user>user_79</user>
+        <revision rev="122">
+          <srcmd5>69a91f7570666ff70858c98549ea7bac</srcmd5>
+          <time>1658762222</time>
+          <user>user_95</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:44 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:02 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:XYZ/_config?user=factory%20bot
@@ -316,7 +316,7 @@ http_interactions:
       string: '<status code="ok" />
 
 '
-  recorded_at: Thu, 21 Jul 2022 16:47:44 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:02 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:XYZ/_config
@@ -346,17 +346,17 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 'Prefer: foo'
-  recorded_at: Thu, 21 Jul 2022 16:47:44 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:02 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:XYZ/_meta?user=user_80
+    uri: http://backend:5352/source/home:tom:Staging:XYZ/_meta?user=user_96
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:XYZ">
-          <title>Sleep the Brave</title>
+          <title>The Far-Distant Oxus</title>
           <description/>
-          <group groupid="group_34" role="maintainer"/>
+          <group groupid="group_42" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -377,25 +377,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '160'
+      - '165'
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:XYZ">
-          <title>Sleep the Brave</title>
+          <title>The Far-Distant Oxus</title>
           <description></description>
-          <group groupid="group_34" role="maintainer"/>
+          <group groupid="group_42" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:44 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:02 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:XYZ/package_with_file/_meta?user=user_81
+    uri: http://backend:5352/source/home:tom:Staging:XYZ/package_with_file/_meta?user=user_97
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:XYZ">
-          <title>Look to Windward</title>
-          <description>Est qui occaecati voluptatem.</description>
+          <title>The Moving Toyshop</title>
+          <description>Dolores accusamus dolorem ut.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -416,21 +416,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '170'
+      - '172'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:XYZ">
-          <title>Look to Windward</title>
-          <description>Est qui occaecati voluptatem.</description>
+          <title>The Moving Toyshop</title>
+          <description>Dolores accusamus dolorem ut.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:44 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:02 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:XYZ/package_with_file/_config
     body:
       encoding: UTF-8
-      string: Error modi beatae. Ratione et molestiae. Tenetur facilis ut.
+      string: Alias quisquam aliquam. Qui voluptatem nulla. Laborum dignissimos impedit.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -454,21 +454,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="3" vrev="3">
-          <srcmd5>a9687165cbbd9a035299ea3d920c336d</srcmd5>
+        <revision rev="5" vrev="5">
+          <srcmd5>f3e382f373fd9a185e2f8ccf6bdf45d6</srcmd5>
           <version>unknown</version>
-          <time>1658422064</time>
+          <time>1658762222</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:44 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:02 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:XYZ/package_with_file/somefile.txt
     body:
       encoding: UTF-8
-      string: Est harum rerum. Facilis cumque cum. Ducimus consequuntur consequatur.
+      string: Rerum numquam aspernatur. Ipsum repellat facere. Temporibus optio eum.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -492,23 +492,23 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="4" vrev="4">
-          <srcmd5>6ad17244a002f34889a3d35946c5b42b</srcmd5>
+        <revision rev="6" vrev="6">
+          <srcmd5>4df0940b280ee5be7db1129c7f7a8086</srcmd5>
           <version>unknown</version>
-          <time>1658422064</time>
+          <time>1658762222</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:44 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:02 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/project_6/_meta?user=tom
+    uri: http://backend:5352/source/project_9/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
-        <project name="project_6">
-          <title>Blithe Spirit</title>
+        <project name="project_9">
+          <title>A Handful of Dust</title>
           <description/>
         </project>
     headers:
@@ -530,23 +530,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '99'
+      - '103'
     body:
       encoding: UTF-8
       string: |
-        <project name="project_6">
-          <title>Blithe Spirit</title>
+        <project name="project_9">
+          <title>A Handful of Dust</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:44 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:03 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/project_7/_meta?user=tom
+    uri: http://backend:5352/source/project_10/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
-        <project name="project_7">
-          <title>Ego Dominus Tuus</title>
+        <project name="project_10">
+          <title>Look to Windward</title>
           <description/>
         </project>
     headers:
@@ -568,23 +568,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '102'
+      - '103'
     body:
       encoding: UTF-8
       string: |
-        <project name="project_7">
-          <title>Ego Dominus Tuus</title>
+        <project name="project_10">
+          <title>Look to Windward</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:44 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:03 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/project_8/_meta?user=tom
+    uri: http://backend:5352/source/project_11/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
-        <project name="project_8">
-          <title>Jacob Have I Loved</title>
+        <project name="project_11">
+          <title>To Sail Beyond the Sunset</title>
           <description/>
         </project>
     headers:
@@ -606,22 +606,22 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '104'
+      - '112'
     body:
       encoding: UTF-8
       string: |
-        <project name="project_8">
-          <title>Jacob Have I Loved</title>
+        <project name="project_11">
+          <title>To Sail Beyond the Sunset</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:44 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:03 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=tom
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_34">
+        <workflow project="home:tom" managers="group_42">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
           <staging_project name="home:tom:Staging:XYZ"/>
@@ -650,21 +650,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="318">
-          <srcmd5>ad8d2f4e9e8b25f9c4a7d904dea766ac</srcmd5>
-          <time>1658422064</time>
+        <revision rev="123">
+          <srcmd5>53e516c57def135224733cf9f77eb5cb</srcmd5>
+          <time>1658762223</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:44 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:03 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=tom
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_34">
+        <workflow project="home:tom" managers="group_42">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
           <staging_project name="home:tom:Staging:XYZ"/>
@@ -693,14 +693,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="319">
-          <srcmd5>ad8d2f4e9e8b25f9c4a7d904dea766ac</srcmd5>
-          <time>1658422064</time>
+        <revision rev="124">
+          <srcmd5>53e516c57def135224733cf9f77eb5cb</srcmd5>
+          <time>1658762223</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:44 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:03 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:new_project/_meta?user=tom
@@ -708,19 +708,19 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="home:tom:new_project">
-          <title>Sleep the Brave</title>
+          <title>The Far-Distant Oxus</title>
           <description/>
-          <person userid="user_82" role="maintainer"/>
-          <group groupid="group_34" role="maintainer"/>
-          <group groupid="group_35" role="maintainer"/>
+          <person userid="user_98" role="maintainer"/>
+          <group groupid="group_42" role="maintainer"/>
+          <group groupid="group_43" role="maintainer"/>
           <sourceaccess>
             <disable/>
           </sourceaccess>
           <repository name="staging_repository">
             <download arch="x86_64" url="http://suse.com" repotype="rpmmd"/>
-            <path project="project_6" repository="repository_4"/>
-            <path project="project_7" repository="repository_5"/>
-            <path project="project_8" repository="repository_6"/>
+            <path project="project_9" repository="repository_7"/>
+            <path project="project_10" repository="repository_8"/>
+            <path project="project_11" repository="repository_9"/>
             <arch>x86_64</arch>
           </repository>
         </project>
@@ -743,28 +743,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '629'
+      - '636'
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:new_project">
-          <title>Sleep the Brave</title>
+          <title>The Far-Distant Oxus</title>
           <description></description>
-          <person userid="user_82" role="maintainer"/>
-          <group groupid="group_34" role="maintainer"/>
-          <group groupid="group_35" role="maintainer"/>
+          <person userid="user_98" role="maintainer"/>
+          <group groupid="group_42" role="maintainer"/>
+          <group groupid="group_43" role="maintainer"/>
           <sourceaccess>
             <disable/>
           </sourceaccess>
           <repository name="staging_repository">
             <download arch="x86_64" repotype="rpmmd" url="http://suse.com"/>
-            <path project="project_6" repository="repository_4"/>
-            <path project="project_7" repository="repository_5"/>
-            <path project="project_8" repository="repository_6"/>
+            <path project="project_9" repository="repository_7"/>
+            <path project="project_10" repository="repository_8"/>
+            <path project="project_11" repository="repository_9"/>
             <arch>x86_64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:44 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:03 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:new_project/_config?comment=Copying%20project%20home:tom:Staging:XYZ&user=tom
@@ -796,7 +796,7 @@ http_interactions:
       string: '<status code="ok" />
 
 '
-  recorded_at: Thu, 21 Jul 2022 16:47:44 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:03 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:new_project/_config
@@ -826,5 +826,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 'Prefer: foo'
-  recorded_at: Thu, 21 Jul 2022 16:47:44 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:03 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Project/Staging_Project/_copy/copies_flags.yml
+++ b/src/api/spec/cassettes/Project/Staging_Project/_copy/copies_flags.yml
@@ -39,14 +39,14 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:44 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_83
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_87
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_36">
+        <workflow project="home:tom" managers="group_38">
           <staging_project name="home:tom:Staging:A"/>
         </workflow>
     headers:
@@ -72,24 +72,24 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="320">
-          <srcmd5>b2986a92cbef7d6cfa4b5c41cfaeaba0</srcmd5>
-          <time>1658422064</time>
-          <user>user_83</user>
+        <revision rev="110">
+          <srcmd5>d4f91ca16eeb0e66406ec8d50f7a1a84</srcmd5>
+          <time>1658762220</time>
+          <user>user_87</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:44 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_83
+    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_87
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_38" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -117,16 +117,16 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_38" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:44 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_83
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_87
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_36">
+        <workflow project="home:tom" managers="group_38">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -153,24 +153,24 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="321">
-          <srcmd5>d3dc403b3bbd9c1401b638e11d486c21</srcmd5>
-          <time>1658422064</time>
-          <user>user_83</user>
+        <revision rev="111">
+          <srcmd5>efa9f8d9f557caca90de3461b2503017</srcmd5>
+          <time>1658762220</time>
+          <user>user_87</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:44 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_83
+    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_87
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:B">
           <title/>
           <description/>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_38" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -198,12 +198,12 @@ http_interactions:
         <project name="home:tom:Staging:B">
           <title></title>
           <description></description>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_38" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:44 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:01 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_meta?user=user_83
+    uri: http://backend:5352/source/home:tom/_meta?user=user_87
     body:
       encoding: UTF-8
       string: |
@@ -211,7 +211,7 @@ http_interactions:
           <title/>
           <description/>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_36" role="reviewer"/>
+          <group groupid="group_38" role="reviewer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -240,16 +240,16 @@ http_interactions:
           <title></title>
           <description></description>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_36" role="reviewer"/>
+          <group groupid="group_38" role="reviewer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:45 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:01 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_83
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_87
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_36">
+        <workflow project="home:tom" managers="group_38">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
           <staging_project name="home:tom:Staging:XYZ"/>
@@ -277,14 +277,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="322">
-          <srcmd5>a5c3e38a776d77d6a78474167fff0550</srcmd5>
-          <time>1658422065</time>
-          <user>user_83</user>
+        <revision rev="112">
+          <srcmd5>f3a7be969a24cd003e2d208c6669a307</srcmd5>
+          <time>1658762221</time>
+          <user>user_87</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:45 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:01 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:XYZ/_config?user=factory%20bot
@@ -300,8 +300,8 @@ http_interactions:
       - Ruby
   response:
     status:
-      code: 200
-      message: OK
+      code: 404
+      message: project 'home tom Staging XYZ' does not exist
     headers:
       Content-Type:
       - text/xml
@@ -310,53 +310,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '21'
+      - '168'
     body:
       encoding: UTF-8
-      string: '<status code="ok" />
-
-'
-  recorded_at: Thu, 21 Jul 2022 16:47:45 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:tom:Staging:XYZ/_config
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '11'
-    body:
-      encoding: UTF-8
-      string: 'Prefer: foo'
-  recorded_at: Thu, 21 Jul 2022 16:47:45 GMT
+      string: |
+        <status code="404">
+          <summary>project 'home:tom:Staging:XYZ' does not exist</summary>
+          <details>404 project 'home:tom:Staging:XYZ' does not exist</details>
+        </status>
+  recorded_at: Mon, 25 Jul 2022 15:17:01 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:XYZ/_meta?user=user_84
+    uri: http://backend:5352/source/home:tom:Staging:XYZ/_meta?user=user_88
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:XYZ">
-          <title>Cabbages and Kings</title>
+          <title>That Hideous Strength</title>
           <description/>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_38" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -377,25 +349,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '163'
+      - '166'
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:XYZ">
-          <title>Cabbages and Kings</title>
+          <title>That Hideous Strength</title>
           <description></description>
-          <group groupid="group_36" role="maintainer"/>
+          <group groupid="group_38" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:45 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:01 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:XYZ/package_with_file/_meta?user=user_85
+    uri: http://backend:5352/source/home:tom:Staging:XYZ/package_with_file/_meta?user=user_89
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:XYZ">
-          <title>Those Barren Leaves, Thrones, Dominations</title>
-          <description>Ea necessitatibus veritatis in.</description>
+          <title>Tiger! Tiger!</title>
+          <description>Sequi sapiente vel soluta.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -416,21 +388,22 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '197'
+      - '164'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:XYZ">
-          <title>Those Barren Leaves, Thrones, Dominations</title>
-          <description>Ea necessitatibus veritatis in.</description>
+          <title>Tiger! Tiger!</title>
+          <description>Sequi sapiente vel soluta.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:45 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:01 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:XYZ/package_with_file/_config
     body:
       encoding: UTF-8
-      string: Hic sed id. Omnis voluptas laboriosam. Aliquid id nesciunt.
+      string: Reiciendis rem dolores. Possimus deserunt atque. Accusamus voluptas
+        repellendus.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -454,21 +427,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="5" vrev="5">
-          <srcmd5>cfa823478d237a73c5567e62e05e2ee7</srcmd5>
+        <revision rev="1" vrev="1">
+          <srcmd5>94b1047810aed6172a67720526316b46</srcmd5>
           <version>unknown</version>
-          <time>1658422065</time>
+          <time>1658762221</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:45 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:01 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:XYZ/package_with_file/somefile.txt
     body:
       encoding: UTF-8
-      string: Odit incidunt enim. Fugiat debitis consequuntur. Sit voluptas quia.
+      string: Quia perferendis similique. Consequatur ut nulla. Eaque autem perferendis.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -492,22 +465,60 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="6" vrev="6">
-          <srcmd5>b6e02605ab4edd5a9bd80959e98ee5c7</srcmd5>
+        <revision rev="2" vrev="2">
+          <srcmd5>96cf41d5438d79b81a2e8dd85f3a8840</srcmd5>
           <version>unknown</version>
-          <time>1658422065</time>
+          <time>1658762221</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:45 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:01 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/project_9/_meta?user=tom
+    uri: http://backend:5352/source/project_3/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
-        <project name="project_9">
+        <project name="project_3">
+          <title>Taming a Sea Horse</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '104'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_3">
+          <title>Taming a Sea Horse</title>
+          <description></description>
+        </project>
+  recorded_at: Mon, 25 Jul 2022 15:17:01 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_4/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_4">
           <title>A Passage to India</title>
           <description/>
         </project>
@@ -534,19 +545,19 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <project name="project_9">
+        <project name="project_4">
           <title>A Passage to India</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:45 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:01 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/project_10/_meta?user=tom
+    uri: http://backend:5352/source/project_5/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
-        <project name="project_10">
-          <title>A Summer Bird-Cage</title>
+        <project name="project_5">
+          <title>Absalom, Absalom!</title>
           <description/>
         </project>
     headers:
@@ -568,60 +579,22 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '105'
+      - '103'
     body:
       encoding: UTF-8
       string: |
-        <project name="project_10">
-          <title>A Summer Bird-Cage</title>
+        <project name="project_5">
+          <title>Absalom, Absalom!</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:45 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/project_11/_meta?user=tom
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="project_11">
-          <title>Oh! To be in England</title>
-          <description/>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '107'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="project_11">
-          <title>Oh! To be in England</title>
-          <description></description>
-        </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:45 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:01 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=tom
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_36">
+        <workflow project="home:tom" managers="group_38">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
           <staging_project name="home:tom:Staging:XYZ"/>
@@ -650,21 +623,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="323">
-          <srcmd5>04f21b281bb410a0657af4c5d73273bc</srcmd5>
-          <time>1658422065</time>
+        <revision rev="113">
+          <srcmd5>1adecba8089b302ee91d7ab49a8c412c</srcmd5>
+          <time>1658762221</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:45 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:01 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=tom
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_36">
+        <workflow project="home:tom" managers="group_38">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
           <staging_project name="home:tom:Staging:XYZ"/>
@@ -693,14 +666,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="324">
-          <srcmd5>04f21b281bb410a0657af4c5d73273bc</srcmd5>
-          <time>1658422065</time>
+        <revision rev="114">
+          <srcmd5>1adecba8089b302ee91d7ab49a8c412c</srcmd5>
+          <time>1658762221</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:45 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:01 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:new_project/_meta?user=tom
@@ -708,19 +681,19 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="home:tom:new_project">
-          <title>Cabbages and Kings</title>
+          <title>That Hideous Strength</title>
           <description/>
-          <person userid="user_86" role="maintainer"/>
-          <group groupid="group_36" role="maintainer"/>
-          <group groupid="group_37" role="maintainer"/>
+          <person userid="user_90" role="maintainer"/>
+          <group groupid="group_38" role="maintainer"/>
+          <group groupid="group_39" role="maintainer"/>
           <sourceaccess>
             <disable/>
           </sourceaccess>
           <repository name="staging_repository">
             <download arch="x86_64" url="http://suse.com" repotype="rpmmd"/>
-            <path project="project_9" repository="repository_7"/>
-            <path project="project_10" repository="repository_8"/>
-            <path project="project_11" repository="repository_9"/>
+            <path project="project_3" repository="repository_1"/>
+            <path project="project_4" repository="repository_2"/>
+            <path project="project_5" repository="repository_3"/>
             <arch>x86_64</arch>
           </repository>
         </project>
@@ -743,88 +716,26 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '634'
+      - '635'
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:new_project">
-          <title>Cabbages and Kings</title>
+          <title>That Hideous Strength</title>
           <description></description>
-          <person userid="user_86" role="maintainer"/>
-          <group groupid="group_36" role="maintainer"/>
-          <group groupid="group_37" role="maintainer"/>
+          <person userid="user_90" role="maintainer"/>
+          <group groupid="group_38" role="maintainer"/>
+          <group groupid="group_39" role="maintainer"/>
           <sourceaccess>
             <disable/>
           </sourceaccess>
           <repository name="staging_repository">
             <download arch="x86_64" repotype="rpmmd" url="http://suse.com"/>
-            <path project="project_9" repository="repository_7"/>
-            <path project="project_10" repository="repository_8"/>
-            <path project="project_11" repository="repository_9"/>
+            <path project="project_3" repository="repository_1"/>
+            <path project="project_4" repository="repository_2"/>
+            <path project="project_5" repository="repository_3"/>
             <arch>x86_64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:45 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:tom:new_project/_config?comment=Copying%20project%20home:tom:Staging:XYZ&user=tom
-    body:
-      encoding: UTF-8
-      string: 'Prefer: foo'
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '21'
-    body:
-      encoding: UTF-8
-      string: '<status code="ok" />
-
-'
-  recorded_at: Thu, 21 Jul 2022 16:47:45 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:tom:new_project/_config
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '11'
-    body:
-      encoding: UTF-8
-      string: 'Prefer: foo'
-  recorded_at: Thu, 21 Jul 2022 16:47:45 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:01 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Project/Staging_Project/_copy/copies_the_project_config.yml
+++ b/src/api/spec/cassettes/Project/Staging_Project/_copy/copies_the_project_config.yml
@@ -39,14 +39,14 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:45 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:05 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_87
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_107
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_38">
+        <workflow project="home:tom" managers="group_48">
           <staging_project name="home:tom:Staging:A"/>
         </workflow>
     headers:
@@ -68,28 +68,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '172'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="325">
-          <srcmd5>d4f91ca16eeb0e66406ec8d50f7a1a84</srcmd5>
-          <time>1658422065</time>
-          <user>user_87</user>
+        <revision rev="135">
+          <srcmd5>75cb215b358fb34a206d867ae730c414</srcmd5>
+          <time>1658762225</time>
+          <user>user_107</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:45 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:05 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_87
+    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_107
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_38" role="maintainer"/>
+          <group groupid="group_48" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -117,16 +117,16 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_38" role="maintainer"/>
+          <group groupid="group_48" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:45 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:05 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_87
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_107
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_38">
+        <workflow project="home:tom" managers="group_48">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -149,28 +149,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '172'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="326">
-          <srcmd5>efa9f8d9f557caca90de3461b2503017</srcmd5>
-          <time>1658422065</time>
-          <user>user_87</user>
+        <revision rev="136">
+          <srcmd5>a8fd7a6e6a294cb5fe201df95df4c8b9</srcmd5>
+          <time>1658762225</time>
+          <user>user_107</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:45 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:05 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_87
+    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_107
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:B">
           <title/>
           <description/>
-          <group groupid="group_38" role="maintainer"/>
+          <group groupid="group_48" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -198,12 +198,12 @@ http_interactions:
         <project name="home:tom:Staging:B">
           <title></title>
           <description></description>
-          <group groupid="group_38" role="maintainer"/>
+          <group groupid="group_48" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:45 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:05 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_meta?user=user_87
+    uri: http://backend:5352/source/home:tom/_meta?user=user_107
     body:
       encoding: UTF-8
       string: |
@@ -211,7 +211,7 @@ http_interactions:
           <title/>
           <description/>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_38" role="reviewer"/>
+          <group groupid="group_48" role="reviewer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -240,16 +240,16 @@ http_interactions:
           <title></title>
           <description></description>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_38" role="reviewer"/>
+          <group groupid="group_48" role="reviewer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:45 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:05 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_87
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_107
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_38">
+        <workflow project="home:tom" managers="group_48">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
           <staging_project name="home:tom:Staging:XYZ"/>
@@ -273,18 +273,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '172'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="327">
-          <srcmd5>f3a7be969a24cd003e2d208c6669a307</srcmd5>
-          <time>1658422065</time>
-          <user>user_87</user>
+        <revision rev="137">
+          <srcmd5>691b3f9d17325fd31e1b189d0c960efc</srcmd5>
+          <time>1658762225</time>
+          <user>user_107</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:45 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:05 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:XYZ/_config?user=factory%20bot
@@ -316,7 +316,7 @@ http_interactions:
       string: '<status code="ok" />
 
 '
-  recorded_at: Thu, 21 Jul 2022 16:47:45 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:05 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:XYZ/_config
@@ -346,17 +346,17 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 'Prefer: foo'
-  recorded_at: Thu, 21 Jul 2022 16:47:45 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:05 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:XYZ/_meta?user=user_88
+    uri: http://backend:5352/source/home:tom:Staging:XYZ/_meta?user=user_108
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:XYZ">
-          <title>Have His Carcase</title>
+          <title>The Way Through the Woods</title>
           <description/>
-          <group groupid="group_38" role="maintainer"/>
+          <group groupid="group_48" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -377,25 +377,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '161'
+      - '170'
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:XYZ">
-          <title>Have His Carcase</title>
+          <title>The Way Through the Woods</title>
           <description></description>
-          <group groupid="group_38" role="maintainer"/>
+          <group groupid="group_48" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:45 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:05 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:XYZ/package_with_file/_meta?user=user_89
+    uri: http://backend:5352/source/home:tom:Staging:XYZ/package_with_file/_meta?user=user_109
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:XYZ">
-          <title>The Millstone</title>
-          <description>Dignissimos odio cupiditate perferendis.</description>
+          <title>An Instant In The Wind</title>
+          <description>Id architecto aut quasi.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -416,21 +416,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '178'
+      - '171'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:XYZ">
-          <title>The Millstone</title>
-          <description>Dignissimos odio cupiditate perferendis.</description>
+          <title>An Instant In The Wind</title>
+          <description>Id architecto aut quasi.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:46 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:05 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:XYZ/package_with_file/_config
     body:
       encoding: UTF-8
-      string: Ut quibusdam ea. Et quis alias. Distinctio beatae velit.
+      string: Qui mollitia sapiente. Fugit molestiae optio. Ut illo recusandae.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -450,25 +450,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="7" vrev="7">
-          <srcmd5>dfe9c7b82fd4c3299f09664523d5f322</srcmd5>
+        <revision rev="11" vrev="11">
+          <srcmd5>3bfeb6f719cd742a761b0caa424c85df</srcmd5>
           <version>unknown</version>
-          <time>1658422066</time>
+          <time>1658762225</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:46 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:05 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:XYZ/package_with_file/somefile.txt
     body:
       encoding: UTF-8
-      string: Consectetur eius aut. Cupiditate dolores reprehenderit. Vel nulla earum.
+      string: Sint fugiat eum. Consequatur magni enim. Odit quod ut.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -488,27 +488,27 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="8" vrev="8">
-          <srcmd5>136a579bc423c5e206d8cac0e3752133</srcmd5>
+        <revision rev="12" vrev="12">
+          <srcmd5>2396535684df556fa4914fba4f2ef682</srcmd5>
           <version>unknown</version>
-          <time>1658422066</time>
+          <time>1658762225</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:46 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:05 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/project_12/_meta?user=tom
+    uri: http://backend:5352/source/project_18/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
-        <project name="project_12">
-          <title>The Lathe of Heaven</title>
+        <project name="project_18">
+          <title>Tirra Lirra by the River</title>
           <description/>
         </project>
     headers:
@@ -530,23 +530,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '106'
+      - '111'
     body:
       encoding: UTF-8
       string: |
-        <project name="project_12">
-          <title>The Lathe of Heaven</title>
+        <project name="project_18">
+          <title>Tirra Lirra by the River</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:46 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:05 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/project_13/_meta?user=tom
+    uri: http://backend:5352/source/project_19/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
-        <project name="project_13">
-          <title>Clouds of Witness</title>
+        <project name="project_19">
+          <title>The Parliament of Man</title>
           <description/>
         </project>
     headers:
@@ -568,23 +568,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '104'
+      - '108'
     body:
       encoding: UTF-8
       string: |
-        <project name="project_13">
-          <title>Clouds of Witness</title>
+        <project name="project_19">
+          <title>The Parliament of Man</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:46 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:05 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/project_14/_meta?user=tom
+    uri: http://backend:5352/source/project_20/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
-        <project name="project_14">
-          <title>Mother Night</title>
+        <project name="project_20">
+          <title>Some Buried Caesar</title>
           <description/>
         </project>
     headers:
@@ -606,22 +606,22 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '99'
+      - '105'
     body:
       encoding: UTF-8
       string: |
-        <project name="project_14">
-          <title>Mother Night</title>
+        <project name="project_20">
+          <title>Some Buried Caesar</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:46 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:05 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=tom
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_38">
+        <workflow project="home:tom" managers="group_48">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
           <staging_project name="home:tom:Staging:XYZ"/>
@@ -650,21 +650,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="328">
-          <srcmd5>1adecba8089b302ee91d7ab49a8c412c</srcmd5>
-          <time>1658422066</time>
+        <revision rev="138">
+          <srcmd5>cde72ecf566d54063b7ac8bd7a3bd867</srcmd5>
+          <time>1658762225</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:46 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:05 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=tom
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_38">
+        <workflow project="home:tom" managers="group_48">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
           <staging_project name="home:tom:Staging:XYZ"/>
@@ -693,14 +693,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="329">
-          <srcmd5>1adecba8089b302ee91d7ab49a8c412c</srcmd5>
-          <time>1658422066</time>
+        <revision rev="139">
+          <srcmd5>cde72ecf566d54063b7ac8bd7a3bd867</srcmd5>
+          <time>1658762225</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:46 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:05 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:new_project/_meta?user=tom
@@ -708,19 +708,19 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="home:tom:new_project">
-          <title>Have His Carcase</title>
+          <title>The Way Through the Woods</title>
           <description/>
-          <person userid="user_90" role="maintainer"/>
-          <group groupid="group_38" role="maintainer"/>
-          <group groupid="group_39" role="maintainer"/>
+          <person userid="user_110" role="maintainer"/>
+          <group groupid="group_48" role="maintainer"/>
+          <group groupid="group_49" role="maintainer"/>
           <sourceaccess>
             <disable/>
           </sourceaccess>
           <repository name="staging_repository">
             <download arch="x86_64" url="http://suse.com" repotype="rpmmd"/>
-            <path project="project_12" repository="repository_10"/>
-            <path project="project_13" repository="repository_11"/>
-            <path project="project_14" repository="repository_12"/>
+            <path project="project_18" repository="repository_16"/>
+            <path project="project_19" repository="repository_17"/>
+            <path project="project_20" repository="repository_18"/>
             <arch>x86_64</arch>
           </repository>
         </project>
@@ -743,28 +743,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '636'
+      - '646'
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:new_project">
-          <title>Have His Carcase</title>
+          <title>The Way Through the Woods</title>
           <description></description>
-          <person userid="user_90" role="maintainer"/>
-          <group groupid="group_38" role="maintainer"/>
-          <group groupid="group_39" role="maintainer"/>
+          <person userid="user_110" role="maintainer"/>
+          <group groupid="group_48" role="maintainer"/>
+          <group groupid="group_49" role="maintainer"/>
           <sourceaccess>
             <disable/>
           </sourceaccess>
           <repository name="staging_repository">
             <download arch="x86_64" repotype="rpmmd" url="http://suse.com"/>
-            <path project="project_12" repository="repository_10"/>
-            <path project="project_13" repository="repository_11"/>
-            <path project="project_14" repository="repository_12"/>
+            <path project="project_18" repository="repository_16"/>
+            <path project="project_19" repository="repository_17"/>
+            <path project="project_20" repository="repository_18"/>
             <arch>x86_64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:46 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:new_project/_config?comment=Copying%20project%20home:tom:Staging:XYZ&user=tom
@@ -796,7 +796,7 @@ http_interactions:
       string: '<status code="ok" />
 
 '
-  recorded_at: Thu, 21 Jul 2022 16:47:46 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:06 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:new_project/_config
@@ -826,5 +826,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 'Prefer: foo'
-  recorded_at: Thu, 21 Jul 2022 16:47:46 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:06 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Project/Staging_Project/_copy/copies_the_relationships.yml
+++ b/src/api/spec/cassettes/Project/Staging_Project/_copy/copies_the_relationships.yml
@@ -39,14 +39,14 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:46 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:04 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_91
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_103
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_40">
+        <workflow project="home:tom" managers="group_46">
           <staging_project name="home:tom:Staging:A"/>
         </workflow>
     headers:
@@ -68,28 +68,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '172'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="330">
-          <srcmd5>69f848200e8bcca9c0e7f4bcdb7b0716</srcmd5>
-          <time>1658422066</time>
-          <user>user_91</user>
+        <revision rev="130">
+          <srcmd5>0533b72d3c03801dce3591df9ce42ad5</srcmd5>
+          <time>1658762224</time>
+          <user>user_103</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:46 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:04 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_91
+    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_103
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_40" role="maintainer"/>
+          <group groupid="group_46" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -117,16 +117,16 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_40" role="maintainer"/>
+          <group groupid="group_46" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:46 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:04 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_91
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_103
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_40">
+        <workflow project="home:tom" managers="group_46">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -149,28 +149,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '172'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="331">
-          <srcmd5>a330a52ac328e66004667fd4e01e31f1</srcmd5>
-          <time>1658422066</time>
-          <user>user_91</user>
+        <revision rev="131">
+          <srcmd5>bb6347f26343ee7f993573e110d3778d</srcmd5>
+          <time>1658762224</time>
+          <user>user_103</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:46 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:04 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_91
+    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_103
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:B">
           <title/>
           <description/>
-          <group groupid="group_40" role="maintainer"/>
+          <group groupid="group_46" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -198,12 +198,12 @@ http_interactions:
         <project name="home:tom:Staging:B">
           <title></title>
           <description></description>
-          <group groupid="group_40" role="maintainer"/>
+          <group groupid="group_46" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:46 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:04 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_meta?user=user_91
+    uri: http://backend:5352/source/home:tom/_meta?user=user_103
     body:
       encoding: UTF-8
       string: |
@@ -211,7 +211,7 @@ http_interactions:
           <title/>
           <description/>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_40" role="reviewer"/>
+          <group groupid="group_46" role="reviewer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -240,16 +240,16 @@ http_interactions:
           <title></title>
           <description></description>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_40" role="reviewer"/>
+          <group groupid="group_46" role="reviewer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:46 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:04 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_91
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_103
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_40">
+        <workflow project="home:tom" managers="group_46">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
           <staging_project name="home:tom:Staging:XYZ"/>
@@ -273,18 +273,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '172'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="332">
-          <srcmd5>cea99c0832c1b7c843fab4dba9758657</srcmd5>
-          <time>1658422066</time>
-          <user>user_91</user>
+        <revision rev="132">
+          <srcmd5>323347045864b7878e4de56def32af71</srcmd5>
+          <time>1658762224</time>
+          <user>user_103</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:46 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:04 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:XYZ/_config?user=factory%20bot
@@ -316,7 +316,7 @@ http_interactions:
       string: '<status code="ok" />
 
 '
-  recorded_at: Thu, 21 Jul 2022 16:47:46 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:04 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:XYZ/_config
@@ -346,17 +346,17 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 'Prefer: foo'
-  recorded_at: Thu, 21 Jul 2022 16:47:46 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:04 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:XYZ/_meta?user=user_92
+    uri: http://backend:5352/source/home:tom:Staging:XYZ/_meta?user=user_104
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:XYZ">
-          <title>Everything is Illuminated</title>
+          <title>Noli Me Tangere</title>
           <description/>
-          <group groupid="group_40" role="maintainer"/>
+          <group groupid="group_46" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -377,25 +377,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '170'
+      - '160'
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:XYZ">
-          <title>Everything is Illuminated</title>
+          <title>Noli Me Tangere</title>
           <description></description>
-          <group groupid="group_40" role="maintainer"/>
+          <group groupid="group_46" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:46 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:04 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:XYZ/package_with_file/_meta?user=user_93
+    uri: http://backend:5352/source/home:tom:Staging:XYZ/package_with_file/_meta?user=user_105
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:XYZ">
-          <title>The Glory and the Dream</title>
-          <description>Repellendus error sed sed.</description>
+          <title>A Glass of Blessings</title>
+          <description>Ut delectus porro magni.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -416,21 +416,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '174'
+      - '169'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:XYZ">
-          <title>The Glory and the Dream</title>
-          <description>Repellendus error sed sed.</description>
+          <title>A Glass of Blessings</title>
+          <description>Ut delectus porro magni.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:46 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:04 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:XYZ/package_with_file/_config
     body:
       encoding: UTF-8
-      string: Ea corporis totam. Quasi velit qui. Voluptate vero dolor.
+      string: Voluptas et nesciunt. Porro accusamus saepe. Eum illo voluptatem.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -455,20 +455,20 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="9" vrev="9">
-          <srcmd5>14d8fc5fa6c1d509e82e067782d45181</srcmd5>
+          <srcmd5>c7f23e21605bfc9428d134bb51bdd09e</srcmd5>
           <version>unknown</version>
-          <time>1658422066</time>
+          <time>1658762224</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:46 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:04 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:XYZ/package_with_file/somefile.txt
     body:
       encoding: UTF-8
-      string: Ab nam ut. Quae sint dicta. Culpa assumenda maiores.
+      string: Laboriosam ratione voluptatem. Voluptas cumque officiis. Qui quo maiores.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -493,14 +493,14 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="10" vrev="10">
-          <srcmd5>23b5a11c70bc4f9739fdff37e5b967b4</srcmd5>
+          <srcmd5>78fb8e7d995b432ebc1ce03e85f30e8f</srcmd5>
           <version>unknown</version>
-          <time>1658422066</time>
+          <time>1658762224</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:46 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:04 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_15/_meta?user=tom
@@ -508,7 +508,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="project_15">
-          <title>Endless Night</title>
+          <title>Frequent Hearses</title>
           <description/>
         </project>
     headers:
@@ -530,15 +530,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '100'
+      - '103'
     body:
       encoding: UTF-8
       string: |
         <project name="project_15">
-          <title>Endless Night</title>
+          <title>Frequent Hearses</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:47 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:04 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_16/_meta?user=tom
@@ -546,7 +546,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="project_16">
-          <title>The Cricket on the Hearth</title>
+          <title>Cabbages and Kings</title>
           <description/>
         </project>
     headers:
@@ -568,15 +568,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '112'
+      - '105'
     body:
       encoding: UTF-8
       string: |
         <project name="project_16">
-          <title>The Cricket on the Hearth</title>
+          <title>Cabbages and Kings</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:47 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:04 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_17/_meta?user=tom
@@ -584,7 +584,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="project_17">
-          <title>O Jerusalem!</title>
+          <title>The Waste Land</title>
           <description/>
         </project>
     headers:
@@ -606,22 +606,22 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '99'
+      - '101'
     body:
       encoding: UTF-8
       string: |
         <project name="project_17">
-          <title>O Jerusalem!</title>
+          <title>The Waste Land</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:47 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:04 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=tom
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_40">
+        <workflow project="home:tom" managers="group_46">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
           <staging_project name="home:tom:Staging:XYZ"/>
@@ -650,21 +650,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="333">
-          <srcmd5>af757438206f56ea78661ecfc7565672</srcmd5>
-          <time>1658422067</time>
+        <revision rev="133">
+          <srcmd5>c5915ac22cb91c8553a1979d1b081cdb</srcmd5>
+          <time>1658762224</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:47 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:04 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=tom
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_40">
+        <workflow project="home:tom" managers="group_46">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
           <staging_project name="home:tom:Staging:XYZ"/>
@@ -693,14 +693,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="334">
-          <srcmd5>af757438206f56ea78661ecfc7565672</srcmd5>
-          <time>1658422067</time>
+        <revision rev="134">
+          <srcmd5>c5915ac22cb91c8553a1979d1b081cdb</srcmd5>
+          <time>1658762225</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:47 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:05 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:new_project/_meta?user=tom
@@ -708,11 +708,11 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="home:tom:new_project">
-          <title>Everything is Illuminated</title>
+          <title>Noli Me Tangere</title>
           <description/>
-          <person userid="user_94" role="maintainer"/>
-          <group groupid="group_40" role="maintainer"/>
-          <group groupid="group_41" role="maintainer"/>
+          <person userid="user_106" role="maintainer"/>
+          <group groupid="group_46" role="maintainer"/>
+          <group groupid="group_47" role="maintainer"/>
           <sourceaccess>
             <disable/>
           </sourceaccess>
@@ -743,16 +743,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '645'
+      - '636'
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:new_project">
-          <title>Everything is Illuminated</title>
+          <title>Noli Me Tangere</title>
           <description></description>
-          <person userid="user_94" role="maintainer"/>
-          <group groupid="group_40" role="maintainer"/>
-          <group groupid="group_41" role="maintainer"/>
+          <person userid="user_106" role="maintainer"/>
+          <group groupid="group_46" role="maintainer"/>
+          <group groupid="group_47" role="maintainer"/>
           <sourceaccess>
             <disable/>
           </sourceaccess>
@@ -764,7 +764,7 @@ http_interactions:
             <arch>x86_64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:47 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:05 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:new_project/_config?comment=Copying%20project%20home:tom:Staging:XYZ&user=tom
@@ -796,7 +796,7 @@ http_interactions:
       string: '<status code="ok" />
 
 '
-  recorded_at: Thu, 21 Jul 2022 16:47:47 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:05 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:new_project/_config
@@ -826,5 +826,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 'Prefer: foo'
-  recorded_at: Thu, 21 Jul 2022 16:47:47 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:05 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Project/Staging_Project/_copy/copies_the_repositories_and_it_s_relations.yml
+++ b/src/api/spec/cassettes/Project/Staging_Project/_copy/copies_the_repositories_and_it_s_relations.yml
@@ -39,14 +39,14 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:47 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:03 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_95
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_99
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_42">
+        <workflow project="home:tom" managers="group_44">
           <staging_project name="home:tom:Staging:A"/>
         </workflow>
     headers:
@@ -72,24 +72,24 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="335">
-          <srcmd5>d084873351cbb99443a1831eed2fb8b7</srcmd5>
-          <time>1658422067</time>
-          <user>user_95</user>
+        <revision rev="125">
+          <srcmd5>15d36fb2534dad25a1fd365da1cbcbd1</srcmd5>
+          <time>1658762223</time>
+          <user>user_99</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:47 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:03 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_95
+    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_99
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_42" role="maintainer"/>
+          <group groupid="group_44" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -117,16 +117,16 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_42" role="maintainer"/>
+          <group groupid="group_44" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:47 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:03 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_95
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_99
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_42">
+        <workflow project="home:tom" managers="group_44">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -153,24 +153,24 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="336">
-          <srcmd5>b11b8a091b868c430167d82991588166</srcmd5>
-          <time>1658422067</time>
-          <user>user_95</user>
+        <revision rev="126">
+          <srcmd5>d4595345353536ee1b2c3735705fa53a</srcmd5>
+          <time>1658762223</time>
+          <user>user_99</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:47 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:03 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_95
+    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_99
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:B">
           <title/>
           <description/>
-          <group groupid="group_42" role="maintainer"/>
+          <group groupid="group_44" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -198,12 +198,12 @@ http_interactions:
         <project name="home:tom:Staging:B">
           <title></title>
           <description></description>
-          <group groupid="group_42" role="maintainer"/>
+          <group groupid="group_44" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:47 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:03 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_meta?user=user_95
+    uri: http://backend:5352/source/home:tom/_meta?user=user_99
     body:
       encoding: UTF-8
       string: |
@@ -211,7 +211,7 @@ http_interactions:
           <title/>
           <description/>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_42" role="reviewer"/>
+          <group groupid="group_44" role="reviewer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -240,16 +240,16 @@ http_interactions:
           <title></title>
           <description></description>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_42" role="reviewer"/>
+          <group groupid="group_44" role="reviewer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:47 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:03 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_95
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_99
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_42">
+        <workflow project="home:tom" managers="group_44">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
           <staging_project name="home:tom:Staging:XYZ"/>
@@ -277,14 +277,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="337">
-          <srcmd5>69a91f7570666ff70858c98549ea7bac</srcmd5>
-          <time>1658422067</time>
-          <user>user_95</user>
+        <revision rev="127">
+          <srcmd5>7d52d33d8e4b9c904b8d545310e70f21</srcmd5>
+          <time>1658762223</time>
+          <user>user_99</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:47 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:03 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:XYZ/_config?user=factory%20bot
@@ -316,7 +316,7 @@ http_interactions:
       string: '<status code="ok" />
 
 '
-  recorded_at: Thu, 21 Jul 2022 16:47:47 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:03 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:XYZ/_config
@@ -346,17 +346,17 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 'Prefer: foo'
-  recorded_at: Thu, 21 Jul 2022 16:47:47 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:03 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:XYZ/_meta?user=user_96
+    uri: http://backend:5352/source/home:tom:Staging:XYZ/_meta?user=user_100
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:XYZ">
-          <title>Sleep the Brave</title>
+          <title>Let Us Now Praise Famous Men</title>
           <description/>
-          <group groupid="group_42" role="maintainer"/>
+          <group groupid="group_44" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -377,25 +377,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '160'
+      - '173'
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:XYZ">
-          <title>Sleep the Brave</title>
+          <title>Let Us Now Praise Famous Men</title>
           <description></description>
-          <group groupid="group_42" role="maintainer"/>
+          <group groupid="group_44" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:47 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:03 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:XYZ/package_with_file/_meta?user=user_97
+    uri: http://backend:5352/source/home:tom:Staging:XYZ/package_with_file/_meta?user=user_101
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:XYZ">
-          <title>Where Angels Fear to Tread</title>
-          <description>Qui minus qui odit.</description>
+          <title>What's Become of Waring</title>
+          <description>Sed necessitatibus aut deserunt.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -416,21 +416,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '170'
+      - '180'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:XYZ">
-          <title>Where Angels Fear to Tread</title>
-          <description>Qui minus qui odit.</description>
+          <title>What's Become of Waring</title>
+          <description>Sed necessitatibus aut deserunt.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:47 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:03 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:XYZ/package_with_file/_config
     body:
       encoding: UTF-8
-      string: Quae porro incidunt. Quas et dolores. Est aut reprehenderit.
+      string: Culpa vero ut. Qui omnis est. Repellendus quaerat architecto.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -450,25 +450,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '209'
+      - '207'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="11" vrev="11">
-          <srcmd5>ac7312c185dd87de5566e78f239deb09</srcmd5>
+        <revision rev="7" vrev="7">
+          <srcmd5>28c79853107c380590f8c3cf16be9460</srcmd5>
           <version>unknown</version>
-          <time>1658422067</time>
+          <time>1658762223</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:47 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:03 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:XYZ/package_with_file/somefile.txt
     body:
       encoding: UTF-8
-      string: Animi debitis reiciendis. Ad saepe necessitatibus. Dicta dolor in.
+      string: Aut hic qui. Adipisci fuga porro. Consequatur explicabo corporis.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -488,27 +488,27 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '209'
+      - '207'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="12" vrev="12">
-          <srcmd5>75cd24b1cb57924c1c6586ebd4f0aa88</srcmd5>
+        <revision rev="8" vrev="8">
+          <srcmd5>e4624639cfa8e0a04e797cd8f422b38b</srcmd5>
           <version>unknown</version>
-          <time>1658422067</time>
+          <time>1658762223</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:47 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:03 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/project_18/_meta?user=tom
+    uri: http://backend:5352/source/project_12/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
-        <project name="project_18">
-          <title>A Farewell to Arms</title>
+        <project name="project_12">
+          <title>An Acceptable Time</title>
           <description/>
         </project>
     headers:
@@ -534,19 +534,19 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <project name="project_18">
-          <title>A Farewell to Arms</title>
+        <project name="project_12">
+          <title>An Acceptable Time</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:47 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:03 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/project_19/_meta?user=tom
+    uri: http://backend:5352/source/project_13/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
-        <project name="project_19">
-          <title>A Many-Splendoured Thing</title>
+        <project name="project_13">
+          <title>Little Hands Clapping</title>
           <description/>
         </project>
     headers:
@@ -568,23 +568,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '111'
+      - '108'
     body:
       encoding: UTF-8
       string: |
-        <project name="project_19">
-          <title>A Many-Splendoured Thing</title>
+        <project name="project_13">
+          <title>Little Hands Clapping</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:48 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:04 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/project_20/_meta?user=tom
+    uri: http://backend:5352/source/project_14/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
-        <project name="project_20">
-          <title>Gone with the Wind</title>
+        <project name="project_14">
+          <title>To Sail Beyond the Sunset</title>
           <description/>
         </project>
     headers:
@@ -606,22 +606,22 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '105'
+      - '112'
     body:
       encoding: UTF-8
       string: |
-        <project name="project_20">
-          <title>Gone with the Wind</title>
+        <project name="project_14">
+          <title>To Sail Beyond the Sunset</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:48 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:04 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=tom
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_42">
+        <workflow project="home:tom" managers="group_44">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
           <staging_project name="home:tom:Staging:XYZ"/>
@@ -650,21 +650,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="338">
-          <srcmd5>53e516c57def135224733cf9f77eb5cb</srcmd5>
-          <time>1658422068</time>
+        <revision rev="128">
+          <srcmd5>5042bd654c4544af7934e76ba9d9a133</srcmd5>
+          <time>1658762224</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:48 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:04 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=tom
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_42">
+        <workflow project="home:tom" managers="group_44">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
           <staging_project name="home:tom:Staging:XYZ"/>
@@ -693,14 +693,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="339">
-          <srcmd5>53e516c57def135224733cf9f77eb5cb</srcmd5>
-          <time>1658422068</time>
+        <revision rev="129">
+          <srcmd5>5042bd654c4544af7934e76ba9d9a133</srcmd5>
+          <time>1658762224</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:48 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:04 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:new_project/_meta?user=tom
@@ -708,19 +708,19 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="home:tom:new_project">
-          <title>Sleep the Brave</title>
+          <title>Let Us Now Praise Famous Men</title>
           <description/>
-          <person userid="user_98" role="maintainer"/>
-          <group groupid="group_42" role="maintainer"/>
-          <group groupid="group_43" role="maintainer"/>
+          <person userid="user_102" role="maintainer"/>
+          <group groupid="group_44" role="maintainer"/>
+          <group groupid="group_45" role="maintainer"/>
           <sourceaccess>
             <disable/>
           </sourceaccess>
           <repository name="staging_repository">
             <download arch="x86_64" url="http://suse.com" repotype="rpmmd"/>
-            <path project="project_18" repository="repository_16"/>
-            <path project="project_19" repository="repository_17"/>
-            <path project="project_20" repository="repository_18"/>
+            <path project="project_12" repository="repository_10"/>
+            <path project="project_13" repository="repository_11"/>
+            <path project="project_14" repository="repository_12"/>
             <arch>x86_64</arch>
           </repository>
         </project>
@@ -743,28 +743,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '635'
+      - '649'
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:new_project">
-          <title>Sleep the Brave</title>
+          <title>Let Us Now Praise Famous Men</title>
           <description></description>
-          <person userid="user_98" role="maintainer"/>
-          <group groupid="group_42" role="maintainer"/>
-          <group groupid="group_43" role="maintainer"/>
+          <person userid="user_102" role="maintainer"/>
+          <group groupid="group_44" role="maintainer"/>
+          <group groupid="group_45" role="maintainer"/>
           <sourceaccess>
             <disable/>
           </sourceaccess>
           <repository name="staging_repository">
             <download arch="x86_64" repotype="rpmmd" url="http://suse.com"/>
-            <path project="project_18" repository="repository_16"/>
-            <path project="project_19" repository="repository_17"/>
-            <path project="project_20" repository="repository_18"/>
+            <path project="project_12" repository="repository_10"/>
+            <path project="project_13" repository="repository_11"/>
+            <path project="project_14" repository="repository_12"/>
             <arch>x86_64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:48 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:04 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:new_project/_config?comment=Copying%20project%20home:tom:Staging:XYZ&user=tom
@@ -796,7 +796,7 @@ http_interactions:
       string: '<status code="ok" />
 
 '
-  recorded_at: Thu, 21 Jul 2022 16:47:48 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:04 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:new_project/_config
@@ -826,5 +826,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 'Prefer: foo'
-  recorded_at: Thu, 21 Jul 2022 16:47:48 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:04 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Project/Staging_Project/_copy/creates_a_new_staging_project.yml
+++ b/src/api/spec/cassettes/Project/Staging_Project/_copy/creates_a_new_staging_project.yml
@@ -39,14 +39,14 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:43 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:01 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_75
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_91
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_32">
+        <workflow project="home:tom" managers="group_40">
           <staging_project name="home:tom:Staging:A"/>
         </workflow>
     headers:
@@ -72,24 +72,24 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="310">
-          <srcmd5>b7ffeab3caa6206fe9442e7269046544</srcmd5>
-          <time>1658422063</time>
-          <user>user_75</user>
+        <revision rev="115">
+          <srcmd5>69f848200e8bcca9c0e7f4bcdb7b0716</srcmd5>
+          <time>1658762221</time>
+          <user>user_91</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:43 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:01 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_75
+    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_91
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_32" role="maintainer"/>
+          <group groupid="group_40" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -117,16 +117,16 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_32" role="maintainer"/>
+          <group groupid="group_40" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:43 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:01 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_75
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_91
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_32">
+        <workflow project="home:tom" managers="group_40">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -153,24 +153,24 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="311">
-          <srcmd5>0481fbadf19cc95a40fb41c271230f7e</srcmd5>
-          <time>1658422063</time>
-          <user>user_75</user>
+        <revision rev="116">
+          <srcmd5>a330a52ac328e66004667fd4e01e31f1</srcmd5>
+          <time>1658762221</time>
+          <user>user_91</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:43 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:01 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_75
+    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_91
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:B">
           <title/>
           <description/>
-          <group groupid="group_32" role="maintainer"/>
+          <group groupid="group_40" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -198,12 +198,12 @@ http_interactions:
         <project name="home:tom:Staging:B">
           <title></title>
           <description></description>
-          <group groupid="group_32" role="maintainer"/>
+          <group groupid="group_40" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:43 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:01 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_meta?user=user_75
+    uri: http://backend:5352/source/home:tom/_meta?user=user_91
     body:
       encoding: UTF-8
       string: |
@@ -211,7 +211,7 @@ http_interactions:
           <title/>
           <description/>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_32" role="reviewer"/>
+          <group groupid="group_40" role="reviewer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -240,16 +240,16 @@ http_interactions:
           <title></title>
           <description></description>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_32" role="reviewer"/>
+          <group groupid="group_40" role="reviewer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:43 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:01 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_75
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_91
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_32">
+        <workflow project="home:tom" managers="group_40">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
           <staging_project name="home:tom:Staging:XYZ"/>
@@ -277,14 +277,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="312">
-          <srcmd5>31e23194a479fd5501f41406e704bf60</srcmd5>
-          <time>1658422063</time>
-          <user>user_75</user>
+        <revision rev="117">
+          <srcmd5>cea99c0832c1b7c843fab4dba9758657</srcmd5>
+          <time>1658762221</time>
+          <user>user_91</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:43 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:01 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:XYZ/_config?user=factory%20bot
@@ -300,8 +300,8 @@ http_interactions:
       - Ruby
   response:
     status:
-      code: 404
-      message: project 'home tom Staging XYZ' does not exist
+      code: 200
+      message: OK
     headers:
       Content-Type:
       - text/xml
@@ -310,25 +310,53 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '168'
+      - '21'
     body:
       encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:tom:Staging:XYZ' does not exist</summary>
-          <details>404 project 'home:tom:Staging:XYZ' does not exist</details>
-        </status>
-  recorded_at: Thu, 21 Jul 2022 16:47:43 GMT
+      string: '<status code="ok" />
+
+'
+  recorded_at: Mon, 25 Jul 2022 15:17:01 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom:Staging:XYZ/_config
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '11'
+    body:
+      encoding: UTF-8
+      string: 'Prefer: foo'
+  recorded_at: Mon, 25 Jul 2022 15:17:01 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:XYZ/_meta?user=user_76
+    uri: http://backend:5352/source/home:tom:Staging:XYZ/_meta?user=user_92
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:XYZ">
-          <title>The Parliament of Man</title>
+          <title>Down to a Sunless Sea</title>
           <description/>
-          <group groupid="group_32" role="maintainer"/>
+          <group groupid="group_40" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -354,20 +382,20 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:XYZ">
-          <title>The Parliament of Man</title>
+          <title>Down to a Sunless Sea</title>
           <description></description>
-          <group groupid="group_32" role="maintainer"/>
+          <group groupid="group_40" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:43 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:02 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:XYZ/package_with_file/_meta?user=user_77
+    uri: http://backend:5352/source/home:tom:Staging:XYZ/package_with_file/_meta?user=user_93
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:XYZ">
-          <title>A Summer Bird-Cage</title>
-          <description>Quaerat dolorem architecto autem.</description>
+          <title>Infinite Jest</title>
+          <description>Doloribus possimus dolorem excepturi.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -388,21 +416,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '176'
+      - '175'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:XYZ">
-          <title>A Summer Bird-Cage</title>
-          <description>Quaerat dolorem architecto autem.</description>
+          <title>Infinite Jest</title>
+          <description>Doloribus possimus dolorem excepturi.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:43 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:02 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:XYZ/package_with_file/_config
     body:
       encoding: UTF-8
-      string: Culpa qui doloremque. Laboriosam et officiis. Nostrum aut minima.
+      string: Porro occaecati veritatis. Odit vel id. Est labore asperiores.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -426,21 +454,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1" vrev="1">
-          <srcmd5>74868707bb6e924508392233539586a5</srcmd5>
+        <revision rev="3" vrev="3">
+          <srcmd5>ffa808335f557cf1f350a48e3ebb065a</srcmd5>
           <version>unknown</version>
-          <time>1658422063</time>
+          <time>1658762222</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:43 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:02 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:XYZ/package_with_file/somefile.txt
     body:
       encoding: UTF-8
-      string: Amet veritatis rerum. Vitae fugit aut. Qui magnam debitis.
+      string: Ea et aut. Et vero et. Eos eum tempore.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -464,23 +492,23 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2" vrev="2">
-          <srcmd5>f93645625f51d559a07e543afdd9c61a</srcmd5>
+        <revision rev="4" vrev="4">
+          <srcmd5>ad6d46d4d58c808762f8d934f2d094b2</srcmd5>
           <version>unknown</version>
-          <time>1658422063</time>
+          <time>1658762222</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:43 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:02 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/project_3/_meta?user=tom
+    uri: http://backend:5352/source/project_6/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
-        <project name="project_3">
-          <title>To Sail Beyond the Sunset</title>
+        <project name="project_6">
+          <title>An Evil Cradling</title>
           <description/>
         </project>
     headers:
@@ -502,23 +530,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '111'
+      - '102'
     body:
       encoding: UTF-8
       string: |
-        <project name="project_3">
-          <title>To Sail Beyond the Sunset</title>
+        <project name="project_6">
+          <title>An Evil Cradling</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:43 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:02 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/project_4/_meta?user=tom
+    uri: http://backend:5352/source/project_7/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
-        <project name="project_4">
-          <title>I Will Fear No Evil</title>
+        <project name="project_7">
+          <title>Eyeless in Gaza</title>
           <description/>
         </project>
     headers:
@@ -540,23 +568,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '105'
+      - '101'
     body:
       encoding: UTF-8
       string: |
-        <project name="project_4">
-          <title>I Will Fear No Evil</title>
+        <project name="project_7">
+          <title>Eyeless in Gaza</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:43 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:02 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/project_5/_meta?user=tom
+    uri: http://backend:5352/source/project_8/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
-        <project name="project_5">
-          <title>Some Buried Caesar</title>
+        <project name="project_8">
+          <title>Brandy of the Damned</title>
           <description/>
         </project>
     headers:
@@ -578,22 +606,22 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '104'
+      - '106'
     body:
       encoding: UTF-8
       string: |
-        <project name="project_5">
-          <title>Some Buried Caesar</title>
+        <project name="project_8">
+          <title>Brandy of the Damned</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:43 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:02 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=tom
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_32">
+        <workflow project="home:tom" managers="group_40">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
           <staging_project name="home:tom:Staging:XYZ"/>
@@ -622,21 +650,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="313">
-          <srcmd5>061e0b2523d379ff65fd480e7383498c</srcmd5>
-          <time>1658422063</time>
+        <revision rev="118">
+          <srcmd5>af757438206f56ea78661ecfc7565672</srcmd5>
+          <time>1658762222</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:43 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:02 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=tom
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_32">
+        <workflow project="home:tom" managers="group_40">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
           <staging_project name="home:tom:Staging:XYZ"/>
@@ -665,14 +693,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="314">
-          <srcmd5>061e0b2523d379ff65fd480e7383498c</srcmd5>
-          <time>1658422063</time>
+        <revision rev="119">
+          <srcmd5>af757438206f56ea78661ecfc7565672</srcmd5>
+          <time>1658762222</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:43 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:02 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:new_project/_meta?user=tom
@@ -680,19 +708,19 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="home:tom:new_project">
-          <title>The Parliament of Man</title>
+          <title>Down to a Sunless Sea</title>
           <description/>
-          <person userid="user_78" role="maintainer"/>
-          <group groupid="group_32" role="maintainer"/>
-          <group groupid="group_33" role="maintainer"/>
+          <person userid="user_94" role="maintainer"/>
+          <group groupid="group_40" role="maintainer"/>
+          <group groupid="group_41" role="maintainer"/>
           <sourceaccess>
             <disable/>
           </sourceaccess>
           <repository name="staging_repository">
             <download arch="x86_64" url="http://suse.com" repotype="rpmmd"/>
-            <path project="project_3" repository="repository_1"/>
-            <path project="project_4" repository="repository_2"/>
-            <path project="project_5" repository="repository_3"/>
+            <path project="project_6" repository="repository_4"/>
+            <path project="project_7" repository="repository_5"/>
+            <path project="project_8" repository="repository_6"/>
             <arch>x86_64</arch>
           </repository>
         </project>
@@ -720,21 +748,83 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="home:tom:new_project">
-          <title>The Parliament of Man</title>
+          <title>Down to a Sunless Sea</title>
           <description></description>
-          <person userid="user_78" role="maintainer"/>
-          <group groupid="group_32" role="maintainer"/>
-          <group groupid="group_33" role="maintainer"/>
+          <person userid="user_94" role="maintainer"/>
+          <group groupid="group_40" role="maintainer"/>
+          <group groupid="group_41" role="maintainer"/>
           <sourceaccess>
             <disable/>
           </sourceaccess>
           <repository name="staging_repository">
             <download arch="x86_64" repotype="rpmmd" url="http://suse.com"/>
-            <path project="project_3" repository="repository_1"/>
-            <path project="project_4" repository="repository_2"/>
-            <path project="project_5" repository="repository_3"/>
+            <path project="project_6" repository="repository_4"/>
+            <path project="project_7" repository="repository_5"/>
+            <path project="project_8" repository="repository_6"/>
             <arch>x86_64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:43 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:02 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom:new_project/_config?comment=Copying%20project%20home:tom:Staging:XYZ&user=tom
+    body:
+      encoding: UTF-8
+      string: 'Prefer: foo'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+  recorded_at: Mon, 25 Jul 2022 15:17:02 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom:new_project/_config
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '11'
+    body:
+      encoding: UTF-8
+      string: 'Prefer: foo'
+  recorded_at: Mon, 25 Jul 2022 15:17:02 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Project/Staging_Project/_copy/when_the_repository_contains_path_elements_that_link_to_repositories_of_the_same_project/ensures_that_the_new_created_path_is_also_self_referencing.yml
+++ b/src/api/spec/cassettes/Project/Staging_Project/_copy/when_the_repository_contains_path_elements_that_link_to_repositories_of_the_same_project/ensures_that_the_new_created_path_is_also_self_referencing.yml
@@ -39,14 +39,14 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:48 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:06 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_99
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_111
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_44">
+        <workflow project="home:tom" managers="group_50">
           <staging_project name="home:tom:Staging:A"/>
         </workflow>
     headers:
@@ -68,28 +68,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '172'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="340">
-          <srcmd5>15d36fb2534dad25a1fd365da1cbcbd1</srcmd5>
-          <time>1658422068</time>
-          <user>user_99</user>
+        <revision rev="140">
+          <srcmd5>deff3c2c83ffc237a0ce62cc2d286cfd</srcmd5>
+          <time>1658762226</time>
+          <user>user_111</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:48 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:06 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_99
+    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_111
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_44" role="maintainer"/>
+          <group groupid="group_50" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -117,16 +117,16 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_44" role="maintainer"/>
+          <group groupid="group_50" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:48 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:06 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_99
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_111
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_44">
+        <workflow project="home:tom" managers="group_50">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -149,28 +149,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '172'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="341">
-          <srcmd5>d4595345353536ee1b2c3735705fa53a</srcmd5>
-          <time>1658422068</time>
-          <user>user_99</user>
+        <revision rev="141">
+          <srcmd5>60166c7db4b1fedd23ee5fb1e55ab112</srcmd5>
+          <time>1658762226</time>
+          <user>user_111</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:48 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:06 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_99
+    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_111
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:B">
           <title/>
           <description/>
-          <group groupid="group_44" role="maintainer"/>
+          <group groupid="group_50" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -198,12 +198,12 @@ http_interactions:
         <project name="home:tom:Staging:B">
           <title></title>
           <description></description>
-          <group groupid="group_44" role="maintainer"/>
+          <group groupid="group_50" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:48 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:06 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_meta?user=user_99
+    uri: http://backend:5352/source/home:tom/_meta?user=user_111
     body:
       encoding: UTF-8
       string: |
@@ -211,7 +211,7 @@ http_interactions:
           <title/>
           <description/>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_44" role="reviewer"/>
+          <group groupid="group_50" role="reviewer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -240,16 +240,16 @@ http_interactions:
           <title></title>
           <description></description>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_44" role="reviewer"/>
+          <group groupid="group_50" role="reviewer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:48 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:06 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_99
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_111
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_44">
+        <workflow project="home:tom" managers="group_50">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
           <staging_project name="home:tom:Staging:XYZ"/>
@@ -273,18 +273,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '172'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="342">
-          <srcmd5>7d52d33d8e4b9c904b8d545310e70f21</srcmd5>
-          <time>1658422068</time>
-          <user>user_99</user>
+        <revision rev="142">
+          <srcmd5>bd58c22bb29c9da7b07f11f583432f99</srcmd5>
+          <time>1658762226</time>
+          <user>user_111</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:48 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:XYZ/_config?user=factory%20bot
@@ -316,7 +316,7 @@ http_interactions:
       string: '<status code="ok" />
 
 '
-  recorded_at: Thu, 21 Jul 2022 16:47:48 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:06 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:XYZ/_config
@@ -346,57 +346,18 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 'Prefer: foo'
-  recorded_at: Thu, 21 Jul 2022 16:47:48 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:06 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:XYZ/_meta?user=user_100
+    uri: http://backend:5352/source/home:tom:Staging:XYZ/_meta?user=user_112
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:XYZ">
-          <title>Precious Bane</title>
+          <title>This Side of Paradise</title>
           <description/>
-          <group groupid="group_44" role="maintainer"/>
+          <group groupid="group_50" role="maintainer"/>
         </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '158'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:tom:Staging:XYZ">
-          <title>Precious Bane</title>
-          <description></description>
-          <group groupid="group_44" role="maintainer"/>
-        </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:48 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:tom:Staging:XYZ/package_with_file/_meta?user=user_101
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="package_with_file" project="home:tom:Staging:XYZ">
-          <title>Rosemary Sutcliff</title>
-          <description>Voluptatem in quod iure.</description>
-        </package>
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -420,18 +381,56 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
+        <project name="home:tom:Staging:XYZ">
+          <title>This Side of Paradise</title>
+          <description></description>
+          <group groupid="group_50" role="maintainer"/>
+        </project>
+  recorded_at: Mon, 25 Jul 2022 15:17:06 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom:Staging:XYZ/package_with_file/_meta?user=user_113
+    body:
+      encoding: UTF-8
+      string: |
         <package name="package_with_file" project="home:tom:Staging:XYZ">
-          <title>Rosemary Sutcliff</title>
-          <description>Voluptatem in quod iure.</description>
+          <title>The Cricket on the Hearth</title>
+          <description>Ullam repellendus eos quod.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:48 GMT
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '177'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_file" project="home:tom:Staging:XYZ">
+          <title>The Cricket on the Hearth</title>
+          <description>Ullam repellendus eos quod.</description>
+        </package>
+  recorded_at: Mon, 25 Jul 2022 15:17:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:XYZ/package_with_file/_config
     body:
       encoding: UTF-8
-      string: Earum itaque adipisci. Quo exercitationem accusantium. Fugit maxime
-        dolorum.
+      string: Perferendis quia modi. Aperiam vitae id. Aspernatur alias qui.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -456,21 +455,20 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="13" vrev="13">
-          <srcmd5>ce0cea83e1fe77d3e5ceb0b8e91cd698</srcmd5>
+          <srcmd5>128a682f85941460db690f3317773833</srcmd5>
           <version>unknown</version>
-          <time>1658422068</time>
+          <time>1658762226</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:48 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:XYZ/package_with_file/somefile.txt
     body:
       encoding: UTF-8
-      string: Perspiciatis ut fuga. Excepturi earum laudantium. Voluptatum voluptatem
-        adipisci.
+      string: Sunt quos ut. Laboriosam quos enim. Magnam consequatur accusantium.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -495,14 +493,14 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="14" vrev="14">
-          <srcmd5>aa6621441b66e26d0f7f333b900f91c4</srcmd5>
+          <srcmd5>d366cd5bd9652c57481fc662bcd2f99f</srcmd5>
           <version>unknown</version>
-          <time>1658422068</time>
+          <time>1658762226</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:48 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_21/_meta?user=tom
@@ -510,7 +508,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="project_21">
-          <title>Some Buried Caesar</title>
+          <title>The Golden Bowl</title>
           <description/>
         </project>
     headers:
@@ -532,15 +530,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '105'
+      - '102'
     body:
       encoding: UTF-8
       string: |
         <project name="project_21">
-          <title>Some Buried Caesar</title>
+          <title>The Golden Bowl</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:48 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_22/_meta?user=tom
@@ -548,7 +546,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="project_22">
-          <title>Fear and Trembling</title>
+          <title>The Needle's Eye</title>
           <description/>
         </project>
     headers:
@@ -570,15 +568,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '105'
+      - '103'
     body:
       encoding: UTF-8
       string: |
         <project name="project_22">
-          <title>Fear and Trembling</title>
+          <title>The Needle's Eye</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:48 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_23/_meta?user=tom
@@ -586,7 +584,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="project_23">
-          <title>A Passage to India</title>
+          <title>Oh! To be in England</title>
           <description/>
         </project>
     headers:
@@ -608,22 +606,22 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '105'
+      - '107'
     body:
       encoding: UTF-8
       string: |
         <project name="project_23">
-          <title>A Passage to India</title>
+          <title>Oh! To be in England</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:48 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=tom
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_44">
+        <workflow project="home:tom" managers="group_50">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
           <staging_project name="home:tom:Staging:XYZ"/>
@@ -652,21 +650,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="343">
-          <srcmd5>5042bd654c4544af7934e76ba9d9a133</srcmd5>
-          <time>1658422069</time>
+        <revision rev="143">
+          <srcmd5>19f24b65df15f5ea7d7a6b8079759cb0</srcmd5>
+          <time>1658762226</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:49 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=tom
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_44">
+        <workflow project="home:tom" managers="group_50">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
           <staging_project name="home:tom:Staging:XYZ"/>
@@ -695,14 +693,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="344">
-          <srcmd5>5042bd654c4544af7934e76ba9d9a133</srcmd5>
-          <time>1658422069</time>
+        <revision rev="144">
+          <srcmd5>19f24b65df15f5ea7d7a6b8079759cb0</srcmd5>
+          <time>1658762226</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:49 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:new_project/_meta?user=tom
@@ -710,11 +708,11 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="home:tom:new_project">
-          <title>Precious Bane</title>
+          <title>This Side of Paradise</title>
           <description/>
-          <person userid="user_102" role="maintainer"/>
-          <group groupid="group_44" role="maintainer"/>
-          <group groupid="group_45" role="maintainer"/>
+          <person userid="user_114" role="maintainer"/>
+          <group groupid="group_50" role="maintainer"/>
+          <group groupid="group_51" role="maintainer"/>
           <sourceaccess>
             <disable/>
           </sourceaccess>
@@ -749,16 +747,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '810'
+      - '818'
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:new_project">
-          <title>Precious Bane</title>
+          <title>This Side of Paradise</title>
           <description></description>
-          <person userid="user_102" role="maintainer"/>
-          <group groupid="group_44" role="maintainer"/>
-          <group groupid="group_45" role="maintainer"/>
+          <person userid="user_114" role="maintainer"/>
+          <group groupid="group_50" role="maintainer"/>
+          <group groupid="group_51" role="maintainer"/>
           <sourceaccess>
             <disable/>
           </sourceaccess>
@@ -774,7 +772,7 @@ http_interactions:
             <arch>x86_64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:49 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:new_project/_config?comment=Copying%20project%20home:tom:Staging:XYZ&user=tom
@@ -806,7 +804,7 @@ http_interactions:
       string: '<status code="ok" />
 
 '
-  recorded_at: Thu, 21 Jul 2022 16:47:49 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:06 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:new_project/_config
@@ -836,5 +834,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 'Prefer: foo'
-  recorded_at: Thu, 21 Jul 2022 16:47:49 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:06 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Project/Staging_Project/_copy/when_the_repository_contains_path_elements_that_link_to_repositories_of_the_same_project/renames_the_repository_link_if_it_contains_a_reference_to_the_project.yml
+++ b/src/api/spec/cassettes/Project/Staging_Project/_copy/when_the_repository_contains_path_elements_that_link_to_repositories_of_the_same_project/renames_the_repository_link_if_it_contains_a_reference_to_the_project.yml
@@ -39,14 +39,14 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:49 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:07 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_103
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_115
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_46">
+        <workflow project="home:tom" managers="group_52">
           <staging_project name="home:tom:Staging:A"/>
         </workflow>
     headers:
@@ -72,24 +72,24 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="345">
-          <srcmd5>0533b72d3c03801dce3591df9ce42ad5</srcmd5>
-          <time>1658422069</time>
-          <user>user_103</user>
+        <revision rev="145">
+          <srcmd5>6599d08130ab7378e715272906272d61</srcmd5>
+          <time>1658762227</time>
+          <user>user_115</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:49 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:07 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_103
+    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_115
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_46" role="maintainer"/>
+          <group groupid="group_52" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -117,16 +117,16 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_46" role="maintainer"/>
+          <group groupid="group_52" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:49 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:07 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_103
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_115
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_46">
+        <workflow project="home:tom" managers="group_52">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -153,24 +153,24 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="346">
-          <srcmd5>bb6347f26343ee7f993573e110d3778d</srcmd5>
-          <time>1658422069</time>
-          <user>user_103</user>
+        <revision rev="146">
+          <srcmd5>af4c1f44974258b5d8219f0b9316f2b1</srcmd5>
+          <time>1658762227</time>
+          <user>user_115</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:49 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:07 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_103
+    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_115
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:B">
           <title/>
           <description/>
-          <group groupid="group_46" role="maintainer"/>
+          <group groupid="group_52" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -198,12 +198,12 @@ http_interactions:
         <project name="home:tom:Staging:B">
           <title></title>
           <description></description>
-          <group groupid="group_46" role="maintainer"/>
+          <group groupid="group_52" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:49 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:07 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_meta?user=user_103
+    uri: http://backend:5352/source/home:tom/_meta?user=user_115
     body:
       encoding: UTF-8
       string: |
@@ -211,7 +211,7 @@ http_interactions:
           <title/>
           <description/>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_46" role="reviewer"/>
+          <group groupid="group_52" role="reviewer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -240,16 +240,16 @@ http_interactions:
           <title></title>
           <description></description>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_46" role="reviewer"/>
+          <group groupid="group_52" role="reviewer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:49 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:07 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_103
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_115
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_46">
+        <workflow project="home:tom" managers="group_52">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
           <staging_project name="home:tom:Staging:XYZ"/>
@@ -277,14 +277,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="347">
-          <srcmd5>323347045864b7878e4de56def32af71</srcmd5>
-          <time>1658422069</time>
-          <user>user_103</user>
+        <revision rev="147">
+          <srcmd5>8783557f66669dfb33e6974e9bb12bd3</srcmd5>
+          <time>1658762227</time>
+          <user>user_115</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:49 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:07 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:XYZ/_config?user=factory%20bot
@@ -316,7 +316,7 @@ http_interactions:
       string: '<status code="ok" />
 
 '
-  recorded_at: Thu, 21 Jul 2022 16:47:49 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:07 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:Staging:XYZ/_config
@@ -346,17 +346,17 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 'Prefer: foo'
-  recorded_at: Thu, 21 Jul 2022 16:47:49 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:07 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:XYZ/_meta?user=user_104
+    uri: http://backend:5352/source/home:tom:Staging:XYZ/_meta?user=user_116
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:XYZ">
-          <title>Dying of the Light</title>
+          <title>Stranger in a Strange Land</title>
           <description/>
-          <group groupid="group_46" role="maintainer"/>
+          <group groupid="group_52" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -377,25 +377,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '163'
+      - '171'
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:XYZ">
-          <title>Dying of the Light</title>
+          <title>Stranger in a Strange Land</title>
           <description></description>
-          <group groupid="group_46" role="maintainer"/>
+          <group groupid="group_52" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:49 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:07 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:XYZ/package_with_file/_meta?user=user_105
+    uri: http://backend:5352/source/home:tom:Staging:XYZ/package_with_file/_meta?user=user_117
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:XYZ">
-          <title>In Death Ground</title>
-          <description>Nesciunt accusamus ullam quia.</description>
+          <title>No Highway</title>
+          <description>Beatae officia veniam molestiae.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -416,21 +416,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '170'
+      - '167'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:XYZ">
-          <title>In Death Ground</title>
-          <description>Nesciunt accusamus ullam quia.</description>
+          <title>No Highway</title>
+          <description>Beatae officia veniam molestiae.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:49 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:07 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:XYZ/package_with_file/_config
     body:
       encoding: UTF-8
-      string: Quisquam est ab. Soluta error rerum. Recusandae eius voluptatem.
+      string: Ab animi quisquam. Eius et et. Commodi totam illum.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -455,20 +455,20 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="15" vrev="15">
-          <srcmd5>628aa7a7ee975d3d197619fe995d911c</srcmd5>
+          <srcmd5>588c071bf9e4aca3a80cf3b4b1de270e</srcmd5>
           <version>unknown</version>
-          <time>1658422069</time>
+          <time>1658762227</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:49 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:07 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:XYZ/package_with_file/somefile.txt
     body:
       encoding: UTF-8
-      string: Eius voluptatem nam. Possimus magni labore. Nobis ea maiores.
+      string: Quidem dolor consequatur. Illo pariatur ipsam. Aut odit dolor.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -493,14 +493,14 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="16" vrev="16">
-          <srcmd5>f6b7fead9b03325fae4f58e60086c2e8</srcmd5>
+          <srcmd5>9970dcb6ae494b79bf19a4fb31393b2f</srcmd5>
           <version>unknown</version>
-          <time>1658422069</time>
+          <time>1658762227</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:49 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:07 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_24/_meta?user=tom
@@ -508,7 +508,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="project_24">
-          <title>I Sing the Body Electric</title>
+          <title>The Moving Finger</title>
           <description/>
         </project>
     headers:
@@ -530,15 +530,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '111'
+      - '104'
     body:
       encoding: UTF-8
       string: |
         <project name="project_24">
-          <title>I Sing the Body Electric</title>
+          <title>The Moving Finger</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:49 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:07 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_25/_meta?user=tom
@@ -546,7 +546,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="project_25">
-          <title>As I Lay Dying</title>
+          <title>Endless Night</title>
           <description/>
         </project>
     headers:
@@ -568,15 +568,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '101'
+      - '100'
     body:
       encoding: UTF-8
       string: |
         <project name="project_25">
-          <title>As I Lay Dying</title>
+          <title>Endless Night</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:49 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:07 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_26/_meta?user=tom
@@ -584,7 +584,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="project_26">
-          <title>The Last Enemy</title>
+          <title>Rosemary Sutcliff</title>
           <description/>
         </project>
     headers:
@@ -606,22 +606,22 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '101'
+      - '104'
     body:
       encoding: UTF-8
       string: |
         <project name="project_26">
-          <title>The Last Enemy</title>
+          <title>Rosemary Sutcliff</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:49 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:07 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=tom
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_46">
+        <workflow project="home:tom" managers="group_52">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
           <staging_project name="home:tom:Staging:XYZ"/>
@@ -650,21 +650,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="348">
-          <srcmd5>c5915ac22cb91c8553a1979d1b081cdb</srcmd5>
-          <time>1658422070</time>
+        <revision rev="148">
+          <srcmd5>a6d1253faa4b13465f52db97ea05fc78</srcmd5>
+          <time>1658762227</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:50 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:07 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=tom
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_46">
+        <workflow project="home:tom" managers="group_52">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
           <staging_project name="home:tom:Staging:XYZ"/>
@@ -693,14 +693,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="349">
-          <srcmd5>c5915ac22cb91c8553a1979d1b081cdb</srcmd5>
-          <time>1658422070</time>
+        <revision rev="149">
+          <srcmd5>a6d1253faa4b13465f52db97ea05fc78</srcmd5>
+          <time>1658762227</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:50 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:07 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:new_project/_meta?user=tom
@@ -708,11 +708,11 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="home:tom:new_project">
-          <title>Dying of the Light</title>
+          <title>Stranger in a Strange Land</title>
           <description/>
-          <person userid="user_106" role="maintainer"/>
-          <group groupid="group_46" role="maintainer"/>
-          <group groupid="group_47" role="maintainer"/>
+          <person userid="user_118" role="maintainer"/>
+          <group groupid="group_52" role="maintainer"/>
+          <group groupid="group_53" role="maintainer"/>
           <sourceaccess>
             <disable/>
           </sourceaccess>
@@ -747,16 +747,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '815'
+      - '823'
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:new_project">
-          <title>Dying of the Light</title>
+          <title>Stranger in a Strange Land</title>
           <description></description>
-          <person userid="user_106" role="maintainer"/>
-          <group groupid="group_46" role="maintainer"/>
-          <group groupid="group_47" role="maintainer"/>
+          <person userid="user_118" role="maintainer"/>
+          <group groupid="group_52" role="maintainer"/>
+          <group groupid="group_53" role="maintainer"/>
           <sourceaccess>
             <disable/>
           </sourceaccess>
@@ -772,7 +772,7 @@ http_interactions:
             <arch>x86_64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:50 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:07 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:new_project/_config?comment=Copying%20project%20home:tom:Staging:XYZ&user=tom
@@ -804,7 +804,7 @@ http_interactions:
       string: '<status code="ok" />
 
 '
-  recorded_at: Thu, 21 Jul 2022 16:47:50 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:07 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:new_project/_config
@@ -834,5 +834,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 'Prefer: foo'
-  recorded_at: Thu, 21 Jul 2022 16:47:50 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:07 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Project/Staging_Project/_missing_reviews/contains_all_open_reviews_of_staged_requests.yml
+++ b/src/api/spec/cassettes/Project/Staging_Project/_missing_reviews/contains_all_open_reviews_of_staged_requests.yml
@@ -39,14 +39,14 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:22 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:32 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_43
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_47
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_15">
+        <workflow project="home:tom" managers="group_18">
           <staging_project name="home:tom:Staging:A"/>
         </workflow>
     headers:
@@ -68,28 +68,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="253">
-          <srcmd5>2e4fd7acfe7e7c1f399a1329f38a7407</srcmd5>
-          <time>1658422042</time>
-          <user>user_43</user>
+        <revision rev="35">
+          <srcmd5>5c67ecfcd81a37d620b7a9e487b797d8</srcmd5>
+          <time>1658762192</time>
+          <user>user_47</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:22 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:32 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_43
+    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_47
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_15" role="maintainer"/>
+          <group groupid="group_18" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -117,16 +117,16 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_15" role="maintainer"/>
+          <group groupid="group_18" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:22 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:32 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_43
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_47
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_15">
+        <workflow project="home:tom" managers="group_18">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -149,28 +149,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="254">
-          <srcmd5>9baea94f04f89a4aef426e3f265e78df</srcmd5>
-          <time>1658422042</time>
-          <user>user_43</user>
+        <revision rev="36">
+          <srcmd5>f025f824c96dccfb93d74370e8a285d6</srcmd5>
+          <time>1658762192</time>
+          <user>user_47</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:22 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:32 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_43
+    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_47
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:B">
           <title/>
           <description/>
-          <group groupid="group_15" role="maintainer"/>
+          <group groupid="group_18" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -198,12 +198,12 @@ http_interactions:
         <project name="home:tom:Staging:B">
           <title></title>
           <description></description>
-          <group groupid="group_15" role="maintainer"/>
+          <group groupid="group_18" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:22 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:32 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_meta?user=user_43
+    uri: http://backend:5352/source/home:tom/_meta?user=user_47
     body:
       encoding: UTF-8
       string: |
@@ -211,7 +211,7 @@ http_interactions:
           <title/>
           <description/>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_15" role="reviewer"/>
+          <group groupid="group_18" role="reviewer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -240,18 +240,18 @@ http_interactions:
           <title></title>
           <description></description>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_15" role="reviewer"/>
+          <group groupid="group_18" role="reviewer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:22 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:32 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_44
+    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_48
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>The Line of Beauty</title>
-          <description>Perferendis vel ut aliquid.</description>
+          <title>That Hideous Strength</title>
+          <description>Ipsa veniam fugiat vel.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -272,21 +272,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '168'
+      - '167'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>The Line of Beauty</title>
-          <description>Perferendis vel ut aliquid.</description>
+          <title>That Hideous Strength</title>
+          <description>Ipsa veniam fugiat vel.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:22 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:32 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_config
     body:
       encoding: UTF-8
-      string: Quam sunt voluptatem. Accusantium hic occaecati. Ipsum omnis laboriosam.
+      string: Porro ducimus quae. Amet nesciunt alias. Cumque natus accusantium.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -306,25 +306,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="125" vrev="125">
-          <srcmd5>dffbee79bcf8aeccb71d780e4f4cd0d6</srcmd5>
+        <revision rev="33" vrev="33">
+          <srcmd5>9842f8bad37334efa02e1ea75216b0a0</srcmd5>
           <version>unknown</version>
-          <time>1658422042</time>
+          <time>1658762192</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:22 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:32 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/somefile.txt
     body:
       encoding: UTF-8
-      string: Et necessitatibus velit. Ut distinctio est. Dignissimos alias praesentium.
+      string: Saepe nesciunt illo. Est autem tenetur. Est quia et.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -344,19 +344,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="126" vrev="126">
-          <srcmd5>fe8906e363bfa92f5c27fbc604f019c2</srcmd5>
+        <revision rev="34" vrev="34">
+          <srcmd5>eb8364c759f2bb592d464ca6511a0c95</srcmd5>
           <version>unknown</version>
-          <time>1658422042</time>
+          <time>1658762192</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:22 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:32 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/_meta?user=tom
@@ -364,7 +364,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>Infinite Jest</title>
+          <title>All the King's Men</title>
           <description/>
         </project>
     headers:
@@ -386,15 +386,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '104'
+      - '109'
     body:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>Infinite Jest</title>
+          <title>All the King's Men</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:22 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:32 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package/_meta?user=tom
@@ -402,8 +402,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>A Time of Gifts</title>
-          <description>Ratione consequatur molestiae nesciunt.</description>
+          <title>No Country for Old Men</title>
+          <description>Exercitationem aut voluptas quia.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -424,15 +424,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '170'
+      - '171'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>A Time of Gifts</title>
-          <description>Ratione consequatur molestiae nesciunt.</description>
+          <title>No Country for Old Men</title>
+          <description>Exercitationem aut voluptas quia.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:22 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:32 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_meta?user=tom
@@ -440,7 +440,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>The Painted Veil</title>
+          <title>Little Hands Clapping</title>
           <description/>
         </project>
     headers:
@@ -462,15 +462,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '107'
+      - '112'
     body:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>The Painted Veil</title>
+          <title>Little Hands Clapping</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:22 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:32 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_project/_attribute?meta=1&user=tom
@@ -499,18 +499,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '166'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="126">
-          <srcmd5>268c765b83f5f2ff620c9dd150cae3ae</srcmd5>
-          <time>1658422042</time>
+        <revision rev="32">
+          <srcmd5>30c0a395d0b225d092e0c58d5fde7a18</srcmd5>
+          <time>1658762192</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:22 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:32 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/source_package/_meta?user=tom
@@ -518,8 +518,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>The Last Temptation</title>
-          <description>Eveniet et commodi tempora.</description>
+          <title>The Moving Finger</title>
+          <description>Ducimus modi mollitia asperiores.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -540,15 +540,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '162'
+      - '166'
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>The Last Temptation</title>
-          <description>Eveniet et commodi tempora.</description>
+          <title>The Moving Finger</title>
+          <description>Ducimus modi mollitia asperiores.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:22 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:32 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package
@@ -580,7 +580,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:22 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:33 GMT
 - request:
     method: post
     uri: http://backend:5352/source/source_project/source_package?cmd=diff&expand=1&filelimit=10000&opackage=target_package&oproject=target_project&tarlimit=10000&view=xml&withissues=1
@@ -604,7 +604,7 @@ http_interactions:
       Content-Type:
       - text/xml
       Content-Length:
-      - '329'
+      - '328'
       Cache-Control:
       - no-cache
       Connection:
@@ -612,15 +612,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="f0ade37f19a7eee38b40dd0309766ea1">
-          <old project="target_project" package="target_package" rev="28" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+        <sourcediff key="22bfb82bf1c9f9c9dd66ba87930cd41c">
+          <old project="target_project" package="target_package" rev="1" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <new project="source_project" package="source_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files>
           </files>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:22 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:33 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_1/_meta?user=tom
@@ -628,7 +628,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="project_1">
-          <title>Of Human Bondage</title>
+          <title>Gone with the Wind</title>
           <description/>
         </project>
     headers:
@@ -650,15 +650,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '102'
+      - '104'
     body:
       encoding: UTF-8
       string: |
         <project name="project_1">
-          <title>Of Human Bondage</title>
+          <title>Gone with the Wind</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:22 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:33 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_1/package_1/_meta?user=tom
@@ -666,8 +666,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_1" project="project_1">
-          <title>Ring of Bright Water</title>
-          <description>Omnis aut pariatur voluptas.</description>
+          <title>A Darkling Plain</title>
+          <description>Incidunt tenetur est repudiandae.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -688,13 +688,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '154'
+      - '155'
     body:
       encoding: UTF-8
       string: |
         <package name="package_1" project="project_1">
-          <title>Ring of Bright Water</title>
-          <description>Omnis aut pariatur voluptas.</description>
+          <title>A Darkling Plain</title>
+          <description>Incidunt tenetur est repudiandae.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:22 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:33 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Project/Staging_Project/_missing_reviews/when_there_is_an_accepted_review/1_1_1_2_1.yml
+++ b/src/api/spec/cassettes/Project/Staging_Project/_missing_reviews/when_there_is_an_accepted_review/1_1_1_2_1.yml
@@ -39,14 +39,14 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:23 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:33 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_47
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_51
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_17">
+        <workflow project="home:tom" managers="group_20">
           <staging_project name="home:tom:Staging:A"/>
         </workflow>
     headers:
@@ -68,28 +68,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="255">
-          <srcmd5>0872b7780d1bc24edbb4ad86f6349db4</srcmd5>
-          <time>1658422043</time>
-          <user>user_47</user>
+        <revision rev="37">
+          <srcmd5>9a93e226d354e8c0b628b3cce0ea7b2c</srcmd5>
+          <time>1658762193</time>
+          <user>user_51</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:23 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:33 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_47
+    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_51
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_17" role="maintainer"/>
+          <group groupid="group_20" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -117,16 +117,16 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_17" role="maintainer"/>
+          <group groupid="group_20" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:23 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:33 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_47
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_51
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_17">
+        <workflow project="home:tom" managers="group_20">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -149,28 +149,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="256">
-          <srcmd5>28c643daa46daa799be96aaa9e558cb9</srcmd5>
-          <time>1658422043</time>
-          <user>user_47</user>
+        <revision rev="38">
+          <srcmd5>8da317e26168b4639bbbf4172477283b</srcmd5>
+          <time>1658762193</time>
+          <user>user_51</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:23 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:33 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_47
+    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_51
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:B">
           <title/>
           <description/>
-          <group groupid="group_17" role="maintainer"/>
+          <group groupid="group_20" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -198,12 +198,12 @@ http_interactions:
         <project name="home:tom:Staging:B">
           <title></title>
           <description></description>
-          <group groupid="group_17" role="maintainer"/>
+          <group groupid="group_20" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:23 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:33 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_meta?user=user_47
+    uri: http://backend:5352/source/home:tom/_meta?user=user_51
     body:
       encoding: UTF-8
       string: |
@@ -211,7 +211,7 @@ http_interactions:
           <title/>
           <description/>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_17" role="reviewer"/>
+          <group groupid="group_20" role="reviewer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -240,18 +240,18 @@ http_interactions:
           <title></title>
           <description></description>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_17" role="reviewer"/>
+          <group groupid="group_20" role="reviewer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:23 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:33 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_48
+    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_52
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>The Heart Is a Lonely Hunter</title>
-          <description>Qui excepturi ducimus quia.</description>
+          <title>In Dubious Battle</title>
+          <description>Voluptatem sunt consectetur sit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -272,21 +272,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '178'
+      - '172'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>The Heart Is a Lonely Hunter</title>
-          <description>Qui excepturi ducimus quia.</description>
+          <title>In Dubious Battle</title>
+          <description>Voluptatem sunt consectetur sit.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:23 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:33 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_config
     body:
       encoding: UTF-8
-      string: Et sit consequatur. Sint et quasi. Ex expedita voluptatum.
+      string: Ipsum aut architecto. Facilis et aspernatur. Amet qui et.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -306,25 +306,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="127" vrev="127">
-          <srcmd5>cad74654803e325fc557019670baf1b9</srcmd5>
+        <revision rev="35" vrev="35">
+          <srcmd5>aee31446fc86888a0c4d177622c1d17c</srcmd5>
           <version>unknown</version>
-          <time>1658422043</time>
+          <time>1658762193</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:23 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:33 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/somefile.txt
     body:
       encoding: UTF-8
-      string: Et eaque quod. Quae laborum ducimus. Voluptates blanditiis reprehenderit.
+      string: Adipisci id perspiciatis. Perspiciatis rerum occaecati. Sequi rem debitis.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -344,19 +344,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="128" vrev="128">
-          <srcmd5>b39b976be607428ec23f5c3ae1c4218b</srcmd5>
+        <revision rev="36" vrev="36">
+          <srcmd5>de9f6222d7bdacaa47c7574eeb6f2131</srcmd5>
           <version>unknown</version>
-          <time>1658422043</time>
+          <time>1658762193</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:23 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:33 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/_meta?user=tom
@@ -364,7 +364,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>Blue Remembered Earth</title>
+          <title>A Darkling Plain</title>
           <description/>
         </project>
     headers:
@@ -386,15 +386,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '112'
+      - '107'
     body:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>Blue Remembered Earth</title>
+          <title>A Darkling Plain</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:23 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:33 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package/_meta?user=tom
@@ -402,8 +402,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>Mr Standfast</title>
-          <description>Veritatis id ex eos.</description>
+          <title>The Road Less Traveled</title>
+          <description>Omnis molestiae et officiis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -424,15 +424,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '148'
+      - '166'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>Mr Standfast</title>
-          <description>Veritatis id ex eos.</description>
+          <title>The Road Less Traveled</title>
+          <description>Omnis molestiae et officiis.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:23 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:33 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_meta?user=tom
@@ -440,7 +440,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Dance Dance Dance</title>
+          <title>Stranger in a Strange Land</title>
           <description/>
         </project>
     headers:
@@ -462,15 +462,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '108'
+      - '117'
     body:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Dance Dance Dance</title>
+          <title>Stranger in a Strange Land</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:23 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:33 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_project/_attribute?meta=1&user=tom
@@ -499,18 +499,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '166'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="128">
-          <srcmd5>ae99470e831fd63b655d9b8dfc09de57</srcmd5>
-          <time>1658422043</time>
+        <revision rev="34">
+          <srcmd5>795431ce71fc295fe9ca348e940076d9</srcmd5>
+          <time>1658762193</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:23 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:33 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/source_package/_meta?user=tom
@@ -518,8 +518,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>Beneath the Bleeding</title>
-          <description>Quas est velit dolorem.</description>
+          <title>Everything is Illuminated</title>
+          <description>Repudiandae et saepe id.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -540,15 +540,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '159'
+      - '165'
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>Beneath the Bleeding</title>
-          <description>Quas est velit dolorem.</description>
+          <title>Everything is Illuminated</title>
+          <description>Repudiandae et saepe id.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:23 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:33 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package
@@ -580,7 +580,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:23 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:33 GMT
 - request:
     method: post
     uri: http://backend:5352/source/source_project/source_package?cmd=diff&expand=1&filelimit=10000&opackage=target_package&oproject=target_project&tarlimit=10000&view=xml&withissues=1
@@ -604,7 +604,7 @@ http_interactions:
       Content-Type:
       - text/xml
       Content-Length:
-      - '329'
+      - '328'
       Cache-Control:
       - no-cache
       Connection:
@@ -612,15 +612,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="f0ade37f19a7eee38b40dd0309766ea1">
-          <old project="target_project" package="target_package" rev="28" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+        <sourcediff key="22bfb82bf1c9f9c9dd66ba87930cd41c">
+          <old project="target_project" package="target_package" rev="1" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <new project="source_project" package="source_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files>
           </files>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:23 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:33 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_2/_meta?user=tom
@@ -628,7 +628,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="project_2">
-          <title>The Moon by Night</title>
+          <title>Dying of the Light</title>
           <description/>
         </project>
     headers:
@@ -650,15 +650,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '103'
+      - '104'
     body:
       encoding: UTF-8
       string: |
         <project name="project_2">
-          <title>The Moon by Night</title>
+          <title>Dying of the Light</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:23 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:33 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_2/package_2/_meta?user=tom
@@ -666,8 +666,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_2" project="project_2">
-          <title>Oh! To be in England</title>
-          <description>Alias quos et eum.</description>
+          <title>Cover Her Face</title>
+          <description>Corrupti saepe voluptates eos.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -688,13 +688,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '144'
+      - '150'
     body:
       encoding: UTF-8
       string: |
         <package name="package_2" project="project_2">
-          <title>Oh! To be in England</title>
-          <description>Alias quos et eum.</description>
+          <title>Cover Her Face</title>
+          <description>Corrupti saepe voluptates eos.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:23 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:34 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Project/Staging_Project/_overall_state/when_request_got_revoked/1_1_3_2_1.yml
+++ b/src/api/spec/cassettes/Project/Staging_Project/_overall_state/when_request_got_revoked/1_1_3_2_1.yml
@@ -39,7 +39,7 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:19 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:28 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_28
@@ -68,18 +68,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="243">
+        <revision rev="19">
           <srcmd5>33b89e17035874bcdd6155d34a1b1c95</srcmd5>
-          <time>1658422039</time>
+          <time>1658762188</time>
           <user>user_28</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:19 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:28 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_28
@@ -119,7 +119,7 @@ http_interactions:
           <description></description>
           <group groupid="group_10" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:19 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:28 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_28
@@ -149,18 +149,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="244">
+        <revision rev="20">
           <srcmd5>099b346d81b5ac016569baf46446c6f9</srcmd5>
-          <time>1658422039</time>
+          <time>1658762188</time>
           <user>user_28</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:19 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:28 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_28
@@ -200,7 +200,7 @@ http_interactions:
           <description></description>
           <group groupid="group_10" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:19 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:28 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_meta?user=user_28
@@ -242,7 +242,7 @@ http_interactions:
           <person userid="tom" role="maintainer"/>
           <group groupid="group_10" role="reviewer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:19 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:28 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_29
@@ -250,8 +250,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>All the King's Men</title>
-          <description>Ut similique animi vero.</description>
+          <title>The Curious Incident of the Dog in the Night-Time</title>
+          <description>Ullam est voluptatem minima.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -272,21 +272,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '165'
+      - '200'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>All the King's Men</title>
-          <description>Ut similique animi vero.</description>
+          <title>The Curious Incident of the Dog in the Night-Time</title>
+          <description>Ullam est voluptatem minima.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:19 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:28 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_config
     body:
       encoding: UTF-8
-      string: Rerum aliquam optio. Nihil est doloremque. Labore itaque vel.
+      string: Voluptatem repellendus et. Pariatur quia consequuntur. Sit sed laudantium.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -306,25 +306,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="115" vrev="115">
-          <srcmd5>ffc452e261ac90c006ee6023ae745d89</srcmd5>
+        <revision rev="19" vrev="19">
+          <srcmd5>86809beaebccb4023fde6cc956243d22</srcmd5>
           <version>unknown</version>
-          <time>1658422039</time>
+          <time>1658762188</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:19 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:28 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/somefile.txt
     body:
       encoding: UTF-8
-      string: Sapiente enim fugiat. Amet fugiat corporis. Sit adipisci ratione.
+      string: Enim id vel. Alias beatae nulla. Fuga dicta ut.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -344,19 +344,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="116" vrev="116">
-          <srcmd5>fac9302a363cc8dd8ad6462f472cc872</srcmd5>
+        <revision rev="20" vrev="20">
+          <srcmd5>d1a22d8945ea6c4475998da04b1a361f</srcmd5>
           <version>unknown</version>
-          <time>1658422039</time>
+          <time>1658762188</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:19 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:28 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/_meta?user=tom
@@ -364,7 +364,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>A Scanner Darkly</title>
+          <title>The Moon by Night</title>
           <description/>
         </project>
     headers:
@@ -386,15 +386,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '107'
+      - '108'
     body:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>A Scanner Darkly</title>
+          <title>The Moon by Night</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:19 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:28 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package/_meta?user=tom
@@ -402,8 +402,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>A Summer Bird-Cage</title>
-          <description>Voluptatem esse quis aliquid.</description>
+          <title>His Dark Materials</title>
+          <description>Et sit aut dolore.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -424,15 +424,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '163'
+      - '152'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>A Summer Bird-Cage</title>
-          <description>Voluptatem esse quis aliquid.</description>
+          <title>His Dark Materials</title>
+          <description>Et sit aut dolore.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:19 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:28 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_meta?user=tom
@@ -440,7 +440,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Tiger! Tiger!</title>
+          <title>Quo Vadis</title>
           <description/>
         </project>
     headers:
@@ -462,15 +462,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '104'
+      - '100'
     body:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Tiger! Tiger!</title>
+          <title>Quo Vadis</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:19 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:28 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_project/_attribute?meta=1&user=tom
@@ -499,18 +499,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '166'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="116">
-          <srcmd5>821ee7c7798ffc65e112f0da6f50701a</srcmd5>
-          <time>1658422039</time>
+        <revision rev="22">
+          <srcmd5>b720efad533ccfbae92566757a8fec48</srcmd5>
+          <time>1658762188</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:19 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:28 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/source_package/_meta?user=tom
@@ -518,8 +518,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>After Many a Summer Dies the Swan</title>
-          <description>Mollitia sapiente fuga ex.</description>
+          <title>A Time of Gifts</title>
+          <description>Id ex reprehenderit quos.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -540,15 +540,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '175'
+      - '156'
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>After Many a Summer Dies the Swan</title>
-          <description>Mollitia sapiente fuga ex.</description>
+          <title>A Time of Gifts</title>
+          <description>Id ex reprehenderit quos.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:19 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:28 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package
@@ -580,7 +580,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:19 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:28 GMT
 - request:
     method: post
     uri: http://backend:5352/source/source_project/source_package?cmd=diff&expand=1&filelimit=10000&opackage=target_package&oproject=target_project&tarlimit=10000&view=xml&withissues=1
@@ -604,7 +604,7 @@ http_interactions:
       Content-Type:
       - text/xml
       Content-Length:
-      - '329'
+      - '328'
       Cache-Control:
       - no-cache
       Connection:
@@ -612,13 +612,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="f0ade37f19a7eee38b40dd0309766ea1">
-          <old project="target_project" package="target_package" rev="28" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+        <sourcediff key="22bfb82bf1c9f9c9dd66ba87930cd41c">
+          <old project="target_project" package="target_package" rev="1" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <new project="source_project" package="source_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files>
           </files>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:19 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:28 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Project/Staging_Project/_overall_state/when_there_are_failed_checks_on_build_repo/1_1_3_7_1.yml
+++ b/src/api/spec/cassettes/Project/Staging_Project/_overall_state/when_there_are_failed_checks_on_build_repo/1_1_3_7_1.yml
@@ -39,14 +39,14 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:18 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:26 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_25
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_19
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_9">
+        <workflow project="home:tom" managers="group_7">
           <staging_project name="home:tom:Staging:A"/>
         </workflow>
     headers:
@@ -68,28 +68,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="241">
-          <srcmd5>3ffe5c98d1c545ee60091d10c2531c8f</srcmd5>
-          <time>1658422038</time>
-          <user>user_25</user>
+        <revision rev="13">
+          <srcmd5>85c3cca148545c736607e59bf75c78e5</srcmd5>
+          <time>1658762186</time>
+          <user>user_19</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:18 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:26 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_25
+    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_19
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_9" role="maintainer"/>
+          <group groupid="group_7" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -117,16 +117,16 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_9" role="maintainer"/>
+          <group groupid="group_7" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:18 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:26 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_25
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_19
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_9">
+        <workflow project="home:tom" managers="group_7">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -149,28 +149,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="242">
-          <srcmd5>5d7fc29c6e4227df61f666d885856eab</srcmd5>
-          <time>1658422038</time>
-          <user>user_25</user>
+        <revision rev="14">
+          <srcmd5>ac4f612dac98513520b40b03c44c0f4f</srcmd5>
+          <time>1658762186</time>
+          <user>user_19</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:18 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:26 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_25
+    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_19
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:B">
           <title/>
           <description/>
-          <group groupid="group_9" role="maintainer"/>
+          <group groupid="group_7" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -198,12 +198,12 @@ http_interactions:
         <project name="home:tom:Staging:B">
           <title></title>
           <description></description>
-          <group groupid="group_9" role="maintainer"/>
+          <group groupid="group_7" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:18 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:26 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_meta?user=user_25
+    uri: http://backend:5352/source/home:tom/_meta?user=user_19
     body:
       encoding: UTF-8
       string: |
@@ -211,7 +211,7 @@ http_interactions:
           <title/>
           <description/>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_9" role="reviewer"/>
+          <group groupid="group_7" role="reviewer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -240,18 +240,18 @@ http_interactions:
           <title></title>
           <description></description>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_9" role="reviewer"/>
+          <group groupid="group_7" role="reviewer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:18 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:26 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_26
+    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_20
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>Many Waters</title>
-          <description>Itaque perferendis reiciendis voluptatem.</description>
+          <title>I Sing the Body Electric</title>
+          <description>Dolore et provident ut.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -272,21 +272,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '175'
+      - '170'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>Many Waters</title>
-          <description>Itaque perferendis reiciendis voluptatem.</description>
+          <title>I Sing the Body Electric</title>
+          <description>Dolore et provident ut.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:18 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:26 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_config
     body:
       encoding: UTF-8
-      string: Consequatur amet aut. Tempora eligendi voluptas. Porro harum est.
+      string: Est deleniti in. Quisquam minima inventore. Officia et velit.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -306,26 +306,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="113" vrev="113">
-          <srcmd5>caf9d0acc642c5440127be292350ccff</srcmd5>
+        <revision rev="13" vrev="13">
+          <srcmd5>7720b14bee522d137ba5b95b0ce27fd4</srcmd5>
           <version>unknown</version>
-          <time>1658422038</time>
+          <time>1658762186</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:18 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:26 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/somefile.txt
     body:
       encoding: UTF-8
-      string: Consequatur voluptatem ea. Laboriosam doloribus quaerat. Doloremque
-        veniam rerum.
+      string: Eius placeat dolorem. Est illum dolor. Excepturi dolor eos.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -345,19 +344,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="114" vrev="114">
-          <srcmd5>3ba717b5686be7fb080c6d5cb8188c30</srcmd5>
+        <revision rev="14" vrev="14">
+          <srcmd5>8f37fdb19f67f58105cdfca5d15c2efc</srcmd5>
           <version>unknown</version>
-          <time>1658422038</time>
+          <time>1658762186</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:18 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:26 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/_meta?user=tom
@@ -365,7 +364,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>From Here to Eternity</title>
+          <title>For Whom the Bell Tolls</title>
           <description/>
         </project>
     headers:
@@ -387,15 +386,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '112'
+      - '114'
     body:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>From Here to Eternity</title>
+          <title>For Whom the Bell Tolls</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:18 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:26 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package/_meta?user=tom
@@ -403,8 +402,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>I Sing the Body Electric</title>
-          <description>Commodi doloremque hic ratione.</description>
+          <title>The Stars' Tennis Balls</title>
+          <description>Rem consequatur dolore est.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -425,15 +424,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '166'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>I Sing the Body Electric</title>
-          <description>Commodi doloremque hic ratione.</description>
+          <title>The Stars' Tennis Balls</title>
+          <description>Rem consequatur dolore est.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:18 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:26 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_meta?user=tom
@@ -441,7 +440,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Antic Hay</title>
+          <title>Alone on a Wide, Wide Sea</title>
           <description/>
         </project>
     headers:
@@ -463,15 +462,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '100'
+      - '116'
     body:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Antic Hay</title>
+          <title>Alone on a Wide, Wide Sea</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:18 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:26 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_project/_attribute?meta=1&user=tom
@@ -500,18 +499,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '166'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="114">
-          <srcmd5>0975d67d2e8a4d5eae10011fb8899b1d</srcmd5>
-          <time>1658422038</time>
+        <revision rev="16">
+          <srcmd5>d6e402cfaf67d2e0115d404c60d871f6</srcmd5>
+          <time>1658762186</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:18 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:26 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/source_package/_meta?user=tom
@@ -519,8 +518,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>The Mermaids Singing</title>
-          <description>Officiis impedit quos ab.</description>
+          <title>A Time of Gifts</title>
+          <description>Explicabo et quo culpa.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -541,15 +540,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '161'
+      - '154'
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>The Mermaids Singing</title>
-          <description>Officiis impedit quos ab.</description>
+          <title>A Time of Gifts</title>
+          <description>Explicabo et quo culpa.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:18 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:26 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package
@@ -581,7 +580,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:19 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:26 GMT
 - request:
     method: post
     uri: http://backend:5352/source/source_project/source_package?cmd=diff&expand=1&filelimit=10000&opackage=target_package&oproject=target_project&tarlimit=10000&view=xml&withissues=1
@@ -605,7 +604,7 @@ http_interactions:
       Content-Type:
       - text/xml
       Content-Length:
-      - '329'
+      - '328'
       Cache-Control:
       - no-cache
       Connection:
@@ -613,15 +612,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="f0ade37f19a7eee38b40dd0309766ea1">
-          <old project="target_project" package="target_package" rev="28" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+        <sourcediff key="22bfb82bf1c9f9c9dd66ba87930cd41c">
+          <old project="target_project" package="target_package" rev="1" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <new project="source_project" package="source_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files>
           </files>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:19 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:26 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:Staging:A/_result?code=unresolvable
@@ -653,5 +652,5 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 21 Jul 2022 16:47:19 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:26 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Project/Staging_Project/_overall_state/when_there_are_failed_checks_on_build_repo/1_1_3_7_2.yml
+++ b/src/api/spec/cassettes/Project/Staging_Project/_overall_state/when_there_are_failed_checks_on_build_repo/1_1_3_7_2.yml
@@ -39,14 +39,14 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:17 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:25 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_22
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_16
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_8">
+        <workflow project="home:tom" managers="group_6">
           <staging_project name="home:tom:Staging:A"/>
         </workflow>
     headers:
@@ -68,28 +68,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="239">
-          <srcmd5>fa20c26f540ca47bc5c5aafdf5916d71</srcmd5>
-          <time>1658422037</time>
-          <user>user_22</user>
+        <revision rev="11">
+          <srcmd5>5689657db49214a80e4a99e7f4023d50</srcmd5>
+          <time>1658762185</time>
+          <user>user_16</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:17 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:25 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_22
+    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_16
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_8" role="maintainer"/>
+          <group groupid="group_6" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -117,16 +117,16 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_8" role="maintainer"/>
+          <group groupid="group_6" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:17 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:25 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_22
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_16
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_8">
+        <workflow project="home:tom" managers="group_6">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -149,28 +149,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="240">
-          <srcmd5>f3ab7aa01f41d6a5b3406e553c17c510</srcmd5>
-          <time>1658422038</time>
-          <user>user_22</user>
+        <revision rev="12">
+          <srcmd5>5bb31242c174857bc5255247b77b6be9</srcmd5>
+          <time>1658762185</time>
+          <user>user_16</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:18 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:25 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_22
+    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_16
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:B">
           <title/>
           <description/>
-          <group groupid="group_8" role="maintainer"/>
+          <group groupid="group_6" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -198,12 +198,12 @@ http_interactions:
         <project name="home:tom:Staging:B">
           <title></title>
           <description></description>
-          <group groupid="group_8" role="maintainer"/>
+          <group groupid="group_6" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:18 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:25 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_meta?user=user_22
+    uri: http://backend:5352/source/home:tom/_meta?user=user_16
     body:
       encoding: UTF-8
       string: |
@@ -211,7 +211,7 @@ http_interactions:
           <title/>
           <description/>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_8" role="reviewer"/>
+          <group groupid="group_6" role="reviewer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -240,18 +240,18 @@ http_interactions:
           <title></title>
           <description></description>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_8" role="reviewer"/>
+          <group groupid="group_6" role="reviewer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:18 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:25 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_23
+    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_17
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>Fame Is the Spur</title>
-          <description>Omnis reiciendis ex laborum.</description>
+          <title>By Grand Central Station I Sat Down and Wept</title>
+          <description>Aut culpa quam tempore.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -272,21 +272,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '190'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>Fame Is the Spur</title>
-          <description>Omnis reiciendis ex laborum.</description>
+          <title>By Grand Central Station I Sat Down and Wept</title>
+          <description>Aut culpa quam tempore.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:18 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:25 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_config
     body:
       encoding: UTF-8
-      string: Magnam quo dolores. Repudiandae eveniet porro. Ipsam excepturi ipsum.
+      string: Quam iure est. Non aliquid consequatur. Nihil error laudantium.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -306,25 +306,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="111" vrev="111">
-          <srcmd5>161f426fe5ba366d35e066ecbbfed4f6</srcmd5>
+        <revision rev="11" vrev="11">
+          <srcmd5>5c46cf9986b627b83ec1f73b25b8e900</srcmd5>
           <version>unknown</version>
-          <time>1658422038</time>
+          <time>1658762185</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:18 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:25 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/somefile.txt
     body:
       encoding: UTF-8
-      string: Iure ut qui. Hic dolore est. Non cum libero.
+      string: Sequi temporibus et. Nihil impedit aliquid. Aliquid consectetur ratione.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -344,19 +344,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="112" vrev="112">
-          <srcmd5>36d6ab9b721ff1e3fce9ad3d814a27ff</srcmd5>
+        <revision rev="12" vrev="12">
+          <srcmd5>8ff895614ed9491aacdd0b9963c254aa</srcmd5>
           <version>unknown</version>
-          <time>1658422038</time>
+          <time>1658762185</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:18 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:25 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/_meta?user=tom
@@ -364,7 +364,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>Where Angels Fear to Tread</title>
+          <title>The Doors of Perception</title>
           <description/>
         </project>
     headers:
@@ -386,15 +386,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '117'
+      - '114'
     body:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>Where Angels Fear to Tread</title>
+          <title>The Doors of Perception</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:18 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:25 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package/_meta?user=tom
@@ -402,8 +402,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>The Widening Gyre</title>
-          <description>Veniam architecto non numquam.</description>
+          <title>The Glory and the Dream</title>
+          <description>Consequatur dolores est facere.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -424,15 +424,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '163'
+      - '170'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>The Widening Gyre</title>
-          <description>Veniam architecto non numquam.</description>
+          <title>The Glory and the Dream</title>
+          <description>Consequatur dolores est facere.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:18 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:25 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_meta?user=tom
@@ -440,7 +440,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Endless Night</title>
+          <title>A Many-Splendoured Thing</title>
           <description/>
         </project>
     headers:
@@ -462,15 +462,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '104'
+      - '115'
     body:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Endless Night</title>
+          <title>A Many-Splendoured Thing</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:18 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:25 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_project/_attribute?meta=1&user=tom
@@ -499,18 +499,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '166'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="112">
-          <srcmd5>88f9eb2ec37d6e6bec49f42a36e4d53d</srcmd5>
-          <time>1658422038</time>
+        <revision rev="14">
+          <srcmd5>96d14c6911e65015fa46c2b60ec28cf9</srcmd5>
+          <time>1658762185</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:18 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:25 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/source_package/_meta?user=tom
@@ -518,8 +518,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>Unweaving the Rainbow</title>
-          <description>Repellendus eligendi odit temporibus.</description>
+          <title>Ah, Wilderness!</title>
+          <description>Voluptas aut iste dolores.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -540,15 +540,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '174'
+      - '157'
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>Unweaving the Rainbow</title>
-          <description>Repellendus eligendi odit temporibus.</description>
+          <title>Ah, Wilderness!</title>
+          <description>Voluptas aut iste dolores.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:18 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:25 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package
@@ -580,7 +580,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:18 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:25 GMT
 - request:
     method: post
     uri: http://backend:5352/source/source_project/source_package?cmd=diff&expand=1&filelimit=10000&opackage=target_package&oproject=target_project&tarlimit=10000&view=xml&withissues=1
@@ -604,7 +604,7 @@ http_interactions:
       Content-Type:
       - text/xml
       Content-Length:
-      - '329'
+      - '328'
       Cache-Control:
       - no-cache
       Connection:
@@ -612,13 +612,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="f0ade37f19a7eee38b40dd0309766ea1">
-          <old project="target_project" package="target_package" rev="28" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+        <sourcediff key="22bfb82bf1c9f9c9dd66ba87930cd41c">
+          <old project="target_project" package="target_package" rev="1" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <new project="source_project" package="source_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files>
           </files>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:18 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:25 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Project/Staging_Project/_overall_state/when_there_are_failed_checks_on_published_repo/1_1_3_6_1.yml
+++ b/src/api/spec/cassettes/Project/Staging_Project/_overall_state/when_there_are_failed_checks_on_published_repo/1_1_3_6_1.yml
@@ -39,14 +39,14 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:21 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:27 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_40
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_25
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_14">
+        <workflow project="home:tom" managers="group_9">
           <staging_project name="home:tom:Staging:A"/>
         </workflow>
     headers:
@@ -68,28 +68,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="251">
-          <srcmd5>28a4f214137e224d34a88c08563edbbc</srcmd5>
-          <time>1658422041</time>
-          <user>user_40</user>
+        <revision rev="17">
+          <srcmd5>3ffe5c98d1c545ee60091d10c2531c8f</srcmd5>
+          <time>1658762187</time>
+          <user>user_25</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:21 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:27 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_40
+    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_25
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_14" role="maintainer"/>
+          <group groupid="group_9" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -110,23 +110,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '143'
+      - '142'
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_14" role="maintainer"/>
+          <group groupid="group_9" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:21 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:27 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_40
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_25
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_14">
+        <workflow project="home:tom" managers="group_9">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -149,28 +149,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="252">
-          <srcmd5>b51eca1973a50fd5e7f8596a7d1eb483</srcmd5>
-          <time>1658422041</time>
-          <user>user_40</user>
+        <revision rev="18">
+          <srcmd5>5d7fc29c6e4227df61f666d885856eab</srcmd5>
+          <time>1658762187</time>
+          <user>user_25</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:21 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:27 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_40
+    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_25
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:B">
           <title/>
           <description/>
-          <group groupid="group_14" role="maintainer"/>
+          <group groupid="group_9" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -191,19 +191,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '143'
+      - '142'
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:B">
           <title></title>
           <description></description>
-          <group groupid="group_14" role="maintainer"/>
+          <group groupid="group_9" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:21 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:27 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_meta?user=user_40
+    uri: http://backend:5352/source/home:tom/_meta?user=user_25
     body:
       encoding: UTF-8
       string: |
@@ -211,7 +211,7 @@ http_interactions:
           <title/>
           <description/>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_14" role="reviewer"/>
+          <group groupid="group_9" role="reviewer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -232,7 +232,7 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '174'
+      - '173'
     body:
       encoding: UTF-8
       string: |
@@ -240,18 +240,18 @@ http_interactions:
           <title></title>
           <description></description>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_14" role="reviewer"/>
+          <group groupid="group_9" role="reviewer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:21 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:27 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_41
+    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_26
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>In Death Ground</title>
-          <description>Corrupti possimus rerum provident.</description>
+          <title>Dance Dance Dance</title>
+          <description>Consequatur maiores exercitationem magnam.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -272,21 +272,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '172'
+      - '182'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>In Death Ground</title>
-          <description>Corrupti possimus rerum provident.</description>
+          <title>Dance Dance Dance</title>
+          <description>Consequatur maiores exercitationem magnam.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:21 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:27 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_config
     body:
       encoding: UTF-8
-      string: Molestiae nostrum voluptate. Id minus voluptatem. Inventore ipsa ullam.
+      string: Id molestiae ea. Ratione voluptas ab. Molestiae eum omnis.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -306,25 +306,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="123" vrev="123">
-          <srcmd5>b84e2b9152f0a1da5144d19718c0fad6</srcmd5>
+        <revision rev="17" vrev="17">
+          <srcmd5>b4aa34fa9e22db16d0dcbfef52043b2e</srcmd5>
           <version>unknown</version>
-          <time>1658422041</time>
+          <time>1658762187</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:21 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:27 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/somefile.txt
     body:
       encoding: UTF-8
-      string: Quasi voluptatibus quo. Mollitia sed consequatur. Ut accusantium veritatis.
+      string: Repellat sapiente consequuntur. Et aut incidunt. Omnis placeat fugiat.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -344,19 +344,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="124" vrev="124">
-          <srcmd5>d6e5e62629299055ff264d651feafcf0</srcmd5>
+        <revision rev="18" vrev="18">
+          <srcmd5>6a2cb784d0e2a51071f36b8a1163597b</srcmd5>
           <version>unknown</version>
-          <time>1658422041</time>
+          <time>1658762187</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:21 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:27 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/_meta?user=tom
@@ -364,7 +364,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>The Widening Gyre</title>
+          <title>The Painted Veil</title>
           <description/>
         </project>
     headers:
@@ -386,15 +386,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '108'
+      - '107'
     body:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>The Widening Gyre</title>
+          <title>The Painted Veil</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:21 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:27 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package/_meta?user=tom
@@ -402,8 +402,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>Surprised by Joy</title>
-          <description>Omnis qui deleniti ut.</description>
+          <title>The Last Enemy</title>
+          <description>Dicta dolores sit enim.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -424,15 +424,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '154'
+      - '153'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>Surprised by Joy</title>
-          <description>Omnis qui deleniti ut.</description>
+          <title>The Last Enemy</title>
+          <description>Dicta dolores sit enim.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:21 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:27 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_meta?user=tom
@@ -440,7 +440,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>The Moving Finger</title>
+          <title>Dance Dance Dance</title>
           <description/>
         </project>
     headers:
@@ -467,10 +467,10 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>The Moving Finger</title>
+          <title>Dance Dance Dance</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:22 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:27 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_project/_attribute?meta=1&user=tom
@@ -499,18 +499,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '166'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="124">
-          <srcmd5>849355b56e68a49003e0d32a34905ed2</srcmd5>
-          <time>1658422042</time>
+        <revision rev="20">
+          <srcmd5>ae99470e831fd63b655d9b8dfc09de57</srcmd5>
+          <time>1658762187</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:22 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:27 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/source_package/_meta?user=tom
@@ -518,8 +518,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>Stranger in a Strange Land</title>
-          <description>Delectus autem placeat laborum.</description>
+          <title>In Death Ground</title>
+          <description>Ipsum necessitatibus unde quos.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -540,15 +540,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '173'
+      - '162'
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>Stranger in a Strange Land</title>
-          <description>Delectus autem placeat laborum.</description>
+          <title>In Death Ground</title>
+          <description>Ipsum necessitatibus unde quos.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:22 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:27 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package
@@ -580,7 +580,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:22 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:27 GMT
 - request:
     method: post
     uri: http://backend:5352/source/source_project/source_package?cmd=diff&expand=1&filelimit=10000&opackage=target_package&oproject=target_project&tarlimit=10000&view=xml&withissues=1
@@ -604,7 +604,7 @@ http_interactions:
       Content-Type:
       - text/xml
       Content-Length:
-      - '329'
+      - '328'
       Cache-Control:
       - no-cache
       Connection:
@@ -612,15 +612,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="f0ade37f19a7eee38b40dd0309766ea1">
-          <old project="target_project" package="target_package" rev="28" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+        <sourcediff key="22bfb82bf1c9f9c9dd66ba87930cd41c">
+          <old project="target_project" package="target_package" rev="1" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <new project="source_project" package="source_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files>
           </files>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:22 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:27 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:Staging:A/_result?code=unresolvable
@@ -652,5 +652,5 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 21 Jul 2022 16:47:22 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:28 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Project/Staging_Project/_overall_state/when_there_are_missing_checks_on_build_repo/1_1_3_4_1.yml
+++ b/src/api/spec/cassettes/Project/Staging_Project/_overall_state/when_there_are_missing_checks_on_build_repo/1_1_3_4_1.yml
@@ -39,14 +39,14 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:15 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:30 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_10
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_40
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_4">
+        <workflow project="home:tom" managers="group_14">
           <staging_project name="home:tom:Staging:A"/>
         </workflow>
     headers:
@@ -68,28 +68,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="231">
-          <srcmd5>515f7ce3a2341337728adb149303de7f</srcmd5>
-          <time>1658422035</time>
-          <user>user_10</user>
+        <revision rev="27">
+          <srcmd5>28a4f214137e224d34a88c08563edbbc</srcmd5>
+          <time>1658762190</time>
+          <user>user_40</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:15 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:30 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_10
+    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_40
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_4" role="maintainer"/>
+          <group groupid="group_14" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -110,23 +110,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '142'
+      - '143'
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_4" role="maintainer"/>
+          <group groupid="group_14" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:15 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:30 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_10
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_40
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_4">
+        <workflow project="home:tom" managers="group_14">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -149,28 +149,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="232">
-          <srcmd5>c6417b6071a20402467d1a3992a0ee56</srcmd5>
-          <time>1658422035</time>
-          <user>user_10</user>
+        <revision rev="28">
+          <srcmd5>b51eca1973a50fd5e7f8596a7d1eb483</srcmd5>
+          <time>1658762190</time>
+          <user>user_40</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:15 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:30 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_10
+    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_40
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:B">
           <title/>
           <description/>
-          <group groupid="group_4" role="maintainer"/>
+          <group groupid="group_14" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -191,19 +191,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '142'
+      - '143'
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:B">
           <title></title>
           <description></description>
-          <group groupid="group_4" role="maintainer"/>
+          <group groupid="group_14" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:15 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:30 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_meta?user=user_10
+    uri: http://backend:5352/source/home:tom/_meta?user=user_40
     body:
       encoding: UTF-8
       string: |
@@ -211,7 +211,7 @@ http_interactions:
           <title/>
           <description/>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_4" role="reviewer"/>
+          <group groupid="group_14" role="reviewer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -232,7 +232,7 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '173'
+      - '174'
     body:
       encoding: UTF-8
       string: |
@@ -240,18 +240,18 @@ http_interactions:
           <title></title>
           <description></description>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_4" role="reviewer"/>
+          <group groupid="group_14" role="reviewer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:15 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:30 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_11
+    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_41
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>Recalled to Life</title>
-          <description>Laboriosam iusto ipsam beatae.</description>
+          <title>Shall not Perish</title>
+          <description>Sed sint cumque aperiam.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -272,21 +272,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '169'
+      - '163'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>Recalled to Life</title>
-          <description>Laboriosam iusto ipsam beatae.</description>
+          <title>Shall not Perish</title>
+          <description>Sed sint cumque aperiam.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:15 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:31 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_config
     body:
       encoding: UTF-8
-      string: Alias vero aut. Et totam repudiandae. Mollitia veritatis ea.
+      string: Rem aut quasi. Explicabo animi eos. Dolor corrupti quaerat.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -306,25 +306,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="103" vrev="103">
-          <srcmd5>630534e938676993f3fb1d68a70194f4</srcmd5>
+        <revision rev="27" vrev="27">
+          <srcmd5>2f009991b66f7603ffdb8012fae54683</srcmd5>
           <version>unknown</version>
-          <time>1658422035</time>
+          <time>1658762191</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:15 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:31 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/somefile.txt
     body:
       encoding: UTF-8
-      string: Quod dolores dolore. Ipsam temporibus aut. Aut ut praesentium.
+      string: Et minima sit. Qui quo et. Accusantium culpa optio.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -344,19 +344,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="104" vrev="104">
-          <srcmd5>fb7337f2bcf66c9ed4c5fd7994d51be6</srcmd5>
+        <revision rev="28" vrev="28">
+          <srcmd5>0a57bb3f50bbf3785a225c305e0f9efb</srcmd5>
           <version>unknown</version>
-          <time>1658422035</time>
+          <time>1658762191</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:15 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:31 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/_meta?user=tom
@@ -364,7 +364,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>Wildfire at Midnight</title>
+          <title>It's a Battlefield</title>
           <description/>
         </project>
     headers:
@@ -386,15 +386,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '111'
+      - '109'
     body:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>Wildfire at Midnight</title>
+          <title>It's a Battlefield</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:15 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:31 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package/_meta?user=tom
@@ -402,8 +402,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>Blood's a Rover</title>
-          <description>Voluptates nisi et quia.</description>
+          <title>Cover Her Face</title>
+          <description>Tempore ut alias saepe.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -424,15 +424,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '155'
+      - '153'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>Blood's a Rover</title>
-          <description>Voluptates nisi et quia.</description>
+          <title>Cover Her Face</title>
+          <description>Tempore ut alias saepe.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:15 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:31 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_meta?user=tom
@@ -440,7 +440,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>A Swiftly Tilting Planet</title>
+          <title>The Green Bay Tree</title>
           <description/>
         </project>
     headers:
@@ -462,15 +462,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '115'
+      - '109'
     body:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>A Swiftly Tilting Planet</title>
+          <title>The Green Bay Tree</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:15 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:31 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_project/_attribute?meta=1&user=tom
@@ -499,18 +499,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '166'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="104">
-          <srcmd5>6d0c52dc02f50ac483a1882b493f3df1</srcmd5>
-          <time>1658422035</time>
+        <revision rev="30">
+          <srcmd5>bb0aab35e64c3fab23b4e132f3bbab7c</srcmd5>
+          <time>1658762191</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:15 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:31 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/source_package/_meta?user=tom
@@ -518,8 +518,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>Rosemary Sutcliff</title>
-          <description>Vero et dignissimos rerum.</description>
+          <title>The Moving Finger</title>
+          <description>Ullam eveniet officia ad.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -540,15 +540,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '159'
+      - '158'
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>Rosemary Sutcliff</title>
-          <description>Vero et dignissimos rerum.</description>
+          <title>The Moving Finger</title>
+          <description>Ullam eveniet officia ad.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:15 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:31 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package
@@ -580,7 +580,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:15 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:31 GMT
 - request:
     method: post
     uri: http://backend:5352/source/source_project/source_package?cmd=diff&expand=1&filelimit=10000&opackage=target_package&oproject=target_project&tarlimit=10000&view=xml&withissues=1
@@ -604,7 +604,7 @@ http_interactions:
       Content-Type:
       - text/xml
       Content-Length:
-      - '329'
+      - '328'
       Cache-Control:
       - no-cache
       Connection:
@@ -612,15 +612,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="f0ade37f19a7eee38b40dd0309766ea1">
-          <old project="target_project" package="target_package" rev="28" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+        <sourcediff key="22bfb82bf1c9f9c9dd66ba87930cd41c">
+          <old project="target_project" package="target_package" rev="1" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <new project="source_project" package="source_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files>
           </files>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:15 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:31 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:Staging:A/_result?code=unresolvable
@@ -652,5 +652,5 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 21 Jul 2022 16:47:15 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:31 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Project/Staging_Project/_overall_state/when_there_are_missing_checks_on_published_repo/1_1_3_3_1.yml
+++ b/src/api/spec/cassettes/Project/Staging_Project/_overall_state/when_there_are_missing_checks_on_published_repo/1_1_3_3_1.yml
@@ -39,7 +39,7 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:15 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:24 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_13
@@ -68,18 +68,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '169'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="233">
+        <revision rev="9">
           <srcmd5>9d761273eb8bf2e708d31d530927791b</srcmd5>
-          <time>1658422035</time>
+          <time>1658762184</time>
           <user>user_13</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:15 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:24 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_13
@@ -119,7 +119,7 @@ http_interactions:
           <description></description>
           <group groupid="group_5" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:15 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:24 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_13
@@ -149,18 +149,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="234">
+        <revision rev="10">
           <srcmd5>e829666c315cff727170aef11ee34f36</srcmd5>
-          <time>1658422035</time>
+          <time>1658762184</time>
           <user>user_13</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:15 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:24 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_13
@@ -200,7 +200,7 @@ http_interactions:
           <description></description>
           <group groupid="group_5" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:16 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:24 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_meta?user=user_13
@@ -242,7 +242,7 @@ http_interactions:
           <person userid="tom" role="maintainer"/>
           <group groupid="group_5" role="reviewer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:16 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:24 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_14
@@ -250,8 +250,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>His Dark Materials</title>
-          <description>Omnis dolor necessitatibus saepe.</description>
+          <title>Time To Murder And Create</title>
+          <description>Sed qui perferendis odit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -272,21 +272,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '174'
+      - '173'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>His Dark Materials</title>
-          <description>Omnis dolor necessitatibus saepe.</description>
+          <title>Time To Murder And Create</title>
+          <description>Sed qui perferendis odit.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:16 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:24 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_config
     body:
       encoding: UTF-8
-      string: Repellendus dolor laudantium. Enim officia ducimus. Laboriosam et aut.
+      string: At eum excepturi. Assumenda voluptatibus ut. Voluptatem debitis culpa.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -306,25 +306,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '207'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="105" vrev="105">
-          <srcmd5>29ba64feba256d715a9464f1bb63a8ef</srcmd5>
+        <revision rev="9" vrev="9">
+          <srcmd5>4e67fd18ccc76e2f0602146bf5db4eb5</srcmd5>
           <version>unknown</version>
-          <time>1658422036</time>
+          <time>1658762184</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:16 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:24 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/somefile.txt
     body:
       encoding: UTF-8
-      string: Minima nulla perferendis. Aut enim recusandae. Et ut dolorum.
+      string: Quod non repellat. Qui non praesentium. Et sunt perferendis.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -344,19 +344,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="106" vrev="106">
-          <srcmd5>cd2b0d1a36c8345a45db7b312b3ad430</srcmd5>
+        <revision rev="10" vrev="10">
+          <srcmd5>387985438c51368cbb205152a1856b8d</srcmd5>
           <version>unknown</version>
-          <time>1658422036</time>
+          <time>1658762184</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:16 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:24 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/_meta?user=tom
@@ -364,7 +364,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>To Your Scattered Bodies Go</title>
+          <title>The Moving Finger</title>
           <description/>
         </project>
     headers:
@@ -386,15 +386,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '118'
+      - '108'
     body:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>To Your Scattered Bodies Go</title>
+          <title>The Moving Finger</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:16 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:24 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package/_meta?user=tom
@@ -402,8 +402,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>Nine Coaches Waiting</title>
-          <description>Quisquam quo consequuntur quaerat.</description>
+          <title>Taming a Sea Horse</title>
+          <description>Explicabo quos deserunt quia.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -424,15 +424,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '170'
+      - '163'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>Nine Coaches Waiting</title>
-          <description>Quisquam quo consequuntur quaerat.</description>
+          <title>Taming a Sea Horse</title>
+          <description>Explicabo quos deserunt quia.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:16 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:25 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_meta?user=tom
@@ -440,7 +440,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Number the Stars</title>
+          <title>Cabbages and Kings</title>
           <description/>
         </project>
     headers:
@@ -462,15 +462,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '107'
+      - '109'
     body:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Number the Stars</title>
+          <title>Cabbages and Kings</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:16 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:25 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_project/_attribute?meta=1&user=tom
@@ -499,18 +499,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '166'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="106">
-          <srcmd5>1e9907d0c1a0101ea58f91d52132c5fb</srcmd5>
-          <time>1658422036</time>
+        <revision rev="12">
+          <srcmd5>d4175ec0d7367ba3f31fc7a13be43d82</srcmd5>
+          <time>1658762185</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:16 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:25 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/source_package/_meta?user=tom
@@ -518,8 +518,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>The Doors of Perception</title>
-          <description>Tempore a et enim.</description>
+          <title>The Green Bay Tree</title>
+          <description>Impedit molestiae veniam aut.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -540,15 +540,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '157'
+      - '163'
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>The Doors of Perception</title>
-          <description>Tempore a et enim.</description>
+          <title>The Green Bay Tree</title>
+          <description>Impedit molestiae veniam aut.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:16 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:25 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package
@@ -580,7 +580,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:16 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:25 GMT
 - request:
     method: post
     uri: http://backend:5352/source/source_project/source_package?cmd=diff&expand=1&filelimit=10000&opackage=target_package&oproject=target_project&tarlimit=10000&view=xml&withissues=1
@@ -604,7 +604,7 @@ http_interactions:
       Content-Type:
       - text/xml
       Content-Length:
-      - '329'
+      - '328'
       Cache-Control:
       - no-cache
       Connection:
@@ -612,15 +612,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="f0ade37f19a7eee38b40dd0309766ea1">
-          <old project="target_project" package="target_package" rev="28" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+        <sourcediff key="22bfb82bf1c9f9c9dd66ba87930cd41c">
+          <old project="target_project" package="target_package" rev="1" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <new project="source_project" package="source_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files>
           </files>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:16 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:25 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:Staging:A/_result?code=unresolvable
@@ -652,5 +652,5 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 21 Jul 2022 16:47:16 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:25 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Project/Staging_Project/_overall_state/when_there_are_no_staged_requests/1_1_3_1_1.yml
+++ b/src/api/spec/cassettes/Project/Staging_Project/_overall_state/when_there_are_no_staged_requests/1_1_3_1_1.yml
@@ -39,14 +39,14 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:17 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:28 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_19
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_31
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_7">
+        <workflow project="home:tom" managers="group_11">
           <staging_project name="home:tom:Staging:A"/>
         </workflow>
     headers:
@@ -68,28 +68,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="237">
-          <srcmd5>85c3cca148545c736607e59bf75c78e5</srcmd5>
-          <time>1658422037</time>
-          <user>user_19</user>
+        <revision rev="21">
+          <srcmd5>549eb4d72e1e3a62d47f9af36338cd38</srcmd5>
+          <time>1658762188</time>
+          <user>user_31</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:17 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:28 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_19
+    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_31
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_7" role="maintainer"/>
+          <group groupid="group_11" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -110,23 +110,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '142'
+      - '143'
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_7" role="maintainer"/>
+          <group groupid="group_11" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:17 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:28 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_19
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_31
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_7">
+        <workflow project="home:tom" managers="group_11">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -149,28 +149,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="238">
-          <srcmd5>ac4f612dac98513520b40b03c44c0f4f</srcmd5>
-          <time>1658422037</time>
-          <user>user_19</user>
+        <revision rev="22">
+          <srcmd5>a054745d8cdaafcf79501bf152331d81</srcmd5>
+          <time>1658762188</time>
+          <user>user_31</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:17 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:28 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_19
+    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_31
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:B">
           <title/>
           <description/>
-          <group groupid="group_7" role="maintainer"/>
+          <group groupid="group_11" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -191,19 +191,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '142'
+      - '143'
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:B">
           <title></title>
           <description></description>
-          <group groupid="group_7" role="maintainer"/>
+          <group groupid="group_11" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:17 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:28 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_meta?user=user_19
+    uri: http://backend:5352/source/home:tom/_meta?user=user_31
     body:
       encoding: UTF-8
       string: |
@@ -211,7 +211,7 @@ http_interactions:
           <title/>
           <description/>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_7" role="reviewer"/>
+          <group groupid="group_11" role="reviewer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -232,7 +232,7 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '173'
+      - '174'
     body:
       encoding: UTF-8
       string: |
@@ -240,18 +240,18 @@ http_interactions:
           <title></title>
           <description></description>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_7" role="reviewer"/>
+          <group groupid="group_11" role="reviewer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:17 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:28 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_20
+    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_32
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>The Heart Is a Lonely Hunter</title>
-          <description>Itaque non distinctio est.</description>
+          <title>What's Become of Waring</title>
+          <description>Fugiat deleniti itaque molestiae.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -272,21 +272,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '177'
+      - '179'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>The Heart Is a Lonely Hunter</title>
-          <description>Itaque non distinctio est.</description>
+          <title>What's Become of Waring</title>
+          <description>Fugiat deleniti itaque molestiae.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:17 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:29 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_config
     body:
       encoding: UTF-8
-      string: Ratione nulla aperiam. Assumenda et labore. Rerum doloribus dolore.
+      string: Deleniti dolorem magnam. Fugiat amet odit. Magni incidunt aperiam.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -306,25 +306,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="109" vrev="109">
-          <srcmd5>4bb1dbdb96ea94aee2f9152f252d22ab</srcmd5>
+        <revision rev="21" vrev="21">
+          <srcmd5>1bebed5e1da267f40359375e108ba029</srcmd5>
           <version>unknown</version>
-          <time>1658422037</time>
+          <time>1658762189</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:17 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:29 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/somefile.txt
     body:
       encoding: UTF-8
-      string: Earum occaecati quasi. Voluptatem quam sunt. Nemo architecto nisi.
+      string: Eos assumenda enim. Quia aliquid ea. Sequi est cumque.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -344,19 +344,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="110" vrev="110">
-          <srcmd5>732fc09978542598d6da6723e0345a0d</srcmd5>
+        <revision rev="22" vrev="22">
+          <srcmd5>ad1285f1a83e28a3e1c67c1dd5770568</srcmd5>
           <version>unknown</version>
-          <time>1658422037</time>
+          <time>1658762189</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:17 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:29 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/_meta?user=tom
@@ -364,7 +364,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>The Skull Beneath the Skin</title>
+          <title>That Good Night</title>
           <description/>
         </project>
     headers:
@@ -386,15 +386,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '117'
+      - '106'
     body:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>The Skull Beneath the Skin</title>
+          <title>That Good Night</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:17 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:29 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package/_meta?user=tom
@@ -402,8 +402,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>Nectar in a Sieve</title>
-          <description>Aspernatur est tempora quia.</description>
+          <title>A Darkling Plain</title>
+          <description>Ad repellendus consectetur quis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -424,15 +424,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '161'
+      - '164'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>Nectar in a Sieve</title>
-          <description>Aspernatur est tempora quia.</description>
+          <title>A Darkling Plain</title>
+          <description>Ad repellendus consectetur quis.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:17 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:29 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_meta?user=tom
@@ -440,7 +440,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Jacob Have I Loved</title>
+          <title>The Proper Study</title>
           <description/>
         </project>
     headers:
@@ -462,15 +462,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '109'
+      - '107'
     body:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Jacob Have I Loved</title>
+          <title>The Proper Study</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:17 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:29 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_project/_attribute?meta=1&user=tom
@@ -499,18 +499,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '166'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="110">
-          <srcmd5>37e0adc225d3dfe3989c7b665bc0533c</srcmd5>
-          <time>1658422037</time>
+        <revision rev="24">
+          <srcmd5>434ab39aa0d26b2e48883cbc7d493fc5</srcmd5>
+          <time>1658762189</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:17 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:29 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/source_package/_meta?user=tom
@@ -518,8 +518,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>Postern of Fate</title>
-          <description>Facilis cumque explicabo sint.</description>
+          <title>All the King's Men</title>
+          <description>Fuga impedit quo suscipit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -540,15 +540,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '161'
+      - '160'
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>Postern of Fate</title>
-          <description>Facilis cumque explicabo sint.</description>
+          <title>All the King's Men</title>
+          <description>Fuga impedit quo suscipit.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:17 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:29 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package
@@ -580,7 +580,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:17 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:29 GMT
 - request:
     method: post
     uri: http://backend:5352/source/source_project/source_package?cmd=diff&expand=1&filelimit=10000&opackage=target_package&oproject=target_project&tarlimit=10000&view=xml&withissues=1
@@ -604,7 +604,7 @@ http_interactions:
       Content-Type:
       - text/xml
       Content-Length:
-      - '329'
+      - '328'
       Cache-Control:
       - no-cache
       Connection:
@@ -612,13 +612,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="f0ade37f19a7eee38b40dd0309766ea1">
-          <old project="target_project" package="target_package" rev="28" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+        <sourcediff key="22bfb82bf1c9f9c9dd66ba87930cd41c">
+          <old project="target_project" package="target_package" rev="1" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <new project="source_project" package="source_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files>
           </files>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:17 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:29 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Project/Staging_Project/_overall_state/when_there_are_pending_checks/1_1_3_5_1.yml
+++ b/src/api/spec/cassettes/Project/Staging_Project/_overall_state/when_there_are_pending_checks/1_1_3_5_1.yml
@@ -39,14 +39,14 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:14 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:30 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_7
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_37
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_3">
+        <workflow project="home:tom" managers="group_13">
           <staging_project name="home:tom:Staging:A"/>
         </workflow>
     headers:
@@ -72,24 +72,24 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="229">
-          <srcmd5>f0940018fa04fe1d6d2efbf34b7820f9</srcmd5>
-          <time>1658422034</time>
-          <user>user_7</user>
+        <revision rev="25">
+          <srcmd5>f9c73038c942398a7b90f1ff3d726316</srcmd5>
+          <time>1658762190</time>
+          <user>user_37</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:14 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:30 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_7
+    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_37
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_3" role="maintainer"/>
+          <group groupid="group_13" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -110,23 +110,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '142'
+      - '143'
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_3" role="maintainer"/>
+          <group groupid="group_13" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:14 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:30 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_7
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_37
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_3">
+        <workflow project="home:tom" managers="group_13">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -153,24 +153,24 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="230">
-          <srcmd5>bec7e8d607d10bdf9618708b08c89d4c</srcmd5>
-          <time>1658422034</time>
-          <user>user_7</user>
+        <revision rev="26">
+          <srcmd5>97d26821d655a635438ebcc84e5540c0</srcmd5>
+          <time>1658762190</time>
+          <user>user_37</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:14 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:30 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_7
+    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_37
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:B">
           <title/>
           <description/>
-          <group groupid="group_3" role="maintainer"/>
+          <group groupid="group_13" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -191,19 +191,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '142'
+      - '143'
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:B">
           <title></title>
           <description></description>
-          <group groupid="group_3" role="maintainer"/>
+          <group groupid="group_13" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:14 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:30 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_meta?user=user_7
+    uri: http://backend:5352/source/home:tom/_meta?user=user_37
     body:
       encoding: UTF-8
       string: |
@@ -211,7 +211,7 @@ http_interactions:
           <title/>
           <description/>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_3" role="reviewer"/>
+          <group groupid="group_13" role="reviewer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -232,7 +232,7 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '173'
+      - '174'
     body:
       encoding: UTF-8
       string: |
@@ -240,18 +240,18 @@ http_interactions:
           <title></title>
           <description></description>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_3" role="reviewer"/>
+          <group groupid="group_13" role="reviewer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:14 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:30 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_8
+    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_38
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>As I Lay Dying</title>
-          <description>Similique error hic sequi.</description>
+          <title>Fair Stood the Wind for France</title>
+          <description>Sed quod modi repudiandae.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -272,21 +272,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '163'
+      - '179'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>As I Lay Dying</title>
-          <description>Similique error hic sequi.</description>
+          <title>Fair Stood the Wind for France</title>
+          <description>Sed quod modi repudiandae.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:14 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:30 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_config
     body:
       encoding: UTF-8
-      string: Quisquam ullam delectus. Aliquid nam est. Incidunt corrupti soluta.
+      string: Rerum sint sit. Reprehenderit accusamus velit. Maiores excepturi est.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -306,25 +306,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="101" vrev="101">
-          <srcmd5>092a5bb0c94045fcbd06c1ceaea13d83</srcmd5>
+        <revision rev="25" vrev="25">
+          <srcmd5>7248a79024dc2d7817d4fdabbd06ceac</srcmd5>
           <version>unknown</version>
-          <time>1658422034</time>
+          <time>1658762190</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:14 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:30 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/somefile.txt
     body:
       encoding: UTF-8
-      string: Voluptatibus neque dicta. Quia vel sit. Omnis id quibusdam.
+      string: Animi ut nihil. Qui praesentium voluptates. Animi minima sit.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -344,19 +344,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="102" vrev="102">
-          <srcmd5>e0bbe657f6e8a1314ab66478e3d82b06</srcmd5>
+        <revision rev="26" vrev="26">
+          <srcmd5>f413f4503365f18c1b6f05b03d3660c6</srcmd5>
           <version>unknown</version>
-          <time>1658422034</time>
+          <time>1658762190</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:14 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:30 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/_meta?user=tom
@@ -364,7 +364,83 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>Brandy of the Damned</title>
+          <title>Blue Remembered Earth</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '112'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="target_project">
+          <title>Blue Remembered Earth</title>
+          <description></description>
+        </project>
+  recorded_at: Mon, 25 Jul 2022 15:16:30 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/target_project/target_package/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="target_project">
+          <title>A Time of Gifts</title>
+          <description>Quaerat iure magni quia.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '155'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="target_project">
+          <title>A Time of Gifts</title>
+          <description>Quaerat iure magni quia.</description>
+        </package>
+  recorded_at: Mon, 25 Jul 2022 15:16:30 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/source_project/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="source_project">
+          <title>Time of our Darkness</title>
           <description/>
         </project>
     headers:
@@ -390,87 +466,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <project name="target_project">
-          <title>Brandy of the Damned</title>
+        <project name="source_project">
+          <title>Time of our Darkness</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:14 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/target_project/target_package/_meta?user=tom
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="target_package" project="target_project">
-          <title>Gone with the Wind</title>
-          <description>Est voluptate autem minima.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '161'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="target_package" project="target_project">
-          <title>Gone with the Wind</title>
-          <description>Est voluptate autem minima.</description>
-        </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:14 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/source_project/_meta?user=tom
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="source_project">
-          <title>To a God Unknown</title>
-          <description/>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '107'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="source_project">
-          <title>To a God Unknown</title>
-          <description></description>
-        </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:14 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:30 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_project/_attribute?meta=1&user=tom
@@ -499,18 +499,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '166'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="102">
-          <srcmd5>b6a07fca0cbf8c1a08164765aa471f9b</srcmd5>
-          <time>1658422035</time>
+        <revision rev="28">
+          <srcmd5>f984899a70a2f396552adfe8c024bd1d</srcmd5>
+          <time>1658762190</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:15 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:30 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/source_package/_meta?user=tom
@@ -518,8 +518,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>Many Waters</title>
-          <description>Atque ut ut eos.</description>
+          <title>Stranger in a Strange Land</title>
+          <description>Nostrum facilis ex fugiat.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -540,15 +540,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '143'
+      - '168'
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>Many Waters</title>
-          <description>Atque ut ut eos.</description>
+          <title>Stranger in a Strange Land</title>
+          <description>Nostrum facilis ex fugiat.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:15 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:30 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package
@@ -580,7 +580,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:15 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:30 GMT
 - request:
     method: post
     uri: http://backend:5352/source/source_project/source_package?cmd=diff&expand=1&filelimit=10000&opackage=target_package&oproject=target_project&tarlimit=10000&view=xml&withissues=1
@@ -604,7 +604,7 @@ http_interactions:
       Content-Type:
       - text/xml
       Content-Length:
-      - '329'
+      - '328'
       Cache-Control:
       - no-cache
       Connection:
@@ -612,15 +612,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="f0ade37f19a7eee38b40dd0309766ea1">
-          <old project="target_project" package="target_package" rev="28" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+        <sourcediff key="22bfb82bf1c9f9c9dd66ba87930cd41c">
+          <old project="target_project" package="target_package" rev="1" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <new project="source_project" package="source_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files>
           </files>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:15 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:30 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:Staging:A/_result?code=unresolvable
@@ -652,5 +652,5 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 21 Jul 2022 16:47:15 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:30 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Project/Staging_Project/_overall_state/when_there_are_succeeded_checks/1_1_3_8_1.yml
+++ b/src/api/spec/cassettes/Project/Staging_Project/_overall_state/when_there_are_succeeded_checks/1_1_3_8_1.yml
@@ -39,14 +39,14 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:14 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:26 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_4
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_22
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_2">
+        <workflow project="home:tom" managers="group_8">
           <staging_project name="home:tom:Staging:A"/>
         </workflow>
     headers:
@@ -72,24 +72,24 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="227">
-          <srcmd5>7b2493cbf69cbaf2db433b7573c6f9ba</srcmd5>
-          <time>1658422034</time>
-          <user>user_4</user>
+        <revision rev="15">
+          <srcmd5>fa20c26f540ca47bc5c5aafdf5916d71</srcmd5>
+          <time>1658762186</time>
+          <user>user_22</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:14 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:26 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_4
+    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_22
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_2" role="maintainer"/>
+          <group groupid="group_8" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -117,16 +117,16 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_2" role="maintainer"/>
+          <group groupid="group_8" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:14 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:26 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_4
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_22
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_2">
+        <workflow project="home:tom" managers="group_8">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -153,24 +153,24 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="228">
-          <srcmd5>8634a186b5a256cc97a4519875b4d59b</srcmd5>
-          <time>1658422034</time>
-          <user>user_4</user>
+        <revision rev="16">
+          <srcmd5>f3ab7aa01f41d6a5b3406e553c17c510</srcmd5>
+          <time>1658762186</time>
+          <user>user_22</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:14 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:26 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_4
+    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_22
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:B">
           <title/>
           <description/>
-          <group groupid="group_2" role="maintainer"/>
+          <group groupid="group_8" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -198,12 +198,12 @@ http_interactions:
         <project name="home:tom:Staging:B">
           <title></title>
           <description></description>
-          <group groupid="group_2" role="maintainer"/>
+          <group groupid="group_8" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:14 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:26 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_meta?user=user_4
+    uri: http://backend:5352/source/home:tom/_meta?user=user_22
     body:
       encoding: UTF-8
       string: |
@@ -211,7 +211,7 @@ http_interactions:
           <title/>
           <description/>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_2" role="reviewer"/>
+          <group groupid="group_8" role="reviewer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -240,18 +240,18 @@ http_interactions:
           <title></title>
           <description></description>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_2" role="reviewer"/>
+          <group groupid="group_8" role="reviewer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:14 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:26 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_5
+    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_23
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>The Golden Bowl</title>
-          <description>Nisi dolorem necessitatibus facilis.</description>
+          <title>Dulce et Decorum Est</title>
+          <description>Voluptatem omnis qui non.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -272,21 +272,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '174'
+      - '168'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>The Golden Bowl</title>
-          <description>Nisi dolorem necessitatibus facilis.</description>
+          <title>Dulce et Decorum Est</title>
+          <description>Voluptatem omnis qui non.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:14 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:26 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_config
     body:
       encoding: UTF-8
-      string: Velit provident nisi. Deleniti velit ut. Repudiandae expedita qui.
+      string: Corrupti ipsum magnam. Deserunt eaque dolor. Sed itaque voluptatem.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -310,21 +310,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="99" vrev="99">
-          <srcmd5>189572fc47638bddf994cd0a8e600c40</srcmd5>
+        <revision rev="15" vrev="15">
+          <srcmd5>e30dfba355a387da581c77eeb58cda16</srcmd5>
           <version>unknown</version>
-          <time>1658422034</time>
+          <time>1658762186</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:14 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:26 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/somefile.txt
     body:
       encoding: UTF-8
-      string: Dicta enim quasi. Est aut iusto. Maiores non dolores.
+      string: Animi quis est. Autem magnam impedit. Est beatae veniam.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -344,19 +344,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="100" vrev="100">
-          <srcmd5>5cd22c8f25148f45105dd13f5002c1c3</srcmd5>
+        <revision rev="16" vrev="16">
+          <srcmd5>051b8ba0cdd98e13d38dd750b00e29ae</srcmd5>
           <version>unknown</version>
-          <time>1658422034</time>
+          <time>1658762186</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:14 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:26 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/_meta?user=tom
@@ -364,7 +364,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>Edna O'Brien</title>
+          <title>What's Become of Waring</title>
           <description/>
         </project>
     headers:
@@ -386,15 +386,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '103'
+      - '114'
     body:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>Edna O'Brien</title>
+          <title>What's Become of Waring</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:14 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:27 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package/_meta?user=tom
@@ -402,8 +402,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>An Evil Cradling</title>
-          <description>Similique sint nemo repellendus.</description>
+          <title>Recalled to Life</title>
+          <description>Qui ut incidunt cumque.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -424,15 +424,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '164'
+      - '155'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>An Evil Cradling</title>
-          <description>Similique sint nemo repellendus.</description>
+          <title>Recalled to Life</title>
+          <description>Qui ut incidunt cumque.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:14 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:27 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_meta?user=tom
@@ -440,7 +440,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>The Line of Beauty</title>
+          <title>A Catskill Eagle</title>
           <description/>
         </project>
     headers:
@@ -462,15 +462,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '109'
+      - '107'
     body:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>The Line of Beauty</title>
+          <title>A Catskill Eagle</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:14 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:27 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_project/_attribute?meta=1&user=tom
@@ -499,18 +499,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '166'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="100">
-          <srcmd5>895cda5a2d96cef7e7581656433d29b1</srcmd5>
-          <time>1658422034</time>
+        <revision rev="18">
+          <srcmd5>d85f3189ce5c5caf01eb8a24a10b782a</srcmd5>
+          <time>1658762187</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:14 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:27 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/source_package/_meta?user=tom
@@ -518,8 +518,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>Edna O'Brien</title>
-          <description>Vel quis quas consequatur.</description>
+          <title>Recalled to Life</title>
+          <description>Rerum qui omnis ut.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -540,15 +540,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '154'
+      - '151'
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>Edna O'Brien</title>
-          <description>Vel quis quas consequatur.</description>
+          <title>Recalled to Life</title>
+          <description>Rerum qui omnis ut.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:14 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:27 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package
@@ -580,7 +580,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:14 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:27 GMT
 - request:
     method: post
     uri: http://backend:5352/source/source_project/source_package?cmd=diff&expand=1&filelimit=10000&opackage=target_package&oproject=target_project&tarlimit=10000&view=xml&withissues=1
@@ -604,7 +604,7 @@ http_interactions:
       Content-Type:
       - text/xml
       Content-Length:
-      - '329'
+      - '328'
       Cache-Control:
       - no-cache
       Connection:
@@ -612,15 +612,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="f0ade37f19a7eee38b40dd0309766ea1">
-          <old project="target_project" package="target_package" rev="28" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+        <sourcediff key="22bfb82bf1c9f9c9dd66ba87930cd41c">
+          <old project="target_project" package="target_package" rev="1" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <new project="source_project" package="source_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files>
           </files>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:14 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:27 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:Staging:A/_result?code=unresolvable
@@ -652,5 +652,5 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 21 Jul 2022 16:47:14 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:27 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Project/Staging_Project/_overall_state/when_we_only_have_outdated_checks/1_1_3_9_1.yml
+++ b/src/api/spec/cassettes/Project/Staging_Project/_overall_state/when_we_only_have_outdated_checks/1_1_3_9_1.yml
@@ -39,14 +39,14 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:20 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:23 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_34
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_7
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_12">
+        <workflow project="home:tom" managers="group_3">
           <staging_project name="home:tom:Staging:A"/>
         </workflow>
     headers:
@@ -68,28 +68,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '168'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="247">
-          <srcmd5>33c0a11cb2e81dab6027313a4a6adc4c</srcmd5>
-          <time>1658422040</time>
-          <user>user_34</user>
+        <revision rev="5">
+          <srcmd5>f0940018fa04fe1d6d2efbf34b7820f9</srcmd5>
+          <time>1658762183</time>
+          <user>user_7</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:20 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:23 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_34
+    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_7
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_12" role="maintainer"/>
+          <group groupid="group_3" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -110,23 +110,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '143'
+      - '142'
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_12" role="maintainer"/>
+          <group groupid="group_3" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:20 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:23 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_34
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_7
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_12">
+        <workflow project="home:tom" managers="group_3">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -149,28 +149,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '168'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="248">
-          <srcmd5>ea297d3e5cfff25de75c46a25104f932</srcmd5>
-          <time>1658422040</time>
-          <user>user_34</user>
+        <revision rev="6">
+          <srcmd5>bec7e8d607d10bdf9618708b08c89d4c</srcmd5>
+          <time>1658762183</time>
+          <user>user_7</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:20 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:23 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_34
+    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_7
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:B">
           <title/>
           <description/>
-          <group groupid="group_12" role="maintainer"/>
+          <group groupid="group_3" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -191,19 +191,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '143'
+      - '142'
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:B">
           <title></title>
           <description></description>
-          <group groupid="group_12" role="maintainer"/>
+          <group groupid="group_3" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:20 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:23 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_meta?user=user_34
+    uri: http://backend:5352/source/home:tom/_meta?user=user_7
     body:
       encoding: UTF-8
       string: |
@@ -211,7 +211,7 @@ http_interactions:
           <title/>
           <description/>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_12" role="reviewer"/>
+          <group groupid="group_3" role="reviewer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -232,7 +232,7 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '174'
+      - '173'
     body:
       encoding: UTF-8
       string: |
@@ -240,18 +240,18 @@ http_interactions:
           <title></title>
           <description></description>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_12" role="reviewer"/>
+          <group groupid="group_3" role="reviewer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:20 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:23 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_35
+    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_8
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>The Needle's Eye</title>
-          <description>Ut quae et dignissimos.</description>
+          <title>A Catskill Eagle</title>
+          <description>Officia nemo fuga saepe.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -272,21 +272,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '162'
+      - '163'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>The Needle's Eye</title>
-          <description>Ut quae et dignissimos.</description>
+          <title>A Catskill Eagle</title>
+          <description>Officia nemo fuga saepe.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:20 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:23 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_config
     body:
       encoding: UTF-8
-      string: Praesentium libero voluptas. Minima porro amet. Aut voluptatem animi.
+      string: Est placeat aut. Voluptas dolorem tenetur. Dicta dolores occaecati.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -306,26 +306,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '207'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="119" vrev="119">
-          <srcmd5>0f710e3e2e598ebd38ba12b858401d4f</srcmd5>
+        <revision rev="5" vrev="5">
+          <srcmd5>913a6a1895029463532fc2ca6a15ad84</srcmd5>
           <version>unknown</version>
-          <time>1658422040</time>
+          <time>1658762183</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:20 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:23 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/somefile.txt
     body:
       encoding: UTF-8
-      string: Quidem necessitatibus cumque. Vel ad necessitatibus. Voluptates ducimus
-        commodi.
+      string: Error vitae consectetur. Eos rerum commodi. Ea voluptatibus sit.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -345,19 +344,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '207'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="120" vrev="120">
-          <srcmd5>fde86b8328db8111d268f7f8e4142d7f</srcmd5>
+        <revision rev="6" vrev="6">
+          <srcmd5>980cd237d92dd8453173fa34cab5474c</srcmd5>
           <version>unknown</version>
-          <time>1658422040</time>
+          <time>1658762183</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:20 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:23 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/_meta?user=tom
@@ -365,7 +364,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>Infinite Jest</title>
+          <title>The Torment of Others</title>
           <description/>
         </project>
     headers:
@@ -387,15 +386,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '104'
+      - '112'
     body:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>Infinite Jest</title>
+          <title>The Torment of Others</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:20 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:23 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package/_meta?user=tom
@@ -403,8 +402,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>Moab Is My Washpot</title>
-          <description>Repellendus temporibus assumenda id.</description>
+          <title>The Grapes of Wrath</title>
+          <description>Eaque reprehenderit non quis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -425,15 +424,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '170'
+      - '164'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>Moab Is My Washpot</title>
-          <description>Repellendus temporibus assumenda id.</description>
+          <title>The Grapes of Wrath</title>
+          <description>Eaque reprehenderit non quis.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:20 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:23 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_meta?user=tom
@@ -441,7 +440,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Recalled to Life</title>
+          <title>From Here to Eternity</title>
           <description/>
         </project>
     headers:
@@ -463,15 +462,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '107'
+      - '112'
     body:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Recalled to Life</title>
+          <title>From Here to Eternity</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:20 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:23 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_project/_attribute?meta=1&user=tom
@@ -500,18 +499,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '165'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="120">
-          <srcmd5>c9c0d1cc1803fd772c072886e03810aa</srcmd5>
-          <time>1658422040</time>
+        <revision rev="8">
+          <srcmd5>9c2c73bdcce9aea532ee38709baef4b5</srcmd5>
+          <time>1658762183</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:20 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:23 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/source_package/_meta?user=tom
@@ -519,8 +518,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>The Monkey's Raincoat</title>
-          <description>Et rem unde praesentium.</description>
+          <title>The Painted Veil</title>
+          <description>Ullam dolor qui earum.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -541,15 +540,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '161'
+      - '154'
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>The Monkey's Raincoat</title>
-          <description>Et rem unde praesentium.</description>
+          <title>The Painted Veil</title>
+          <description>Ullam dolor qui earum.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:20 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:23 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package
@@ -581,7 +580,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:20 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:23 GMT
 - request:
     method: post
     uri: http://backend:5352/source/source_project/source_package?cmd=diff&expand=1&filelimit=10000&opackage=target_package&oproject=target_project&tarlimit=10000&view=xml&withissues=1
@@ -605,7 +604,7 @@ http_interactions:
       Content-Type:
       - text/xml
       Content-Length:
-      - '329'
+      - '328'
       Cache-Control:
       - no-cache
       Connection:
@@ -613,15 +612,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="f0ade37f19a7eee38b40dd0309766ea1">
-          <old project="target_project" package="target_package" rev="28" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+        <sourcediff key="22bfb82bf1c9f9c9dd66ba87930cd41c">
+          <old project="target_project" package="target_package" rev="1" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <new project="source_project" package="source_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files>
           </files>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:20 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:23 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:Staging:A/_result?code=unresolvable
@@ -653,5 +652,5 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 21 Jul 2022 16:47:20 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:23 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Project/Staging_Project/_overall_state/when_we_only_have_outdated_checks/1_1_3_9_2.yml
+++ b/src/api/spec/cassettes/Project/Staging_Project/_overall_state/when_we_only_have_outdated_checks/1_1_3_9_2.yml
@@ -39,220 +39,16 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:19 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:22 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_31
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_4
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_11">
+        <workflow project="home:tom" managers="group_2">
           <staging_project name="home:tom:Staging:A"/>
         </workflow>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '171'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="245">
-          <srcmd5>549eb4d72e1e3a62d47f9af36338cd38</srcmd5>
-          <time>1658422039</time>
-          <user>user_31</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:19 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_31
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:tom:Staging:A">
-          <title/>
-          <description/>
-          <group groupid="group_11" role="maintainer"/>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '143'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:tom:Staging:A">
-          <title></title>
-          <description></description>
-          <group groupid="group_11" role="maintainer"/>
-        </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:19 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_31
-    body:
-      encoding: UTF-8
-      string: |
-        <workflow project="home:tom" managers="group_11">
-          <staging_project name="home:tom:Staging:A"/>
-          <staging_project name="home:tom:Staging:B"/>
-        </workflow>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '171'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="246">
-          <srcmd5>a054745d8cdaafcf79501bf152331d81</srcmd5>
-          <time>1658422039</time>
-          <user>user_31</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:19 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_31
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:tom:Staging:B">
-          <title/>
-          <description/>
-          <group groupid="group_11" role="maintainer"/>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '143'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:tom:Staging:B">
-          <title></title>
-          <description></description>
-          <group groupid="group_11" role="maintainer"/>
-        </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:19 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:tom/_meta?user=user_31
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:tom">
-          <title/>
-          <description/>
-          <person userid="tom" role="maintainer"/>
-          <group groupid="group_11" role="reviewer"/>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '174'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:tom">
-          <title></title>
-          <description></description>
-          <person userid="tom" role="maintainer"/>
-          <group groupid="group_11" role="reviewer"/>
-        </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:19 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_32
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="package_with_file" project="home:tom:Staging:A">
-          <title>I Will Fear No Evil</title>
-          <description>Similique labore eaque ea.</description>
-        </package>
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -276,17 +72,221 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
+        <revision rev="3">
+          <srcmd5>7b2493cbf69cbaf2db433b7573c6f9ba</srcmd5>
+          <time>1658762182</time>
+          <user>user_4</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Mon, 25 Jul 2022 15:16:22 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_4
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom:Staging:A">
+          <title/>
+          <description/>
+          <group groupid="group_2" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '142'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom:Staging:A">
+          <title></title>
+          <description></description>
+          <group groupid="group_2" role="maintainer"/>
+        </project>
+  recorded_at: Mon, 25 Jul 2022 15:16:22 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_4
+    body:
+      encoding: UTF-8
+      string: |
+        <workflow project="home:tom" managers="group_2">
+          <staging_project name="home:tom:Staging:A"/>
+          <staging_project name="home:tom:Staging:B"/>
+        </workflow>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '168'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="4">
+          <srcmd5>8634a186b5a256cc97a4519875b4d59b</srcmd5>
+          <time>1658762182</time>
+          <user>user_4</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Mon, 25 Jul 2022 15:16:22 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_4
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom:Staging:B">
+          <title/>
+          <description/>
+          <group groupid="group_2" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '142'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom:Staging:B">
+          <title></title>
+          <description></description>
+          <group groupid="group_2" role="maintainer"/>
+        </project>
+  recorded_at: Mon, 25 Jul 2022 15:16:22 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/_meta?user=user_4
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+          <group groupid="group_2" role="reviewer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '173'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer"/>
+          <group groupid="group_2" role="reviewer"/>
+        </project>
+  recorded_at: Mon, 25 Jul 2022 15:16:22 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_5
+    body:
+      encoding: UTF-8
+      string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>I Will Fear No Evil</title>
-          <description>Similique labore eaque ea.</description>
+          <title>Butter In a Lordly Dish</title>
+          <description>Aut quibusdam magni eius.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:19 GMT
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '171'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_file" project="home:tom:Staging:A">
+          <title>Butter In a Lordly Dish</title>
+          <description>Aut quibusdam magni eius.</description>
+        </package>
+  recorded_at: Mon, 25 Jul 2022 15:16:22 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_config
     body:
       encoding: UTF-8
-      string: Voluptatem ratione magni. Ex iure velit. Et non est.
+      string: Et et dicta. Consequatur voluptatem quibusdam. Non dolores dolore.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -306,26 +306,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '207'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="117" vrev="117">
-          <srcmd5>c4054ff2c01222fd45f2385cfeb0bfe9</srcmd5>
+        <revision rev="3" vrev="3">
+          <srcmd5>17cef2c996c525ad505cd22ee436e837</srcmd5>
           <version>unknown</version>
-          <time>1658422039</time>
+          <time>1658762182</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:19 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:22 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/somefile.txt
     body:
       encoding: UTF-8
-      string: Accusantium dolorum inventore. Hic maiores ducimus. Doloremque possimus
-        sint.
+      string: Aut inventore debitis. Fugit tempora sit. Sapiente corrupti dignissimos.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -345,19 +344,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '207'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="118" vrev="118">
-          <srcmd5>2996021fcadc4f56dd872d50e6132dd1</srcmd5>
+        <revision rev="4" vrev="4">
+          <srcmd5>2c329dfa64f2e0a1292406980fac9431</srcmd5>
           <version>unknown</version>
-          <time>1658422039</time>
+          <time>1658762182</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:20 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:22 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/_meta?user=tom
@@ -365,7 +364,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>The Millstone</title>
+          <title>The Parliament of Man</title>
           <description/>
         </project>
     headers:
@@ -387,15 +386,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '104'
+      - '112'
     body:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>The Millstone</title>
+          <title>The Parliament of Man</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:20 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:22 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package/_meta?user=tom
@@ -403,8 +402,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>The Far-Distant Oxus</title>
-          <description>Eos nobis molestiae porro.</description>
+          <title>A Confederacy of Dunces</title>
+          <description>Eaque id quia debitis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -425,15 +424,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '162'
+      - '161'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>The Far-Distant Oxus</title>
-          <description>Eos nobis molestiae porro.</description>
+          <title>A Confederacy of Dunces</title>
+          <description>Eaque id quia debitis.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:20 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:22 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_meta?user=tom
@@ -441,7 +440,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>The Proper Study</title>
+          <title>A Confederacy of Dunces</title>
           <description/>
         </project>
     headers:
@@ -463,15 +462,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '107'
+      - '114'
     body:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>The Proper Study</title>
+          <title>A Confederacy of Dunces</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:20 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:22 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_project/_attribute?meta=1&user=tom
@@ -500,18 +499,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '165'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="118">
-          <srcmd5>434ab39aa0d26b2e48883cbc7d493fc5</srcmd5>
-          <time>1658422040</time>
+        <revision rev="6">
+          <srcmd5>36df4f82dd80c711fc1dffdb9b2d8b73</srcmd5>
+          <time>1658762182</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:20 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:22 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/source_package/_meta?user=tom
@@ -519,8 +518,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>A Confederacy of Dunces</title>
-          <description>Et exercitationem modi repudiandae.</description>
+          <title>Edna O'Brien</title>
+          <description>Vel debitis non consectetur.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -541,15 +540,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '174'
+      - '156'
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>A Confederacy of Dunces</title>
-          <description>Et exercitationem modi repudiandae.</description>
+          <title>Edna O'Brien</title>
+          <description>Vel debitis non consectetur.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:20 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:22 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package
@@ -581,7 +580,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:20 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:23 GMT
 - request:
     method: post
     uri: http://backend:5352/source/source_project/source_package?cmd=diff&expand=1&filelimit=10000&opackage=target_package&oproject=target_project&tarlimit=10000&view=xml&withissues=1
@@ -605,7 +604,7 @@ http_interactions:
       Content-Type:
       - text/xml
       Content-Length:
-      - '329'
+      - '328'
       Cache-Control:
       - no-cache
       Connection:
@@ -613,13 +612,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="f0ade37f19a7eee38b40dd0309766ea1">
-          <old project="target_project" package="target_package" rev="28" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+        <sourcediff key="22bfb82bf1c9f9c9dd66ba87930cd41c">
+          <old project="target_project" package="target_package" rev="1" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <new project="source_project" package="source_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files>
           </files>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:20 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:23 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Project/Staging_Project/_overall_state/when_we_only_have_outdated_checks/1_1_3_9_3.yml
+++ b/src/api/spec/cassettes/Project/Staging_Project/_overall_state/when_we_only_have_outdated_checks/1_1_3_9_3.yml
@@ -39,14 +39,14 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:21 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:23 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_37
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_10
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_13">
+        <workflow project="home:tom" managers="group_4">
           <staging_project name="home:tom:Staging:A"/>
         </workflow>
     headers:
@@ -68,28 +68,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '169'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="249">
-          <srcmd5>f9c73038c942398a7b90f1ff3d726316</srcmd5>
-          <time>1658422041</time>
-          <user>user_37</user>
+        <revision rev="7">
+          <srcmd5>515f7ce3a2341337728adb149303de7f</srcmd5>
+          <time>1658762183</time>
+          <user>user_10</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:21 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:23 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_37
+    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_10
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_13" role="maintainer"/>
+          <group groupid="group_4" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -110,23 +110,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '143'
+      - '142'
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_13" role="maintainer"/>
+          <group groupid="group_4" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:21 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:23 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_37
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_10
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_13">
+        <workflow project="home:tom" managers="group_4">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -149,28 +149,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '169'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="250">
-          <srcmd5>97d26821d655a635438ebcc84e5540c0</srcmd5>
-          <time>1658422041</time>
-          <user>user_37</user>
+        <revision rev="8">
+          <srcmd5>c6417b6071a20402467d1a3992a0ee56</srcmd5>
+          <time>1658762183</time>
+          <user>user_10</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:21 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:23 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_37
+    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_10
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:B">
           <title/>
           <description/>
-          <group groupid="group_13" role="maintainer"/>
+          <group groupid="group_4" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -191,19 +191,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '143'
+      - '142'
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:B">
           <title></title>
           <description></description>
-          <group groupid="group_13" role="maintainer"/>
+          <group groupid="group_4" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:21 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:23 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_meta?user=user_37
+    uri: http://backend:5352/source/home:tom/_meta?user=user_10
     body:
       encoding: UTF-8
       string: |
@@ -211,7 +211,7 @@ http_interactions:
           <title/>
           <description/>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_13" role="reviewer"/>
+          <group groupid="group_4" role="reviewer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -232,7 +232,7 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '174'
+      - '173'
     body:
       encoding: UTF-8
       string: |
@@ -240,18 +240,18 @@ http_interactions:
           <title></title>
           <description></description>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_13" role="reviewer"/>
+          <group groupid="group_4" role="reviewer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:21 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:24 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_38
+    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_11
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>It's a Battlefield</title>
-          <description>Quia et exercitationem qui.</description>
+          <title>The Heart Is Deceitful Above All Things</title>
+          <description>Iure magni similique cumque.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -272,21 +272,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '168'
+      - '190'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>It's a Battlefield</title>
-          <description>Quia et exercitationem qui.</description>
+          <title>The Heart Is Deceitful Above All Things</title>
+          <description>Iure magni similique cumque.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:21 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:24 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_config
     body:
       encoding: UTF-8
-      string: Explicabo commodi dolor. Facilis quia amet. Rerum nostrum occaecati.
+      string: Voluptas reiciendis aut. Et quia quo. Provident et sed.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -306,25 +306,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '207'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="121" vrev="121">
-          <srcmd5>3a24f954a33fd9431b19893428bc0e42</srcmd5>
+        <revision rev="7" vrev="7">
+          <srcmd5>15b864b0aa30f926cced6d8232fbbdb3</srcmd5>
           <version>unknown</version>
-          <time>1658422041</time>
+          <time>1658762184</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:21 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:24 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/somefile.txt
     body:
       encoding: UTF-8
-      string: Et modi facere. Nostrum nihil odit. Possimus quia expedita.
+      string: Tenetur est iste. Fugiat consequatur error. Beatae distinctio laborum.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -344,19 +344,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '207'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="122" vrev="122">
-          <srcmd5>b69f8973e35cb25e5ef1e261b0ea5a89</srcmd5>
+        <revision rev="8" vrev="8">
+          <srcmd5>1ce2b1a4b460cb7323b2e8c856205514</srcmd5>
           <version>unknown</version>
-          <time>1658422041</time>
+          <time>1658762184</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:21 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:24 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/_meta?user=tom
@@ -364,7 +364,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>An Evil Cradling</title>
+          <title>To Say Nothing of the Dog</title>
           <description/>
         </project>
     headers:
@@ -386,15 +386,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '107'
+      - '116'
     body:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>An Evil Cradling</title>
+          <title>To Say Nothing of the Dog</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:21 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:24 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package/_meta?user=tom
@@ -402,8 +402,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>Precious Bane</title>
-          <description>Vitae ut est omnis.</description>
+          <title>Ring of Bright Water</title>
+          <description>Eos sit voluptatem sed.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -424,15 +424,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '148'
+      - '159'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>Precious Bane</title>
-          <description>Vitae ut est omnis.</description>
+          <title>Ring of Bright Water</title>
+          <description>Eos sit voluptatem sed.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:21 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:24 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_meta?user=tom
@@ -440,7 +440,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Françoise Sagan</title>
+          <title>The Soldier's Art</title>
           <description/>
         </project>
     headers:
@@ -462,12 +462,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '107'
+      - '108'
     body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        PHByb2plY3QgbmFtZT0ic291cmNlX3Byb2plY3QiPgogIDx0aXRsZT5GcmFuw6dvaXNlIFNhZ2FuPC90aXRsZT4KICA8ZGVzY3JpcHRpb24+PC9kZXNjcmlwdGlvbj4KPC9wcm9qZWN0Pgo=
-  recorded_at: Thu, 21 Jul 2022 16:47:21 GMT
+      encoding: UTF-8
+      string: |
+        <project name="source_project">
+          <title>The Soldier's Art</title>
+          <description></description>
+        </project>
+  recorded_at: Mon, 25 Jul 2022 15:16:24 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_project/_attribute?meta=1&user=tom
@@ -496,18 +499,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '166'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="122">
-          <srcmd5>ec4a5c614b55d3659a0232d6685ff6ff</srcmd5>
-          <time>1658422041</time>
+        <revision rev="10">
+          <srcmd5>d33387edb5512edee4f06b98067328ce</srcmd5>
+          <time>1658762184</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:21 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:24 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/source_package/_meta?user=tom
@@ -515,8 +518,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>Of Human Bondage</title>
-          <description>Veniam beatae sunt aut.</description>
+          <title>Blood's a Rover</title>
+          <description>Magni esse aut quae.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -537,15 +540,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '155'
+      - '151'
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>Of Human Bondage</title>
-          <description>Veniam beatae sunt aut.</description>
+          <title>Blood's a Rover</title>
+          <description>Magni esse aut quae.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:21 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:24 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package
@@ -577,7 +580,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:21 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:24 GMT
 - request:
     method: post
     uri: http://backend:5352/source/source_project/source_package?cmd=diff&expand=1&filelimit=10000&opackage=target_package&oproject=target_project&tarlimit=10000&view=xml&withissues=1
@@ -601,7 +604,7 @@ http_interactions:
       Content-Type:
       - text/xml
       Content-Length:
-      - '329'
+      - '328'
       Cache-Control:
       - no-cache
       Connection:
@@ -609,13 +612,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="f0ade37f19a7eee38b40dd0309766ea1">
-          <old project="target_project" package="target_package" rev="28" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+        <sourcediff key="22bfb82bf1c9f9c9dd66ba87930cd41c">
+          <old project="target_project" package="target_package" rev="1" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <new project="source_project" package="source_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files>
           </files>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:21 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:24 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Project/Staging_Project/_overall_state/with_disabled_repository/1_1_3_10_1.yml
+++ b/src/api/spec/cassettes/Project/Staging_Project/_overall_state/with_disabled_repository/1_1_3_10_1.yml
@@ -39,14 +39,14 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:16 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:29 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_16
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_34
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_6">
+        <workflow project="home:tom" managers="group_12">
           <staging_project name="home:tom:Staging:A"/>
         </workflow>
     headers:
@@ -68,28 +68,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="235">
-          <srcmd5>5689657db49214a80e4a99e7f4023d50</srcmd5>
-          <time>1658422036</time>
-          <user>user_16</user>
+        <revision rev="23">
+          <srcmd5>33c0a11cb2e81dab6027313a4a6adc4c</srcmd5>
+          <time>1658762189</time>
+          <user>user_34</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:16 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:29 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_16
+    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_34
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_6" role="maintainer"/>
+          <group groupid="group_12" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -110,23 +110,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '142'
+      - '143'
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_6" role="maintainer"/>
+          <group groupid="group_12" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:16 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:29 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_16
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_34
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_6">
+        <workflow project="home:tom" managers="group_12">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -149,28 +149,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="236">
-          <srcmd5>5bb31242c174857bc5255247b77b6be9</srcmd5>
-          <time>1658422036</time>
-          <user>user_16</user>
+        <revision rev="24">
+          <srcmd5>ea297d3e5cfff25de75c46a25104f932</srcmd5>
+          <time>1658762189</time>
+          <user>user_34</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:16 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:29 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_16
+    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_34
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:B">
           <title/>
           <description/>
-          <group groupid="group_6" role="maintainer"/>
+          <group groupid="group_12" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -191,19 +191,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '142'
+      - '143'
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:B">
           <title></title>
           <description></description>
-          <group groupid="group_6" role="maintainer"/>
+          <group groupid="group_12" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:16 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:29 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_meta?user=user_16
+    uri: http://backend:5352/source/home:tom/_meta?user=user_34
     body:
       encoding: UTF-8
       string: |
@@ -211,7 +211,7 @@ http_interactions:
           <title/>
           <description/>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_6" role="reviewer"/>
+          <group groupid="group_12" role="reviewer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -232,7 +232,7 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '173'
+      - '174'
     body:
       encoding: UTF-8
       string: |
@@ -240,18 +240,18 @@ http_interactions:
           <title></title>
           <description></description>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_6" role="reviewer"/>
+          <group groupid="group_12" role="reviewer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:16 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:29 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_17
+    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_35
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>Taming a Sea Horse</title>
-          <description>Omnis aut numquam ex.</description>
+          <title>Have His Carcase</title>
+          <description>Corporis ut blanditiis nisi.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -272,21 +272,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '162'
+      - '167'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>Taming a Sea Horse</title>
-          <description>Omnis aut numquam ex.</description>
+          <title>Have His Carcase</title>
+          <description>Corporis ut blanditiis nisi.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:16 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:29 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_config
     body:
       encoding: UTF-8
-      string: Tempora ut quia. Quisquam necessitatibus tempora. Ut nihil qui.
+      string: Ipsa cumque qui. Reprehenderit nulla repellat. Veniam ut itaque.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -306,26 +306,26 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="107" vrev="107">
-          <srcmd5>c3d03ba7f4af7f12ea1a9a7420f8c90b</srcmd5>
+        <revision rev="23" vrev="23">
+          <srcmd5>554d4b5eb85805439a4cc9d70b78b654</srcmd5>
           <version>unknown</version>
-          <time>1658422036</time>
+          <time>1658762189</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:16 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:29 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/somefile.txt
     body:
       encoding: UTF-8
-      string: Temporibus perspiciatis voluptate. Dignissimos modi quisquam. Pariatur
-        magni rerum.
+      string: Assumenda necessitatibus expedita. Sed ab consequatur. Nostrum libero
+        aut.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -345,19 +345,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="108" vrev="108">
-          <srcmd5>518fa259280a5770864848266b024e8b</srcmd5>
+        <revision rev="24" vrev="24">
+          <srcmd5>e489fba981fdc0c049ae1d3ec95ed37f</srcmd5>
           <version>unknown</version>
-          <time>1658422036</time>
+          <time>1658762189</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:16 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:29 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/_meta?user=tom
@@ -365,7 +365,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>Specimen Days</title>
+          <title>The Stars' Tennis Balls</title>
           <description/>
         </project>
     headers:
@@ -387,15 +387,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '104'
+      - '114'
     body:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>Specimen Days</title>
+          <title>The Stars' Tennis Balls</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:16 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:29 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package/_meta?user=tom
@@ -403,8 +403,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>The Widening Gyre</title>
-          <description>Eligendi quae quasi distinctio.</description>
+          <title>The Golden Bowl</title>
+          <description>Aut similique qui tempora.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -425,15 +425,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '164'
+      - '157'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>The Widening Gyre</title>
-          <description>Eligendi quae quasi distinctio.</description>
+          <title>The Golden Bowl</title>
+          <description>Aut similique qui tempora.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:16 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:29 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_meta?user=tom
@@ -441,7 +441,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>The Golden Apples of the Sun</title>
+          <title>A Monstrous Regiment of Women</title>
           <description/>
         </project>
     headers:
@@ -463,15 +463,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '119'
+      - '120'
     body:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>The Golden Apples of the Sun</title>
+          <title>A Monstrous Regiment of Women</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:16 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:29 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_project/_attribute?meta=1&user=tom
@@ -500,18 +500,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '166'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="108">
-          <srcmd5>c8bfcb34c1ce133829c00ceef8d7dd92</srcmd5>
-          <time>1658422037</time>
+        <revision rev="26">
+          <srcmd5>01957e85220b619ccdba66005818f26c</srcmd5>
+          <time>1658762189</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:17 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:29 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/source_package/_meta?user=tom
@@ -519,8 +519,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>The Yellow Meads of Asphodel</title>
-          <description>Dolorum est recusandae minima.</description>
+          <title>Behold the Man</title>
+          <description>Quos aliquid fuga est.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -541,15 +541,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '174'
+      - '152'
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>The Yellow Meads of Asphodel</title>
-          <description>Dolorum est recusandae minima.</description>
+          <title>Behold the Man</title>
+          <description>Quos aliquid fuga est.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:17 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:29 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package
@@ -581,7 +581,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:17 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:29 GMT
 - request:
     method: post
     uri: http://backend:5352/source/source_project/source_package?cmd=diff&expand=1&filelimit=10000&opackage=target_package&oproject=target_project&tarlimit=10000&view=xml&withissues=1
@@ -605,7 +605,7 @@ http_interactions:
       Content-Type:
       - text/xml
       Content-Length:
-      - '329'
+      - '328'
       Cache-Control:
       - no-cache
       Connection:
@@ -613,15 +613,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="f0ade37f19a7eee38b40dd0309766ea1">
-          <old project="target_project" package="target_package" rev="28" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+        <sourcediff key="22bfb82bf1c9f9c9dd66ba87930cd41c">
+          <old project="target_project" package="target_package" rev="1" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <new project="source_project" package="source_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files>
           </files>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:17 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:29 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:Staging:A/_result?code=unresolvable
@@ -653,5 +653,5 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 21 Jul 2022 16:47:17 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:29 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Project/Staging_Project/_unassign_managers_group/1_1_5_1.yml
+++ b/src/api/spec/cassettes/Project/Staging_Project/_unassign_managers_group/1_1_5_1.yml
@@ -39,14 +39,14 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:41 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_69
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_85
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_28">
+        <workflow project="home:tom" managers="group_37">
           <staging_project name="home:tom:Staging:A"/>
         </workflow>
     headers:
@@ -72,24 +72,24 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="301">
-          <srcmd5>71d78a3c9c2792b3438fd55addd93dea</srcmd5>
-          <time>1658422061</time>
-          <user>user_69</user>
+        <revision rev="107">
+          <srcmd5>2491346e565cf0a120fb6303c5ae94f5</srcmd5>
+          <time>1658762220</time>
+          <user>user_85</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:41 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_69
+    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_85
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:A">
           <title/>
           <description/>
-          <group groupid="group_28" role="maintainer"/>
+          <group groupid="group_37" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -117,16 +117,16 @@ http_interactions:
         <project name="home:tom:Staging:A">
           <title></title>
           <description></description>
-          <group groupid="group_28" role="maintainer"/>
+          <group groupid="group_37" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:41 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_69
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_85
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_28">
+        <workflow project="home:tom" managers="group_37">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -153,24 +153,24 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="302">
-          <srcmd5>b885dd2550e612cb2b37ef62d0ecfbfe</srcmd5>
-          <time>1658422061</time>
-          <user>user_69</user>
+        <revision rev="108">
+          <srcmd5>408154e2c5740f0941cf52d4f87eba46</srcmd5>
+          <time>1658762220</time>
+          <user>user_85</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:41 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_69
+    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_85
     body:
       encoding: UTF-8
       string: |
         <project name="home:tom:Staging:B">
           <title/>
           <description/>
-          <group groupid="group_28" role="maintainer"/>
+          <group groupid="group_37" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -198,12 +198,12 @@ http_interactions:
         <project name="home:tom:Staging:B">
           <title></title>
           <description></description>
-          <group groupid="group_28" role="maintainer"/>
+          <group groupid="group_37" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:41 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_meta?user=user_69
+    uri: http://backend:5352/source/home:tom/_meta?user=user_85
     body:
       encoding: UTF-8
       string: |
@@ -211,7 +211,7 @@ http_interactions:
           <title/>
           <description/>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_28" role="reviewer"/>
+          <group groupid="group_37" role="reviewer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -240,18 +240,18 @@ http_interactions:
           <title></title>
           <description></description>
           <person userid="tom" role="maintainer"/>
-          <group groupid="group_28" role="reviewer"/>
+          <group groupid="group_37" role="reviewer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:41 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_70
+    uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_86
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>In Death Ground</title>
-          <description>Voluptates ea voluptas et.</description>
+          <title>Recalled to Life</title>
+          <description>Qui repudiandae aut ipsa.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -277,16 +277,16 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>In Death Ground</title>
-          <description>Voluptates ea voluptas et.</description>
+          <title>Recalled to Life</title>
+          <description>Qui repudiandae aut ipsa.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:41 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_config
     body:
       encoding: UTF-8
-      string: Quia ad quos. Saepe accusamus quas. Aliquam magnam ut.
+      string: Consequatur iste rerum. Minus fugiat ratione. Beatae animi consectetur.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -306,25 +306,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="147" vrev="147">
-          <srcmd5>96aafac2424bd5aa5cfcc90f688ea5fc</srcmd5>
+        <revision rev="67" vrev="67">
+          <srcmd5>571621c8e7839f6ab37f4656507658e6</srcmd5>
           <version>unknown</version>
-          <time>1658422061</time>
+          <time>1658762220</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:41 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/somefile.txt
     body:
       encoding: UTF-8
-      string: Qui non et. Velit ut enim. Temporibus quo ipsam.
+      string: Vel et totam. Itaque earum ut. Numquam animi facilis.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -344,26 +344,26 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="148" vrev="148">
-          <srcmd5>5843f8a0ee599094b6a30569021a5a6c</srcmd5>
+        <revision rev="68" vrev="68">
+          <srcmd5>9f32c1fd62997737c554bf78835705a1</srcmd5>
           <version>unknown</version>
-          <time>1658422061</time>
+          <time>1658762220</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:41 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_69
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_85
     body:
       encoding: UTF-8
       string: |
-        <workflow project="home:tom" managers="group_28">
+        <workflow project="home:tom" managers="group_37">
           <staging_project name="home:tom:Staging:A"/>
           <staging_project name="home:tom:Staging:B"/>
         </workflow>
@@ -390,14 +390,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="303">
-          <srcmd5>b885dd2550e612cb2b37ef62d0ecfbfe</srcmd5>
-          <time>1658422061</time>
-          <user>user_69</user>
+        <revision rev="109">
+          <srcmd5>408154e2c5740f0941cf52d4f87eba46</srcmd5>
+          <time>1658762220</time>
+          <user>user_85</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:41 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=tom
@@ -441,5 +441,5 @@ http_interactions:
             <arch>x86_64</arch>
           </repository>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:41 GMT
+  recorded_at: Mon, 25 Jul 2022 15:17:00 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Project/Staging_Project/_untracked_requests/1_1_2_1.yml
+++ b/src/api/spec/cassettes/Project/Staging_Project/_untracked_requests/1_1_2_1.yml
@@ -39,7 +39,7 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:13 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:21 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_1
@@ -68,18 +68,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '170'
+      - '168'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="225">
+        <revision rev="1">
           <srcmd5>e5041e116aada333f093a54cd9eb647e</srcmd5>
-          <time>1658422033</time>
+          <time>1658762181</time>
           <user>user_1</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:13 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:21 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=user_1
@@ -119,7 +119,7 @@ http_interactions:
           <description></description>
           <group groupid="group_1" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:13 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:21 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=user_1
@@ -149,18 +149,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '170'
+      - '168'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="226">
+        <revision rev="2">
           <srcmd5>24931ffd0c813a8a478aa1e474921c59</srcmd5>
-          <time>1658422033</time>
+          <time>1658762181</time>
           <user>user_1</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:13 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:21 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=user_1
@@ -200,7 +200,7 @@ http_interactions:
           <description></description>
           <group groupid="group_1" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:13 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:21 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_meta?user=user_1
@@ -242,7 +242,7 @@ http_interactions:
           <person userid="tom" role="maintainer"/>
           <group groupid="group_1" role="reviewer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:13 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:21 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_meta?user=user_2
@@ -250,8 +250,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_file" project="home:tom:Staging:A">
-          <title>Françoise Sagan</title>
-          <description>Et repellat tempora est.</description>
+          <title>The Little Foxes</title>
+          <description>Quas temporibus aut animi.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -272,18 +272,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '163'
+      - '165'
     body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        PHBhY2thZ2UgbmFtZT0icGFja2FnZV93aXRoX2ZpbGUiIHByb2plY3Q9ImhvbWU6dG9tOlN0YWdpbmc6QSI+CiAgPHRpdGxlPkZyYW7Dp29pc2UgU2FnYW48L3RpdGxlPgogIDxkZXNjcmlwdGlvbj5FdCByZXBlbGxhdCB0ZW1wb3JhIGVzdC48L2Rlc2NyaXB0aW9uPgo8L3BhY2thZ2U+Cg==
-  recorded_at: Thu, 21 Jul 2022 16:47:13 GMT
+      encoding: UTF-8
+      string: |
+        <package name="package_with_file" project="home:tom:Staging:A">
+          <title>The Little Foxes</title>
+          <description>Quas temporibus aut animi.</description>
+        </package>
+  recorded_at: Mon, 25 Jul 2022 15:16:21 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/_config
     body:
       encoding: UTF-8
-      string: Est repellendus fugit. Tempore consequatur iste. Accusamus omnis rerum.
+      string: Beatae tenetur dolorum. Dolorem totam amet. Eos quibusdam incidunt.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -303,25 +306,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '209'
+      - '207'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="97" vrev="97">
-          <srcmd5>cc4ea3bb9e9b89cab159438c95d90a7b</srcmd5>
+        <revision rev="1" vrev="1">
+          <srcmd5>8ef844511a0660d4b52258ba8446329a</srcmd5>
           <version>unknown</version>
-          <time>1658422033</time>
+          <time>1658762181</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:13 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:21 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:Staging:A/package_with_file/somefile.txt
     body:
       encoding: UTF-8
-      string: Vel incidunt eligendi. Nemo accusamus maxime. Eius sit consequatur.
+      string: Voluptas in eum. Dicta nobis sequi. Tempora repellat nulla.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -341,19 +344,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '209'
+      - '207'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="98" vrev="98">
-          <srcmd5>44e458580fe5c46480427a0f515d67ae</srcmd5>
+        <revision rev="2" vrev="2">
+          <srcmd5>2b63f6189eb52b329e6fc1e80683bc33</srcmd5>
           <version>unknown</version>
-          <time>1658422033</time>
+          <time>1658762181</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:13 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:21 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/_meta?user=tom
@@ -361,7 +364,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>The Wealth of Nations</title>
+          <title>Mr Standfast</title>
           <description/>
         </project>
     headers:
@@ -383,15 +386,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '112'
+      - '103'
     body:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>The Wealth of Nations</title>
+          <title>Mr Standfast</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:13 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:21 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package/_meta?user=tom
@@ -399,8 +402,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>Ego Dominus Tuus</title>
-          <description>Quis qui harum assumenda.</description>
+          <title>The Waste Land</title>
+          <description>Modi sed iure doloremque.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -421,15 +424,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '157'
+      - '155'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>Ego Dominus Tuus</title>
-          <description>Quis qui harum assumenda.</description>
+          <title>The Waste Land</title>
+          <description>Modi sed iure doloremque.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:13 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:22 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_meta?user=tom
@@ -437,7 +440,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>To a God Unknown</title>
+          <title>Absalom, Absalom!</title>
           <description/>
         </project>
     headers:
@@ -459,15 +462,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '107'
+      - '108'
     body:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>To a God Unknown</title>
+          <title>Absalom, Absalom!</title>
           <description></description>
         </project>
-  recorded_at: Thu, 21 Jul 2022 16:47:13 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:22 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_project/_attribute?meta=1&user=tom
@@ -496,18 +499,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '166'
+      - '165'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="98">
-          <srcmd5>b6a07fca0cbf8c1a08164765aa471f9b</srcmd5>
-          <time>1658422033</time>
+        <revision rev="4">
+          <srcmd5>cb80160a31d216186df1b5b5ab718580</srcmd5>
+          <time>1658762182</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 16:47:13 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:22 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/source_package/_meta?user=tom
@@ -515,8 +518,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>Oh! To be in England</title>
-          <description>Aut voluptate rem molestiae.</description>
+          <title>The Millstone</title>
+          <description>Eligendi voluptatem in provident.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -537,15 +540,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '164'
+      - '162'
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>Oh! To be in England</title>
-          <description>Aut voluptate rem molestiae.</description>
+          <title>The Millstone</title>
+          <description>Eligendi voluptatem in provident.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 16:47:13 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:22 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package
@@ -577,7 +580,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 16:47:13 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:22 GMT
 - request:
     method: post
     uri: http://backend:5352/source/source_project/source_package?cmd=diff&expand=1&filelimit=10000&opackage=target_package&oproject=target_project&tarlimit=10000&view=xml&withissues=1
@@ -605,17 +608,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '329'
+      - '328'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="f0ade37f19a7eee38b40dd0309766ea1">
-          <old project="target_project" package="target_package" rev="28" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+        <sourcediff key="22bfb82bf1c9f9c9dd66ba87930cd41c">
+          <old project="target_project" package="target_package" rev="1" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <new project="source_project" package="source_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files>
           </files>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 21 Jul 2022 16:47:13 GMT
+  recorded_at: Mon, 25 Jul 2022 15:16:22 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/ProjectPolicy/staging/accept_/deny_with_approver_that_has_no_write_access_to_target_project.yml
+++ b/src/api/spec/cassettes/ProjectPolicy/staging/accept_/deny_with_approver_that_has_no_write_access_to_target_project.yml
@@ -1,0 +1,596 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/_meta?user=user_25
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>Number the Stars</title>
+          <description/>
+          <person userid="Rudi" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '153'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>Number the Stars</title>
+          <description></description>
+          <person userid="Rudi" role="maintainer"/>
+        </project>
+  recorded_at: Wed, 13 Jul 2022 18:24:13 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/aaa_base/_meta?user=user_26
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="aaa_base" project="openSUSE:Factory">
+          <title>Let Us Now Praise Famous Men</title>
+          <description>Facere perspiciatis quaerat nihil.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '174'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="aaa_base" project="openSUSE:Factory">
+          <title>Let Us Now Praise Famous Men</title>
+          <description>Facere perspiciatis quaerat nihil.</description>
+        </package>
+  recorded_at: Wed, 13 Jul 2022 18:24:13 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/aaa_base/_meta?user=user_26
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="aaa_base" project="openSUSE:Factory">
+          <title>Let Us Now Praise Famous Men</title>
+          <description>Facere perspiciatis quaerat nihil.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '174'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="aaa_base" project="openSUSE:Factory">
+          <title>Let Us Now Praise Famous Men</title>
+          <description>Facere perspiciatis quaerat nihil.</description>
+        </package>
+  recorded_at: Wed, 13 Jul 2022 18:24:13 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/_project/_staging_workflow?user=user_27
+    body:
+      encoding: UTF-8
+      string: |
+        <workflow project="openSUSE:Factory" managers="factory-staging">
+          <staging_project name="openSUSE:Factory:Staging:A"/>
+        </workflow>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '169'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="9">
+          <srcmd5>f52d2fa228da5a7a62608afca232acfe</srcmd5>
+          <time>1657736653</time>
+          <user>user_27</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 13 Jul 2022 18:24:13 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=user_27
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title/>
+          <description/>
+          <group groupid="factory-staging" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '158'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title></title>
+          <description></description>
+          <group groupid="factory-staging" role="maintainer"/>
+        </project>
+  recorded_at: Wed, 13 Jul 2022 18:24:13 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/_project/_staging_workflow?user=user_27
+    body:
+      encoding: UTF-8
+      string: |
+        <workflow project="openSUSE:Factory" managers="factory-staging">
+          <staging_project name="openSUSE:Factory:Staging:A"/>
+          <staging_project name="openSUSE:Factory:Staging:B"/>
+        </workflow>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '170'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="10">
+          <srcmd5>709bb8e6a36709d62f4b7877d2ee542a</srcmd5>
+          <time>1657736653</time>
+          <user>user_27</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 13 Jul 2022 18:24:13 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:B/_meta?user=user_27
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title/>
+          <description/>
+          <group groupid="factory-staging" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '158'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title></title>
+          <description></description>
+          <group groupid="factory-staging" role="maintainer"/>
+        </project>
+  recorded_at: Wed, 13 Jul 2022 18:24:13 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/_meta?user=user_27
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>Number the Stars</title>
+          <description/>
+          <person userid="Rudi" role="maintainer"/>
+          <group groupid="factory-staging" role="reviewer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '206'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>Number the Stars</title>
+          <description></description>
+          <person userid="Rudi" role="maintainer"/>
+          <group groupid="factory-staging" role="reviewer"/>
+        </project>
+  recorded_at: Wed, 13 Jul 2022 18:24:13 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/devel:base/_meta?user=user_28
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="devel:base">
+          <title>The Glory and the Dream</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '110'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="devel:base">
+          <title>The Glory and the Dream</title>
+          <description></description>
+        </project>
+  recorded_at: Wed, 13 Jul 2022 18:24:13 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/devel:base/aaa_base/_meta?user=user_29
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="aaa_base" project="devel:base">
+          <title>Quo Vadis</title>
+          <description>Repudiandae sunt ipsam non.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '142'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="aaa_base" project="devel:base">
+          <title>Quo Vadis</title>
+          <description>Repudiandae sunt ipsam non.</description>
+        </package>
+  recorded_at: Wed, 13 Jul 2022 18:24:13 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/devel:base/aaa_base/_config
+    body:
+      encoding: UTF-8
+      string: Nesciunt iusto voluptatem. Aut et qui. Vel dolorum delectus.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="9" vrev="9">
+          <srcmd5>59d77a29cb477b02d2e74c8c719bb69f</srcmd5>
+          <version>unknown</version>
+          <time>1657736653</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 13 Jul 2022 18:24:13 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/devel:base/aaa_base/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Ut veniam ut. Pariatur sapiente architecto. Voluptatem vitae eum.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="10" vrev="10">
+          <srcmd5>1184f445f81a235b8196e6d36ddc5656</srcmd5>
+          <version>unknown</version>
+          <time>1657736653</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 13 Jul 2022 18:24:13 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/devel:base/aaa_base
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '295'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="aaa_base" rev="10" vrev="10" srcmd5="1184f445f81a235b8196e6d36ddc5656">
+          <entry name="_config" md5="b0bc26bd89c46bf70f32602f705672c4" size="60" mtime="1657736653"/>
+          <entry name="somefile.txt" md5="cc271519ca715cac45588d2150a1aa85" size="65" mtime="1657736653"/>
+        </directory>
+  recorded_at: Wed, 13 Jul 2022 18:24:14 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/devel:base/aaa_base?cmd=diff&expand=1&filelimit=10000&opackage=aaa_base&oproject=openSUSE:Factory&tarlimit=10000&view=xml&withissues=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '825'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="1dbdbefe12902f20cde175aaa99a8e55">
+          <old project="openSUSE:Factory" package="aaa_base" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="devel:base" package="aaa_base" rev="10" srcmd5="1184f445f81a235b8196e6d36ddc5656"/>
+          <files>
+            <file state="added">
+              <new name="_config" md5="b0bc26bd89c46bf70f32602f705672c4" size="60"/>
+              <diff lines="3">@@ -0,0 +1,1 @@
+        +Nesciunt iusto voluptatem. Aut et qui. Vel dolorum delectus.
+        \ No newline at end of file
+        </diff>
+            </file>
+            <file state="added">
+              <new name="somefile.txt" md5="cc271519ca715cac45588d2150a1aa85" size="65"/>
+              <diff lines="3">@@ -0,0 +1,1 @@
+        +Ut veniam ut. Pariatur sapiente architecto. Voluptatem vitae eum.
+        \ No newline at end of file
+        </diff>
+            </file>
+          </files>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Wed, 13 Jul 2022 18:24:14 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/devel:base/aaa_base?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '295'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="aaa_base" rev="10" vrev="10" srcmd5="1184f445f81a235b8196e6d36ddc5656">
+          <entry name="_config" md5="b0bc26bd89c46bf70f32602f705672c4" size="60" mtime="1657736653"/>
+          <entry name="somefile.txt" md5="cc271519ca715cac45588d2150a1aa85" size="65" mtime="1657736653"/>
+        </directory>
+  recorded_at: Wed, 13 Jul 2022 18:24:14 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/ProjectPolicy/staging/accept_/deny_without_write_access_to_staging_project.yml
+++ b/src/api/spec/cassettes/ProjectPolicy/staging/accept_/deny_without_write_access_to_staging_project.yml
@@ -1,0 +1,562 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/_meta?user=user_13
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>Jacob Have I Loved</title>
+          <description/>
+          <person userid="Rudi" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '155'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>Jacob Have I Loved</title>
+          <description></description>
+          <person userid="Rudi" role="maintainer"/>
+        </project>
+  recorded_at: Wed, 13 Jul 2022 18:24:12 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/aaa_base/_meta?user=user_14
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="aaa_base" project="openSUSE:Factory">
+          <title>Clouds of Witness</title>
+          <description>Possimus aspernatur ut nostrum.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '160'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="aaa_base" project="openSUSE:Factory">
+          <title>Clouds of Witness</title>
+          <description>Possimus aspernatur ut nostrum.</description>
+        </package>
+  recorded_at: Wed, 13 Jul 2022 18:24:12 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/aaa_base/_meta?user=user_14
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="aaa_base" project="openSUSE:Factory">
+          <title>Clouds of Witness</title>
+          <description>Possimus aspernatur ut nostrum.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '160'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="aaa_base" project="openSUSE:Factory">
+          <title>Clouds of Witness</title>
+          <description>Possimus aspernatur ut nostrum.</description>
+        </package>
+  recorded_at: Wed, 13 Jul 2022 18:24:12 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/_project/_staging_workflow?user=user_15
+    body:
+      encoding: UTF-8
+      string: |
+        <workflow project="openSUSE:Factory" managers="factory-staging">
+          <staging_project name="openSUSE:Factory:Staging:A"/>
+        </workflow>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '169'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="5">
+          <srcmd5>f52d2fa228da5a7a62608afca232acfe</srcmd5>
+          <time>1657736652</time>
+          <user>user_15</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 13 Jul 2022 18:24:12 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=user_15
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title/>
+          <description/>
+          <group groupid="factory-staging" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '158'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title></title>
+          <description></description>
+          <group groupid="factory-staging" role="maintainer"/>
+        </project>
+  recorded_at: Wed, 13 Jul 2022 18:24:12 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/_project/_staging_workflow?user=user_15
+    body:
+      encoding: UTF-8
+      string: |
+        <workflow project="openSUSE:Factory" managers="factory-staging">
+          <staging_project name="openSUSE:Factory:Staging:A"/>
+          <staging_project name="openSUSE:Factory:Staging:B"/>
+        </workflow>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '169'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="6">
+          <srcmd5>709bb8e6a36709d62f4b7877d2ee542a</srcmd5>
+          <time>1657736652</time>
+          <user>user_15</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 13 Jul 2022 18:24:12 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:B/_meta?user=user_15
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title/>
+          <description/>
+          <group groupid="factory-staging" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '158'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title></title>
+          <description></description>
+          <group groupid="factory-staging" role="maintainer"/>
+        </project>
+  recorded_at: Wed, 13 Jul 2022 18:24:12 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/_meta?user=user_15
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>Jacob Have I Loved</title>
+          <description/>
+          <person userid="Rudi" role="maintainer"/>
+          <group groupid="factory-staging" role="reviewer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '208'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>Jacob Have I Loved</title>
+          <description></description>
+          <person userid="Rudi" role="maintainer"/>
+          <group groupid="factory-staging" role="reviewer"/>
+        </project>
+  recorded_at: Wed, 13 Jul 2022 18:24:12 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/devel:base/_meta?user=user_16
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="devel:base">
+          <title>A Monstrous Regiment of Women</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '116'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="devel:base">
+          <title>A Monstrous Regiment of Women</title>
+          <description></description>
+        </project>
+  recorded_at: Wed, 13 Jul 2022 18:24:12 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/devel:base/aaa_base/_meta?user=user_17
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="aaa_base" project="devel:base">
+          <title>A Glass of Blessings</title>
+          <description>Omnis harum autem pariatur.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '153'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="aaa_base" project="devel:base">
+          <title>A Glass of Blessings</title>
+          <description>Omnis harum autem pariatur.</description>
+        </package>
+  recorded_at: Wed, 13 Jul 2022 18:24:12 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/devel:base/aaa_base/_config
+    body:
+      encoding: UTF-8
+      string: Culpa possimus aspernatur. Et deleniti quis. Recusandae atque dolores.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="5" vrev="5">
+          <srcmd5>723d15e6aa1683ba28467a626f1e430c</srcmd5>
+          <version>unknown</version>
+          <time>1657736652</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 13 Jul 2022 18:24:12 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/devel:base/aaa_base/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Dolorem enim ipsam. Dolores natus dolorum. Corrupti quia quos.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="6" vrev="6">
+          <srcmd5>52c4701cd484c80809ab1305828fc2b2</srcmd5>
+          <version>unknown</version>
+          <time>1657736652</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 13 Jul 2022 18:24:12 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/devel:base/aaa_base
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '293'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="aaa_base" rev="6" vrev="6" srcmd5="52c4701cd484c80809ab1305828fc2b2">
+          <entry name="_config" md5="d38bf734ba622037f247dbe0ecebb72e" size="70" mtime="1657736652"/>
+          <entry name="somefile.txt" md5="f1b1bf378d89f5131e74c77a524ea1d7" size="62" mtime="1657736652"/>
+        </directory>
+  recorded_at: Wed, 13 Jul 2022 18:24:12 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/devel:base/aaa_base?cmd=diff&expand=1&filelimit=10000&opackage=aaa_base&oproject=openSUSE:Factory&tarlimit=10000&view=xml&withissues=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '831'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="a81ca367f38f531b22f8d612d36c6f9b">
+          <old project="openSUSE:Factory" package="aaa_base" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="devel:base" package="aaa_base" rev="6" srcmd5="52c4701cd484c80809ab1305828fc2b2"/>
+          <files>
+            <file state="added">
+              <new name="_config" md5="d38bf734ba622037f247dbe0ecebb72e" size="70"/>
+              <diff lines="3">@@ -0,0 +1,1 @@
+        +Culpa possimus aspernatur. Et deleniti quis. Recusandae atque dolores.
+        \ No newline at end of file
+        </diff>
+            </file>
+            <file state="added">
+              <new name="somefile.txt" md5="f1b1bf378d89f5131e74c77a524ea1d7" size="62"/>
+              <diff lines="3">@@ -0,0 +1,1 @@
+        +Dolorem enim ipsam. Dolores natus dolorum. Corrupti quia quos.
+        \ No newline at end of file
+        </diff>
+            </file>
+          </files>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Wed, 13 Jul 2022 18:24:12 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/ProjectPolicy/staging/accept_/deny_without_write_access_to_target_project.yml
+++ b/src/api/spec/cassettes/ProjectPolicy/staging/accept_/deny_without_write_access_to_target_project.yml
@@ -1,0 +1,597 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/_meta?user=user_1
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>A Farewell to Arms</title>
+          <description/>
+          <person userid="Rudi" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '155'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>A Farewell to Arms</title>
+          <description></description>
+          <person userid="Rudi" role="maintainer"/>
+        </project>
+  recorded_at: Wed, 13 Jul 2022 18:24:10 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/aaa_base/_meta?user=user_2
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="aaa_base" project="openSUSE:Factory">
+          <title>Mother Night</title>
+          <description>Non nihil perferendis cumque.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '153'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="aaa_base" project="openSUSE:Factory">
+          <title>Mother Night</title>
+          <description>Non nihil perferendis cumque.</description>
+        </package>
+  recorded_at: Wed, 13 Jul 2022 18:24:10 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/aaa_base/_meta?user=user_2
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="aaa_base" project="openSUSE:Factory">
+          <title>Mother Night</title>
+          <description>Non nihil perferendis cumque.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '153'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="aaa_base" project="openSUSE:Factory">
+          <title>Mother Night</title>
+          <description>Non nihil perferendis cumque.</description>
+        </package>
+  recorded_at: Wed, 13 Jul 2022 18:24:10 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/_project/_staging_workflow?user=user_3
+    body:
+      encoding: UTF-8
+      string: |
+        <workflow project="openSUSE:Factory" managers="factory-staging">
+          <staging_project name="openSUSE:Factory:Staging:A"/>
+        </workflow>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '168'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="1">
+          <srcmd5>f52d2fa228da5a7a62608afca232acfe</srcmd5>
+          <time>1657736650</time>
+          <user>user_3</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 13 Jul 2022 18:24:10 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=user_3
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title/>
+          <description/>
+          <group groupid="factory-staging" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '158'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title></title>
+          <description></description>
+          <group groupid="factory-staging" role="maintainer"/>
+        </project>
+  recorded_at: Wed, 13 Jul 2022 18:24:10 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/_project/_staging_workflow?user=user_3
+    body:
+      encoding: UTF-8
+      string: |
+        <workflow project="openSUSE:Factory" managers="factory-staging">
+          <staging_project name="openSUSE:Factory:Staging:A"/>
+          <staging_project name="openSUSE:Factory:Staging:B"/>
+        </workflow>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '168'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="2">
+          <srcmd5>709bb8e6a36709d62f4b7877d2ee542a</srcmd5>
+          <time>1657736650</time>
+          <user>user_3</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 13 Jul 2022 18:24:10 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:B/_meta?user=user_3
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title/>
+          <description/>
+          <group groupid="factory-staging" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '158'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title></title>
+          <description></description>
+          <group groupid="factory-staging" role="maintainer"/>
+        </project>
+  recorded_at: Wed, 13 Jul 2022 18:24:10 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/_meta?user=user_3
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>A Farewell to Arms</title>
+          <description/>
+          <person userid="Rudi" role="maintainer"/>
+          <group groupid="factory-staging" role="reviewer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '208'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>A Farewell to Arms</title>
+          <description></description>
+          <person userid="Rudi" role="maintainer"/>
+          <group groupid="factory-staging" role="reviewer"/>
+        </project>
+  recorded_at: Wed, 13 Jul 2022 18:24:10 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/devel:base/_meta?user=user_4
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="devel:base">
+          <title>The Mirror Crack'd from Side to Side</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '123'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="devel:base">
+          <title>The Mirror Crack'd from Side to Side</title>
+          <description></description>
+        </project>
+  recorded_at: Wed, 13 Jul 2022 18:24:10 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/devel:base/aaa_base/_meta?user=user_5
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="aaa_base" project="devel:base">
+          <title>Vanity Fair</title>
+          <description>Nobis in quas quis.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '136'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="aaa_base" project="devel:base">
+          <title>Vanity Fair</title>
+          <description>Nobis in quas quis.</description>
+        </package>
+  recorded_at: Wed, 13 Jul 2022 18:24:10 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/devel:base/aaa_base/_config
+    body:
+      encoding: UTF-8
+      string: Repellendus dolor iste. Est voluptas repudiandae. Rerum asperiores dolorum.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="1" vrev="1">
+          <srcmd5>f720a0122343c2b6f8b4095047c483a2</srcmd5>
+          <version>unknown</version>
+          <time>1657736650</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 13 Jul 2022 18:24:10 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/devel:base/aaa_base/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Occaecati ab accusamus. Accusantium doloremque deserunt. Ut praesentium
+        velit.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="2" vrev="2">
+          <srcmd5>53d0eeeb5e45822298c70b59f64e7f75</srcmd5>
+          <version>unknown</version>
+          <time>1657736650</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 13 Jul 2022 18:24:10 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/devel:base/aaa_base
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '293'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="aaa_base" rev="2" vrev="2" srcmd5="53d0eeeb5e45822298c70b59f64e7f75">
+          <entry name="_config" md5="a4f8c5a7c7e59eaf629b132005c2a973" size="75" mtime="1657736650"/>
+          <entry name="somefile.txt" md5="84f545f4b94e5a9468383639c3d16eaa" size="78" mtime="1657736650"/>
+        </directory>
+  recorded_at: Wed, 13 Jul 2022 18:24:10 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/devel:base/aaa_base?cmd=diff&expand=1&filelimit=10000&opackage=aaa_base&oproject=openSUSE:Factory&tarlimit=10000&view=xml&withissues=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '852'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="9acaf7c9326eaadbdc1897f1a00b9ba9">
+          <old project="openSUSE:Factory" package="aaa_base" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="devel:base" package="aaa_base" rev="2" srcmd5="53d0eeeb5e45822298c70b59f64e7f75"/>
+          <files>
+            <file state="added">
+              <new name="_config" md5="a4f8c5a7c7e59eaf629b132005c2a973" size="75"/>
+              <diff lines="3">@@ -0,0 +1,1 @@
+        +Repellendus dolor iste. Est voluptas repudiandae. Rerum asperiores dolorum.
+        \ No newline at end of file
+        </diff>
+            </file>
+            <file state="added">
+              <new name="somefile.txt" md5="84f545f4b94e5a9468383639c3d16eaa" size="78"/>
+              <diff lines="3">@@ -0,0 +1,1 @@
+        +Occaecati ab accusamus. Accusantium doloremque deserunt. Ut praesentium velit.
+        \ No newline at end of file
+        </diff>
+            </file>
+          </files>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Wed, 13 Jul 2022 18:24:10 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/devel:base/aaa_base?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '293'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="aaa_base" rev="2" vrev="2" srcmd5="53d0eeeb5e45822298c70b59f64e7f75">
+          <entry name="_config" md5="a4f8c5a7c7e59eaf629b132005c2a973" size="75" mtime="1657736650"/>
+          <entry name="somefile.txt" md5="84f545f4b94e5a9468383639c3d16eaa" size="78" mtime="1657736650"/>
+        </directory>
+  recorded_at: Wed, 13 Jul 2022 18:24:10 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/ProjectPolicy/staging/accept_/permit_with_write_access_to_staging_project_and_target_project.yml
+++ b/src/api/spec/cassettes/ProjectPolicy/staging/accept_/permit_with_write_access_to_staging_project_and_target_project.yml
@@ -1,0 +1,630 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/_meta?user=user_19
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>Paths of Glory</title>
+          <description/>
+          <person userid="Rudi" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '151'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>Paths of Glory</title>
+          <description></description>
+          <person userid="Rudi" role="maintainer"/>
+        </project>
+  recorded_at: Wed, 13 Jul 2022 18:24:12 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/aaa_base/_meta?user=user_20
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="aaa_base" project="openSUSE:Factory">
+          <title>Cover Her Face</title>
+          <description>Iusto sit culpa perferendis.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '154'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="aaa_base" project="openSUSE:Factory">
+          <title>Cover Her Face</title>
+          <description>Iusto sit culpa perferendis.</description>
+        </package>
+  recorded_at: Wed, 13 Jul 2022 18:24:12 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/aaa_base/_meta?user=user_20
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="aaa_base" project="openSUSE:Factory">
+          <title>Cover Her Face</title>
+          <description>Iusto sit culpa perferendis.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '154'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="aaa_base" project="openSUSE:Factory">
+          <title>Cover Her Face</title>
+          <description>Iusto sit culpa perferendis.</description>
+        </package>
+  recorded_at: Wed, 13 Jul 2022 18:24:12 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/_project/_staging_workflow?user=user_21
+    body:
+      encoding: UTF-8
+      string: |
+        <workflow project="openSUSE:Factory" managers="factory-staging">
+          <staging_project name="openSUSE:Factory:Staging:A"/>
+        </workflow>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '169'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="7">
+          <srcmd5>f52d2fa228da5a7a62608afca232acfe</srcmd5>
+          <time>1657736653</time>
+          <user>user_21</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 13 Jul 2022 18:24:13 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=user_21
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title/>
+          <description/>
+          <group groupid="factory-staging" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '158'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title></title>
+          <description></description>
+          <group groupid="factory-staging" role="maintainer"/>
+        </project>
+  recorded_at: Wed, 13 Jul 2022 18:24:13 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/_project/_staging_workflow?user=user_21
+    body:
+      encoding: UTF-8
+      string: |
+        <workflow project="openSUSE:Factory" managers="factory-staging">
+          <staging_project name="openSUSE:Factory:Staging:A"/>
+          <staging_project name="openSUSE:Factory:Staging:B"/>
+        </workflow>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '169'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="8">
+          <srcmd5>709bb8e6a36709d62f4b7877d2ee542a</srcmd5>
+          <time>1657736653</time>
+          <user>user_21</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 13 Jul 2022 18:24:13 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:B/_meta?user=user_21
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title/>
+          <description/>
+          <group groupid="factory-staging" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '158'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title></title>
+          <description></description>
+          <group groupid="factory-staging" role="maintainer"/>
+        </project>
+  recorded_at: Wed, 13 Jul 2022 18:24:13 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/_meta?user=user_21
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>Paths of Glory</title>
+          <description/>
+          <person userid="Rudi" role="maintainer"/>
+          <group groupid="factory-staging" role="reviewer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '204'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>Paths of Glory</title>
+          <description></description>
+          <person userid="Rudi" role="maintainer"/>
+          <group groupid="factory-staging" role="reviewer"/>
+        </project>
+  recorded_at: Wed, 13 Jul 2022 18:24:13 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/devel:base/_meta?user=user_22
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="devel:base">
+          <title>Stranger in a Strange Land</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '113'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="devel:base">
+          <title>Stranger in a Strange Land</title>
+          <description></description>
+        </project>
+  recorded_at: Wed, 13 Jul 2022 18:24:13 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/devel:base/aaa_base/_meta?user=user_23
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="aaa_base" project="devel:base">
+          <title>The House of Mirth</title>
+          <description>Officia ad perferendis ut.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '150'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="aaa_base" project="devel:base">
+          <title>The House of Mirth</title>
+          <description>Officia ad perferendis ut.</description>
+        </package>
+  recorded_at: Wed, 13 Jul 2022 18:24:13 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/devel:base/aaa_base/_config
+    body:
+      encoding: UTF-8
+      string: Culpa cum provident. Aliquid illo consequatur. Accusantium cum ea.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="7" vrev="7">
+          <srcmd5>a3961980d7613b2f8305a3ca2d3cf3b7</srcmd5>
+          <version>unknown</version>
+          <time>1657736653</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 13 Jul 2022 18:24:13 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/devel:base/aaa_base/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Et non dolore. Odit rem qui. Sint optio unde.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="8" vrev="8">
+          <srcmd5>07d8b2adb5e900efaebdafb0f627640e</srcmd5>
+          <version>unknown</version>
+          <time>1657736653</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 13 Jul 2022 18:24:13 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/devel:base/aaa_base
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '293'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="aaa_base" rev="8" vrev="8" srcmd5="07d8b2adb5e900efaebdafb0f627640e">
+          <entry name="_config" md5="1d4092d5c83d6c4c81e178b70458ab54" size="66" mtime="1657736653"/>
+          <entry name="somefile.txt" md5="e12d36a0258e9abc59c8fffa20f1405f" size="45" mtime="1657736653"/>
+        </directory>
+  recorded_at: Wed, 13 Jul 2022 18:24:13 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/devel:base/aaa_base?cmd=diff&expand=1&filelimit=10000&opackage=aaa_base&oproject=openSUSE:Factory&tarlimit=10000&view=xml&withissues=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '810'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="b75eb52d2d03715f0485291d9b8ba685">
+          <old project="openSUSE:Factory" package="aaa_base" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="devel:base" package="aaa_base" rev="8" srcmd5="07d8b2adb5e900efaebdafb0f627640e"/>
+          <files>
+            <file state="added">
+              <new name="_config" md5="1d4092d5c83d6c4c81e178b70458ab54" size="66"/>
+              <diff lines="3">@@ -0,0 +1,1 @@
+        +Culpa cum provident. Aliquid illo consequatur. Accusantium cum ea.
+        \ No newline at end of file
+        </diff>
+            </file>
+            <file state="added">
+              <new name="somefile.txt" md5="e12d36a0258e9abc59c8fffa20f1405f" size="45"/>
+              <diff lines="3">@@ -0,0 +1,1 @@
+        +Et non dolore. Odit rem qui. Sint optio unde.
+        \ No newline at end of file
+        </diff>
+            </file>
+          </files>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Wed, 13 Jul 2022 18:24:13 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/devel:base/aaa_base?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '293'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="aaa_base" rev="8" vrev="8" srcmd5="07d8b2adb5e900efaebdafb0f627640e">
+          <entry name="_config" md5="1d4092d5c83d6c4c81e178b70458ab54" size="66" mtime="1657736653"/>
+          <entry name="somefile.txt" md5="e12d36a0258e9abc59c8fffa20f1405f" size="45" mtime="1657736653"/>
+        </directory>
+  recorded_at: Wed, 13 Jul 2022 18:24:13 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/devel:base/aaa_base?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '293'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="aaa_base" rev="8" vrev="8" srcmd5="07d8b2adb5e900efaebdafb0f627640e">
+          <entry name="_config" md5="1d4092d5c83d6c4c81e178b70458ab54" size="66" mtime="1657736653"/>
+          <entry name="somefile.txt" md5="e12d36a0258e9abc59c8fffa20f1405f" size="45" mtime="1657736653"/>
+        </directory>
+  recorded_at: Wed, 13 Jul 2022 18:24:13 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/ProjectPolicy/staging/accept_/permit_without_write_access_to_target_project_and_pre_approved_requests.yml
+++ b/src/api/spec/cassettes/ProjectPolicy/staging/accept_/permit_without_write_access_to_target_project_and_pre_approved_requests.yml
@@ -1,0 +1,630 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/_meta?user=user_7
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>This Side of Paradise</title>
+          <description/>
+          <person userid="Rudi" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '158'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>This Side of Paradise</title>
+          <description></description>
+          <person userid="Rudi" role="maintainer"/>
+        </project>
+  recorded_at: Wed, 13 Jul 2022 18:24:11 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/aaa_base/_meta?user=user_8
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="aaa_base" project="openSUSE:Factory">
+          <title>Little Hands Clapping</title>
+          <description>Ducimus corrupti autem dolores.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '164'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="aaa_base" project="openSUSE:Factory">
+          <title>Little Hands Clapping</title>
+          <description>Ducimus corrupti autem dolores.</description>
+        </package>
+  recorded_at: Wed, 13 Jul 2022 18:24:11 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/aaa_base/_meta?user=user_8
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="aaa_base" project="openSUSE:Factory">
+          <title>Little Hands Clapping</title>
+          <description>Ducimus corrupti autem dolores.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '164'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="aaa_base" project="openSUSE:Factory">
+          <title>Little Hands Clapping</title>
+          <description>Ducimus corrupti autem dolores.</description>
+        </package>
+  recorded_at: Wed, 13 Jul 2022 18:24:11 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/_project/_staging_workflow?user=user_9
+    body:
+      encoding: UTF-8
+      string: |
+        <workflow project="openSUSE:Factory" managers="factory-staging">
+          <staging_project name="openSUSE:Factory:Staging:A"/>
+        </workflow>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '168'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="3">
+          <srcmd5>f52d2fa228da5a7a62608afca232acfe</srcmd5>
+          <time>1657736651</time>
+          <user>user_9</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 13 Jul 2022 18:24:11 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=user_9
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title/>
+          <description/>
+          <group groupid="factory-staging" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '158'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title></title>
+          <description></description>
+          <group groupid="factory-staging" role="maintainer"/>
+        </project>
+  recorded_at: Wed, 13 Jul 2022 18:24:11 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/_project/_staging_workflow?user=user_9
+    body:
+      encoding: UTF-8
+      string: |
+        <workflow project="openSUSE:Factory" managers="factory-staging">
+          <staging_project name="openSUSE:Factory:Staging:A"/>
+          <staging_project name="openSUSE:Factory:Staging:B"/>
+        </workflow>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '168'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="4">
+          <srcmd5>709bb8e6a36709d62f4b7877d2ee542a</srcmd5>
+          <time>1657736651</time>
+          <user>user_9</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 13 Jul 2022 18:24:11 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:B/_meta?user=user_9
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title/>
+          <description/>
+          <group groupid="factory-staging" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '158'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title></title>
+          <description></description>
+          <group groupid="factory-staging" role="maintainer"/>
+        </project>
+  recorded_at: Wed, 13 Jul 2022 18:24:11 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/_meta?user=user_9
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>This Side of Paradise</title>
+          <description/>
+          <person userid="Rudi" role="maintainer"/>
+          <group groupid="factory-staging" role="reviewer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '211'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>This Side of Paradise</title>
+          <description></description>
+          <person userid="Rudi" role="maintainer"/>
+          <group groupid="factory-staging" role="reviewer"/>
+        </project>
+  recorded_at: Wed, 13 Jul 2022 18:24:11 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/devel:base/_meta?user=user_10
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="devel:base">
+          <title>Such, Such Were the Joys</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '111'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="devel:base">
+          <title>Such, Such Were the Joys</title>
+          <description></description>
+        </project>
+  recorded_at: Wed, 13 Jul 2022 18:24:11 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/devel:base/aaa_base/_meta?user=user_11
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="aaa_base" project="devel:base">
+          <title>That Good Night</title>
+          <description>Non laboriosam iste enim.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '146'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="aaa_base" project="devel:base">
+          <title>That Good Night</title>
+          <description>Non laboriosam iste enim.</description>
+        </package>
+  recorded_at: Wed, 13 Jul 2022 18:24:11 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/devel:base/aaa_base/_config
+    body:
+      encoding: UTF-8
+      string: Et dolorum modi. Quae expedita tempora. Unde qui et.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="3" vrev="3">
+          <srcmd5>1ed79973ebe0884be8bbc32e96fd5d75</srcmd5>
+          <version>unknown</version>
+          <time>1657736651</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 13 Jul 2022 18:24:11 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/devel:base/aaa_base/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Unde accusamus ratione. Fugiat dolores debitis. Quis omnis eos.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="4" vrev="4">
+          <srcmd5>46aebe5e25d174fc77706dd3cb0604d2</srcmd5>
+          <version>unknown</version>
+          <time>1657736651</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 13 Jul 2022 18:24:11 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/devel:base/aaa_base
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '293'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="aaa_base" rev="4" vrev="4" srcmd5="46aebe5e25d174fc77706dd3cb0604d2">
+          <entry name="_config" md5="4246d90406d6ba89803f797481576da6" size="52" mtime="1657736651"/>
+          <entry name="somefile.txt" md5="ed841118bfd3cc8e065be989a7f3524c" size="63" mtime="1657736651"/>
+        </directory>
+  recorded_at: Wed, 13 Jul 2022 18:24:11 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/devel:base/aaa_base?cmd=diff&expand=1&filelimit=10000&opackage=aaa_base&oproject=openSUSE:Factory&tarlimit=10000&view=xml&withissues=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '814'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="09fd72a08571af86b6f08c6bf408e16d">
+          <old project="openSUSE:Factory" package="aaa_base" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="devel:base" package="aaa_base" rev="4" srcmd5="46aebe5e25d174fc77706dd3cb0604d2"/>
+          <files>
+            <file state="added">
+              <new name="_config" md5="4246d90406d6ba89803f797481576da6" size="52"/>
+              <diff lines="3">@@ -0,0 +1,1 @@
+        +Et dolorum modi. Quae expedita tempora. Unde qui et.
+        \ No newline at end of file
+        </diff>
+            </file>
+            <file state="added">
+              <new name="somefile.txt" md5="ed841118bfd3cc8e065be989a7f3524c" size="63"/>
+              <diff lines="3">@@ -0,0 +1,1 @@
+        +Unde accusamus ratione. Fugiat dolores debitis. Quis omnis eos.
+        \ No newline at end of file
+        </diff>
+            </file>
+          </files>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Wed, 13 Jul 2022 18:24:11 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/devel:base/aaa_base?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '293'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="aaa_base" rev="4" vrev="4" srcmd5="46aebe5e25d174fc77706dd3cb0604d2">
+          <entry name="_config" md5="4246d90406d6ba89803f797481576da6" size="52" mtime="1657736651"/>
+          <entry name="somefile.txt" md5="ed841118bfd3cc8e065be989a7f3524c" size="63" mtime="1657736651"/>
+        </directory>
+  recorded_at: Wed, 13 Jul 2022 18:24:11 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/devel:base/aaa_base?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '293'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="aaa_base" rev="4" vrev="4" srcmd5="46aebe5e25d174fc77706dd3cb0604d2">
+          <entry name="_config" md5="4246d90406d6ba89803f797481576da6" size="52" mtime="1657736651"/>
+          <entry name="somefile.txt" md5="ed841118bfd3cc8e065be989a7f3524c" size="63" mtime="1657736651"/>
+        </directory>
+  recorded_at: Wed, 13 Jul 2022 18:24:11 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Staging_StagingProjectsController/POST_accept/when_project_has_a_request/with_nothing_missing/1_4_3_1_1.yml
+++ b/src/api/spec/cassettes/Staging_StagingProjectsController/POST_accept/when_project_has_a_request/with_nothing_missing/1_4_3_1_1.yml
@@ -39,7 +39,7 @@ http_interactions:
           <description></description>
           <person userid="permitted_user" role="maintainer"/>
         </project>
-  recorded_at: Fri, 22 Jul 2022 11:55:07 GMT
+  recorded_at: Mon, 25 Jul 2022 15:48:05 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:permitted_user/_project/_staging_workflow?user=permitted_user
@@ -72,14 +72,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1">
+        <revision rev="5">
           <srcmd5>437960873390f6d51b29cac67e3b5453</srcmd5>
-          <time>1658490907</time>
+          <time>1658764085</time>
           <user>permitted_user</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 22 Jul 2022 11:55:07 GMT
+  recorded_at: Mon, 25 Jul 2022 15:48:05 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:permitted_user:Staging:A/_meta?user=permitted_user
@@ -119,7 +119,7 @@ http_interactions:
           <description></description>
           <group groupid="group_1" role="maintainer"/>
         </project>
-  recorded_at: Fri, 22 Jul 2022 11:55:07 GMT
+  recorded_at: Mon, 25 Jul 2022 15:48:05 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:permitted_user/_project/_staging_workflow?user=permitted_user
@@ -153,14 +153,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2">
+        <revision rev="6">
           <srcmd5>1cb65454e99e97791176705d1691a126</srcmd5>
-          <time>1658490907</time>
+          <time>1658764085</time>
           <user>permitted_user</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 22 Jul 2022 11:55:07 GMT
+  recorded_at: Mon, 25 Jul 2022 15:48:05 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:permitted_user:Staging:B/_meta?user=permitted_user
@@ -200,7 +200,7 @@ http_interactions:
           <description></description>
           <group groupid="group_1" role="maintainer"/>
         </project>
-  recorded_at: Fri, 22 Jul 2022 11:55:07 GMT
+  recorded_at: Mon, 25 Jul 2022 15:48:05 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:permitted_user/_meta?user=permitted_user
@@ -242,7 +242,7 @@ http_interactions:
           <person userid="permitted_user" role="maintainer"/>
           <group groupid="group_1" role="reviewer"/>
         </project>
-  recorded_at: Fri, 22 Jul 2022 11:55:07 GMT
+  recorded_at: Mon, 25 Jul 2022 15:48:05 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/_meta?user=permitted_user
@@ -250,7 +250,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>Absalom, Absalom!</title>
+          <title>The Heart Is a Lonely Hunter</title>
           <description/>
         </project>
     headers:
@@ -272,15 +272,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '108'
+      - '119'
     body:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>Absalom, Absalom!</title>
+          <title>The Heart Is a Lonely Hunter</title>
           <description></description>
         </project>
-  recorded_at: Fri, 22 Jul 2022 11:55:07 GMT
+  recorded_at: Mon, 25 Jul 2022 15:48:05 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package/_meta?user=permitted_user
@@ -288,8 +288,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>Fair Stood the Wind for France</title>
-          <description>Nihil error perferendis quis.</description>
+          <title>Look to Windward</title>
+          <description>Molestiae explicabo molestias harum.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -310,15 +310,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '175'
+      - '168'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>Fair Stood the Wind for France</title>
-          <description>Nihil error perferendis quis.</description>
+          <title>Look to Windward</title>
+          <description>Molestiae explicabo molestias harum.</description>
         </package>
-  recorded_at: Fri, 22 Jul 2022 11:55:07 GMT
+  recorded_at: Mon, 25 Jul 2022 15:48:05 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_meta?user=permitted_user
@@ -326,7 +326,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Carrion Comfort</title>
+          <title>Consider Phlebas</title>
           <description/>
         </project>
     headers:
@@ -348,15 +348,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '106'
+      - '107'
     body:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Carrion Comfort</title>
+          <title>Consider Phlebas</title>
           <description></description>
         </project>
-  recorded_at: Fri, 22 Jul 2022 11:55:07 GMT
+  recorded_at: Mon, 25 Jul 2022 15:48:05 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_project/_attribute?meta=1&user=permitted_user
@@ -385,18 +385,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '176'
+      - '177'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2">
-          <srcmd5>4205f670eb400ff212d2c9248dcce193</srcmd5>
-          <time>1658490907</time>
+        <revision rev="66">
+          <srcmd5>6aab2c5e83adc8c393700492d1d5ba3a</srcmd5>
+          <time>1658764085</time>
           <user>permitted_user</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 22 Jul 2022 11:55:07 GMT
+  recorded_at: Mon, 25 Jul 2022 15:48:05 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/source_package/_meta?user=permitted_user
@@ -404,8 +404,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>The Skull Beneath the Skin</title>
-          <description>Ipsa voluptatibus rerum corporis.</description>
+          <title>A Swiftly Tilting Planet</title>
+          <description>Id eaque excepturi animi.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -426,15 +426,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '175'
+      - '165'
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>The Skull Beneath the Skin</title>
-          <description>Ipsa voluptatibus rerum corporis.</description>
+          <title>A Swiftly Tilting Planet</title>
+          <description>Id eaque excepturi animi.</description>
         </package>
-  recorded_at: Fri, 22 Jul 2022 11:55:07 GMT
+  recorded_at: Mon, 25 Jul 2022 15:48:05 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package
@@ -466,7 +466,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Fri, 22 Jul 2022 11:55:07 GMT
+  recorded_at: Mon, 25 Jul 2022 15:48:06 GMT
 - request:
     method: post
     uri: http://backend:5352/source/source_project/source_package?cmd=diff&expand=1&filelimit=10000&opackage=target_package&oproject=target_project&tarlimit=10000&view=xml&withissues=1
@@ -498,15 +498,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="1d2d66e37ffce337361288aaa1a481e8">
-          <old project="target_project" package="target_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+        <sourcediff key="41624200f44c06023433fa81152364d3">
+          <old project="target_project" package="target_package" rev="8" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <new project="source_project" package="source_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files>
           </files>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Fri, 22 Jul 2022 11:55:07 GMT
+  recorded_at: Mon, 25 Jul 2022 15:48:06 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22source_package%22%20and%20linkinfo/@project=%22source_project%22%20and%20@project=%22source_project%22)
@@ -540,7 +540,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Fri, 22 Jul 2022 11:55:07 GMT
+  recorded_at: Mon, 25 Jul 2022 15:48:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:permitted_user:Staging:A/target_package/_meta?user=staging-hero
@@ -548,8 +548,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="home:permitted_user:Staging:A">
-          <title>The Skull Beneath the Skin</title>
-          <description>Ipsa voluptatibus rerum corporis.</description>
+          <title>A Swiftly Tilting Planet</title>
+          <description>Id eaque excepturi animi.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -570,15 +570,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '190'
+      - '180'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="home:permitted_user:Staging:A">
-          <title>The Skull Beneath the Skin</title>
-          <description>Ipsa voluptatibus rerum corporis.</description>
+          <title>A Swiftly Tilting Planet</title>
+          <description>Id eaque excepturi animi.</description>
         </package>
-  recorded_at: Fri, 22 Jul 2022 11:55:07 GMT
+  recorded_at: Mon, 25 Jul 2022 15:48:06 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:permitted_user:Staging:A/target_package?cmd=branch&noservice=1&opackage=source_package&oproject=source_project&user=staging-hero
@@ -613,12 +613,12 @@ http_interactions:
         <revision rev="1" vrev="1">
           <srcmd5>8e451641a827df5f4f409d1d543fdb7b</srcmd5>
           <version>unknown</version>
-          <time>1658490907</time>
+          <time>1658764086</time>
           <user>staging-hero</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 22 Jul 2022 11:55:07 GMT
+  recorded_at: Mon, 25 Jul 2022 15:48:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:permitted_user:Staging:A/target_package/_meta?user=staging-hero
@@ -626,8 +626,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="home:permitted_user:Staging:A">
-          <title>The Skull Beneath the Skin</title>
-          <description>Ipsa voluptatibus rerum corporis.</description>
+          <title>A Swiftly Tilting Planet</title>
+          <description>Id eaque excepturi animi.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -648,15 +648,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '190'
+      - '180'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="home:permitted_user:Staging:A">
-          <title>The Skull Beneath the Skin</title>
-          <description>Ipsa voluptatibus rerum corporis.</description>
+          <title>A Swiftly Tilting Planet</title>
+          <description>Id eaque excepturi animi.</description>
         </package>
-  recorded_at: Fri, 22 Jul 2022 11:55:07 GMT
+  recorded_at: Mon, 25 Jul 2022 15:48:06 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:permitted_user:Staging:A/target_package
@@ -690,7 +690,7 @@ http_interactions:
           <linkinfo project="source_project" package="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
           <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658490907"/>
         </directory>
-  recorded_at: Fri, 22 Jul 2022 11:55:07 GMT
+  recorded_at: Mon, 25 Jul 2022 15:48:06 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:permitted_user:Staging:A/target_package?view=info
@@ -724,7 +724,7 @@ http_interactions:
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="source_project" package="source_package"/>
         </sourceinfo>
-  recorded_at: Fri, 22 Jul 2022 11:55:07 GMT
+  recorded_at: Mon, 25 Jul 2022 15:48:06 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:permitted_user:Staging:A/target_package
@@ -758,7 +758,7 @@ http_interactions:
           <linkinfo project="source_project" package="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="7eae9f6b12a2579550692e1b40dfc7d6" lsrcmd5="8e451641a827df5f4f409d1d543fdb7b"/>
           <entry name="_link" md5="703fd7abfeaa0a7804702191c078ab66" size="147" mtime="1658490907"/>
         </directory>
-  recorded_at: Fri, 22 Jul 2022 11:55:07 GMT
+  recorded_at: Mon, 25 Jul 2022 15:48:06 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:permitted_user:Staging:A/target_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -781,12 +781,12 @@ http_interactions:
     headers:
       Content-Type:
       - text/xml
+      Content-Length:
+      - '348'
       Cache-Control:
       - no-cache
       Connection:
       - close
-      Content-Length:
-      - '348'
     body:
       encoding: UTF-8
       string: |
@@ -797,7 +797,7 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Fri, 22 Jul 2022 11:55:08 GMT
+  recorded_at: Mon, 25 Jul 2022 15:48:06 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:permitted_user:Staging:A/target_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -820,12 +820,12 @@ http_interactions:
     headers:
       Content-Type:
       - text/xml
+      Content-Length:
+      - '395'
       Cache-Control:
       - no-cache
       Connection:
       - close
-      Content-Length:
-      - '395'
     body:
       encoding: UTF-8
       string: |
@@ -836,7 +836,7 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Fri, 22 Jul 2022 11:55:08 GMT
+  recorded_at: Mon, 25 Jul 2022 15:48:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:permitted_user/_project/_staging_workflow?user=staging-hero
@@ -870,14 +870,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="3">
+        <revision rev="7">
           <srcmd5>1cb65454e99e97791176705d1691a126</srcmd5>
-          <time>1658490908</time>
+          <time>1658764086</time>
           <user>staging-hero</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 22 Jul 2022 11:55:08 GMT
+  recorded_at: Mon, 25 Jul 2022 15:48:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:permitted_user:Staging:A/_meta?user=staging-hero
@@ -919,7 +919,7 @@ http_interactions:
           <person userid="staging-hero" role="maintainer"/>
           <group groupid="group_1" role="maintainer"/>
         </project>
-  recorded_at: Fri, 22 Jul 2022 11:55:08 GMT
+  recorded_at: Mon, 25 Jul 2022 15:48:06 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package?expand=1
@@ -951,7 +951,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Fri, 22 Jul 2022 11:55:08 GMT
+  recorded_at: Mon, 25 Jul 2022 15:48:06 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package?expand=1
@@ -983,7 +983,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Fri, 22 Jul 2022 11:55:08 GMT
+  recorded_at: Mon, 25 Jul 2022 15:48:06 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:permitted_user:Staging:A/_result?code=unresolvable
@@ -1015,7 +1015,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Fri, 22 Jul 2022 11:55:08 GMT
+  recorded_at: Mon, 25 Jul 2022 15:48:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:permitted_user/_project/_staging_workflow?user=permitted_user
@@ -1049,14 +1049,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="4">
+        <revision rev="8">
           <srcmd5>1cb65454e99e97791176705d1691a126</srcmd5>
-          <time>1658490908</time>
+          <time>1658764086</time>
           <user>permitted_user</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 22 Jul 2022 11:55:08 GMT
+  recorded_at: Mon, 25 Jul 2022 15:48:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:permitted_user:Staging:A/_meta?user=permitted_user
@@ -1104,7 +1104,7 @@ http_interactions:
             <disable/>
           </build>
         </project>
-  recorded_at: Fri, 22 Jul 2022 11:55:08 GMT
+  recorded_at: Mon, 25 Jul 2022 15:48:06 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package?expand=1
@@ -1136,7 +1136,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Fri, 22 Jul 2022 11:55:08 GMT
+  recorded_at: Mon, 25 Jul 2022 15:48:06 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package?expand=1
@@ -1168,7 +1168,7 @@ http_interactions:
       string: |
         <directory name="source_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Fri, 22 Jul 2022 11:55:08 GMT
+  recorded_at: Mon, 25 Jul 2022 15:48:06 GMT
 - request:
     method: post
     uri: http://backend:5352/source/target_project/target_package?cmd=copy&comment=Fixes%20issue%20%2342&expand=1&keeplink=1&noservice=1&opackage=source_package&oproject=source_project&requestid=1&user=permitted_user&withacceptinfo=1
@@ -1200,16 +1200,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1" vrev="1">
+        <revision rev="9" vrev="9">
           <srcmd5>d41d8cd98f00b204e9800998ecf8427e</srcmd5>
           <version>unknown</version>
-          <time>1658490908</time>
+          <time>1658764086</time>
           <user>permitted_user</user>
           <comment>Fixes issue #42</comment>
           <requestid>1</requestid>
-          <acceptinfo rev="1" srcmd5="d41d8cd98f00b204e9800998ecf8427e" osrcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <acceptinfo rev="9" srcmd5="d41d8cd98f00b204e9800998ecf8427e" osrcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
         </revision>
-  recorded_at: Fri, 22 Jul 2022 11:55:08 GMT
+  recorded_at: Mon, 25 Jul 2022 15:48:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package/_meta?user=permitted_user
@@ -1217,8 +1217,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>Fair Stood the Wind for France</title>
-          <description>Nihil error perferendis quis.</description>
+          <title>Look to Windward</title>
+          <description>Molestiae explicabo molestias harum.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1239,15 +1239,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '175'
+      - '168'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>Fair Stood the Wind for France</title>
-          <description>Nihil error perferendis quis.</description>
+          <title>Look to Windward</title>
+          <description>Molestiae explicabo molestias harum.</description>
         </package>
-  recorded_at: Fri, 22 Jul 2022 11:55:08 GMT
+  recorded_at: Mon, 25 Jul 2022 15:48:06 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package
@@ -1277,9 +1277,9 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="target_package" rev="1" vrev="1" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <directory name="target_package" rev="9" vrev="9" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Fri, 22 Jul 2022 11:55:08 GMT
+  recorded_at: Mon, 25 Jul 2022 15:48:06 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package?view=info
@@ -1309,10 +1309,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="target_package" rev="1" vrev="1" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <sourceinfo package="target_package" rev="9" vrev="9" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
           <error>no source uploaded</error>
         </sourceinfo>
-  recorded_at: Fri, 22 Jul 2022 11:55:08 GMT
+  recorded_at: Mon, 25 Jul 2022 15:48:06 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package
@@ -1342,9 +1342,9 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="target_package" rev="1" vrev="1" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <directory name="target_package" rev="9" vrev="9" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Fri, 22 Jul 2022 11:55:08 GMT
+  recorded_at: Mon, 25 Jul 2022 15:48:06 GMT
 - request:
     method: post
     uri: http://backend:5352/source/target_project/target_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -1376,12 +1376,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="5f6ba5b116b5c2e09ac680ad128e9a9c">
+        <sourcediff key="64d8dcc3860ad0331c818dfca89a0bff">
           <old project="target_project" package="target_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="target_project" package="target_package" rev="1" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="target_project" package="target_package" rev="9" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files/>
         </sourcediff>
-  recorded_at: Fri, 22 Jul 2022 11:55:08 GMT
+  recorded_at: Mon, 25 Jul 2022 15:48:06 GMT
 - request:
     method: delete
     uri: http://backend:5352/source/home:permitted_user:Staging:A/target_package?comment&user=permitted_user
@@ -1413,5 +1413,5 @@ http_interactions:
       string: '<status code="ok" />
 
 '
-  recorded_at: Fri, 22 Jul 2022 11:55:08 GMT
+  recorded_at: Mon, 25 Jul 2022 15:48:06 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/controllers/staging/staging_projects_controller_spec.rb
+++ b/src/api/spec/controllers/staging/staging_projects_controller_spec.rb
@@ -288,7 +288,7 @@ RSpec.describe Staging::StagingProjectsController do
       end
 
       it { is_expected.to have_http_status(:bad_request) }
-      it { expect(response.body).to match('Staging project is not in state acceptable.') }
+      it { expect(response.body).to match('Staging Project is not acceptable: empty is not an acceptable state') }
 
       context 'with force parameter' do
         subject! do
@@ -297,6 +297,7 @@ RSpec.describe Staging::StagingProjectsController do
 
         it 'still fails' do
           expect(subject).to have_http_status(:bad_request)
+          expect(response.body).to match('Staging Project is not acceptable: is not in state building, failed or testing')
         end
       end
     end
@@ -340,7 +341,7 @@ RSpec.describe Staging::StagingProjectsController do
 
         it 'returns correct error' do
           subject
-          expect(response.body).to match('Staging project is not in state acceptable.')
+          expect(response.body).to match('Staging Project is not acceptable: testing is not an acceptable state')
         end
       end
     end

--- a/src/api/spec/policies/project_policy_spec.rb
+++ b/src/api/spec/policies/project_policy_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe ProjectPolicy, vcr: true do
+  subject { ProjectPolicy }
+
+  context 'staging' do
+    let(:unauthorized_user) { create(:confirmed_user, login: 'Henne') }
+    let(:staging_manager) { create(:confirmed_user, login: 'Dominique') }
+    let(:group) { create(:group, title: 'factory-staging', users: [staging_manager]) }
+    let(:code_stream_manager) { create(:confirmed_user, login: 'Rudi') }
+    let(:release_manager) do
+      release_manager = create(:confirmed_user, login: 'Max')
+      create(:relationship_project_user,
+             user: release_manager,
+             project: staging_project)
+      release_manager
+    end
+    let(:source_project) { create(:project, name: 'devel:base') }
+    let(:source_package) { create(:package_with_file, name: 'aaa_base', project: source_project) }
+    let(:target_project) { create(:project_with_package, name: 'openSUSE:Factory', package_name: 'aaa_base', maintainer: code_stream_manager) }
+    let(:staging_workflow) do
+      workflow = create(:staging_workflow, project: target_project, managers_group: group)
+      submit_request = create(:bs_request_with_submit_action, target_project: target_project,
+                                                              target_package: 'aaa_base',
+                                                              source_project: source_project.name,
+                                                              source_package: source_package.name)
+      submit_request.reviews.map { |review| review.update(state: 'accepted') }
+      submit_request.update(state: 'new')
+      workflow.staging_projects.first.staged_requests << submit_request
+
+      workflow
+    end
+    let(:staging_project) { staging_workflow.staging_projects.first }
+
+    permissions :accept? do
+      it 'deny without write access to staging project' do
+        expect(subject).not_to permit(unauthorized_user, staging_project)
+      end
+
+      it 'deny without write access to target project' do
+        expect { subject.new(release_manager, staging_project).accept? }
+          .to raise_error(an_instance_of(Pundit::NotAuthorizedError).and(having_attributes(reason: :request_state_change)))
+      end
+
+      it 'deny with approver that has no write access to target project' do
+        staging_workflow.staged_requests.map { |bs_request| bs_request.update(approver: unauthorized_user) }
+        expect { subject.new(release_manager, staging_project).accept? }
+          .to raise_error(an_instance_of(Pundit::NotAuthorizedError).and(having_attributes(reason: :request_state_change)))
+      end
+
+      it 'permit with write access to staging project and target project' do
+        create(:relationship_project_user,
+               user: code_stream_manager,
+               project: staging_project)
+        expect(subject).to permit(code_stream_manager, staging_project)
+      end
+
+      it 'permit without write access to target project and pre approved requests' do
+        staging_workflow.staged_requests.map { |bs_request| bs_request.update(approver: code_stream_manager) }
+        expect(subject).to permit(release_manager, staging_project)
+      end
+    end
+  end
+end


### PR DESCRIPTION
SLSA requires seperation of release managers and code stream managers.
Therefore release managers just approve reviews and the code stream
managers using the request approve mechanism.

As consequence the release managers have no write access anymore
in the GA projects:
 * request gets not accepted directly via staging api, just indirect
   via approve mechanism
 * modifications outside of the requests (like fiddeling with local links)
   are not allowed anymore

jsc#OBS-200