### PR TITLE
Run RuboCop cops from ViewComponent namespace only for view components

### DIFF
--- a/src/api/.rubocop.yml
+++ b/src/api/.rubocop.yml
@@ -420,3 +420,10 @@ RSpec/Rails/AvoidSetupHook:
 
 Bundler/OrderedGems:
   Enabled: false
+
+##################### View Component ###########################
+
+ViewComponent:
+  # Custom cops under the RuboCop::Cop::ViewComponent module (lib/rubocop/cop/view_component) will run only for view components, which are always under app/components/
+  Include:
+    - "app/components/**/*.rb"

--- a/src/api/lib/rubocop/cop/view_component/avoid_global_state.rb
+++ b/src/api/lib/rubocop/cop/view_component/avoid_global_state.rb
@@ -13,18 +13,9 @@ module RuboCop
         #
         # @param [RuboCop::AST::ClassNode]
         def on_class(node)
-          return unless view_component?(node)
-
           params(node).each do |param|
             add_offense(param)
           end
-        end
-
-        private
-
-        # We can safely assume a class node is a view component if its name ends with Component
-        def view_component?(node)
-          node.identifier.short_name.to_s.end_with?('Component')
         end
       end
     end

--- a/src/api/spec/lib/rubocop/cop/view_component/avoid_global_state_spec.rb
+++ b/src/api/spec/lib/rubocop/cop/view_component/avoid_global_state_spec.rb
@@ -2,9 +2,13 @@ require 'rails_helper'
 require './lib/rubocop/cop/view_component/avoid_global_state'
 
 RSpec.describe RuboCop::Cop::ViewComponent::AvoidGlobalState, :config do
+  let(:config) do
+    RuboCop::Config.new({ 'ViewComponent' => { 'Include' => ['app/components/**/*.rb'] } }, '/some/.rubocop.yml')
+  end
+
   context 'when a view component uses params' do
     it 'registers an offense' do
-      expect_offense(<<~RUBY)
+      expect_offense(<<~RUBY, 'app/components/my_component.rb')
         class MyComponent < ApplicationComponent
           def initialize
             @abc = params[:abc]
@@ -17,7 +21,7 @@ RSpec.describe RuboCop::Cop::ViewComponent::AvoidGlobalState, :config do
 
   context 'when a view component does not use params' do
     it 'does not register an offense' do
-      expect_no_offenses(<<~RUBY)
+      expect_no_offenses(<<~RUBY, 'app/components/my_component.rb')
         class MyComponent < ApplicationComponent
           def initialize
             @abc = 'abc'
@@ -29,7 +33,7 @@ RSpec.describe RuboCop::Cop::ViewComponent::AvoidGlobalState, :config do
 
   context 'when a class which is not a view component uses params' do
     it 'does not register an offense' do
-      expect_no_offenses(<<~RUBY)
+      expect_no_offenses(<<~RUBY, 'app/controllers/clients_controller.rb')
         class ClientsController < ApplicationController
           def show
             @client = Client.find(params[:id])


### PR DESCRIPTION
This approach is more efficient since only view components are linted, not all files. It's also much more robust, since it relies on the path, not on class names ending with `Component`.

[rubocop-rspec](https://github.com/rubocop/rubocop-rspec/blob/5416f729d4cd0c676334c356a67240dbd2aafd32/config/default.yml#L2-L7) and [rubocop-graphql](https://github.com/DmitryTsepelev/rubocop-graphql/blob/c9303c6b6c136df8f1e4c1ce4b10006c0f43b9a6/config/default.yml#L1-L4) use the same technique.

For reviewers: If you add `params[:something]` to any view component and run `bundle exec rubocop`, it will raise an offense. It doesn't though for other files. This proves the `Include` configuration works.