### PR TITLE
Set flash message and redirect instead of raising a non-existant exception NotFoundError

### DIFF
--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -145,7 +145,10 @@ class Webui::RequestController < Webui::WebuiController
 
   def beta_show
     # TODO: Remove this once request_show_redesign is rolled out
-    raise NotFoundError unless Flipper.enabled?(:request_show_redesign, User.session)
+    unless Flipper.enabled?(:request_show_redesign, User.session)
+      flash[:error] = 'This page is not accessible unless you enabled the "Request show redesign" beta feature in the beta program.'
+      redirect_back(fallback_location: root_path)
+    end
 
     @diff_limit = params[:full_diff] ? 0 : nil
     @diff_to_superseded_id = params[:diff_to_superseded]

--- a/src/api/app/controllers/webui/watched_items_controller.rb
+++ b/src/api/app/controllers/webui/watched_items_controller.rb
@@ -38,6 +38,9 @@ class Webui::WatchedItemsController < Webui::WebuiController
   end
 
   def check_user_belongs_feature_flag
-    raise NotFoundError unless Flipper.enabled?(:new_watchlist, User.session)
+    return if Flipper.enabled?(:new_watchlist, User.session)
+
+    flash[:error] = 'This page is not accessible unless you enabled the "New watchlist" beta feature in the beta program.'
+    redirect_back(fallback_location: root_path)
   end
 end

--- a/src/api/spec/controllers/webui/watched_items_controller_spec.rb
+++ b/src/api/spec/controllers/webui/watched_items_controller_spec.rb
@@ -64,8 +64,9 @@ RSpec.describe Webui::WatchedItemsController, type: :controller do
 
         subject { put :toggle_watched_item, params: { package_name: package, project_name: package.project } }
 
-        it 'raises an exception' do
-          expect { subject }.to raise_error(NotFoundError)
+        it 'redirects and assigns flash error' do
+          expect(subject).to redirect_to(root_url)
+          expect(subject.request.flash[:error]).to eq('This page is not accessible unless you enabled the "New watchlist" beta feature in the beta program.')
         end
       end
     end


### PR DESCRIPTION
In the API we define `NotFoundError` to add a specific message to a 404 error: _"Make sure you are in the beta program"_.

In the WebUI, even if we set a specific message, it won't be displayed on the error page. So it doesn't make sense to define `NotFoundError`. Therefore we ~raise an `ActiveRecord::RecordNotFound`~ set a flash message and redirect to the root path instead.

Co-authored-by: Eduardo Navarro <enavarro@suse.com>