### PR TITLE
Refactoring: standardize SCM acronym

### DIFF
--- a/src/api/app/components/workflow_run_request_action_filter_component.rb
+++ b/src/api/app/components/workflow_run_request_action_filter_component.rb
@@ -5,6 +5,6 @@ class WorkflowRunRequestActionFilterComponent < ApplicationComponent
     @request_action = request_action
     @token_id = token_id
     @generic_event_type = 'pull_request'
-    @filter_options = ['all'] + ScmWebhook::ALLOWED_PULL_REQUEST_ACTIONS + ScmWebhook::ALLOWED_MERGE_REQUEST_ACTIONS
+    @filter_options = ['all'] + SCMWebhook::ALLOWED_PULL_REQUEST_ACTIONS + SCMWebhook::ALLOWED_MERGE_REQUEST_ACTIONS
   end
 end

--- a/src/api/app/controllers/trigger/errors.rb
+++ b/src/api/app/controllers/trigger/errors.rb
@@ -7,7 +7,7 @@ module Trigger::Errors
           'No valid token found'
   end
 
-  class BadScmPayload < APIError
+  class BadSCMPayload < APIError
     setup 'bad_request',
           400,
           'Failed to parse the JSON payload of your request'

--- a/src/api/app/controllers/trigger_workflow_controller.rb
+++ b/src/api/app/controllers/trigger_workflow_controller.rb
@@ -57,12 +57,12 @@ class TriggerWorkflowController < TriggerController
 
   def payload
     request_body = request.body.read
-    raise BadScmPayload if request_body.blank?
+    raise BadSCMPayload if request_body.blank?
 
     begin
       JSON.parse(request_body)
     rescue JSON::ParserError
-      raise BadScmPayload
+      raise BadSCMPayload
     end
   end
 
@@ -74,7 +74,7 @@ class TriggerWorkflowController < TriggerController
   end
 
   def extract_scm_webhook
-    @scm_webhook = TriggerControllerService::ScmExtractor.new(scm, event, payload).call
+    @scm_webhook = TriggerControllerService::SCMExtractor.new(scm, event, payload).call
 
     # There are plenty of different pull/merge request action which we don't support.
     # Those should not cause an error, we simply ignore them.

--- a/src/api/app/instrumentations/scm_webhook_instrumentation.rb
+++ b/src/api/app/instrumentations/scm_webhook_instrumentation.rb
@@ -1,4 +1,4 @@
-module ScmWebhookInstrumentation
+module SCMWebhookInstrumentation
   extend ActiveSupport::Concern
 
   # Define callbacks with ActiveModel::Callback which is included in ActiveModel::Model

--- a/src/api/app/jobs/report_to_scm_job.rb
+++ b/src/api/app/jobs/report_to_scm_job.rb
@@ -1,5 +1,4 @@
-# We don't properly capitalize SCM in the class name since CreateJob is doing `CLASS_NAME.to_s.camelize.safe_constantize`
-class ReportToScmJob < CreateJob
+class ReportToSCMJob < CreateJob
   ALLOWED_EVENTS = ['Event::BuildFail', 'Event::BuildSuccess'].freeze
 
   queue_as :scm

--- a/src/api/app/models/event/base.rb
+++ b/src/api/app/models/event/base.rb
@@ -160,6 +160,10 @@ module Event
       save
       create_jobs.each do |job|
         job_class = job.to_s.camelize.safe_constantize
+
+        # we want to keep SCM capitalized in the job name, so we catch the case and overwrite the name
+        job_class = ReportToSCMJob.name.safe_constantize if job.to_s.camelize.casecmp(ReportToSCMJob.name).zero?
+
         raise "#{job.to_s.camelize} does not map to a constant" if job_class.nil?
 
         job_obj = job_class.new

--- a/src/api/app/models/scm_status_report.rb
+++ b/src/api/app/models/scm_status_report.rb
@@ -6,7 +6,7 @@
 #
 # The details of the request and the response will be shown in the
 # Reports to the SCM tab in Workflow Runs show page.
-class ScmStatusReport < ApplicationRecord
+class SCMStatusReport < ApplicationRecord
   belongs_to :workflow_run
 
   enum status: {

--- a/src/api/app/models/scm_webhook.rb
+++ b/src/api/app/models/scm_webhook.rb
@@ -1,11 +1,11 @@
 # Contains the payload extracted from a SCM webhook and provides helper methods to know which webhook event we're dealing with
-class ScmWebhook
+class SCMWebhook
   include ActiveModel::Model
-  include ScmWebhookInstrumentation # for run_callbacks
+  include SCMWebhookInstrumentation # for run_callbacks
 
   attr_accessor :payload
 
-  validates_with ScmWebhookEventValidator
+  validates_with SCMWebhookEventValidator
 
   ALLOWED_PULL_REQUEST_ACTIONS = ['closed', 'opened', 'reopened', 'synchronize'].freeze
   ALLOWED_MERGE_REQUEST_ACTIONS = ['close', 'merge', 'open', 'reopen', 'update'].freeze

--- a/src/api/app/models/workflow_run.rb
+++ b/src/api/app/models/workflow_run.rb
@@ -28,7 +28,7 @@ class WorkflowRun < ApplicationRecord
 
   belongs_to :token, class_name: 'Token::Workflow', optional: true
   has_many :artifacts, class_name: 'WorkflowArtifactsPerStep', dependent: :destroy
-  has_many :scm_status_reports, dependent: :destroy
+  has_many :scm_status_reports, class_name: 'SCMStatusReport', dependent: :destroy
 
   paginates_per 20
 
@@ -49,7 +49,7 @@ class WorkflowRun < ApplicationRecord
     update(status: 'fail') # set WorkflowRun status
     scm_status_reports.create(response_body: message,
                               request_parameters: JSON.generate(options.slice(*PERMITTED_OPTIONS)),
-                              status: 'fail') # set ScmStatusReport status
+                              status: 'fail') # set SCMStatusReport status
   end
 
   # Stores info from a succesful SCM status report. The default value for 'status' is 'success'.
@@ -133,12 +133,12 @@ class WorkflowRun < ApplicationRecord
 
   def pull_request_with_allowed_action
     hook_event == 'pull_request' &&
