### PR TITLE
Fix search endpoints where match parameter is required

### DIFF
--- a/src/api/public/apidocs-new/paths/search_package.yaml
+++ b/src/api/public/apidocs-new/paths/search_package.yaml
@@ -12,10 +12,11 @@ get:
       name: match
       schema:
         type: string
+      required: yes
       description: |
         Expression based in XPath.
 
-        Not providing a value or providing a value of `*` will return all packages.
+        Providing a value of `*` will return all packages.
 
         Available predicates are:
           - Package fields: `@name`, `title`, `description`, and `kind`.

--- a/src/api/public/apidocs-new/paths/search_person.yaml
+++ b/src/api/public/apidocs-new/paths/search_person.yaml
@@ -8,6 +8,7 @@ get:
       name: match
       schema:
         type: string
+      required: yes
       description: |
         Expression based in XPath.
 

--- a/src/api/public/apidocs-new/paths/search_project.yaml
+++ b/src/api/public/apidocs-new/paths/search_project.yaml
@@ -12,10 +12,11 @@ get:
       name: match
       schema:
         type: string
+      required: yes
       description: |
         Expression based in XPath.
 
-        Not providing a value or providing a value of `*` will return all projects.
+        Providing a value of `*` will return all projects.
 
         Available predicates are:
           - Project fields: `@name`, `@kind`, `title`, `description`, `url`, and `remoteurl`.


### PR DESCRIPTION
Also remove that for the match parameter not providing a value will return all packages. This is not the case in those endpoints.

As an example:
```
> osc api "/search/project?match="
Server returned an error: HTTP Error 400: Bad Request
No predicate found in match argument
```