### PR TITLE
Fix alignment of added/removed lines in CodeRay

### DIFF
--- a/src/api/app/assets/stylesheets/webui/coderay.scss
+++ b/src/api/app/assets/stylesheets/webui/coderay.scss
@@ -26,7 +26,6 @@ span.CodeRay { white-space: pre }
 }
 
 .CodeRay .line, .CodeRay .code { width: 100% }
-.CodeRay .line { padding-left: 0.25rem }
 
 .CodeRay .debug { color: $card-bg; background: $blue }
 


### PR DESCRIPTION
The line class is only applied to highlighted lines, not all of them, so the padding was only applied to those instead of the whole document. This broke the alignment, making diffs harder to read.

Before:

![Screenshot_20220930_141633](https://user-images.githubusercontent.com/1622084/193267619-be14a959-0455-4500-a6b2-107e6bfa274e.png)

After:

![Screenshot_20220930_141721](https://user-images.githubusercontent.com/1622084/193267740-758a4668-dc92-4bac-aff3-90a53b969615.png)