### PR TITLE
Temporarily comment out ScmInitialStatusReporter calls

### DIFF
--- a/src/api/app/models/token/workflow.rb
+++ b/src/api/app/models/token/workflow.rb
@@ -31,9 +31,9 @@ class Token::Workflow < Token
     return validation_errors unless validation_errors.none?
 
     # This is just an initial generic report to give a feedback asap. Initial status pending
-    ScmInitialStatusReporter.new(@scm_webhook.payload, @scm_webhook.payload, scm_token, workflow_run).call
+    # ScmInitialStatusReporter.new(@scm_webhook.payload, @scm_webhook.payload, scm_token, workflow_run).call
     @workflows.each(&:call)
-    ScmInitialStatusReporter.new(@scm_webhook.payload, @scm_webhook.payload, scm_token, workflow_run, 'success').call
+    # ScmInitialStatusReporter.new(@scm_webhook.payload, @scm_webhook.payload, scm_token, workflow_run, 'success').call
 
     # Always returning validation errors to report them back to the SCM in order to help users debug their workflows
     validation_errors

--- a/src/api/spec/models/token/workflow_spec.rb
+++ b/src/api/spec/models/token/workflow_spec.rb
@@ -100,10 +100,10 @@ RSpec.describe Token::Workflow do
 
       it { expect { subject }.to change(workflow_token, :triggered_at) & change(workflow_run, :response_url).to('https://api.github.com') }
 
-      it do
-        subject
-        expect(ScmInitialStatusReporter).to have_received(:new).twice
-      end
+      # it do
+      #   subject
+      #   expect(ScmInitialStatusReporter).to have_received(:new).twice
+      # end
     end
 
     context 'with validation errors' do


### PR DESCRIPTION
This class is broken after merging #12646. To not block deployments, we disable this feature which isn't really critical. The other SCM reports for builds are still working as expected.

Once #12809 is merged, this change will be reverted.