### PR TITLE
Do not overwrite dynamic finder find_by_number! for BsRequest

### DIFF
--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -57,8 +57,8 @@ class Webui::RequestController < Webui::WebuiController
       request.addreview(opts)
     rescue BsRequestPermissionCheck::AddReviewNotPermitted
       flash[:error] = "Not permitted to add a review to '#{params[:number]}'"
-    rescue ActiveRecord::RecordInvalid, APIError => e
-      flash[:error] = "Unable add review to '#{params[:number]}': #{e.message}"
+    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotFound, APIError => e
+      flash[:error] = "Unable to add review to request with id '#{params[:number]}': #{e.message}"
     end
     redirect_to controller: :request, action: 'show', number: params[:number]
   end

--- a/src/api/app/controllers/webui/requests/submissions_controller.rb
+++ b/src/api/app/controllers/webui/requests/submissions_controller.rb
@@ -54,6 +54,8 @@ module Webui
                                  superseded_by: @bs_request.number)
         rescue APIError => e
           supersede_errors << e.message.to_s
+        rescue ActiveRecord::RecordNotFound
+          supersede_errors << "Couldn't find request with id '#{request_number}'"
         end
 
         return if supersede_errors.empty?

--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -107,18 +107,6 @@ class BsRequest < ApplicationRecord
     end
   end
 
-  def self.find_by_number!(number)
-    # overload for propper error reporting
-    r = BsRequest.find_by_number(number)
-    unless r
-      # the external visible request id is stored in number row.
-      # the database id must not be exposed to the outside
-      raise NotFoundError, "Couldn't find request with id '#{number}'"
-    end
-
-    r
-  end
-
   def self.list(opts)
     # All types means don't pass 'type'
     opts.delete(:types) if [opts[:types]].flatten.include?('all')

--- a/src/api/spec/features/webui/requests_spec.rb
+++ b/src/api/spec/features/webui/requests_spec.rb
@@ -278,7 +278,7 @@ RSpec.describe 'Bootstrap_Requests', type: :feature, js: true, vcr: true do
         find(:id, 'review_type').select('Project')
         fill_in 'review_project', with: 'INVALID/PROJECT'
         click_button('Accept')
-        expect(page).to have_css('#flash', text: 'Unable add review to')
+        expect(page).to have_css('#flash', text: 'Unable to add review to request')
       end
     end
 

--- a/src/api/test/functional/request_controller_test.rb
+++ b/src/api/test/functional/request_controller_test.rb
@@ -2335,7 +2335,7 @@ class RequestControllerTest < ActionDispatch::IntegrationTest
     assert_match(/review state change for group test_group is not permitted for Iggy/, @response.body)
     post '/request/987654321?cmd=changereviewstate&newstate=accepted&by_group=test_group'
     assert_response 404
-    assert_match(/Couldn't find request with id '987654321'/, @response.body)
+    assert_match(/Couldn't find BsRequest/, @response.body)
 
     # Only partly matching by_ arguments
     login_adrian


### PR DESCRIPTION
It's confusing any developer who's used to the built-in dynamic finders for ActiveRecord models. If we want a custom exception message for BsRequest#number, we can still do it without overwriting `find_by_number!`.