### PR TITLE
Handle multiple BsRequestActionSubmit actions

### DIFF
--- a/src/api/app/assets/javascripts/webui/request.js
+++ b/src/api/app/assets/javascripts/webui/request.js
@@ -135,6 +135,33 @@ $(document).ready(function(){
     }
   });
   // TODO: Remove the enclosing code when the request_show_redesign feature is finished - END
+
+  // NOTE: Add value of selected tab in dropdown urls
+  $('#request-tabs .nav-item .nav-link').on('click', function() {
+    var tabName = $(this).attr('aria-controls');
+    $.each($('.dropdown-menu .dropdown-item'), function(){
+      var href = $(this).attr('href');
+      if(href){
+        var regex = /tab_name=([aA-zZ-]+)/;
+        var matches = href.match(regex);
+        if(matches !== null){
+          href = href.replace(matches[0], 'tab_name=' + tabName);
+        } else if(href.match(/\?/g)){
+          href = href + '&tab_name=' + tabName;
+        } else {
+          href = href + '?tab_name=' + tabName;
+        }
+        $(this).attr('href', href);
+      }
+    });
+  });
+
+  var selectedTab = $('.selected-tab').data('selected');
+  if(document.getElementById(selectedTab + '-nav-item')){
+    $('#'+selectedTab + '-nav-item a').click();
+  } else{
+    $('#conversation-nav-item a').click();
+  }
 });
 
 // TODO: Remove the following method when the request_show_redesign feature is finished

--- a/src/api/app/assets/javascripts/webui/request.js
+++ b/src/api/app/assets/javascripts/webui/request.js
@@ -135,9 +135,6 @@ $(document).ready(function(){
     }
   });
   // TODO: Remove the enclosing code when the request_show_redesign feature is finished - END
-  $('#changes-item').on('shown.bs.tab', function () {
-    loadChanges();
-  });
 });
 
 // TODO: Remove the following method when the request_show_redesign feature is finished
@@ -165,20 +162,6 @@ function loadDiffs(element){
   $.ajax({
     url: url,
     success: function(){
-      $('.loading-diff').addClass('invisible');
-    }
-  });
-}
-
-function loadChanges() {
-  $('.loading-diff').removeClass('invisible');
-  var element = $('#changes-item');
-  // Always retrieve the changes of the first request action, by now
-  // TODO: request-action-id should be retrieved from the select component, when it is introduced
-  var url = '/request/' + element.data('request-number') + '/request_action/' + element.data('request-action-id') + '/changes';
-  $.ajax({
-    url: url,
-    success: function() {
       $('.loading-diff').addClass('invisible');
     }
   });

--- a/src/api/app/assets/stylesheets/webui/requests.scss
+++ b/src/api/app/assets/stylesheets/webui/requests.scss
@@ -37,3 +37,8 @@
     @extend .text-break;
   }
 }
+
+.scrollable-dropdown {
+  overflow-y: scroll;
+  height: 400px;
+}

--- a/src/api/app/components/request_decision_component.rb
+++ b/src/api/app/components/request_decision_component.rb
@@ -1,11 +1,10 @@
 class RequestDecisionComponent < ApplicationComponent
-  def initialize(bs_request:, actions:, is_target_maintainer:, is_author:)
+  def initialize(bs_request:, action:, is_target_maintainer:, is_author:)
     super
 
     @bs_request = bs_request
-    @actions = actions
     @is_target_maintainer = is_target_maintainer
-    @action = @actions.first
+    @action = action
     @is_author = is_author
   end
 
@@ -14,7 +13,7 @@ class RequestDecisionComponent < ApplicationComponent
   end
 
   def single_action_request
-    @actions.count == 1
+    @single_action_request ||= @bs_request.bs_request_actions.count == 1
   end
 
   def confirmation

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -103,7 +103,7 @@ class Webui::RequestController < Webui::WebuiController
       @diff_to_superseded_id = params[:diff_to_superseded]
 
       # Handling request actions
