### PR TITLE
[api] honor release target parameters on project release

### DIFF
--- a/docs/api/api/api.txt
+++ b/docs/api/api/api.txt
@@ -483,6 +483,8 @@ Additional Parameters:
   resign: resign all binaries with new target project key
   setrelease: define a specific release tag when used with "release" command. Setting it to "-" strips
               the release string. Note: this modifies only the filename.
+  target_repository: allows filtering based on given target repository name
+  target_project: allows filtering based on given target project name
   withbinaries: copies also binaries on copy command
   withhistory: copies sources with history on copy command
 

--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -595,6 +595,9 @@ class SourceController < ApplicationController
           repo_bad_type = true
           next
         end
+        next if params[:target_project].present? && params[:target_project] != releasetarget.target_repository.project.name
+        next if params[:target_repository].present? && params[:target_repository] != releasetarget.target_repository.name
+
         unless User.session!.can_modify?(releasetarget.target_repository.project)
           raise CmdExecutionNoPermission, "no permission to write in project #{releasetarget.target_repository.project.name}"
         end

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -1157,6 +1157,8 @@ class Project < ApplicationRecord
 
         pkg.project.repositories.each do |repo|
           repo.release_targets.each do |releasetarget|
+            next if params[:target_project].present? && params[:target_project] != releasetarget.target_repository.project.name
+            next if params[:target_repository].present? && params[:target_repository] != releasetarget.target_repository.name
             # release source and binaries
             # permission checking happens inside this function
             release_package(pkg,


### PR DESCRIPTION
Filter permission check and release action for given target CGI parameter. Unlike with package release command a project repo definition is still needed atm.

Former state is kind of dangerous as it would release also unwanted targets and osc offers to do so since quite some time. There was also no way for the user to filter if source repo is listed multiple times.