### PR TITLE
ci: add minimum GitHub token permissions for workflows

### DIFF
--- a/.github/workflows/brakeman.yml
+++ b/.github/workflows/brakeman.yml
@@ -2,6 +2,9 @@ name: Brakeman
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull_request_labeler.yml
+++ b/.github/workflows/pull_request_labeler.yml
@@ -2,8 +2,14 @@ name: "Pull Request Labeler"
 on:
 - pull_request_target
 
+permissions:
+  contents: read
+
 jobs:
   pull_request_labeler:
+    permissions:
+      contents: read  # for actions/labeler to determine modified files
+      pull-requests: write  # for actions/labeler to add labels to PRs
     runs-on: ubuntu-latest
     steps:
     - uses: actions/labeler@v3


### PR DESCRIPTION
### Description
This PR adds minimum token permissions for the GITHUB_TOKEN in GitHub Actions workflows using https://github.com/step-security/secure-workflows.

The GitHub Actions workflow has a GITHUB_TOKEN with write access to multiple scopes.
Here is an example of the permissions in one of the workflow runs:
https://github.com/openSUSE/open-build-service/runs/8251662522?check_suite_focus=true#step:1:19

After this change, the scopes will be reduced to the minimum needed for the following workflows:

- brakeman.yml
- pull_request_labeler.yml

The following workflow file already has the least privileged token permission set:

- scorecards.yml

### Motivation and Context

- This is a security best practice, so if the GITHUB_TOKEN is compromised due to a vulnerability or compromised Action, the damage will be reduced.
- GitHub recommends defining minimum GITHUB_TOKEN permissions.
   https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
- The Open Source Security Foundation (OpenSSF) [Scorecards](https://github.com/ossf/scorecard) also treats not setting token permissions as a high-risk issue. This change will help increase the Scorecard score for this repository.

Signed-off-by: Ashish Kurmi <akurmi@stepsecurity.io>