### PR TITLE
[backend] support triggerscmsync with default branch

### DIFF
--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -442,7 +442,7 @@ class SourceController < ApplicationController
 
   # POST /source?cmd=triggerscmsync
   def global_command_triggerscmsync
-    pass_to_backend('/source' + build_query_from_hash(params, [:cmd, :scmrepository, :scmbranch]))
+    pass_to_backend('/source' + build_query_from_hash(params, [:cmd, :scmrepository, :scmbranch, :isdefaultbranch]))
   end
 
   private

--- a/src/backend/BSSrcServer/ScmsyncDB.pm
+++ b/src/backend/BSSrcServer/ScmsyncDB.pm
@@ -82,7 +82,16 @@ sub getscmsyncpackages {
 
   $scmsync_repo   =~ s/\.git$//;
 
-  my $sh = BSSQLite::dbdo_bind($h, 'SELECT project, package FROM scmsync WHERE scmsync_repo = ? AND scmsync_branch = ?', [$scmsync_repo], [$scmsync_branch]);
+  my $sh;
+  if ($scmsync_branch) {
+    $sh = BSSQLite::dbdo_bind($h, 'SELECT project, package FROM scmsync WHERE scmsync_repo = ? AND scmsync_branch = ?', [$scmsync_repo], [$scmsync_branch]);
+  } elsif ($scmsync_branch eq '') {
+    # default branch only
+    $sh = BSSQLite::dbdo_bind($h, 'SELECT project, package FROM scmsync WHERE scmsync_repo = ? AND scmsync_branch IS NULL', [$scmsync_repo]);
+  } else {
+    # all branches
+    $sh = BSSQLite::dbdo_bind($h, 'SELECT project, package FROM scmsync WHERE scmsync_repo = ?', [$scmsync_repo]);
+  };
   my ($project, $package);
   $sh->bind_columns(\$project, \$package);
   my @ary;

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -347,10 +347,17 @@ sub notify_all_repservers {
 
 sub triggerscmsync {
   my ($cgi) = @_;
-  my $scmrepo = $cgi->{'scmrepository'};
-  my $scmbranch = $cgi->{'scmbranch'};
 
   return '<status code="fail" details="scmsync tracking is not enabled" />\n' unless $BSConfig::source_db_sqlite;
+
+  triggerscmsyncrun($cgi, $cgi->{'scmrepository'}, $cgi->{'scmbranch'});
+  triggerscmsyncrun($cgi, $cgi->{'scmrepository'}, '') if $cgi->{'isdefaultbranch'};
+
+  return $BSStdServer::return_ok;
+}
+
+sub triggerscmsyncrun {
+  my ($cgi, $scmrepo, $scmbranch) = @_;
 
   for my $ref (BSSrcServer::ScmsyncDB::getscmsyncpackages($scmrepo, $scmbranch)) {
     my $scmsync;
@@ -365,7 +372,6 @@ sub triggerscmsync {
     next unless $scmsync;
     BSSrcServer::Service::runservice_obsscm($cgi, @$ref[0], @$ref[1], $scmsync);
   }
-  return $BSStdServer::return_ok;
 }
 
 sub triggerservicerun {
@@ -7497,7 +7503,7 @@ my $dispatches = [
   '!- HEAD:' => undef,
 
   'POST:/source cmd=orderkiwirepos' => \&orderkiwirepos,
-  'POST:/source cmd=triggerscmsync scmrepository:? scmbranch:?' => \&triggerscmsync,
+  'POST:/source cmd=triggerscmsync scmrepository:? scmbranch:? isdefaultbranch:?' => \&triggerscmsync,
   'POST:/source cmd: *:*' => \&unknowncmd,
 
   # /source name space: manage project and package data


### PR DESCRIPTION
scmsync tags may specify the default branch.

We need to run twice here as it may got specified explicit or not. And the default branch may have changed.