### PR TITLE
Store 'fail' status in ScmStatusReport

### DIFF
--- a/src/api/app/models/workflow_run.rb
+++ b/src/api/app/models/workflow_run.rb
@@ -46,12 +46,13 @@ class WorkflowRun < ApplicationRecord
   # Stores debug info to help figure out what went wrong when trying to save a Status in the SCM.
   # Marks the workflow run as failed also.
   def save_scm_report_failure(message, options)
-    update(status: 'fail')
+    update(status: 'fail') # set WorkflowRun status
     scm_status_reports.create(response_body: message,
-                              request_parameters: JSON.generate(options.slice(*PERMITTED_OPTIONS)))
+                              request_parameters: JSON.generate(options.slice(*PERMITTED_OPTIONS)),
+                              status: 'fail') # set ScmStatusReport status
   end
 
-  # Stores info from a succesful SCM status report
+  # Stores info from a succesful SCM status report. The default value for 'status' is 'success'.
   def save_scm_report_success(options)
     scm_status_reports.create(request_parameters: JSON.generate(options.slice(*PERMITTED_OPTIONS)))
   end

--- a/src/api/spec/models/workflow_run_spec.rb
+++ b/src/api/spec/models/workflow_run_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe WorkflowRun, vcr: true do
 
       it { expect { subject }.to change(ScmStatusReport, :count).by(1) }
       it { expect(JSON.parse(subject.request_parameters)).to include('api_endpoint' => 'https://api.github.com') }
+      it { expect(subject.status).to eq('success') }
     end
 
     context 'when providing some other keys' do
@@ -18,6 +19,7 @@ RSpec.describe WorkflowRun, vcr: true do
 
       it { expect { subject }.to change(ScmStatusReport, :count).by(1) }
       it { expect(JSON.parse(subject.request_parameters)).to be_empty }
+      it { expect(subject.status).to eq('success') }
     end
   end
 
@@ -30,6 +32,7 @@ RSpec.describe WorkflowRun, vcr: true do
       it { expect { subject }.to change(ScmStatusReport, :count).by(1) }
       it { expect(JSON.parse(subject.request_parameters)).to include('api_endpoint' => 'https://api.github.com') }
       it { expect(subject.response_body).to eql('oops it failed') }
+      it { expect(subject.status).to eq('fail') }
 
       it 'marks the workflow run as failed' do
         subject
@@ -43,6 +46,7 @@ RSpec.describe WorkflowRun, vcr: true do
       it { expect { subject }.to change(ScmStatusReport, :count).by(1) }
       it { expect(JSON.parse(subject.request_parameters)).to be_empty }
       it { expect(subject.response_body).to eql('oops it failed') }
+      it { expect(subject.status).to eq('fail') }
 
       it 'marks the workflow run as failed' do
         subject


### PR DESCRIPTION
ScmStatusReport#status can contain 'success' or 'fail' depending if OBS can report back to the SCM or not.

Even if it was impossible to report back, we were storing 'success' because it was the default value. With the current changes, we start storing 'fail' in such cases.

Fixes #12773

Co-authored-by: Daniel Donisa <daniel.donisa@suse.com>
Co-authored-by: Eduardo Navarro <enavarro@suse.com>