### PR TITLE
Show confirmation dialog when deleting from the upper link from the watchlist

### DIFF
--- a/src/api/app/components/watchlist_component.html.haml
+++ b/src/api/app/components/watchlist_component.html.haml
@@ -5,12 +5,18 @@
 
   - if @object_to_be_watched && @object_to_be_watched.persisted?
     .nav-item.pb-2.mb-4.border-bottom.border-gray-500
-      = link_to(toggle_watchable_path, method: :put, class: 'nav-link', remote: true) do
-        - if object_to_be_watched_in_watchlist?
+      - if object_to_be_watched_in_watchlist?
+        = link_to('#', class: 'nav-link',
+                  data: { toggle: 'modal',
+                          target: '#delete-item-from-watchlist-modal',
+                          modal_title: "Do you really want to remove this #{watchable_type_text} from the watchlist?",
+                          confirmation_text: "Please confirm you want to remove this #{watchable_type_text} from the watchlist.",
+                          action: toggle_watchable_path }) do
           %p.mb-0.text-light
             %i.fas.fa-times-circle
             %span Remove this #{watchable_type_text} from Watchlist
-        - else
+      - else
+        = link_to(toggle_watchable_path, method: :put, class: 'nav-link', remote: true) do
           %p.mb-0.text-light
             %i.fas.fa-plus-circle
             %span Watch this #{watchable_type_text}

--- a/src/api/app/components/watchlist_component.html.haml
+++ b/src/api/app/components/watchlist_component.html.haml
@@ -9,11 +9,11 @@
         - if object_to_be_watched_in_watchlist?
           %p.mb-0.text-light
             %i.fas.fa-times-circle
-            %span= remove_from_watchlist_text
+            %span Remove this #{watchable_type_text} from Watchlist
         - else
           %p.mb-0.text-light
             %i.fas.fa-plus-circle
-            %span= add_to_watchlist_text
+            %span Watch this #{watchable_type_text}
 
   = render WatchedItemsListComponent.new(items: projects, class_name: 'Project')
   = render WatchedItemsListComponent.new(items: packages, class_name: 'Package')

--- a/src/api/app/components/watchlist_component.rb
+++ b/src/api/app/components/watchlist_component.rb
@@ -1,14 +1,8 @@
 class WatchlistComponent < ApplicationComponent
-  REMOVE_FROM_WATCHLIST_TEXT = {
-    'Package' => 'Remove this package from Watchlist',
-    'Project' => 'Remove this project from Watchlist',
-    'BsRequest' => 'Remove this request from Watchlist'
-  }.freeze
-
-  ADD_TO_WATCHLIST_TEXT = {
-    'Package' => 'Watch this package',
-    'Project' => 'Watch this project',
-    'BsRequest' => 'Watch this request'
+  WATCHABLE_TYPE_TEXT = {
+    'Package' => 'package',
+    'Project' => 'project',
+    'BsRequest' => 'request'
   }.freeze
 
   def initialize(user:, bs_request: nil, package: nil, project: nil)
@@ -42,12 +36,8 @@ class WatchlistComponent < ApplicationComponent
     @user.watched_items.exists?(watchable: @object_to_be_watched)
   end
 
-  def add_to_watchlist_text
-    ADD_TO_WATCHLIST_TEXT[@object_to_be_watched.class.name]
-  end
-
-  def remove_from_watchlist_text
-    REMOVE_FROM_WATCHLIST_TEXT[@object_to_be_watched.class.name]
+  def watchable_type_text
+    WATCHABLE_TYPE_TEXT[@object_to_be_watched.class.name]
   end
 
   def toggle_watchable_path


### PR DESCRIPTION
The user is already asked for confirmation when deleting an element of the watchlist, clicking on the delete icons. Asking for confirmation was missing, when deleting from the upper link of the watchlist.