### PR TITLE
Fix link of adding/removing a package in watchlist

### DIFF
--- a/src/api/app/controllers/webui/watched_items_controller.rb
+++ b/src/api/app/controllers/webui/watched_items_controller.rb
@@ -28,13 +28,14 @@ class Webui::WatchedItemsController < Webui::WebuiController
   private
 
   def set_watchable
-    @watchable = if params[:project_name] && params[:package_name]
-                   @package = Package.get_by_project_and_name(params[:project_name], params[:package_name])
-                 elsif params[:project_name]
-                   @project = Project.get_by_name(params[:project_name])
-                 elsif params[:number]
-                   @bs_request = BsRequest.find_by(number: params[:number])
-                 end
+    if params[:project_name]
+      @project = Project.get_by_name(params[:project_name])
+      @package = Package.get_by_project_and_name(params[:project_name], params[:package_name]) if params[:package_name]
+    elsif params[:number]
+      @bs_request = BsRequest.find_by(number: params[:number])
+    end
+
+    @watchable = @package || @project || @bs_request
   end
 
   def check_user_belongs_feature_flag


### PR DESCRIPTION
The `@project` variable was not assigned in AJAX requests - it was only assigned in the webui controller. This made not possible to find the package.

Making sure that the `@project` variable is also set for a package in the WatchedItems controller fixes the issue.

How to test the fix, for reviewers:
- Go to a page of a package.
- Click in Watchlist.
- Add/Remove the package from the Watchlist.
- See that the link has changed to Remove/add package from the watchlist.