### PR TITLE
Handle new comments and replies

### DIFF
--- a/src/api/app/components/bs_request_activity_timeline_component.html.haml
+++ b/src/api/app/components/bs_request_activity_timeline_component.html.haml
@@ -17,6 +17,7 @@
   - timeline.each do |comment_or_history_element|
     .timeline-item
       - if comment_or_history_element.is_a?(Comment)
-        = render BsRequestCommentComponent.new(comment: comment_or_history_element, level: 1, commentable: comment_or_history_element.commentable)
+        .comments-thread
+          = render BsRequestCommentComponent.new(comment: comment_or_history_element, level: 1, commentable: comment_or_history_element.commentable)
       - else
         = render BsRequestHistoryElementComponent.new(element: comment_or_history_element)

--- a/src/api/app/models/comment.rb
+++ b/src/api/app/models/comment.rb
@@ -45,6 +45,10 @@ class Comment < ApplicationRecord
                                           when: updated_at.strftime('%Y-%m-%dT%H:%M:%S') })
   end
 
+  def unused_parent?
+    parent && parent.user.is_nobody? && parent.children.length.zero?
+  end
+
   private
 
   def create_event
@@ -59,7 +63,7 @@ class Comment < ApplicationRecord
   end
 
   def delete_parent_if_unused
-    parent.destroy if parent && parent.user.is_nobody? && parent.children.length.zero?
+    parent.destroy if unused_parent?
   end
 
   # build an array of users, commenting or being mentioned on the commentable of this comment

--- a/src/api/app/views/webui/comment/_content.html.haml
+++ b/src/api/app/views/webui/comment/_content.html.haml
@@ -16,4 +16,3 @@
 - if level > 3
   - comment.children.includes(:user).each do |children|
     = render partial: 'webui/comment/content', locals: { comment: children, commentable: commentable, level: level + 1 }
-

--- a/src/api/app/views/webui/comment/beta/_comments_thread.html.haml
+++ b/src/api/app/views/webui/comment/beta/_comments_thread.html.haml
@@ -1,0 +1,3 @@
+.timeline-item
+  .comments-thread
+    = render(BsRequestCommentComponent.new(comment: comment.root, level: 1, commentable: commentable))

--- a/src/api/app/views/webui/request/beta_show_tabs/_overview.html.haml
+++ b/src/api/app/views/webui/request/beta_show_tabs/_overview.html.haml
@@ -24,7 +24,7 @@
 
       .col-md-8.order-md-1.order-sm-2
         %h4.list-group.mb-4 Comments & Request History
-        .comments-list{ data: { comment_counter: local_assigns[:comment_counter_id] } }
+        .timeline{ data: { comment_counter: local_assigns[:comment_counter_id] } }
           = render BsRequestActivityTimelineComponent.new(bs_request: bs_request)
         .comment_new.mt-3
           = render partial: 'webui/comment/new', locals: { commentable: bs_request }


### PR DESCRIPTION
This changeset handles the creation of new comments, replies, edits and deletions in the beta request show view. 

Comments for Project and Package should behave and look like always.

## How To Test It
1. Open a request. You can do it from the [review-app link](https://obs-reviewlab.opensuse.org/danidoni-handle-new-comments-and-replies-correctly-in-the-beta-request-show-page/request/show/2).
2. Go into the notifications page.
3. Open the first request.
4. Create new comments using the 'Add comment' button.
5. Edit existing comments using the 'Edit' button below an existing comment.
6. Reply existing comments using the 'Reply' button below an existing comment.
7. Delete existing comments using the 'Delete' button below an existing comment.