-      action_id = params[:action_id] || @bs_request.bs_request_actions.first.id
+      action_id = params[:request_action_id] || @bs_request.bs_request_actions.first.id
       @action = @bs_request.webui_actions(filelimit: @diff_limit, tarlimit: @diff_limit, diff_to_superseded: @diff_to_superseded,
                                           diffs: true, action_id: action_id.to_i, cacheonly: 1).first
       @active_action = @bs_request.bs_request_actions.find(action_id)

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -114,6 +114,7 @@ class Webui::RequestController < Webui::WebuiController
       @open_reviews_for_staging_projects = @bs_request.reviews.opened.for_staging_projects
       @not_full_diff = BsRequest.truncated_diffs?([@action])
       @refresh = @action[:diff_not_cached]
+      @active_tab = params[:tab_name] || 'conversation'
 
       if @refresh
         bs_request_action = BsRequestAction.find(@action[:id])

--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -238,6 +238,8 @@ class BsRequest < ApplicationRecord
     request
   end
 
+  # TODO: refactor this method as soon as the request_show_redesign feature is rolled out.
+  # Now it expects an array of action hashes we'll never display more than one action at a time.
   def self.truncated_diffs?(actions)
     submit_requests = actions.select { |action| action[:type] == :submit && action[:sourcediff] }
 

--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -822,6 +822,10 @@ class BsRequestAction < ApplicationRecord
     ' '
   end
 
+  def name
+    raise AbstractMethodCalled
+  end
+
   private
 
   def cache_diffs

--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -823,7 +823,15 @@ class BsRequestAction < ApplicationRecord
   end
 
   def name
-    raise AbstractMethodCalled
+    uniq_key
+  end
+
+  def commit_details
+    package = Package.find_by_project_and_name(source_project, source_package)
+
+    return nil if package.nil? && source_rev.nil?
+
+    package.commit(source_rev) || package.commit
   end
 
   private

--- a/src/api/app/models/bs_request_action_add_role.rb
+++ b/src/api/app/models/bs_request_action_add_role.rb
@@ -51,6 +51,10 @@ class BsRequestActionAddRole < BsRequestAction
     node.group(name: group_name, role: role)
   end
 
+  def name
+    uniq_key.gsub('add_role/', 'Add Role ')
+  end
+
   #### Alias of methods
 end
 

--- a/src/api/app/models/bs_request_action_change_devel.rb
+++ b/src/api/app/models/bs_request_action_change_devel.rb
@@ -30,6 +30,10 @@ class BsRequestActionChangeDevel < BsRequestAction
     "changedevel/#{target_project}/#{target_package}"
   end
 
+  def name
+    uniq_key.gsub('changedevel/', 'Change Devel ')
+  end
+
   #### Alias of methods
 end
 

--- a/src/api/app/models/bs_request_action_delete.rb
+++ b/src/api/app/models/bs_request_action_delete.rb
@@ -70,6 +70,16 @@ class BsRequestActionDelete < BsRequestAction
     end
   end
 
+  def name
+    if target_package
+      "Delete #{target_package}"
+    elsif target_repository
+      "Delete #{target_repository}"
+    else
+      "Delete #{target_project}"
+    end
+  end
+
   private
 
   def remove_repository(opts)

--- a/src/api/app/models/bs_request_action_maintenance_incident.rb
+++ b/src/api/app/models/bs_request_action_maintenance_incident.rb
@@ -108,6 +108,10 @@ class BsRequestActionMaintenanceIncident < BsRequestAction
     super(ignore_build_state, ignore_delegate)
   end
 
+  def name
+    "Incident #{uniq_key}"
+  end
+
   private
 
   def _merge_pkg_into_maintenance_incident(incident_project)

