### PR TITLE
Allow users to manage their own home project and its packages

### DIFF
--- a/src/api/spec/cassettes/Webui_PackageController/GET_revisions/with_source_access/sets_the_package.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/GET_revisions/with_source_access/sets_the_package.yml
@@ -39,17 +39,56 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:37 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:07 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_one_revision/_meta?user=tom
+    uri: http://backend:5352/source/some_dev_project123/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
-        <package name="package_with_one_revision" project="home:tom">
-          <title>Fear and Trembling</title>
-          <description>Nesciunt fugit a tempora.</description>
+        <project name="some_dev_project123">
+          <title>The Moving Finger</title>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '156'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="some_dev_project123">
+          <title>The Moving Finger</title>
+          <description></description>
+          <person userid="tom" role="maintainer"/>
+        </project>
+  recorded_at: Mon, 18 Jul 2022 09:03:07 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/some_dev_project123/package_with_one_revision/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_one_revision" project="some_dev_project123">
+          <title>Terrible Swift Sword</title>
+          <description>Ratione molestiae et quisquam.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,19 +109,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '164'
+      - '182'
     body:
       encoding: UTF-8
       string: |
-        <package name="package_with_one_revision" project="home:tom">
-          <title>Fear and Trembling</title>
-          <description>Nesciunt fugit a tempora.</description>
+        <package name="package_with_one_revision" project="some_dev_project123">
+          <title>Terrible Swift Sword</title>
+          <description>Ratione molestiae et quisquam.</description>
         </package>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:37 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:07 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_one_revision/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_one_revision/somefile.txt
     body:
       encoding: US-ASCII
       string: '0'
@@ -112,16 +150,15 @@ http_interactions:
         <revision rev="1" vrev="1">
           <srcmd5>cabf9a1f9a0b7c19d4f7ff46166f4ee0</srcmd5>
           <version>unknown</version>
-          <time>1590766597</time>
+          <time>1658134987</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:37 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:07 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:tom/package_with_one_revision
+    uri: http://backend:5352/source/some_dev_project123/package_with_one_revision
     body:
       encoding: US-ASCII
       string: ''
@@ -149,13 +186,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="package_with_one_revision" rev="1" vrev="1" srcmd5="cabf9a1f9a0b7c19d4f7ff46166f4ee0">
-          <entry name="somefile.txt" md5="cfcd208495d565ef66e7dff9f98764da" size="1" mtime="1590766355"/>
+          <entry name="somefile.txt" md5="cfcd208495d565ef66e7dff9f98764da" size="1" mtime="1658134711"/>
         </directory>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:37 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:07 GMT
 - request:
     method: delete
-    uri: http://backend:5352/source/home:tom/package_with_one_revision?comment&user=tom
+    uri: http://backend:5352/source/some_dev_project123/package_with_one_revision?comment&user=tom
     body:
       encoding: US-ASCII
       string: ''
@@ -184,6 +220,5 @@ http_interactions:
       string: '<status code="ok" />
 
 '
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:37 GMT
-recorded_with: VCR 5.1.0
+  recorded_at: Mon, 18 Jul 2022 09:03:08 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Webui_PackageController/GET_revisions/with_source_access/sets_the_project.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/GET_revisions/with_source_access/sets_the_project.yml
@@ -39,17 +39,56 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:36 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:08 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_one_revision/_meta?user=tom
+    uri: http://backend:5352/source/some_dev_project123/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
-        <package name="package_with_one_revision" project="home:tom">
-          <title>The Other Side of Silence</title>
-          <description>Atque vel sit sed.</description>
+        <project name="some_dev_project123">
+          <title>Blue Remembered Earth</title>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '160'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="some_dev_project123">
+          <title>Blue Remembered Earth</title>
+          <description></description>
+          <person userid="tom" role="maintainer"/>
+        </project>
+  recorded_at: Mon, 18 Jul 2022 09:03:08 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/some_dev_project123/package_with_one_revision/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_one_revision" project="some_dev_project123">
+          <title>Waiting for the Barbarians</title>
+          <description>Tempora aut vitae maiores.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,19 +109,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '164'
+      - '184'
     body:
       encoding: UTF-8
       string: |
-        <package name="package_with_one_revision" project="home:tom">
-          <title>The Other Side of Silence</title>
-          <description>Atque vel sit sed.</description>
+        <package name="package_with_one_revision" project="some_dev_project123">
+          <title>Waiting for the Barbarians</title>
+          <description>Tempora aut vitae maiores.</description>
         </package>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:36 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:08 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_one_revision/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_one_revision/somefile.txt
     body:
       encoding: US-ASCII
       string: '0'
@@ -109,19 +147,18 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="5" vrev="5">
+        <revision rev="1" vrev="1">
           <srcmd5>cabf9a1f9a0b7c19d4f7ff46166f4ee0</srcmd5>
           <version>unknown</version>
-          <time>1590766596</time>
+          <time>1658134988</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:36 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:08 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:tom/package_with_one_revision
+    uri: http://backend:5352/source/some_dev_project123/package_with_one_revision
     body:
       encoding: US-ASCII
       string: ''
@@ -148,14 +185,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_one_revision" rev="5" vrev="5" srcmd5="cabf9a1f9a0b7c19d4f7ff46166f4ee0">
-          <entry name="somefile.txt" md5="cfcd208495d565ef66e7dff9f98764da" size="1" mtime="1590766355"/>
+        <directory name="package_with_one_revision" rev="1" vrev="1" srcmd5="cabf9a1f9a0b7c19d4f7ff46166f4ee0">
+          <entry name="somefile.txt" md5="cfcd208495d565ef66e7dff9f98764da" size="1" mtime="1658134711"/>
         </directory>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:36 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:08 GMT
 - request:
     method: delete
-    uri: http://backend:5352/source/home:tom/package_with_one_revision?comment&user=tom
+    uri: http://backend:5352/source/some_dev_project123/package_with_one_revision?comment&user=tom
     body:
       encoding: US-ASCII
       string: ''
@@ -184,6 +220,5 @@ http_interactions:
       string: '<status code="ok" />
 
 '
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:36 GMT
-recorded_with: VCR 5.1.0
+  recorded_at: Mon, 18 Jul 2022 09:03:08 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Webui_PackageController/GET_revisions/with_source_access/when_not_passing_the_rev_parameter/and_passing_the_page_parameter/returns_the_paginated_revisions_for_the_page_parameter_s_value.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/GET_revisions/with_source_access/when_not_passing_the_rev_parameter/and_passing_the_page_parameter/returns_the_paginated_revisions_for_the_page_parameter_s_value.yml
@@ -39,17 +39,56 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:42 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:11 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_one_revision/_meta?user=tom
+    uri: http://backend:5352/source/some_dev_project123/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
-        <package name="package_with_one_revision" project="home:tom">
-          <title>If I Forget Thee Jerusalem</title>
-          <description>Tenetur voluptatibus minima earum.</description>
+        <project name="some_dev_project123">
+          <title>In Death Ground</title>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '154'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="some_dev_project123">
+          <title>In Death Ground</title>
+          <description></description>
+          <person userid="tom" role="maintainer"/>
+        </project>
+  recorded_at: Mon, 18 Jul 2022 09:03:11 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/some_dev_project123/package_with_one_revision/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_one_revision" project="some_dev_project123">
+          <title>Number the Stars</title>
+          <description>Qui vel expedita similique.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,19 +109,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '181'
+      - '175'
     body:
       encoding: UTF-8
       string: |
-        <package name="package_with_one_revision" project="home:tom">
-          <title>If I Forget Thee Jerusalem</title>
-          <description>Tenetur voluptatibus minima earum.</description>
+        <package name="package_with_one_revision" project="some_dev_project123">
+          <title>Number the Stars</title>
+          <description>Qui vel expedita similique.</description>
         </package>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:42 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:11 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_one_revision/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_one_revision/somefile.txt
     body:
       encoding: US-ASCII
       string: '0'
@@ -112,16 +150,15 @@ http_interactions:
         <revision rev="1" vrev="1">
           <srcmd5>cabf9a1f9a0b7c19d4f7ff46166f4ee0</srcmd5>
           <version>unknown</version>
