### PR TITLE
Unify rescue from Pundit::NotAuthorizedError

### DIFF
--- a/src/api/app/controllers/application_controller.rb
+++ b/src/api/app/controllers/application_controller.rb
@@ -12,6 +12,7 @@ class ApplicationController < ActionController::Base
   include FlipperFeature
 
   include RescueHandler
+  include RescueAuthorizationHandler
   include SetCurrentRequestDetails
 
   # session :disabled => true

--- a/src/api/app/controllers/concerns/rescue_authorization_handler.rb
+++ b/src/api/app/controllers/concerns/rescue_authorization_handler.rb
@@ -44,7 +44,7 @@ module RescueAuthorizationHandler
       when :anonymous_user
         'Please login to access the resource'
       else
-        "Sorry, you are not authorized to #{action_for_exception(exception)} this #{ActiveSupport::Inflector.underscore(exception.record.class.to_s).humanize}."
+        "Sorry, you are not authorized to #{action_for_exception(exception)} this #{ActiveSupport::Inflector.underscore(exception.record.class.to_s).humanize(capitalize: false)}."
       end
     end
 

--- a/src/api/app/controllers/concerns/rescue_authorization_handler.rb
+++ b/src/api/app/controllers/concerns/rescue_authorization_handler.rb
@@ -1,0 +1,63 @@
+module RescueAuthorizationHandler
+  extend ActiveSupport::Concern
+
+  included do # rubocop:disable Metrics/BlockLength
+    rescue_from Pundit::NotAuthorizedError do |exception|
+      if RoutesHelper::APIMatcher.matches?(request)
+        render_error status: 403,
+                     errorcode: authorization_errorcode(exception),
+                     message: authorization_message(exception)
+      else
+        respond_to do |format|
+          format.js { render json: { error: authorization_message(exception) }, status: 400 }
+          format.any do
+            flash[:error] = authorization_message(exception)
+            redirect_path = unauthorized_redirect_path(exception)
+            if redirect_path
+              redirect_to(redirect_path)
+            else
+              redirect_back(fallback_location: root_path)
+            end
+          end
+        end
+      end
+    end
+
+    private
+
+    def action_for_exception(exception)
+      case exception.query.to_s.chop
+      when 'index' then 'list'
+      when 'show' then 'view'
+      when 'new' then 'create'
+      when 'destroy' then 'delete'
+      else exception.query.to_s.chop
+      end
+    end
+
+    def authorization_errorcode(exception)
+      "#{action_for_exception(exception)}_#{ActiveSupport::Inflector.underscore(exception.record.class.to_s)}_not_authorized"
+    end
+
+    def authorization_message(exception)
+      case exception.reason
+      when :anonymous_user
+        'Please login to access the resource'
+      else
+        "Sorry, you are not authorized to #{action_for_exception(exception)} this #{ActiveSupport::Inflector.underscore(exception.record.class.to_s).humanize}."
+      end
+    end
+
+    def unauthorized_redirect_path(exception)
+      case exception.reason
+      when :anonymous_user
+        mode = CONFIG['proxy_auth_mode'] || :off
+        if mode == :off
+          new_session_path
+        else
+          root_path
+        end
+      end
+    end
+  end
+end

--- a/src/api/app/controllers/concerns/rescue_handler.rb
+++ b/src/api/app/controllers/concerns/rescue_handler.rb
@@ -46,29 +46,5 @@ module RescueHandler
     rescue_from Backend::NotFoundError, ActiveRecord::RecordNotFound do |exception|
       render_error message: exception.message, status: 404, errorcode: 'not_found'
     end
-
-    rescue_from Pundit::NotAuthorizedError do |exception|
-      message = 'You are not authorized to perform this action.'
-
-      pundit_action =
-        case exception.try(:query).to_s
-        when 'index?' then 'list'
-        when 'show?' then 'view'
-        when 'create?', 'new?' then 'create'
-        when 'update?' then 'update'
-        when 'edit?' then 'edit'
-        when 'destroy?' then 'delete'
-        when 'create_branch?' then 'create_branch'
-        when 'accept?' then 'accept'
-        when 'trigger?' then 'trigger'
-        else exception.try(:query)
-        end
-
-      message = "You are not authorized to #{pundit_action} this #{ActiveSupport::Inflector.underscore(exception.record.class.to_s).humanize}." if pundit_action && exception.record
-
-      render_error status: 403,
-                   errorcode: "#{pundit_action}_#{ActiveSupport::Inflector.underscore(exception.record.class.to_s)}_not_authorized",
-                   message: message
-    end
   end
 end

