### PR TITLE
Track current object in the watchlist

### DIFF
--- a/src/api/app/components/watched_items_list_component.html.haml
+++ b/src/api/app/components/watched_items_list_component.html.haml
@@ -15,7 +15,9 @@
                             target: '#delete-item-from-watchlist-modal',
                             modal_title: 'Do you really want to remove this package from the watchlist?',
                             confirmation_text: "Please confirm you want to remove '#{name}' from the watchlist.",
-                            action: project_package_toggle_watched_item_path(project_name: item.project.name, package_name: item.name) }) do
+                            action: project_package_toggle_watched_item_path(project_name: item.project.name,
+                                                                             package_name: item.name,
+                                                                             current_object: current_object_params) }) do
             %i.fa.fa-times-circle{ title: 'Remove package from watchlist' }
       - when 'Project'
         - name = item.name
@@ -30,7 +32,7 @@
                             target: '#delete-item-from-watchlist-modal',
                             modal_title: 'Do you really want to remove this project from the watchlist?',
                             confirmation_text: "Please confirm you want to remove '#{name}' from the watchlist.",
-                            action: project_toggle_watched_item_path(project_name: name) }) do
+                            action: project_toggle_watched_item_path(project_name: name, current_object: current_object_params) }) do
             %i.fa.fa-times-circle{ title: 'Remove project from watchlist' }
       - when 'BsRequest'
         - name = "##{item.number} #{helpers.request_type_of_action(item)}"
@@ -44,7 +46,7 @@
                             target: '#delete-item-from-watchlist-modal',
                             modal_title: 'Do you really want to remove this request from the watchlist?',
                             confirmation_text: "Please confirm you want to remove '#{name}' from the watchlist.",
-                            action: toggle_watched_item_request_path(number: item.number) }) do
+                            action: toggle_watched_item_request_path(number: item.number, current_object: current_object_params) }) do
             %i.fa.fa-times-circle{ title: 'Remove request from watchlist' }
         .extended-info.mt-2.mb-3.collapsed
           .triangle.left

--- a/src/api/app/components/watched_items_list_component.rb
+++ b/src/api/app/components/watched_items_list_component.rb
@@ -11,11 +11,13 @@ class WatchedItemsListComponent < ApplicationComponent
     'BsRequest' => 'There are no requests in the watchlist yet.'
   }.freeze
 
-  def initialize(items:, class_name:)
+  def initialize(items:, class_name:, current_object:)
     super
 
     @items = items
     @class_name = class_name
+    @current_object = current_object
+    @current_object_class_name = @current_object.class.name
   end
 
   private
@@ -26,5 +28,17 @@ class WatchedItemsListComponent < ApplicationComponent
 
   def empty_list_text
     EMPTY_LIST_TEXTS[@class_name]
+  end
+
+  def current_object_params
+    object_type = @current_object.class.name
+    case object_type
+    when 'Project'
+      { type: object_type, name: @current_object.name }
+    when 'Package'
+      { type: object_type, package_name: @current_object.name, project_name: @current_object.project_name }
+    when 'BsRequest'
+      { type: object_type, number: @current_object.number }
+    end
   end
 end

--- a/src/api/app/components/watchlist_component.html.haml
+++ b/src/api/app/components/watchlist_component.html.haml
@@ -21,9 +21,9 @@
             %i.fas.fa-plus-circle
             %span Watch this #{watchable_type_text}
 
-  = render WatchedItemsListComponent.new(items: projects, class_name: 'Project')
-  = render WatchedItemsListComponent.new(items: packages, class_name: 'Package')
-  = render WatchedItemsListComponent.new(items: bs_requests, class_name: 'BsRequest')
+  = render WatchedItemsListComponent.new(items: projects, class_name: 'Project', current_object: @current_object)
+  = render WatchedItemsListComponent.new(items: packages, class_name: 'Package', current_object: @current_object)
+  = render WatchedItemsListComponent.new(items: bs_requests, class_name: 'BsRequest', current_object: @current_object)
 
 :javascript
   toggleCollapsibleTooltip();