-          <time>1590766602</time>
+          <time>1658134991</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:42 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:11 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:tom/package_with_one_revision
+    uri: http://backend:5352/source/some_dev_project123/package_with_one_revision
     body:
       encoding: US-ASCII
       string: ''
@@ -149,19 +186,18 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="package_with_one_revision" rev="1" vrev="1" srcmd5="cabf9a1f9a0b7c19d4f7ff46166f4ee0">
-          <entry name="somefile.txt" md5="cfcd208495d565ef66e7dff9f98764da" size="1" mtime="1590766355"/>
+          <entry name="somefile.txt" md5="cfcd208495d565ef66e7dff9f98764da" size="1" mtime="1658134711"/>
         </directory>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:42 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:11 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/_meta?user=tom
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
-        <package name="package_with_25_revisions" project="home:tom">
-          <title>Recalled to Life</title>
-          <description>Delectus eum culpa officia.</description>
+        <package name="package_with_25_revisions" project="some_dev_project123">
+          <title>The Mirror Crack'd from Side to Side</title>
+          <description>Quod aut nam sint.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -182,19 +218,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '164'
+      - '186'
     body:
       encoding: UTF-8
       string: |
-        <package name="package_with_25_revisions" project="home:tom">
-          <title>Recalled to Life</title>
-          <description>Delectus eum culpa officia.</description>
+        <package name="package_with_25_revisions" project="some_dev_project123">
+          <title>The Mirror Crack'd from Side to Side</title>
+          <description>Quod aut nam sint.</description>
         </package>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:42 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:11 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '0'
@@ -224,16 +259,15 @@ http_interactions:
         <revision rev="1" vrev="1">
           <srcmd5>cabf9a1f9a0b7c19d4f7ff46166f4ee0</srcmd5>
           <version>unknown</version>
-          <time>1590766602</time>
+          <time>1658134992</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:42 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:12 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '1'
@@ -263,16 +297,15 @@ http_interactions:
         <revision rev="2" vrev="2">
           <srcmd5>efbe5f0a5dd48df5129b4319df43aa45</srcmd5>
           <version>unknown</version>
-          <time>1590766602</time>
+          <time>1658134992</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:42 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:12 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '2'
@@ -302,16 +335,15 @@ http_interactions:
         <revision rev="3" vrev="3">
           <srcmd5>6ba292a7c75f8b46e4d39ac7cb20ebcd</srcmd5>
           <version>unknown</version>
-          <time>1590766602</time>
+          <time>1658134992</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:42 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:12 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '3'
@@ -341,16 +373,15 @@ http_interactions:
         <revision rev="4" vrev="4">
           <srcmd5>60d83e04e1adc0a7e399a5b10312faf1</srcmd5>
           <version>unknown</version>
-          <time>1590766602</time>
+          <time>1658134992</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:42 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:12 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '4'
@@ -380,16 +411,15 @@ http_interactions:
         <revision rev="5" vrev="5">
           <srcmd5>707a2e3f19f3839311f68573bb195d76</srcmd5>
           <version>unknown</version>
-          <time>1590766602</time>
+          <time>1658134992</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:42 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:12 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '5'
@@ -419,16 +449,15 @@ http_interactions:
         <revision rev="6" vrev="6">
           <srcmd5>2e1c0233c9d99ba83033d89ef12d2784</srcmd5>
           <version>unknown</version>
-          <time>1590766602</time>
+          <time>1658134992</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:42 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:12 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '6'
@@ -458,16 +487,15 @@ http_interactions:
         <revision rev="7" vrev="7">
           <srcmd5>34c36fe4cefd03ba044d562a503da90c</srcmd5>
           <version>unknown</version>
-          <time>1590766602</time>
+          <time>1658134992</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:42 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:12 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '7'
@@ -497,16 +525,15 @@ http_interactions:
         <revision rev="8" vrev="8">
           <srcmd5>98d9e947a4844aafa773b7f41ca63a2c</srcmd5>
           <version>unknown</version>
-          <time>1590766602</time>
+          <time>1658134992</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:42 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:12 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '8'
@@ -536,16 +563,15 @@ http_interactions:
         <revision rev="9" vrev="9">
           <srcmd5>4c43ef90bbe674bd39f1b63ac5eb9bb8</srcmd5>
           <version>unknown</version>
-          <time>1590766602</time>
+          <time>1658134992</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:42 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:12 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '9'
@@ -575,16 +601,15 @@ http_interactions:
         <revision rev="10" vrev="10">
           <srcmd5>7283d008aa323d5b07e2f8c3522c6c8b</srcmd5>
           <version>unknown</version>
-          <time>1590766602</time>
+          <time>1658134992</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:43 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:12 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '10'
@@ -614,16 +639,15 @@ http_interactions:
         <revision rev="11" vrev="11">
           <srcmd5>17c17e93312d5e5aa167bb78c136a1fa</srcmd5>
           <version>unknown</version>
-          <time>1590766603</time>
+          <time>1658134992</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:43 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:12 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '11'
@@ -653,16 +677,15 @@ http_interactions:
         <revision rev="12" vrev="12">
           <srcmd5>63ca1c1c9c75b3b15f69b88ce8b792d5</srcmd5>
           <version>unknown</version>
-          <time>1590766603</time>
+          <time>1658134992</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:43 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:12 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '12'
@@ -692,16 +715,15 @@ http_interactions:
         <revision rev="13" vrev="13">
           <srcmd5>30b77d193b0927cc779a2ef6f647448c</srcmd5>
           <version>unknown</version>
-          <time>1590766603</time>
+          <time>1658134992</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:43 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:12 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '13'
@@ -731,16 +753,15 @@ http_interactions:
         <revision rev="14" vrev="14">
           <srcmd5>41ef40a25c049fdf2c8b47b12d12817e</srcmd5>
           <version>unknown</version>
-          <time>1590766603</time>
+          <time>1658134992</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:43 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:12 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '14'
@@ -770,16 +791,15 @@ http_interactions:
         <revision rev="15" vrev="15">
           <srcmd5>013560d729108133227a7b0a4fc7e49a</srcmd5>
           <version>unknown</version>
-          <time>1590766603</time>
+          <time>1658134992</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:43 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:12 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '15'
@@ -809,16 +829,15 @@ http_interactions:
         <revision rev="16" vrev="16">
           <srcmd5>d60cff72a23bd84779257aff2dc7854a</srcmd5>
           <version>unknown</version>
-          <time>1590766603</time>
+          <time>1658134992</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:43 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:12 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '16'
@@ -848,16 +867,15 @@ http_interactions:
         <revision rev="17" vrev="17">
           <srcmd5>4a326cc87dbc3522a2ba7208321a6c0e</srcmd5>
           <version>unknown</version>
-          <time>1590766603</time>
+          <time>1658134992</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:43 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:12 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '17'
@@ -887,16 +905,15 @@ http_interactions:
         <revision rev="18" vrev="18">
           <srcmd5>08a3004f5d0dbd0429f0bd8a23f43d7e</srcmd5>
           <version>unknown</version>
-          <time>1590766603</time>
+          <time>1658134992</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:43 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:12 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '18'
@@ -926,16 +943,15 @@ http_interactions:
         <revision rev="19" vrev="19">
           <srcmd5>8c118c7493a3ef6113f9ed623439342a</srcmd5>
           <version>unknown</version>
-          <time>1590766603</time>
+          <time>1658134992</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:43 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:12 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '19'
@@ -965,16 +981,15 @@ http_interactions:
         <revision rev="20" vrev="20">
           <srcmd5>678488e31d48cdb0fe85149e141865a0</srcmd5>
           <version>unknown</version>
-          <time>1590766603</time>
+          <time>1658134992</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:43 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:12 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '20'
@@ -1004,16 +1019,15 @@ http_interactions:
         <revision rev="21" vrev="21">
           <srcmd5>d73dafb822a442712c7f84b1837f695e</srcmd5>
           <version>unknown</version>
-          <time>1590766603</time>
+          <time>1658134992</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:43 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:12 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '21'
@@ -1043,16 +1057,15 @@ http_interactions:
         <revision rev="22" vrev="22">
           <srcmd5>57c604a283b6334adb697c75572a6e1a</srcmd5>
           <version>unknown</version>
