### PR TITLE
Document deprecated POST search endpoints

### DIFF
--- a/src/api/public/apidocs-new/paths/search.yaml
+++ b/src/api/public/apidocs-new/paths/search.yaml
@@ -148,3 +148,11 @@ get:
       $ref: '../components/responses/unauthorized.yaml'
   tags:
     - Search
+
+post:
+  deprecated: true
+  summary: Search in projects or in packages.
+  description: |
+    This endpoint is exactly the same as `GET /search`, please use that one.
+  tags:
+    - Search

--- a/src/api/public/apidocs-new/paths/search_missing_owner.yaml
+++ b/src/api/public/apidocs-new/paths/search_missing_owner.yaml
@@ -58,3 +58,13 @@ get:
                 summary: 'Project not found: bla'
   tags:
     - Search
+
+post:
+  deprecated: true
+  summary: |
+    Search for packages that miss the definition for a by default
+    responsible person or group.
+  description: |
+    This endpoint is exactly the same as `GET /search/missing_owner`, please use that one.
+  tags:
+    - Search

--- a/src/api/public/apidocs-new/paths/search_owner.yaml
+++ b/src/api/public/apidocs-new/paths/search_owner.yaml
@@ -98,3 +98,11 @@ get:
                 summary: 'Project not found: bla'
   tags:
     - Search
+
+post:
+  deprecated: true
+  summary: Search for the default responsible person or group (the owner).
+  description: |
+    This endpoint is exactly the same as `GET /search/owner`, please use that one.
+  tags:
+    - Search

--- a/src/api/public/apidocs-new/paths/search_project_id.yaml
+++ b/src/api/public/apidocs-new/paths/search_project_id.yaml
@@ -75,3 +75,11 @@ get:
       $ref: '../components/responses/unauthorized.yaml'
   tags:
     - Search
+
+post:
+  deprecated: true
+  summary: List projects that match a XPath condition.
+  description: |
+    This endpoint is exactly the same as `GET /search/project/id`, please use that one.
+  tags:
+    - Search

--- a/src/api/public/apidocs-new/paths/search_published_binary_id.yaml
+++ b/src/api/public/apidocs-new/paths/search_published_binary_id.yaml
@@ -41,3 +41,11 @@ get:
               summary: Not Found
   tags:
     - Search
+
+post:
+  deprecated: true
+  summary: Search for currently available binaries in the publish area.
+  description: |
+    This endpoint is exactly the same as `GET /search/published/binary/id`, please use that one.
+  tags:
+    - Search

--- a/src/api/public/apidocs-new/paths/search_published_pattern_id.yaml
+++ b/src/api/public/apidocs-new/paths/search_published_pattern_id.yaml
@@ -28,3 +28,11 @@ get:
       $ref: '../components/responses/unauthorized.yaml'
   tags:
     - Search
+
+post:
+  deprecated: true
+  summary: Search for published patterns.
+  description: |
+    This endpoint is exactly the same as `GET /search/published/pattern/id`, please use that one.
+  tags:
+    - Search

--- a/src/api/public/apidocs-new/paths/search_published_repoinfo_id.yaml
+++ b/src/api/public/apidocs-new/paths/search_published_repoinfo_id.yaml
@@ -28,3 +28,11 @@ get:
       $ref: '../components/responses/unauthorized.yaml'
   tags:
     - Search
+
+post:
+  deprecated: true
+  summary: Search for currently available repositories in the publish area.
+  description: |
+    This endpoint is exactly the same as `GET /search/published/repoinfo/id`, please use that one.
+  tags:
+    - Search


### PR DESCRIPTION
The details of the POST endpoints aren't listed to avoid having outdated information if we update their GET counterparts.