### PR TITLE
Stop handling linkinfo in sourcediff components

### DIFF
--- a/src/api/app/components/sourcediff_component.html.haml
+++ b/src/api/app/components/sourcediff_component.html.haml
@@ -31,7 +31,7 @@
                                                                                   index: file_index,
                                                                                   last: sourcediff['filenames'].last == filename,
                                                                                   package: @action[:spkg],
-                                                                                  linkinfo: linkinfo }
+                                                                                  linkinfo: nil }
           - else
             .mb-2
               %p.lead

--- a/src/api/app/components/sourcediff_component.rb
+++ b/src/api/app/components/sourcediff_component.rb
@@ -1,17 +1,16 @@
 class SourcediffComponent < ApplicationComponent
-  attr_accessor :bs_request, :action, :index, :refresh, :linkinfo
+  attr_accessor :bs_request, :action, :index, :refresh
 
   delegate :diff_label, to: :helpers
   delegate :diff_data, to: :helpers
 
-  def initialize(bs_request:, action:, index:, refresh:, linkinfo: nil)
+  def initialize(bs_request:, action:, index:, refresh:)
     super
 
     @bs_request = bs_request
     @action = action
     @index = index
     @refresh = refresh
-    @linkinfo = linkinfo
   end
 
   def file_view_path(filename, sourcediff)

--- a/src/api/app/components/sourcediff_tab_component.html.haml
+++ b/src/api/app/components/sourcediff_tab_component.html.haml
@@ -40,7 +40,7 @@
                                                                                           index: file_index,
                                                                                           last: sourcediff['filenames'].last == filename,
                                                                                           package: @action[:spkg],
-                                                                                          linkinfo: linkinfo }
+                                                                                          linkinfo: nil }
             - else
               .mb-2
                 %p.lead

--- a/src/api/app/components/sourcediff_tab_component.rb
+++ b/src/api/app/components/sourcediff_tab_component.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 class SourcediffTabComponent < ApplicationComponent
-  attr_accessor :bs_request, :action, :active, :index, :refresh, :linkinfo
+  attr_accessor :bs_request, :action, :active, :index, :refresh
 
   delegate :valid_xml_id, to: :helpers
   delegate :request_action_header, to: :helpers
   delegate :diff_label, to: :helpers
   delegate :diff_data, to: :helpers
 
-  def initialize(bs_request:, action:, active:, index:, refresh:, linkinfo: nil)
+  def initialize(bs_request:, action:, active:, index:, refresh:)
     super
 
     @bs_request = bs_request
@@ -16,7 +16,6 @@ class SourcediffTabComponent < ApplicationComponent
     @active = active
     @index = index
     @refresh = refresh
-    @linkinfo = linkinfo
   end
 
   def file_view_path(filename, sourcediff)

--- a/src/api/app/views/webui/request/request_action.js.erb
+++ b/src/api/app/views/webui/request/request_action.js.erb
@@ -1,1 +1,1 @@
-$('.tab-content.sourcediff').append("<%= escape_javascript(render(SourcediffTabComponent.new(bs_request: @bs_request, action: @action, active: @active, index: @index, refresh: @refresh, linkinfo: @linkinfo))) %>");
+$('.tab-content.sourcediff').append("<%= escape_javascript(render(SourcediffTabComponent.new(bs_request: @bs_request, action: @action, active: @active, index: @index, refresh: @refresh))) %>");

--- a/src/api/app/views/webui/request/request_action_changes.js.erb
+++ b/src/api/app/views/webui/request/request_action_changes.js.erb
@@ -1,1 +1,1 @@
-$('.tab-content.sourcediff').html("<%= escape_javascript(render(SourcediffComponent.new(bs_request: @bs_request, action: @action, index: 0, refresh: @refresh, linkinfo: @linkinfo))) %>");
+$('.tab-content.sourcediff').html("<%= escape_javascript(render(SourcediffComponent.new(bs_request: @bs_request, action: @action, index: 0, refresh: @refresh))) %>");


### PR DESCRIPTION
The partial `_revision_diff_detail` is called from the package's controller action `rdiff` (alias `package_rdiff`) or from the request view.

In the first situation, we are setting @linkinfo on the [package controller](https://github.com/openSUSE/open-build-service/blob/334ae03e608468a85b152ce4310571cfc3bb7630/src/api/app/controllers/webui/package_controller.rb#L256) and then it is passed to the partial.

In the second situation, we never set @linkinfo on the [request controller](https://github.com/openSUSE/open-build-service/blob/master/src/api/app/controllers/webui/request_controller.rb).
So there is no need to pass @linkinfo to the component in order to always end up passing nil to the partial.

The changes were introduced in [this commit](https://github.com/openSUSE/open-build-service/commit/d1210aca842c01795e262602de6878d137c5e387) and this [follow-up PR](https://github.com/openSUSE/open-build-service/pull/13033).