### PR TITLE
[api] sanities permission check

### DIFF
--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -622,7 +622,8 @@ class SourceController < ApplicationController
     project_name = params[:project]
 
     @project = Project.find_by_name(project_name)
-    raise CmdExecutionNoPermission, "no permission to execute command 'copy'" unless (@project && User.session!.can_modify?(@project)) || User.session!.can_create_project?(project_name)
+    raise CmdExecutionNoPermission, "no permission to execute command 'copy'" unless (@project && User.session!.can_modify?(@project)) ||
+                                                                                     (@project.nil? && User.session!.can_create_project?(project_name))
 
     oprj = Project.get_by_name(params[:oproject], includeallpackages: 1)
     if params.key?(:makeolder) || params.key?(:makeoriginolder)


### PR DESCRIPTION
only because you can not write to project (may exist and be locked) it does not mean
you can create it when you have write access on the upper level.