### PR TITLE
Downgrade nokogiri from 1.13.7 back to 1.13.6

### DIFF
--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -247,7 +247,7 @@ GEM
     mousetrap-rails (1.4.6)
     mysql2 (0.5.2)
     nio4r (2.5.8)
-    nokogiri (1.13.7)
+    nokogiri (1.13.6)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     parallel (1.17.0)


### PR DESCRIPTION
This PR removes the need to upgrade nokogiri in #12801. That nokogiri upgrade requires ruby version >= 2.6.0 on [the 2.10 build](https://build.opensuse.org/package/show/OBS:Server:2.10:Staging/obs-server) and we don't want to upgrade ruby right now.