--- a/src/api/app/models/bs_request_action_maintenance_release.rb
+++ b/src/api/app/models/bs_request_action_maintenance_release.rb
@@ -148,6 +148,10 @@ class BsRequestActionMaintenanceRelease < BsRequestAction
     pi['rating']
   end
 
+  def name
+    "Release #{uniq_key}"
+  end
+
   private
 
   def sanity_check!

--- a/src/api/app/models/bs_request_action_release.rb
+++ b/src/api/app/models/bs_request_action_release.rb
@@ -96,6 +96,10 @@ class BsRequestActionRelease < BsRequestAction
     pi['rating']
   end
 
+  def name
+    "Release #{uniq_key}"
+  end
+
   private
 
   def sanity_check!

--- a/src/api/app/models/bs_request_action_set_bugowner.rb
+++ b/src/api/app/models/bs_request_action_set_bugowner.rb
@@ -44,6 +44,10 @@ class BsRequestActionSetBugowner < BsRequestAction
     node.group(name: group_name)   if group_name
   end
 
+  def name
+    uniq_key.gsub('setbugowner/', 'Set Bugowner ')
+  end
+
   #### Alias of methods
 end
 

--- a/src/api/app/models/bs_request_action_submit.rb
+++ b/src/api/app/models/bs_request_action_submit.rb
@@ -138,6 +138,10 @@ class BsRequestActionSubmit < BsRequestAction
     raise PostRequestNoPermission, msg
   end
 
+  def name
+    "Submit #{uniq_key}"
+  end
+
   #### Alias of methods
 end
 

--- a/src/api/app/views/webui/request/_action_text.html.haml
+++ b/src/api/app/views/webui/request/_action_text.html.haml
@@ -1,0 +1,10 @@
+- if (details = action.commit_details)
+  %p.mt-0.mb-0.font-weight-normal
+    = details['comment']&.truncate(50) || action.name
+    %span.float-right.ml-5
+      = details['rev']
+  %p.mb-0.mt-0.text-muted.font-weight-light.small
+    = details['user']
+    #{ApplicationController.helpers.time_ago_in_words(details['time'].to_i)} ago
+- else
+  %p Commit information is missing

--- a/src/api/app/views/webui/request/_actions_details.html.haml
+++ b/src/api/app/views/webui/request/_actions_details.html.haml
@@ -1,0 +1,25 @@
+- submit_actions = bs_request.bs_request_actions.where(type: 'submit')
+- if submit_actions.count > 1
+  .d-flex.align-items-center
+    %p.mb-0 This request contains multiple actions
+    .dropdown.ml-2
+      %button.btn.btn-outline-primary.btn-sm.dropdown-toggle{ 'aria-expanded' => 'false', 'data-toggle' => 'dropdown',
+                                                              :type => 'button', 'data-boundary' => 'viewport' }
+        Select Action
+      %ul.dropdown-menu.dropdown-menu-left.scrollable-dropdown
+        %li
+          %h6.dropdown-header
+            %span Action
+            %span.float-right Revision
+        - submit_actions.each do |action_item|
+          %li
+            %hr.dropdown-divider
+            = link_to((render partial: 'action_text', locals: { action: action_item }),
+                      request_show_path(number: bs_request.number,
+                                        request_action_id: action_item.id,
+                                        full_diff: diff_limit,
+                                        diff_to_superseded: diff_to_superseded_id),
+                      class: "dropdown-item #{action_item.id == active_action.id ? 'disabled' : ''}")
+%p
+  = 'Showing' if submit_actions.count > 1
+  %span.font-italic= request_action_header(action, bs_request.creator)

--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -47,23 +47,23 @@
                                                         diff_to_superseded_id: @diff_to_superseded_id, diff_limit: @diff_limit }
 
     %ul.nav.nav-tabs.scrollable-tabs#request-tabs{ role: 'tablist' }
