### PR TITLE
Add the build results badge for the package

### DIFF
--- a/src/api/app/assets/images/badge-failed.svg
+++ b/src/api/app/assets/images/badge-failed.svg
@@ -1,0 +1,30 @@
+<svg aria-label="build service: failed" height="20" role="img" version="1.1" viewBox="0 0 139 20" width="139" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<title>build service: failed</title>
+<linearGradient id="s" x2="0" y2="100%">
+<stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+<stop offset="1" stop-opacity=".1"/>
+</linearGradient>
+<clipPath id="r">
+<rect fill="#fff" height="20" rx="3" width="139"/>
+</clipPath>
+<g clip-path="url(#r)">
+<rect fill="#555" height="20" width="98" x="0"/>
+<rect fill="#e05d44" height="20" width="41" x="98"/>
+<rect fill="url(#s)" height="20" width="139"/>
+</g>
+<g font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-anchor="middle" text-rendering="geometricPrecision">
+<image height="14" width="14" x="6" xlink:href="data:image/svg+xml;base64,PHN2ZyBlbmFibGUtYmFja2dyb3VuZD0ibmV3IDAgMCAxMDI0IDc2OCIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgMzU0LjA2IDMxMi4zOSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KIDxwb2x5Z29uIHRyYW5zZm9ybT0ibWF0cml4KDIuMDAwMSAwIDAgMi4wMDAxIC00NDguMTQgLTU1MC42MykiIHBvaW50cz0iMzYwIDI4Ni43MyAzNjAgMzUxLjQ5IDM5OC4zIDM3MS43MSA0MDEuMDggNDEyLjQ1IDM1MiA0MzEuNSAzNTIgMzUxLjUgMzUyIDM0Ny42OSAzNTIgMjc1LjMiIGZpbGw9IiNkMWQxZDEiLz4KIDxnIHRyYW5zZm9ybT0ibWF0cml4KDIuMDAwMSAwIDAgMi4wMDAxIC00NDguMTQgLTU1MC42MykiPgogIDxwb2x5Z29uIHBvaW50cz0iMzIxIDI5OC43MyAzMTQgMjg2LjkxIDMxNCAzNTUuMjkgMzIxIDM1My44OSIgZmlsbD0iI2QxZDFkMSIvPgogIDxwb2x5Z29uIHBvaW50cz0iMjgzLjAyIDMwOS42NCAyNzYuMDIgMjk4LjIyIDI3NiAzNjIuODkgMjgzLjAyIDM2MS40OSIgZmlsbD0iI2QxZDFkMSIvPgogIDxwb2x5Z29uIHBvaW50cz0iMzI2IDM1Mi44OSAzMTcgMzU0LjY5IDMxNCAzNTUuMjkgMzE0IDI4Ni43MyAyOTUgMjk4LjE2IDI5NSAzNTkuMDkgMjg3IDM2MC42OSAyNzggMzYyLjQ5IDI3NiAzNjIuODkgMjc2IDI5OC4xNiAyNTcgMzA5LjU5IDI1NyAzNjYuNjkgMjMxLjc0IDM3MS43MSAyMjQuMDYgNDEyLjQ1IDI3OCA0MjAuNDggMzM0Ljk0IDQyOC45NiAzNTIgNDMxLjUgMzUyIDM3NS4xMiAzNTIgMzUxLjUgMzUyIDM0Ny42OSAzNTIgMjc1LjMgMzMzIDI4Ni43MyAzMzMgMzUxLjQ5IiBmaWxsPSIjY2VjZWNlIi8+CiA8L2c+CiA8cG9seWdvbiB0cmFuc2Zvcm09Im1hdHJpeCgyLjAwMDEgMCAwIDIuMDAwMSAtNDQ4LjE0IC01NTAuNjMpIiBwb2ludHM9IjI1NyAzMDkuNTkgMjU3IDM2Ni42OSAyMzEuNzQgMzcxLjcxIDIyNC4wNiA0MTIuNDUgMzUyIDQzMS41IDM1MiAzNTEuNSAzNTIgMzQ3LjY5IDM1MiAyNzUuMyAzMzMgMjg2LjczIDMzMyAzNTEuNDkgMzE0IDM1NS4yOSAzMTQgMjg2LjczIDI5NSAyOTguMTYgMjk1IDM1OS4wOSAyNzYgMzYyLjg5IDI3NiAyOTguMTYiIGZpbGw9IiNmZmYiLz4KIDx0ZXh0IHg9IjU1Mi4xNjkxMyIgeT0iNjMuNjgxNDc3IiBmaWxsPSIjMDAwMDAwIiBmb250LWZhbWlseT0ic2Fucy1zZXJpZiIgZm9udC1zaXplPSI0MHB4IiBsZXR0ZXItc3BhY2luZz0iMHB4IiBzdHJva2Utd2lkdGg9IjFweCIgd29yZC1zcGFjaW5nPSIwcHgiIHN0eWxlPSJsaW5lLWhlaWdodDoxMjUlIiB4bWw6c3BhY2U9InByZXNlcnZlIj48dHNwYW4geD0iNTUyLjE2OTEzIiB5PSIxMDAuNDYyMjkiLz48dHNwYW4geD0iNTUyLjE2OTEzIiB5PSIxNTAuNDYyMjMiLz48L3RleHQ+Cjwvc3ZnPgo=" xmlns:xlink="http://www.w3.org/1999/xlink" y="3"/>
+<text aria-hidden="true" fill="#010101" fill-opacity=".3" font-size="11" textLength="70" x="59.0" y="15">
+build service
+</text>
+<text fill="#fff" font-size="11" textLength="70" x="59.0" y="14">
+build service
+</text>
+<text aria-hidden="true" fill="#010101" fill-opacity=".3" font-size="11" textLength="31" x="117.5" y="15">
+failed
+</text>
+<text fill="#fff" font-size="11" textLength="31" x="117.5" y="14">
+failed
+</text>
+</g>
+</svg>

