### PR TITLE
Display review's project/package name as string

### DIFF
--- a/src/api/app/components/bs_request_overview_avatars_component.html.haml
+++ b/src/api/app/components/bs_request_overview_avatars_component.html.haml
@@ -1,15 +1,15 @@
 %ul.list-inline.d-flex.flex-row-reverse.avatars.m-0
-  - if number_of_hidden_avatars.positive?
-    %li.list-inline-item
-      %span.rounded-circle.bg-light.border.border-gray-400.avatars-counter{ title: "#{number_of_hidden_avatars} more users involved" }
-        +#{number_of_hidden_avatars}
-  - avatars_to_display.each do |avatar_object|
-    %li.list-inline-item
-      = helpers.image_tag_for(avatar_object, size: 23, custom_class: 'rounded-circle bg-light border border-gray-400')
-
   - if avatar_objects.empty? && @review.for_package?
     %li.list-inline-item
       %i.fa.fa-archive.text-warning.rounded-circle.bg-light.border.border-gray-400.simulated-avatar
   - elsif avatar_objects.empty? && @review.for_project?
     %li.list-inline-item
       %i.fa.fa-cubes.text-secondary.rounded-circle.bg-light.border.border-gray-400.simulated-avatar
+  - else
+    - if number_of_hidden_avatars.positive?
+      %li.list-inline-item
+        %span.rounded-circle.bg-light.border.border-gray-400.avatars-counter{ title: "#{number_of_hidden_avatars} more users involved" }
+          +#{number_of_hidden_avatars}
+    - avatars_to_display.each do |avatar_object|
+      %li.list-inline-item
+        = helpers.image_tag_for(avatar_object, size: 23, custom_class: 'rounded-circle bg-light border border-gray-400')

--- a/src/api/app/components/bs_request_overview_avatars_component.rb
+++ b/src/api/app/components/bs_request_overview_avatars_component.rb
@@ -13,12 +13,24 @@ class BsRequestOverviewAvatarsComponent < ApplicationComponent
     @avatar_objects ||= if @review.for_user?
                           [@review.user]
                         elsif @review.for_group?
-                          [@review.group.users, @review.group].flatten
+                          group_avatar_objects
                         elsif @review.for_package?
-                          @review.package.project.users
+                          package_avatar_objects
                         elsif @review.for_project?
-                          @review.project.users
+                          project_avatar_objects
                         end
+  end
+
+  def group_avatar_objects
+    [@review.group.users, @review.group].flatten
+  end
+
+  def package_avatar_objects
+    [@review.package&.project&.users].flatten.compact
+  end
+
+  def project_avatar_objects
+    [@review.project&.users].flatten.compact
   end
 
   def avatars_to_display

--- a/src/api/app/views/webui/request/beta_show_tabs/_review_summary.html.haml
+++ b/src/api/app/views/webui/request/beta_show_tabs/_review_summary.html.haml
@@ -1,28 +1,23 @@
--# FIXME: We don't render anything when the project got deleted because this nullifies the association. It should point to
-  `Project.deleted_instance` or maybe the project got created with the same name again in the meanwhile?
-- unless (review.for_project? || review.for_package?) && review.project.nil?
-  .d-flex.flex-row.pt-1
-    .pl-3
-      - if review.accepted?
-        %i.fas.fa-sm.fa-check.text-primary.align-middle.pr-1
-      - if review.declined?
-        %i.fas.fa-times.text-danger.align-middle.pr-2
-      - if review.new?
-        %i.fas.fa-2xs.fa-circle.text-warning.align-middle.pr-2
+.d-flex.flex-row.pt-1
+  .pl-3
+    - if review.accepted?
+      %i.fas.fa-sm.fa-check.text-primary.align-middle.pr-1
+    - if review.declined?
+      %i.fas.fa-times.text-danger.align-middle.pr-2
+    - if review.new?
+      %i.fas.fa-2xs.fa-circle.text-warning.align-middle.pr-2
 
-    = render BsRequestOverviewAvatarsComponent.new(review)
+  = render BsRequestOverviewAvatarsComponent.new(review)
 
-    .pl-1
-      - if review.for_user?
-        = user_with_realname_and_icon(review.by_user, short: true, no_icon: true)
-      - elsif review.for_group?
-        = link_to(review.by_group, group_path(Group.find_by(title: review.by_group)))
-      - elsif review.for_package?
-        = link_to("#{review.by_project} / #{review.by_package}", package_users_path(project: review.by_project,
-          package: review.by_package))
-      - elsif review.for_project?
-        = link_to(review.by_project, project_users_path(project: review.by_project))
-
-      - if (review.accepted? || review.declined?) && !review.for_user?
-        by
-        = link_to(review.reviewer, user_path(User.find_by(login: review.reviewer)))
+  .pl-1
+    - if review.for_user?
+      = user_with_realname_and_icon(review.by_user, short: true, no_icon: true)
+    - elsif review.for_group?
+      = link_to(review.by_group, group_path(Group.find_by(title: review.by_group)))
+    - elsif review.for_package?
+      = project_or_package_link(project: review.by_project, package: review.by_package, short: true)
+    - elsif review.for_project?
+      = project_or_package_link(project: review.by_project, short: true)
+    - if (review.accepted? || review.declined?) && !review.for_user?
+      by
+      = link_to(review.reviewer, user_path(User.find_by(login: review.reviewer)))


### PR DESCRIPTION
Sometimes the package associated with the review is deleted, i.e. after accepting a deletion request. So we stop retrieving those packages and simply display their names as a string.

We do something similar with the deleted projects. Before we didn't display the associated review at all.

As we can't retrieve the users and their avatars, we display the project or package icon as an avatar in the REVIEW section.

**When the project was deleted:**

![Screenshot 2022-09-01 at 12-15-06 Open Build Service](https://user-images.githubusercontent.com/2581944/187896726-e9d5d756-6a73-4573-805a-aa4b15862e91.png)

**When the package was deleted:**

![Screenshot 2022-09-01 at 12-14-53 Open Build Service](https://user-images.githubusercontent.com/2581944/187896728-2c77558e-e7ce-40d1-b847-5f727e2be17f.png)