### PR TITLE
Add test for requests without HTTP_ACCEPT header

### DIFF
--- a/src/api/spec/requests/default_xml_spec.rb
+++ b/src/api/spec/requests/default_xml_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe 'All requests', type: :request do
+  it 'prefers XML over HTML' do
+    get '/search/request', headers: { 'ACCEPT' => nil }
+
+    expect(response.content_type).to eq('application/xml; charset=utf-8')
+  end
+end


### PR DESCRIPTION
See more details in the PreferXmlOverHtml initializer.

This PR is related to #13021.

Co-authored-by: Dany Marcoux <dmarcoux@suse.com>