### PR TITLE
Do not display the request creator name, only their login

### DIFF
--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -19,7 +19,7 @@
               = link_to(@bs_request.superseded_by, number: @bs_request.superseded_by)
         %span.font-italic.align-self-md-center
           Created by
-          = user_with_realname_and_icon(@bs_request.creator)
+          = user_with_realname_and_icon(@bs_request.creator, short: true)
           = fuzzy_time(@bs_request.created_at)
     %ul.nav.nav-tabs.scrollable-tabs#request-tabs{ role: 'tablist' }
       %li.nav-item.scrollable-tab-link


### PR DESCRIPTION
To align with how we display users on the request show redesign in the changes from #12858

Before:
![before](https://user-images.githubusercontent.com/1102934/182605008-8413b12b-8db5-41ff-9020-92e3c0fa07eb.png)

Now:
![now](https://user-images.githubusercontent.com/1102934/182605011-49049146-7a7c-483a-8bb7-d57612f55095.png)