--- a/src/api/app/controllers/concerns/webui/rescue_handler.rb
+++ b/src/api/app/controllers/concerns/webui/rescue_handler.rb
@@ -2,22 +2,6 @@ module Webui::RescueHandler
   extend ActiveSupport::Concern
 
   included do
-    rescue_from Pundit::NotAuthorizedError do |exception|
-      message = unauthorized_message(exception)
-      redirect_path = unauthorized_path(exception)
-
-      if request.xhr?
-        render json: { error: message }, status: 400
-      else
-        flash[:error] = message
-        if redirect_path
-          redirect_to(redirect_path)
-        else
-          redirect_back(fallback_location: root_path)
-        end
-      end
-    end
-
     rescue_from Backend::Error, Timeout::Error do |exception|
       Airbrake.notify(exception)
       message = case exception
@@ -42,55 +26,6 @@ module Webui::RescueHandler
     rescue_from MissingParameterError do |exception|
       logger.debug "#{exception.class.name} #{exception.message} #{exception.backtrace.join('\n')}"
       render file: Rails.public_path.join('404'), status: 404, layout: false, formats: [:html]
-    end
-
-    private
-
-    UNAUTHORIZED_MESSAGE = 'Sorry, you are not authorized to perform this action.'.freeze
-    def unauthorized_message(exception)
-      pundit_action = action_for_query(exception.query)
-
-      if exception.reason
-        message_for_reason(exception.reason)
-      elsif pundit_action && exception.record
-        "Sorry, you are not authorized to #{pundit_action} this #{exception.record.class}."
-      else
-        UNAUTHORIZED_MESSAGE
-      end
-    end
-
-    def action_for_query(query) # rubocop:disable Metrics/CyclomaticComplexity
-      case query.to_s
-      when 'index?' then 'list'
-      when 'show?' then 'view'
-      when 'create?', 'new?' then 'create'
-      when 'update?' then 'update'
-      when 'edit?' then 'edit'
-      when 'destroy?' then 'delete'
-      when 'create_branch?' then 'create_branch'
-      else query
-      end
-    end
-
-    def message_for_reason(reason)
-      case reason
-      when ApplicationPolicy::ANONYMOUS_USER
-        request.xhr? ? 'Please login' : 'Please login to access the requested page.'
-      else
-        UNAUTHORIZED_MESSAGE
-      end
-    end
-
-    def unauthorized_path(exception)
-      case exception.reason
-      when :anonymous_user
-        mode = CONFIG['proxy_auth_mode'] || :off
-        if mode == :off
-          new_session_path
-        else
-          root_path
-        end
-      end
     end
   end
 end

--- a/src/api/app/controllers/webui/groups_controller.rb
+++ b/src/api/app/controllers/webui/groups_controller.rb
@@ -4,20 +4,20 @@ class Webui::GroupsController < Webui::WebuiController
   after_action :verify_authorized, except: [:show, :autocomplete]
 
   def index
-    authorize Group, :index?
+    authorize Group.new, :index?
     @groups = Group.all.includes(:users)
   end
 
   def show; end
 
   def new
-    authorize Group, :create?
+    authorize Group.new, :create?
   end
 
   def create
-    authorize Group, :create?
-
     group = Group.new(title: group_params[:title])
+    authorize group, :create?
+
     if group.save && group.replace_members(group_params[:members])
       flash[:success] = "Group '#{group}' successfully created."
       redirect_to controller: :groups, action: :index

--- a/src/api/app/controllers/webui/packages/branches_controller.rb
+++ b/src/api/app/controllers/webui/packages/branches_controller.rb
@@ -84,7 +84,7 @@ module Webui
         flash[:notice] = 'You have already branched this package'
         redirect_to(package_show_path(project: e.project, package: e.package))
       rescue CreateProjectNoPermission
-        flash[:error] = 'Sorry, you are not authorized to create this Project.'
+        flash[:error] = 'Sorry, you are not authorized to create this project.'
         redirect_back(fallback_location: root_path)
       rescue ArgumentError, Package::UnknownObjectError, Project::UnknownObjectError, APIError, ActiveRecord::RecordInvalid => e
         flash[:error] = "Failed to branch: #{e.message}"

--- a/src/api/spec/controllers/webui/download_on_demand_controller_spec.rb
+++ b/src/api/spec/controllers/webui/download_on_demand_controller_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Webui::DownloadOnDemandController do
       end
 
       it { is_expected.to redirect_to(root_path) }
