### PR TITLE
Document package services commands with OpenAPI

### DIFF
--- a/src/api/public/apidocs-new/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs-new/OBS-v2.10.50.yaml
@@ -299,6 +299,8 @@ paths:
     $ref: 'paths/source_project_name_package_name_cmd_runservice.yaml'
   /source/{project_name}/{package_name}?cmd=showlinked:
     $ref: 'paths/source_project_name_package_name_cmd_showlinked.yaml'
+  /source/{project_name}/{package_name}?cmd=waitservice:
+    $ref: 'paths/source_project_name_package_name_cmd_waitservice.yaml'
 
   /trigger/{operation}:
     $ref: 'paths/trigger_operation.yaml'

--- a/src/api/public/apidocs-new/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs-new/OBS-v2.10.50.yaml
@@ -295,6 +295,8 @@ paths:
 
   /source/{project_name}/{package_name}?cmd=diff:
     $ref: 'paths/source_project_name_package_name_cmd_diff.yaml'
+  /source/{project_name}/{package_name}?cmd=runservice:
+    $ref: 'paths/source_project_name_package_name_cmd_runservice.yaml'
   /source/{project_name}/{package_name}?cmd=showlinked:
     $ref: 'paths/source_project_name_package_name_cmd_showlinked.yaml'
 

--- a/src/api/public/apidocs-new/paths/source_project_name_package_name_cmd_runservice.yaml
+++ b/src/api/public/apidocs-new/paths/source_project_name_package_name_cmd_runservice.yaml
@@ -1,0 +1,80 @@
+post:
+  summary: Trigger run of defined services.
+  description: Trigger run of defined services in the `_service` file.
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/project_name.yaml'
+    - $ref: '../components/parameters/package_name.yaml'
+    - in: query
+      name: comment
+      schema:
+        type: string
+      description: Set a comment.
+      default: trigger service run
+      example: Trigger services once more.
+    - in: query
+      name: user
+      schema:
+        type: string
+      description: Set the user who triggers the services.
+      example: Iggy
+  responses:
+    '200':
+      $ref: '../components/responses/succeeded.yaml'
+    '400':
+      description: |
+        Bad Request.
+
+        XML Schema used for body validation: [status.xsd](../schema/status.xsd)
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          examples:
+            Package is _project:
+              value:
+                code: 400
+                origin: backend
+                summary: triggerservicerun does not work with _project
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '403':
+      description: Forbidden.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          examples:
+            No Permission to Run Services:
+              value:
+                code: cmd_execution_no_permission
+                summary: no permission to modify package test in project home:Admin
+    '404':
+      description: |
+        Not Found.
+
+        XML Schema used for body validation: [status.xsd](../schema/status.xsd)
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          examples:
+            Unknown Project:
+              value:
+                code: unknown_project
+                summary: "Project not found: home:some_project"
+            Unknown Package:
+              value:
+                code: unknown_package
+                summary: "Package not found: home:some_project/some_package"
+            No Source Service Defined:
+              value:
+                code: not_found
+                summary: |
+                  <status code="404">
+                    <summary>no source service defined!</summary>
+                    <details>404 no source service defined!</details>
+                  </status>
+  tags:
+    - Sources - Packages

--- a/src/api/public/apidocs-new/paths/source_project_name_package_name_cmd_waitservice.yaml
+++ b/src/api/public/apidocs-new/paths/source_project_name_package_name_cmd_waitservice.yaml
@@ -1,0 +1,43 @@
+post:
+  summary: Return when the last run of defined services has finished.
+  description: |
+    Return an `Ok` code when the last run of defined services in the `_service` file has finished.
+
+    If a run of services is in progress, wait until all services finish.
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/project_name.yaml'
+    - $ref: '../components/parameters/package_name.yaml'
+  responses:
+    '200':
+      $ref: '../components/responses/succeeded.yaml'
+    '400':
+      description: Bad Request.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          examples:
+            Service Not Installed:
+              value:
+                code: 400
+                origin: backend
+                summary: " 400 remote error: /usr/lib/obs/service//set_version.service  No such file or directory (http://backend:5152/sourceupdate/home:Admin/obs-server?timeout=3600)"
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '403':
+      description: Forbidden.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          examples:
+            No Permission to Wait for Services:
+              value:
+                code: cmd_execution_no_permission
+                summary: no permission to modify package test in project home:Admin
+    '404':
+      $ref: '../components/responses/unknown_project_or_package.yaml'
+  tags:
+    - Sources - Packages


### PR DESCRIPTION
For reviewers, access directly to the documented endpoint in the review app through these links:
- [runservice](https://obs-reviewlab.opensuse.org/eduardoj-apidocs_newpackage_cmd_runservice/apidocs-new/index#/Sources%20-%20Packages/post_source__project_name___package_name__cmd_runservice)
- [waitservice](https://obs-reviewlab.opensuse.org/eduardoj-apidocs_newpackage_cmd_runservice/apidocs-new/index#/Sources%20-%20Packages/post_source__project_name___package_name__cmd_waitservice)