### PR TITLE
Fix eager loading token STI classes

### DIFF
--- a/src/api/config/environments/development.rb
+++ b/src/api/config/environments/development.rb
@@ -17,6 +17,7 @@ OBSApi::Application.configure do
                                   "app/models/event/**.rb",
                                   "app/models/history_element/**.rb",
                                   "app/models/owner_search/**.rb",
+                                  "app/models/token.rb",
                                   "app/models/token/**.rb"]
   config.eager_load_paths += sti_classes_to_eager_load
   ActiveSupport::Reloader.to_prepare do


### PR DESCRIPTION
While loading the Token STI classes present under
app/models/token/**.rb,

We need to load the sti subclasses under token/**.rb to avoid the
problems specified in #12879. Right, but `app/models/token/errors.rb` is
not an sti subclass, its a module. Its eager loading fails with

    /obs/src/api/app/models/token.rb:18:in `<class:Token>': uninitialized constant Token::Errors (NameError)

    include Token::Errors
                 ^^^^^^^^

Because we didn't load `Token` yet...

See https://github.com/openSUSE/open-build-service/pull/12879