--- a/src/api/app/components/watchlist_component.rb
+++ b/src/api/app/components/watchlist_component.rb
@@ -5,11 +5,12 @@ class WatchlistComponent < ApplicationComponent
     'BsRequest' => 'request'
   }.freeze
 
-  def initialize(user:, bs_request: nil, package: nil, project: nil)
+  def initialize(user:, current_object:, bs_request: nil, package: nil, project: nil)
     super
 
     @user = user
     @object_to_be_watched = object_to_be_watched(bs_request, package, project)
+    @current_object = current_object
   end
 
   private
@@ -33,21 +34,21 @@ class WatchlistComponent < ApplicationComponent
   end
 
   def object_to_be_watched_in_watchlist?
-    @user.watched_items.exists?(watchable: @object_to_be_watched)
+    @user.watched_items.exists?(watchable: @current_object)
   end
 
   def watchable_type_text
-    WATCHABLE_TYPE_TEXT[@object_to_be_watched.class.name]
+    WATCHABLE_TYPE_TEXT[@current_object.class.name]
   end
 
   def toggle_watchable_path
-    case @object_to_be_watched
+    case @current_object
     when Package
-      project_package_toggle_watched_item_path(project_name: @object_to_be_watched.project.name, package_name: @object_to_be_watched.name)
+      project_package_toggle_watched_item_path(project_name: @current_object.project.name, package_name: @current_object.name)
     when Project
-      project_toggle_watched_item_path(project_name: @object_to_be_watched.name)
+      project_toggle_watched_item_path(project_name: @current_object.name)
     when BsRequest
-      toggle_watched_item_request_path(number: @object_to_be_watched.number)
+      toggle_watched_item_request_path(number: @current_object.number)
     end
   end
 

--- a/src/api/app/controllers/webui/watched_items_controller.rb
+++ b/src/api/app/controllers/webui/watched_items_controller.rb
@@ -2,6 +2,7 @@ class Webui::WatchedItemsController < Webui::WebuiController
   before_action :require_login
   before_action :check_user_belongs_feature_flag
   before_action :set_watchable
+  before_action :set_current_object
 
   FLASH_PER_WATCHABLE_TYPE = {
     Package => 'package',
@@ -36,6 +37,22 @@ class Webui::WatchedItemsController < Webui::WebuiController
     end
 
     @watchable = @package || @project || @bs_request
+  end
+
+  def set_current_object
+    params[:current_object] ||= {}
+    object_type = params[:current_object][:type]
+    @current_object = case object_type
+                      when 'BsRequest'
+                        BsRequest.find_by(number: params[:current_object][:number])
+                      when 'Project'
+                        Project.get_by_name(params[:current_object][:name])
+                      when 'Package'
+                        current_object = params[:current_object]
+                        Package.get_by_project_and_name(current_object[:project_name], current_object[:package_name])
+                      end
+
+    @current_object = @watchable if @current_object.nil?
   end
 
   def check_user_belongs_feature_flag

--- a/src/api/app/views/layouts/webui/webui.html.haml
+++ b/src/api/app/views/layouts/webui/webui.html.haml
@@ -81,7 +81,8 @@
             = render WatchlistComponent.new(user: User.session!,
                                             bs_request: @bs_request,
                                             package: @package,
-                                            project: @project)
+                                            project: @project,
+                                            current_object: @bs_request || @package || @project)
           = render DeleteConfirmationDialogComponent.new(modal_id: 'delete-item-from-watchlist-modal', method: :put, options: { remote: true })
         - else
           = render partial: 'layouts/webui/watchlist'

--- a/src/api/app/views/webui/watched_items/toggle_watched_item.js.erb
+++ b/src/api/app/views/webui/watched_items/toggle_watched_item.js.erb
@@ -3,5 +3,6 @@ $('#flash').html("<%= escape_javascript(render(partial: 'layouts/webui/flash'))%
 $('.watchlist-collapse').html("<%= escape_javascript(render WatchlistComponent.new(user: User.session!,
                                                                                    bs_request: @bs_request,
                                                                                    package: @package,
-                                                                                   project: @project)) %>");
+                                                                                   project: @project,
+                                                                                   current_object: @current_object)) %>");
 collectDeleteConfirmationModalsAndSetValues();

