### PR TITLE
Improve HTML in request show redesign's conversation tab

### DIFF
--- a/src/api/app/views/webui/request/beta_show_tabs/_conversation.html.haml
+++ b/src/api/app/views/webui/request/beta_show_tabs/_conversation.html.haml
@@ -1,5 +1,5 @@
 .row
-  .col-md-12#conversation
+  .col-md-12
     .mb-4#description-text
       - if bs_request.description.present?
         = render partial: 'webui/shared/collapsible_text', locals: { text: bs_request.description }

--- a/src/api/app/views/webui/request/beta_show_tabs/_conversation.html.haml
+++ b/src/api/app/views/webui/request/beta_show_tabs/_conversation.html.haml
@@ -5,34 +5,34 @@
         = render partial: 'webui/shared/collapsible_text', locals: { text: bs_request.description }
       - else
         %i No description set
-    .row
-      .col-md-4.order-md-2.order-sm-1.mb-4#side-links
-        - if accepted_reviews.present? || declined_reviews.present? || open_reviews.present?
-          .d-flex.justify-content-between
-            %h4
-              Reviews
-            = render AddReviewDropdownComponent.new(bs_request: bs_request, user: User.session,
-                                                    can_add_reviews: can_add_reviews,
-                                                    my_open_reviews: my_open_reviews)
-          = render AddReviewCollapsibleComponent.new
-          .mb-4
-            = render partial: 'webui/request/beta_show_tabs/review_summary', collection: accepted_reviews, as: :review
-            = render partial: 'webui/request/beta_show_tabs/review_summary', collection: declined_reviews, as: :review
-            = render partial: 'webui/request/beta_show_tabs/review_summary', collection: open_reviews, as: :review
+.row
+  .col-md-4.order-md-2.order-sm-1.mb-4#side-links
+    - if accepted_reviews.present? || declined_reviews.present? || open_reviews.present?
+      .d-flex.justify-content-between
+        %h4
+          Reviews
+        = render AddReviewDropdownComponent.new(bs_request: bs_request, user: User.session,
+                                                can_add_reviews: can_add_reviews,
+                                                my_open_reviews: my_open_reviews)
+      = render AddReviewCollapsibleComponent.new
+      .mb-4
+        = render partial: 'webui/request/beta_show_tabs/review_summary', collection: accepted_reviews, as: :review
+        = render partial: 'webui/request/beta_show_tabs/review_summary', collection: declined_reviews, as: :review
+        = render partial: 'webui/request/beta_show_tabs/review_summary', collection: open_reviews, as: :review
 
-        - open_reviews_for_staging_projects.each do |review|
-          .pl-3
-            %i.fas.fa-info-circle.text-info
-            - staging_project = review.project
-            Is staged in
-            = link_to(review.by_project, staging_workflow_staging_project_path(staging_project.staging_workflow.project, staging_project.name))
-      .col-md-8.order-md-1.order-sm-2
-        %h4.list-group.mb-4 Comments & Request History
-        .timeline{ data: { comment_counter: local_assigns[:comment_counter_id] } }
-          = render BsRequestActivityTimelineComponent.new(bs_request: bs_request)
-        .comment_new.mt-3
-          = render partial: 'webui/comment/new', locals: { commentable: bs_request }
-        %hr
-        = render RequestDecisionComponent.new(bs_request: bs_request, actions: actions,
-                                              is_target_maintainer: is_target_maintainer,
-                                              is_author: is_author)
+    - open_reviews_for_staging_projects.each do |review|
+      .pl-3
+        %i.fas.fa-info-circle.text-info
+        - staging_project = review.project
+        Is staged in
+        = link_to(review.by_project, staging_workflow_staging_project_path(staging_project.staging_workflow.project, staging_project.name))
+  .col-md-8.order-md-1.order-sm-2
+    %h4.list-group.mb-4 Comments & Request History
+    .timeline{ data: { comment_counter: local_assigns[:comment_counter_id] } }
+      = render BsRequestActivityTimelineComponent.new(bs_request: bs_request)
+    .comment_new.mt-3
+      = render partial: 'webui/comment/new', locals: { commentable: bs_request }
+    %hr
+    = render RequestDecisionComponent.new(bs_request: bs_request, actions: actions,
+                                          is_target_maintainer: is_target_maintainer,
+                                          is_author: is_author)


### PR DESCRIPTION
This made the HTML somewhat hard to follow and caused issues in the layout when the request description is a collapsible text element.

Fixes #12937

Before, with the issue highlighted in the HTML:
![issue](https://user-images.githubusercontent.com/1102934/184645232-62517840-5724-4346-8866-801a033f0427.png)

After:
![after](https://user-images.githubusercontent.com/1102934/184645266-6f145f9a-60ea-4f8e-8801-0a0a53e43be6.png)