### PR TITLE
Make brakeman use ruby 3.1.1

### DIFF
--- a/.github/workflows/brakeman.yml
+++ b/.github/workflows/brakeman.yml
@@ -8,11 +8,12 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    container: ruby:3.1.1
     steps:
     - uses: actions/checkout@v2
     - name: Install Brakeman
       run: |
-        sudo gem install --no-format-executable brakeman -v 5.1.1
+        gem install --no-format-executable brakeman -v 5.1.1
     - name: Brakeman
       run: |
         brakeman --rails6 -p src/api


### PR DESCRIPTION
This prevents us from using some Ruby 3 syntax, and this is a simple way to fix that

(Yes, I did misspell brakeman in the branch name)