--- a/src/api/app/assets/images/badge-percent.svg
+++ b/src/api/app/assets/images/badge-percent.svg
@@ -1,0 +1,30 @@
+<svg aria-label="build service: %PERCENTAGE%" height="20" role="img" version="1.1" viewBox="0 0 140 20" width="140" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<title>build service: %PERCENTAGE%</title>
+<linearGradient id="s" x2="0" y2="100%">
+<stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+<stop offset="1" stop-opacity=".1"/>
+</linearGradient>
+<clipPath id="r">
+<rect fill="#fff" height="20" rx="3" width="140"/>
+</clipPath>
+<g clip-path="url(#r)">
+<rect fill="#555" height="20" width="98" x="0"/>
+<rect fill="#e05d44" height="20" width="42" x="98"/>
+<rect fill="url(#s)" height="20" width="140"/>
+</g>
+<g font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-anchor="middle" text-rendering="geometricPrecision">
+<image height="14" width="14" x="6" xlink:href="data:image/svg+xml;base64,PHN2ZyBlbmFibGUtYmFja2dyb3VuZD0ibmV3IDAgMCAxMDI0IDc2OCIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgMzU0LjA2IDMxMi4zOSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KIDxwb2x5Z29uIHRyYW5zZm9ybT0ibWF0cml4KDIuMDAwMSAwIDAgMi4wMDAxIC00NDguMTQgLTU1MC42MykiIHBvaW50cz0iMzYwIDI4Ni43MyAzNjAgMzUxLjQ5IDM5OC4zIDM3MS43MSA0MDEuMDggNDEyLjQ1IDM1MiA0MzEuNSAzNTIgMzUxLjUgMzUyIDM0Ny42OSAzNTIgMjc1LjMiIGZpbGw9IiNkMWQxZDEiLz4KIDxnIHRyYW5zZm9ybT0ibWF0cml4KDIuMDAwMSAwIDAgMi4wMDAxIC00NDguMTQgLTU1MC42MykiPgogIDxwb2x5Z29uIHBvaW50cz0iMzIxIDI5OC43MyAzMTQgMjg2LjkxIDMxNCAzNTUuMjkgMzIxIDM1My44OSIgZmlsbD0iI2QxZDFkMSIvPgogIDxwb2x5Z29uIHBvaW50cz0iMjgzLjAyIDMwOS42NCAyNzYuMDIgMjk4LjIyIDI3NiAzNjIuODkgMjgzLjAyIDM2MS40OSIgZmlsbD0iI2QxZDFkMSIvPgogIDxwb2x5Z29uIHBvaW50cz0iMzI2IDM1Mi44OSAzMTcgMzU0LjY5IDMxNCAzNTUuMjkgMzE0IDI4Ni43MyAyOTUgMjk4LjE2IDI5NSAzNTkuMDkgMjg3IDM2MC42OSAyNzggMzYyLjQ5IDI3NiAzNjIuODkgMjc2IDI5OC4xNiAyNTcgMzA5LjU5IDI1NyAzNjYuNjkgMjMxLjc0IDM3MS43MSAyMjQuMDYgNDEyLjQ1IDI3OCA0MjAuNDggMzM0Ljk0IDQyOC45NiAzNTIgNDMxLjUgMzUyIDM3NS4xMiAzNTIgMzUxLjUgMzUyIDM0Ny42OSAzNTIgMjc1LjMgMzMzIDI4Ni43MyAzMzMgMzUxLjQ5IiBmaWxsPSIjY2VjZWNlIi8+CiA8L2c+CiA8cG9seWdvbiB0cmFuc2Zvcm09Im1hdHJpeCgyLjAwMDEgMCAwIDIuMDAwMSAtNDQ4LjE0IC01NTAuNjMpIiBwb2ludHM9IjI1NyAzMDkuNTkgMjU3IDM2Ni42OSAyMzEuNzQgMzcxLjcxIDIyNC4wNiA0MTIuNDUgMzUyIDQzMS41IDM1MiAzNTEuNSAzNTIgMzQ3LjY5IDM1MiAyNzUuMyAzMzMgMjg2LjczIDMzMyAzNTEuNDkgMzE0IDM1NS4yOSAzMTQgMjg2LjczIDI5NSAyOTguMTYgMjk1IDM1OS4wOSAyNzYgMzYyLjg5IDI3NiAyOTguMTYiIGZpbGw9IiNmZmYiLz4KIDx0ZXh0IHg9IjU1Mi4xNjkxMyIgeT0iNjMuNjgxNDc3IiBmaWxsPSIjMDAwMDAwIiBmb250LWZhbWlseT0ic2Fucy1zZXJpZiIgZm9udC1zaXplPSI0MHB4IiBsZXR0ZXItc3BhY2luZz0iMHB4IiBzdHJva2Utd2lkdGg9IjFweCIgd29yZC1zcGFjaW5nPSIwcHgiIHN0eWxlPSJsaW5lLWhlaWdodDoxMjUlIiB4bWw6c3BhY2U9InByZXNlcnZlIj48dHNwYW4geD0iNTUyLjE2OTEzIiB5PSIxMDAuNDYyMjkiLz48dHNwYW4geD0iNTUyLjE2OTEzIiB5PSIxNTAuNDYyMjMiLz48L3RleHQ+Cjwvc3ZnPgo=" xmlns:xlink="http://www.w3.org/1999/xlink" y="3"/>
+<text aria-hidden="true" fill="#010101" fill-opacity=".3" font-size="11" textLength="70" x="59.0" y="15">
+build service
+</text>
+<text fill="#fff" font-size="11" textLength="70" x="59.0" y="14">
+build service
+</text>
+<text aria-hidden="true" fill="#010101" fill-opacity=".3" font-size="11" x="118.0" y="15">
+%PERCENTAGE%
+</text>
+<text fill="#fff" font-size="11" x="118.0" y="14">
+%PERCENTAGE%
+</text>
+</g>
+</svg>

