### PR TITLE
Address haml-lint offenses for InstanceVariables

### DIFF
--- a/src/api/app/components/sourcediff_component.html.haml
+++ b/src/api/app/components/sourcediff_component.html.haml
@@ -30,7 +30,8 @@
                                                                                   file: sourcediff['files'][filename],
                                                                                   index: file_index,
                                                                                   last: sourcediff['filenames'].last == filename,
-                                                                                  package: @action[:spkg] }
+                                                                                  package: @action[:spkg],
+                                                                                  linkinfo: @linkinfo }
           - else
             .mb-2
               %p.lead

--- a/src/api/app/components/sourcediff_tab_component.html.haml
+++ b/src/api/app/components/sourcediff_tab_component.html.haml
@@ -39,7 +39,8 @@
                                                                                           file: sourcediff['files'][filename],
                                                                                           index: file_index,
                                                                                           last: sourcediff['filenames'].last == filename,
-                                                                                          package: @action[:spkg] }
+                                                                                          package: @action[:spkg],
+                                                                                          linkinfo: @linkinfo }
             - else
               .mb-2
                 %p.lead

--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -585,9 +585,8 @@ class Webui::PackageController < Webui::WebuiController
   def rpmlint_log
     @log = Backend::Api::BuildResults::Binaries.rpmlint_log(params[:project], params[:package], params[:repository], params[:architecture])
     @log.encode!(xml: :text)
-    render partial: 'rpmlint_log'
   rescue Backend::NotFoundError
-    render plain: 'No rpmlint log'
+    # We inform users in the view that there is no log...
   end
 
   def meta

--- a/src/api/app/views/layouts/webui/_footer.html.haml
+++ b/src/api/app/views/layouts/webui/_footer.html.haml
@@ -14,7 +14,7 @@
     %ul
       %li= link_to('Projects', projects_path)
       %li= link_to('Search', search_path, class: 'search-link')
-      - unless @spider_bot
+      - unless spider_bot
         %li= link_to('Status Monitor', monitor_path)
   %div
     %strong.text-uppercase Help

--- a/src/api/app/views/layouts/webui/_left_navigation.html.haml
+++ b/src/api/app/views/layouts/webui/_left_navigation.html.haml
@@ -1,8 +1,8 @@
 #left-navigation
   - if User.session
-    = render partial: 'layouts/webui/places', locals: { navigation: :left }
+    = render partial: 'layouts/webui/places', locals: { navigation: :left, spider_bot: spider_bot }
     - if content_for(:actions)
       = render partial: 'layouts/webui/actions', locals: { navigation: :left }
   - else
-    = render partial: 'layouts/webui/left_navigation_nobody'
+    = render partial: 'layouts/webui/left_navigation_nobody', locals: { spider_bot: spider_bot }
 

--- a/src/api/app/views/layouts/webui/_left_navigation_nobody.html.haml
+++ b/src/api/app/views/layouts/webui/_left_navigation_nobody.html.haml
@@ -6,7 +6,7 @@
     = link_to(projects_path, class: 'nav-link', title: 'All Projects') do
       %i.fas.fa-list.fa-lg.mr-2
       %span.nav-item-name All Projects
-  - unless @spider_bot
+  - unless spider_bot
     %li.nav-item
       = link_to(monitor_path, class: 'nav-link', title: 'Status Monitor') do
         %i.fas.fa-heartbeat.fa-lg.mr-2

--- a/src/api/app/views/layouts/webui/_places.html.haml
+++ b/src/api/app/views/layouts/webui/_places.html.haml
@@ -52,7 +52,7 @@
       = link_to(projects_path, class: 'nav-link', title: 'All Projects') do
         %i.fas.fa-list.fa-lg.mr-2
         %span.nav-item-name All Projects
-    - unless @spider_bot
+    - unless spider_bot
       %li.nav-item
         = link_to(monitor_path, class: 'nav-link', title: 'Status Monitor') do
           %i.fas.fa-heartbeat.fa-lg.mr-2

--- a/src/api/app/views/layouts/webui/webui.html.haml
+++ b/src/api/app/views/layouts/webui/webui.html.haml
@@ -43,7 +43,7 @@
       #top-navigation-area
         = render partial: 'layouts/webui/top_navigation'
       .bg-dark#left-navigation-area{ class: "#{'collapsed' if sidebar_collapsed?}" }
-        = render partial: 'layouts/webui/left_navigation'
+        = render partial: 'layouts/webui/left_navigation', locals: { spider_bot: @spider_bot }
         = render partial: 'layouts/webui/left_navigation_collapse_button'
       .d-flex.flex-column#content-area
         - if @current_notification
@@ -61,7 +61,7 @@
               = yield
 
         .container-fluid.mt-4.mb-2.py-2#footer
-          = render partial: 'layouts/webui/footer'
+          = render partial: 'layouts/webui/footer', locals: { spider_bot: @spider_bot }
         .container-fluid.py-2#sponsors
           = render SponsorsComponent.new
         .container-fluid.mt-2.py-2#footer-legal

--- a/src/api/app/views/webui/attribute/edit.html.haml
+++ b/src/api/app/views/webui/attribute/edit.html.haml
@@ -1,6 +1,6 @@
 - @pagetitle = "Edit Attribute #{@attribute.fullname} on #{@container.class} #{@container.name}"
 .card
-  = render(partial: "webui/#{@container.model_name.singular}/tabs", locals: { project: @project, package: @package })
+  = render(partial: "webui/#{@container.model_name.singular}/tabs", locals: { project: @project, package: @package, spider_bot: @spider_bot })
 
   .card-body
     %h3= @pagetitle

--- a/src/api/app/views/webui/attribute/index.html.haml
+++ b/src/api/app/views/webui/attribute/index.html.haml
@@ -2,7 +2,7 @@
 - can_update_container = policy(@container).update?
 
 .card
-  = render(partial: "webui/#{@container.model_name.singular}/tabs", locals: { project: @project, package: @package })
+  = render(partial: "webui/#{@container.model_name.singular}/tabs", locals: { project: @project, package: @package, spider_bot: @spider_bot })
 
   .card-body
     %h3= @pagetitle