-      it { expect(flash[:error]).to eq('Sorry, you are not authorized to create this Download repository.') }
+      it { expect(flash[:error]).to eq('Sorry, you are not authorized to create this download repository.') }
       it { expect(DownloadRepository.where(dod_parameters[:download_repository])).not_to exist }
     end
 
@@ -85,7 +85,7 @@ RSpec.describe Webui::DownloadOnDemandController do
       end
 
       it { is_expected.to redirect_to(root_path) }
-      it { expect(flash[:error]).to eq('Sorry, you are not authorized to delete this Download repository.') }
+      it { expect(flash[:error]).to eq('Sorry, you are not authorized to delete this download repository.') }
       it { expect(DownloadRepository.where(id: dod_repository.id)).to exist }
     end
 
@@ -127,7 +127,7 @@ RSpec.describe Webui::DownloadOnDemandController do
       end
 
       it { is_expected.to redirect_to(root_path) }
-      it { expect(flash[:error]).to eq('Sorry, you are not authorized to update this Download repository.') }
+      it { expect(flash[:error]).to eq('Sorry, you are not authorized to update this download repository.') }
 
       it 'updates the DownloadRepository' do
         expect(dod_repository.url).to eq('http://suse.com')

--- a/src/api/spec/controllers/webui/download_on_demand_controller_spec.rb
+++ b/src/api/spec/controllers/webui/download_on_demand_controller_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Webui::DownloadOnDemandController do
       end
 
       it { is_expected.to redirect_to(root_path) }
-      it { expect(flash[:error]).to eq('Sorry, you are not authorized to create this DownloadRepository.') }
+      it { expect(flash[:error]).to eq('Sorry, you are not authorized to create this Download repository.') }
       it { expect(DownloadRepository.where(dod_parameters[:download_repository])).not_to exist }
     end
 
@@ -85,7 +85,7 @@ RSpec.describe Webui::DownloadOnDemandController do
       end
 
       it { is_expected.to redirect_to(root_path) }
-      it { expect(flash[:error]).to eq('Sorry, you are not authorized to delete this DownloadRepository.') }
+      it { expect(flash[:error]).to eq('Sorry, you are not authorized to delete this Download repository.') }
       it { expect(DownloadRepository.where(id: dod_repository.id)).to exist }
     end
 
@@ -127,7 +127,7 @@ RSpec.describe Webui::DownloadOnDemandController do
       end
 
       it { is_expected.to redirect_to(root_path) }
-      it { expect(flash[:error]).to eq('Sorry, you are not authorized to update this DownloadRepository.') }
+      it { expect(flash[:error]).to eq('Sorry, you are not authorized to update this Download repository.') }
 
       it 'updates the DownloadRepository' do
         expect(dod_repository.url).to eq('http://suse.com')

--- a/src/api/spec/controllers/webui/groups_controller_spec.rb
+++ b/src/api/spec/controllers/webui/groups_controller_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Webui::GroupsController do
       it 'does not allow to create a group' do
         post :create, params: { group: { title: group.title, members: users_to_add.map(&:login).join(',') } }
 
-        expect(flash[:error]).to eq('Sorry, you are not authorized to create this Class.')
+        expect(flash[:error]).to eq('Sorry, you are not authorized to create this group.')
       end
     end
 

--- a/src/api/spec/controllers/webui/package_controller_spec.rb
+++ b/src/api/spec/controllers/webui/package_controller_spec.rb
@@ -1128,7 +1128,7 @@ RSpec.describe Webui::PackageController, vcr: true do
 
       before do
         login(user)
-        get :edit, params: { project: admins_home_project, package: package_from_admin }, format: :js
+        get :edit, params: { project: admins_home_project, package: package_from_admin }
       end
 
       it { expect(response).to redirect_to(root_path) }
@@ -1183,8 +1183,7 @@ RSpec.describe Webui::PackageController, vcr: true do
               project: admins_home_project,
               package_details: package_params,
               package: package_from_admin.name
-            },
-            format: :js
+            }
     end
 
     it { expect(response).to redirect_to(root_path) }

--- a/src/api/spec/controllers/webui/package_controller_spec.rb
+++ b/src/api/spec/controllers/webui/package_controller_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Webui::PackageController, vcr: true do
       it 'does not allow other users than the owner to delete a package' do
         post :remove, params: { project: target_project, package: target_package }
 