-      %li.nav-item.scrollable-tab-link
-        = link_to('Conversation', '#conversation', class: 'nav-link text-nowrap active', 'aria-controls': 'conversation',
+      %li.nav-item.scrollable-tab-link#conversation-nav-item
+        = link_to('Conversation', '#conversation', class: 'nav-link text-nowrap', 'aria-controls': 'conversation',
                   'aria-selected': 'true', 'data-toggle': 'tab', role: 'tab')
       - if @action[:sprj] || @action[:spkg]
-        %li.nav-item.scrollable-tab-link
+        %li.nav-item.scrollable-tab-link#build-results-nav-item
           = link_to('Build Results', '#build-results', class: 'nav-link text-nowrap', 'aria-controls': 'build-results',
                     'aria-selected': 'false', 'data-toggle': 'tab', role: 'tab')
       - if @action[:type].in?(actions_for_diff)
-        %li.nav-item.scrollable-tab-link#changes-item{ 'data-request-number': @bs_request.number, 'data-request-action-id': @action[:id] }
+        %li.nav-item.scrollable-tab-link#changes-nav-item{ 'data-request-number': @bs_request.number, 'data-request-action-id': @action[:id] }
           = link_to('Changes', '#changes', class: 'nav-link text-nowrap', 'aria-controls': 'changes', 'aria-selected': 'false',
                     'data-toggle': 'tab', role: 'tab')
       - if @action[:type].in?(actions_for_diff)
-        %li.nav-item.scrollable-tab-link
+        %li.nav-item.scrollable-tab-link#mentioned-issues-nav-item
           = link_to('Mentioned Issues', '#mentioned-issues', class: 'nav-link text-nowrap', 'aria-controls': 'mentioned-issues',
                     'aria-selected': 'false', 'data-toggle': 'tab', role: 'tab')
     .tab-content.p-4#request-tabs-content
-      .tab-pane.fade.show.p-2.active#conversation{ 'aria-labelledby': 'conversation-tab', role: 'tabpanel' }
+      .tab-pane.fade.show.p-2#conversation{ 'aria-labelledby': 'conversation-tab', role: 'tabpanel' }
         = render partial: 'webui/request/beta_show_tabs/conversation', locals: { bs_request: @bs_request, can_add_reviews: @can_add_reviews,
                                                                              open_reviews: @open_reviews,
                                                                              accepted_reviews: @accepted_reviews,

--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -1,6 +1,6 @@
 :ruby
   @pagetitle = "Request #{@bs_request.number}"
-  @pagetitle += ": #{@actions.first[:name]}" if @actions.count == 1
+  @pagetitle += ": #{@action[:name]}"
   actions_for_diff = [:submit, :delete, :maintenance_incident, :maintenance_release]
 
 - if @can_add_reviews
@@ -26,7 +26,7 @@
 
 .card
   .card-body.p-0
-    .card-title.px-4.pt-4.mb-0
+    .card-title.p-4.mb-0
       %h3
         Request #{@bs_request.number}
         %span.badge.ml-1{ class: "badge-#{request_badge_color(@bs_request.state)}" }
@@ -34,25 +34,28 @@
           - if @bs_request.superseded_by.present?
             by
             = link_to(@bs_request.superseded_by, number: @bs_request.superseded_by)
-    %p.font-italic.px-4
-      Created by
-      = user_with_realname_and_icon(@bs_request.creator)
-      = fuzzy_time(@bs_request.created_at)
-      - if @bs_request.superseding.present?
-        = '. Supersedes'
-        - @bs_request.superseding.each do |supersed|
-          = link_to "##{supersed['number']}", number: supersed['number']
-    %p.px-4= request_action_header(@actions.first, @bs_request.creator) # TODO: adapt when handling requests with multiple actions
+      %p.font-italic
+        Created by
+        = user_with_realname_and_icon(@bs_request.creator)
+        = fuzzy_time(@bs_request.created_at)
+        - if @bs_request.superseding.present?
+          = '. Supersedes'
+          - @bs_request.superseding.each do |supersed|
+            = link_to "##{supersed['number']}", number: supersed['number']
+
+        = render partial: 'actions_details', locals: { bs_request: @bs_request, action: @action, active_action: @active_action,
+                                                        diff_to_superseded_id: @diff_to_superseded_id, diff_limit: @diff_limit }
+
     %ul.nav.nav-tabs.scrollable-tabs#request-tabs{ role: 'tablist' }
       %li.nav-item.scrollable-tab-link
         = link_to('Conversation', '#conversation', class: 'nav-link text-nowrap active', 'aria-controls': 'conversation',
                   'aria-selected': 'true', 'data-toggle': 'tab', role: 'tab')
-      - if @actions.first[:sprj] || @actions.first[:spkg]
+      - if @action[:sprj] || @action[:spkg]
         %li.nav-item.scrollable-tab-link
           = link_to('Build Results', '#build-results', class: 'nav-link text-nowrap', 'aria-controls': 'build-results',
                     'aria-selected': 'false', 'data-toggle': 'tab', role: 'tab')
       - if @action[:type].in?(actions_for_diff)
-        %li.nav-item.scrollable-tab-link#changes-item{ 'data-request-number': @bs_request.number, 'data-request-action-id': @actions.first[:id] }
+        %li.nav-item.scrollable-tab-link#changes-item{ 'data-request-number': @bs_request.number, 'data-request-action-id': @action[:id] }
           = link_to('Changes', '#changes', class: 'nav-link text-nowrap', 'aria-controls': 'changes', 'aria-selected': 'false',
                     'data-toggle': 'tab', role: 'tab')
       - if @action[:type].in?(actions_for_diff)
@@ -70,12 +73,12 @@
                                                                              actions: @actions,
                                                                              is_target_maintainer: @is_target_maintainer,
                                                                              is_author: @is_author }
-      - if @actions.first[:sprj] || @actions.first[:spkg]
+      - if @action[:sprj] || @action[:spkg]
         .tab-pane.fade.p-2#build-results{ 'aria-labelledby': 'build-results-tab', role: 'tabpanel' }
-          = render partial: 'webui/request/beta_show_tabs/build_results', locals: { project: @actions.first[:sprj], package: @actions.first[:spkg] }
+          = render partial: 'webui/request/beta_show_tabs/build_results', locals: { project: @action[:sprj], package: @action[:spkg] }
       - if @action[:type].in?(actions_for_diff)
         .tab-pane.fade.p-2#changes{ 'aria-labelledby': 'changes-tab', role: 'tabpanel' }
-          = render partial: 'webui/request/beta_show_tabs/changes'
-      - if @action[:type].in?(actions_for_diff)
+          = render partial: 'webui/request/beta_show_tabs/changes', locals: { bs_request: @bs_request, action: @action, refresh: @refresh }
         .tab-pane.fade.p-2#mentioned-issues{ 'aria-labelledby': 'mentioned-issues-tab', role: 'tabpanel' }
           = render partial: 'webui/request/beta_show_tabs/mentioned_issues'
+    .selected-tab{ 'data-selected': @active_tab }

--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -70,7 +70,7 @@
                                                                              declined_reviews: @declined_reviews,
                                                                              open_reviews_for_staging_projects: @open_reviews_for_staging_projects,
                                                                              my_open_reviews: @my_open_reviews,
-                                                                             actions: @actions,
+                                                                             action: @action,
                                                                              is_target_maintainer: @is_target_maintainer,
                                                                              is_author: @is_author }
       - if @action[:sprj] || @action[:spkg]

