### PR TITLE
Display relevant information about the actions in the action selector

### DIFF
--- a/src/api/app/views/webui/request/_action_text.html.haml
+++ b/src/api/app/views/webui/request/_action_text.html.haml
@@ -1,10 +1,28 @@
-- if (details = action.commit_details)
+- details = action.commit_details
+- if details
+  - if details.key?('comment')
+    %p.mt-0.mb-0.font-weight-normal
+      = details['comment'].truncate(50)
+    %p.mb-0.mt-0.text-muted.font-weight-light.small
+      = action.name
+  - else
+    %p.mt-0.mb-0.font-weight-normal
+      = action.name
+  %span.float-right.ml-5
+    = details['rev']
+- else
   %p.mt-0.mb-0.font-weight-normal
-    = details['comment']&.truncate(50) || action.name
-    %span.float-right.ml-5
-      = details['rev']
+    = action.name
+-# add_role, delete and set_bugowner are actions on the target repo, so they don't need to mention where they are coming from
+- unless %w[add_role delete set_bugowner].include?(action.type)
   %p.mb-0.mt-0.text-muted.font-weight-light.small
+    from
+    = action.source_project
+    - if action.source_package
+      \/
+      = action.source_package
+- if details
+  %p.mb-0.mt-0.text-muted.font-weight-light.small
+    by
     = details['user']
     #{ApplicationController.helpers.time_ago_in_words(details['time'].to_i)} ago
-- else
-  %p Commit information is missing


### PR DESCRIPTION
This PR makes it so that the following information is always visible in the action selector dropdown:
* action type (through `action.name`)
* source_project/source_package (where applicable, only project or both)
* target_project/target_package (plus other targets if included in `action.name`)
* commit information (if available)

# To verify
1. Create a request with multiple actions
2. Click on `Select Action ▾` button and see a dropdown
3. Dropdown should include all the information specified above wherever applicable

![image](https://user-images.githubusercontent.com/114928900/195611465-e7c9a21b-c7dd-4e3c-8ce4-7857793e7db1.png)
