### PR TITLE
Introduces commit_opts[:login] for delete_on_backend

### DIFF
--- a/src/api/app/models/bs_request_action_delete.rb
+++ b/src/api/app/models/bs_request_action_delete.rb
@@ -58,7 +58,9 @@ class BsRequestActionDelete < BsRequestAction
       Package.source_path(target_project, target_package)
     else
       project = Project.get_by_name(target_project)
-      project.commit_opts = { comment: bs_request.description, request: bs_request }
+      commit_opts_user = bs_request.creator if bs_request.accept_at
+      commit_opts_user = bs_request.approver if bs_request.approver
+      project.commit_opts = { comment: bs_request.description, request: bs_request, login: commit_opts_user }
       project.destroy
       "/source/#{target_project}"
     end

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -1452,7 +1452,8 @@ class Project < ApplicationRecord
   def delete_on_backend
     if CONFIG['global_write_through'] && !@commit_opts[:no_backend_write]
       begin
-        options = { user: User.session!.login, comment: @commit_opts[:comment] }
+        options = { comment: @commit_opts[:comment] }
+        options[:user] = @commit_opts[:login] || User.session!.login
         options[:requestid] = @commit_opts[:request].number if @commit_opts[:request]
         Backend::Api::Sources::Project.delete(name, options)
       rescue Backend::NotFoundError


### PR DESCRIPTION
And uses this from BsRequestActionDelete.

Before we have relied on User.run_as in BsRequest.auto_accept
to set User.session (which is a Thread/fiber-local variable).
But in an `after_commit` callback this is not working reliably.
Maybe a race or something with nested transcations or whatnot.
Couldn't figure it out...