### PR TITLE
Return an error when filter definition is wrong

### DIFF
--- a/src/api/app/validators/workflow_filters_validator.rb
+++ b/src/api/app/validators/workflow_filters_validator.rb
@@ -20,6 +20,7 @@ class WorkflowFiltersValidator < ActiveModel::Validator
   def validate_filters
     # Filters aren't mandatory in a workflow
     return unless @workflow_instructions.key?(:filters)
+    return @workflow.errors.add(:filters, 'definition is wrong') unless valid_filters_definition?
 
     if unsupported_filters.present?
       @workflow.errors.add(:filters,
@@ -30,6 +31,11 @@ class WorkflowFiltersValidator < ActiveModel::Validator
 
     @workflow.errors.add(:filters, "#{unsupported_filter_values.to_sentence} have unsupported values, " \
                                    "#{SUPPORTED_FILTER_VALUES.map { |key| "'#{key}'" }.to_sentence} are the only supported values.")
+  end
+
+  # FIXME: Remove once we have general workflow.yml validation
+  def valid_filters_definition?
+    @workflow_instructions[:filters].is_a?(Hash)
   end
 
   def unsupported_filters

--- a/src/api/spec/validators/workflow_filters_validator_spec.rb
+++ b/src/api/spec/validators/workflow_filters_validator_spec.rb
@@ -50,6 +50,16 @@ RSpec.describe WorkflowFiltersValidator do
       end
     end
 
+    context 'with multiple filters' do
+      let(:workflow_instructions) { { filters: [{ event: 'push' }] } }
+
+      it 'is not valid and has an error message' do
+        subject.valid?
+        expect(subject.errors.full_messages.to_sentence).to eq('Filters definition is wrong and ' \
+                                                               "Documentation for filters: #{described_class::DOCUMENTATION_LINK}")
+      end
+    end
+
     context 'with supported filters and filter values' do
       let(:workflow_instructions) { { filters: { event: 'something', branches: { only: [] } } } }
 


### PR DESCRIPTION
This filter definition is wrong:

```
rebuild_master:
  steps:
    - rebuild_package:
        source_project: home:gyribeiro:containers
        source_package: toolbox-osc
        project: home:gyribeiro:containers
        package: toolbox-osc
  filters:
    - event: push
 ```
 
It should be like:

```
  filters:
    event: push
```

When we detect something like this, we return a validation error to notify the user.

Fixes #12742