### PR TITLE
Fix deprecation warning for RuboCop Style/MethodCallWithArgsParentheses cop

### DIFF
--- a/src/api/.rubocop.yml
+++ b/src/api/.rubocop.yml
@@ -58,7 +58,7 @@ Style/MethodCallWithArgsParentheses:
   # list is the list of offending functions when introducing. Removing functions
   # from here leads to autocorrecting calls, if you call a new DSL function, add
   # it here
-  IgnoredMethods:
+  AllowedMethods:
     - abort
     - add_column
     - add_element


### PR DESCRIPTION
This was the deprecation warning:

> Warning: obsolete parameter `IgnoredMethods` (for `Style/MethodCallWithArgsParentheses`) found in .rubocop.yml `IgnoredMethods` has been renamed to `AllowedMethods` and/or `AllowedPatterns`.