### PR TITLE
Include `cacheonly` and `nodiff` parameters in package diff

### DIFF
--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -940,7 +940,7 @@ class SourceController < ApplicationController
     path = request.path_info
     path += build_query_from_hash(params, [:cmd, :rev, :orev, :oproject, :opackage, :expand, :linkrev, :olinkrev,
                                            :unified, :missingok, :meta, :file, :filelimit, :tarlimit,
-                                           :view, :withissues, :onlyissues, :cacheonly])
+                                           :view, :withissues, :onlyissues, :cacheonly, :nodiff])
     pass_to_backend(path)
   end
 

--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -940,7 +940,7 @@ class SourceController < ApplicationController
     path = request.path_info
     path += build_query_from_hash(params, [:cmd, :rev, :orev, :oproject, :opackage, :expand, :linkrev, :olinkrev,
                                            :unified, :missingok, :meta, :file, :filelimit, :tarlimit,
-                                           :view, :withissues, :onlyissues])
+                                           :view, :withissues, :onlyissues, :cacheonly])
     pass_to_backend(path)
   end
 


### PR DESCRIPTION
Calling the API endpoint `/source/:project_name/:package_name?cmd=diff` with `cacheonly` and/or `nodiff` parameters didn't make a difference when retrieving the results from the backend. Both parameters should have been included in the list of parameters accepted by the endpoint above mentioned as they were introduced. Please have a look at the descriptions of the commits for details.