--- a/src/api/app/views/webui/request/beta_show_tabs/_changes.html.haml
+++ b/src/api/app/views/webui/request/beta_show_tabs/_changes.html.haml
@@ -1,4 +1,2 @@
-.d-flex.justify-content-center.loading-diff
-  .spinner-border{ role: 'status' }
-    %span.sr-only Loading...
 .tab-content.sourcediff
+  = render SourcediffComponent.new(bs_request: bs_request, action: action, index: 0, refresh: refresh)

--- a/src/api/app/views/webui/request/beta_show_tabs/_conversation.html.haml
+++ b/src/api/app/views/webui/request/beta_show_tabs/_conversation.html.haml
@@ -33,6 +33,6 @@
     .comment_new.mt-3
       = render partial: 'webui/comment/new', locals: { commentable: bs_request }
     %hr
-    = render RequestDecisionComponent.new(bs_request: bs_request, actions: actions,
+    = render RequestDecisionComponent.new(bs_request: bs_request, action: action,
                                           is_target_maintainer: is_target_maintainer,
                                           is_author: is_author)

--- a/src/api/config/brakeman.ignore
+++ b/src/api/config/brakeman.ignore
@@ -47,7 +47,7 @@
       "check_name": "VerbConfusion",
       "message": "Potential HTTP verb confusion. `HEAD` is routed like `GET` but `request.get?` will return `false`",
       "file": "app/controllers/build_controller.rb",
-      "line": 10,
+      "line": 15,
       "link": "https://brakemanscanner.org/docs/warning_types/http_verb_confusion/",
       "code": "if request.get? then\n  pass_to_backend\n  return\nend",
       "render_path": null,
@@ -63,11 +63,31 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
+      "fingerprint": "3c8a644a0f40a3d1051aeb8874a2c3bd541d53b206432d55ee9496f3bf128564",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/controllers/webui/request_controller.rb",
+      "line": 120,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "Delayed::Job.where(\"handler LIKE '%job_class: BsRequestActionWebuiInfosJob%#{BsRequestAction.find(BsRequest.find_by!(:number => params[:number]).webui_actions(:filelimit => ((0 or nil)), :tarlimit => ((0 or nil)), :diff_to_superseded => BsRequest.find_by!(:number => params[:number]).superseding.find_by(:number => params[:diff_to_superseded]), :diffs => true, :action_id => (params[:action_id] or BsRequest.find_by!(:number => params[:number]).bs_request_actions.first.id).to_i, :cacheonly => 1).first[:id]).to_global_id.uri}%'\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Webui::RequestController",
+        "method": "show"
+      },
+      "user_input": "BsRequestAction.find(BsRequest.find_by!(:number => params[:number]).webui_actions(:filelimit => ((0 or nil)), :tarlimit => ((0 or nil)), :diff_to_superseded => BsRequest.find_by!(:number => params[:number]).superseding.find_by(:number => params[:diff_to_superseded]), :diffs => true, :action_id => (params[:action_id] or BsRequest.find_by!(:number => params[:number]).bs_request_actions.first.id).to_i, :cacheonly => 1).first[:id]).to_global_id",
+      "confidence": "Medium",
+      "note": ""
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
       "fingerprint": "425cc6614ece3076fd4dee2f72c0dea417e7ee2b20962f48eaaed13d7f22d82f",
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/controllers/webui/request_controller.rb",
-      "line": 172,
+      "line": 188,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "Delayed::Job.where(\"handler LIKE '%job_class: BsRequestActionWebuiInfosJob%#{BsRequestAction.find(BsRequest.find_by!(:number => params[:number]).webui_actions(:filelimit => ((0 or nil)), :tarlimit => ((0 or nil)), :diff_to_superseded => BsRequest.find_by!(:number => params[:number]).superseding.find_by(:number => params[:diff_to_superseded]), :diffs => true, :action_id => params[\"id\"].to_i, :cacheonly => 1).find do\n (action[:id] == params[\"id\"].to_i)\n end[:id]).to_global_id.uri}%'\")",
       "render_path": null,
