### PR TITLE
Simplify require_request method in Webui::RequestController

### DIFF
--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -288,12 +288,7 @@ class Webui::RequestController < Webui::WebuiController
   end
 
   def require_request
-    required_parameters :number
-    @bs_request = BsRequest.find_by_number(params[:number])
-    return if @bs_request
-
-    flash[:error] = "Can't find request #{params[:number]}"
-    redirect_back(fallback_location: root_url) && return
+    @bs_request = BsRequest.find_by!(number: params[:number])
   end
 
   def target_package_maintainers

--- a/src/api/config/brakeman.ignore
+++ b/src/api/config/brakeman.ignore
@@ -63,6 +63,26 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
+      "fingerprint": "425cc6614ece3076fd4dee2f72c0dea417e7ee2b20962f48eaaed13d7f22d82f",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/controllers/webui/request_controller.rb",
+      "line": 168,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "Delayed::Job.where(\"handler LIKE '%job_class: BsRequestActionWebuiInfosJob%#{BsRequestAction.find(BsRequest.find_by!(:number => params[:number]).webui_actions(:filelimit => ((0 or nil)), :tarlimit => ((0 or nil)), :diff_to_superseded => BsRequest.find_by!(:number => params[:number]).superseding.find_by(:number => params[:diff_to_superseded]), :diffs => true, :action_id => params[\"id\"].to_i, :cacheonly => 1).find do\n (action[:id] == params[\"id\"].to_i)\n end[:id]).to_global_id.uri}%'\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Webui::RequestController",
+        "method": "request_action"
+      },
+      "user_input": "BsRequestAction.find(BsRequest.find_by!(:number => params[:number]).webui_actions(:filelimit => ((0 or nil)), :tarlimit => ((0 or nil)), :diff_to_superseded => BsRequest.find_by!(:number => params[:number]).superseding.find_by(:number => params[:diff_to_superseded]), :diffs => true, :action_id => params[\"id\"].to_i, :cacheonly => 1).find do\n (action[:id] == params[\"id\"].to_i)\n end[:id]).to_global_id",
+      "confidence": "Medium",
+      "note": "Passing a hash to find_by! is safe as the hash values are escaped."
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
       "fingerprint": "45840f44547aeced1506343b80e3fe0ad1b6262ae3799e5086907ff71bddb03c",
       "check_name": "SQL",
       "message": "Possible SQL injection",
@@ -98,26 +118,6 @@
       },
       "user_input": "union_query",
       "confidence": "Weak",
-      "note": ""
-    },
-    {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
-      "fingerprint": "5bfd5e36955af7d64f99b0af2cca1319b332c7a14d6c06eba2d75ccb65842b9a",
-      "check_name": "SQL",
-      "message": "Possible SQL injection",
-      "file": "app/controllers/webui/request_controller.rb",
-      "line": 154,
-      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "Delayed::Job.where(\"handler LIKE '%job_class: BsRequestActionWebuiInfosJob%#{BsRequestAction.find(BsRequest.find_by_number(params[:number]).webui_actions(:filelimit => ((0 or nil)), :tarlimit => ((0 or nil)), :diff_to_superseded => BsRequest.find_by_number(params[:number]).superseding.find_by(:number => params[:diff_to_superseded]), :diffs => true, :action_id => params[\"id\"].to_i, :cacheonly => 1).find do\n (action[:id] == params[\"id\"].to_i)\n end[:id]).to_global_id.uri}%'\")",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Webui::RequestController",
-        "method": "request_action"
-      },
-      "user_input": "BsRequestAction.find(BsRequest.find_by_number(params[:number]).webui_actions(:filelimit => ((0 or nil)), :tarlimit => ((0 or nil)), :diff_to_superseded => BsRequest.find_by_number(params[:number]).superseding.find_by(:number => params[:diff_to_superseded]), :diffs => true, :action_id => params[\"id\"].to_i, :cacheonly => 1).find do\n (action[:id] == params[\"id\"].to_i)\n end[:id]).to_global_id",
-      "confidence": "Medium",
       "note": ""
     },
     {
@@ -208,7 +208,7 @@
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/controllers/source_controller.rb",
-      "line": 452,
+      "line": 456,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "@project.lock(params[:comment])",
       "render_path": null,
@@ -299,7 +299,7 @@
       "check_name": "RegexDoS",
       "message": "Model attribute used in regular expression",
       "file": "app/models/binary_release.rb",
-      "line": 93,
+      "line": 84,
       "link": "https://brakemanscanner.org/docs/warning_types/denial_of_service/",
       "code": "/^#{Package.striping_multibuild_suffix(binary[\"package\"])}:/",
       "render_path": null,
@@ -389,6 +389,6 @@
       "note": "All fields are quoted, so this is safe."
     }
   ],
-  "updated": "2021-10-22 16:26:51 +0200",
+  "updated": "2022-07-25 15:04:59 +0000",
   "brakeman_version": "5.1.1"
 }

--- a/src/api/spec/controllers/webui/request_controller_spec.rb
+++ b/src/api/spec/controllers/webui/request_controller_spec.rb
@@ -48,15 +48,6 @@ RSpec.describe Webui::RequestController, vcr: true do
       end
     end
 
-    context 'if request does not exist' do
-      before do
-        get :show, params: { number: '200000' }
-      end
-
-      it { expect(flash[:error]).to eq("Can't find request 200000") }
-      it { expect(response).to redirect_to(root_url) }
-    end
-
     context 'when there are package maintainers' do
       # The hint will only be shown, when the target package has at least one
       # maintainer. So we'll gonna add a maintainer to the target package.
@@ -313,17 +304,6 @@ RSpec.describe Webui::RequestController, vcr: true do
                                          description: 'blah blah blah' }
         end.to change(BsRequest, :count).by(1)
         expect(BsRequest.last.bs_request_actions).to eq(devel_package.project.target_of_bs_request_actions)
-      end
-    end
-
-    context 'with invalid parameters' do
-      before do
-        login(receiver)
-        post :changerequest, params: { number: 1899, accepted: 'accepted' }
-      end
-
-      it 'without request' do
-        expect(flash[:error]).to eq('Can\'t find request 1899')
       end
     end
 


### PR DESCRIPTION
`require_request` is used in a before_filter callback for `changerequest`, `show` and `request_action` actions. The request number has to be passed in the [show](https://github.com/openSUSE/open-build-service/blob/9dbda912de8d0a62aa135f11a7255b00bbb66ca0/src/api/config/routes/webui_routes.rb#L291) and [request_action](https://github.com/openSUSE/open-build-service/blob/9dbda912de8d0a62aa135f11a7255b00bbb66ca0/src/api/config/routes/webui_routes.rb#L297) routes, so it's impossible to not have `number` in the `params`. As for `changerequest`, the request number is also passed in the `params` via a [hidden field](https://github.com/openSUSE/open-build-service/blob/349e41e8a177cd9094d4af8715ebe554f384b28f/src/api/app/views/webui/request/_decision_tab.html.haml#L2) when the form is submitted. So unless a user changes the HTML, it's always going to be there. And if this happens, there's nothing we can do.

This explains why relying on required_parameters and all this custom code is not needed. We can instead do it the Rails way and rely on `find_by!`, which raises `ActiveRecord::RecordNotFound` if the request isn't found, then the controller responds with 404.