### PR TITLE
Document package showlinked command with OpenAPI

### DIFF
--- a/src/api/public/apidocs-new/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs-new/OBS-v2.10.50.yaml
@@ -44,6 +44,7 @@ tags:
 
   - name: Sources
   - name: Sources - Projects
+  - name: Sources - Packages
   - name: Trigger
   - name: Workers
 
@@ -289,6 +290,11 @@ paths:
     $ref: 'paths/source_project_name_cmd_undelete.yaml'
   /source/{project_name}?cmd=unlock:
     $ref: 'paths/source_project_name_cmd_unlock.yaml'
+
+  # Sources - Packages
+
+  /source/{project_name}/{package_name}?cmd=showlinked:
+    $ref: 'paths/source_project_name_package_name_cmd_showlinked.yaml'
 
   /trigger/{operation}:
     $ref: 'paths/trigger_operation.yaml'

--- a/src/api/public/apidocs-new/components/responses/unknown_project_or_package.yaml
+++ b/src/api/public/apidocs-new/components/responses/unknown_project_or_package.yaml
@@ -1,0 +1,17 @@
+description: |
+  Not Found.
+
+  XML Schema used for body validation: [status.xsd](../schema/status.xsd)
+content:
+  application/xml; charset=utf-8:
+    schema:
+      $ref: '../schemas/api_response.yaml'
+    examples:
+      Unknown Project:
+        value:
+          code: unknown_project
+          summary: "Project not found: home:some_project"
+      Unknown Package:
+        value:
+          code: unknown_package
+          summary: "Package not found: home:some_project/some_package"

--- a/src/api/public/apidocs-new/paths/source_project_name_package_name_cmd_showlinked.yaml
+++ b/src/api/public/apidocs-new/paths/source_project_name_package_name_cmd_showlinked.yaml
@@ -1,0 +1,48 @@
+post:
+  summary: List all packages linking to this one.
+  description: List all packages linking to this one. Despite using the method `POST`, this endpoint doesn't alter any data.
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/project_name.yaml'
+    - $ref: '../components/parameters/package_name.yaml'
+  responses:
+    '200':
+      description: OK
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            type: array
+            items:
+              type: object
+              properties:
+                name:
+                  type: string
+                  xml:
+                    attribute: true
+                project:
+                  type: string
+                  xml:
+                    attribute: true
+              xml:
+                name: package
+            xml:
+              name: collection
+              wrapped : true
+          examples:
+            No results:
+              value: |
+                <?xml version="1.0" encoding="UTF-8"?>
+                <collection/>
+            Two linked packages:
+              value:
+                - name: hello_world
+                  project: home:Admin:branches:home:Admin
+                - name: hello_world2
+                  project: home:Admin:branches:home:Admin
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '404':
+      $ref: '../components/responses/unknown_project_or_package.yaml'
+  tags:
+    - Sources - Packages


### PR DESCRIPTION
For reviewers, access directly to the documented endpoint in the review app through this [link](https://obs-reviewlab.opensuse.org/eduardoj-apidocs_newpackage_cmd_showlinked/apidocs-new/index#/Sources%20-%20Packages/post_source__project_name___package_name__cmd_showlinked).