--- a/src/api/spec/components/watched_items_list_component_spec.rb
+++ b/src/api/spec/components/watched_items_list_component_spec.rb
@@ -2,11 +2,12 @@ require 'rails_helper'
 
 RSpec.describe WatchedItemsListComponent, type: :component do
   let(:user) { create(:confirmed_user) }
+  let(:current_object) { create(:package) }
 
   context 'when dealing with packages' do
     context 'and the user is not watching packages' do
       before do
-        render_inline(described_class.new(items: [], class_name: 'Package'))
+        render_inline(described_class.new(items: [], class_name: 'Package', current_object: current_object))
       end
 
       it 'does not show any watched package in the list' do
@@ -19,7 +20,7 @@ RSpec.describe WatchedItemsListComponent, type: :component do
       let(:packages) { create_list(:package, 2) }
 
       before do
-        render_inline(described_class.new(items: packages, class_name: 'Package'))
+        render_inline(described_class.new(items: packages, class_name: 'Package', current_object: current_object))
       end
 
       it 'does show the watched package in the list' do
@@ -32,7 +33,7 @@ RSpec.describe WatchedItemsListComponent, type: :component do
   context 'when dealing with projects' do
     context 'and the user is not watching projects' do
       before do
-        render_inline(described_class.new(items: [], class_name: 'Project'))
+        render_inline(described_class.new(items: [], class_name: 'Project', current_object: current_object))
       end
 
       it 'does not show any watched project in the list' do
@@ -45,7 +46,7 @@ RSpec.describe WatchedItemsListComponent, type: :component do
       let(:projects) { create_list(:project, 2) }
 
       before do
-        render_inline(described_class.new(items: projects, class_name: 'Project'))
+        render_inline(described_class.new(items: projects, class_name: 'Project', current_object: current_object))
       end
 
       it 'does show the watched project in the list' do
@@ -58,7 +59,7 @@ RSpec.describe WatchedItemsListComponent, type: :component do
   context 'when dealing with requests' do
     context 'and the user is not watching requests' do
       before do
-        render_inline(described_class.new(items: [], class_name: 'BsRequest'))
+        render_inline(described_class.new(items: [], class_name: 'BsRequest', current_object: current_object))
       end
 
       it 'does not show any watched request in the list' do
@@ -71,7 +72,7 @@ RSpec.describe WatchedItemsListComponent, type: :component do
       let(:requests) { create_list(:bs_request_with_submit_action, 2) }
 
       before do
-        render_inline(described_class.new(items: requests, class_name: 'BsRequest'))
+        render_inline(described_class.new(items: requests, class_name: 'BsRequest', current_object: current_object))
       end
 
       it 'does show the watched request in the list' do

--- a/src/api/spec/components/watchlist_component_spec.rb
+++ b/src/api/spec/components/watchlist_component_spec.rb
@@ -4,8 +4,10 @@ RSpec.describe WatchlistComponent, type: :component do
   let(:user) { create(:confirmed_user) }
 
   context 'when there is no watchable item in the current page' do
+    let(:current_object) { create(:package) }
+
     before do
-      render_inline(described_class.new(user: user))
+      render_inline(described_class.new(user: user, current_object: current_object))
     end
 
     ['package', 'project', 'request'].each do |item_name|
@@ -21,7 +23,7 @@ RSpec.describe WatchlistComponent, type: :component do
 
     before do
       create(:watched_item, :for_packages, watchable: package, user: another_user)
-      render_inline(described_class.new(user: user, package: package, project: package.project))
+      render_inline(described_class.new(user: user, package: package, project: package.project, current_object: package))
     end
 
     it 'does not show anything' do
@@ -36,7 +38,7 @@ RSpec.describe WatchlistComponent, type: :component do
 
       context 'and the package is not yet watched' do
         before do