--- a/src/api/app/assets/images/badge-succeeded.svg
+++ b/src/api/app/assets/images/badge-succeeded.svg
@@ -1,0 +1,30 @@
+<svg aria-label="build service: succeeded" height="20" role="img" version="1.1" viewBox="0 0 168 20" width="168" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<title>build service: succeeded</title>
+<linearGradient id="s" x2="0" y2="100%">
+<stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+<stop offset="1" stop-opacity=".1"/>
+</linearGradient>
+<clipPath id="r">
+<rect fill="#fff" height="20" rx="3" width="168"/>
+</clipPath>
+<g clip-path="url(#r)">
+<rect fill="#555" height="20" width="98" x="0"/>
+<rect fill="#4c1" height="20" width="70" x="98"/>
+<rect fill="url(#s)" height="20" width="168"/>
+</g>
+<g font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-anchor="middle" text-rendering="geometricPrecision">
+<image height="14" width="14" x="6" xlink:href="data:image/svg+xml;base64,PHN2ZyBlbmFibGUtYmFja2dyb3VuZD0ibmV3IDAgMCAxMDI0IDc2OCIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgMzU0LjA2IDMxMi4zOSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KIDxwb2x5Z29uIHRyYW5zZm9ybT0ibWF0cml4KDIuMDAwMSAwIDAgMi4wMDAxIC00NDguMTQgLTU1MC42MykiIHBvaW50cz0iMzYwIDI4Ni43MyAzNjAgMzUxLjQ5IDM5OC4zIDM3MS43MSA0MDEuMDggNDEyLjQ1IDM1MiA0MzEuNSAzNTIgMzUxLjUgMzUyIDM0Ny42OSAzNTIgMjc1LjMiIGZpbGw9IiNkMWQxZDEiLz4KIDxnIHRyYW5zZm9ybT0ibWF0cml4KDIuMDAwMSAwIDAgMi4wMDAxIC00NDguMTQgLTU1MC42MykiPgogIDxwb2x5Z29uIHBvaW50cz0iMzIxIDI5OC43MyAzMTQgMjg2LjkxIDMxNCAzNTUuMjkgMzIxIDM1My44OSIgZmlsbD0iI2QxZDFkMSIvPgogIDxwb2x5Z29uIHBvaW50cz0iMjgzLjAyIDMwOS42NCAyNzYuMDIgMjk4LjIyIDI3NiAzNjIuODkgMjgzLjAyIDM2MS40OSIgZmlsbD0iI2QxZDFkMSIvPgogIDxwb2x5Z29uIHBvaW50cz0iMzI2IDM1Mi44OSAzMTcgMzU0LjY5IDMxNCAzNTUuMjkgMzE0IDI4Ni43MyAyOTUgMjk4LjE2IDI5NSAzNTkuMDkgMjg3IDM2MC42OSAyNzggMzYyLjQ5IDI3NiAzNjIuODkgMjc2IDI5OC4xNiAyNTcgMzA5LjU5IDI1NyAzNjYuNjkgMjMxLjc0IDM3MS43MSAyMjQuMDYgNDEyLjQ1IDI3OCA0MjAuNDggMzM0Ljk0IDQyOC45NiAzNTIgNDMxLjUgMzUyIDM3NS4xMiAzNTIgMzUxLjUgMzUyIDM0Ny42OSAzNTIgMjc1LjMgMzMzIDI4Ni43MyAzMzMgMzUxLjQ5IiBmaWxsPSIjY2VjZWNlIi8+CiA8L2c+CiA8cG9seWdvbiB0cmFuc2Zvcm09Im1hdHJpeCgyLjAwMDEgMCAwIDIuMDAwMSAtNDQ4LjE0IC01NTAuNjMpIiBwb2ludHM9IjI1NyAzMDkuNTkgMjU3IDM2Ni42OSAyMzEuNzQgMzcxLjcxIDIyNC4wNiA0MTIuNDUgMzUyIDQzMS41IDM1MiAzNTEuNSAzNTIgMzQ3LjY5IDM1MiAyNzUuMyAzMzMgMjg2LjczIDMzMyAzNTEuNDkgMzE0IDM1NS4yOSAzMTQgMjg2LjczIDI5NSAyOTguMTYgMjk1IDM1OS4wOSAyNzYgMzYyLjg5IDI3NiAyOTguMTYiIGZpbGw9IiNmZmYiLz4KIDx0ZXh0IHg9IjU1Mi4xNjkxMyIgeT0iNjMuNjgxNDc3IiBmaWxsPSIjMDAwMDAwIiBmb250LWZhbWlseT0ic2Fucy1zZXJpZiIgZm9udC1zaXplPSI0MHB4IiBsZXR0ZXItc3BhY2luZz0iMHB4IiBzdHJva2Utd2lkdGg9IjFweCIgd29yZC1zcGFjaW5nPSIwcHgiIHN0eWxlPSJsaW5lLWhlaWdodDoxMjUlIiB4bWw6c3BhY2U9InByZXNlcnZlIj48dHNwYW4geD0iNTUyLjE2OTEzIiB5PSIxMDAuNDYyMjkiLz48dHNwYW4geD0iNTUyLjE2OTEzIiB5PSIxNTAuNDYyMjMiLz48L3RleHQ+Cjwvc3ZnPgo=" xmlns:xlink="http://www.w3.org/1999/xlink" y="3"/>
+<text aria-hidden="true" fill="#010101" fill-opacity=".3" font-size="11" textLength="70" x="59.0" y="15">
+build service
+</text>
+<text fill="#fff" font-size="11" textLength="70" x="59.0" y="14">
+build service
+</text>
+<text aria-hidden="true" fill="#010101" fill-opacity=".3" font-size="11" textLength="60" x="132.0" y="15">
+succeeded
+</text>
+<text fill="#fff" font-size="11" textLength="60" x="132.0" y="14">
+succeeded
+</text>
+</g>
+</svg>

