### PR TITLE
Provide the timestamp of creation of reviews via API

### DIFF
--- a/docs/api/api/request.rng
+++ b/docs/api/api/request.rng
@@ -35,6 +35,11 @@
 	</attribute>
       </optional>
       <optional>
+	<attribute name="created">
+          <data type="string" />
+	</attribute>
+      </optional>
+      <optional>
 	<attribute name="superseded_by">
           <data type="integer" />
 	</attribute>

--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -202,6 +202,7 @@ class BsRequest < ApplicationRecord
         end
       end
 
+      state.delete('created')
       str = state.delete('when')
       request.updated_when = Time.zone.parse(str) if str
       str = state.delete('superseded_by') || ''
@@ -381,7 +382,7 @@ class BsRequest < ApplicationRecord
       r.priority(priority) unless priority == 'moderate'
 
       # state element
-      attributes = { name: state, who: commenter, when: updated_when.strftime('%Y-%m-%dT%H:%M:%S') }
+      attributes = { name: state, who: commenter, when: updated_when.strftime('%Y-%m-%dT%H:%M:%S'), created: created_at.strftime('%Y-%m-%dT%H:%M:%S') }
       attributes[:superseded_by] = superseded_by if superseded_by
       attributes[:approver] = approver if approver
       r.state(attributes) do |s|

--- a/src/api/test/functional/request_controller_test.rb
+++ b/src/api/test/functional/request_controller_test.rb
@@ -322,7 +322,7 @@ class RequestControllerTest < ActionDispatch::IntegrationTest
                      'acceptinfo' => { 'rev' => '1', 'srcmd5' => '1ded65e42c0f04bd08075dfd1fd08105', 'osrcmd5' => 'd41d8cd98f00b204e9800998ecf8427e' }
                    },
                    'priority' => 'low',
-                   'state' => { 'name' => 'accepted', 'who' => 'Iggy', 'when' => '2010-07-12T00:00:04', 'comment' => 'approved' },
+                   'state' => { 'name' => 'accepted', 'who' => 'Iggy', 'when' => '2010-07-12T00:00:04', 'created' => '2010-07-12T00:00:00', 'comment' => 'approved' },
                    'history' => [
                      { 'who' => 'Iggy', 'when' => '2010-07-12T00:00:00', 'description' => 'Request created', 'comment' => 'DESCRIPTION IS HERE' },
                      { 'who' => 'Iggy', 'when' => '2010-07-12T00:00:01', 'description' => 'Request got a new priority: critical => low', 'comment' => 'dontcare' },
@@ -1091,6 +1091,7 @@ class RequestControllerTest < ActionDispatch::IntegrationTest
                      'name' => 'review',
                      'who' => 'tom',
                      'when' => '2010-07-12T00:00:05',
+                     'created' => '2010-07-12T00:00:00',
                      'comment' => 'reopen2'
                    },
                    'review' => [{
@@ -3527,6 +3528,7 @@ class RequestControllerTest < ActionDispatch::IntegrationTest
                                 { 'name' => 'declined',
                                   'who' => 'Iggy',
                                   'when' => '2010-07-12T00:00:01',
+                                  'created' => '2010-07-12T00:00:00',
                                   'comment' => "The target project 'home:Iggy:fordecline' has been removed" },
                    'history' => [{ 'who' => 'Iggy',
                                    'when' => '2010-07-12T00:00:00',
@@ -3550,6 +3552,7 @@ class RequestControllerTest < ActionDispatch::IntegrationTest
                    'state' => { 'name' => 'revoked',
                                 'who' => 'Iggy',
                                 'when' => '2010-07-12T00:00:02',
+                                'created' => '2010-07-12T00:00:00',
                                 'comment' => {} },
                    'history' =>
                                 [{ 'who' => 'Iggy', 'when' => '2010-07-12T00:00:00',

--- a/src/api/test/unit/bs_request_test.rb
+++ b/src/api/test/unit/bs_request_test.rb
@@ -97,7 +97,10 @@ class BsRequestTest < ActiveSupport::TestCase
       </request>
     XML
     req = BsRequest.new_from_xml(xml)
-    req.save!
+    new_time = Time.zone.local(2012, 11, 7, 0, 0, 0)
+    Timecop.freeze(new_time) do
+      req.save!
+    end
     # number got increased by one
     assert_equal 1027, req.number
 
@@ -113,7 +116,7 @@ class BsRequestTest < ActiveSupport::TestCase
           <acceptinfo rev="1" srcmd5="806a6e27ed7915d1bb8d8a989404fd5a" osrcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
         </action>
         <priority>critical</priority>
-        <state name="review" who="Iggy" when="2012-11-07T21:13:12">
+        <state name="review" who="Iggy" when="2012-11-07T21:13:12" created="2012-11-07T00:00:00">
           <comment>No comment</comment>
         </state>
         <review state="new" when="2017-09-01T09:11:11" by_user="adrian"/>


### PR DESCRIPTION
Looks like the request API contained the creation timestamps of reviews. This PR brings it back.

Fixes #OBS-215