### PR TITLE
[backend] mkosi: fix followupfile regex in bs_signer

### DIFF
--- a/src/backend/bs_signer
+++ b/src/backend/bs_signer
@@ -791,8 +791,8 @@ sub signjob {
       if (!$followupfile && grep {/\.followup.spec$/} @files) {
 	$followupfile = (grep {/\.followup.spec$/} @files)[0];
       }
-      if (!$followupfile && grep {/^mkosi\.*/} @files) {
-	$followupfile = (grep {/^mkosi\.*/} @files)[0];
+      if (!$followupfile && grep {/^mkosi\./} @files) {
+	$followupfile = (grep {/^mkosi\./} @files)[0];
       }
     }
 


### PR DESCRIPTION
An extra `*` means that instead of matching on `mkosi.*` we are matching on `mkosi*`, which happens to include the mkosi package itself, that thus fails as a spurious second build is started.

```
[   29s] lamb13 finished "build mkosi.spec" at Sat Sep 17 22:42:51 UTC 2022.
[   29s]
[   29s] ### VM INTERACTION START ###
[   29s] [   24.170425][    T1] sysrq: Power Off
[   29s] [   24.176008][   T18] reboot: Power down
[   29s] ### VM INTERACTION END ###
[   29s] build: extracting built packages...
[   29s] RPMS/noarch/mkosi-13+186+g769318a-15.1.noarch.rpm
[   29s] SRPMS/mkosi-13+186+g769318a-15.1.src.rpm
[   29s] OTHER/_statistics
[   29s] OTHER/rpmlint.log
[    0s] Using BUILD_ROOT=/var/cache/obs/worker/root_6/.mount
[    0s] Using BUILD_ARCH=x86_64:i686:i586:i486:i386
[    0s] Doing kvm build in /var/cache/obs/worker/root_6/root
[    0s]
[    0s] I don't know how to build mkosi-13+186+g769318a-15.1.noarch.rpm
[    0s]
[    0s] lamb18 failed "build mkosi-13+186+g769318a-15.1.noarch.rpm" at Sat Sep 17 22:43:14 UTC 2022.
```

Fix the regex.

```
$ perl -e 'my $f = "mkosi.foobar"; print(grep {/^mkosi\./} $f);'
mkosi.foobar
$ perl -e 'my $f = "mkosi-13-4.2.noarch.rpm"; print(grep {/^mkosi\./} $f);' $
```

Follow-up for 71715da2cf3d5db87b78e7a067dbb8a10c2a0711