### PR TITLE
Do not crash on workflow run scope when token does not exist

### DIFF
--- a/src/api/app/policies/workflow_run_policy.rb
+++ b/src/api/app/policies/workflow_run_policy.rb
@@ -8,7 +8,7 @@ class WorkflowRunPolicy < ApplicationPolicy
 
     def resolve
       token = Token.find_by(id: opts[:token_id])
-      raise Pundit::NotAuthorizedError, 'you are not authorized to access those workflow runs' unless token.owned_by?(user)
+      raise Pundit::NotAuthorizedError, 'you are not authorized to access those workflow runs' unless token.present? && token.owned_by?(user)
       raise Pundit::NotAuthorizedError, 'the token is not of type workflow' unless token.type == 'Token::Workflow'
 
       scope.where(token_id: token.id).order(created_at: :desc)

--- a/src/api/spec/policies/workflow_run_policy_spec.rb
+++ b/src/api/spec/policies/workflow_run_policy_spec.rb
@@ -26,6 +26,12 @@ RSpec.describe WorkflowRunPolicy do
       end
     end
 
+    context 'when the token does not exist' do
+      it 'does not crash and raises a not authorized error' do
+        expect { subject.new(User.session, WorkflowRun, { token_id: nil }).resolve }.to raise_error(Pundit::NotAuthorizedError)
+      end
+    end
+
     context 'when the user does not have permission' do
       before do
         User.session = create(:confirmed_user, login: 'bar')


### PR DESCRIPTION
We receive exceptions on the workflow_runs#index endpoint
when the workflow token doesn't exist. Lets return in the used
policy scope to prevent this from happening.

Fixes #12874