-      ScmWebhook::ALLOWED_PULL_REQUEST_ACTIONS.include?(payload['action'])
+      SCMWebhook::ALLOWED_PULL_REQUEST_ACTIONS.include?(payload['action'])
   end
 
   def merge_request_with_allowed_action
     hook_event == 'Merge Request Hook' &&
-      ScmWebhook::ALLOWED_MERGE_REQUEST_ACTIONS.include?(payload.dig('object_attributes', 'action'))
+      SCMWebhook::ALLOWED_MERGE_REQUEST_ACTIONS.include?(payload.dig('object_attributes', 'action'))
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/src/api/app/services/scm_exception_handler.rb
+++ b/src/api/app/services/scm_exception_handler.rb
@@ -57,7 +57,7 @@ class SCMExceptionHandler
                                                                          @event_payload[:package],
                                                                          host: Configuration.obs_url)
     end
-    @workflow_run.save_scm_report_failure("Failed to report back to #{scm}: #{ScmExceptionMessage.for(exception: exception, scm: scm)}",
+    @workflow_run.save_scm_report_failure("Failed to report back to #{scm}: #{SCMExceptionMessage.for(exception: exception, scm: scm)}",
                                           {
                                             api_endpoint: @event_subscription_payload[:api_endpoint],
                                             target_repository_full_name: @event_subscription_payload[:target_repository_full_name],

--- a/src/api/app/services/scm_exception_message.rb
+++ b/src/api/app/services/scm_exception_message.rb
@@ -1,4 +1,4 @@
-class ScmExceptionMessage
+class SCMExceptionMessage
   GITHUB_EXCEPTIONS = {
     Octokit::AbuseDetected =>
       'You have triggered an abuse detection mechanism and have been temporarily blocked from content creation. Please retry your request again later.',

--- a/src/api/app/services/trigger_controller_service/scm_extractor.rb
+++ b/src/api/app/services/trigger_controller_service/scm_extractor.rb
@@ -1,7 +1,7 @@
 # TODO: Extract SCM-specific code to separate classes. This class is too big for GitHub and GitLab.
 module TriggerControllerService
   # NOTE: this class is coupled to GitHub pull requests events and GitLab merge requests events.
-  class ScmExtractor
+  class SCMExtractor
     def initialize(scm, event, payload)
       # TODO: What should we do when the user sends a wwwurlencoded payload? Raise an exception?
       @payload = payload.deep_symbolize_keys
@@ -13,9 +13,9 @@ module TriggerControllerService
     def call
       case @scm
       when 'github'
-        ScmWebhook.new(payload: github_extractor_payload)
+        SCMWebhook.new(payload: github_extractor_payload)
       when 'gitlab'
-        ScmWebhook.new(payload: gitlab_extractor_payload)
+        SCMWebhook.new(payload: gitlab_extractor_payload)
       end
     end
 
@@ -71,7 +71,7 @@ module TriggerControllerService
                          path_with_namespace: @payload.dig(:project, :path_with_namespace),
                          # We need this for SCMStatusReporter#call
                          project_id: @payload[:project_id],
-                         # We need this for ScmWebhookEventValidator#valid_push_event
+                         # We need this for SCMWebhookEventValidator#valid_push_event
                          ref: @payload[:ref] })
       when 'Tag Push Hook'
         gitlab_payload_tag(payload)
@@ -129,7 +129,7 @@ module TriggerControllerService
                        target_branch: @payload[:after],
                        # We need this for Workflows::YAMLDownloader#download_url
                        path_with_namespace: @payload.dig(:project, :path_with_namespace),
-                       # We need this for ScmWebhookEventValidator#valid_push_event
+                       # We need this for SCMWebhookEventValidator#valid_push_event
                        ref: @payload[:ref],
                        # We need this for Workflow::Step#branch_request_content_{github,gitlab}
                        commit_sha: @payload[:after]

--- a/src/api/app/validators/scm_webhook_event_validator.rb
+++ b/src/api/app/validators/scm_webhook_event_validator.rb
@@ -1,4 +1,4 @@
-class ScmWebhookEventValidator < ActiveModel::Validator
+class SCMWebhookEventValidator < ActiveModel::Validator
   ALLOWED_GITHUB_EVENTS = ['pull_request', 'push'].freeze
   ALLOWED_GITLAB_EVENTS = ['Merge Request Hook', 'Push Hook', 'Tag Push Hook'].freeze
 
@@ -19,7 +19,7 @@ class ScmWebhookEventValidator < ActiveModel::Validator
 
     case @record.payload[:event]
     when 'pull_request'
-      return true if ScmWebhook::ALLOWED_PULL_REQUEST_ACTIONS.include?(@record.payload[:action])
+      return true if SCMWebhook::ALLOWED_PULL_REQUEST_ACTIONS.include?(@record.payload[:action])
 
       @record.errors.add(:base, 'Pull request action not supported.')
     when 'push'
@@ -35,7 +35,7 @@ class ScmWebhookEventValidator < ActiveModel::Validator
 
     case @record.payload[:event]
     when 'Merge Request Hook'
-      return true if ScmWebhook::ALLOWED_MERGE_REQUEST_ACTIONS.include?(@record.payload[:action])
+      return true if SCMWebhook::ALLOWED_MERGE_REQUEST_ACTIONS.include?(@record.payload[:action])
 
       @record.errors.add(:base, 'Merge request action not supported.')
     when 'Push Hook', 'Tag Push Hook'

--- a/src/api/config/initializers/zeitwerk.rb
+++ b/src/api/config/initializers/zeitwerk.rb
@@ -8,10 +8,17 @@ Rails.autoloaders.each do |autoloader|
     'opensuse_upstream_tarball_url_finder' => 'OpenSUSEUpstreamTarballURLFinder',
     'opensuse_upstream_version_finder' => 'OpenSUSEUpstreamVersionFinder',
     'remote_url' => 'RemoteURL',
+    'report_to_scm_job' => 'ReportToSCMJob',
     'rss_channel' => 'RSSChannel',
     'url_generator' => 'URLGenerator',
+    'scm_status_report' => 'SCMStatusReport',
     'scm_status_reporter' => 'SCMStatusReporter',
     'scm_exception_handler' => 'SCMExceptionHandler',
+    'scm_exception_message' => 'SCMExceptionMessage',
+    'scm_extractor' => 'SCMExtractor',
+    'scm_webhook' => 'SCMWebhook',
+    'scm_webhook_event_validator' => 'SCMWebhookEventValidator',
+    'scm_webhook_instrumentation' => 'SCMWebhookInstrumentation',
     'yaml_to_workflows_service' => 'YAMLToWorkflowsService',
     'yaml_downloader' => 'YAMLDownloader'
   )

--- a/src/api/spec/components/previews/workflow_artifacts_per_step_component_preview.rb
+++ b/src/api/spec/components/previews/workflow_artifacts_per_step_component_preview.rb
@@ -69,7 +69,7 @@ class WorkflowArtifactsPerStepComponentPreview < ViewComponent::Preview
   end
 
   def scm_webhook
-    ScmWebhook.new(payload: extractor_payload)
+    SCMWebhook.new(payload: extractor_payload)
   end
 
   def token

--- a/src/api/spec/components/workflow_artifacts_per_step_component_spec.rb
+++ b/src/api/spec/components/workflow_artifacts_per_step_component_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe WorkflowArtifactsPerStepComponent, type: :component do
            request_payload: request_payload)
   end
   let(:scm_webhook) do