-        expect(flash[:error]).to eq('Sorry, you are not authorized to delete this Package.')
+        expect(flash[:error]).to eq('Sorry, you are not authorized to delete this package.')
         expect(target_project.packages).not_to be_empty
       end
 
@@ -258,7 +258,7 @@ RSpec.describe Webui::PackageController, vcr: true do
         remove_file_post
       end
 
-      it { expect(flash[:error]).to eq('Sorry, you are not authorized to update this Package.') }
+      it { expect(flash[:error]).to eq('Sorry, you are not authorized to update this package.') }
       it { expect(Package.where(name: 'my_package')).to exist }
     end
   end
@@ -413,7 +413,7 @@ RSpec.describe Webui::PackageController, vcr: true do
       end
 
       it { expect(a_request(:post, post_url)).not_to have_been_made }
-      it { expect(flash[:error]).to eq('Sorry, you are not authorized to update this Package.') }
+      it { expect(flash[:error]).to eq('Sorry, you are not authorized to update this package.') }
       it { is_expected.to redirect_to(root_path) }
     end
   end
@@ -1103,7 +1103,7 @@ RSpec.describe Webui::PackageController, vcr: true do
         let(:my_user) { create(:confirmed_user, login: 'another_user') }
 
         it { expect(response).to redirect_to(root_path) }
-        it { expect(flash[:error]).to eq('Sorry, you are not authorized to create this Package.') }
+        it { expect(flash[:error]).to eq('Sorry, you are not authorized to create this package.') }
       end
     end
   end

--- a/src/api/spec/controllers/webui/packages/branches_controller_spec.rb
+++ b/src/api/spec/controllers/webui/packages/branches_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Webui::Packages::BranchesController, vcr: true do
 
     it 'shows an error if user has no permissions for source project' do
       post :create, params: { linked_project: source_project, linked_package: source_package, target_project: 'home:admin:nope' }
-      expect(flash[:error]).to eq('Sorry, you are not authorized to create this Project.')
+      expect(flash[:error]).to eq('Sorry, you are not authorized to create this project.')
       expect(response).to redirect_to(root_path)
     end
 

--- a/src/api/spec/controllers/webui/patchinfo_controller_spec.rb
+++ b/src/api/spec/controllers/webui/patchinfo_controller_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Webui::PatchinfoController, vcr: true do
       end
 
       it { expect(response).to have_http_status(:redirect) }
-      it { expect(flash[:error]).to eq('Sorry, you are not authorized to update this Project.') }
+      it { expect(flash[:error]).to eq('Sorry, you are not authorized to update this project.') }
     end
 
     context 'when it fails to create the patchinfo package' do

--- a/src/api/spec/controllers/webui/project_controller_spec.rb
+++ b/src/api/spec/controllers/webui/project_controller_spec.rb
@@ -624,7 +624,7 @@ RSpec.describe Webui::ProjectController, vcr: true do
 
     context "with a user that can't create attributes" do
       before do
-        post :edit_comment, params: { project: user.home_project, package: package, text: text, last_comment: 'Last comment', format: 'js' }
+        post :edit_comment, params: { project: user.home_project, package: package, text: text, last_comment: 'Last comment' }
       end
 
       it { expect(response).to redirect_to(new_session_path) }

--- a/src/api/spec/controllers/webui/projects/project_configuration_controller_spec.rb
+++ b/src/api/spec/controllers/webui/projects/project_configuration_controller_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Webui::Projects::ProjectConfigurationController, vcr: true do
         post :update, params: { project_name: another_project.name, config: 'save config' }
       end
 
-      it { expect(flash[:error]).to eq('Sorry, you are not authorized to update this Project.') }
+      it { expect(flash[:error]).to eq('Sorry, you are not authorized to update this project.') }
       it { expect(response.status).to eq(302) }
       it { expect(response).to redirect_to(root_path) }
     end

--- a/src/api/spec/controllers/webui/repositories_controller_spec.rb
+++ b/src/api/spec/controllers/webui/repositories_controller_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe Webui::RepositoriesController, vcr: true do
                                        }
         end
 
-        it { expect(response.body).to eq('{"error":"Sorry, you are not authorized to create this Download repository."}') }
+        it { expect(response.body).to eq('{"error":"Sorry, you are not authorized to create this download repository."}') }
       end
     end
 

--- a/src/api/spec/controllers/webui/repositories_controller_spec.rb
+++ b/src/api/spec/controllers/webui/repositories_controller_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe Webui::RepositoriesController, vcr: true do
                                        }
         end
 
