### PR TITLE
Remove trigger_workflow from initializer

### DIFF
--- a/src/api/config/initializers/flipper.rb
+++ b/src/api/config/initializers/flipper.rb
@@ -1,5 +1,4 @@
 ENABLED_FEATURE_TOGGLES = [
-  { name: :trigger_workflow, description: 'Better SCM and CI integration with OBS workflows' },
   { name: :new_watchlist, description: 'New implementation of watchlist including projects, packages and requests' },
   { name: :request_show_redesign, description: 'Redesign of the request pages to improve the collaboration workflow' }
 ].freeze


### PR DESCRIPTION
That makes the feature not to be listed on the beta features configuration page.

TODO in the reference instance as soon as this is deployed:

- [x] Move all the users to the rollout group.
- [ ] Add group `rollout` to the `trigger_workflow` feature in Flipper.
- [ ] Remove group `trigger_workflow` in the `trigger_workflow` feature in Flipper.