### PR TITLE
Don't render add_reviewer_modal if user doesn't have permission to do so

### DIFF
--- a/src/api/app/views/webui/request/show.html.haml
+++ b/src/api/app/views/webui/request/show.html.haml
@@ -64,6 +64,6 @@
       .card-body
         = render partial: 'request_history', locals: { bs_request: @bs_request, history: @history }
 
-- if User.session
+- if @can_add_reviews
   = render partial: 'webui/request/add_reviewer_dialog'
 = render partial: 'webui/request/show_package_maintainers', locals: { package_maintainers: @package_maintainers }


### PR DESCRIPTION
We should only render the partial if the user is permitted to
add a reviewer to the request.

Realized this while reviewing https://github.com/openSUSE/open-build-service/pull/12869
Its not a big problem, users still cannot add a review when they don't have the permission to do so.