--- a/src/api/app/views/webui/attribute/new.html.haml
+++ b/src/api/app/views/webui/attribute/new.html.haml
@@ -1,7 +1,7 @@
 - @pagetitle = 'Add Attribute'
 
 .card
-  = render(partial: "webui/#{@container.model_name.singular}/tabs", locals: { project: @project, package: @package })
+  = render(partial: "webui/#{@container.model_name.singular}/tabs", locals: { project: @project, package: @package, spider_bot: @spider_bot })
 
   .card-body
     %h3= @pagetitle

--- a/src/api/app/views/webui/distributions/new.html.haml
+++ b/src/api/app/views/webui/distributions/new.html.haml
@@ -2,7 +2,7 @@
 
 
 .card.mb-3
-  = render partial: 'webui/project/tabs', locals: { project: @project }
+  = render partial: 'webui/project/tabs', locals: { project: @project, spider_bot: @spider_bot }
   .card-body
     %h3 Add Repositories to #{@project}
     .row

--- a/src/api/app/views/webui/kiwi/images/_preferences.html.haml
+++ b/src/api/app/views/webui/kiwi/images/_preferences.html.haml
@@ -3,7 +3,7 @@
     %h5.card-header#image-name
       Preferences
     .card-body
-      - @image.preferences.each do |preference|
+      - image.preferences.each do |preference|
         %h6= preference.profile
         %ul.list-inline
           %li.list-inline-item
@@ -23,4 +23,4 @@
         = link_to('#', data: { target: '#preferences-edit', toggle: 'modal' }) do
           %i.fas.fa-edit.text-secondary
           Edit Preferences
-        = render partial: 'preferences_form', locals: { f: f }
+        = render partial: 'preferences_form', locals: { f: f, image: image }

--- a/src/api/app/views/webui/kiwi/images/_preferences_form.html.haml
+++ b/src/api/app/views/webui/kiwi/images/_preferences_form.html.haml
@@ -9,7 +9,7 @@
           Kiwi Image name cannot be empty!
       .modal-body
         .dialog
-          - @image.preferences.each do |preference|
+          - image.preferences.each do |preference|
             = f.fields_for(:preferences, preference) do |preference_fields|
               %h4= preference.profile
               = preference_fields.label :version do

--- a/src/api/app/views/webui/kiwi/images/_profiles.html.haml
+++ b/src/api/app/views/webui/kiwi/images/_profiles.html.haml
@@ -3,11 +3,11 @@
     Profiles
   .card-body
     %p Select one or more profiles to build. At least one profile needs to be selected to trigger builds.
-    - if @image.profiles.empty?
+    - if image.profiles.empty?
       %p There are no profiles
     - else
       %ul.list-unstyled
-        - @image.profiles.each do |profile|
+        - image.profiles.each do |profile|
           %li
             = f.fields_for(:profiles, profile) do |profile_fields|
               .custom-control.custom-checkbox

--- a/src/api/app/views/webui/kiwi/images/edit.html.haml
+++ b/src/api/app/views/webui/kiwi/images/edit.html.haml
@@ -15,11 +15,11 @@
                                                    is_edit_details_action: @is_edit_details_action }
 
     .col-12#kiwi-preferences{ class: "#{'d-none' unless @is_edit_details_action}" }
-      = render partial: 'webui/kiwi/images/preferences', locals: { f: f }
+      = render partial: 'webui/kiwi/images/preferences', locals: { f: f, image: @image }
 
     .col-12#kiwi-image-profiles-section{ class: "#{'d-none' unless @is_edit_software_action}" }
       .card.mb-3
-        = render partial: 'webui/kiwi/images/profiles', locals: { f: f }
+        = render partial: 'webui/kiwi/images/profiles', locals: { f: f, image: @image }
 
     .col-12#kiwi-image-repositories-section{ class: "#{'d-none' unless @is_edit_software_action}" }
       .card.mb-3

--- a/src/api/app/views/webui/main/_latest_updates.html.haml
+++ b/src/api/app/views/webui/main/_latest_updates.html.haml
@@ -6,7 +6,7 @@
       = link_to(latest_updates_feed_path(format: 'rss'), title: 'RSS Feed') do
         %i.fa.fa-rss
   .list-group
-    - @latest_updates.each do |update|
+    - latest_updates.each do |update|
       .list-group-item.list-group-item-integrated.border-left-0.border-right-0
         .row
           .col-1

--- a/src/api/app/views/webui/main/index.html.haml
+++ b/src/api/app/views/webui/main/index.html.haml
@@ -25,4 +25,4 @@
           = render SignUpComponent.new
     - if @status_messages.present? || User.admin_session?
       = render partial: 'status_messages', locals: { status_messages: @status_messages }
-    = render(partial: 'latest_updates') if @latest_updates && (::Configuration.anonymous || User.session)
+    = render(partial: 'latest_updates', locals: { latest_updates: @latest_updates }) if @latest_updates && (::Configuration.anonymous || User.session)

--- a/src/api/app/views/webui/package/_commit_item.html.haml
+++ b/src/api/app/views/webui/package/_commit_item.html.haml
@@ -26,10 +26,10 @@
   %ul.nav.float-right
     - if commit['rev'] != '1'
       %li.nav-item
-        = link_to(package_rdiff_path(@project, @package, rev: commit['rev'], linkrev: 'base'), class: 'nav-link') do
+        = link_to(package_rdiff_path(project, package, rev: commit['rev'], linkrev: 'base'), class: 'nav-link') do
           %i.fas.fa-copy.text-gray-500
           Files Changed
     %li.nav-item
-      = link_to(package_show_path(@project, @package, rev: commit['rev']), class: 'nav-link') do
+      = link_to(package_show_path(project, package, rev: commit['rev']), class: 'nav-link') do
         %i.fas.fa-folder-open.text-warning
         Browse Source

