### PR TITLE
Remove obsolete `plugin` script

### DIFF
--- a/src/api/script/plugin
+++ b/src/api/script/plugin
@@ -1,3 +1,0 @@
-#!/usr/bin/ruby.ruby3.1
-require File.dirname(__FILE__) + '/../config/boot'
-require 'commands/plugin'


### PR DESCRIPTION
It belongs to the initial import of the rails application. It is not used.