### PR TITLE
Distinguish comments from history elements in the request conversation

### DIFF
--- a/src/api/app/assets/javascripts/webui/comment.js
+++ b/src/api/app/assets/javascripts/webui/comment.js
@@ -45,7 +45,13 @@ $(document).ready(function(){
 
   // This is being used to render a new root comment by the beta request show view
   $('.comment_new').on('ajax:complete', '.post-comment-form', function(_, data) {
-    $(this).closest('.comment_new').prev().append(data.responseText);
+    $(this).closest('.comment_new').prev().append(
+      '<div class="timeline-item">' +
+        '<div class="comments-thread">' +
+          data.responseText +
+        '</div>' +
+      '</div>'
+    );
     $(this).trigger("reset");
   });
 
@@ -88,14 +94,14 @@ $(document).ready(function(){
     });
   });
 
-  $('body').on('click', 'button[id*="edit_button_of_"]', function (e) {
-    var closest = $(e.target).parent().parent().find('button[id*="reply_button_of_"]');
+  $('body').on('click', '[id*="edit_button_of_"]', function (e) {
+    var closest = $(e.target).parent().parent().find('[id*="reply_button_of_"]');
     if (!closest.hasClass('collapsed'))
       closest.trigger('click');
   });
 
-  $('body').on('click', 'button[id*="reply_button_of_"]', function (e) {
-    var closest = $(e.target).parent().parent().find('button[id*="edit_button_of_"]');
+  $('body').on('click', '[id*="reply_button_of_"]', function (e) {
+    var closest = $(e.target).parent().parent().find('[id*="edit_button_of_"]');
     if (!closest.hasClass('collapsed'))
       closest.trigger('click');
   });

--- a/src/api/app/assets/stylesheets/webui/comments.scss
+++ b/src/api/app/assets/stylesheets/webui/comments.scss
@@ -21,6 +21,57 @@
   }
 }
 
+.comment-bubble {
+  $comment-bubble-outline: $gray-400;
+  @extend .rounded;
+  @extend .p-3;
+  @extend .mb-2;
+  border: 1px solid $comment-bubble-outline;
+  position: relative;
+  min-width: 20%;
+
+  // Arrow on the top left of the comment bubble
+  $comment-bubble-arrow-top-position: 0;
+  $comment-bubble-arrow-left-position: 14px;
+  $comment-bubble-arrow-size: 16px;
+  // This creates two triangles.
+  // `::before` creates a triangle which matches the color of the comment bubble's outline.
+  //
+  // `::after` creates a triangle which matches the color of Bootstrap's card background color.
+  // It is displayed on top of the one created by `::before` with a small offset.
+  //
+  // Together, they produce a single comment bubble arrow... Magic!
+  &::before, &::after {
+    content: '';
+    position: absolute;
+    top: $comment-bubble-arrow-top-position;
+    left: $comment-bubble-arrow-left-position;
+    width: 0;
+    height: 0;
+    border: $comment-bubble-arrow-size solid transparent;
+    border-bottom-color: $gray-400;
+    border-top: 0;
+    border-left: 0;
+    margin-left: -($comment-bubble-arrow-size / 2);
+    margin-top: -$comment-bubble-arrow-size;
+  }
+  &::after {
+    top: $comment-bubble-arrow-top-position + 2px;
+    left: $comment-bubble-arrow-left-position + 1px;
+    z-index: 1;
+    border-bottom-color: $card-bg;
+  }
+
+  .dropdown {
+    top: -10px;
+    left: 5px;
+  }
+
+  p:last-of-type {
+    margin-bottom: 0;
+  }
+}
+
 .comment-preview {
   min-height: 6.9rem;
 }

--- a/src/api/app/components/bs_request_comment_component.html.haml
+++ b/src/api/app/components/bs_request_comment_component.html.haml
@@ -7,8 +7,40 @@
     = link_to("#comment-#{comment.id}", title: l(comment.created_at.utc), name: "comment-#{comment.id}") do
       #{time_ago_in_words(comment.created_at)} ago
 .timeline-item-comment
-  = helpers.render_as_markdown(comment)
-  = render partial: 'webui/comment/reply', locals: { comment: comment, level: 0, commentable: commentable }
+  .comment-bubble
+    - if policy(comment).update? || policy(comment).destroy?
+      .dropdown.dropleft.float-right
+        = link_to('#', role: 'button', 'data-toggle': 'dropdown', 'aria-expanded': 'false', class: 'text-dark') do
+          %i.fas.fa-ellipsis
+        .dropdown-menu
+          - if policy(comment).update?
+            = link_to("#edit_form_of_#{comment.id}", id: "edit_button_of_#{comment.id}", 'data-toggle': 'collapse',
+                      class: 'dropdown-item collapsed') do
+              Edit
+          - if policy(comment).destroy?
+            = link_to('#', data: { toggle: 'modal', target: "#delete-comment-modal-#{comment.id}" },
+                      class: 'dropdown-item delete_link', title: 'Delete comment') do
+              Delete
+
+    = helpers.render_as_markdown(comment)
+
+    - if policy(comment).update?
+      .collapse{ id: "edit_form_of_#{comment.id}" }
+        = render(partial: 'webui/comment/comment_field', locals: { form_method: :put,
+         comment: comment, commentable: commentable, element_suffix: "edit_#{comment.id}", has_cancel: true })
+
+    - if policy(comment).destroy?
+      = render(partial: 'webui/comment/delete_dialog', locals: { comment: comment })
+
+  - if User.session
+    .mb-2
+      = link_to("#reply_form_of_#{comment.id}", id: "reply_button_of_#{comment.id}", 'data-toggle': 'collapse',
+                class: 'font-italic small collapsed') do
+        Reply
+      .collapse{ id: "reply_form_of_#{comment.id}" }
+        = render(partial: 'webui/comment/comment_field', locals: { form_method: :post,
+         comment: comment.children.new, commentable: commentable, element_suffix: "reply_for_#{comment.id}", has_cancel: true })
+
   - if level <= 3
     - comment.children.includes(:user).each do |children|
       = render BsRequestCommentComponent.new(comment: children, level: level + 1, commentable: commentable)

--- a/src/api/app/components/bs_request_history_element_component.html.haml
+++ b/src/api/app/components/bs_request_history_element_component.html.haml
@@ -12,4 +12,4 @@
       #{time_ago_in_words(element.created_at)} ago
 
 .timeline-item-comment
-  = render partial: 'webui/shared/collapsible_text', locals: { text: element.comment }
+  = render partial: 'webui/shared/collapsible_text', locals: { text: element.comment, extra_css_classes: css_for_comment }

--- a/src/api/app/components/bs_request_history_element_component.rb
+++ b/src/api/app/components/bs_request_history_element_component.rb
@@ -25,4 +25,13 @@ class BsRequestHistoryElementComponent < ApplicationComponent
       tag.i(nil, class: 'fas fa-code-commit text-dark')
     end
   end
+
+  # While all history elements possibly have a comment, not all of them are from an actual human...
+  def element_with_comment_from_human?
+    ['RequestReviewAdded', 'ReviewAccepted', 'ReviewDeclined', 'RequestAccepted', 'RequestDeclined'].include?(@element.type.demodulize)
+  end
+
+  def css_for_comment
+    element_with_comment_from_human? ? 'comment-bubble' : ''
+  end
 end

--- a/src/api/app/views/webui/shared/_collapsible_text.html.haml
+++ b/src/api/app/views/webui/shared/_collapsible_text.html.haml
@@ -1,5 +1,5 @@
 -# NOTE: look into app/assets/stylesheets/webui/collapsible-text.scss
 - if text.present?
-  .obs-collapsible-textbox
+  .obs-collapsible-textbox{ class: "#{extra_css_classes if defined?(extra_css_classes)}" }
     .obs-collapsible-text
       = sanitize(simple_format(text), tags: %w[br p])


### PR DESCRIPTION
With bubbles around comments, we distinguish them from history elements in the request conversation. On top of this, we display different icons for some of the history elements, making them stand out even more. For example, when a review was accepted, we show the same checkmark icon as in the _Reviews_ section.

Preview:

![Screenshot 2022-09-05 at 17-07-33 Open Build Service](https://user-images.githubusercontent.com/1102934/188478609-82ab3a2e-fcf1-46c1-8e7b-84190f41544f.png)

![example](https://user-images.githubusercontent.com/1102934/188478637-6a7020be-1b35-4472-8c15-77ba77320977.gif)