### PR TITLE
Remove unneeded class for heading in request show redesign

### DIFF
--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -9,7 +9,7 @@
 .card
   .card-body.p-0
     .card-title.px-4.pt-4.mb-0
-      %h3.mr-md-4
+      %h3
         Request #{@bs_request.number}
         %span.badge.ml-1{ class: "badge-#{request_badge_color(@bs_request.state)}" }
           = @bs_request.state


### PR DESCRIPTION
Nothing is rendered to the right of this heading, so we can safely remove the CSS class. 