### PR TITLE
Add overview and reviewers information

### DIFF
--- a/src/api/app/components/bs_request_activity_timeline_component.html.haml
+++ b/src/api/app/components/bs_request_activity_timeline_component.html.haml
@@ -14,8 +14,6 @@
           - bs_request.superseding.each do |superseded_request|
             = link_to("request ##{superseded_request.number}", request_show_path(superseded_request.number, anchor: 'overview'))
 
-      = render partial: 'webui/shared/collapsible_text', locals: { text: bs_request.description }
-
   - timeline.each do |comment_or_history_element|
     .timeline-item
       - if comment_or_history_element.is_a?(Comment)

--- a/src/api/app/components/bs_request_overview_avatars_component.html.haml
+++ b/src/api/app/components/bs_request_overview_avatars_component.html.haml
@@ -1,0 +1,11 @@
+%ul.list-inline.d-flex.flex-row-reverse.avatars.m-0
+  - avatar_objects.each do |avatar_object|
+    %li.list-inline-item
+      = helpers.image_tag_for(avatar_object, size: 23, custom_class: 'rounded-circle bg-light border border-gray-400')
+
+  - if avatar_objects.empty? && @review.for_package?
+    %li.list-inline-item
+      %i.fa.fa-archive.text-warning.rounded-circle.bg-light.border.border-gray-400.simulated-avatar
+  - elsif avatar_objects.empty? && @review.for_project?
+    %li.list-inline-item
+      %i.fa.fa-cubes.text-secondary.rounded-circle.bg-light.border.border-gray-400.simulated-avatar

--- a/src/api/app/components/bs_request_overview_avatars_component.rb
+++ b/src/api/app/components/bs_request_overview_avatars_component.rb
@@ -1,0 +1,23 @@
+class BsRequestOverviewAvatarsComponent < ApplicationComponent
+  MAXIMUM_DISPLAYED_AVATARS = 2
+
+  def initialize(review)
+    super
+
+    @review = review
+  end
+
+  private
+
+  def avatar_objects
+    @avatar_objects ||= if @review.for_user?
+                          [@review.user]
+                        elsif @review.for_group?
+                          [@review.group.users.first(MAXIMUM_DISPLAYED_AVATARS), @review.group].flatten
+                        elsif @review.for_package?
+                          @review.package.project.users.first(MAXIMUM_DISPLAYED_AVATARS)
+                        elsif @review.for_project?
+                          @review.project.users.first(MAXIMUM_DISPLAYED_AVATARS)
+                        end
+  end
+end

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -103,6 +103,10 @@ class Webui::RequestController < Webui::WebuiController
       @diff_to_superseded_id = params[:diff_to_superseded]
       @actions = @bs_request.webui_actions(filelimit: @diff_limit, tarlimit: @diff_limit, diff_to_superseded: @diff_to_superseded, diffs: false)
 
+      @open_reviews = @bs_request.reviews.opened.for_non_staging_projects
+      @accepted_reviews = @bs_request.reviews.accepted.for_non_staging_projects
+      @declined_reviews = @bs_request.reviews.declined.for_non_staging_projects
+      @open_reviews_for_staging_projects = @bs_request.reviews.opened.for_staging_projects
       # TODO: Remove this `render` line once request_show_redesign is rolled out
       render :beta_show
     else

--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -35,6 +35,10 @@
       Created by
       = user_with_realname_and_icon(@bs_request.creator)
       = fuzzy_time(@bs_request.created_at)
+      - if @bs_request.superseding.present?
+        = '. Supersedes'
+        - @bs_request.superseding.each do |supersed|
+          = link_to "##{supersed['number']}", number: supersed['number']
     %p.px-4= request_action_header(@actions.first, @bs_request.creator) # TODO: adapt when handling requests with multiple actions
     %ul.nav.nav-tabs.scrollable-tabs#request-tabs{ role: 'tablist' }
       %li.nav-item.scrollable-tab-link
@@ -51,7 +55,11 @@
                   'aria-selected': 'false', 'data-toggle': 'tab', role: 'tab')
     .tab-content.p-4#request-tabs-content
       .tab-pane.fade.show.p-2.active#overview{ 'aria-labelledby': 'overview-tab', role: 'tabpanel' }
-        = render partial: 'webui/request/beta_show_tabs/overview', locals: { bs_request: @bs_request }
+        = render partial: 'webui/request/beta_show_tabs/overview', locals: { bs_request: @bs_request, can_add_reviews: @can_add_reviews,
+                                                                             open_reviews: @open_reviews,
+                                                                             accepted_reviews: @accepted_reviews,
+                                                                             declined_reviews: @declined_reviews,
+                                                                             open_reviews_for_staging_projects: @open_reviews_for_staging_projects }
       .tab-pane.fade.p-2#build-results{ 'aria-labelledby': 'build-results-tab', role: 'tabpanel' }
         = render partial: 'webui/request/beta_show_tabs/build_results', locals: { project: @actions.first[:sprj], package: @actions.first[:spkg] }
       .tab-pane.fade.p-2#changes{ 'aria-labelledby': 'changes-tab', role: 'tabpanel' }

