### PR TITLE
Send only exception class name to metrics

### DIFF
--- a/src/api/app/services/github_status_reporter.rb
+++ b/src/api/app/services/github_status_reporter.rb
@@ -37,7 +37,7 @@ class GithubStatusReporter < SCMExceptionHandler
   rescue Faraday::ConnectionFailed => e
     @workflow_run.save_scm_report_failure("Failed to report back to GitHub: #{e.message}", request_context) if @workflow_run.present?
   ensure
-    RabbitmqBus.send_to_bus('metrics', "scm_status_report,status=fail,scm=#{@event_subscription_payload[:scm]},exception=#{e} value=1") if e.present? && @workflow_run.present?
+    RabbitmqBus.send_to_bus('metrics', "scm_status_report,status=fail,scm=#{@event_subscription_payload[:scm]},exception=#{e.class} value=1") if e.present? && @workflow_run.present?
   end
   # rubocop:enable Metrics/PerceivedComplexity
   # rubocop:enable Metrics/CyclomaticComplexity

--- a/src/api/app/services/gitlab_status_reporter.rb
+++ b/src/api/app/services/gitlab_status_reporter.rb
@@ -22,7 +22,7 @@ class GitlabStatusReporter < SCMExceptionHandler
     end
   rescue Gitlab::Error::Error => e
     rescue_with_handler(e) || raise(e)
-    RabbitmqBus.send_to_bus('metrics', "scm_status_report,status=fail,scm=#{@event_subscription_payload[:scm]},exception=#{e} value=1") if @workflow_run.present?
+    RabbitmqBus.send_to_bus('metrics', "scm_status_report,status=fail,scm=#{@event_subscription_payload[:scm]},exception=#{e.class} value=1") if @workflow_run.present?
   end
 
   def self.scm_final_state(event_type)


### PR DESCRIPTION
I introduced this line to send metrics for exceptions related to the SCM status report:
```
RabbitmqBus.send_to_bus('metrics', "scm_status_report,status=fail,scm=#{@event_subscription_payload[:scm]},exception=#{e} value=1")
```

I wrongly assumed the interpolation (or #to_s) of an Exception object returned its class name. The examples I tested confirmed my assumptions. However, in production we are getting something like this:

```
telegraf_1  | 2022-07-18T06:39:47Z E! [inputs.amqp_consumer] Error in plugin: metric parse error: expected field at 1:68: "scm_status_report,status=fail,scm=gitlab,exception=Server responded with code 403, message: 403 Forbidden. Request URI: https://gitlab.com/api/v4/projects/37880292/statuses/e20492f88e82c193879ec532868e21f2a6067ca8 value=1"
```

The reason is that the interpolation (or #to_s) of an Exception object returns the exception message, if any, otherwise the class name. That's clear in the documentation https://ruby-doc.org/core-3.1.2/Exception.html#method-i-to_s

So, I use `e.class` from now on.