-          <time>1590766603</time>
+          <time>1658134992</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:43 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:12 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '22'
@@ -1082,16 +1095,15 @@ http_interactions:
         <revision rev="23" vrev="23">
           <srcmd5>e40b414cd11db9031f1298d3682a77a1</srcmd5>
           <version>unknown</version>
-          <time>1590766603</time>
+          <time>1658134992</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:43 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:12 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '23'
@@ -1121,16 +1133,15 @@ http_interactions:
         <revision rev="24" vrev="24">
           <srcmd5>c512ba6b3decfc855fc3af4f0cdc4387</srcmd5>
           <version>unknown</version>
-          <time>1590766603</time>
+          <time>1658134992</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:43 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:12 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '24'
@@ -1160,16 +1171,15 @@ http_interactions:
         <revision rev="25" vrev="25">
           <srcmd5>81a16cd46abebb5f5ec34f4ee6397d9e</srcmd5>
           <version>unknown</version>
-          <time>1590766603</time>
+          <time>1658134992</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:43 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:12 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions
     body:
       encoding: US-ASCII
       string: ''
@@ -1197,13 +1207,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="package_with_25_revisions" rev="25" vrev="25" srcmd5="81a16cd46abebb5f5ec34f4ee6397d9e">
-          <entry name="somefile.txt" md5="1ff1de774005f8da13f42943881c655f" size="2" mtime="1590766357"/>
+          <entry name="somefile.txt" md5="1ff1de774005f8da13f42943881c655f" size="2" mtime="1658134817"/>
         </directory>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:43 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:12 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions
     body:
       encoding: US-ASCII
       string: ''
@@ -1231,13 +1240,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="package_with_25_revisions" rev="25" vrev="25" srcmd5="81a16cd46abebb5f5ec34f4ee6397d9e">
-          <entry name="somefile.txt" md5="1ff1de774005f8da13f42943881c655f" size="2" mtime="1590766357"/>
+          <entry name="somefile.txt" md5="1ff1de774005f8da13f42943881c655f" size="2" mtime="1658134817"/>
         </directory>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:43 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:12 GMT
 - request:
     method: delete
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions?comment&user=tom
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions?comment&user=tom
     body:
       encoding: US-ASCII
       string: ''
@@ -1266,11 +1274,10 @@ http_interactions:
       string: '<status code="ok" />
 
 '
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:44 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:12 GMT
 - request:
     method: delete
-    uri: http://backend:5352/source/home:tom/package_with_one_revision?comment&user=tom
+    uri: http://backend:5352/source/some_dev_project123/package_with_one_revision?comment&user=tom
     body:
       encoding: US-ASCII
       string: ''
@@ -1299,6 +1306,5 @@ http_interactions:
       string: '<status code="ok" />
 
 '
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:44 GMT
-recorded_with: VCR 5.1.0
+  recorded_at: Mon, 18 Jul 2022 09:03:12 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Webui_PackageController/GET_revisions/with_source_access/when_not_passing_the_rev_parameter/and_passing_the_show_all_parameter/returns_revisions_without_pagination.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/GET_revisions/with_source_access/when_not_passing_the_rev_parameter/and_passing_the_show_all_parameter/returns_revisions_without_pagination.yml
@@ -39,17 +39,56 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:40 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:10 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_one_revision/_meta?user=tom
+    uri: http://backend:5352/source/some_dev_project123/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
-        <package name="package_with_one_revision" project="home:tom">
-          <title>Paths of Glory</title>
-          <description>Dolorem alias fugiat sapiente.</description>
+        <project name="some_dev_project123">
+          <title>The Proper Study</title>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '155'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="some_dev_project123">
+          <title>The Proper Study</title>
+          <description></description>
+          <person userid="tom" role="maintainer"/>
+        </project>
+  recorded_at: Mon, 18 Jul 2022 09:03:10 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/some_dev_project123/package_with_one_revision/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_one_revision" project="some_dev_project123">
+          <title>The Lathe of Heaven</title>
+          <description>Quos ad sit nihil.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,19 +109,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '165'
+      - '169'
     body:
       encoding: UTF-8
       string: |
-        <package name="package_with_one_revision" project="home:tom">
-          <title>Paths of Glory</title>
-          <description>Dolorem alias fugiat sapiente.</description>
+        <package name="package_with_one_revision" project="some_dev_project123">
+          <title>The Lathe of Heaven</title>
+          <description>Quos ad sit nihil.</description>
         </package>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:40 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:10 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_one_revision/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_one_revision/somefile.txt
     body:
       encoding: US-ASCII
       string: '0'
@@ -112,16 +150,15 @@ http_interactions:
         <revision rev="1" vrev="1">
           <srcmd5>cabf9a1f9a0b7c19d4f7ff46166f4ee0</srcmd5>
           <version>unknown</version>
-          <time>1590766600</time>
+          <time>1658134990</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:40 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:10 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:tom/package_with_one_revision
+    uri: http://backend:5352/source/some_dev_project123/package_with_one_revision
     body:
       encoding: US-ASCII
       string: ''
@@ -149,19 +186,18 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="package_with_one_revision" rev="1" vrev="1" srcmd5="cabf9a1f9a0b7c19d4f7ff46166f4ee0">
-          <entry name="somefile.txt" md5="cfcd208495d565ef66e7dff9f98764da" size="1" mtime="1590766355"/>
+          <entry name="somefile.txt" md5="cfcd208495d565ef66e7dff9f98764da" size="1" mtime="1658134711"/>
         </directory>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:40 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:10 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/_meta?user=tom
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
-        <package name="package_with_25_revisions" project="home:tom">
-          <title>Vanity Fair</title>
-          <description>Vitae laborum modi dicta.</description>
+        <package name="package_with_25_revisions" project="some_dev_project123">
+          <title>The Green Bay Tree</title>
+          <description>Aut deleniti sed corporis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -182,19 +218,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '157'
+      - '176'
     body:
       encoding: UTF-8
       string: |
-        <package name="package_with_25_revisions" project="home:tom">
-          <title>Vanity Fair</title>
-          <description>Vitae laborum modi dicta.</description>
+        <package name="package_with_25_revisions" project="some_dev_project123">
+          <title>The Green Bay Tree</title>
+          <description>Aut deleniti sed corporis.</description>
         </package>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:40 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:10 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '0'
@@ -224,16 +259,15 @@ http_interactions:
         <revision rev="1" vrev="1">
           <srcmd5>cabf9a1f9a0b7c19d4f7ff46166f4ee0</srcmd5>
           <version>unknown</version>
-          <time>1590766600</time>
+          <time>1658134990</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:40 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:10 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '1'
@@ -263,16 +297,15 @@ http_interactions:
         <revision rev="2" vrev="2">
           <srcmd5>efbe5f0a5dd48df5129b4319df43aa45</srcmd5>
           <version>unknown</version>
-          <time>1590766600</time>
+          <time>1658134990</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:40 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:10 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '2'
@@ -302,16 +335,15 @@ http_interactions:
         <revision rev="3" vrev="3">
           <srcmd5>6ba292a7c75f8b46e4d39ac7cb20ebcd</srcmd5>
           <version>unknown</version>
-          <time>1590766600</time>
+          <time>1658134990</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:40 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:10 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '3'
@@ -341,16 +373,15 @@ http_interactions:
         <revision rev="4" vrev="4">
           <srcmd5>60d83e04e1adc0a7e399a5b10312faf1</srcmd5>
           <version>unknown</version>
-          <time>1590766600</time>
+          <time>1658134990</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:40 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:10 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '4'
@@ -380,16 +411,15 @@ http_interactions:
         <revision rev="5" vrev="5">
           <srcmd5>707a2e3f19f3839311f68573bb195d76</srcmd5>
           <version>unknown</version>
-          <time>1590766600</time>
+          <time>1658134990</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:40 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:10 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '5'
@@ -419,16 +449,15 @@ http_interactions:
         <revision rev="6" vrev="6">
           <srcmd5>2e1c0233c9d99ba83033d89ef12d2784</srcmd5>
           <version>unknown</version>
-          <time>1590766600</time>
+          <time>1658134990</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:40 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:10 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '6'
@@ -458,16 +487,15 @@ http_interactions:
         <revision rev="7" vrev="7">
           <srcmd5>34c36fe4cefd03ba044d562a503da90c</srcmd5>
           <version>unknown</version>