--- a/src/api/app/assets/images/badge-unknown.svg
+++ b/src/api/app/assets/images/badge-unknown.svg
@@ -1,0 +1,30 @@
+<svg aria-label="build service: unknown" height="20" role="img" version="1.1" viewBox="0 0 158 20" width="158" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<title>build service: unknown</title>
+<linearGradient id="s" x2="0" y2="100%">
+<stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+<stop offset="1" stop-opacity=".1"/>
+</linearGradient>
+<clipPath id="r">
+<rect fill="#fff" height="20" rx="3" width="158"/>
+</clipPath>
+<g clip-path="url(#r)">
+<rect fill="#555" height="20" width="98" x="0"/>
+<rect fill="#007ec6" height="20" width="60" x="98"/>
+<rect fill="url(#s)" height="20" width="158"/>
+</g>
+<g font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-anchor="middle" text-rendering="geometricPrecision">
+<image height="14" width="14" x="6" xlink:href="data:image/svg+xml;base64,PHN2ZyBlbmFibGUtYmFja2dyb3VuZD0ibmV3IDAgMCAxMDI0IDc2OCIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgMzU0LjA2IDMxMi4zOSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KIDxwb2x5Z29uIHRyYW5zZm9ybT0ibWF0cml4KDIuMDAwMSAwIDAgMi4wMDAxIC00NDguMTQgLTU1MC42MykiIHBvaW50cz0iMzYwIDI4Ni43MyAzNjAgMzUxLjQ5IDM5OC4zIDM3MS43MSA0MDEuMDggNDEyLjQ1IDM1MiA0MzEuNSAzNTIgMzUxLjUgMzUyIDM0Ny42OSAzNTIgMjc1LjMiIGZpbGw9IiNkMWQxZDEiLz4KIDxnIHRyYW5zZm9ybT0ibWF0cml4KDIuMDAwMSAwIDAgMi4wMDAxIC00NDguMTQgLTU1MC42MykiPgogIDxwb2x5Z29uIHBvaW50cz0iMzIxIDI5OC43MyAzMTQgMjg2LjkxIDMxNCAzNTUuMjkgMzIxIDM1My44OSIgZmlsbD0iI2QxZDFkMSIvPgogIDxwb2x5Z29uIHBvaW50cz0iMjgzLjAyIDMwOS42NCAyNzYuMDIgMjk4LjIyIDI3NiAzNjIuODkgMjgzLjAyIDM2MS40OSIgZmlsbD0iI2QxZDFkMSIvPgogIDxwb2x5Z29uIHBvaW50cz0iMzI2IDM1Mi44OSAzMTcgMzU0LjY5IDMxNCAzNTUuMjkgMzE0IDI4Ni43MyAyOTUgMjk4LjE2IDI5NSAzNTkuMDkgMjg3IDM2MC42OSAyNzggMzYyLjQ5IDI3NiAzNjIuODkgMjc2IDI5OC4xNiAyNTcgMzA5LjU5IDI1NyAzNjYuNjkgMjMxLjc0IDM3MS43MSAyMjQuMDYgNDEyLjQ1IDI3OCA0MjAuNDggMzM0Ljk0IDQyOC45NiAzNTIgNDMxLjUgMzUyIDM3NS4xMiAzNTIgMzUxLjUgMzUyIDM0Ny42OSAzNTIgMjc1LjMgMzMzIDI4Ni43MyAzMzMgMzUxLjQ5IiBmaWxsPSIjY2VjZWNlIi8+CiA8L2c+CiA8cG9seWdvbiB0cmFuc2Zvcm09Im1hdHJpeCgyLjAwMDEgMCAwIDIuMDAwMSAtNDQ4LjE0IC01NTAuNjMpIiBwb2ludHM9IjI1NyAzMDkuNTkgMjU3IDM2Ni42OSAyMzEuNzQgMzcxLjcxIDIyNC4wNiA0MTIuNDUgMzUyIDQzMS41IDM1MiAzNTEuNSAzNTIgMzQ3LjY5IDM1MiAyNzUuMyAzMzMgMjg2LjczIDMzMyAzNTEuNDkgMzE0IDM1NS4yOSAzMTQgMjg2LjczIDI5NSAyOTguMTYgMjk1IDM1OS4wOSAyNzYgMzYyLjg5IDI3NiAyOTguMTYiIGZpbGw9IiNmZmYiLz4KIDx0ZXh0IHg9IjU1Mi4xNjkxMyIgeT0iNjMuNjgxNDc3IiBmaWxsPSIjMDAwMDAwIiBmb250LWZhbWlseT0ic2Fucy1zZXJpZiIgZm9udC1zaXplPSI0MHB4IiBsZXR0ZXItc3BhY2luZz0iMHB4IiBzdHJva2Utd2lkdGg9IjFweCIgd29yZC1zcGFjaW5nPSIwcHgiIHN0eWxlPSJsaW5lLWhlaWdodDoxMjUlIiB4bWw6c3BhY2U9InByZXNlcnZlIj48dHNwYW4geD0iNTUyLjE2OTEzIiB5PSIxMDAuNDYyMjkiLz48dHNwYW4geD0iNTUyLjE2OTEzIiB5PSIxNTAuNDYyMjMiLz48L3RleHQ+Cjwvc3ZnPgo=" xmlns:xlink="http://www.w3.org/1999/xlink" y="3"/>
+<text aria-hidden="true" fill="#010101" fill-opacity=".3" font-size="11" textLength="70" x="59.0" y="15">
+build service
+</text>
+<text fill="#fff" font-size="11" textLength="70" x="59.0" y="14">
+build service
+</text>
+<text aria-hidden="true" fill="#010101" fill-opacity=".3" font-size="11" textLength="50" x="127.0" y="15">
+unknown
+</text>
+<text fill="#fff" font-size="11" textLength="50" x="127.0" y="14">
+unknown
+</text>
+</g>
+</svg>

