### PR TITLE
Call `Backend::Test.start` only when necessary

### DIFF
--- a/src/api/app/controllers/application_controller.rb
+++ b/src/api/app/controllers/application_controller.rb
@@ -114,7 +114,6 @@ class ApplicationController < ActionController::Base
 
   def volley_backend_path(path)
     logger.debug "[backend] VOLLEY: #{path}"
-    Backend::Test.start
     backend_http = Net::HTTP.new(CONFIG['source_host'], CONFIG['source_port'])
     backend_http.read_timeout = 1000
 

--- a/src/api/app/controllers/search_controller.rb
+++ b/src/api/app/controllers/search_controller.rb
@@ -103,8 +103,6 @@ class SearchController < ApplicationController
   end
 
   def owner
-    Backend::Test.start if Rails.env.test?
-
     if params[:binary].present?
       owners = OwnerSearch::Assignee.new(params).for(params[:binary])
     elsif (obj = owner_group_or_user)

--- a/src/api/app/controllers/webui/search_controller.rb
+++ b/src/api/app/controllers/webui/search_controller.rb
@@ -8,8 +8,6 @@ class Webui::SearchController < Webui::WebuiController
   end
 
   def owner
-    Backend::Test.start if Rails.env.test?
-
     # If the search is too short, return
     return if @search_text.blank?
 

--- a/src/api/app/lib/backend/connection.rb
+++ b/src/api/app/lib/backend/connection.rb
@@ -10,7 +10,6 @@ module Backend
     end
 
     def self.get(path, in_headers = {})
-      Backend::Test.start
       start_time = Time.now
       Rails.logger.debug { "[backend] GET: #{path}" }
       timeout = in_headers.delete('Timeout') || 1000
@@ -43,7 +42,6 @@ module Backend
     end
 
     def self.delete(path, in_headers = {})
-      Backend::Test.start
       start_time = Time.now
       Rails.logger.debug { "[backend] DELETE: #{path}" }
       timeout = in_headers.delete('Timeout') || 1000
@@ -78,7 +76,6 @@ module Backend
     #### private
 
     def self.put_or_post(method, path, data, in_headers)
-      Backend::Test.start
       start_time = Time.now
       Rails.logger.debug { "[backend] #{method}: #{path}" }
       timeout = in_headers.delete('Timeout')

--- a/src/api/spec/support/backend.rb
+++ b/src/api/spec/support/backend.rb
@@ -1,12 +1,5 @@
 # Allow connections to localhost
 WebMock.disable_net_connect!(allow_localhost: true)
 
-RSpec.configure do |config|
-  # build each factory and call #valid? on it
-  config.before(:suite) do
-    # Backend::Test.start
-  end
-end
-
 # for mocking the backend
 require 'support/vcr'

--- a/src/api/test/unit/bs_request_test.rb
+++ b/src/api/test/unit/bs_request_test.rb
@@ -8,6 +8,7 @@ class BsRequestTest < ActiveSupport::TestCase
   end
 
   test 'if create works' do
+    Backend::Test.start
     xml = '<request>
               <action type="submit">
                 <source project="BaseDistro" package="pack2" rev="1"/>


### PR DESCRIPTION
The `Backend::Test.start` call is only needed when running the minitests. This PR removes the calls to start the test backend from the codebase, not from the tests.

Once the backend test is up, it keeps running until minitests are finished.

Add a call to start the test backend in the first minitest from the group of tests run in the `test:api:group1` group. This makes it possible to run this whole group of tests with a test backend.