@@ -208,7 +228,7 @@
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/controllers/source_controller.rb",
-      "line": 456,
+      "line": 474,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "@project.lock(params[:comment])",
       "render_path": null,
@@ -407,8 +427,28 @@
       "user_input": "if package_name.blank? then\n  \"(reviews.state=#{quote(review_state)} and reviews.by_project=#{quote(project_name)})\"\nelse\n  \"(reviews.state=#{quote(review_state)} and reviews.by_project=#{quote(project_name)} and reviews.by_package=#{quote(package_name)})\"\nend",
       "confidence": "Weak",
       "note": "All fields are quoted, so this is safe."
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "e5e5f63e6b870bf0a96201519e57a40efba6183a455e565cf14c842d1e0525d3",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/controllers/webui/request_controller.rb",
+      "line": 121,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "Delayed::Job.where(\"handler LIKE '%job_class: BsRequestActionWebuiInfosJob%#{BsRequestAction.find(BsRequest.find_by!(:number => params[:number]).webui_actions(:filelimit => ((0 or nil)), :tarlimit => ((0 or nil)), :diff_to_superseded => BsRequest.find_by!(:number => params[:number]).superseding.find_by(:number => params[:diff_to_superseded]), :diffs => true, :action_id => (params[:request_action_id] or BsRequest.find_by!(:number => params[:number]).bs_request_actions.first.id).to_i, :cacheonly => 1).first[:id]).to_global_id.uri}%'\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Webui::RequestController",
+        "method": "show"
+      },
+      "user_input": "BsRequestAction.find(BsRequest.find_by!(:number => params[:number]).webui_actions(:filelimit => ((0 or nil)), :tarlimit => ((0 or nil)), :diff_to_superseded => BsRequest.find_by!(:number => params[:number]).superseding.find_by(:number => params[:diff_to_superseded]), :diffs => true, :action_id => (params[:request_action_id] or BsRequest.find_by!(:number => params[:number]).bs_request_actions.first.id).to_i, :cacheonly => 1).first[:id]).to_global_id",
+      "confidence": "Medium",
+      "note": ""
     }
   ],
