### PR TITLE
Split package and project name by the slice delimiter only

### DIFF
--- a/src/api/app/components/watched_items_list_component.html.haml
+++ b/src/api/app/components/watched_items_list_component.html.haml
@@ -5,9 +5,11 @@
       - when 'Package'
         - name = "#{item.project}/#{item}"
         .d-flex.flex-row.flex-wrap.align-items-baseline
-          = link_to(package_show_path(item.project, item), class: 'text-word-break-all') do
+          = link_to(package_show_path(item.project, item), class: 'd-flex flex-row flex-wrap align-items-baseline') do
             %i.fas.fa-archive.mr-1
-            = name
+            - name.split(%r{(/)}).each_slice(2).map(&:join).map(&:strip).each do |slice|
+              %span.d-inline
+                = slice
           = link_to('#', class: 'text-light ml-auto',
                     data: { toggle: 'modal',
                             target: '#delete-item-from-watchlist-modal',
@@ -18,9 +20,11 @@
       - when 'Project'
         - name = item.name
         .d-flex.flex-row.flex-wrap.align-items-baseline
-          = link_to(project_show_path(item), class: 'text-word-break-all') do
+          = link_to(project_show_path(item), class: 'd-flex flex-row flex-wrap align-items-baseline') do
             %i.fas.fa-cubes.mr-1
-            = name
+            - name.split(/(:)/).each_slice(2).map(&:join).map(&:strip).each do |slice|
+              %span.d-inline
+                = slice
           = link_to('#', class: 'text-light ml-auto',
                     data: { toggle: 'modal',
                             target: '#delete-item-from-watchlist-modal',


### PR DESCRIPTION
When the package or project name is very long and the watchlist bar width is not wide enough, the name breaks and go to the next line at any character as needed. With this PR the name breaks into slices and go to the next line with the entire slice at a meaningful character (for packages the delimiter is `/`, for projects it is `:`)


After:
![after](https://user-images.githubusercontent.com/7080830/190409545-954195d3-e135-4bbe-8bcf-71d204bf7d2c.png)
![after-html](https://user-images.githubusercontent.com/7080830/190409550-7af1a041-d3cc-467f-aa88-ea9e1cf75c62.png)


Fixes: https://trello.com/c/m9bg1tV7