### PR TITLE
Make architecture_name parameter optional

### DIFF
--- a/src/api/public/apidocs-new/paths/published_project_name_repository_name_architecture_name_binary_filename_view_ymp.yaml
+++ b/src/api/public/apidocs-new/paths/published_project_name_repository_name_architecture_name_binary_filename_view_ymp.yaml
@@ -10,7 +10,12 @@ get:
   parameters:
     - $ref: '../components/parameters/project_name.yaml'
     - $ref: '../components/parameters/repository_name.yaml'
-    - $ref: '../components/parameters/architecture_name.yaml'
+    - in: path
+      name: architecture_name
+      schema:
+        type: string
+      description: Architecture name
+      example: x86_64
     - $ref: '../components/parameters/binary_filename.yaml'
   responses:
     '200':


### PR DESCRIPTION
Using a reference to the already defined `architecture_name` parameter makes the parameter required, and, for this particular endpoint, this is not the case.

For reviewers:
- Navigate to http://localhost:3000/apidocs-new/index.html#/Published%20Binaries/get_published__project_name___repository_name___architecture_name___binary_filename__view_ymp and check that the `architecture_name` parameter is now not required.