### PR TITLE
Report exception to scm status report

### DIFF
--- a/src/api/app/services/scm_exception_handler.rb
+++ b/src/api/app/services/scm_exception_handler.rb
@@ -67,6 +67,5 @@ class SCMExceptionHandler
                                               target_url: target_url
                                             }
                                           })
-    RabbitmqBus.send_to_bus('metrics', "scm_status_report,scm=#{scm},exception=#{exception} value=1")
   end
 end

--- a/src/api/app/services/scm_status_reporter.rb
+++ b/src/api/app/services/scm_status_reporter.rb
@@ -45,7 +45,10 @@ class SCMStatusReporter < SCMExceptionHandler
   rescue Octokit::Error, Gitlab::Error::Error => e
     rescue_with_handler(e) || raise(e)
   rescue Faraday::ConnectionFailed => e
-    @workflow_run.update_as_failed("Failed to report back to GitHub: #{e.message}")
+    if @workflow_run.present?
+      @workflow_run.save_scm_report_failure("Failed to report back to GitHub: #{e.message}",
+                                            request_context)
+    end
   end
   # rubocop:enable Metrics/PerceivedComplexity
   # rubocop:enable Metrics/CyclomaticComplexity

--- a/src/api/app/services/scm_status_reporter.rb
+++ b/src/api/app/services/scm_status_reporter.rb
@@ -40,8 +40,6 @@ class SCMStatusReporter < SCMExceptionHandler
       @workflow_run.save_scm_report_failure("Failed to report back to GitHub: #{e.message}",
                                             request_context)
     end
-
-    RabbitmqBus.send_to_bus('metrics', "scm_status_report,scm=github,exception=#{e} value=1")
   rescue Octokit::Error, Gitlab::Error::Error => e
     rescue_with_handler(e) || raise(e)
   rescue Faraday::ConnectionFailed => e
@@ -49,6 +47,8 @@ class SCMStatusReporter < SCMExceptionHandler
       @workflow_run.save_scm_report_failure("Failed to report back to GitHub: #{e.message}",
                                             request_context)
     end
+  ensure
+    RabbitmqBus.send_to_bus('metrics', "scm_status_report,scm=#{@event_subscription_payload[:scm]},exception=#{e} value=1") if e.present?
   end
   # rubocop:enable Metrics/PerceivedComplexity
   # rubocop:enable Metrics/CyclomaticComplexity


### PR DESCRIPTION
One of the exceptions caught by the reporter wasn't stored in a `ScmStatusReport` but in the `WorkflowRun`.
As the exception happens when there is a network glitch between GitHub and Octokit (as mentioned in [this commit](https://github.com/openSUSE/open-build-service/commit/12108241edde4873fcd399b89db51f6726e9adaa)), I don't see why it can not be stored in the `ScmStatusReport` so I adapt the code and apply DRY to the instrumentation.