### PR TITLE
Convert usage of egrep to grep -E

### DIFF
--- a/dist/munin/obs_worker_cpu_mem
+++ b/dist/munin/obs_worker_cpu_mem
@@ -121,12 +121,12 @@ HZ=${HZ:-100}
 
 extinfo=""
 
-if egrep -q '^cpu +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+' /proc/stat; then
+if grep -E -q '^cpu +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+' /proc/stat; then
 	extinfo="iowait irq softirq"
-	if egrep -q '^cpu +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+' /proc/stat; then
+	if grep -E -q '^cpu +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+' /proc/stat; then
 		extextinfo="steal"
 	fi
-	if egrep -q '^cpu +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+' /proc/stat; then
+	if grep -E -q '^cpu +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+' /proc/stat; then
 		extextextinfo="guest"
 	fi
 
@@ -134,7 +134,7 @@ fi
 
 if [ "$1" = "config" ]; then
 
-	NCPU=$(egrep '^cpu[0-9]+ ' /proc/stat | wc -l)
+	NCPU=$(grep -E '^cpu[0-9]+ ' /proc/stat | wc -l)
 	if [ "$scaleto100" = "yes" ]; then
 		graphlimit=100
 	else

--- a/dist/obs_import_srcdebtree
+++ b/dist/obs_import_srcdebtree
@@ -94,7 +94,7 @@ if true; then
         do
             ( pushd tmp &&
                 (
-                    if [ x$(echo $f | egrep "_[0-9]") != x"" ]; then
+                    if [ x$(echo $f | grep -E "_[0-9]") != x"" ]; then
                         pkgname=${f%%-[0-9].[*-[0-9]*-[0-9]*.*}
                     else
                         pkgname=${f%%-[0-9]*-[0-9]*.*}

--- a/dist/obs_import_srcrpmtree
+++ b/dist/obs_import_srcrpmtree
@@ -27,7 +27,7 @@ lslist=$(cat tmp/.ls)
 rm -f tmp/.ftpls
 for f in $ftplist
 do
-    if [ x$(echo $f | egrep "_[0-9]") != x"" ]
+    if [ x$(echo $f | grep -E "_[0-9]") != x"" ]
     then
        pkgname=${f%%-[0-9].[*-[0-9]*-[0-9]*.*}
     else
@@ -68,7 +68,7 @@ for f in $ftplist
 do
   (cd tmp &&
      (
-                if [ x$(echo $f | egrep "_[0-9]") != x"" ]
+                if [ x$(echo $f | grep -E "_[0-9]") != x"" ]
                 then
                    pkgname=${f%%-[0-9].[*-[0-9]*-[0-9]*.*}
                 else

--- a/dist/obsstoragesetup
+++ b/dist/obsstoragesetup
@@ -350,7 +350,7 @@ case "$1" in
 			echo "Found XEN virtualization"
 			RUN_VIRT=1
 		else
-			if grep ^flags /proc/cpuinfo | egrep -q " (svm|vmx) " && modprobe kvm; then
+			if grep ^flags /proc/cpuinfo | grep -E -q " (svm|vmx) " && modprobe kvm; then
 				echo "Found KVM virtualization"
 				RUN_VIRT=1
 		                # support virtio
@@ -399,7 +399,7 @@ case "$1" in
 				OBS_INSTANCE_MEMORY=$(( $TOTALMEM / ( 2 * $OBS_WORKER_INSTANCES ) ))
 				echo "OBS_INSTANCE_MEMORY=\"$OBS_INSTANCE_MEMORY\"" >> /etc/buildhost.config
                         fi
-			if grep ^flags /proc/cpuinfo | egrep -q " (svm|vmx) " && test -n "$RUN_VIRT"; then
+			if grep ^flags /proc/cpuinfo | grep -E -q " (svm|vmx) " && test -n "$RUN_VIRT"; then
                                 # try to use hugetlb on kvm
 				mkdir -p /dev/hugetlbfs # systemd may have mounted it already
 			        HUGETLBINSTANCEMEM=$(( ($OBS_INSTANCE_MEMORY * 512) / 1024 )) # 2M page sizes


### PR DESCRIPTION
grep 3.8 starts throwing warnings, and `egrep`/`fgrep` will be dropped long term
https://bugzilla.opensuse.org/show_bug.cgi?id=1203092