### PR TITLE
Remove css property scroll smooth

### DIFF
--- a/src/api/app/assets/stylesheets/webui/application.scss
+++ b/src/api/app/assets/stylesheets/webui/application.scss
@@ -75,5 +75,4 @@
 html {
     overflow-y: scroll !important;
     scroll-padding-top: $top-navigation-height;
-    scroll-behavior: smooth;
 }


### PR DESCRIPTION
We need to remove this property because it affects the logging of build logs. With the presence of this property, the logs get stuck.
Fixes #13086