--- a/src/api/app/views/webui/package/_files_view.html.haml
+++ b/src/api/app/views/webui/package/_files_view.html.haml
@@ -35,7 +35,7 @@
       %h5.card-header.border-top
         Revision #{revision} (latest revision is #{current_rev})
     .card-body
-      = render partial: 'commit_item', locals: { revision: revision, commit: package.commit(revision) }
+      = render partial: 'commit_item', locals: { project: project, package: package, revision: revision, commit: package.commit(revision) }
   - elsif srcmd5
     %h5
       Source MD5 is #{srcmd5} (latest revision is #{current_rev})

--- a/src/api/app/views/webui/package/_live_build_log_controls.html.haml
+++ b/src/api/app/views/webui/package/_live_build_log_controls.html.haml
@@ -7,26 +7,26 @@
     Stop refresh
 
   - if User.session
-    = link_to(raw_logfile_path(package: @package_name, project: @project, arch: @arch, repository: @repo),
+    = link_to(raw_logfile_path(package: package_name, project: project, arch: arch, repository: repo),
               target: :_blank,
               rel: 'noopener',
               class: 'live-link-action btn-secondary') do
       %i.fas.fa-download
       Download logfile
   - else
-    = link_to(public_build_path(package: @package_name, project: @project, arch: @arch, repository: @repo, filename: '_log'),
+    = link_to(public_build_path(package: package_name, project: project, arch: arch, repository: repo, filename: '_log'),
               target: :_blank,
               rel: 'noopener',
               class: 'live-link-action btn-secondary') do
       %i.fas.fa-download
       Download logfile
-  - if @can_modify
-    = link_to(package_trigger_rebuild_path(project: @project, package: @package_name, arch: @arch, repository: @repo),
+  - if can_modify
+    = link_to(package_trigger_rebuild_path(project: project, package: package_name, arch: arch, repository: repo),
               class: 'link_trigger_rebuild live-link-action btn-warning d-none',
               method: :post) do
       %i.fas.fa-redo
       Trigger Rebuild
-    = link_to(package_abort_build_path(project: @project, package: @package_name, arch: @arch, repository: @repo),
+    = link_to(package_abort_build_path(project: project, package: package_name, arch: arch, repository: repo),
               class: 'link_abort_build live-link-action btn-danger d-none') do
       %i.far.fa-times-circle
       Abort Build

--- a/src/api/app/views/webui/package/_revision_diff_detail.html.haml
+++ b/src/api/app/views/webui/package/_revision_diff_detail.html.haml
@@ -1,7 +1,7 @@
 - diff_content = file.dig('diff', '_content')
 .position-relative
   = render partial: 'webui/package/revision_diff_detail_buttons',
-  locals: { file_view_path: file_view_path, filename: filename, index: index, last: last, has_content: diff_content.present? }
+  locals: { file_view_path: file_view_path, filename: filename, index: index, last: last, has_content: diff_content.present?, linkinfo: linkinfo }
   - if diff_content.present?
     %details.card.details-with-coderay{ open: expand_diff?(filename, file['state']), id: "revision_details_#{index}", data: { package: package } }
       %summary.card-header.py-3

--- a/src/api/app/views/webui/package/_revision_diff_detail_buttons.html.haml
+++ b/src/api/app/views/webui/package/_revision_diff_detail_buttons.html.haml
@@ -7,7 +7,7 @@
   href: "#revision_details_#{index + 1}",
   title: 'Go down to the next diff' }
     %i.fas.fa-chevron-down
-  - if file_view_path && has_content && !@linkinfo && viewable_file?(filename)
+  - if file_view_path && has_content && !linkinfo && viewable_file?(filename)
     = link_to(file_view_path, class: 'btn btn-outline-secondary', title: 'View the whole file') do
       %span.d-none.d-sm-none.d-md-block View file
       %i.far.fa-file.d-block.d-sm-block.d-md-none

--- a/src/api/app/views/webui/package/_rpmlint_log.html.haml
+++ b/src/api/app/views/webui/package/_rpmlint_log.html.haml
@@ -1,2 +1,0 @@
-- @log.lines.each do |line|
-  = colorize_line(line)

--- a/src/api/app/views/webui/package/_tabs.html.haml
+++ b/src/api/app/views/webui/package/_tabs.html.haml
@@ -2,7 +2,7 @@
   = tab_link('Overview', package_show_path(project, package), false, 'scrollable-tab-link')
   - if package.name == 'patchinfo'
     = tab_link('Details', show_patchinfo_path(project, package), false, 'scrollable-tab-link')
-  - unless @spider_bot
+  - unless spider_bot
     = tab_link('Repositories', repositories_path(project, package), false, 'scrollable-tab-link')
     = tab_link('Revisions', package_view_revisions_path(project, package), false, 'scrollable-tab-link')
     = tab_link('Requests', package_requests_path(project, package), false, 'scrollable-tab-link')

--- a/src/api/app/views/webui/package/binaries.html.haml
+++ b/src/api/app/views/webui/package/binaries.html.haml
@@ -1,7 +1,7 @@
 - @pagetitle = "State of #{@repository} for #{@project} / #{@package_name}"
 
 .card
-  = render partial: 'tabs', locals: { package: @package, project: @project }
+  = render partial: 'tabs', locals: { package: @package, project: @project, spider_bot: @spider_bot }
   .card-body
     %h3= @pagetitle
     %ul.list-inline

--- a/src/api/app/views/webui/package/binary.html.haml
+++ b/src/api/app/views/webui/package/binary.html.haml
@@ -2,7 +2,7 @@
 - @metarobots = 'noindex' # files change too often
 
 .card
-  = render partial: 'tabs', locals: { package: @package, project: @project }
+  = render partial: 'tabs', locals: { package: @package, project: @project, spider_bot: @spider_bot }
 
   .card-body
     %h3

--- a/src/api/app/views/webui/package/dependency.html.haml
+++ b/src/api/app/views/webui/package/dependency.html.haml
@@ -1,7 +1,7 @@
 - @pagetitle = "Dependency information about #{@filename}"
 
 .card
-  = render partial: 'tabs', locals: { package: @package, project: @project }
+  = render partial: 'tabs', locals: { package: @package, project: @project, spider_bot: @spider_bot }
 
   .card-body
     %h3 Dependency of #{@filename}

--- a/src/api/app/views/webui/package/live_build_log.html.haml
+++ b/src/api/app/views/webui/package/live_build_log.html.haml
@@ -2,7 +2,7 @@
 - @metarobots = 'noindex,nofollow'
 
 .card.mb-3
-  = render partial: 'tabs', locals: { project: @project, package: @package }
+  = render partial: 'tabs', locals: { project: @project, package: @package, spider_bot: @spider_bot }
   .card-body
     %h3= @pagetitle
     %p
@@ -20,7 +20,8 @@
         %summary #{@what_depends_on.length} #{'package'.pluralize(@what_depends_on.length)} with a direct dependency to this package.
         %strong Packages:
         = @what_depends_on.join(', ')
-    = render partial: 'live_build_log_controls'
+    = render partial: 'live_build_log_controls', locals: { can_modify: @can_modify, package_name: @package_name, project: @project,
+                                                           arch: @arch, repo: @repo }
     #log-space-wrapper{ data: { url: package_update_build_log_path(package: @package_name, project: @project,
                                                                    status: @status, arch: @arch, repository: @repo) } }
       .d-block.text-center.shadow-sm.position-sticky.w-100#log-info
