### PR TITLE
Label PRs as documentation when they contain release notes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -9,6 +9,7 @@ Backend:
 - docs/**/*
 - '**/*.md'
 - src/api/public/apidocs-new/**/*
+- ReleaseNotes-*
 
 "Test Suite / CI :syringe:":
 - .circleci/**/*


### PR DESCRIPTION
After submitting #12994, I thought this could be automated.