### PR TITLE
Replace instance variable by passed local variable

### DIFF
--- a/src/api/app/views/webui/package/_revision_diff_detail_buttons.html.haml
+++ b/src/api/app/views/webui/package/_revision_diff_detail_buttons.html.haml
@@ -7,9 +7,7 @@
   href: "#revision_details_#{index + 1}",
   title: 'Go down to the next diff' }
     %i.fas.fa-chevron-down
-  -# haml-lint:disable InstanceVariables
-  - if file_view_path && has_content && !@linkinfo && viewable_file?(filename)
-    -# haml-lint:enable InstanceVariables
+  - if file_view_path && has_content && !linkinfo && viewable_file?(filename)
     = link_to(file_view_path, class: 'btn btn-outline-secondary', title: 'View the whole file') do
       %span.d-none.d-sm-none.d-md-block View file
       %i.far.fa-file.d-block.d-sm-block.d-md-none


### PR DESCRIPTION
Change missing from previous commit [d1210ac](https://github.com/openSUSE/open-build-service/commit/d1210aca842c01795e262602de6878d137c5e387) where the goal was stopping using `@linkinfo` inside the partial to use `linkinfo` instead.