-          <time>1590766600</time>
+          <time>1658134990</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:40 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:10 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '7'
@@ -497,16 +525,15 @@ http_interactions:
         <revision rev="8" vrev="8">
           <srcmd5>98d9e947a4844aafa773b7f41ca63a2c</srcmd5>
           <version>unknown</version>
-          <time>1590766600</time>
+          <time>1658134990</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:40 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:10 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '8'
@@ -536,16 +563,15 @@ http_interactions:
         <revision rev="9" vrev="9">
           <srcmd5>4c43ef90bbe674bd39f1b63ac5eb9bb8</srcmd5>
           <version>unknown</version>
-          <time>1590766600</time>
+          <time>1658134990</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:40 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:10 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '9'
@@ -575,16 +601,15 @@ http_interactions:
         <revision rev="10" vrev="10">
           <srcmd5>7283d008aa323d5b07e2f8c3522c6c8b</srcmd5>
           <version>unknown</version>
-          <time>1590766600</time>
+          <time>1658134990</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:41 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:10 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '10'
@@ -614,16 +639,15 @@ http_interactions:
         <revision rev="11" vrev="11">
           <srcmd5>17c17e93312d5e5aa167bb78c136a1fa</srcmd5>
           <version>unknown</version>
-          <time>1590766601</time>
+          <time>1658134990</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:41 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:10 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '11'
@@ -653,16 +677,15 @@ http_interactions:
         <revision rev="12" vrev="12">
           <srcmd5>63ca1c1c9c75b3b15f69b88ce8b792d5</srcmd5>
           <version>unknown</version>
-          <time>1590766601</time>
+          <time>1658134990</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:41 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:11 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '12'
@@ -692,16 +715,15 @@ http_interactions:
         <revision rev="13" vrev="13">
           <srcmd5>30b77d193b0927cc779a2ef6f647448c</srcmd5>
           <version>unknown</version>
-          <time>1590766601</time>
+          <time>1658134991</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:41 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:11 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '13'
@@ -731,16 +753,15 @@ http_interactions:
         <revision rev="14" vrev="14">
           <srcmd5>41ef40a25c049fdf2c8b47b12d12817e</srcmd5>
           <version>unknown</version>
-          <time>1590766601</time>
+          <time>1658134991</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:41 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:11 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '14'
@@ -770,16 +791,15 @@ http_interactions:
         <revision rev="15" vrev="15">
           <srcmd5>013560d729108133227a7b0a4fc7e49a</srcmd5>
           <version>unknown</version>
-          <time>1590766601</time>
+          <time>1658134991</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:41 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:11 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '15'
@@ -809,16 +829,15 @@ http_interactions:
         <revision rev="16" vrev="16">
           <srcmd5>d60cff72a23bd84779257aff2dc7854a</srcmd5>
           <version>unknown</version>
-          <time>1590766601</time>
+          <time>1658134991</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:41 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:11 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '16'
@@ -848,16 +867,15 @@ http_interactions:
         <revision rev="17" vrev="17">
           <srcmd5>4a326cc87dbc3522a2ba7208321a6c0e</srcmd5>
           <version>unknown</version>
-          <time>1590766601</time>
+          <time>1658134991</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:41 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:11 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '17'
@@ -887,16 +905,15 @@ http_interactions:
         <revision rev="18" vrev="18">
           <srcmd5>08a3004f5d0dbd0429f0bd8a23f43d7e</srcmd5>
           <version>unknown</version>
-          <time>1590766601</time>
+          <time>1658134991</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:41 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:11 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '18'
@@ -926,16 +943,15 @@ http_interactions:
         <revision rev="19" vrev="19">
           <srcmd5>8c118c7493a3ef6113f9ed623439342a</srcmd5>
           <version>unknown</version>
-          <time>1590766601</time>
+          <time>1658134991</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:41 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:11 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '19'
@@ -965,16 +981,15 @@ http_interactions:
         <revision rev="20" vrev="20">
           <srcmd5>678488e31d48cdb0fe85149e141865a0</srcmd5>
           <version>unknown</version>
-          <time>1590766601</time>
+          <time>1658134991</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:41 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:11 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '20'
@@ -1004,16 +1019,15 @@ http_interactions:
         <revision rev="21" vrev="21">
           <srcmd5>d73dafb822a442712c7f84b1837f695e</srcmd5>
           <version>unknown</version>
-          <time>1590766601</time>
+          <time>1658134991</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:41 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:11 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '21'
@@ -1043,16 +1057,15 @@ http_interactions:
         <revision rev="22" vrev="22">
           <srcmd5>57c604a283b6334adb697c75572a6e1a</srcmd5>
           <version>unknown</version>
-          <time>1590766601</time>
+          <time>1658134991</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:41 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:11 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '22'
@@ -1082,16 +1095,15 @@ http_interactions:
         <revision rev="23" vrev="23">
           <srcmd5>e40b414cd11db9031f1298d3682a77a1</srcmd5>
           <version>unknown</version>
-          <time>1590766601</time>
+          <time>1658134991</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:41 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:11 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '23'
@@ -1121,16 +1133,15 @@ http_interactions:
         <revision rev="24" vrev="24">
           <srcmd5>c512ba6b3decfc855fc3af4f0cdc4387</srcmd5>
           <version>unknown</version>
-          <time>1590766601</time>
+          <time>1658134991</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:41 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:11 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '24'
@@ -1160,16 +1171,15 @@ http_interactions:
         <revision rev="25" vrev="25">
           <srcmd5>81a16cd46abebb5f5ec34f4ee6397d9e</srcmd5>
           <version>unknown</version>
-          <time>1590766601</time>
+          <time>1658134991</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:41 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:11 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions
     body:
       encoding: US-ASCII
       string: ''
@@ -1197,13 +1207,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="package_with_25_revisions" rev="25" vrev="25" srcmd5="81a16cd46abebb5f5ec34f4ee6397d9e">
-          <entry name="somefile.txt" md5="1ff1de774005f8da13f42943881c655f" size="2" mtime="1590766357"/>
+          <entry name="somefile.txt" md5="1ff1de774005f8da13f42943881c655f" size="2" mtime="1658134817"/>
         </directory>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:41 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:11 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions
     body:
       encoding: US-ASCII
       string: ''
@@ -1231,13 +1240,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="package_with_25_revisions" rev="25" vrev="25" srcmd5="81a16cd46abebb5f5ec34f4ee6397d9e">
-          <entry name="somefile.txt" md5="1ff1de774005f8da13f42943881c655f" size="2" mtime="1590766357"/>
+          <entry name="somefile.txt" md5="1ff1de774005f8da13f42943881c655f" size="2" mtime="1658134817"/>
         </directory>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:41 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:11 GMT
 - request:
     method: delete
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions?comment&user=tom
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions?comment&user=tom
     body:
       encoding: US-ASCII
       string: ''
@@ -1266,11 +1274,10 @@ http_interactions:
       string: '<status code="ok" />
 
 '
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:42 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:11 GMT
 - request:
     method: delete
-    uri: http://backend:5352/source/home:tom/package_with_one_revision?comment&user=tom
+    uri: http://backend:5352/source/some_dev_project123/package_with_one_revision?comment&user=tom
     body:
       encoding: US-ASCII
       string: ''
@@ -1299,6 +1306,5 @@ http_interactions:
       string: '<status code="ok" />
 
 '
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:42 GMT
-recorded_with: VCR 5.1.0
+  recorded_at: Mon, 18 Jul 2022 09:03:11 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Webui_PackageController/GET_revisions/with_source_access/when_not_passing_the_rev_parameter/returns_revisions_with_the_default_pagination.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/GET_revisions/with_source_access/when_not_passing_the_rev_parameter/returns_revisions_with_the_default_pagination.yml
@@ -39,17 +39,56 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:38 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:08 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_one_revision/_meta?user=tom
+    uri: http://backend:5352/source/some_dev_project123/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
-        <package name="package_with_one_revision" project="home:tom">
-          <title>Carrion Comfort</title>
-          <description>Dolor eum est quo.</description>
+        <project name="some_dev_project123">
+          <title>By Grand Central Station I Sat Down and Wept</title>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '183'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="some_dev_project123">
+          <title>By Grand Central Station I Sat Down and Wept</title>
+          <description></description>
+          <person userid="tom" role="maintainer"/>
+        </project>
+  recorded_at: Mon, 18 Jul 2022 09:03:08 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/some_dev_project123/package_with_one_revision/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_one_revision" project="some_dev_project123">
+          <title>Let Us Now Praise Famous Men</title>
+          <description>Et itaque et aut.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,19 +109,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '154'
+      - '177'
     body:
       encoding: UTF-8
       string: |