--- a/src/api/app/views/webui/request/beta_show_tabs/_overview.html.haml
+++ b/src/api/app/views/webui/request/beta_show_tabs/_overview.html.haml
@@ -1,6 +1,30 @@
-%h4.list-group.mb-4 Comments & Request History
-.comments-list{ data: { comment_counter: local_assigns[:comment_counter_id] } }
-  = render BsRequestActivityTimelineComponent.new(bs_request: bs_request)
+.row
+  .col-md-12#overview
+    .mb-4#description-text
+      - if bs_request.description.present?
+        = render partial: 'webui/shared/collapsible_text', locals: { text: bs_request.description }
+      - else
+        %i No description set
+    .row
+      .col-md-4.order-md-2.order-sm-1.mb-4#side-links
+        - if accepted_reviews.present? || declined_reviews.present? || open_reviews.present?
+          %h4
+            Reviews
+          .mb-4
+            = render partial: 'webui/request/beta_show_tabs/review_summary', collection: accepted_reviews, as: :review
+            = render partial: 'webui/request/beta_show_tabs/review_summary', collection: declined_reviews, as: :review
+            = render partial: 'webui/request/beta_show_tabs/review_summary', collection: open_reviews, as: :review
 
-  .comment_new.mt-3
-    = render partial: 'webui/comment/new', locals: { commentable: bs_request }
+        - open_reviews_for_staging_projects.each do |review|
+          .pl-3
+            %i.fas.fa-info-circle.text-info
+            - staging_project = review.project
+            Is staged in
+            = link_to(review.by_project, staging_workflow_staging_project_path(staging_project.staging_workflow.project, staging_project.name))
+
+      .col-md-8.order-md-1.order-sm-2
+        %h4.list-group.mb-4 Comments & Request History
+        .comments-list{ data: { comment_counter: local_assigns[:comment_counter_id] } }
+          = render BsRequestActivityTimelineComponent.new(bs_request: bs_request)
+        .comment_new.mt-3
+          = render partial: 'webui/comment/new', locals: { commentable: bs_request }

--- a/src/api/app/views/webui/request/beta_show_tabs/_review_summary.html.haml
+++ b/src/api/app/views/webui/request/beta_show_tabs/_review_summary.html.haml
@@ -1,0 +1,28 @@
+-# FIXME: We don't render anything when the project got deleted because this nullifies the association. It should point to
+  `Project.deleted_instance` or maybe the project got created with the same name again in the meanwhile?
+- unless (review.for_project? || review.for_package?) && review.project.nil?
+  .d-flex.flex-row.pt-1
+    .pl-3
+      - if review.accepted?
+        %i.fas.fa-sm.fa-check.text-primary.align-middle.pr-1
+      - if review.declined?
+        %i.fas.fa-times.text-danger.align-middle.pr-2
+      - if review.new?
+        %i.fas.fa-2xs.fa-circle.text-warning.align-middle.pr-2
+
+    = render BsRequestOverviewAvatarsComponent.new(review)
+
+    .pl-1
+      - if review.for_user?
+        = user_with_realname_and_icon(review.by_user, short: true, no_icon: true)
+      - elsif review.for_group?
+        = link_to(review.by_group, group_path(Group.find_by(title: review.by_group)))
+      - elsif review.for_package?
+        = link_to("#{review.by_project} / #{review.by_package}", package_users_path(project: review.by_project,
+          package: review.by_package))
+      - elsif review.for_project?
+        = link_to(review.by_project, project_users_path(project: review.by_project))
+
+      - if (review.accepted? || review.declined?) && !review.for_user?
+        by
+        = link_to(review.reviewer, user_path(User.find_by(login: review.reviewer)))


### PR DESCRIPTION
Preview of the changes:
![Screenshot 2022-08-09 at 17-35-56 Open Build Service](https://user-images.githubusercontent.com/2581944/183695538-00f50d7b-693e-4d80-899d-bf9beb5bf12c.png)
For reviewers:
- Log in as `Iggy` / `buildservice`
- Visit https://obs-reviewlab.opensuse.org/rubhanazeem-request-overview/request/show/2
- If you don't see the request show redesign, the feature toggle `request_show_redesign` needs to enabled for the `staff` group in the [Flipper UI](https://obs-reviewlab.opensuse.org/rubhanazeem-request-overview/flipper/features)
- Visit again the request#show page and you should see the redesign now


~**DO NOT MERGE** until we squash the commits.~