@@ -40,7 +41,8 @@
           Build failed
       %pre.p-4.bg-light.text-pre-wrap#log-space
     - unless @workerid
-      = render partial: 'live_build_log_controls'
+      = render partial: 'live_build_log_controls', locals: { can_modify: @can_modify, package_name: @package_name, project: @project,
+                                                             arch: @arch, repo: @repo }
 
 :javascript
   liveLog = new LiveLog('#log-space-wrapper', '.start_refresh', '.stop_refresh', '#status', #{@finished}, '#log-info',

--- a/src/api/app/views/webui/package/meta.html.haml
+++ b/src/api/app/views/webui/package/meta.html.haml
@@ -2,7 +2,7 @@
 - @pagetitle = "Meta Configuration of Package #{@package}"
 
 .card
-  = render(partial: 'webui/package/tabs', locals: { project: @project, package: @package })
+  = render(partial: 'webui/package/tabs', locals: { project: @project, package: @package, spider_bot: @spider_bot })
 
   .card-body
     %h3= @pagetitle

--- a/src/api/app/views/webui/package/new.html.haml
+++ b/src/api/app/views/webui/package/new.html.haml
@@ -4,7 +4,7 @@
   .col
     .card
       -# We display the project tabs since we're creating a package in the context of the project `@project`
-      = render partial: 'webui/project/tabs', locals: { project: @project }
+      = render partial: 'webui/project/tabs', locals: { project: @project, spider_bot: @spider_bot }
       .card-body
         .row
           .col-12

--- a/src/api/app/views/webui/package/rdiff.html.haml
+++ b/src/api/app/views/webui/package/rdiff.html.haml
@@ -9,7 +9,7 @@
   = render partial: 'webui/shared/truncated_diff_hint', locals: { path: package_rdiff_path(path_variables) }
 
 .card
-  = render partial: 'tabs', locals: { project: @project, package: @package }
+  = render partial: 'tabs', locals: { project: @project, package: @package, spider_bot: @spider_bot }
   .card-body
     .row.mb-4
       .col-12
@@ -38,7 +38,8 @@
                 file: @files[filename],
                 index: index,
                 last: @filenames.last == filename,
-                package: @package }
+                package: @package,
+                linkinfo: @linkinfo }
         - else
           .mb-2
             %p.lead No source changes.

--- a/src/api/app/views/webui/package/requests.html.haml
+++ b/src/api/app/views/webui/package/requests.html.haml
@@ -1,7 +1,7 @@
 - @pagetitle = "Requests for #{@package}"
 
 .card
-  = render(partial: 'webui/package/tabs', locals: { project: @project, package: @package })
+  = render(partial: 'webui/package/tabs', locals: { project: @project, package: @package, spider_bot: @spider_bot })
 
   .card-body
     %h3= @pagetitle

--- a/src/api/app/views/webui/package/revisions.html.haml
+++ b/src/api/app/views/webui/package/revisions.html.haml
@@ -1,7 +1,7 @@
 - @pagetitle = "Revisions of #{@package}"
 
 .card
-  = render(partial: 'webui/package/tabs', locals: { project: @project, package: @package })
+  = render(partial: 'webui/package/tabs', locals: { project: @project, package: @package, spider_bot: @spider_bot })
 
   .card-body
     %h3

--- a/src/api/app/views/webui/package/rpmlint_log.html.haml
+++ b/src/api/app/views/webui/package/rpmlint_log.html.haml
@@ -1,0 +1,7 @@
+- @pagetitle = 'Rpmlint Log'
+
+- if @log
+  - @log.lines.each do |line|
+    = colorize_line(line)
+- else
+  No rpmlint log

--- a/src/api/app/views/webui/package/show.html.haml
+++ b/src/api/app/views/webui/package/show.html.haml
@@ -17,7 +17,7 @@
                                             is_working: @forced_unexpand.blank? }
 
 .card.mb-3
-  = render partial: 'tabs', locals: { project: @project, package: @package }
+  = render partial: 'tabs', locals: { project: @project, package: @package, spider_bot: @spider_bot }
   .card-body
     .row
       .col-md-8

--- a/src/api/app/views/webui/package/simple_file_view.html.haml
+++ b/src/api/app/views/webui/package/simple_file_view.html.haml
@@ -1,7 +1,7 @@
 - @pagetitle = "File #{@filename} of Package #{@package}"
 
 .card.mb-3
-  = render partial: 'tabs', locals: { project: @project, package: @package }
+  = render partial: 'tabs', locals: { project: @project, package: @package, spider_bot: @spider_bot }
   .card-body
     %h3= @pagetitle
     %pre.border.border-dotted.bg-light.p-2.mb-0= force_utf8_and_transform_nonprintables(@file)