-        <package name="package_with_one_revision" project="home:tom">
-          <title>Carrion Comfort</title>
-          <description>Dolor eum est quo.</description>
+        <package name="package_with_one_revision" project="some_dev_project123">
+          <title>Let Us Now Praise Famous Men</title>
+          <description>Et itaque et aut.</description>
         </package>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:38 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:09 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_one_revision/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_one_revision/somefile.txt
     body:
       encoding: US-ASCII
       string: '0'
@@ -112,16 +150,15 @@ http_interactions:
         <revision rev="1" vrev="1">
           <srcmd5>cabf9a1f9a0b7c19d4f7ff46166f4ee0</srcmd5>
           <version>unknown</version>
-          <time>1590766598</time>
+          <time>1658134989</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:38 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:09 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:tom/package_with_one_revision
+    uri: http://backend:5352/source/some_dev_project123/package_with_one_revision
     body:
       encoding: US-ASCII
       string: ''
@@ -149,19 +186,18 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="package_with_one_revision" rev="1" vrev="1" srcmd5="cabf9a1f9a0b7c19d4f7ff46166f4ee0">
-          <entry name="somefile.txt" md5="cfcd208495d565ef66e7dff9f98764da" size="1" mtime="1590766355"/>
+          <entry name="somefile.txt" md5="cfcd208495d565ef66e7dff9f98764da" size="1" mtime="1658134711"/>
         </directory>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:38 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:09 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/_meta?user=tom
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
-        <package name="package_with_25_revisions" project="home:tom">
-          <title>Ring of Bright Water</title>
-          <description>Incidunt nisi dolorem quis.</description>
+        <package name="package_with_25_revisions" project="some_dev_project123">
+          <title>Tirra Lirra by the River</title>
+          <description>Et ipsa eum velit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -182,19 +218,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '168'
+      - '174'
     body:
       encoding: UTF-8
       string: |
-        <package name="package_with_25_revisions" project="home:tom">
-          <title>Ring of Bright Water</title>
-          <description>Incidunt nisi dolorem quis.</description>
+        <package name="package_with_25_revisions" project="some_dev_project123">
+          <title>Tirra Lirra by the River</title>
+          <description>Et ipsa eum velit.</description>
         </package>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:38 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:09 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '0'
@@ -224,16 +259,15 @@ http_interactions:
         <revision rev="1" vrev="1">
           <srcmd5>cabf9a1f9a0b7c19d4f7ff46166f4ee0</srcmd5>
           <version>unknown</version>
-          <time>1590766598</time>
+          <time>1658134989</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:38 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:09 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '1'
@@ -263,16 +297,15 @@ http_interactions:
         <revision rev="2" vrev="2">
           <srcmd5>efbe5f0a5dd48df5129b4319df43aa45</srcmd5>
           <version>unknown</version>
-          <time>1590766598</time>
+          <time>1658134989</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:38 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:09 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '2'
@@ -302,16 +335,15 @@ http_interactions:
         <revision rev="3" vrev="3">
           <srcmd5>6ba292a7c75f8b46e4d39ac7cb20ebcd</srcmd5>
           <version>unknown</version>
-          <time>1590766598</time>
+          <time>1658134989</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:38 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:09 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '3'
@@ -341,16 +373,15 @@ http_interactions:
         <revision rev="4" vrev="4">
           <srcmd5>60d83e04e1adc0a7e399a5b10312faf1</srcmd5>
           <version>unknown</version>
-          <time>1590766598</time>
+          <time>1658134989</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:38 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:09 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '4'
@@ -380,16 +411,15 @@ http_interactions:
         <revision rev="5" vrev="5">
           <srcmd5>707a2e3f19f3839311f68573bb195d76</srcmd5>
           <version>unknown</version>
-          <time>1590766598</time>
+          <time>1658134989</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:38 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:09 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '5'
@@ -419,16 +449,15 @@ http_interactions:
         <revision rev="6" vrev="6">
           <srcmd5>2e1c0233c9d99ba83033d89ef12d2784</srcmd5>
           <version>unknown</version>
-          <time>1590766598</time>
+          <time>1658134989</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:39 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:09 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '6'
@@ -458,16 +487,15 @@ http_interactions:
         <revision rev="7" vrev="7">
           <srcmd5>34c36fe4cefd03ba044d562a503da90c</srcmd5>
           <version>unknown</version>
-          <time>1590766599</time>
+          <time>1658134989</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:39 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:09 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '7'
@@ -497,16 +525,15 @@ http_interactions:
         <revision rev="8" vrev="8">
           <srcmd5>98d9e947a4844aafa773b7f41ca63a2c</srcmd5>
           <version>unknown</version>
-          <time>1590766599</time>
+          <time>1658134989</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:39 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:09 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '8'
@@ -536,16 +563,15 @@ http_interactions:
         <revision rev="9" vrev="9">
           <srcmd5>4c43ef90bbe674bd39f1b63ac5eb9bb8</srcmd5>
           <version>unknown</version>
-          <time>1590766599</time>
+          <time>1658134989</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:39 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:09 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '9'
@@ -575,16 +601,15 @@ http_interactions:
         <revision rev="10" vrev="10">
           <srcmd5>7283d008aa323d5b07e2f8c3522c6c8b</srcmd5>
           <version>unknown</version>
-          <time>1590766599</time>
+          <time>1658134989</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:39 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:09 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '10'
@@ -614,16 +639,15 @@ http_interactions:
         <revision rev="11" vrev="11">
           <srcmd5>17c17e93312d5e5aa167bb78c136a1fa</srcmd5>
           <version>unknown</version>
-          <time>1590766599</time>
+          <time>1658134989</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:39 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:09 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '11'
@@ -653,16 +677,15 @@ http_interactions:
         <revision rev="12" vrev="12">
           <srcmd5>63ca1c1c9c75b3b15f69b88ce8b792d5</srcmd5>
           <version>unknown</version>
-          <time>1590766599</time>
+          <time>1658134989</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:39 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:09 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '12'
@@ -692,16 +715,15 @@ http_interactions:
         <revision rev="13" vrev="13">
           <srcmd5>30b77d193b0927cc779a2ef6f647448c</srcmd5>
           <version>unknown</version>
-          <time>1590766599</time>
+          <time>1658134989</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:39 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:09 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '13'
@@ -731,16 +753,15 @@ http_interactions:
         <revision rev="14" vrev="14">
           <srcmd5>41ef40a25c049fdf2c8b47b12d12817e</srcmd5>
           <version>unknown</version>
-          <time>1590766599</time>
+          <time>1658134989</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:39 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:09 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '14'
@@ -770,16 +791,15 @@ http_interactions:
         <revision rev="15" vrev="15">
           <srcmd5>013560d729108133227a7b0a4fc7e49a</srcmd5>
           <version>unknown</version>
-          <time>1590766599</time>
+          <time>1658134989</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:39 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:09 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '15'
@@ -809,16 +829,15 @@ http_interactions:
         <revision rev="16" vrev="16">
           <srcmd5>d60cff72a23bd84779257aff2dc7854a</srcmd5>
           <version>unknown</version>
-          <time>1590766599</time>
+          <time>1658134989</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:39 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:09 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '16'
@@ -848,16 +867,15 @@ http_interactions:
         <revision rev="17" vrev="17">
           <srcmd5>4a326cc87dbc3522a2ba7208321a6c0e</srcmd5>
           <version>unknown</version>
-          <time>1590766599</time>
+          <time>1658134989</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:39 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:09 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '17'
@@ -887,16 +905,15 @@ http_interactions:
         <revision rev="18" vrev="18">
           <srcmd5>08a3004f5d0dbd0429f0bd8a23f43d7e</srcmd5>
           <version>unknown</version>
