### PR TITLE
Validate limit in OwnerSearch::Base

### DIFF
--- a/src/api/app/models/owner_search/base.rb
+++ b/src/api/app/models/owner_search/base.rb
@@ -20,6 +20,8 @@ module OwnerSearch
       self.attribute = AttribType.find_by_name!(params[:attribute] || 'OBS:OwnerRootProject')
 
       self.limit = (params[:limit] || 1).to_i
+
+      raise InvalidLimitError, "The limit (#{limit}) must be either a positive number, 0 or -1." unless limit >= -1
     end
 
     attr_accessor :params, :attribute, :limit

--- a/src/api/lib/api_error.rb
+++ b/src/api/lib/api_error.rb
@@ -89,6 +89,8 @@ class InvalidParameterError < APIError; end
 
 class InvalidProjectNameError < APIError; end
 
+class InvalidLimitError < APIError; end
+
 class UnknownCommandError < APIError; end
 
 class NotMissingError < APIError; end


### PR DESCRIPTION
The other search endpoints do not rely on the `limit`parameter, at least not in the same way. They use it for the pagination, so validating the limit only in `OwnerSearch::Base` is fine.