### PR TITLE
Send metrics about exceptions on ScmStatusReport

### DIFF
--- a/src/api/app/services/scm_exception_handler.rb
+++ b/src/api/app/services/scm_exception_handler.rb
@@ -67,5 +67,6 @@ class SCMExceptionHandler
                                               target_url: target_url
                                             }
                                           })
+    RabbitmqBus.send_to_bus('metrics', "scm_status_report,scm=#{scm},exception=#{exception} value=1")
   end
 end

--- a/src/api/app/services/scm_status_reporter.rb
+++ b/src/api/app/services/scm_status_reporter.rb
@@ -40,6 +40,8 @@ class SCMStatusReporter < SCMExceptionHandler
       @workflow_run.save_scm_report_failure("Failed to report back to GitHub: #{e.message}",
                                             request_context)
     end
+
+    RabbitmqBus.send_to_bus('metrics', "scm_status_report,scm=github,exception=#{e} value=1")
   rescue Octokit::Error, Gitlab::Error::Error => e
     rescue_with_handler(e) || raise(e)
   rescue Faraday::ConnectionFailed => e


### PR DESCRIPTION
To track the reason why OBS could not report back to the SCM.