-    ScmWebhook.new(payload: extractor_payload)
+    SCMWebhook.new(payload: extractor_payload)
   end
   let(:artifacts_per_step) do
     WorkflowArtifactsPerStep.new(workflow_run: workflow_run, artifacts: artifacts, step: step_name)

--- a/src/api/spec/components/workflow_run_request_action_filter_component_spec.rb
+++ b/src/api/spec/components/workflow_run_request_action_filter_component_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe WorkflowRunRequestActionFilterComponent, type: :component do
 
   it 'shows correct filter options' do
     render_inline(described_class.new(token_id: workflow_token.id))
-    filters = ['all'] + ScmWebhook::ALLOWED_PULL_REQUEST_ACTIONS + ScmWebhook::ALLOWED_MERGE_REQUEST_ACTIONS
+    filters = ['all'] + SCMWebhook::ALLOWED_PULL_REQUEST_ACTIONS + SCMWebhook::ALLOWED_MERGE_REQUEST_ACTIONS
 
     filters.each do |filter|
       expect(rendered_content).to have_text(filter)

--- a/src/api/spec/factories/workflow_runs.rb
+++ b/src/api/spec/factories/workflow_runs.rb
@@ -55,7 +55,7 @@ FactoryBot.define do
       end
 
       after(:create) do |workflow_run, _evaluator|
-        ScmStatusReport.create(workflow_run: workflow_run,
+        SCMStatusReport.create(workflow_run: workflow_run,
                                response_body: "<status code=\"ok\">\n  <summary>Ok</summary>\n</status>\n",
                                request_parameters: JSON.generate({
                                                                    api_endpoint: 'https://api.github.com',
@@ -67,7 +67,7 @@ FactoryBot.define do
                                                                      target_url: nil
                                                                    }
                                                                  }),
-                               status: ScmStatusReport.statuses[:success])
+                               status: SCMStatusReport.statuses[:success])
       end
     end
 
@@ -88,7 +88,7 @@ FactoryBot.define do
       end
 
       after(:create) do |workflow_run, _evaluator|
-        ScmStatusReport.create(workflow_run: workflow_run,
+        SCMStatusReport.create(workflow_run: workflow_run,
                                response_body: 'Failed to report back to GitHub: Unauthorized request. Please check your credentials again.',
                                request_parameters: JSON.generate({
                                                                    api_endpoint: 'https://api.github.com',
@@ -100,7 +100,7 @@ FactoryBot.define do
                                                                      target_url: nil
                                                                    }
                                                                  }),
-                               status: ScmStatusReport.statuses[:fail])
+                               status: SCMStatusReport.statuses[:fail])
       end
     end
   end

--- a/src/api/spec/jobs/report_to_scm_job_spec.rb
+++ b/src/api/spec/jobs/report_to_scm_job_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe ReportToScmJob, vcr: false do
+RSpec.describe ReportToSCMJob, vcr: false do
   let(:user) { create(:confirmed_user, login: 'foolano') }
   let(:token) { Token::Workflow.create(executor: user, scm_token: 'fake_token') }
   let(:project) { create(:project, name: 'project_1', maintainer: user) }

--- a/src/api/spec/models/scm_webhook_spec.rb
+++ b/src/api/spec/models/scm_webhook_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe ScmWebhook, type: :model do
+RSpec.describe SCMWebhook, type: :model do
   describe '#new_pull_request?' do
     subject { described_class.new(payload: payload).new_pull_request? }
 

--- a/src/api/spec/models/token/workflow_spec.rb
+++ b/src/api/spec/models/token/workflow_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Token::Workflow do
       it do
         expect do
           workflow_token.call({ workflow_run: workflow_run,
-                                scm_webhook: ScmWebhook.new(payload: {}) })
+                                scm_webhook: SCMWebhook.new(payload: {}) })
         end.to raise_error(Token::Errors::MissingPayload, 'A payload is required').and(change(workflow_token, :triggered_at))
       end
     end
@@ -26,7 +26,7 @@ RSpec.describe Token::Workflow do
       it "changes the token's triggered_at field and raises an error with a helpful message" do
         expect do
           workflow_token.call({ workflow_run: workflow_run,
-                                scm_webhook: ScmWebhook.new(payload: { something: 123 }) })
+                                scm_webhook: SCMWebhook.new(payload: { something: 123 }) })
         end.to change(workflow_token, :triggered_at).and(raise_error(Token::Errors::SCMTokenInvalid, 'Your SCM token secret is not properly set in your OBS workflow token.' \
                                                                                                      "\nCheck #{described_class::AUTHENTICATION_DOCUMENTATION_LINK}"))
       end
@@ -67,8 +67,8 @@ RSpec.describe Token::Workflow do
           target_repository_full_name: 'openSUSE/open-build-service'
         }
       end
