### PR TITLE
[backend] re-add helminfo to bs_repserver

### DIFF
--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -2390,7 +2390,7 @@ sub putjob {
 
   my $ev = {'type' => 'built', 'arch' => $arch, 'job' => $job};
 
-  if ($BSConfig::sign && (@{$kiwitree_tosign || []} || grep {$_->{'name'} =~ /\.(?:d?rpm|sha256|iso|pkg\.tar\.gz|pkg\.tar\.xz|pkg\.tar\.zst|AppImage|deb|appx|raw|efi|roothash|usrhash)$/} @$uploaded)) {
+  if ($BSConfig::sign && (@{$kiwitree_tosign || []} || grep {$_->{'name'} =~ /\.(?:d?rpm|sha256|iso|pkg\.tar\.gz|pkg\.tar\.xz|pkg\.tar\.zst|AppImage|deb|appx|helminfo|raw|efi|roothash|usrhash)$/} @$uploaded)) {
     if (@{$kiwitree_tosign || []}) {
       my $c = '';
       $c .= BSHTTP::urlencode($_)."\n" for @$kiwitree_tosign;


### PR DESCRIPTION
Removed by mistake in https://github.com/openSUSE/open-build-service/pull/12972

Not sure how I didn't notice, sorry about that