-        it { expect(response.body).to eq('{"error":"Sorry, you are not authorized to create this DownloadRepository."}') }
+        it { expect(response.body).to eq('{"error":"Sorry, you are not authorized to create this Download repository."}') }
       end
     end
 

--- a/src/api/spec/controllers/webui/staging/projects_controller_spec.rb
+++ b/src/api/spec/controllers/webui/staging/projects_controller_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Webui::Staging::ProjectsController do
       end
 
       it { expect(Project.where(name: 'Apache')).not_to exist }
-      it { expect(flash[:error]).to eq('Sorry, you are not authorized to create this Project.') }
+      it { expect(flash[:error]).to eq('Sorry, you are not authorized to create this project.') }
       it { expect(CreateProjectLogEntryJob).not_to have_been_enqueued }
     end
 

--- a/src/api/spec/controllers/webui/users_controller_spec.rb
+++ b/src/api/spec/controllers/webui/users_controller_spec.rb
@@ -425,7 +425,7 @@ RSpec.describe Webui::UsersController do
 
       it 'shows an error message' do
         expect(controller).to set_flash[:error]
-        expect(flash[:error]).to eq('Please login to access the requested page.')
+        expect(flash[:error]).to eq('Please login to access the resource')
       end
     end
   end

--- a/src/api/spec/controllers/webui/webui_controller_spec.rb
+++ b/src/api/spec/controllers/webui/webui_controller_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Webui::WebuiController do
     it 'redirects to main page for new users' do
       get :show, params: { id: 1 }
       expect(response).to redirect_to(new_session_path)
-      expect(flash[:error]).to eq('Please login to access the requested page.')
+      expect(flash[:error]).to eq('Please login to access the resource')
     end
 
     it 'does not redirect for a confirmed user' do

--- a/src/api/spec/features/webui/attributes_spec.rb
+++ b/src/api/spec/features/webui/attributes_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'Attributes', type: :feature, js: true do
         click_link('Add Attribute')
         find('select#attrib_attrib_type_id').select('OBS:VeryImportantProject')
         click_button('Add')
-        expect(page).to have_content('Sorry, you are not authorized to create this Attrib.')
+        expect(page).to have_content('Sorry, you are not authorized to create this attrib.')
       end
     end
   end

--- a/src/api/spec/features/webui/packages_spec.rb
+++ b/src/api/spec/features/webui/packages_spec.rb
@@ -369,7 +369,7 @@ RSpec.describe 'Packages', type: :feature, js: true, vcr: true do
         login other_user
         visit new_package_path(project: global_project)
 
-        expect(page).to have_text('Sorry, you are not authorized to create this Package')
+        expect(page).to have_text('Sorry, you are not authorized to create this package')
         expect(page).to have_current_path(root_path, ignore_query: true)
       end
 

--- a/src/api/test/functional/request_controller_test.rb
+++ b/src/api/test/functional/request_controller_test.rb
@@ -902,7 +902,7 @@ class RequestControllerTest < ActionDispatch::IntegrationTest
     post '/request?cmd=create', params: format(req_template, approver: 'fred')
     assert_response 403
     assert_xml_tag(tag: 'status', attributes: { code: 'create_bs_request_not_authorized' })
-    assert_xml_tag(tag: 'summary', content: 'Sorry, you are not authorized to create this Bs request.')
+    assert_xml_tag(tag: 'summary', content: 'Sorry, you are not authorized to create this bs request.')
 
     # request creation succeeds because we are "Iggy"
     post '/request?cmd=create', params: format(req_template, approver: 'Iggy')

--- a/src/api/test/functional/request_controller_test.rb
+++ b/src/api/test/functional/request_controller_test.rb
@@ -902,7 +902,7 @@ class RequestControllerTest < ActionDispatch::IntegrationTest
     post '/request?cmd=create', params: format(req_template, approver: 'fred')
     assert_response 403
     assert_xml_tag(tag: 'status', attributes: { code: 'create_bs_request_not_authorized' })
-    assert_xml_tag(tag: 'summary', content: 'You are not authorized to create this Bs request.')
+    assert_xml_tag(tag: 'summary', content: 'Sorry, you are not authorized to create this Bs request.')
 
     # request creation succeeds because we are "Iggy"
     post '/request?cmd=create', params: format(req_template, approver: 'Iggy')


### PR DESCRIPTION
So you can use `Pundit::NotAuthorizedError.reason` also in the API.
We need that because we have many actions that do not only check
permissions but also processability.