--- a/src/api/app/controllers/webui/packages/badge_controller.rb
+++ b/src/api/app/controllers/webui/packages/badge_controller.rb
@@ -1,0 +1,36 @@
+module Webui
+  module Packages
+    class BadgeController < Packages::MainController
+      before_action :set_project
+      before_action :set_package
+
+      def show
+        results = @package.buildresult(@project, false, true).results[@package.name]
+        results = results.select { |r| r.architecture == params[:architecture] } if params[:architecture]
+        results = results.select { |r| r.repository == params[:repository] } if params[:repository]
+        send_data(create_badge(results), type: 'image/svg+xml', disposition: 'inline')
+      end
+
+      private
+
+      def create_badge(results)
+        filename = 'badge-unknown.svg'
+        return Rails.application.assets[filename].source if results.blank?
+
+        filename = 'badge-failed.svg' if results.any? { |r| r.code == 'failed' }
+        filename = 'badge-succeeded.svg' if results.all? { |r| r.code == 'succeeded' }
+        filename = 'badge-percent.svg' if params[:type] == 'percent'
+        get_badge_file(filename, results)
+      end
+
+      def get_badge_file(filename, results)
+        file = Rails.application.assets[filename].source
+        return file unless params[:type] == 'percent'
+
+        succeeded = results.select { |r| r.code == 'succeeded' }.try(:length).to_i
+        file.gsub!('#e05d44', '#4c1') if succeeded == results.length
+        file.gsub('%PERCENTAGE%', "#{100 * succeeded / results.length}%")
+      end
+    end
+  end
+end

