### PR TITLE
Document package set_flag/remove_flag commands with OpenAPI

### DIFF
--- a/src/api/public/apidocs-new/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs-new/OBS-v2.10.50.yaml
@@ -295,6 +295,8 @@ paths:
 
   /source/{project_name}/{package_name}?cmd=diff:
     $ref: 'paths/source_project_name_package_name_cmd_diff.yaml'
+  /source/{project_name}/{package_name}?cmd=remove_flag:
+    $ref: 'paths/source_project_name_package_name_cmd_remove_flag.yaml'
   /source/{project_name}/{package_name}?cmd=runservice:
     $ref: 'paths/source_project_name_package_name_cmd_runservice.yaml'
   /source/{project_name}/{package_name}?cmd=set_flag:

--- a/src/api/public/apidocs-new/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs-new/OBS-v2.10.50.yaml
@@ -297,6 +297,8 @@ paths:
     $ref: 'paths/source_project_name_package_name_cmd_diff.yaml'
   /source/{project_name}/{package_name}?cmd=runservice:
     $ref: 'paths/source_project_name_package_name_cmd_runservice.yaml'
+  /source/{project_name}/{package_name}?cmd=set_flag:
+    $ref: 'paths/source_project_name_package_name_cmd_set_flag.yaml'
   /source/{project_name}/{package_name}?cmd=showlinked:
     $ref: 'paths/source_project_name_package_name_cmd_showlinked.yaml'
   /source/{project_name}/{package_name}?cmd=waitservice:

--- a/src/api/public/apidocs-new/paths/source_project_name_package_name_cmd_remove_flag.yaml
+++ b/src/api/public/apidocs-new/paths/source_project_name_package_name_cmd_remove_flag.yaml
@@ -1,0 +1,72 @@
+post:
+  summary: Remove a specific flag.
+  description: Remove a specific flag for a package.
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/project_name.yaml'
+    - $ref: '../components/parameters/package_name.yaml'
+    - in: query
+      name: flag
+      required: true
+      schema:
+        type: string
+        enum:
+          - access
+          - binarydownload
+          - build
+          - debuginfo
+          - lock
+          - publish
+          - sourceaccess
+          - useforbuild
+      description: Name of the flag to be removed.
+      example: build
+    - in: query
+      name: repository
+      schema:
+        type: string
+      description: Repository for which the flag is to be removed.
+      example: openSUSE_Tumbleweed
+    - in: query
+      name: arch
+      schema:
+        type: string
+      description: Architecture for which the flag is to be removed.
+      example: x86_64
+  responses:
+    '200':
+      $ref: '../components/responses/succeeded.yaml'
+    '400':
+      description: |
+        Bad Request.
+
+        XML Schema used for body validation: [status.xsd](../schema/status.xsd)
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          examples:
+            Missing Parameter flag:
+              value:
+                code: missing_parameter
+                summary: Required Parameter flag missing
+            Invalid flag:
+              value:
+                code: invalid_flag
+                summary: "Error: unknown flag type 'RANDOM_STRING' not found."
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '403':
+      description: Forbidden
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          example:
+            code: cmd_execution_no_permission
+            summary: no permission to modify package test in project home:Admin
+    '404':
+      $ref: '../components/responses/unknown_project_or_package.yaml'
+  tags:
+    - Sources - Packages

--- a/src/api/public/apidocs-new/paths/source_project_name_package_name_cmd_set_flag.yaml
+++ b/src/api/public/apidocs-new/paths/source_project_name_package_name_cmd_set_flag.yaml
@@ -1,0 +1,90 @@
+post:
+  summary: Enable or disable a specific flag.
+  description:  Enable or disable a specific flag for a package.
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/project_name.yaml'
+    - $ref: '../components/parameters/package_name.yaml'
+    - in: query
+      name: flag
+      required: true
+      schema:
+        type: string
+        enum:
+          - access
+          - binarydownload
+          - build
+          - debuginfo
+          - lock
+          - publish
+          - sourceaccess
+          - useforbuild
+      description: Name of the flag to be set.
+      example: build
+    - in: query
+      name: status
+      required: true
+      schema:
+        type: string
+        enum:
+          - enable
+          - disable
+      description: Status of the flag to be set.
+      example: enable
+    - in: query
+      name: repository
+      schema:
+        type: string
+      description: Repository for which the flag is to be set.
+      example: openSUSE_Tumbleweed
+    - in: query
+      name: arch
+      schema:
+        type: string
+      description: Architecture for which the flag is to be set.
+      example: x86_64
+  responses:
+    '200':
+      $ref: '../components/responses/succeeded.yaml'
+    '400':
+      description: |
+        Bad Request.
+
+        XML Schema used for body validation: [status.xsd](../schema/status.xsd)
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          examples:
+            Missing Parameter flag:
+              value:
+                code: missing_parameter
+                summary: Required Parameter flag missing
+            Missing Parameter status:
+              value:
+                code: missing_parameter
+                summary: Required Parameter status missing
+            Invalid flag:
+              value:
+                code: invalid_flag
+                summary: "Error: unknown flag type 'RANDOM_STRING' not found."
+            Invalid status:
+              value:
+                code: invalid_flag
+                summary: "Error: unknown status flag 'RANDOM_STRING'"
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '403':
+      description: Forbidden
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          example:
+            code: cmd_execution_no_permission
+            summary: no permission to modify package test in project home:Admin
+    '404':
+      $ref: '../components/responses/unknown_project_or_package.yaml'
+  tags:
+    - Sources - Packages


### PR DESCRIPTION
For reviewers, access directly to the documented endpoint in the review app through these links:
- [set_flag](https://obs-reviewlab.opensuse.org/eduardoj-apidocs_newpackage_cmd_set_flag_remove_flag/apidocs-new/index#/Sources%20-%20Packages/post_source__project_name___package_name__cmd_set_flag)
- [remove_flag](https://obs-reviewlab.opensuse.org/eduardoj-apidocs_newpackage_cmd_set_flag_remove_flag/apidocs-new/index#/Sources%20-%20Packages/post_source__project_name___package_name__cmd_remove_flag)