### PR TITLE
Consider maintainer role when showing reviewers for review by_package

### DIFF
--- a/src/api/app/components/bs_request_overview_avatars_component.rb
+++ b/src/api/app/components/bs_request_overview_avatars_component.rb
@@ -26,7 +26,13 @@ class BsRequestOverviewAvatarsComponent < ApplicationComponent
   end
 
   def package_avatar_objects
-    [@review.package&.project&.users].flatten.compact
+    relationships = Relationship.includes(:user, :group)
+    # if the package explicitly has maintainer or reviewer assigned return them
+    reviewers = relationships.for_package(@review.package).user_with_maintainer_role
+    # otherwise, check the related project for responsible user
+    reviewers = relationships.for_project(@review.package.project).user_with_maintainer_role if
+      reviewers.empty?
+    reviewers
   end
 
   def project_avatar_objects

--- a/src/api/app/models/relationship.rb
+++ b/src/api/app/models/relationship.rb
@@ -50,10 +50,19 @@ class Relationship < ApplicationRecord
     joins(:role, :group).order('roles.title, groups.title')
   }
   scope :maintainers, lambda {
-    where(role_id: Role.hashed['maintainer'])
+    where(role: Role.hashed['maintainer'])
   }
+  # FIXME: This probably can be refactored to avoid instantiation inside the `map`
+  scope :user_with_maintainer_role, lambda {
+    where(role: Role.hashed['maintainer'])
+      .map { |relation| relation.user || relation.group.users }
+      .flatten.uniq
+  }
+  scope :for_package, ->(package) { where(package: package) }
+  scope :for_project, ->(project) { where(project: project) }
+
   scope :bugowners, lambda {
-    where(role_id: Role.hashed['bugowner'])
+    where(role: Role.hashed['bugowner'])
   }
 
   scope :bugowners_with_email, lambda {

--- a/src/api/spec/components/bs_request_overview_avatars_component_spec.rb
+++ b/src/api/spec/components/bs_request_overview_avatars_component_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe BsRequestOverviewAvatarsComponent, type: :component do
+  describe '#package_avatar_objects' do
+    let(:user) { create(:user, login: 'King') }
+    let(:review) { create(:review, by_project: package.project.name, by_package: package.name) }
+    let(:project) { create(:project_with_package, name: 'Apache', package_name: 'apache2') }
+    let(:package) { project.packages.first }
+    let(:other_user) { create(:user, login: 'bob', realname: 'Bob') }
+
+    context 'when we have a review by_package' do
+      context 'and we have a maintainer assigned to the package' do
+        let(:maintainer) { Role.hashed['maintainer'] }
+
+        before do
+          package.relationships.create(user: other_user, role: maintainer)
+          render_inline(described_class.new(review))
+        end
+
+        it 'renders the maintainers of the package' do
+          expect(rendered_content).to have_selector('img[title="Bob"]', count: 1)
+        end
+      end
+
+      context 'but we do not have a maintainer assigned to the package' do
+        context 'but we have a maintainer on the packages project' do
+          let(:maintainer) { Role.hashed['maintainer'] }
+
+          before do
+            project.relationships.create(user: other_user, role: maintainer)
+            render_inline(described_class.new(review))
+          end
+
+          it 'renders the maintainers of the project' do
+            expect(rendered_content).to have_selector('img[title="Bob"]', count: 1)
+          end
+        end
+
+        context 'and we do not have it anywhere else' do
+          before do
+            render_inline(described_class.new(review))
+          end
+
+          it 'do not render a maintainer' do
+            expect(rendered_content).to have_selector('img[title="Bob"]', count: 0)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Right now we show all users that have a role assigned on a package,
no matter if the role empowers or requires the user to leave a review
or not. We only want to show user that have a reviewer or maintainer
role on the package. Also if the package has a maintainer or reviewer
assigned we first want to show those and only default to the project
one's if they are missing.

## How to test
1. Create `Project A` and inside it create `Package A`.
2. Add `Iggy` as `reviewer`.
3. Add `user_1` as `maintainer`.
4. Create `Package B` inside `Project B`.
5. Add `user_2` as `maintainer` of `Package B`.
6. Add `user_3` as `reviewer` of `Package B`.
7. Branch `Package A`, change something and `Submit Request`.
8. In the request, `Add Review` for a package `Package B`.
9. In the request,  the `Review` section should list: `Iggy` and `user_2`.