-  "updated": "2022-07-26 11:16:21 +0000",
+  "updated": "2022-09-12 09:02:28 +0000",
   "brakeman_version": "5.1.1"
 }

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -288,7 +288,7 @@ OBSApi::Application.routes.draw do
     controller 'webui/request' do
       post 'request/add_reviewer' => :add_reviewer
       post 'request/modify_review' => :modify_review
-      get 'request/show/:number' => :show, as: 'request_show', constraints: cons
+      get 'request/show/:number/(request_action/:request_action_id)' => :show, as: 'request_show', constraints: cons
       post 'request/sourcediff' => :sourcediff
       post 'request/changerequest' => :changerequest
       get 'request/diff/:number' => :diff

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -295,7 +295,6 @@ OBSApi::Application.routes.draw do
       get 'request/list_small' => :list_small, as: 'request_list_small'
       post 'request/set_bugowner_request' => :set_bugowner_request
       get 'request/:number/request_action/:id' => :request_action, as: 'request_action'
-      get 'request/:number/request_action/:id/changes' => :request_action_changes, as: 'request_action_changes'
     end
 
     resources :requests, only: [], param: :number, controller: 'webui/bs_requests' do


### PR DESCRIPTION
In the beta request show page, we introduced a dropdown to select among different request actions.

How to test?

- Create a request with multiple actions:
`osc --apiurl=http://localhost:3000/ creq -a submit home:Admin hello_world home:Iggy -a submit home:Admin ruby home:Iggy`
or use this
`osc --apiurl=http://localhost:3000 creq $(osc --apiurl=http://localhost:3000 list home:Admin | xargs -I % echo "-a submit home:Admin % home:Iggy" | tr "\n" " ")`

- Open the last request show page in the web UI (with the `request_show_redesign` beta feature enabled)
- You have to see a dropdown on the left. Change between actions.
- You will see some changes
  - The text under the title of the request (the one describing the action)
  - The Changes tab content changes