--- a/src/api/app/views/webui/package/statistics.html.haml
+++ b/src/api/app/views/webui/package/statistics.html.haml
@@ -2,7 +2,7 @@
 - @metarobots = 'noindex' # files change too often
 
 .card.mb-3
-  = render partial: 'tabs', locals: { project: @project, package: @package }
+  = render partial: 'tabs', locals: { project: @project, package: @package, spider_bot: @spider_bot }
   .card-body
     - if @statistics
       .row

--- a/src/api/app/views/webui/package/users.html.haml
+++ b/src/api/app/views/webui/package/users.html.haml
@@ -1,7 +1,7 @@
 - @pagetitle = "Users of #{@package} (Project #{@project})"
 
 .card.mb-3
-  = render partial: 'tabs', locals: { project: @project, package: @package }
+  = render partial: 'tabs', locals: { project: @project, package: @package, spider_bot: @spider_bot }
   .card-body
     = render partial: 'webui/shared/user_or_groups_roles/index',
              locals: { project: @project, package: @package, users: @users, roles: @roles, groups: @groups }

--- a/src/api/app/views/webui/package/view_file.html.haml
+++ b/src/api/app/views/webui/package/view_file.html.haml
@@ -2,7 +2,7 @@
 - content_for(:content_for_head, javascript_include_tag('webui/cm2/codemirror-file'))
 
 .card.mb-3
-  = render partial: 'tabs', locals: { project: @project, package: @package }
+  = render partial: 'tabs', locals: { project: @project, package: @package, spider_bot: @spider_bot }
   .card-body
     %h3.text-word-break-all
       File #{@filename} of Package #{@package}

--- a/src/api/app/views/webui/packages/branches/into.html.haml
+++ b/src/api/app/views/webui/packages/branches/into.html.haml
@@ -3,7 +3,7 @@
 .row
   .col
     .card
-      = render partial: 'webui/project/tabs', locals: { project: @project }
+      = render partial: 'webui/project/tabs', locals: { project: @project, spider_bot: @spider_bot }
       .card-body
         .row
           .col-12

--- a/src/api/app/views/webui/packages/branches/new.html.haml
+++ b/src/api/app/views/webui/packages/branches/new.html.haml
@@ -5,7 +5,7 @@
 .row
   .col
     .card
-      = render partial: 'webui/package/tabs', locals: { project: @project, package: @package }
+      = render partial: 'webui/package/tabs', locals: { project: @project, package: @package, spider_bot: @spider_bot }
       .card-body
         .row
           .col-12

--- a/src/api/app/views/webui/packages/build_reason/index.html.haml
+++ b/src/api/app/views/webui/packages/build_reason/index.html.haml
@@ -1,7 +1,7 @@
 - @pagetitle = "Build Reason for #{@project} / #{@package_name}"
 
 .card
-  = render partial: 'webui/package/tabs', locals: { project: @project, package: @package }
+  = render partial: 'webui/package/tabs', locals: { project: @project, package: @package, spider_bot: @spider_bot }
   .card-body
     %h3
       = @pagetitle

--- a/src/api/app/views/webui/packages/files/new.html.haml
+++ b/src/api/app/views/webui/packages/files/new.html.haml
@@ -3,7 +3,7 @@
 .row
   .col
     .card
-      = render partial: 'webui/package/tabs', locals: { project: @project, package: @package }
+      = render partial: 'webui/package/tabs', locals: { project: @project, package: @package, spider_bot: @spider_bot }
       .card-body
         .col-12
           %h3 Upload file to #{@project.name}/#{@package.name}

--- a/src/api/app/views/webui/packages/job_history/index.html.haml
+++ b/src/api/app/views/webui/packages/job_history/index.html.haml
@@ -2,7 +2,7 @@
 - @metarobots = 'index,nofollow'
 
 .card
-  = render partial: 'webui/package/tabs', locals: { project: @project, package: @package }
+  = render partial: 'webui/package/tabs', locals: { project: @project, package: @package, spider_bot: @spider_bot }
 
   .card-body
     %h3= @pagetitle

--- a/src/api/app/views/webui/patchinfo/edit.html.haml
+++ b/src/api/app/views/webui/patchinfo/edit.html.haml
@@ -1,7 +1,7 @@
 - @pagetitle = "Edit Patchinfo for #{@project}"
 
 .card
-  = render partial: 'webui/package/tabs', locals: { project: @project, package: @package }
+  = render partial: 'webui/package/tabs', locals: { project: @project, package: @package, spider_bot: @spider_bot }
   .card-body
     %h3= @pagetitle
 

--- a/src/api/app/views/webui/patchinfo/show.html.haml
+++ b/src/api/app/views/webui/patchinfo/show.html.haml
@@ -1,7 +1,7 @@
 - @pagetitle = @package
 
 .card.mb-3
-  = render partial: 'webui/package/tabs', locals: { project: @project, package: @package }
+  = render partial: 'webui/package/tabs', locals: { project: @project, package: @package, spider_bot: @spider_bot }
   .card-body
     .patchinfo.row
       .col-md-8

--- a/src/api/app/views/webui/project/_form.html.haml
+++ b/src/api/app/views/webui/project/_form.html.haml
@@ -29,5 +29,5 @@
   = check_box_tag(:disable_publishing, 1, false, class: 'custom-control-input')
   = label_tag(:disable_publishing, 'Disable build results publishing', class: 'custom-control-label')
 
-- if @show_restore_message
+- if show_restore_message
   = hidden_field_tag(:restore_option_provided, true)

--- a/src/api/app/views/webui/project/_monitor_control.html.haml
+++ b/src/api/app/views/webui/project/_monitor_control.html.haml
@@ -64,7 +64,7 @@
         %h5.modal-title
           Build status legend
       .modal-body
-        - @legend.each do |status, description|
+        - legend.each do |status, description|
           %p
             %strong
               #{status}:

