### PR TITLE
Move Package.download_url_for_binary back to PackageController

### DIFF
--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -1375,17 +1375,6 @@ class Package < ApplicationRecord
     { project: project.name, package: name }
   end
 
-  def download_url_for_binary(repository_name:, architecture_name:, filename:, package_name: nil)
-    package_name ||= name
-
-    if enabled_for?('publish', repository_name, architecture_name)
-      published_url = Backend::Api::BuildResults::Binaries.download_url_for_file(project.name, repository_name, package_name, architecture_name, filename)
-      return published_url if published_url
-    end
-
-    return "/build/#{project}/#{repository_name}/#{architecture_name}/#{package_name}/#{filename}" if User.session
-  end
-
   private
 
   def extract_kiwi_element(element)

--- a/src/api/app/views/webui/package/binaries.html.haml
+++ b/src/api/app/views/webui/package/binaries.html.haml
@@ -1,4 +1,4 @@
-- @pagetitle = "State of #{@repository} for #{@project} / #{@package_name}"
+- @pagetitle = "State of #{@repository} for #{@project} / #{params[:package]}"
 
 .card
   = render partial: 'tabs', locals: { package: @package, project: @project }
@@ -41,7 +41,7 @@
                 %td.px-2 #{binary[:filename]} (#{number_to_human_size(binary[:size])})
                 %td.text-nowrap.text-right.px-2
                   - render_partial = render partial: 'webui/package/binaries/binaries_actions', locals: { project: @project,
-                                                                                                                 package_name: @package_name,
+                                                                                                                 package_name: params[:package],
                                                                                                                  package: @package,
                                                                                                                  binary: binary,
                                                                                                                  repository: @repository,
@@ -53,7 +53,7 @@
       %ul.list-inline
         - if User.possibly_nobody.can_modify?(@package)
           = render partial: 'webui/package/binaries/trigger_rebuild_wipe_binaries', locals: { result: result, project: @project,
-                                                            package: @package_name, repository: @repository }
+                                                            package: params[:package], repository: @repository }
 
         = render partial: 'webui/package/binaries/show_statistics_job_history_build_reason', locals: { result: result,
-          project: @project, package: @package_name, repository: @repository }
+          project: @project, package: params[:package], repository: @repository }

--- a/src/api/spec/features/webui/packages_spec.rb
+++ b/src/api/spec/features/webui/packages_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe 'Packages', type: :feature, js: true, vcr: true do
 
     it 'via binaries view' do
       allow(Buildresult).to receive(:find_hashed)
-        .with(project: user.home_project, package: package.name, repository: repository.name, view: ['binarylist', 'status'])
+        .with(project: user.home_project.name, package: package.name, repository: repository.name, view: ['binarylist', 'status'])
         .and_return(Xmlhash.parse(fake_buildresult))
 
       visit package_binaries_path(project: user.home_project, package: package, repository: repository.name)


### PR DESCRIPTION
We need to account for packages that come through project links. The only reasonable place you can know about this is the controller. An instantiated `Package` doesn't know which `Project` it was instantiated with in `Package.get_by_project_and_name`...

Fixes #13147