--- a/src/api/app/models/local_build_result/for_package.rb
+++ b/src/api/app/models/local_build_result/for_package.rb
@@ -1,7 +1,7 @@
 class LocalBuildResult
   class ForPackage
     include ActiveModel::Model
-    attr_accessor :package, :project, :show_all
+    attr_accessor :package, :project, :show_all, :lastbuild
     attr_reader :excluded_counter, :results
 
     def initialize(attributes = {})
@@ -56,7 +56,7 @@ class LocalBuildResult
     end
 
     def backend_build_result
-      backend_results = Buildresult.find_hashed(project: project, package: package, view: 'status', multibuild: '1', locallink: '1')
+      backend_results = Buildresult.find_hashed(project: project, package: package, view: 'status', multibuild: '1', locallink: '1', lastbuild: lastbuild ? '1' : '0')
       backend_results.elements('result').sort_by { |a| a['repository'] }
     end
   end

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -848,8 +848,8 @@ class Package < ApplicationRecord
     Service.new(package: self)
   end
 
-  def buildresult(prj = project, show_all = false)
-    LocalBuildResult::ForPackage.new(package: self, project: prj, show_all: show_all)
+  def buildresult(prj = project, show_all = false, lastbuild = false)
+    LocalBuildResult::ForPackage.new(package: self, project: prj, show_all: show_all, lastbuild: lastbuild)
   end
 
   # FIXME: That you can overwrite package_name is rather confusing, but needed because of multibuild :-/

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -271,6 +271,7 @@ OBSApi::Application.routes.draw do
         resources :submissions, controller: 'webui/requests/submissions', only: [:new, :create], constraints: cons
         resource :files, controller: 'webui/packages/files', only: [:new, :create], constraints: cons
         put 'toggle_watched_item', controller: 'webui/watched_items', constraints: cons
+        resource :badge, controller: 'webui/packages/badge', only: [:show], constraints: ->(request) { request.format == :svg }
       end
 
       resources :role_additions, controller: 'webui/requests/role_additions', only: [:new, :create], constraints: cons