--- a/src/api/app/views/webui/project/_tabs.html.haml
+++ b/src/api/app/views/webui/project/_tabs.html.haml
@@ -1,6 +1,6 @@
 .bg-light.scrollable-tabs
   = tab_link('Overview', [project_show_path(project), keys_and_certificates_path(project)], false, 'scrollable-tab-link')
-  - unless @spider_bot
+  - unless spider_bot
     - if project.is_maintenance?
       = tab_link('Incidents', project_maintenance_incidents_path(project), false, 'scrollable-tab-link')
       = tab_link('Maintained Projects', project_maintained_projects_path(project), false, 'scrollable-tab-link')

--- a/src/api/app/views/webui/project/keys_and_certificates.html.haml
+++ b/src/api/app/views/webui/project/keys_and_certificates.html.haml
@@ -1,7 +1,7 @@
 - @pagetitle = "Key and certificate for #{@project}"
 
 .card.mb-3
-  = render partial: 'tabs', locals: { project: @project }
+  = render partial: 'tabs', locals: { project: @project, spider_bot: @spider_bot }
   .card-body
     %h3.card-title= @pagetitle
     .row

--- a/src/api/app/views/webui/project/monitor.html.haml
+++ b/src/api/app/views/webui/project/monitor.html.haml
@@ -1,7 +1,7 @@
 - @pagetitle = "Show #{@project}"
 
 .card.mb-3
-  = render partial: 'tabs', locals: { project: @project }
+  = render partial: 'tabs', locals: { project: @project, spider_bot: @spider_bot }
   .card-body#project-monitor
 
     - if @buildresult_unavailable
@@ -11,7 +11,7 @@
         locals: { project: @project, activate_client_search: @activate_client_search,
         status: @avail_status_values, repositories: @avail_repo_values, architectures: @avail_arch_values,
         repository_filter: @repo_filter, architecture_filter: @arch_filter, status_filter: @status_filter,
-        lastbuild_switch: @lastbuild_switch }
+        lastbuild_switch: @lastbuild_switch, legend: @legend }
       - tableinfo = []
       .row.mt-4
         .col-md-12.obs-dataTable.invisible

--- a/src/api/app/views/webui/project/new.html.haml
+++ b/src/api/app/views/webui/project/new.html.haml
@@ -19,7 +19,7 @@
           if you want to restore the project. If you want to start from scratch, click the 'Create Project' button again.
           %strong (Be aware that starting from scratch would mean that you'd delete the old state of the project and it can never get restored again!)
     = form_for(@project, url: projects_create_path, method: :post) do |form|
-      - locals = { form: form, configuration: @configuration }
+      - locals = { form: form, configuration: @configuration, show_restore_message: @show_restore_message }
       - locals[:namespace] = @namespace if @namespace.present?
       = render partial: 'form', locals: locals
       = submit_tag('Accept', class: 'btn btn-sm btn-primary px-4')

--- a/src/api/app/views/webui/project/release_request.html.haml
+++ b/src/api/app/views/webui/project/release_request.html.haml
@@ -3,7 +3,7 @@
 .row
   .col
     .card
-      = render partial: 'tabs', locals: { project: @project }
+      = render partial: 'tabs', locals: { project: @project, spider_bot: @spider_bot }
       .card-body
         .row
           .col-12

--- a/src/api/app/views/webui/project/requests.html.haml
+++ b/src/api/app/views/webui/project/requests.html.haml
@@ -1,7 +1,7 @@
 - @pagetitle = "Requests for #{@project}"
 
 .card
-  = render(partial: 'tabs', locals: { project: @project })
+  = render(partial: 'tabs', locals: { project: @project, spider_bot: @spider_bot })
 
   .card-body
     %h3= @pagetitle

--- a/src/api/app/views/webui/project/show.html.haml
+++ b/src/api/app/views/webui/project/show.html.haml
@@ -10,7 +10,7 @@
                                                           release_targets: @release_targets }
 
 .card.mb-3
-  = render partial: 'tabs', locals: { project: @project }
+  = render partial: 'tabs', locals: { project: @project, spider_bot: @spider_bot }
   .card-body
     .row
       .col-md-8

--- a/src/api/app/views/webui/project/show_actions/_request_to_release.html.haml
+++ b/src/api/app/views/webui/project/show_actions/_request_to_release.html.haml
@@ -1,4 +1,4 @@
 %li.nav-item
-  = link_to(project_release_request_path(@project), class: 'nav-link', title: 'Request to Release') do
+  = link_to(project_release_request_path(project), class: 'nav-link', title: 'Request to Release') do
     %i.fas.fa-share-square.fa-lg.mr-2
     %span.nav-item-name Request to Release

--- a/src/api/app/views/webui/project/subprojects.html.haml
+++ b/src/api/app/views/webui/project/subprojects.html.haml
@@ -3,7 +3,7 @@
   render partial: 'subprojects_actions', locals: { project: @project }
 
 .card.mb-3
-  = render partial: 'tabs', locals: { project: @project }
+  = render partial: 'tabs', locals: { project: @project, spider_bot: @spider_bot }
   .card-body
     .row
       .col-md-12

--- a/src/api/app/views/webui/project/users.html.haml
+++ b/src/api/app/views/webui/project/users.html.haml
@@ -1,7 +1,7 @@
 - @pagetitle = "Users of #{@project}"
 
 .card.mb-3
-  = render partial: 'tabs', locals: { project: @project }
+  = render partial: 'tabs', locals: { project: @project, spider_bot: @spider_bot }
   .card-body
     = render partial: 'webui/shared/user_or_groups_roles/index',
              locals: { project: @project, package: @package, users: @users, roles: @roles, groups: @groups }

--- a/src/api/app/views/webui/projects/maintained_projects/index.html.haml
+++ b/src/api/app/views/webui/projects/maintained_projects/index.html.haml
@@ -4,7 +4,7 @@
   data_source = project_maintained_projects_path(@project, :json)
 
 .card
-  = render partial: 'webui/project/tabs', locals: { project: @project }
+  = render partial: 'webui/project/tabs', locals: { project: @project, spider_bot: @spider_bot }
   .card-body
     %h3 Maintained Projects
 

