### PR TITLE
[backend] support sending of a large number of obscpio files

### DIFF
--- a/src/backend/BSCpio.pm
+++ b/src/backend/BSCpio.pm
@@ -79,8 +79,14 @@ sub openentfile {
   my ($ent, $file, $s, $follow) = @_;
   my $name = $ent->{'name'};
   my $fd;
-  if (ref($file)) {
-    $fd = $file;
+  my $type = ref($file);
+  if ($type) {
+    if ($type eq 'CODE') {
+      $fd = $file->();
+      die("$name: open: $!\n") unless $fd;
+    } else {
+      $fd = $file;
+    }
   } else {
     @$s = lstat($file);
     return (undef, "$name: $file: $!\n") unless @$s;

--- a/src/backend/BSSrcrep.pm
+++ b/src/backend/BSSrcrep.pm
@@ -115,13 +115,17 @@ sub filesha256 {
 # small helper to build cpio requests
 sub cpiofile {
   my ($projid, $packid, $filename, $md5, $forcehandle) = @_;
-  if ($forcehandle || $filename =~ /\.obscpio$/s) {
+  if ($forcehandle) {
     my $fd = gensym;
     if (!fileopen($projid, $packid, $filename, $md5, $fd)) {
       return {'name' => $filename, 'error' => "fileopen $md5: $!"};
     } else {
       return {'name' => $filename, 'filename' => $fd};
     }
+  }
+  if ($filename =~ /\.obscpio$/s) {
+    return {'name' => $filename, 'error' => "fileopen $md5: $!"} unless -e "$srcrep/$packid/$md5-$filename";
+    return {'name' => $filename, 'filename' => sub { my $fd = gensym; return fileopen($projid, $packid, $filename, $md5, $fd) ? $fd : undef}};
   }
   return {'name' => $filename, 'filename' => filepath($projid, $packid, $filename, $md5)};
 }

--- a/src/backend/BSTar.pm
+++ b/src/backend/BSTar.pm
@@ -179,8 +179,14 @@ sub writetar {
     my $f;
     if (exists $ent->{'file'}) {
       my $file = $ent->{'file'};
-      if (ref($file)) {
-        $f = $file;
+      my $type = ref($file);
+      if ($type) {
+        if ($type eq 'CODE') {
+	  $f = $file->();
+	  die("$file: open: $!\n") unless $f;
+	} else {
+          $f = $file;
+	}
       } else {
         @s = lstat($file);
         die("$file: $!\n") unless @s;


### PR DESCRIPTION
We used to pre-open obscpio files if we are building a cpio list.
This has the disadvantage that we run into the filesystem limit
if we need to send a large number of obscpio files.

This commit adds support for passing a function reference as
file handle to BSCpio and BSTar. We use this to lazily open
obscpio files from the source repository.