### PR TITLE
Temporarily disable haml-lint's InstanceVariables check

### DIFF
--- a/src/api/app/views/layouts/webui/_footer.html.haml
+++ b/src/api/app/views/layouts/webui/_footer.html.haml
@@ -14,7 +14,9 @@
     %ul
       %li= link_to('Projects', projects_path)
       %li= link_to('Search', search_path, class: 'search-link')
+      -# haml-lint:disable InstanceVariables
       - unless @spider_bot
+        -# haml-lint:enable InstanceVariables
         %li= link_to('Status Monitor', monitor_path)
   %div
     %strong.text-uppercase Help

--- a/src/api/app/views/layouts/webui/_left_navigation_nobody.html.haml
+++ b/src/api/app/views/layouts/webui/_left_navigation_nobody.html.haml
@@ -6,7 +6,9 @@
     = link_to(projects_path, class: 'nav-link', title: 'All Projects') do
       %i.fas.fa-list.fa-lg.mr-2
       %span.nav-item-name All Projects
+  -# haml-lint:disable InstanceVariables
   - unless @spider_bot
+    -# haml-lint:enable InstanceVariables
     %li.nav-item
       = link_to(monitor_path, class: 'nav-link', title: 'Status Monitor') do
         %i.fas.fa-heartbeat.fa-lg.mr-2

--- a/src/api/app/views/layouts/webui/_places.html.haml
+++ b/src/api/app/views/layouts/webui/_places.html.haml
@@ -52,7 +52,9 @@
       = link_to(projects_path, class: 'nav-link', title: 'All Projects') do
         %i.fas.fa-list.fa-lg.mr-2
         %span.nav-item-name All Projects
+    -# haml-lint:disable InstanceVariables
     - unless @spider_bot
+      -# haml-lint:enable InstanceVariables
       %li.nav-item
         = link_to(monitor_path, class: 'nav-link', title: 'Status Monitor') do
           %i.fas.fa-heartbeat.fa-lg.mr-2

--- a/src/api/app/views/webui/kiwi/images/_preferences.html.haml
+++ b/src/api/app/views/webui/kiwi/images/_preferences.html.haml
@@ -3,7 +3,9 @@
     %h5.card-header#image-name
       Preferences
     .card-body
+      -# haml-lint:disable InstanceVariables
       - @image.preferences.each do |preference|
+        -# haml-lint:enable InstanceVariables
         %h6= preference.profile
         %ul.list-inline
           %li.list-inline-item

--- a/src/api/app/views/webui/kiwi/images/_preferences_form.html.haml
+++ b/src/api/app/views/webui/kiwi/images/_preferences_form.html.haml
@@ -9,7 +9,9 @@
           Kiwi Image name cannot be empty!
       .modal-body
         .dialog
+          -# haml-lint:disable InstanceVariables
           - @image.preferences.each do |preference|
+            -# haml-lint:enable InstanceVariables
             = f.fields_for(:preferences, preference) do |preference_fields|
               %h4= preference.profile
               = preference_fields.label :version do

--- a/src/api/app/views/webui/kiwi/images/_profiles.html.haml
+++ b/src/api/app/views/webui/kiwi/images/_profiles.html.haml
@@ -3,11 +3,15 @@
     Profiles
   .card-body
     %p Select one or more profiles to build. At least one profile needs to be selected to trigger builds.
+    -# haml-lint:disable InstanceVariables
     - if @image.profiles.empty?
+      -# haml-lint:enable InstanceVariables
       %p There are no profiles
     - else
       %ul.list-unstyled
+        -# haml-lint:disable InstanceVariables
         - @image.profiles.each do |profile|
+          -# haml-lint:enable InstanceVariables
           %li
             = f.fields_for(:profiles, profile) do |profile_fields|
               .custom-control.custom-checkbox

--- a/src/api/app/views/webui/main/_latest_updates.html.haml
+++ b/src/api/app/views/webui/main/_latest_updates.html.haml
@@ -6,7 +6,9 @@
       = link_to(latest_updates_feed_path(format: 'rss'), title: 'RSS Feed') do
         %i.fa.fa-rss
   .list-group
+    -# haml-lint:disable InstanceVariables
     - @latest_updates.each do |update|
+      -# haml-lint:enable InstanceVariables
       .list-group-item.list-group-item-integrated.border-left-0.border-right-0
         .row
           .col-1

--- a/src/api/app/views/webui/package/_commit_item.html.haml
+++ b/src/api/app/views/webui/package/_commit_item.html.haml
@@ -26,10 +26,14 @@
   %ul.nav.float-right
     - if commit['rev'] != '1'
       %li.nav-item
+        -# haml-lint:disable InstanceVariables
         = link_to(package_rdiff_path(@project, @package, rev: commit['rev'], linkrev: 'base'), class: 'nav-link') do
+          -# haml-lint:enable InstanceVariables
           %i.fas.fa-copy.text-gray-500
           Files Changed
     %li.nav-item
+      -# haml-lint:disable InstanceVariables
       = link_to(package_show_path(@project, @package, rev: commit['rev']), class: 'nav-link') do
+        -# haml-lint:enable InstanceVariables
         %i.fas.fa-folder-open.text-warning
         Browse Source

--- a/src/api/app/views/webui/package/_live_build_log_controls.html.haml
+++ b/src/api/app/views/webui/package/_live_build_log_controls.html.haml
@@ -1,3 +1,4 @@
+-# haml-lint:disable InstanceVariables
 %p.d-flex
   = link_to('#', class: 'start_refresh d-none live-link-action btn-info') do
     %i.far.fa-play-circle