-          <time>1590766599</time>
+          <time>1658134989</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:39 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:09 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '18'
@@ -926,16 +943,15 @@ http_interactions:
         <revision rev="19" vrev="19">
           <srcmd5>8c118c7493a3ef6113f9ed623439342a</srcmd5>
           <version>unknown</version>
-          <time>1590766599</time>
+          <time>1658134989</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:39 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:09 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '19'
@@ -965,16 +981,15 @@ http_interactions:
         <revision rev="20" vrev="20">
           <srcmd5>678488e31d48cdb0fe85149e141865a0</srcmd5>
           <version>unknown</version>
-          <time>1590766599</time>
+          <time>1658134989</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:39 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:09 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '20'
@@ -1004,16 +1019,15 @@ http_interactions:
         <revision rev="21" vrev="21">
           <srcmd5>d73dafb822a442712c7f84b1837f695e</srcmd5>
           <version>unknown</version>
-          <time>1590766599</time>
+          <time>1658134989</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:39 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:09 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '21'
@@ -1043,16 +1057,15 @@ http_interactions:
         <revision rev="22" vrev="22">
           <srcmd5>57c604a283b6334adb697c75572a6e1a</srcmd5>
           <version>unknown</version>
-          <time>1590766599</time>
+          <time>1658134989</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:39 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:09 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '22'
@@ -1082,16 +1095,15 @@ http_interactions:
         <revision rev="23" vrev="23">
           <srcmd5>e40b414cd11db9031f1298d3682a77a1</srcmd5>
           <version>unknown</version>
-          <time>1590766599</time>
+          <time>1658134989</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:39 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:09 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '23'
@@ -1121,16 +1133,15 @@ http_interactions:
         <revision rev="24" vrev="24">
           <srcmd5>c512ba6b3decfc855fc3af4f0cdc4387</srcmd5>
           <version>unknown</version>
-          <time>1590766599</time>
+          <time>1658134989</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:40 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:09 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions/somefile.txt
     body:
       encoding: US-ASCII
       string: '24'
@@ -1160,16 +1171,15 @@ http_interactions:
         <revision rev="25" vrev="25">
           <srcmd5>81a16cd46abebb5f5ec34f4ee6397d9e</srcmd5>
           <version>unknown</version>
-          <time>1590766600</time>
+          <time>1658134989</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:40 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:10 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions
     body:
       encoding: US-ASCII
       string: ''
@@ -1197,13 +1207,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="package_with_25_revisions" rev="25" vrev="25" srcmd5="81a16cd46abebb5f5ec34f4ee6397d9e">
-          <entry name="somefile.txt" md5="1ff1de774005f8da13f42943881c655f" size="2" mtime="1590766357"/>
+          <entry name="somefile.txt" md5="1ff1de774005f8da13f42943881c655f" size="2" mtime="1658134817"/>
         </directory>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:40 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:10 GMT
 - request:
     method: delete
-    uri: http://backend:5352/source/home:tom/package_with_25_revisions?comment&user=tom
+    uri: http://backend:5352/source/some_dev_project123/package_with_25_revisions?comment&user=tom
     body:
       encoding: US-ASCII
       string: ''
@@ -1232,11 +1241,10 @@ http_interactions:
       string: '<status code="ok" />
 
 '
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:40 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:10 GMT
 - request:
     method: delete
-    uri: http://backend:5352/source/home:tom/package_with_one_revision?comment&user=tom
+    uri: http://backend:5352/source/some_dev_project123/package_with_one_revision?comment&user=tom
     body:
       encoding: US-ASCII
       string: ''
@@ -1265,6 +1273,5 @@ http_interactions:
       string: '<status code="ok" />
 
 '
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:40 GMT
-recorded_with: VCR 5.1.0
+  recorded_at: Mon, 18 Jul 2022 09:03:10 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Webui_PackageController/GET_revisions/with_source_access/when_passing_the_rev_parameter/and_passing_the_page_parameter/returns_the_paginated_revisions_for_the_page_parameter_s_value.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/GET_revisions/with_source_access/when_passing_the_rev_parameter/and_passing_the_page_parameter/returns_the_paginated_revisions_for_the_page_parameter_s_value.yml
@@ -39,17 +39,56 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:37 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:13 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_one_revision/_meta?user=tom
+    uri: http://backend:5352/source/some_dev_project123/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
-        <package name="package_with_one_revision" project="home:tom">
-          <title>Blithe Spirit</title>
-          <description>Aliquam maiores consequatur tempora.</description>
+        <project name="some_dev_project123">
+          <title>Edna O'Brien</title>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '151'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="some_dev_project123">
+          <title>Edna O'Brien</title>
+          <description></description>
+          <person userid="tom" role="maintainer"/>
+        </project>
+  recorded_at: Mon, 18 Jul 2022 09:03:14 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/some_dev_project123/package_with_one_revision/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_one_revision" project="some_dev_project123">
+          <title>Tirra Lirra by the River</title>
+          <description>Blanditiis nemo explicabo culpa.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,19 +109,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '170'
+      - '188'
     body:
       encoding: UTF-8
       string: |
-        <package name="package_with_one_revision" project="home:tom">
-          <title>Blithe Spirit</title>
-          <description>Aliquam maiores consequatur tempora.</description>
+        <package name="package_with_one_revision" project="some_dev_project123">
+          <title>Tirra Lirra by the River</title>
+          <description>Blanditiis nemo explicabo culpa.</description>
         </package>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:37 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:14 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_one_revision/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_one_revision/somefile.txt
     body:
       encoding: US-ASCII
       string: '0'
@@ -112,16 +150,15 @@ http_interactions:
         <revision rev="1" vrev="1">
           <srcmd5>cabf9a1f9a0b7c19d4f7ff46166f4ee0</srcmd5>
           <version>unknown</version>
-          <time>1590766597</time>
+          <time>1658134994</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:37 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:14 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:tom/package_with_one_revision
+    uri: http://backend:5352/source/some_dev_project123/package_with_one_revision
     body:
       encoding: US-ASCII
       string: ''
@@ -149,13 +186,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="package_with_one_revision" rev="1" vrev="1" srcmd5="cabf9a1f9a0b7c19d4f7ff46166f4ee0">
-          <entry name="somefile.txt" md5="cfcd208495d565ef66e7dff9f98764da" size="1" mtime="1590766355"/>
+          <entry name="somefile.txt" md5="cfcd208495d565ef66e7dff9f98764da" size="1" mtime="1658134711"/>
         </directory>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:37 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:14 GMT
 - request:
     method: delete
-    uri: http://backend:5352/source/home:tom/package_with_one_revision?comment&user=tom
+    uri: http://backend:5352/source/some_dev_project123/package_with_one_revision?comment&user=tom
     body:
       encoding: US-ASCII
       string: ''
@@ -184,6 +220,5 @@ http_interactions:
       string: '<status code="ok" />
 
 '
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:37 GMT
-recorded_with: VCR 5.1.0
+  recorded_at: Mon, 18 Jul 2022 09:03:14 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Webui_PackageController/GET_revisions/with_source_access/when_passing_the_rev_parameter/and_passing_the_show_all_parameter/returns_revisions_up_to_rev_parameter_s_value_without_pagination.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/GET_revisions/with_source_access/when_passing_the_rev_parameter/and_passing_the_show_all_parameter/returns_revisions_up_to_rev_parameter_s_value_without_pagination.yml
@@ -39,17 +39,56 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:38 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:14 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_one_revision/_meta?user=tom
+    uri: http://backend:5352/source/some_dev_project123/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
-        <package name="package_with_one_revision" project="home:tom">
-          <title>That Good Night</title>
-          <description>Dignissimos pariatur dolor laudantium.</description>
+        <project name="some_dev_project123">
+          <title>Jacob Have I Loved</title>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '157'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="some_dev_project123">
+          <title>Jacob Have I Loved</title>
+          <description></description>
+          <person userid="tom" role="maintainer"/>
+        </project>
+  recorded_at: Mon, 18 Jul 2022 09:03:14 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/some_dev_project123/package_with_one_revision/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_one_revision" project="some_dev_project123">
+          <title>No Longer at Ease</title>
+          <description>Est tempore quibusdam cum.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,19 +109,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '174'
+      - '175'
     body:
       encoding: UTF-8
       string: |
