### PR TITLE
Display a message when there are no users/groups

### DIFF
--- a/src/api/app/views/webui/shared/user_or_groups_roles/_index.html.haml
+++ b/src/api/app/views/webui/shared/user_or_groups_roles/_index.html.haml
@@ -28,6 +28,9 @@
                  locals: { records: users, roles: roles, type: 'user',
                            user_is_maintainer: user_is_maintainer,
                            project: project, package: package }
+  - else
+    %p
+      %i There are no users...
 
   - if user_is_maintainer
     .pt-4
@@ -54,6 +57,10 @@
                  locals: { records: groups, roles: roles, type: 'group',
                            user_is_maintainer: user_is_maintainer,
                            project: project, package: package }
+  - else
+    %p
+      %i There are no groups...
+
   - if user_is_maintainer
     .pt-4
       = render(partial: 'webui/shared/user_or_groups_roles/add_group_dialog', locals: { project: project.to_param, package: package.to_param })


### PR DESCRIPTION
Without this, it seems to be broken.

Before:
![before](https://user-images.githubusercontent.com/1102934/184856588-1a07fa75-e8ce-48ef-9a40-b938f828ab39.png)

Now:
![preview](https://user-images.githubusercontent.com/1102934/184856592-5ffbdbb8-5b4e-4406-9dfb-e3f1a43f1e48.png)