-      let(:scm_extractor) { TriggerControllerService::ScmExtractor.new(scm, event, github_payload) }
-      let(:scm_webhook) { ScmWebhook.new(payload: github_extractor_payload) }
+      let(:scm_extractor) { TriggerControllerService::SCMExtractor.new(scm, event, github_payload) }
+      let(:scm_webhook) { SCMWebhook.new(payload: github_extractor_payload) }
       let(:yaml_downloader) { Workflows::YAMLDownloader.new(scm_webhook.payload, token: workflow_token) }
       let(:yaml_file) { Rails.root.join('spec/support/files/workflows.yml').expand_path }
       let(:yaml_to_workflows_service) { Workflows::YAMLToWorkflowsService.new(yaml_file: yaml_file, scm_webhook: scm_webhook, token: workflow_token, workflow_run: workflow_run) }
@@ -82,7 +82,7 @@ RSpec.describe Token::Workflow do
         # Skipping call since it's tested in the Workflow model
         allow(workflow).to receive(:call).and_return(true)
 
-        allow(TriggerControllerService::ScmExtractor).to receive(:new).with(scm, event, github_payload).and_return(scm_extractor)
+        allow(TriggerControllerService::SCMExtractor).to receive(:new).with(scm, event, github_payload).and_return(scm_extractor)
         allow(scm_extractor).to receive(:call).and_return(scm_webhook)
         allow(Workflows::YAMLDownloader).to receive(:new).with(scm_webhook.payload, token: workflow_token).and_return(yaml_downloader)
         allow(yaml_downloader).to receive(:call).and_return(yaml_file)
@@ -134,15 +134,15 @@ RSpec.describe Token::Workflow do
           api_endpoint: 'https://api.github.com'
         }
       end
-      let(:scm_extractor) { TriggerControllerService::ScmExtractor.new(scm, event, github_payload) }
-      let(:scm_webhook) { ScmWebhook.new(payload: github_extractor_payload) }
+      let(:scm_extractor) { TriggerControllerService::SCMExtractor.new(scm, event, github_payload) }
+      let(:scm_webhook) { SCMWebhook.new(payload: github_extractor_payload) }
       let(:yaml_downloader) { Workflows::YAMLDownloader.new(scm_webhook.payload, token: workflow_token) }
       let(:yaml_file) { Rails.root.join('spec/support/files/workflows.yml').expand_path }
       let(:yaml_to_workflows_service) { Workflows::YAMLToWorkflowsService.new(yaml_file: yaml_file, scm_webhook: scm_webhook, token: workflow_token, workflow_run: workflow_run) }
       let(:workflows) { [Workflow.new(scm_webhook: scm_webhook, token: workflow_token, workflow_instructions: {})] }
 
       before do
-        allow(TriggerControllerService::ScmExtractor).to receive(:new).with(scm, event, github_payload).and_return(scm_extractor)
+        allow(TriggerControllerService::SCMExtractor).to receive(:new).with(scm, event, github_payload).and_return(scm_extractor)
         allow(scm_extractor).to receive(:call).and_return(scm_webhook)
         allow(Workflows::YAMLDownloader).to receive(:new).with(scm_webhook.payload, token: workflow_token).and_return(yaml_downloader)
         allow(yaml_downloader).to receive(:call).and_return(yaml_file)

--- a/src/api/spec/models/workflow/step/branch_package_step_spec.rb
+++ b/src/api/spec/models/workflow/step/branch_package_step_spec.rb
@@ -159,7 +159,7 @@ RSpec.describe Workflow::Step::BranchPackageStep, vcr: true do
 
     context 'when the SCM is GitHub' do
       let(:scm_webhook) do