-        <package name="package_with_one_revision" project="home:tom">
-          <title>That Good Night</title>
-          <description>Dignissimos pariatur dolor laudantium.</description>
+        <package name="package_with_one_revision" project="some_dev_project123">
+          <title>No Longer at Ease</title>
+          <description>Est tempore quibusdam cum.</description>
         </package>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:38 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:14 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_one_revision/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_one_revision/somefile.txt
     body:
       encoding: US-ASCII
       string: '0'
@@ -112,16 +150,15 @@ http_interactions:
         <revision rev="1" vrev="1">
           <srcmd5>cabf9a1f9a0b7c19d4f7ff46166f4ee0</srcmd5>
           <version>unknown</version>
-          <time>1590766598</time>
+          <time>1658134994</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:38 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:14 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:tom/package_with_one_revision
+    uri: http://backend:5352/source/some_dev_project123/package_with_one_revision
     body:
       encoding: US-ASCII
       string: ''
@@ -149,13 +186,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="package_with_one_revision" rev="1" vrev="1" srcmd5="cabf9a1f9a0b7c19d4f7ff46166f4ee0">
-          <entry name="somefile.txt" md5="cfcd208495d565ef66e7dff9f98764da" size="1" mtime="1590766355"/>
+          <entry name="somefile.txt" md5="cfcd208495d565ef66e7dff9f98764da" size="1" mtime="1658134711"/>
         </directory>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:38 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:14 GMT
 - request:
     method: delete
-    uri: http://backend:5352/source/home:tom/package_with_one_revision?comment&user=tom
+    uri: http://backend:5352/source/some_dev_project123/package_with_one_revision?comment&user=tom
     body:
       encoding: US-ASCII
       string: ''
@@ -184,6 +220,5 @@ http_interactions:
       string: '<status code="ok" />
 
 '
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:38 GMT
-recorded_with: VCR 5.1.0
+  recorded_at: Mon, 18 Jul 2022 09:03:15 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Webui_PackageController/GET_revisions/with_source_access/when_passing_the_rev_parameter/returns_revisions_up_to_rev_parameter_s_value_with_the_default_pagination.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/GET_revisions/with_source_access/when_passing_the_rev_parameter/returns_revisions_up_to_rev_parameter_s_value_with_the_default_pagination.yml
@@ -39,17 +39,56 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:37 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:13 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_one_revision/_meta?user=tom
+    uri: http://backend:5352/source/some_dev_project123/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
-        <package name="package_with_one_revision" project="home:tom">
-          <title>Look to Windward</title>
-          <description>Quas et fugit a.</description>
+        <project name="some_dev_project123">
+          <title>Death Be Not Proud</title>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '157'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="some_dev_project123">
+          <title>Death Be Not Proud</title>
+          <description></description>
+          <person userid="tom" role="maintainer"/>
+        </project>
+  recorded_at: Mon, 18 Jul 2022 09:03:13 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/some_dev_project123/package_with_one_revision/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_one_revision" project="some_dev_project123">
+          <title>Butter In a Lordly Dish</title>
+          <description>Repudiandae suscipit qui aut.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,19 +109,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '153'
+      - '184'
     body:
       encoding: UTF-8
       string: |
-        <package name="package_with_one_revision" project="home:tom">
-          <title>Look to Windward</title>
-          <description>Quas et fugit a.</description>
+        <package name="package_with_one_revision" project="some_dev_project123">
+          <title>Butter In a Lordly Dish</title>
+          <description>Repudiandae suscipit qui aut.</description>
         </package>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:37 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:13 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_one_revision/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_one_revision/somefile.txt
     body:
       encoding: US-ASCII
       string: '0'
@@ -112,16 +150,15 @@ http_interactions:
         <revision rev="1" vrev="1">
           <srcmd5>cabf9a1f9a0b7c19d4f7ff46166f4ee0</srcmd5>
           <version>unknown</version>
-          <time>1590766597</time>
+          <time>1658134993</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:37 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:13 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:tom/package_with_one_revision
+    uri: http://backend:5352/source/some_dev_project123/package_with_one_revision
     body:
       encoding: US-ASCII
       string: ''
@@ -149,13 +186,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="package_with_one_revision" rev="1" vrev="1" srcmd5="cabf9a1f9a0b7c19d4f7ff46166f4ee0">
-          <entry name="somefile.txt" md5="cfcd208495d565ef66e7dff9f98764da" size="1" mtime="1590766355"/>
+          <entry name="somefile.txt" md5="cfcd208495d565ef66e7dff9f98764da" size="1" mtime="1658134711"/>
         </directory>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:37 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:13 GMT
 - request:
     method: delete
-    uri: http://backend:5352/source/home:tom/package_with_one_revision?comment&user=tom
+    uri: http://backend:5352/source/some_dev_project123/package_with_one_revision?comment&user=tom
     body:
       encoding: US-ASCII
       string: ''
@@ -184,6 +220,5 @@ http_interactions:
       string: '<status code="ok" />
 
 '
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:37 GMT
-recorded_with: VCR 5.1.0
+  recorded_at: Mon, 18 Jul 2022 09:03:13 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Webui_PackageController/GET_revisions/without_source_access/1_6_1_1.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/GET_revisions/without_source_access/1_6_1_1.yml
@@ -39,17 +39,56 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:36 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:16 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_one_revision/_meta?user=tom
+    uri: http://backend:5352/source/some_dev_project123/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
-        <package name="package_with_one_revision" project="home:tom">
-          <title>A Time of Gifts</title>
-          <description>Est inventore dolores error.</description>
+        <project name="some_dev_project123">
+          <title>An Instant In The Wind</title>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '161'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="some_dev_project123">
+          <title>An Instant In The Wind</title>
+          <description></description>
+          <person userid="tom" role="maintainer"/>
+        </project>
+  recorded_at: Mon, 18 Jul 2022 09:03:16 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/some_dev_project123/package_with_one_revision/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_one_revision" project="some_dev_project123">
+          <title>Gone with the Wind</title>
+          <description>Porro quia necessitatibus ullam.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,19 +109,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '164'
+      - '182'
     body:
       encoding: UTF-8
       string: |
-        <package name="package_with_one_revision" project="home:tom">
-          <title>A Time of Gifts</title>
-          <description>Est inventore dolores error.</description>
+        <package name="package_with_one_revision" project="some_dev_project123">
+          <title>Gone with the Wind</title>
+          <description>Porro quia necessitatibus ullam.</description>
         </package>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:36 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:16 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_one_revision/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_one_revision/somefile.txt
     body:
       encoding: US-ASCII
       string: '0'
@@ -109,25 +147,24 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="4" vrev="4">
+        <revision rev="2" vrev="2">
           <srcmd5>cabf9a1f9a0b7c19d4f7ff46166f4ee0</srcmd5>
           <version>unknown</version>
-          <time>1590766596</time>
+          <time>1658134996</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:36 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:16 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_one_revision/_meta?user=tom
+    uri: http://backend:5352/source/some_dev_project123/package_with_one_revision/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
-        <package name="package_with_one_revision" project="home:tom">
-          <title>A Time of Gifts</title>
-          <description>Est inventore dolores error.</description>
+        <package name="package_with_one_revision" project="some_dev_project123">
+          <title>Gone with the Wind</title>
+          <description>Porro quia necessitatibus ullam.</description>
           <sourceaccess>
             <disable/>
           </sourceaccess>
@@ -151,17 +188,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '214'
+      - '232'
     body:
       encoding: UTF-8
       string: |
-        <package name="package_with_one_revision" project="home:tom">
-          <title>A Time of Gifts</title>
-          <description>Est inventore dolores error.</description>
+        <package name="package_with_one_revision" project="some_dev_project123">
+          <title>Gone with the Wind</title>
+          <description>Porro quia necessitatibus ullam.</description>
           <sourceaccess>
             <disable/>
           </sourceaccess>
         </package>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:36 GMT
