### PR TITLE
Show build results only if needed

### DIFF
--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -44,9 +44,10 @@
       %li.nav-item.scrollable-tab-link
         = link_to('Overview', '#overview', class: 'nav-link text-nowrap active', 'aria-controls': 'overview',
                   'aria-selected': 'true', 'data-toggle': 'tab', role: 'tab')
-      %li.nav-item.scrollable-tab-link
-        = link_to('Build Results', '#build-results', class: 'nav-link text-nowrap', 'aria-controls': 'build-results',
-                  'aria-selected': 'false', 'data-toggle': 'tab', role: 'tab')
+      - if @actions.first[:sprj] || @actions.first[:spkg]
+        %li.nav-item.scrollable-tab-link
+          = link_to('Build Results', '#build-results', class: 'nav-link text-nowrap', 'aria-controls': 'build-results',
+                    'aria-selected': 'false', 'data-toggle': 'tab', role: 'tab')
       %li.nav-item.scrollable-tab-link#changes-item{ 'data-request-number': @bs_request.number, 'data-request-action-id': @actions.first[:id] }
         = link_to('Changes', '#changes', class: 'nav-link text-nowrap', 'aria-controls': 'changes', 'aria-selected': 'false',
                   'data-toggle': 'tab', role: 'tab')
@@ -60,8 +61,9 @@
                                                                              accepted_reviews: @accepted_reviews,
                                                                              declined_reviews: @declined_reviews,
                                                                              open_reviews_for_staging_projects: @open_reviews_for_staging_projects }
-      .tab-pane.fade.p-2#build-results{ 'aria-labelledby': 'build-results-tab', role: 'tabpanel' }
-        = render partial: 'webui/request/beta_show_tabs/build_results', locals: { project: @actions.first[:sprj], package: @actions.first[:spkg] }
+      - if @actions.first[:sprj] || @actions.first[:spkg]
+        .tab-pane.fade.p-2#build-results{ 'aria-labelledby': 'build-results-tab', role: 'tabpanel' }
+          = render partial: 'webui/request/beta_show_tabs/build_results', locals: { project: @actions.first[:sprj], package: @actions.first[:spkg] }
       .tab-pane.fade.p-2#changes{ 'aria-labelledby': 'changes-tab', role: 'tabpanel' }
         = render partial: 'webui/request/beta_show_tabs/changes'
       .tab-pane.fade.p-2#mentioned-issues{ 'aria-labelledby': 'mentioned-issues-tab', role: 'tabpanel' }


### PR DESCRIPTION
This would otherwise cause a 500 error whenever the request doesn't have build results.

Fixes #12936

This is the same approach we use in the "old" request page: https://github.com/openSUSE/open-build-service/blob/44680fe5effdf3fe805fca864fac78ee0b81a8ed/src/api/app/views/webui/shared/_buildresult_box.html.haml#L6-L8

We could potentially rely on the request action type later, but for now, this is good enough.  