-        ScmWebhook.new(payload: {
+        SCMWebhook.new(payload: {
                          scm: 'github',
                          event: 'pull_request',
                          action: action,
@@ -261,7 +261,7 @@ RSpec.describe Workflow::Step::BranchPackageStep, vcr: true do
 
       context 'with a push event for a commit' do
         let(:scm_webhook) do
-          ScmWebhook.new(payload: {
+          SCMWebhook.new(payload: {
                            scm: 'github',
                            event: 'push',
                            target_branch: 'main',
@@ -293,7 +293,7 @@ RSpec.describe Workflow::Step::BranchPackageStep, vcr: true do
 
       context 'with a push event for a tag' do
         let(:scm_webhook) do
-          ScmWebhook.new(payload: {
+          SCMWebhook.new(payload: {
                            scm: 'github',
                            event: 'push',
                            target_branch: '123456789012345',
@@ -392,7 +392,7 @@ RSpec.describe Workflow::Step::BranchPackageStep, vcr: true do
 
     context 'when the SCM is GitLab' do
       let(:scm_webhook) do
-        ScmWebhook.new(payload: {
+        SCMWebhook.new(payload: {
                          scm: 'gitlab',
                          event: 'Merge Request Hook',
                          action: action,
@@ -461,7 +461,7 @@ RSpec.describe Workflow::Step::BranchPackageStep, vcr: true do
 
       context 'with a push event for a commit' do
         let(:scm_webhook) do
-          ScmWebhook.new(payload: {
+          SCMWebhook.new(payload: {
                            scm: 'gitlab',
                            event: 'Push Hook',
                            target_branch: 'main',
@@ -496,7 +496,7 @@ RSpec.describe Workflow::Step::BranchPackageStep, vcr: true do
     let(:project) { create(:project, name: 'foo_project', maintainer: user) }
     let(:package) { create(:package_with_file, name: 'bar_package', project: project) }
     let(:scm_webhook) do
-      ScmWebhook.new(payload: {
+      SCMWebhook.new(payload: {
                        scm: 'github',
                        event: 'pull_request',
                        action: 'opened',

--- a/src/api/spec/models/workflow/step/configure_repositories_spec.rb
+++ b/src/api/spec/models/workflow/step/configure_repositories_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Workflow::Step::ConfigureRepositories do
       }
     end
     let(:scm_webhook) do
-      ScmWebhook.new(payload: {
+      SCMWebhook.new(payload: {
                        scm: 'github',
                        event: 'pull_request',
                        action: 'opened',
@@ -51,7 +51,7 @@ RSpec.describe Workflow::Step::ConfigureRepositories do
       let(:another_user) { create(:confirmed_user, :with_home, login: 'Pop') }
       let(:token) { create(:workflow_token, executor: another_user) }
       let(:scm_webhook) do
-        ScmWebhook.new(payload: {
+        SCMWebhook.new(payload: {
                          scm: 'github',
                          event: 'pull_request',
                          action: 'opened',
@@ -351,7 +351,7 @@ RSpec.describe Workflow::Step::ConfigureRepositories do
           ]
       }
     end
-    let(:scm_webhook) { ScmWebhook.new(payload: payload) }
+    let(:scm_webhook) { SCMWebhook.new(payload: payload) }
 
     subject do
       described_class.new(step_instructions: step_instructions,

--- a/src/api/spec/models/workflow/step/link_package_step_spec.rb
+++ b/src/api/spec/models/workflow/step/link_package_step_spec.rb
@@ -221,7 +221,7 @@ RSpec.describe Workflow::Step::LinkPackageStep, vcr: true do
     context 'when the SCM is GitHub' do
       let(:commit_sha) { '123' }
       let(:scm_webhook) do
-        ScmWebhook.new(payload: {
+        SCMWebhook.new(payload: {
                          scm: 'github',
                          event: 'pull_request',
                          action: action,
@@ -299,7 +299,7 @@ RSpec.describe Workflow::Step::LinkPackageStep, vcr: true do
 
       context 'with a push event for a commit' do
         let(:scm_webhook) do
-          ScmWebhook.new(payload: {
+          SCMWebhook.new(payload: {
                            scm: 'github',
                            event: 'push',
                            target_branch: 'main',
@@ -328,7 +328,7 @@ RSpec.describe Workflow::Step::LinkPackageStep, vcr: true do
 
       context 'with a push event for a tag' do
         let(:scm_webhook) do
-          ScmWebhook.new(payload: {
+          SCMWebhook.new(payload: {
                            scm: 'github',
                            event: 'push',
                            target_branch: '123456789012345',
@@ -433,7 +433,7 @@ RSpec.describe Workflow::Step::LinkPackageStep, vcr: true do
     context 'when the SCM is GitLab' do
       let(:commit_sha) { '123' }
       let(:scm_webhook) do
-        ScmWebhook.new(payload: {
+        SCMWebhook.new(payload: {
                          scm: 'gitlab',
                          event: 'Merge Request Hook',
                          action: action,
@@ -505,7 +505,7 @@ RSpec.describe Workflow::Step::LinkPackageStep, vcr: true do
 
       context 'with a push event for a commit' do
         let(:scm_webhook) do
-          ScmWebhook.new(payload: {
+          SCMWebhook.new(payload: {
                            scm: 'gitlab',
                            event: 'Push Hook',
                            target_branch: 'main',
@@ -537,7 +537,7 @@ RSpec.describe Workflow::Step::LinkPackageStep, vcr: true do
     let(:project) { create(:project, name: 'foo_project', maintainer: user) }
     let(:package) { create(:package_with_file, name: 'bar_package', project: project) }
     let(:scm_webhook) do
-      ScmWebhook.new(payload: {
+      SCMWebhook.new(payload: {
                        scm: 'github',
                        event: 'pull_request',
                        action: 'opened',

--- a/src/api/spec/models/workflow/step/rebuild_package_step_spec.rb
+++ b/src/api/spec/models/workflow/step/rebuild_package_step_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Workflow::Step::RebuildPackage, vcr: true do
   let(:step_instructions) { { package: package.name, project: project.name } }
 
   let(:scm_webhook) do
-    ScmWebhook.new(payload: {
+    SCMWebhook.new(payload: {
                      scm: 'github',
                      event: 'pull_request',
                      action: 'opened',

--- a/src/api/spec/models/workflow/step/set_flags_step_spec.rb
+++ b/src/api/spec/models/workflow/step/set_flags_step_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Workflow::Step::SetFlags do
       let(:token) { create(:workflow_token, executor: another_user) }
       let!(:project) { create(:project, name: 'home:Iggy') }
       let(:scm_webhook) do
-        ScmWebhook.new(payload: {
+        SCMWebhook.new(payload: {
                          scm: 'github',
                          event: 'pull_request',
                          action: 'opened',
@@ -57,7 +57,7 @@ RSpec.describe Workflow::Step::SetFlags do
 
     context 'when user have the permissions and the project is valid' do
       let(:scm_webhook) do
-        ScmWebhook.new(payload: {
+        SCMWebhook.new(payload: {
                          scm: 'github',
                          event: 'pull_request',
                          action: 'opened',
@@ -108,7 +108,7 @@ RSpec.describe Workflow::Step::SetFlags do
     context 'when user have the permission and the package is valid' do
       let!(:target_package) { create(:package, commit_user: user, project: user.home_project, name: 'ctris-0087aa5c0549a6cc0b4c1bb324d2fa8dc665e063') }
       let(:payload) { { scm: 'gitlab', event: 'Push Hook', commit_sha: '0087aa5c0549a6cc0b4c1bb324d2fa8dc665e063' } }
-      let(:scm_webhook) { ScmWebhook.new(payload: payload) }
+      let(:scm_webhook) { SCMWebhook.new(payload: payload) }
       let(:step_instructions) do
         {
           flags:
@@ -137,7 +137,7 @@ RSpec.describe Workflow::Step::SetFlags do
 
     context 'when there is a duplicate flag' do
       let(:scm_webhook) do
-        ScmWebhook.new(payload: {
+        SCMWebhook.new(payload: {
                          scm: 'github',
                          event: 'pull_request',
                          action: 'opened',
@@ -177,7 +177,7 @@ RSpec.describe Workflow::Step::SetFlags do
 
   describe '#validate_flags' do
     let(:payload) { { scm: 'gitlab', event: 'Push Hook' } }
-    let(:scm_webhook) { ScmWebhook.new(payload: payload) }
+    let(:scm_webhook) { SCMWebhook.new(payload: payload) }
 
     subject do
       described_class.new(step_instructions: step_instructions,

--- a/src/api/spec/models/workflow/step/trigger_services_spec.rb
+++ b/src/api/spec/models/workflow/step/trigger_services_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Workflow::Step::TriggerServices do
   let(:step_instructions) { { package: package.name, project: project.name } }
 
   let(:scm_webhook) do
-    ScmWebhook.new(payload: {
+    SCMWebhook.new(payload: {
                      scm: 'github',
                      event: 'pull_request',
                      action: 'opened',

--- a/src/api/spec/models/workflow/step_spec.rb
+++ b/src/api/spec/models/workflow/step_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Workflow::Step do
 
     context 'for a pull request_event when target_package is in the step instructions' do
       let(:step_instructions) { { target_package: 'hello_world' } }
-      let(:scm_webhook) { ScmWebhook.new(payload: { scm: 'github', event: 'pull_request' }) }
+      let(:scm_webhook) { SCMWebhook.new(payload: { scm: 'github', event: 'pull_request' }) }
 
       it 'returns the value of target_package' do
         expect(subject).to eq('hello_world')
@@ -15,7 +15,7 @@ RSpec.describe Workflow::Step do
 
     context 'for a pull request_event when target_package is not in the step instructions' do
       let(:step_instructions) { { source_package: 'package123' } }
-      let(:scm_webhook) { ScmWebhook.new(payload: { scm: 'github', event: 'pull_request' }) }
+      let(:scm_webhook) { SCMWebhook.new(payload: { scm: 'github', event: 'pull_request' }) }
 
       it 'returns the name of the source package' do
         expect(subject).to eq('package123')
@@ -24,7 +24,7 @@ RSpec.describe Workflow::Step do
 
     context 'with a push event for a commit when target_package is in the step instructions' do
       let(:step_instructions) { { target_package: 'hello_world' } }
-      let(:scm_webhook) { ScmWebhook.new(payload: { scm: 'github', event: 'push', ref: 'refs/heads/main', commit_sha: '456' }) }
+      let(:scm_webhook) { SCMWebhook.new(payload: { scm: 'github', event: 'push', ref: 'refs/heads/main', commit_sha: '456' }) }
 
       it 'returns the value of target_package with the commit SHA as a suffix' do
         expect(subject).to eq('hello_world-456')
@@ -33,7 +33,7 @@ RSpec.describe Workflow::Step do
 
     context 'with a push event for a commit when target_package is not in the step instructions' do
       let(:step_instructions) { { source_package: 'package123' } }
-      let(:scm_webhook) { ScmWebhook.new(payload: { scm: 'github', event: 'push', ref: 'refs/heads/main', commit_sha: '456' }) }
+      let(:scm_webhook) { SCMWebhook.new(payload: { scm: 'github', event: 'push', ref: 'refs/heads/main', commit_sha: '456' }) }
 
       it 'returns the name of the source package with the commit SHA as a suffix' do
         expect(subject).to eq('package123-456')
@@ -42,7 +42,7 @@ RSpec.describe Workflow::Step do
 
     context 'with a push event for a tag when target_package is in the step instructions' do
       let(:step_instructions) { { target_package: 'hello_world' } }
-      let(:scm_webhook) { ScmWebhook.new(payload: { scm: 'github', event: 'push', ref: 'refs/tags/release_abc', tag_name: 'release_abc' }) }
+      let(:scm_webhook) { SCMWebhook.new(payload: { scm: 'github', event: 'push', ref: 'refs/tags/release_abc', tag_name: 'release_abc' }) }
 
       it 'returns the value of target_package with the tag name as a suffix' do
         expect(subject).to eq('hello_world-release_abc')
@@ -51,7 +51,7 @@ RSpec.describe Workflow::Step do
 
     context 'with a push event for a tag when target_package is not in the step instructions' do
       let(:step_instructions) { { source_package: 'package123' } }
-      let(:scm_webhook) { ScmWebhook.new(payload: { scm: 'github', event: 'push', ref: 'refs/tags/release_abc', tag_name: 'release_abc' }) }
+      let(:scm_webhook) { SCMWebhook.new(payload: { scm: 'github', event: 'push', ref: 'refs/tags/release_abc', tag_name: 'release_abc' }) }
 
       it 'returns the name of the source package with the tag name as a suffix' do
         expect(subject).to eq('package123-release_abc')
@@ -89,7 +89,7 @@ RSpec.describe Workflow::Step do
           ]
       }
     end
-    let(:scm_webhook) { ScmWebhook.new(payload: payload) }
+    let(:scm_webhook) { SCMWebhook.new(payload: payload) }
 
     subject do
       step.new(step_instructions: step_instructions, scm_webhook: scm_webhook).target_project_name

--- a/src/api/spec/models/workflow_run_spec.rb
+++ b/src/api/spec/models/workflow_run_spec.rb
@@ -9,32 +9,32 @@ RSpec.describe WorkflowRun, vcr: true do
     context 'when providing a permitted key' do
       let(:options) { { api_endpoint: 'https://api.github.com' } }
 
-      it { expect { subject }.to change(ScmStatusReport, :count).by(1) }
+      it { expect { subject }.to change(SCMStatusReport, :count).by(1) }
 
       it 'stores the correct parameters in request_parameters' do
         subject
-        expect(JSON.parse(ScmStatusReport.last.request_parameters)).to include('api_endpoint' => 'https://api.github.com')
+        expect(JSON.parse(SCMStatusReport.last.request_parameters)).to include('api_endpoint' => 'https://api.github.com')
       end
 
       it 'stores correct status value' do
         subject
-        expect(ScmStatusReport.last.status).to eq('success')
+        expect(SCMStatusReport.last.status).to eq('success')
       end
     end
 
     context 'when providing some other keys' do
       let(:options) { { non_permitted_key: 'some value' } }
 
-      it { expect { subject }.to change(ScmStatusReport, :count).by(1) }
+      it { expect { subject }.to change(SCMStatusReport, :count).by(1) }
 
       it 'stores empty request_parameters' do
         subject
-        expect(JSON.parse(ScmStatusReport.last.request_parameters)).to be_empty
+        expect(JSON.parse(SCMStatusReport.last.request_parameters)).to be_empty
       end
 
       it 'stores correct status value' do
         subject
-        expect(ScmStatusReport.last.status).to eq('success')
+        expect(SCMStatusReport.last.status).to eq('success')
       end
     end
   end
@@ -45,17 +45,17 @@ RSpec.describe WorkflowRun, vcr: true do
     context 'when providing a permitted key' do
       let(:options) { { api_endpoint: 'https://api.github.com' } }
 
-      it { expect { subject }.to change(ScmStatusReport, :count).by(1) }
+      it { expect { subject }.to change(SCMStatusReport, :count).by(1) }
 
       it 'stores the correct parameters in request_parameters' do
         subject
-        expect(JSON.parse(ScmStatusReport.last.request_parameters)).to include('api_endpoint' => 'https://api.github.com')
+        expect(JSON.parse(SCMStatusReport.last.request_parameters)).to include('api_endpoint' => 'https://api.github.com')
       end
 
       it 'stores correct values for failure' do
         subject
-        expect(ScmStatusReport.last.response_body).to eql('oops it failed')
-        expect(ScmStatusReport.last.status).to eq('fail')
+        expect(SCMStatusReport.last.response_body).to eql('oops it failed')
+        expect(SCMStatusReport.last.status).to eq('fail')
       end
 
       it 'marks the workflow run as failed' do
@@ -67,17 +67,17 @@ RSpec.describe WorkflowRun, vcr: true do
     context 'when providing some other keys' do
       let(:options) { { non_permitted_key: 'some value' } }
 
-      it { expect { subject }.to change(ScmStatusReport, :count).by(1) }
+      it { expect { subject }.to change(SCMStatusReport, :count).by(1) }
 
       it 'stores empty request_parameters' do
         subject
-        expect(JSON.parse(ScmStatusReport.last.request_parameters)).to be_empty
+        expect(JSON.parse(SCMStatusReport.last.request_parameters)).to be_empty
       end
 
       it 'stores correct values for failure' do
         subject
-        expect(ScmStatusReport.last.response_body).to eql('oops it failed')
-        expect(ScmStatusReport.last.status).to eq('fail')
+        expect(SCMStatusReport.last.response_body).to eql('oops it failed')
+        expect(SCMStatusReport.last.status).to eq('fail')
       end
 
       it 'marks the workflow run as failed' do

--- a/src/api/spec/models/workflow_spec.rb
+++ b/src/api/spec/models/workflow_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Workflow, type: :model, vcr: true do
   let!(:workflow_run) { create(:workflow_run, token: token) }
 
   subject do
-    described_class.new(workflow_instructions: yaml, scm_webhook: ScmWebhook.new(payload: extractor_payload), token: token, workflow_run: workflow_run)
+    described_class.new(workflow_instructions: yaml, scm_webhook: SCMWebhook.new(payload: extractor_payload), token: token, workflow_run: workflow_run)
   end
 
   describe '#call' do

--- a/src/api/spec/services/github_status_reporter_spec.rb
+++ b/src/api/spec/services/github_status_reporter_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe GithubStatusReporter, type: :service do
         end
 
         it { expect { subject }.to change(EventSubscription, :count).by(-1) }
-        it { expect { subject }.to change(ScmStatusReport, :count).by(1) }
+        it { expect { subject }.to change(SCMStatusReport, :count).by(1) }
 
         it 'tracks the exception in the workflow_run response body and sets the status to fail' do
           subject
@@ -82,7 +82,7 @@ RSpec.describe GithubStatusReporter, type: :service do
           allow(octokit_client).to receive(:create_status).and_raise(Octokit::AccountSuspended)
         end
 
-        it { expect { subject }.to change(ScmStatusReport, :count).by(1) }
+        it { expect { subject }.to change(SCMStatusReport, :count).by(1) }
 
         it 'tracks the exception in the workflow_run response body and sets the status to fail' do
           subject
@@ -97,7 +97,7 @@ RSpec.describe GithubStatusReporter, type: :service do
           allow(octokit_client).to receive(:create_status).and_raise(Faraday::ConnectionFailed.new('Network glitch'))
         end
 
-        it { expect { subject }.to change(ScmStatusReport, :count).by(1) }
+        it { expect { subject }.to change(SCMStatusReport, :count).by(1) }
 
         it 'tracks the exception in the workflow_run response body and sets the status to fail' do
           subject

--- a/src/api/spec/services/trigger_controller_service/scm_extractor_spec.rb
+++ b/src/api/spec/services/trigger_controller_service/scm_extractor_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe TriggerControllerService::ScmExtractor do
+RSpec.describe TriggerControllerService::SCMExtractor do
   describe '#call' do
     subject(:scm_webhook) do
       described_class.new(scm, event, payload).call
@@ -63,8 +63,8 @@ RSpec.describe TriggerControllerService::ScmExtractor do
           }
         end
 
-        it 'returns an instance of ScmWebhook with the extracted data from the GitHub payload' do
-          expect(scm_webhook).to be_instance_of(ScmWebhook)
+        it 'returns an instance of SCMWebhook with the extracted data from the GitHub payload' do
+          expect(scm_webhook).to be_instance_of(SCMWebhook)
           expect(scm_webhook.payload).to eq(expected_hash)
         end
       end
@@ -97,8 +97,8 @@ RSpec.describe TriggerControllerService::ScmExtractor do
           }
         end
 
-        it 'returns an instance of ScmWebhook with the extracted data from the GitHub payload' do
-          expect(scm_webhook).to be_instance_of(ScmWebhook)
+        it 'returns an instance of SCMWebhook with the extracted data from the GitHub payload' do
+          expect(scm_webhook).to be_instance_of(SCMWebhook)
           expect(scm_webhook.payload).to eq(expected_hash)
         end
       end
@@ -132,8 +132,8 @@ RSpec.describe TriggerControllerService::ScmExtractor do
           }
         end
 
-        it 'returns an instance of ScmWebhook with the extracted data from the GitHub payload' do
-          expect(scm_webhook).to be_instance_of(ScmWebhook)
+        it 'returns an instance of SCMWebhook with the extracted data from the GitHub payload' do
+          expect(scm_webhook).to be_instance_of(SCMWebhook)
           expect(scm_webhook.payload).to eq(expected_hash)
         end
       end
@@ -181,8 +181,8 @@ RSpec.describe TriggerControllerService::ScmExtractor do
           }
         end
 
-        it 'returns an instance of ScmWebhook with the extracted data from the GitLab payload' do
-          expect(scm_webhook).to be_instance_of(ScmWebhook)
+        it 'returns an instance of SCMWebhook with the extracted data from the GitLab payload' do
+          expect(scm_webhook).to be_instance_of(SCMWebhook)
           expect(scm_webhook.payload).to eq(expected_hash)
         end
       end
@@ -216,8 +216,8 @@ RSpec.describe TriggerControllerService::ScmExtractor do
           }
         end
 
-        it 'returns an instance of ScmWebhook with the extracted data from the GitLab payload' do
-          expect(scm_webhook).to be_instance_of(ScmWebhook)
+        it 'returns an instance of SCMWebhook with the extracted data from the GitLab payload' do
+          expect(scm_webhook).to be_instance_of(SCMWebhook)
           expect(scm_webhook.payload).to eq(expected_hash)
         end
       end
@@ -250,8 +250,8 @@ RSpec.describe TriggerControllerService::ScmExtractor do
           }
         end
 
-        it 'returns an instance of ScmWebhook with the extracted data from the GitLab payload' do
-          expect(scm_webhook).to be_instance_of(ScmWebhook)
+        it 'returns an instance of SCMWebhook with the extracted data from the GitLab payload' do
+          expect(scm_webhook).to be_instance_of(SCMWebhook)
           expect(scm_webhook.payload).to eq(expected_hash)
         end
       end
@@ -284,8 +284,8 @@ RSpec.describe TriggerControllerService::ScmExtractor do
         }
       end
 
-      it 'returns an instance of ScmWebhook with the extracted data' do
-        expect(scm_webhook).to be_instance_of(ScmWebhook)
+      it 'returns an instance of SCMWebhook with the extracted data' do
+        expect(scm_webhook).to be_instance_of(SCMWebhook)
         expect(scm_webhook.payload).to eq(expected_hash)
       end
     end

--- a/src/api/spec/services/workflows/artifacts_collector_spec.rb
+++ b/src/api/spec/services/workflows/artifacts_collector_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Workflows::ArtifactsCollector, type: :service do
 
       context 'and pull_request event' do
         let(:scm_webhook) do
-          ScmWebhook.new(payload: {
+          SCMWebhook.new(payload: {
                            scm: 'github',
                            event: 'pull_request',
                            pr_number: 1,
@@ -56,7 +56,7 @@ RSpec.describe Workflows::ArtifactsCollector, type: :service do
 
       context 'and push for commit event' do
         let(:scm_webhook) do
-          ScmWebhook.new(payload: {
+          SCMWebhook.new(payload: {
                            scm: 'github',
                            event: 'push',
                            target_branch: 'main',
@@ -87,7 +87,7 @@ RSpec.describe Workflows::ArtifactsCollector, type: :service do
 
       context 'and push for tag event' do
         let(:scm_webhook) do
-          ScmWebhook.new(payload: {
+          SCMWebhook.new(payload: {
                            scm: 'github',
                            event: 'push',
                            target_branch: '2a6b530bcdf7a54d881c62333c9f13b6ce16f3fc',
@@ -135,7 +135,7 @@ RSpec.describe Workflows::ArtifactsCollector, type: :service do
 
       context 'and pull_request event' do
         let(:scm_webhook) do
-          ScmWebhook.new(payload: {
+          SCMWebhook.new(payload: {
                            scm: 'github',
                            event: 'pull_request',
                            pr_number: 1,
@@ -166,7 +166,7 @@ RSpec.describe Workflows::ArtifactsCollector, type: :service do
 
       context 'and push for commit event' do
         let(:scm_webhook) do
-          ScmWebhook.new(payload: {
+          SCMWebhook.new(payload: {
                            scm: 'github',
                            event: 'push',
                            target_branch: 'main',
@@ -197,7 +197,7 @@ RSpec.describe Workflows::ArtifactsCollector, type: :service do
 
       context 'and push for tag event' do
         let(:scm_webhook) do
-          ScmWebhook.new(payload: {
+          SCMWebhook.new(payload: {
                            scm: 'github',
                            event: 'push',
                            target_branch: '2a6b530bcdf7a54d881c62333c9f13b6ce16f3fc',
@@ -243,7 +243,7 @@ RSpec.describe Workflows::ArtifactsCollector, type: :service do
       end
 
       let(:scm_webhook) do
-        ScmWebhook.new(payload: {
+        SCMWebhook.new(payload: {
                          scm: 'github',
                          event: 'pull_request',
                          pr_number: 1,
@@ -280,7 +280,7 @@ RSpec.describe Workflows::ArtifactsCollector, type: :service do
       end
 
       let(:scm_webhook) do
-        ScmWebhook.new(payload: {
+        SCMWebhook.new(payload: {
                          scm: 'github',
                          event: 'pull_request',
                          pr_number: 1,
@@ -342,7 +342,7 @@ RSpec.describe Workflows::ArtifactsCollector, type: :service do
       end
 
       let(:scm_webhook) do
-        ScmWebhook.new(payload: {
+        SCMWebhook.new(payload: {
                          scm: 'github',
                          event: 'pull_request',
                          pr_number: 1,

--- a/src/api/spec/services/workflows/yaml_to_workflows_service_spec.rb
+++ b/src/api/spec/services/workflows/yaml_to_workflows_service_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Workflows::YAMLToWorkflowsService, type: :service do
 
   describe '#call' do
     subject do
-      Workflows::YAMLToWorkflowsService.new(yaml_file: workflows_yml_file, scm_webhook: ScmWebhook.new(payload: payload), token: token, workflow_run: workflow_run).call
+      Workflows::YAMLToWorkflowsService.new(yaml_file: workflows_yml_file, scm_webhook: SCMWebhook.new(payload: payload), token: token, workflow_run: workflow_run).call
     end
 
     context 'it supports many workflows' do

--- a/src/api/spec/validators/scm_webhook_event_validator_spec.rb
+++ b/src/api/spec/validators/scm_webhook_event_validator_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
-RSpec.describe ScmWebhookEventValidator do
+RSpec.describe SCMWebhookEventValidator do
   let(:fake_model) do
     Struct.new(:payload) do
       include ActiveModel::Validations
 
-      validates_with ScmWebhookEventValidator
+      validates_with SCMWebhookEventValidator
     end
   end
 


### PR DESCRIPTION
This PR is only about SCM acronym standardization in the codebase: from `scm|Scm|SCM` occurrences to `SCM` only.

Fixes https://trello.com/c/s5Sr7U2q