### PR TITLE
Set scroll offset for all the pages

### DIFF
--- a/src/api/app/assets/stylesheets/webui/application.scss
+++ b/src/api/app/assets/stylesheets/webui/application.scss
@@ -75,4 +75,5 @@
 html {
     overflow-y: scroll !important;
     scroll-padding-top: $top-navigation-height;
+    scroll-behavior: smooth;
 }

--- a/src/api/app/assets/stylesheets/webui/application.scss
+++ b/src/api/app/assets/stylesheets/webui/application.scss
@@ -74,4 +74,5 @@
 
 html {
     overflow-y: scroll !important;
+    scroll-padding-top: $top-navigation-height;
 }

--- a/src/api/spec/support/shared_examples/features/bootstrap_user_tab.rb
+++ b/src/api/spec/support/shared_examples/features/bootstrap_user_tab.rb
@@ -41,9 +41,8 @@ RSpec.shared_examples 'bootstrap user tab' do
     end
 
     it 'Add non existent user' do
-      add_user_link = page.find('a', text: 'Add User')
-      page.scroll_to(add_user_link)
-      add_user_link.click
+      # FIXME: on mobile, when `screen-offset-top` CSS rule is in place, scrolling and clicking at capybara level does not work
+      page.evaluate_script('$("#add-user").click()')
       sleep 1 # FIXME: Needed to avoid a flickering test because the animation of the modal is sometimes faster than capybara
 
       within('#add-user-role-modal') do
@@ -55,9 +54,8 @@ RSpec.shared_examples 'bootstrap user tab' do
     end
 
     it 'Add an existing user' do
-      add_user_link = page.find('a', text: 'Add User')
-      page.scroll_to(add_user_link)
-      add_user_link.click
+      # FIXME: on mobile, when `screen-offset-top` CSS rule is in place, scrolling and clicking at capybara level does not work
+      page.evaluate_script('$("#add-user").click()')
       sleep 1 # FIXME: Needed to avoid a flickering test because the animation of the modal is sometimes faster than capybara
 
       within('#add-user-role-modal') do
@@ -73,9 +71,8 @@ RSpec.shared_examples 'bootstrap user tab' do
       end
 
       # Adding a user twice...
-      add_user_link = page.find('a', text: 'Add User')
-      page.scroll_to(add_user_link)
-      add_user_link.click
+      # FIXME: on mobile, when `screen-offset-top` CSS rule is in place, scrolling and clicking at capybara level does not work
+      page.evaluate_script('$("#add-user").click()')
       sleep 1 # FIXME: Needed to avoid a flickering test because the animation of the modal is sometimes faster than capybara
 
       within('#add-user-role-modal') do
@@ -154,9 +151,8 @@ RSpec.shared_examples 'bootstrap user tab' do
     end
 
     it 'Add non existent group' do
-      add_group_link = page.find('a', text: 'Add Group')
-      page.scroll_to(add_group_link)
-      add_group_link.click
+      # FIXME: on mobile, when `screen-offset-top` CSS rule is in place, scrolling and clicking at capybara level does not work
+      page.evaluate_script('$("#add-group").click()')
       sleep 1 # FIXME: Needed to avoid a flickering test because the animation of the modal is sometimes faster than capybara
 
       within('#add-group-role-modal') do
@@ -168,9 +164,8 @@ RSpec.shared_examples 'bootstrap user tab' do
     end
 
     it 'Add an existing group' do
-      add_group_link = page.find('a', text: 'Add Group')
-      page.scroll_to(add_group_link)
-      add_group_link.click
+      # FIXME: on mobile, when `screen-offset-top` CSS rule is in place, scrolling and clicking at capybara level does not work
+      page.evaluate_script('$("#add-group").click()')
       sleep 1 # FIXME: Needed to avoid a flickering test because the animation of the modal is sometimes faster than capybara
 
       within('#add-group-role-modal') do
@@ -185,9 +180,8 @@ RSpec.shared_examples 'bootstrap user tab' do
       end
 
       # Adding a group twice...
-      add_group_link = page.find('a', text: 'Add Group')
-      page.scroll_to(add_group_link)
-      add_group_link.click
+      # FIXME: on mobile, when `screen-offset-top` CSS rule is in place, scrolling and clicking at capybara level does not work
+      page.evaluate_script('$("#add-group").click()')
       sleep 1 # FIXME: Needed to avoid a flickering test because the animation of the modal is sometimes faster than capybara
 
       within('#add-group-role-modal') do


### PR DESCRIPTION
This PR adds two CSS rules:
- scroll offset to let anchor scroll the page but do not scroll behind the fixed top nav bar
- let the scroll happen smoothly and visible, instead of jumping to the offset with no animation

![scroll-to-anchor](https://user-images.githubusercontent.com/7080830/188883311-2547b2db-39ed-446d-a222-3fb78441373c.gif)

Fixes: https://trello.com/c/m3aezM5E/1953-comment-anchors-dont-account-for-the-height-of-the-top-navbar-m