### PR TITLE
Fix iso/image listing in view=publishedpath

### DIFF
--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -5864,6 +5864,8 @@ sub published_path {
       $p = "$1/$bin";
     } elsif ($bin =~ /\.exe$/) {
       $p = $bin;
+    } elsif ($bin =~ /\.(xz|qcow2|vmx|box|tar\.gz)$/) {
+      $p = $bin;
     } elsif ($bin =~ /\.pkg\.tar(?:\.gz|\.xz|\.zst)$/) {
       $p = ($cgi->{'arch'} eq 'i586' ? 'i686' : $cgi->{'arch'})."/$bin";
     } elsif ($bin =~ /\.iso(\.report)?$/) {

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -5866,7 +5866,7 @@ sub published_path {
       $p = $bin;
     } elsif ($bin =~ /\.pkg\.tar(?:\.gz|\.xz|\.zst)$/) {
       $p = ($cgi->{'arch'} eq 'i586' ? 'i686' : $cgi->{'arch'})."/$bin";
-    } elsif ($bin =~ /\.iso(?:\.report)$/) {
+    } elsif ($bin =~ /\.iso(\.report)?$/) {
       $p = "iso/$bin";
     } elsif ($bin =~ /-Media\d+$/) {
       $medium = $bin;


### PR DESCRIPTION
Fix matching iso (.iso OR .iso.report not only iso.report) and the common image formats that we publish.

Came across this while trying to use this view for binary download

## RPM

```shell
osc api "/build/OBS:Server:Unstable/15.4/x86_64/obs-server/obs-api-2.11~alpha.20220919T123635.aa52f625-150400.14644.3.noarch.rpm?view=publishedpath"
<publishedpath project="OBS:Server:Unstable" repository="15.4">
  <path>OBS:/Server:/Unstable/15.4/noarch/obs-api-2.11~alpha.20220919T123635.aa52f625-150400.14644.3.noarch.rpm</path>
  <url>https://download.opensuse.org/repositories/OBS:/Server:/Unstable/15.4/noarch/obs-api-2.11~alpha.20220919T123635.aa52f625-150400.14644.3.noarch.rpm</url>
</publishedpath>
```

## ISO

```shell
osc api "/build/OBS:Server:Unstable/images/x86_64/OBS-Appliance:oem/obs-server.x86_64-2.10.51-oem-Build22.540.install.iso?view=publishedpath" 
<publishedpath project="OBS:Server:Unstable" repository="images">
  <path>OBS:/Server:/Unstable/images</path>
  <url>https://download.opensuse.org/repositories/OBS:/Server:/Unstable/images</url>
</publishedpath>
```

## Image formats
```shell
osc api "/build/OBS:Server:Unstable/images/x86_64/OBS-Appliance:oem/obs-server.x86_64-2.10.51-oem-Build22.540.raw.xz?view=publishedpath"
<publishedpath project="OBS:Server:Unstable" repository="images">
  <path>OBS:/Server:/Unstable/images</path>
  <url>https://download.opensuse.org/repositories/OBS:/Server:/Unstable/images</url>
</publishedpath>
```