### PR TITLE
[backend] create output dir before reconstruct_container

### DIFF
--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -2459,6 +2459,7 @@ sub publish {
         print "      + $p\n";
       }
       $containerinfo->{'blobdir'} = $blobdir if $blobdir;
+      mkdir_p($extrep) unless -d $extrep;
       BSPublisher::Container::reconstruct_container($containerinfo, "$extrep/$p");
       my @s = stat("$extrep/$p");
       $bins{$p} = undef;


### PR DESCRIPTION
Needs also to be backported to 2.10 branch