### PR TITLE
Remove trigger_workflow flipper condition from manage tokens link

### DIFF
--- a/src/api/app/views/webui/user/_index_actions.html.haml
+++ b/src/api/app/views/webui/user/_index_actions.html.haml
@@ -2,6 +2,5 @@
   - if configuration.passwords_changable?(user)
     = render partial: 'webui/user/index_actions/change_password'
   = render partial: 'webui/user/index_actions/change_notifications'
-  - if feature_enabled?('trigger_workflow')
-    = render partial: 'webui/user/index_actions/manage_tokens'
+  = render partial: 'webui/user/index_actions/manage_tokens'
   = render partial: 'webui/user/index_actions/manage_beta_features'


### PR DESCRIPTION
After the rollout of the beta feature the link is not shown anymore on the user page.