### PR TITLE
Link to superseded request in the state badge

### DIFF
--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -14,6 +14,9 @@
           = @pagetitle
           %span.badge.ml-1{ class: "badge-#{request_badge_color(@bs_request.state)}" }
             = @bs_request.state
+            - if @bs_request.superseded_by.present?
+              by
+              = link_to(@bs_request.superseded_by, number: @bs_request.superseded_by)
         %span.font-italic.align-self-md-center
           Created by
           = user_with_realname_and_icon(@bs_request.creator)


### PR DESCRIPTION
Instead of having to look at the _Overview_ tab for this information, it's always available and simply convenient.

Preview of the changes:
![superseded-by](https://user-images.githubusercontent.com/1102934/181521437-7f33c68a-09b3-405b-9525-ad5ddd046df7.png)
