### PR TITLE
Generalize tab anchor links (I)

### DIFF
--- a/src/api/app/assets/javascripts/webui/request.js
+++ b/src/api/app/assets/javascripts/webui/request.js
@@ -135,33 +135,6 @@ $(document).ready(function(){
     }
   });
   // TODO: Remove the enclosing code when the request_show_redesign feature is finished - END
-
-  // NOTE: Add value of selected tab in dropdown urls
-  $('#request-tabs .nav-item .nav-link').on('click', function() {
-    var tabName = $(this).attr('aria-controls');
-    $.each($('.dropdown-menu .dropdown-item'), function(){
-      var href = $(this).attr('href');
-      if(href){
-        var regex = /tab_name=([aA-zZ-]+)/;
-        var matches = href.match(regex);
-        if(matches !== null){
-          href = href.replace(matches[0], 'tab_name=' + tabName);
-        } else if(href.match(/\?/g)){
-          href = href + '&tab_name=' + tabName;
-        } else {
-          href = href + '?tab_name=' + tabName;
-        }
-        $(this).attr('href', href);
-      }
-    });
-  });
-
-  var selectedTab = $('.selected-tab').data('selected');
-  if(document.getElementById(selectedTab + '-nav-item')){
-    $('#'+selectedTab + '-nav-item a').click();
-  } else{
-    $('#conversation-nav-item a').click();
-  }
 });
 
 // TODO: Remove the following method when the request_show_redesign feature is finished

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -114,7 +114,6 @@ class Webui::RequestController < Webui::WebuiController
       @open_reviews_for_staging_projects = @bs_request.reviews.opened.for_staging_projects
       @not_full_diff = BsRequest.truncated_diffs?([@action])
       @refresh = @action[:diff_not_cached]
-      @active_tab = params[:tab_name] || 'conversation'
 
       if @refresh
         bs_request_action = BsRequestAction.find(@action[:id])

--- a/src/api/app/views/webui/request/_actions_details.html.haml
+++ b/src/api/app/views/webui/request/_actions_details.html.haml
@@ -2,7 +2,7 @@
 - if submit_actions.count > 1
   .d-flex.align-items-center
     %p.mb-0 This request contains multiple actions
-    .dropdown.ml-2
+    .dropdown.ml-2#request-actions
       %button.btn.btn-outline-primary.btn-sm.dropdown-toggle{ 'aria-expanded' => 'false', 'data-toggle' => 'dropdown',
                                                               :type => 'button', 'data-boundary' => 'viewport' }
         Select Action
@@ -15,11 +15,28 @@
           %li
             %hr.dropdown-divider
             = link_to((render partial: 'action_text', locals: { action: action_item }),
-                      request_show_path(number: bs_request.number,
-                                        request_action_id: action_item.id,
-                                        full_diff: diff_limit,
-                                        diff_to_superseded: diff_to_superseded_id),
-                      class: "dropdown-item #{action_item.id == active_action.id ? 'disabled' : ''}")
+                                                      request_show_path(number: bs_request.number,
+                                                                        request_action_id: action_item.id,
+                                                                        full_diff: diff_limit,
+                                                                        diff_to_superseded: diff_to_superseded_id),
+                                                      class: "dropdown-item #{action_item.id == active_action.id ? 'disabled' : ''}")
 %p
   = 'Showing' if submit_actions.count > 1
   %span.font-italic= request_action_header(action, bs_request.creator)
+
+- content_for :ready_function do
+  :plain
+    var hash_regexp = new RegExp(`\#${hash_prefix}.+`);
+
+    $('#request-actions').on('shown.bs.dropdown', function () {
+      $.each($('#request-actions .dropdown-item'), function () {
+        var href = $(this).attr('href');
+        if (href.search('#') == -1) {
+           href = href + document.location.hash;
+        }
+        else {
+          href = href.replace(hash_regexp, document.location.hash);
+        }
+        $(this).attr('href', href);
+      });
+    });

--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -44,26 +44,26 @@
             = link_to "##{supersed['number']}", number: supersed['number']
 
         = render partial: 'actions_details', locals: { bs_request: @bs_request, action: @action, active_action: @active_action,
-                                                        diff_to_superseded_id: @diff_to_superseded_id, diff_limit: @diff_limit }
+                                                       diff_to_superseded_id: @diff_to_superseded_id, diff_limit: @diff_limit }
 
     %ul.nav.nav-tabs.scrollable-tabs#request-tabs{ role: 'tablist' }
-      %li.nav-item.scrollable-tab-link#conversation-nav-item
+      %li.nav-item.scrollable-tab-link{ role: 'presentation' }
         = link_to('Conversation', '#conversation', class: 'nav-link text-nowrap', 'aria-controls': 'conversation',
-                  'aria-selected': 'true', 'data-toggle': 'tab', role: 'tab')
+                  'aria-selected': 'false', 'data-toggle': 'tab', role: 'tab')
       - if @action[:sprj] || @action[:spkg]
