### PR TITLE
Preparation for Rails 7 - Refactor wrap_parameters.rb initializer

### DIFF
--- a/src/api/config/initializers/prefer_xml_over_html.rb
+++ b/src/api/config/initializers/prefer_xml_over_html.rb
@@ -1,0 +1,19 @@
+# Custom Rack middleware to prefer XML over HTML whenever the HTTP header HTTP_ACCEPT isn't set in a request.
+# Without this, clients like `osc` attempt to fetch HTML and they end up getting 404s as OBS has been defaulting to XML
+# since the commit 8145e40a6266f40ce771052fd11e372efc85e116 was introduced many, many years ago. Changing all clients
+# is a lot of work, so we stick to this default.
+#
+# Details on HTTP_ACCEPT:
+# https://www.rfc-editor.org/rfc/rfc9110.html#name-accept
+class PreferXmlOverHtml
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    env['HTTP_ACCEPT'] ||= 'application/xml'
+    @app.call(env)
+  end
+end
+
+OBSApi::Application.config.middleware.use(PreferXmlOverHtml)

--- a/src/api/config/initializers/wrap_parameters.rb
+++ b/src/api/config/initializers/wrap_parameters.rb
@@ -2,10 +2,8 @@
 
 # This file contains settings for ActionController::ParamsWrapper which
 # is enabled by default.
-require 'active_support/core_ext/hash/conversions'
 require 'action_dispatch/http/request'
 require 'active_support/core_ext/hash/indifferent_access'
-require 'api_error'
 
 # Disable all default rails parameter parsing
 # Context: https://github.com/rails/rails/blob/39413de44c0e2c0dd2d964be5985b03d8f968a7b/guides/source/3_1_release_notes.md#configinitializerswrap_parametersrb
@@ -19,54 +17,24 @@ ActiveSupport.on_load(:active_record) do
   self.include_root_in_json = false
 end
 
-OBSApi::Application.config.middleware.delete 'ActionDispatch::ParamsParser'
+# Redefine JSON parser to use ActiveSupport::HashWithIndifferentAccess
+# Define XML parser, since Rails' default parsers only include JSON. This XML parser also uses ActiveSupport::HashWithIndifferentAccess
+# Context: https://github.com/rails/rails/blob/04972d9b9ef60796dc8f0917817b5392d61fcf09/actionpack/lib/action_dispatch/http/parameters.rb#L35-L46
+original_parsers = ActionDispatch::Request.parameter_parsers
 
-# custom params parser (modified form of ActionDispatch::ParamsParser)
+json_parser = lambda do |raw_post|
+  original_parsers[Mime[:json].symbol].call(raw_post).with_indifferent_access
+end
 
-class MyParamsParser
-  class ParseError < APIError
-  end
-
-  def initialize(app)
-    @app = app
-  end
-
-  def call(env)
-    params = parse_parameters(env)
-    env['action_dispatch.request.request_parameters'] = params if params
-
-    env['HTTP_ACCEPT'] ||= 'application/xml'
-    @app.call(env)
-  end
-
-  def parse_parameters(env)
-    request = ActionDispatch::Request.new(env)
-
-    return false if request.content_length.zero?
-
-    case request.content_mime_type
-    when Mime[:json]
-      begin
-        data = ActiveSupport::JSON.decode(request.raw_post)
-      rescue JSON::ParserError => e
-        Rails.logger.info "failed to parse JSON: #{e.message}"
-        return false
-      end
-      request.body.rewind if request.body.respond_to?(:rewind)
-      data = { _json: data } unless data.is_a?(Hash)
-      data.with_indifferent_access
-    when Mime[:xml]
-      data = Xmlhash.parse(request.body.read)
-      request.body.rewind if request.body.respond_to?(:rewind)
-      if data
-        { xmlhash: data }.with_indifferent_access
-      else
-        false
-      end
-    else
-      false
-    end
+xml_parser = lambda do |raw_post|
+  data = Xmlhash.parse(raw_post)
+  if data
+    { xmlhash: data }.with_indifferent_access
+  else
+    {}
   end
 end
 
-OBSApi::Application.config.middleware.use(MyParamsParser)
+new_parsers = original_parsers.merge({ Mime[:json].symbol => json_parser, Mime[:xml].symbol => xml_parser })
+
+ActionDispatch::Request.parameter_parsers = new_parsers


### PR DESCRIPTION
We bring back the changes which were reverted in #13019 and this time, we have a custom Rack middleware to prefer XML over HTML whenever the HTTP header HTTP_ACCEPT isn't set in a request.