### PR TITLE
Display APIError in format.html better

### DIFF
--- a/src/api/app/controllers/application_controller.rb
+++ b/src/api/app/controllers/application_controller.rb
@@ -252,7 +252,7 @@ class ApplicationController < ActionController::Base
       format.xml { render template: 'status', status: @status }
       format.json { render json: { errorcode: @errorcode, summary: @summary }, status: @status }
       format.html do
-        flash[:error] = "#{@errorcode}(#{@summary}): #{@message}" unless request.env['HTTP_REFERER']
+        flash[:error] = "#{@summary} (#{@errorcode})" unless request.env['HTTP_REFERER']
         redirect_back(fallback_location: root_path)
       end
     end

--- a/src/api/app/controllers/concerns/webui/rescue_handler.rb
+++ b/src/api/app/controllers/concerns/webui/rescue_handler.rb
@@ -1,3 +1,5 @@
+# NOTE: There is also ApplicationController.render_error which will handle APIError
+# exceptions that will happen while requesting HTML from the API
 module Webui::RescueHandler
   extend ActiveSupport::Concern
 

--- a/src/api/spec/controllers/source_controller_spec.rb
+++ b/src/api/spec/controllers/source_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe SourceController, vcr: true do
   describe 'POST #global_command_branch' do
     it 'is not accessible anonymously' do
       post :global_command_branch, params: { cmd: 'branch' }
-      expect(flash[:error]).to eq('anonymous_user(Anonymous user is not allowed here - please login): ')
+      expect(flash[:error]).to eq('Anonymous user is not allowed here - please login (anonymous_user)')
       expect(response).to redirect_to(root_path)
     end
   end
@@ -26,7 +26,7 @@ RSpec.describe SourceController, vcr: true do
   describe 'POST #global_command_createmaintenanceincident' do
     it 'is not accessible anonymously' do
       post :global_command_createmaintenanceincident, params: { cmd: 'createmaintenanceincident' }
-      expect(flash[:error]).to eq('anonymous_user(Anonymous user is not allowed here - please login): ')
+      expect(flash[:error]).to eq('Anonymous user is not allowed here - please login (anonymous_user)')
       expect(response).to redirect_to(root_path)
     end
   end
@@ -50,7 +50,7 @@ RSpec.describe SourceController, vcr: true do
         }
       end
 
-      it { expect(flash[:error]).to eq("invalid_package_name(invalid package name '#{multibuild_package.name}:one'): ") }
+      it { expect(flash[:error]).to eq("invalid package name '#{multibuild_package.name}:one' (invalid_package_name)") }
       it { expect(response.status).to eq(302) }
     end
   end


### PR DESCRIPTION
Turns for instance this

![Screenshot from 2022-09-21 11-55-57](https://user-images.githubusercontent.com/514785/191482826-df3e2a13-8e9b-44d0-bd4a-0adbef44e3aa.png)

into this

![Screenshot from 2022-09-21 12-32-43](https://user-images.githubusercontent.com/514785/191482866-3bf3723d-5465-43f2-bc7a-4fa1c9aab81b.png)
