### PR TITLE
Remove watchlist from initializer

### DIFF
--- a/src/api/config/initializers/flipper.rb
+++ b/src/api/config/initializers/flipper.rb
@@ -1,5 +1,4 @@
 ENABLED_FEATURE_TOGGLES = [
-  { name: :new_watchlist, description: 'New implementation of watchlist including projects, packages and requests' },
   { name: :request_show_redesign, description: 'Redesign of the request pages to improve the collaboration workflow' }
 ].freeze
 


### PR DESCRIPTION
That makes the feature not to be listed on the beta features configuration page.