### PR TITLE
[backend] fix wrong pool usage in crossbuilds

### DIFF
--- a/src/backend/BSSched/Checker.pm
+++ b/src/backend/BSSched/Checker.pm
@@ -611,7 +611,7 @@ sub preparepool {
       $ctx->{'havedelayed'} = 1 if $delayed;
       return ('broken', $error);
     }
-    ($ctx->{'dep2pkg_host'}) = preparehashes($pool, $prp, $prpnotready);
+    ($ctx->{'dep2pkg_host'}) = preparehashes($pool_host, $prp, $prpnotready);
   }
   $ctx->{'pool'} = $pool;
   $ctx->{'pool_host'} = $pool_host if $pool_host;


### PR DESCRIPTION
We renamed a variable but forgot to change one place where it was used.

Should have been in commit 9e8f649a22b5d201b279aae7cc82485e685a5c3e