### PR TITLE
Expand timeline items all the way to the right

### DIFF
--- a/src/api/app/assets/stylesheets/webui/timeline.scss
+++ b/src/api/app/assets/stylesheets/webui/timeline.scss
@@ -6,5 +6,14 @@
     .timeline-item {
         position: relative;
         left: -(($avatars-counter-size / 2) + $timeline-border-width); // The avatars of users involved in timeline items will be displayed on the timeline border
+
+        $timeline-item-avatar-margin: 0.5rem;
+        img.avatars-counter {
+            margin-right: $timeline-item-avatar-margin;
+        }
+
+        .timeline-item-comment {
+            margin-left: $avatars-counter-size + $timeline-border-width + $timeline-item-avatar-margin;
+        }
     }
 }

--- a/src/api/app/components/bs_request_activity_timeline_component.html.haml
+++ b/src/api/app/components/bs_request_activity_timeline_component.html.haml
@@ -1,18 +1,16 @@
 .timeline-item
-  .row
-    .col-auto.pr-0
-      = helpers.image_tag_for(creator, size: 35, custom_class: 'rounded-circle bg-light border border-gray-400 avatars-counter')
-    .col-10
-      %p
-        %i.fas.fa-code-commit.text-dark
-        = link_to(helpers.realname_with_login(creator), user_path(creator))
-        created request
-        = link_to('#request-creation', title: l(bs_request.created_at.utc), name: 'request-creation') do
-          #{time_ago_in_words(bs_request.created_at)} ago
-        - if bs_request.superseding.any?
-          superseding
-          - bs_request.superseding.each do |superseded_request|
-            = link_to("request ##{superseded_request.number}", request_show_path(superseded_request.number, anchor: 'overview'))
+  .d-inline-flex
+    = helpers.image_tag_for(creator, size: 35, custom_class: 'rounded-circle bg-light border border-gray-400 avatars-counter')
+    %p
+      %i.fas.fa-code-commit.text-dark
+      = link_to(helpers.realname_with_login(creator), user_path(creator))
+      created request
+      = link_to('#request-creation', title: l(bs_request.created_at.utc), name: 'request-creation') do
+        #{time_ago_in_words(bs_request.created_at)} ago
+      - if bs_request.superseding.any?
+        superseding
+        - bs_request.superseding.each do |superseded_request|
+          = link_to("request ##{superseded_request.number}", request_show_path(superseded_request.number, anchor: 'overview'))
 
 - timeline.each do |comment_or_history_element|
   .timeline-item

--- a/src/api/app/components/bs_request_comment_component.html.haml
+++ b/src/api/app/components/bs_request_comment_component.html.haml
@@ -1,18 +1,17 @@
-.row
-  .col-auto.pr-0
-    = helpers.image_tag_for(comment.user, size: 35, custom_class: 'rounded-circle bg-light border border-gray-400 avatars-counter')
-  .col-10
-    %p
-      %i.fas.fa-comment.text-dark{ title: 'Comment' }
-      = link_to(helpers.realname_with_login(comment.user), user_path(comment.user))
-      wrote
-      = link_to("#comment-#{comment.id}", title: l(comment.created_at.utc), name: "comment-#{comment.id}") do
-        #{time_ago_in_words(comment.created_at)} ago
-    = helpers.render_as_markdown(comment)
-    = render partial: 'webui/comment/reply', locals: { comment: comment, level: 0, commentable: commentable }
-    - if level <= 3
-      - comment.children.includes(:user).each do |children|
-        = render BsRequestCommentComponent.new(comment: children, level: level + 1, commentable: commentable)
+.d-inline-flex
+  = helpers.image_tag_for(comment.user, size: 35, custom_class: 'rounded-circle bg-light border border-gray-400 avatars-counter')
+  %p
+    %i.fas.fa-comment.text-dark{ title: 'Comment' }
+    = link_to(helpers.realname_with_login(comment.user), user_path(comment.user))
+    wrote
+    = link_to("#comment-#{comment.id}", title: l(comment.created_at.utc), name: "comment-#{comment.id}") do
+      #{time_ago_in_words(comment.created_at)} ago
+.timeline-item-comment
+  = helpers.render_as_markdown(comment)
+  = render partial: 'webui/comment/reply', locals: { comment: comment, level: 0, commentable: commentable }
+  - if level <= 3
+    - comment.children.includes(:user).each do |children|
+      = render BsRequestCommentComponent.new(comment: children, level: level + 1, commentable: commentable)
 
 - if level > 3
   - comment.children.includes(:user).each do |children|

--- a/src/api/app/components/bs_request_history_element_component.html.haml
+++ b/src/api/app/components/bs_request_history_element_component.html.haml
@@ -1,16 +1,15 @@
-.row
-  .col-auto.pr-0
-    = helpers.image_tag_for(element.user, size: 36, custom_class: 'rounded-circle bg-light border border-gray-400 avatars-counter')
-  .col-10
-    %p
-      = icon
-      = link_to(helpers.realname_with_login(element.user), user_path(element.user))
-      - if element.instance_of?(HistoryElement::RequestSuperseded)
-        superseded this request with
-        = link_to("request ##{element.description_extension}", request_show_path(element.description_extension))
-      - else
-        = element.user_action
-      = link_to("#status-history-#{element.id}", title: l(element.created_at.utc), name: "status-history-#{element.id}") do
-        #{time_ago_in_words(element.created_at)} ago
+.d-inline-flex
+  = helpers.image_tag_for(element.user, size: 36, custom_class: 'rounded-circle bg-light border border-gray-400 avatars-counter')
+  %p
+    = icon
+    = link_to(helpers.realname_with_login(element.user), user_path(element.user))
+    - if element.instance_of?(HistoryElement::RequestSuperseded)
+      superseded this request with
+      = link_to("request ##{element.description_extension}", request_show_path(element.description_extension))
+    - else
+      = element.user_action
+    = link_to("#status-history-#{element.id}", title: l(element.created_at.utc), name: "status-history-#{element.id}") do
+      #{time_ago_in_words(element.created_at)} ago
 
-    = render partial: 'webui/shared/collapsible_text', locals: { text: element.comment }
+.timeline-item-comment
+  = render partial: 'webui/shared/collapsible_text', locals: { text: element.comment }


### PR DESCRIPTION
Relying on the Bootstrap grid isn't needed here, so the templates were also simplified.

Before:
<img src="https://user-images.githubusercontent.com/1102934/188895406-1363732f-f78f-4862-b199-84fce7aeb48c.png" width=300>

Now:
<img src="https://user-images.githubusercontent.com/1102934/188895713-0855388d-0af9-41b2-8b70-7c2068244cd4.png" width=300>