### PR TITLE
[backend] preparepool: do not put the pool into the context if there …

### DIFF
--- a/src/backend/BSSched/Checker.pm
+++ b/src/backend/BSSched/Checker.pm
@@ -596,7 +596,6 @@ sub preparepool {
 
   return ('scheduling', undef) if $ctx->{'alllocked'};		# we do not need a pool
   my ($pool, $error, $delayed) = createpool($ctx, $bconf, $ctx->{'prpsearchpath'});
-  $ctx->{'pool'} = $pool;
   if ($error) {
     $ctx->{'havedelayed'} = 1 if $delayed;
     return ('broken', $error);
@@ -605,16 +604,26 @@ sub preparepool {
   $prpnotready = undef if ($ctx->{'repo'}->{'block'} || '') eq 'local';
   ($ctx->{'dep2pkg'}, $ctx->{'dep2src'}, $ctx->{'depislocal'}, $ctx->{'notready'}, $ctx->{'subpacks'}) = preparehashes($pool, $prp, $prpnotready);
 
+  my $pool_host;
   if ($ctx->{'conf_host'}) {
-    ($pool, $error, $delayed) = createpool($ctx, $ctx->{'conf_host'}, $ctx->{'prpsearchpath_host'}, $ctx->{'repo'}->{'crosshostarch'});
-    $ctx->{'pool_host'} = $pool;
+    ($pool_host, $error, $delayed) = createpool($ctx, $ctx->{'conf_host'}, $ctx->{'prpsearchpath_host'}, $ctx->{'repo'}->{'crosshostarch'});
     if ($error) {
       $ctx->{'havedelayed'} = 1 if $delayed;
       return ('broken', $error);
     }
     ($ctx->{'dep2pkg_host'}) = preparehashes($pool, $prp, $prpnotready);
   }
+  $ctx->{'pool'} = $pool;
+  $ctx->{'pool_host'} = $pool_host if $pool_host;
   return ('scheduling', undef);
+}
+
+sub unpreparepool {
+  my ($ctx) = @_;
+  delete $ctx->{'expander'};
+  delete $ctx->{'pool'};
+  delete $ctx->{'pool_host'};
+  delete $ctx->{'pool_local'};
 }
 
 # emulate depsort2 with depsort. This is not very fast,

--- a/src/backend/BSSched/EventHandler.pm
+++ b/src/backend/BSSched/EventHandler.pm
@@ -641,6 +641,7 @@ sub event_memstats {
   eval {
     require Devel::Mallinfo;
     print Devel::Mallinfo::malloc_info_string(0);
+    Devel::Mallinfo::malloc_stats();
   };
   my $gctx = $ectx->{'gctx'};
   my %gctx = %$gctx;

--- a/src/backend/bs_sched
+++ b/src/backend/bs_sched
@@ -1102,6 +1102,7 @@ eval {
     # Step 2c: expand all dependencies, put them in %pdeps hash and sort the packages
     ($state, $details) = $ctx->expandandsort();
     if ($state ne 'scheduling') {
+      $ctx->unpreparepool();
       $ctx->set_repo_state($state, $details);
       print "    $details\n";
       sendrepochangeevent($gctx, $prp);
@@ -1134,10 +1135,7 @@ eval {
 
     # free memory
     Build::forgetdeps($bconf);
-    delete $ctx->{'expander'};
-    delete $ctx->{'pool'};
-    delete $ctx->{'pool_host'};
-    delete $ctx->{'pool_local'};
+    $ctx->unpreparepool();
 
     my $wasfinished = $gctx->{'prpfinished'}->{$prp};
 


### PR DESCRIPTION
…was an error

Also move the memory free code into $ctx->unpreparepool().