### PR TITLE
Add old watched projects to new watched items

### DIFF
--- a/src/api/db/data/20220920115342_copy_old_watched_projects.rb
+++ b/src/api/db/data/20220920115342_copy_old_watched_projects.rb
@@ -1,0 +1,9 @@
+class CopyOldWatchedProjects < ActiveRecord::Migration[6.1]
+  def up
+    WatchedProject.all.each do |old_watched_project|
+      next if old_watched_project.user.watched_items.count.positive?
+
+      WatchedItem.find_or_create_by(watchable: old_watched_project.project, user: old_watched_project.user)
+    end
+  end
+end

--- a/src/api/db/data_schema.rb
+++ b/src/api/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20220318123314)
+DataMigrate::Data.define(version: 20220920115342)


### PR DESCRIPTION
The old watchlist implementation only kept projects. The new watchlist implementation uses other table (`watched_items`) to keep watched items (projects, packages and requests).

Add a data migration to import into the new implementation, the projects which were watched with the old implementation.

Import the projects only if the user doesn't watch any item in the new implementation.

To apply this data migration: `bin/rake data:migrate`

For reviewers:
- Change watched projects accordingly, with and without the beta.
- Run (or rerun) the data migration in the rails console with: `VERSION=2022092011532 bin/rake data:migrate:redo`