--- a/src/api/app/views/webui/projects/maintenance_incident_requests/new.html.haml
+++ b/src/api/app/views/webui/projects/maintenance_incident_requests/new.html.haml
@@ -3,7 +3,7 @@
 .row
   .col
     .card
-      = render partial: 'webui/project/tabs', locals: { project: @project }
+      = render partial: 'webui/project/tabs', locals: { project: @project, spider_bot: @spider_bot }
       .card-body
         .row
           .col-12

--- a/src/api/app/views/webui/projects/maintenance_incidents/index.html.haml
+++ b/src/api/app/views/webui/projects/maintenance_incidents/index.html.haml
@@ -1,7 +1,7 @@
 - @pagetitle = 'Maintenance Incidents'
 
 .card.mb-3
-  = render partial: 'webui/project/tabs', locals: { project: @project }
+  = render partial: 'webui/project/tabs', locals: { project: @project, spider_bot: @spider_bot }
   .card-body
     %h3
       Maintenance incidents

--- a/src/api/app/views/webui/projects/meta/show.html.haml
+++ b/src/api/app/views/webui/projects/meta/show.html.haml
@@ -4,7 +4,7 @@
   @metarobots = 'noindex'
 
 .card
-  = render(partial: 'webui/project/tabs', locals: { project: @project })
+  = render(partial: 'webui/project/tabs', locals: { project: @project, spider_bot: @spider_bot })
 
   .card-body
     %h3= @pagetitle

--- a/src/api/app/views/webui/projects/project_configuration/show.html.haml
+++ b/src/api/app/views/webui/projects/project_configuration/show.html.haml
@@ -4,7 +4,7 @@
   @metarobots = 'noindex'
 
 .card
-  = render(partial: 'webui/project/tabs', locals: { project: @project })
+  = render(partial: 'webui/project/tabs', locals: { project: @project, spider_bot: @spider_bot })
 
   .card-body
     %h3= @pagetitle

--- a/src/api/app/views/webui/projects/pulse/_pulse_list_requests.html.haml
+++ b/src/api/app/views/webui/projects/pulse/_pulse_list_requests.html.haml
@@ -1,5 +1,5 @@
 .row
-  - @requests.take(30).each do |request|
+  - requests.take(30).each do |request|
     %dt.col-12.col-md-2.col-lg-1
       %span{ class: "badge progress-state-#{request.state} text-light" }
         = request.state.to_s

--- a/src/api/app/views/webui/projects/pulse/show.html.haml
+++ b/src/api/app/views/webui/projects/pulse/show.html.haml
@@ -1,7 +1,7 @@
 - @pagetitle = "Pulse for #{@project}"
 
 .card
-  = render(partial: 'webui/project/tabs', locals: { project: @project })
+  = render(partial: 'webui/project/tabs', locals: { project: @project, spider_bot: @spider_bot })
 
   .card-body
     .row.mb-3

--- a/src/api/app/views/webui/projects/rebuild_times/show.html.haml
+++ b/src/api/app/views/webui/projects/rebuild_times/show.html.haml
@@ -6,7 +6,7 @@
   p3 = @longestpaths[2].reverse
 
 .card
-  = render(partial: 'webui/project/tabs', locals: { project: @project })
+  = render(partial: 'webui/project/tabs', locals: { project: @project, spider_bot: @spider_bot })
   .card-body
     %h3
       Rebuildtime:

--- a/src/api/app/views/webui/projects/status/show.html.haml
+++ b/src/api/app/views/webui/projects/status/show.html.haml
@@ -3,7 +3,7 @@
   parsed_result = {}
 
 .card
-  = render partial: 'webui/project/tabs', locals: { project: @project }
+  = render partial: 'webui/project/tabs', locals: { project: @project, spider_bot: @spider_bot }
 
   .card-body
     %h3

--- a/src/api/app/views/webui/repositories/_package_repositories.html.haml
+++ b/src/api/app/views/webui/repositories/_package_repositories.html.haml
@@ -1,5 +1,5 @@
 .card.mb-3
-  = render partial: 'webui/package/tabs', locals: { project: project, package: package }
+  = render partial: 'webui/package/tabs', locals: { project: project, package: package, spider_bot: spider_bot }
   .card-body
     %h3= pagetitle
     - if package.project == project

--- a/src/api/app/views/webui/repositories/_project_repositories.html.haml
+++ b/src/api/app/views/webui/repositories/_project_repositories.html.haml
@@ -1,5 +1,5 @@
 .card.mb-3
-  = render partial: 'webui/project/tabs', locals: { project: project }
+  = render partial: 'webui/project/tabs', locals: { project: project, spider_bot: spider_bot }
   .card-body
     %h3.pb-2= pagetitle
 

--- a/src/api/app/views/webui/repositories/index.html.haml
+++ b/src/api/app/views/webui/repositories/index.html.haml
@@ -11,7 +11,8 @@
                                                       flags: @flags,
                                                       architectures: @architectures,
                                                       user_can_modify: @user_can_modify,
-                                                      pagetitle: @pagetitle }
+                                                      pagetitle: @pagetitle,
+                                                      spider_bot: @spider_bot }
 - else
   - @pagetitle = "Repositories for #{@project}"
   = render partial: 'project_repositories', locals: { project: @project,
@@ -22,4 +23,5 @@
                                                       available_architectures: @available_architectures,
                                                       repositories: @repositories,
                                                       configuration: @configuration,
-                                                      pagetitle: @pagetitle }
+                                                      pagetitle: @pagetitle,
+                                                      spider_bot: @spider_bot }

--- a/src/api/app/views/webui/repositories/state.html.haml
+++ b/src/api/app/views/webui/repositories/state.html.haml
@@ -1,7 +1,7 @@
 - @pagetitle = "Repository State of #{@project.name}"
 - @metarobots = 'noindex'
 .card
-  = render(partial: 'webui/project/tabs', locals: { project: @project })
+  = render(partial: 'webui/project/tabs', locals: { project: @project, spider_bot: @spider_bot })
   .card-body
     %h3
       State of Repository #{@repository} for #{@project}

