### PR TITLE
Reset values for delete confirmation modal on toggle watched item

### DIFF
--- a/src/api/app/views/webui/watched_items/toggle_watched_item.js.erb
+++ b/src/api/app/views/webui/watched_items/toggle_watched_item.js.erb
@@ -4,3 +4,4 @@ $('.watchlist-collapse').html("<%= escape_javascript(render WatchlistComponent.n
                                                                                    bs_request: @bs_request,
                                                                                    package: @package,
                                                                                    project: @project)) %>");
+collectDeleteConfirmationModalsAndSetValues();


### PR DESCRIPTION
We render `DeleteConfirmationDialogComponent` in the layout with `WatchlistComponent`. When an item is added or removed from watchlist the `WatchlistComponent` is rendered again without taking into consideration the `DeleteConfirmationDialogComponent`. This change reset the values used in the delete confirmation modal