### PR TITLE
Improve the style of the request beta_show view

### DIFF
--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -3,13 +3,13 @@
   @pagetitle += ": #{@actions.first[:name]}" if @actions.count == 1
 
 .card
-  .card-body
-    %h3
-      = @pagetitle
-      %span.badge.ml-1{ class: "badge-#{request_badge_color(@bs_request.state)}" }
-        = @bs_request.state
-
-    %ul.nav.nav-tabs.scrollable-tabs.pl-0#request-tabs{ role: 'tablist' }
+  .card-body.p-0
+    .card-title.px-4.pt-4
+      %h3
+        = @pagetitle
+        %span.badge.ml-1{ class: "badge-#{request_badge_color(@bs_request.state)}" }
+          = @bs_request.state
+    %ul.nav.nav-tabs.scrollable-tabs#request-tabs{ role: 'tablist' }
       %li.nav-item.scrollable-tab-link
         = link_to('Overview', '#overview', class: 'nav-link text-nowrap active', 'aria-controls': 'overview',
                   'aria-selected': 'true', 'data-toggle': 'tab', role: 'tab')
@@ -22,7 +22,7 @@
       %li.nav-item.scrollable-tab-link
         = link_to('Mentioned Issues', '#mentioned-issues', class: 'nav-link text-nowrap', 'aria-controls': 'mentioned-issues',
                   'aria-selected': 'false', 'data-toggle': 'tab', role: 'tab')
-    .tab-content#request-tabs-content
+    .tab-content.p-4#request-tabs-content
       .tab-pane.fade.show.p-2.active#overview{ 'aria-labelledby': 'overview-tab', role: 'tabpanel' }
         = render partial: 'webui/request/beta_show_tabs/overview'
       .tab-pane.fade.p-2#build-results{ 'aria-labelledby': 'build-results-tab', role: 'tabpanel' }


### PR DESCRIPTION
Slightly adapt the divs and paddings on the skeleton of the request _beta_show_ view.

**Before:**

![Screenshot 2022-07-22 at 17-35-49 Open Build Service](https://user-images.githubusercontent.com/2581944/180474240-f4f07f66-9bce-408e-b7d8-3d1b46d3f891.png)

**After**

![Screenshot 2022-07-22 at 17-36-13 Open Build Service](https://user-images.githubusercontent.com/2581944/180474263-ad9cbfdd-8994-4482-91cd-8b68a1631500.png)

DO_NOT_MERGE until PR #12849 is merged.