--- a/src/api/app/views/webui/requests/deletions/new.html.haml
+++ b/src/api/app/views/webui/requests/deletions/new.html.haml
@@ -4,9 +4,9 @@
   .col
     .card
       - if @package
-        = render partial: 'webui/package/tabs', locals: { project: @project, package: @package }
+        = render partial: 'webui/package/tabs', locals: { project: @project, package: @package, spider_bot: @spider_bot }
       - else
-        = render partial: 'webui/project/tabs', locals: { project: @project }
+        = render partial: 'webui/project/tabs', locals: { project: @project, spider_bot: @spider_bot }
       .card-body
         .row
           .col-12

--- a/src/api/app/views/webui/requests/devel_project_changes/new.html.haml
+++ b/src/api/app/views/webui/requests/devel_project_changes/new.html.haml
@@ -3,7 +3,7 @@
 .row
   .col
     .card.mb-3
-      = render partial: 'webui/package/tabs', locals: { project: @project, package: @package }
+      = render partial: 'webui/package/tabs', locals: { project: @project, package: @package, spider_bot: @spider_bot }
       .card-body
         .row
           .col-12.col-md-8.col-lg-6

--- a/src/api/app/views/webui/requests/role_additions/new.html.haml
+++ b/src/api/app/views/webui/requests/role_additions/new.html.haml
@@ -4,9 +4,9 @@
   .col
     .card
       - if @package
-        = render partial: 'webui/package/tabs', locals: { project: @project, package: @package }
+        = render partial: 'webui/package/tabs', locals: { project: @project, package: @package, spider_bot: @spider_bot }
       - else
-        = render partial: 'webui/project/tabs', locals: { project: @project }
+        = render partial: 'webui/project/tabs', locals: { project: @project, spider_bot: @spider_bot }
       .card-body
         .row
           .col-12

--- a/src/api/app/views/webui/requests/submissions/new.html.haml
+++ b/src/api/app/views/webui/requests/submissions/new.html.haml
@@ -4,7 +4,7 @@
 .row
   .col
     .card
-      = render partial: 'webui/package/tabs', locals: { project: @project, package: @package }
+      = render partial: 'webui/package/tabs', locals: { project: @project, package: @package, spider_bot: @spider_bot }
       .card-body
         .col-12
           %h3= @pagetitle

--- a/src/api/app/views/webui/shared/user_or_groups_roles/_index.html.haml
+++ b/src/api/app/views/webui/shared/user_or_groups_roles/_index.html.haml
@@ -43,7 +43,7 @@
   %hr
 
   %h3 Group Roles
-  - if @groups.present?
+  - if groups.present?
     %table.responsive.table.table-sm.table-bordered.table-hover.w-100#group-table
       %thead
         %tr

--- a/src/api/app/views/webui/staging/projects/preview_copy.html.haml
+++ b/src/api/app/views/webui/staging/projects/preview_copy.html.haml
@@ -3,7 +3,7 @@
 .row
   .col-xl-10
     .card.mb-3
-      = render(partial: 'webui/project/tabs', locals: { project: @staging_project })
+      = render(partial: 'webui/project/tabs', locals: { project: @staging_project, spider_bot: @spider_bot })
       .card-body
         %h3= @pagetitle
         %p The following data will be copied:

--- a/src/api/app/views/webui/staging/projects/show.html.haml
+++ b/src/api/app/views/webui/staging/projects/show.html.haml
@@ -3,7 +3,7 @@
 .row
   .col-xl-10
     .card.mb-3
-      = render(partial: 'webui/project/tabs', locals: { project: @staging_project })
+      = render(partial: 'webui/project/tabs', locals: { project: @staging_project, spider_bot: @spider_bot })
       .card-body
         %h3= @pagetitle
         %h4.mt-4 Packages

--- a/src/api/app/views/webui/staging/workflows/edit.html.haml
+++ b/src/api/app/views/webui/staging/workflows/edit.html.haml
@@ -8,7 +8,7 @@
 .row
   .col-xl-12
     .card.mb-3
-      = render(partial: 'webui/project/tabs', locals: { project: @project })
+      = render(partial: 'webui/project/tabs', locals: { project: @project, spider_bot: @spider_bot })
       .card-body
         %h3
           = @pagetitle

--- a/src/api/app/views/webui/staging/workflows/new.html.haml
+++ b/src/api/app/views/webui/staging/workflows/new.html.haml
@@ -1,7 +1,7 @@
 - @pagetitle = "Staging Projects for #{@project}"
 
 .card.mb-3
-  = render(partial: 'webui/project/tabs', locals: { project: @project })
+  = render(partial: 'webui/project/tabs', locals: { project: @project, spider_bot: @spider_bot })
   .card-body
     %h3= @pagetitle
     %p

--- a/src/api/app/views/webui/staging/workflows/show.html.haml
+++ b/src/api/app/views/webui/staging/workflows/show.html.haml
@@ -3,7 +3,7 @@
 .row
   .col-xl-10
     .card.mb-3
-      = render(partial: 'webui/project/tabs', locals: { project: @project })
+      = render(partial: 'webui/project/tabs', locals: { project: @project, spider_bot: @spider_bot })
       .card-body
         %h3
           = @pagetitle

--- a/src/api/spec/controllers/webui/package_controller_spec.rb
+++ b/src/api/spec/controllers/webui/package_controller_spec.rb
@@ -1040,7 +1040,7 @@ RSpec.describe Webui::PackageController, vcr: true do
       end
 
       it { is_expected.to have_http_status(:success) }
-      it { is_expected.to render_template('webui/package/_rpmlint_log') }
+      it { is_expected.to render_template('webui/package/rpmlint_log') }
     end
   end
 


### PR DESCRIPTION
Those offenses are now reported after updating haml-lint in https://github.com/openSUSE/open-build-service/pull/12973. They weren't caught in that PR, since we run haml-lint only when Haml templates are updated.

This is what haml-lint reported for all the partials updated in this PR:

> InstanceVariables: Avoid using instance variables in not_breadcrumb_items views