-        %li.nav-item.scrollable-tab-link#build-results-nav-item
+        %li.nav-item.scrollable-tab-link{ role: 'presentation' }
           = link_to('Build Results', '#build-results', class: 'nav-link text-nowrap', 'aria-controls': 'build-results',
                     'aria-selected': 'false', 'data-toggle': 'tab', role: 'tab')
       - if @action[:type].in?(actions_for_diff)
-        %li.nav-item.scrollable-tab-link#changes-nav-item{ 'data-request-number': @bs_request.number, 'data-request-action-id': @action[:id] }
-          = link_to('Changes', '#changes', class: 'nav-link text-nowrap', 'aria-controls': 'changes', 'aria-selected': 'false',
-                    'data-toggle': 'tab', role: 'tab')
+        %li.nav-item.scrollable-tab-link{ role: 'presentation', 'data-request-number': @bs_request.number, 'data-request-action-id': @action[:id] }
+          = link_to('Changes', '#changes', class: 'nav-link text-nowrap', 'aria-controls': 'changes',
+                    'aria-selected': 'false', 'data-toggle': 'tab', role: 'tab')
       - if @action[:type].in?(actions_for_diff)
-        %li.nav-item.scrollable-tab-link#mentioned-issues-nav-item
+        %li.nav-item.scrollable-tab-link{ role: 'presentation' }
           = link_to('Mentioned Issues', '#mentioned-issues', class: 'nav-link text-nowrap', 'aria-controls': 'mentioned-issues',
                     'aria-selected': 'false', 'data-toggle': 'tab', role: 'tab')
     .tab-content.p-4#request-tabs-content
-      .tab-pane.fade.show.p-2#conversation{ 'aria-labelledby': 'conversation-tab', role: 'tabpanel' }
+      .tab-pane.fade.p-2#conversation{ 'aria-labelledby': 'conversation-tab', role: 'tabpanel' }
         = render partial: 'webui/request/beta_show_tabs/conversation', locals: { bs_request: @bs_request, can_add_reviews: @can_add_reviews,
                                                                              open_reviews: @open_reviews,
                                                                              accepted_reviews: @accepted_reviews,
@@ -71,8 +71,7 @@
                                                                              open_reviews_for_staging_projects: @open_reviews_for_staging_projects,
                                                                              my_open_reviews: @my_open_reviews,
                                                                              action: @action,
-                                                                             is_target_maintainer: @is_target_maintainer,
-                                                                             is_author: @is_author }
+                                                                             is_target_maintainer: @is_target_maintainer, is_author: @is_author }
       - if @action[:sprj] || @action[:spkg]
         .tab-pane.fade.p-2#build-results{ 'aria-labelledby': 'build-results-tab', role: 'tabpanel' }
           = render partial: 'webui/request/beta_show_tabs/build_results', locals: { project: @action[:sprj], package: @action[:spkg] }
@@ -81,4 +80,21 @@
           = render partial: 'webui/request/beta_show_tabs/changes', locals: { bs_request: @bs_request, action: @action, refresh: @refresh }
         .tab-pane.fade.p-2#mentioned-issues{ 'aria-labelledby': 'mentioned-issues-tab', role: 'tabpanel' }
           = render partial: 'webui/request/beta_show_tabs/mentioned_issues'
-    .selected-tab{ 'data-selected': @active_tab }
+
+- content_for :ready_function do
+  :plain
+    var hash_prefix = 'tab-pane-';
+
+    // Show tab-pane comming from the url hash. If the url hash is empty, show first tab-pane.
+    var tab_pane_id = document.location.hash.replace('#' + hash_prefix, '#') || $('.nav-tabs .nav-item:first-child .nav-link').attr('href');
+    $('.nav-tabs .nav-link[href="' + tab_pane_id + '"]').tab('show');
+
+    // Change url hash for page-reload
+    $('.nav-tabs .nav-item .nav-link').on('shown.bs.tab', function (event) {
+      if ($(event.target).parent('.nav-item').is(':first-child')) {
+        history.pushState('', document.title, window.location.pathname + window.location.search);
+      }
+      else {
+        document.location.hash = event.target.hash.replace('#', '#' + hash_prefix);
+      }
+    });


### PR DESCRIPTION
This PR creates links to different sections of a page with nav-tabs bootstrap elements. Only in the request page of the beta program.

A following pull request will make this same approach general to the application.

### For reviewers

Here there is a [link](https://obs-reviewlab.opensuse.org/eduardoj-request_workflow_redesigngeneralize_tab_links/request/show/9) to a request with a couple of actions in the the review-app.

![Peek 2022-10-13 14-17_request_workflow_redesign_nav_tabs_I](https://user-images.githubusercontent.com/24919/195594005-8d74e5ed-9e26-4cf5-83f8-53447e0cb620.gif)
