### PR TITLE
Unify metrics for ScmStatusReport

### DIFF
--- a/src/api/app/models/workflow_run.rb
+++ b/src/api/app/models/workflow_run.rb
@@ -50,15 +50,11 @@ class WorkflowRun < ApplicationRecord
     scm_status_reports.create(response_body: message,
                               request_parameters: JSON.generate(options.slice(*PERMITTED_OPTIONS)),
                               status: 'fail') # set ScmStatusReport status
-
-    RabbitmqBus.send_to_bus('metrics', 'scm_status_report,status=fail value=1')
   end
 
   # Stores info from a succesful SCM status report. The default value for 'status' is 'success'.
   def save_scm_report_success(options)
     scm_status_reports.create(request_parameters: JSON.generate(options.slice(*PERMITTED_OPTIONS)))
-
-    RabbitmqBus.send_to_bus('metrics', 'scm_status_report,status=success value=1')
   end
 
   def payload


### PR DESCRIPTION
While working in the Grafana panels I realized the metrics I introduced previously can be unified.

From now on, I don't track the metrics inside the methods `save_scm_report_*` but right after they are called, so I can have access to the SCM and the exception and call them only once with all the needed tags.