### PR TITLE
Introduces perform_active_job example setting

### DIFF
--- a/src/api/spec/support/delayed_job.rb
+++ b/src/api/spec/support/delayed_job.rb
@@ -2,7 +2,9 @@ RSpec.configure do |config|
   config.include ModelsAuthentication, type: :job
 
   # Disabling the delay on delayed jobs
-  config.before do
+  config.before(:example, :perform_active_job) do
     Delayed::Worker.delay_jobs = false
+    ActiveJob::Base.queue_adapter = :test
+    ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
   end
 end


### PR DESCRIPTION
Add this to your example if you want the ActiveJobs scheduled
in it to perform inline.

```
describe #blah, :perform_active_job do
  ...
end
```