--- a/src/api/spec/cassettes/Badge/with_failing_and_succeeding_build_results/displays_the_correct_failed_state.yml
+++ b/src/api/spec/cassettes/Badge/with_failing_and_succeeding_build_results/displays_the_correct_failed_state.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom/my_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - b98ce21d-14e6-4344-87b7-35b01b579fdd
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home tom' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '144'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:tom' does not exist</summary>
+          <details>404 project 'home:tom' does not exist</details>
+        </status>
+  recorded_at: Thu, 20 Oct 2022 08:59:20 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Badge/with_failing_and_succeeding_build_results/displays_the_correct_percentage.yml
+++ b/src/api/spec/cassettes/Badge/with_failing_and_succeeding_build_results/displays_the_correct_percentage.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom/my_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 923dd511-96ae-4727-96d3-719c66dff9c8
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home tom' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '144'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:tom' does not exist</summary>
+          <details>404 project 'home:tom' does not exist</details>
+        </status>
+  recorded_at: Thu, 20 Oct 2022 08:59:19 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Badge/with_succeeding_build_results/displays_the_correct_percentage.yml
+++ b/src/api/spec/cassettes/Badge/with_succeeding_build_results/displays_the_correct_percentage.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom/my_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 11bc9c46-697b-479b-8bde-a38f163d2828
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home tom' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '144'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:tom' does not exist</summary>
+          <details>404 project 'home:tom' does not exist</details>
+        </status>
+  recorded_at: Thu, 20 Oct 2022 08:59:21 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Badge/with_succeeding_build_results/displays_the_suceeded_state.yml
+++ b/src/api/spec/cassettes/Badge/with_succeeding_build_results/displays_the_suceeded_state.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom/my_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 44ee877d-16d6-49f1-8fcd-c6d315637d05
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home tom' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '144'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:tom' does not exist</summary>
+          <details>404 project 'home:tom' does not exist</details>
+        </status>
+  recorded_at: Thu, 20 Oct 2022 08:59:21 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Badge/without_build_results/displays_the_correct_unknown_state.yml
+++ b/src/api/spec/cassettes/Badge/without_build_results/displays_the_correct_unknown_state.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom/my_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - bb177add-2505-4672-9c4f-22a59f029bd2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home tom' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '144'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:tom' does not exist</summary>
+          <details>404 project 'home:tom' does not exist</details>
+        </status>
+  recorded_at: Thu, 20 Oct 2022 08:59:20 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Badge/without_build_results/displays_the_correct_unknown_state_despite_percent_type.yml
+++ b/src/api/spec/cassettes/Badge/without_build_results/displays_the_correct_unknown_state_despite_percent_type.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom/my_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - d702e255-738f-489b-bf09-552955ab8e51
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home tom' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '144'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:tom' does not exist</summary>
+          <details>404 project 'home:tom' does not exist</details>
+        </status>
+  recorded_at: Thu, 20 Oct 2022 08:59:21 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Package/_buildresult/returns_an_object_with_class_LocalBuildResult_ForPackage.yml
+++ b/src/api/spec/cassettes/Package/_buildresult/returns_an_object_with_class_LocalBuildResult_ForPackage.yml
@@ -121,7 +121,7 @@ http_interactions:
   recorded_at: Thu, 06 Sep 2018 10:45:36 GMT
 - request:
     method: get
-    uri: http://backend:5352/build/home:tom/_result?locallink=1&multibuild=1&package=test_package&view=status
+    uri: http://backend:5352/build/home:tom/_result?lastbuild=0&locallink=1&multibuild=1&package=test_package&view=status
     body:
       encoding: US-ASCII
       string: ''

--- a/src/api/spec/cassettes/Packages/log/download_logfile_succesfully.yml
+++ b/src/api/spec/cassettes/Packages/log/download_logfile_succesfully.yml
@@ -566,7 +566,7 @@ http_interactions:
   recorded_at: Fri, 25 Jun 2021 11:31:34 GMT
 - request:
     method: get
-    uri: http://backend:5352/build/home:package_test_user/_result?package=test_package&view=status
+    uri: http://backend:5352/build/home:package_test_user/_result?lastbuild=0&package=test_package&view=status
     body:
       encoding: US-ASCII
       string: ''