-          render_inline(described_class.new(user: user, package: package, project: package.project))
+          render_inline(described_class.new(user: user, package: package, project: package.project, current_object: package))
         end
 
         it { expect(rendered_content).to have_text('There are no packages in the watchlist yet.') }
@@ -47,7 +49,7 @@ RSpec.describe WatchlistComponent, type: :component do
       context 'and the package is already watched' do
         before do
           create(:watched_item, :for_packages, watchable: package, user: user)
-          render_inline(described_class.new(user: user, package: package, project: package.project))
+          render_inline(described_class.new(user: user, package: package, project: package.project, current_object: package))
         end
 
         it { expect(rendered_content).not_to have_text('There are no packages in the watchlist yet.') }
@@ -63,7 +65,7 @@ RSpec.describe WatchlistComponent, type: :component do
         let(:base_package) { create(:package) }
 
         before do
-          render_inline(described_class.new(user: user, package: multibuild_package, project: base_package.project))
+          render_inline(described_class.new(user: user, package: multibuild_package, project: base_package.project, current_object: base_package))
         end
 
         it { expect(rendered_content).to have_text('There are no projects in the watchlist yet.') }
@@ -75,7 +77,11 @@ RSpec.describe WatchlistComponent, type: :component do
         let(:base_package) { 'i_do_not_exist' }
         let(:project) { create(:project) }
 
-        it { expect { described_class.new(user: user, package: multibuild_package, project: project) }.to raise_error(Package::Errors::UnknownObjectError) }
+        it {
+          expect do
+            described_class.new(user: user, package: multibuild_package, project: project, current_object: multibuild_package)
+          end.to raise_error(Package::Errors::UnknownObjectError)
+        }
       end
     end
   end
@@ -85,7 +91,7 @@ RSpec.describe WatchlistComponent, type: :component do
 
     context 'and the project is not yet watched' do
       before do
-        render_inline(described_class.new(user: user, project: project))
+        render_inline(described_class.new(user: user, project: project, current_object: project))
       end
 
       it { expect(rendered_content).to have_text('There are no projects in the watchlist yet.') }
@@ -96,7 +102,7 @@ RSpec.describe WatchlistComponent, type: :component do
     context 'and the project is already watched' do
       before do
         create(:watched_item, :for_packages, watchable: project, user: user)
-        render_inline(described_class.new(user: user, project: project))
+        render_inline(described_class.new(user: user, project: project, current_object: project))
       end
 
       it { expect(rendered_content).not_to have_text('There are no projects in the watchlist yet.') }
@@ -109,7 +115,7 @@ RSpec.describe WatchlistComponent, type: :component do
     let(:project) { Project.new }
 
     before do
-      render_inline(described_class.new(user: user, project: project))
+      render_inline(described_class.new(user: user, project: project, current_object: project))
     end
 
     it { expect(rendered_content).to have_text('There are no projects in the watchlist yet.') }
@@ -120,7 +126,7 @@ RSpec.describe WatchlistComponent, type: :component do
     let(:bs_request) { create(:bs_request_with_submit_action) }
 
     context 'and the request is not yet watched' do
-      before { render_inline(described_class.new(user: user, bs_request: bs_request)) }
+      before { render_inline(described_class.new(user: user, bs_request: bs_request, current_object: bs_request)) }
 
       it { expect(rendered_content).to have_text('There are no requests in the watchlist yet.') }
       it { expect(rendered_content).not_to have_link("##{bs_request.number} Submit") }
@@ -130,7 +136,7 @@ RSpec.describe WatchlistComponent, type: :component do
     context 'and the request is already watched' do
       before do
         create(:watched_item, :for_bs_requests, watchable: bs_request, user: user)
-        render_inline(described_class.new(user: user, bs_request: bs_request))
+        render_inline(described_class.new(user: user, bs_request: bs_request, current_object: bs_request))
       end
 
       it { expect(rendered_content).not_to have_text('There are no requests in the watchlist yet.') }


### PR DESCRIPTION
Before this update, we were trying to generalize watch items. This is not correct because the current object could be different from a watched item. That means on a request page current object is the request. Whereas, the watched items could be a package, project, or request.