### PR TITLE
Set horizontal scrolling in request redesign

### DIFF
--- a/src/api/app/assets/stylesheets/webui/tabs.scss
+++ b/src/api/app/assets/stylesheets/webui/tabs.scss
@@ -1,5 +1,6 @@
 // Scrollable tabs
 
+// When the scrollable tabs are formed  by div and many a.
 .scrollable-tabs {
   overflow: auto;
   white-space: nowrap;
@@ -10,6 +11,25 @@
     padding: 0.5rem 1rem;
     text-align: center;
     &.active {
+      font-weight: 600;
+      border: 1px solid;
+      border-color: $gray-300;
+      border-bottom-color: $white;
+      background-color: $white;
+    }
+  }
+}
+
+// When the scrollable tabs are formed  by ul and many li.
+ul.scrollable-tabs {
+  display: block;
+  overflow-y: hidden;
+
+  li.scrollable-tab-link {
+    display: inline-block;
+    padding: 0.5rem 0 0 0;
+    text-align: center;
+    & > a.active {
       font-weight: 600;
       border: 1px solid;
       border-color: $gray-300;

--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -10,17 +10,17 @@
         = @bs_request.state
 
     %ul.nav.nav-tabs.scrollable-tabs.pl-0#request-tabs{ role: 'tablist' }
-      %li.nav-item
-        = link_to('Overview', '#overview', class: 'nav-link scrollable-tab-link text-nowrap active', 'aria-controls': 'overview',
+      %li.nav-item.scrollable-tab-link
+        = link_to('Overview', '#overview', class: 'nav-link text-nowrap active', 'aria-controls': 'overview',
                   'aria-selected': 'true', 'data-toggle': 'tab', role: 'tab')
-      %li.nav-item
-        = link_to('Build Results', '#build-results', class: 'nav-link scrollable-tab-link text-nowrap', 'aria-controls': 'build-results',
+      %li.nav-item.scrollable-tab-link
+        = link_to('Build Results', '#build-results', class: 'nav-link text-nowrap', 'aria-controls': 'build-results',
                   'aria-selected': 'false', 'data-toggle': 'tab', role: 'tab')
-      %li.nav-item
-        = link_to('Changes', '#changes', class: 'nav-link scrollable-tab-link text-nowrap', 'aria-controls': 'changes', 'aria-selected': 'false',
+      %li.nav-item.scrollable-tab-link
+        = link_to('Changes', '#changes', class: 'nav-link text-nowrap', 'aria-controls': 'changes', 'aria-selected': 'false',
                   'data-toggle': 'tab', role: 'tab')
-      %li.nav-item
-        = link_to('Mentioned Issues', '#mentioned-issues', class: 'nav-link scrollable-tab-link text-nowrap', 'aria-controls': 'mentioned-issues',
+      %li.nav-item.scrollable-tab-link
+        = link_to('Mentioned Issues', '#mentioned-issues', class: 'nav-link text-nowrap', 'aria-controls': 'mentioned-issues',
                   'aria-selected': 'false', 'data-toggle': 'tab', role: 'tab')
     .tab-content#request-tabs-content
       .tab-pane.fade.show.p-2.active#overview{ 'aria-labelledby': 'overview-tab', role: 'tabpanel' }


### PR DESCRIPTION
In the request beta_show view, the tabs formed by a list (ul and li) have been adapted to be horizontally scrollable.

![tabs_request_beta_show](https://user-images.githubusercontent.com/2581944/180438555-6f96e15a-c68a-4055-89ef-a10399043328.gif)