--- a/src/api/spec/features/webui/badge_spec.rb
+++ b/src/api/spec/features/webui/badge_spec.rb
@@ -1,0 +1,85 @@
+require 'browser_helper'
+
+RSpec.describe 'Badge', type: :feature do
+  let(:user) { create(:confirmed_user, :with_home, login: 'tom') }
+  let(:source_project) { user.home_project }
+  let(:source_package) { create(:package, name: 'my_package', project: source_project) }
+
+  context 'without build results' do
+    before do
+      path = "#{CONFIG['source_url']}/build/#{user.home_project}/_result?locallink=1&multibuild=1&lastbuild=1" \
+             "&package=#{source_package}&view=status"
+      stub_request(:get, path).and_return(body:
+        %(<resultlist state="eb0459ee3b000176bb3944a67b7c44fa">
+          </resultlist>))
+    end
+
+    it 'displays the correct unknown state despite percent type' do
+      visit project_package_badge_path(source_project.name, source_package.name, format: 'svg', type: 'percent')
+      xml = Capybara.string(page.body)
+      expect(xml).to have_text('unknown')
+    end
+
+    it 'displays the correct unknown state' do
+      visit project_package_badge_path(source_project.name, source_package.name, format: 'svg')
+      xml = Capybara.string(page.body)
+      expect(xml).to have_text('unknown')
+    end
+  end
+
+  context 'with failing and succeeding build results' do
+    before do
+      path = "#{CONFIG['source_url']}/build/#{user.home_project}/_result?locallink=1&multibuild=1&lastbuild=1" \
+             "&package=#{source_package}&view=status"
+      stub_request(:get, path).and_return(body:
+        %(<resultlist state="eb0459ee3b000176bb3944a67b7c44fa">
+            <result project="home:tom" repository="openSUSE_Leap_42.1" arch="x86_64" code="succeeded" state="building">
+              <status package="my_package" code="succeeded" />
+            </result>
+            <result project="home:tom" repository="images" arch="x86_64" code="failed" state="building">
+              <status package="my_package" code="failed" />
+            </result>
+          </resultlist>))
+    end
+
+    it 'displays the correct percentage' do
+      visit project_package_badge_path(source_project.name, source_package.name, format: 'svg', type: 'percent')
+      xml = Capybara.string(page.body)
+      expect(xml).to have_text('50%')
+    end
+
+    it 'displays the correct failed state' do
+      visit project_package_badge_path(source_project.name, source_package.name, format: 'svg')
+      xml = Capybara.string(page.body)
+      expect(xml).to have_text('failed')
+    end
+  end
+
+  context 'with succeeding build results' do
+    before do
+      path = "#{CONFIG['source_url']}/build/#{user.home_project}/_result?locallink=1&multibuild=1&lastbuild=1" \
+             "&package=#{source_package}&view=status"
+      stub_request(:get, path).and_return(body:
+        %(<resultlist state="eb0459ee3b000176bb3944a67b7c44fa">
+            <result project="home:tom" repository="openSUSE_Leap_42.1" arch="x86_64" code="succeeded" state="building">
+              <status package="my_package" code="succeeded" />
+            </result>
+            <result project="home:tom" repository="images" arch="x86_64" code="succeeded" state="building">
+              <status package="my_package" code="succeeded" />
+            </result>
+          </resultlist>))
+    end
+
+    it 'displays the correct percentage' do
+      visit project_package_badge_path(source_project.name, source_package.name, format: 'svg', type: 'percent')
+      xml = Capybara.string(page.body)
+      expect(xml).to have_text('100%')
+    end
+
+    it 'displays the suceeded state' do
+      visit project_package_badge_path(source_project.name, source_package.name, format: 'svg')
+      xml = Capybara.string(page.body)
+      expect(xml).to have_text('succeeded')
+    end
+  end
+end

--- a/src/api/spec/features/webui/packages_spec.rb
+++ b/src/api/spec/features/webui/packages_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe 'Packages', type: :feature, js: true, vcr: true do
                             </resultlist>
                             )
       result_path = "#{CONFIG['source_url']}/build/#{user.home_project}/_result?"
-      stub_request(:get, result_path + 'view=status&package=test_package&multibuild=1&locallink=1')
+      stub_request(:get, result_path + 'view=status&package=test_package&multibuild=1&locallink=1&lastbuild=0')
         .and_return(body: result)
       stub_request(:get, result_path + "arch=i586&package=#{package}&repository=#{repository.name}&view=status")
         .and_return(body: result)


### PR DESCRIPTION
This adds integration badges for packages

To verify this feature visit `/package/badge/:project/:package.svg` (with optional `percent` and `ratio` type `parameters`)

/package/badge/:project/:package.svg
![](https://user-images.githubusercontent.com/30577011/109442643-1214a700-7a39-11eb-8b5f-9576f1452e17.png)
/package/badge/:project/:package.svg?type=percent
![](https://user-images.githubusercontent.com/30577011/109442640-117c1080-7a39-11eb-8e9c-b24dde8d235e.png)
/package/badge/:project/:package.svg?type=ratio
![](https://user-images.githubusercontent.com/30577011/109442642-1214a700-7a39-11eb-9c4c-9f5eec842ded.png)

I changed it so that instead of requiring the package, the font is bundled under `app/assets/fonts`.

Fixes #2908 and supersedes #10820