-recorded_with: VCR 5.1.0
+  recorded_at: Mon, 18 Jul 2022 09:03:16 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Webui_PackageController/GET_revisions/without_source_access/1_6_1_2.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/GET_revisions/without_source_access/1_6_1_2.yml
@@ -39,17 +39,56 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:35 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:15 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_one_revision/_meta?user=tom
+    uri: http://backend:5352/source/some_dev_project123/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
-        <package name="package_with_one_revision" project="home:tom">
-          <title>In a Dry Season</title>
-          <description>Eveniet sunt itaque sit.</description>
+        <project name="some_dev_project123">
+          <title>Consider the Lilies</title>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '158'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="some_dev_project123">
+          <title>Consider the Lilies</title>
+          <description></description>
+          <person userid="tom" role="maintainer"/>
+        </project>
+  recorded_at: Mon, 18 Jul 2022 09:03:15 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/some_dev_project123/package_with_one_revision/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_one_revision" project="some_dev_project123">
+          <title>A Glass of Blessings</title>
+          <description>Enim consequuntur repellat fuga.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,19 +109,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '160'
+      - '184'
     body:
       encoding: UTF-8
       string: |
-        <package name="package_with_one_revision" project="home:tom">
-          <title>In a Dry Season</title>
-          <description>Eveniet sunt itaque sit.</description>
+        <package name="package_with_one_revision" project="some_dev_project123">
+          <title>A Glass of Blessings</title>
+          <description>Enim consequuntur repellat fuga.</description>
         </package>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:35 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:15 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_one_revision/somefile.txt
+    uri: http://backend:5352/source/some_dev_project123/package_with_one_revision/somefile.txt
     body:
       encoding: US-ASCII
       string: '0'
@@ -109,25 +147,24 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="3" vrev="3">
+        <revision rev="1" vrev="1">
           <srcmd5>cabf9a1f9a0b7c19d4f7ff46166f4ee0</srcmd5>
           <version>unknown</version>
-          <time>1590766595</time>
+          <time>1658134995</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:35 GMT
+  recorded_at: Mon, 18 Jul 2022 09:03:15 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_one_revision/_meta?user=tom
+    uri: http://backend:5352/source/some_dev_project123/package_with_one_revision/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
-        <package name="package_with_one_revision" project="home:tom">
-          <title>In a Dry Season</title>
-          <description>Eveniet sunt itaque sit.</description>
+        <package name="package_with_one_revision" project="some_dev_project123">
+          <title>A Glass of Blessings</title>
+          <description>Enim consequuntur repellat fuga.</description>
           <sourceaccess>
             <disable/>
           </sourceaccess>
@@ -151,17 +188,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '210'
+      - '234'
     body:
       encoding: UTF-8
       string: |
-        <package name="package_with_one_revision" project="home:tom">
-          <title>In a Dry Season</title>
-          <description>Eveniet sunt itaque sit.</description>
+        <package name="package_with_one_revision" project="some_dev_project123">
+          <title>A Glass of Blessings</title>
+          <description>Enim consequuntur repellat fuga.</description>
           <sourceaccess>
             <disable/>
           </sourceaccess>
         </package>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:36:35 GMT
-recorded_with: VCR 5.1.0
+  recorded_at: Mon, 18 Jul 2022 09:03:15 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/controllers/webui/package_controller_spec.rb
+++ b/src/api/spec/controllers/webui/package_controller_spec.rb
@@ -264,7 +264,8 @@ RSpec.describe Webui::PackageController, vcr: true do
   end
 
   describe 'GET #revisions' do
-    let(:package) { create(:package_with_revisions, name: 'package_with_one_revision', revision_count: 1, project: source_project) }
+    let(:project) { create(:project, maintainer: user, name: 'some_dev_project123') }
+    let(:package) { create(:package_with_revisions, name: 'package_with_one_revision', revision_count: 1, project: project) }
     let(:elided_package_name) { 'package_w...revision' }
 
     before do
@@ -275,16 +276,16 @@ RSpec.describe Webui::PackageController, vcr: true do
       before do
         package.add_flag('sourceaccess', 'disable')
         package.save
-        get :revisions, params: { project: source_project, package: package }
+        get :revisions, params: { project: project, package: package }
       end
 
       it { expect(flash[:error]).to eq("You don't have access to the sources of this package: \"#{elided_package_name}\"") }
-      it { expect(response).to redirect_to(project_show_path(project: source_project.name)) }
+      it { expect(response).to redirect_to(project_show_path(project: project.name)) }
     end
 
     context 'with source access' do
       before do
-        get :revisions, params: { project: source_project, package: package }
+        get :revisions, params: { project: project, package: package }
       end
 
       after do
@@ -293,7 +294,7 @@ RSpec.describe Webui::PackageController, vcr: true do
       end
 
       it 'sets the project' do
-        expect(assigns(:project)).to eq(source_project)
+        expect(assigns(:project)).to eq(project)
       end
 
       it 'sets the package' do
@@ -301,11 +302,11 @@ RSpec.describe Webui::PackageController, vcr: true do
       end
 
       context 'when not passing the rev parameter' do
-        let(:package_with_revisions) { create(:package_with_revisions, name: "package_with_#{revision_count}_revisions", revision_count: revision_count, project: source_project) }
+        let(:package_with_revisions) { create(:package_with_revisions, name: "package_with_#{revision_count}_revisions", revision_count: revision_count, project: project) }
         let(:revision_count) { 25 }
 
         before do
-          get :revisions, params: { project: source_project, package: package_with_revisions }
+          get :revisions, params: { project: project, package: package_with_revisions }
         end
 
         after do
@@ -319,7 +320,7 @@ RSpec.describe Webui::PackageController, vcr: true do
 
         context 'and passing the show_all parameter' do
           before do
-            get :revisions, params: { project: source_project, package: package_with_revisions, show_all: 1 }
+            get :revisions, params: { project: project, package: package_with_revisions, show_all: 1 }
           end
 
           it 'returns revisions without pagination' do
@@ -329,7 +330,7 @@ RSpec.describe Webui::PackageController, vcr: true do
 
         context 'and passing the page parameter' do
           before do
-            get :revisions, params: { project: source_project, package: package_with_revisions, page: 2 }
+            get :revisions, params: { project: project, package: package_with_revisions, page: 2 }
           end
 
           it "returns the paginated revisions for the page parameter's value" do
@@ -340,7 +341,7 @@ RSpec.describe Webui::PackageController, vcr: true do
 
       context 'when passing the rev parameter' do
         before do
-          get :revisions, params: { project: source_project, package: package, rev: param_rev }
+          get :revisions, params: { project: project, package: package, rev: param_rev }
         end
 
         let(:param_rev) { 23 }
@@ -351,7 +352,7 @@ RSpec.describe Webui::PackageController, vcr: true do
 
         context 'and passing the show_all parameter' do
           before do
-            get :revisions, params: { project: source_project, package: package, rev: param_rev, show_all: 1 }
+            get :revisions, params: { project: project, package: package, rev: param_rev, show_all: 1 }
           end
 
           it "returns revisions up to rev parameter's value without pagination" do
@@ -361,7 +362,7 @@ RSpec.describe Webui::PackageController, vcr: true do
 
         context 'and passing the page parameter' do
           before do
-            get :revisions, params: { project: source_project, package: package, rev: param_rev, page: 2 }
+            get :revisions, params: { project: project, package: package, rev: param_rev, page: 2 }
           end
 
           it "returns the paginated revisions for the page parameter's value" do


### PR DESCRIPTION
This is needed since users sometimes remove themselves from the maintainers of their own home project. It should have never been possible in the first place for users to do this, but here we are. It was quite confusing to users since they could still see the `Create Package` or `Add User` actions, but they were never authorized to do those actions. They should have been able to do them though. This is now addressed.

For now, we can help users by applying this fix. This code from the custom authorization system is called in Pundit, so both authorization systems (custom and Pundit) are covered.

Another important change here is that nothing can prevent a user from managing their home project or a package in their home project. As an example, it was previously possible to prevent users from accessing the source of their home project by setting `sourceaccess` to `disable` in the local permissions.

Fixes #10067

--- For reviewers

_First scenario: Add yourself back_

1. Log in as a non-admin user (username: _Iggy_ / password: _buildservice_)
2. Go to your home project's users page
3. Remove yourself from the list of users
4. Add yourself back (it works with the changes from this PR, but not without them)

_Second scenario: Create packages/subprojects in your home project, while you aren't listed as a user of your home project_

1. Log in as a non-admin user (username: _Iggy_ / password: _buildservice_)
2. Go to your home project's users page
3. Remove yourself from the list of users
4. Create a package and a subproject in your home project (it works with the changes from this PR, but not without them)