@@ -35,3 +36,4 @@
             title: 'Request permission for browser notifications') do
     %i.far.fa-bell
     Request Browser Notifications
+-# haml-lint:enable InstanceVariables

--- a/src/api/app/views/webui/package/_revision_diff_detail_buttons.html.haml
+++ b/src/api/app/views/webui/package/_revision_diff_detail_buttons.html.haml
@@ -7,7 +7,9 @@
   href: "#revision_details_#{index + 1}",
   title: 'Go down to the next diff' }
     %i.fas.fa-chevron-down
+  -# haml-lint:disable InstanceVariables
   - if file_view_path && has_content && !@linkinfo && viewable_file?(filename)
+    -# haml-lint:enable InstanceVariables
     = link_to(file_view_path, class: 'btn btn-outline-secondary', title: 'View the whole file') do
       %span.d-none.d-sm-none.d-md-block View file
       %i.far.fa-file.d-block.d-sm-block.d-md-none

--- a/src/api/app/views/webui/package/_rpmlint_log.html.haml
+++ b/src/api/app/views/webui/package/_rpmlint_log.html.haml
@@ -1,2 +1,4 @@
+-# haml-lint:disable InstanceVariables
 - @log.lines.each do |line|
+  -# haml-lint:enable InstanceVariables
   = colorize_line(line)

--- a/src/api/app/views/webui/package/_tabs.html.haml
+++ b/src/api/app/views/webui/package/_tabs.html.haml
@@ -2,7 +2,9 @@
   = tab_link('Overview', package_show_path(project, package), false, 'scrollable-tab-link')
   - if package.name == 'patchinfo'
     = tab_link('Details', show_patchinfo_path(project, package), false, 'scrollable-tab-link')
+  -# haml-lint:disable InstanceVariables
   - unless @spider_bot
+    -# haml-lint:enable InstanceVariables
     = tab_link('Repositories', repositories_path(project, package), false, 'scrollable-tab-link')
     = tab_link('Revisions', package_view_revisions_path(project, package), false, 'scrollable-tab-link')
     = tab_link('Requests', package_requests_path(project, package), false, 'scrollable-tab-link')

--- a/src/api/app/views/webui/project/_form.html.haml
+++ b/src/api/app/views/webui/project/_form.html.haml
@@ -29,5 +29,7 @@
   = check_box_tag(:disable_publishing, 1, false, class: 'custom-control-input')
   = label_tag(:disable_publishing, 'Disable build results publishing', class: 'custom-control-label')
 
+-# haml-lint:disable InstanceVariables
 - if @show_restore_message
+  -# haml-lint:enable InstanceVariables
   = hidden_field_tag(:restore_option_provided, true)

--- a/src/api/app/views/webui/project/_monitor_control.html.haml
+++ b/src/api/app/views/webui/project/_monitor_control.html.haml
@@ -64,7 +64,9 @@
         %h5.modal-title
           Build status legend
       .modal-body
+        -# haml-lint:disable InstanceVariables
         - @legend.each do |status, description|
+          -# haml-lint:enable InstanceVariables
           %p
             %strong
               #{status}:

--- a/src/api/app/views/webui/project/_tabs.html.haml
+++ b/src/api/app/views/webui/project/_tabs.html.haml
@@ -1,6 +1,8 @@
 .bg-light.scrollable-tabs
   = tab_link('Overview', [project_show_path(project), keys_and_certificates_path(project)], false, 'scrollable-tab-link')
+  -# haml-lint:disable InstanceVariables
   - unless @spider_bot
+    -# haml-lint:enable InstanceVariables
     - if project.is_maintenance?
       = tab_link('Incidents', project_maintenance_incidents_path(project), false, 'scrollable-tab-link')
       = tab_link('Maintained Projects', project_maintained_projects_path(project), false, 'scrollable-tab-link')

--- a/src/api/app/views/webui/project/show_actions/_request_to_release.html.haml
+++ b/src/api/app/views/webui/project/show_actions/_request_to_release.html.haml
@@ -1,4 +1,6 @@
 %li.nav-item
+  -# haml-lint:disable InstanceVariables
   = link_to(project_release_request_path(@project), class: 'nav-link', title: 'Request to Release') do
+    -# haml-lint:enable InstanceVariables
     %i.fas.fa-share-square.fa-lg.mr-2
     %span.nav-item-name Request to Release

--- a/src/api/app/views/webui/projects/pulse/_pulse_list_requests.html.haml
+++ b/src/api/app/views/webui/projects/pulse/_pulse_list_requests.html.haml
@@ -1,5 +1,7 @@
 .row
+  -# haml-lint:disable InstanceVariables
   - @requests.take(30).each do |request|
+    -# haml-lint:enable InstanceVariables
     %dt.col-12.col-md-2.col-lg-1
       %span{ class: "badge progress-state-#{request.state} text-light" }
         = request.state.to_s

--- a/src/api/app/views/webui/shared/user_or_groups_roles/_index.html.haml
+++ b/src/api/app/views/webui/shared/user_or_groups_roles/_index.html.haml
@@ -43,7 +43,9 @@
   %hr
 
   %h3 Group Roles
+  -# haml-lint:disable InstanceVariables
   - if @groups.present?
+    -# haml-lint:enable InstanceVariables
     %table.responsive.table.table-sm.table-bordered.table-hover.w-100#group-table
       %thead
         %tr


### PR DESCRIPTION
Disabling the check on every line which registers an offense allows us to split the fixes in multiple PRs. This makes everything much easier to review.