### PR TITLE
Generalize tab anchor links (II)

### DIFF
--- a/src/api/app/assets/javascripts/webui/application.js
+++ b/src/api/app/assets/javascripts/webui/application.js
@@ -58,3 +58,4 @@
 //= require webui/new_watchlist/collapsible_tooltip.js
 //= require webui/request_show_redesign/add_review.js
 //= require webui/delete_confirmation_dialog.js
+//= require webui/nav_tabs.js

--- a/src/api/app/assets/javascripts/webui/nav_tabs.js
+++ b/src/api/app/assets/javascripts/webui/nav_tabs.js
@@ -1,17 +1,17 @@
-var hash_prefix = 'tab-pane-';
+var HASH_PREFIX = 'tab-pane-';
 
 $(document).ready(function () {
   // Show tab-pane comming from the url hash. If the url hash is empty, show first tab-pane.
-  var tab_pane_id = document.location.hash.replace('#' + hash_prefix, '#') || $('.nav-tabs .nav-item:first-child .nav-link').attr('href');
-  $('.nav-tabs .nav-link[href="' + tab_pane_id + '"]').tab('show');
+  var tabPaneId = document.location.hash.replace('#' + HASH_PREFIX, '#') || $('.nav-tabs .nav-item:first-child .nav-link').attr('href');
+  $('.nav-tabs .nav-link[href="' + tabPaneId + '"]').tab('show');
 
   // Change url hash for page-reload
   $('.nav-tabs .nav-item .nav-link').on('shown.bs.tab', function (event) {
     if ($(event.target).parent('.nav-item').is(':first-child')) {
-      history.pushState('', document.title, window.location.pathname + window.location.search);
+      window.history.pushState('', document.title, window.location.pathname + window.location.search);
     }
     else {
-      document.location.hash = event.target.hash.replace('#', '#' + hash_prefix);
+      document.location.hash = event.target.hash.replace('#', '#' + HASH_PREFIX);
     }
   });
 });

--- a/src/api/app/assets/javascripts/webui/nav_tabs.js
+++ b/src/api/app/assets/javascripts/webui/nav_tabs.js
@@ -2,11 +2,13 @@ var HASH_PREFIX = 'tab-pane-';
 
 $(document).ready(function () {
   // Show tab-pane comming from the url hash. If the url hash is empty, show first tab-pane.
-  var tabPaneId = document.location.hash.replace('#' + HASH_PREFIX, '#') || $('.nav-tabs .nav-item:first-child .nav-link').attr('href');
-  $('.nav-tabs .nav-link[href="' + tabPaneId + '"]').tab('show');
+  var tabPaneId = document.location.hash.replace('#' + HASH_PREFIX, '#') ||
+    $('.nav-tabs:not(.disable-link-generation) .nav-item:first-child .nav-link').attr('href');
+
+  $('.nav-tabs:not(.disable-link-generation) .nav-link[href="' + tabPaneId + '"]').tab('show');
 
   // Change url hash for page-reload
-  $('.nav-tabs .nav-item .nav-link').on('shown.bs.tab', function (event) {
+  $('.nav-tabs:not(.disable-link-generation) .nav-item .nav-link').on('shown.bs.tab', function (event) {
     if ($(event.target).parent('.nav-item').is(':first-child')) {
       window.history.pushState('', document.title, window.location.pathname + window.location.search);
     }

--- a/src/api/app/assets/javascripts/webui/nav_tabs.js
+++ b/src/api/app/assets/javascripts/webui/nav_tabs.js
@@ -1,0 +1,17 @@
+var hash_prefix = 'tab-pane-';
+
+$(document).ready(function () {
+  // Show tab-pane comming from the url hash. If the url hash is empty, show first tab-pane.
+  var tab_pane_id = document.location.hash.replace('#' + hash_prefix, '#') || $('.nav-tabs .nav-item:first-child .nav-link').attr('href');
+  $('.nav-tabs .nav-link[href="' + tab_pane_id + '"]').tab('show');
+
+  // Change url hash for page-reload
+  $('.nav-tabs .nav-item .nav-link').on('shown.bs.tab', function (event) {
+    if ($(event.target).parent('.nav-item').is(':first-child')) {
+      history.pushState('', document.title, window.location.pathname + window.location.search);
+    }
+    else {
+      document.location.hash = event.target.hash.replace('#', '#' + hash_prefix);
+    }
+  });
+});

--- a/src/api/app/assets/javascripts/webui/user_profile.js
+++ b/src/api/app/assets/javascripts/webui/user_profile.js
@@ -4,6 +4,7 @@ function moveInvolvementToContainer() { // jshint ignore:line
     container = $('.tab-pane#involved-projects-and-packages');
 
   container.prepend($('#involvement'));
+  $('#involvement').removeClass('d-none');
 }
 
 function updateCharactersCount(e) { // jshint ignore:line

--- a/src/api/app/components/workflow_run_detail_component.html.haml
+++ b/src/api/app/components/workflow_run_detail_component.html.haml
@@ -1,19 +1,19 @@
 %ul.nav.nav-tabs#workflow-run-tabs{ role: 'tablist' }
   %li.nav-item{ role: 'presentation' }
-    %a.nav-link.active{ id: "incoming-webhook-tab#{id}", data: { toggle: 'tab' }, href: "#incoming-webhook-tab-content#{id}",
-                        role: 'tab', aria: { controls: "incoming-webhook-tab-content#{id}", selected: 'true' } }
+    %a.nav-link{ id: "incoming-webhook-tab#{id}", data: { toggle: 'tab' }, href: "#incoming-webhook-tab-content#{id}",
+                 role: 'tab', aria: { controls: "incoming-webhook-tab-content#{id}", selected: 'false' } }
       Webhook from #{scm_vendor}
   %li.nav-item{ role: 'presentation' }
     %a.nav-link{ id: "scm-reports-tab#{id}", data: { toggle: 'tab' }, href: "#scm-reports-tab-content#{id}",
-                role: 'tab', aria: { controls: "scm-reports-tab-content#{id}", selected: 'false' } }
+                 role: 'tab', aria: { controls: "scm-reports-tab-content#{id}", selected: 'false' } }
       Reports to the SCM
   %li.nav-item{ role: 'presentation' }
     %a.nav-link{ id: "artifacts#{id}", data: { toggle: 'tab' }, href: "#artifacts-tab-content#{id}",
                  role: 'tab', aria: { controls: "artifacts-tab-content#{id}", selected: 'false' } }
       Artifacts
 .tab-content.p-3#workflow-run-tabs-content
-  .tab-pane.fade.show.active{ id: "incoming-webhook-tab-content#{id}", role: 'tabpanel',
-                              aria: { labelledby: "incoming-webhook-tab#{id}" } }
+  .tab-pane.fade{ id: "incoming-webhook-tab-content#{id}", role: 'tabpanel',
+                  aria: { labelledby: "incoming-webhook-tab#{id}" } }
     %h5 Webhook URL
     %pre.border.p-2#response-url
       = response_url

--- a/src/api/app/views/webui/comment/_comment_field.html.haml
+++ b/src/api/app/views/webui/comment/_comment_field.html.haml
@@ -4,7 +4,7 @@ class: "#{form_method}-comment-form" }, data: { preview_comment_url: preview_com
   = hidden_field_tag :commentable_id, commentable.id, { id: "#{element_suffix}_commentable_id" }
   = f.hidden_field :parent_id, value: comment.parent_id, id: "#{element_suffix}_parent_id"
   .card
-    %ul.nav.nav-tabs.bg-light.px-3.pt-2{ role: 'tablist' }
+    %ul.nav.nav-tabs.bg-light.px-3.pt-2.disable-link-generation{ role: 'tablist' }
       %li.nav-item
         = link_to('Write', "#write_#{element_suffix}", class: 'nav-link active', data: { toggle: 'tab' }, role: 'tab',
         aria: { controls: 'write-comment-tab', selected: 'true' })

--- a/src/api/app/views/webui/groups/show.html.haml
+++ b/src/api/app/views/webui/groups/show.html.haml
@@ -4,7 +4,7 @@
   .bg-light
     %ul.nav.nav-tabs.pt-2.px-3.flex-nowrap.collapsible{ role: 'tablist' }
       %li.nav-item
-        %a.active.nav-link.text-nowrap#group-members-tab{ aria: { controls: 'group-members' },
+        %a.nav-link.text-nowrap#group-members-tab{ aria: { controls: 'group-members' },
           data: { toggle: 'tab' }, href: '#group-members', role: 'tab' }
           Group Members
           %span.badge.badge-primary
@@ -31,7 +31,7 @@
 
   .card-body
     .tab-content
-      .tab-pane.show.active#group-members{ aria: { controls: 'group-members' }, role: 'tabpanel' }
+      .tab-pane#group-members{ aria: { controls: 'group-members' }, role: 'tabpanel' }
         %h3
           Group Members
         = render(partial: 'group_members', locals: { group: @group })
@@ -47,10 +47,3 @@
       .tab-pane#all-requests{ aria: { controls: 'all-requests' }, role: 'tabpanel' }
         %h3 All Requests
         = render(partial: 'webui/shared/requests_table', locals: { id: 'all_requests_table', source_url: group_requests_path(@group) })
-
-- content_for :ready_function do
-  :plain
-    var hash = document.location.hash;
-    if (hash) {
-      $('.nav-tabs a[href="' + hash.replace('tab-', '') + '"]').tab('show');
-    }

--- a/src/api/app/views/webui/kiwi/_tabs.html.haml
+++ b/src/api/app/views/webui/kiwi/_tabs.html.haml
@@ -1,5 +1,5 @@
 .bg-light
-  %ul.nav.nav-tabs.pt-2.px-3.flex-nowrap.collapsible{ role: 'tablist' }
+  %ul.nav.nav-tabs.pt-2.px-3.flex-nowrap.collapsible.disable-link-generation{ role: 'tablist' }
     %li.nav-item
       = link_to('Overview', { controller: 'kiwi/images', action: 'show' }, class: "nav-link #{'active' if action_name == 'show'}")
     %li.nav-item

--- a/src/api/app/views/webui/kiwi/images/_build_info.html.haml
+++ b/src/api/app/views/webui/kiwi/images/_build_info.html.haml
@@ -7,7 +7,7 @@
 
 .card
   .bg-light#buildresult-urls{ data: { buildresult_url: defined?(package) ? package_buildresult_path : project_buildresult_path } }
-    %ul.nav.nav-tabs.pt-2.px-3.flex-nowrap#buildresult-box{ role: 'tablist', data: ajax_data }
+    %ul.nav.nav-tabs.pt-2.px-3.flex-nowrap.disable-link-generation#buildresult-box{ role: 'tablist', data: ajax_data }
       %li.nav-item
         = link_to("#build#{index}", id: "build#{index}-tab", class: 'nav-link active text-nowrap',
           data: { toggle: 'tab' }, role: 'tab', aria: { controls: "build#{index}", selected: true }) do

--- a/src/api/app/views/webui/project/show.html.haml
+++ b/src/api/app/views/webui/project/show.html.haml
@@ -37,8 +37,8 @@
       .bg-light
         %ul.nav.nav-tabs.pt-2.px-3.flex-nowrap#packages-tabs{ role: 'tablist' }
           %li.nav-item
-            %a.nav-link.active#packages-tab{ href: '#packages', role: 'tab', data: { toggle: 'tab' },
-            aria: { controls: 'packages', selected: 'true' } }
+            %a.nav-link#packages-tab{ href: '#packages', role: 'tab', data: { toggle: 'tab' },
+            aria: { controls: 'packages', selected: 'false' } }
               Packages
               %span.badge.badge-primary
                 = @packages.length
@@ -50,7 +50,7 @@
                 %span.badge.badge-primary
                   = @inherited_packages.length
       .tab-content#packages-tabs-content
-        .tab-pane.fade.show.active#packages{ role: 'tabpanel', aria: { labelledby: 'packages-tab' } }
+        .tab-pane.fade#packages{ role: 'tabpanel', aria: { labelledby: 'packages-tab' } }
           = render partial: 'project_packages', locals: { project: @project, packages: @packages }
         .tab-pane.fade#inherited-packages{ role: 'tabpanel', aria: { labelledby: 'inherited-packages-tab' } }
           = render partial: 'project_inherited_packages', locals: { project: @project, inherited_packages: @inherited_packages }

--- a/src/api/app/views/webui/request/_actions_details.html.haml
+++ b/src/api/app/views/webui/request/_actions_details.html.haml
@@ -26,7 +26,7 @@
 
 - content_for :ready_function do
   :plain
-    var hash_regexp = new RegExp(`\#${hash_prefix}.+`);
+    var hashRegexp = new RegExp(`\#${HASH_PREFIX}.+`);
 
     $('#request-actions').on('shown.bs.dropdown', function () {
       $.each($('#request-actions .dropdown-item'), function () {
@@ -35,7 +35,7 @@
            href = href + document.location.hash;
         }
         else {
-          href = href.replace(hash_regexp, document.location.hash);
+          href = href.replace(hashRegexp, document.location.hash);
         }
         $(this).attr('href', href);
       });

--- a/src/api/app/views/webui/request/_handle_request.html.haml
+++ b/src/api/app/views/webui/request/_handle_request.html.haml
@@ -1,7 +1,7 @@
 - if can_handle_request || (can_add_reviews && my_open_reviews.any?)
   .card.mb-3#handle-request
     .bg-light
-      %ul.nav.nav-tabs{ role: 'tablist' }
+      %ul.nav.nav-tabs.disable-link-generation{ role: 'tablist' }
         - if can_handle_request
           %li.nav-item
             %a.nav-link.text-nowrap.active{ href: '#decision', data: { toggle: 'tab' }, role: 'tab' }

--- a/src/api/app/views/webui/request/_request_comments.html.haml
+++ b/src/api/app/views/webui/request/_request_comments.html.haml
@@ -1,5 +1,5 @@
 .bg-light
-  %ul.nav.nav-tabs{ role: 'tablist' }
+  %ul.nav.nav-tabs.disable-link-generation{ role: 'tablist' }
     %li.nav-item
       = link_to('#comments', class: 'nav-link text-nowrap active', data: { toggle: 'tab' }, role: 'tab') do
         Comments for request #{bs_request.number}

--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -80,21 +80,3 @@
           = render partial: 'webui/request/beta_show_tabs/changes', locals: { bs_request: @bs_request, action: @action, refresh: @refresh }
         .tab-pane.fade.p-2#mentioned-issues{ 'aria-labelledby': 'mentioned-issues-tab', role: 'tabpanel' }
           = render partial: 'webui/request/beta_show_tabs/mentioned_issues'
-
-- content_for :ready_function do
-  :plain
-    var hash_prefix = 'tab-pane-';
-
-    // Show tab-pane comming from the url hash. If the url hash is empty, show first tab-pane.
-    var tab_pane_id = document.location.hash.replace('#' + hash_prefix, '#') || $('.nav-tabs .nav-item:first-child .nav-link').attr('href');
-    $('.nav-tabs .nav-link[href="' + tab_pane_id + '"]').tab('show');
-
-    // Change url hash for page-reload
-    $('.nav-tabs .nav-item .nav-link').on('shown.bs.tab', function (event) {
-      if ($(event.target).parent('.nav-item').is(':first-child')) {
-        history.pushState('', document.title, window.location.pathname + window.location.search);
-      }
-      else {
-        document.location.hash = event.target.hash.replace('#', '#' + hash_prefix);
-      }
-    });

--- a/src/api/app/views/webui/request/show.html.haml
+++ b/src/api/app/views/webui/request/show.html.haml
@@ -27,7 +27,7 @@
 
 .card.mb-3
   .bg-light
-    %ul.nav.nav-tabs.bs-request-actions{ role: 'tablist' }
+    %ul.nav.nav-tabs.bs-request-actions.disable-link-generation{ role: 'tablist' }
       - @actions.each_with_index do |action, index|
         %li.nav-item.mw-100
           - xml_id = action[:name] + action[:id].to_s

--- a/src/api/app/views/webui/search/_tabs.html.haml
+++ b/src/api/app/views/webui/search/_tabs.html.haml
@@ -1,5 +1,5 @@
 .bg-light
-  %ul.nav.nav-tabs.pt-2.px-3.flex-nowrap.collapsible{ role: 'tablist' }
+  %ul.nav.nav-tabs.pt-2.px-3.flex-nowrap.collapsible.disable-link-generation{ role: 'tablist' }
     %li.nav-item
       = tab_link('Packages/Projects', search_path, action_name == 'index')
     %li.nav-item

--- a/src/api/app/views/webui/shared/_buildresult_box.html.haml
+++ b/src/api/app/views/webui/shared/_buildresult_box.html.haml
@@ -18,7 +18,7 @@
 
   .card
     .bg-light{ id: "buildresult#{index}-urls", data: { buildresult_url: package ? package_buildresult_path : project_buildresult_path } }
-      %ul.nav.nav-tabs.pt-2.px-3.flex-nowrap{ id: "buildresult#{index}-box", role: 'tablist', data: ajax_data }
+      %ul.nav.nav-tabs.pt-2.px-3.flex-nowrap.disable-link-generation{ id: "buildresult#{index}-box", role: 'tablist', data: ajax_data }
         %li.nav-item
           = link_to("#build#{index}", id: "build#{index}-tab", class: 'nav-link active text-nowrap',
             data: { toggle: 'tab' }, role: 'tab', aria: { controls: "build#{index}", selected: true }) do

--- a/src/api/app/views/webui/user/_involvement.html.haml
+++ b/src/api/app/views/webui/user/_involvement.html.haml
@@ -12,7 +12,7 @@
   roles_html_ids = (roles.map(&:title) << 'owner').map { |role| "role_#{role}" }
   roles_selected = (filters.keys & roles_html_ids).count
 
-#involvement
+.d-none#involvement
   .card.sticky-top.border-0#involved-filters
     .card-body
       = form_with(model: displayed_user, method: :get, local: true, class: 'form-inline justify-content-between') do

--- a/src/api/app/views/webui/user/_involvement_and_activity.html.haml
+++ b/src/api/app/views/webui/user/_involvement_and_activity.html.haml
@@ -8,8 +8,8 @@
     .bg-light.d-none.d-md-block
       %ul.nav.nav-tabs.pt-2.px-3.flex-nowrap.collapsible{ role: 'tablist' }
         %li.nav-item
-          = link_to('#involved-projects-and-packages', id: 'involved-projects-and-packages-tab', class: 'nav-link active text-nowrap',
-                    data: { toggle: 'tab' }, role: 'tab', aria: { controls: 'involved-projects-and-packages', selected: true }) do
+          = link_to('#involved-projects-and-packages', id: 'involved-projects-and-packages-tab', class: 'nav-link text-nowrap',
+                    data: { toggle: 'tab' }, role: 'tab', aria: { controls: 'involved-projects-and-packages', selected: false }) do
             Involved Projects/Packages
         %li.nav-item
           = link_to('#activity', id: 'activity-tab', class: 'nav-link text-nowrap',
@@ -22,7 +22,7 @@
     -# Displaying tabs in medium-large viewports when the Contribution Graph is enabled
     - if contribution_graph?
       .tab-content.d-none.d-md-block
-        .tab-pane.fade.show.active#involved-projects-and-packages{ role: 'tabpanel', aria: { labelledby: 'involved-projects-and-packages-tab' } }
+        .tab-pane.fade#involved-projects-and-packages{ role: 'tabpanel', aria: { labelledby: 'involved-projects-and-packages-tab' } }
         -# Content to be injected by JavaScript
         .tab-pane.fade#activity{ role: 'tabpanel', aria: { labelledby: 'activity-tab' } }
           = render partial: 'webui/user/activity', locals: { activities_per_year: activities_per_year,

--- a/src/api/app/views/webui/users/tasks/index.html.haml
+++ b/src/api/app/views/webui/users/tasks/index.html.haml
@@ -2,7 +2,7 @@
   - @pagetitle = "Tasks for #{User.session!}"
 .card#reviews
   .bg-light
-    %ul.nav.nav-tabs.pt-2.px-3.flex-nowrap.collapsible{ role: 'tablist' }
+    %ul.nav.nav-tabs.pt-2.px-3.flex-nowrap.collapsible.disable-link-generation{ role: 'tablist' }
       %li.nav-item
         - cache "#{User.session!.cache_key_with_version}-reviews-in" do
           %a.nav-link.text-nowrap.active{ href: '#reviews-in', title: "Requests that #{User.session!} has to review" }
@@ -20,8 +20,8 @@
     %ul.nav.nav-tabs.pt-2.px-3.flex-nowrap.collapsible{ role: 'tablist' }
       %li.nav-item
         - cache "#{User.session!.cache_key_with_version}-requests-in" do
-          %a.nav-link.text-nowrap.active#requests-in-tab{ href: '#requests-in', title: "Requests that #{User.session!} has to merge",
-            'data-toggle': 'tab', 'aria-controls': 'requests-in-tab', 'aria-selected': 'true', role: 'tab' }
+          %a.nav-link.text-nowrap#requests-in-tab{ href: '#requests-in', title: "Requests that #{User.session!} has to merge",
+            'data-toggle': 'tab', 'aria-controls': 'requests-in-tab', 'aria-selected': 'false', role: 'tab' }
             Incoming Requests
             %span.badge.badge-primary
               = User.session!.incoming_requests.count
@@ -48,7 +48,7 @@
         .dropdown-menu.dropdown-menu-right
   .card-body
     .tab-content
-      .tab-pane.fade.show.active#requests-in{ role: 'tabpanel', 'aria-labelledby': 'requests-in-tab' }
+      .tab-pane.fade#requests-in{ role: 'tabpanel', 'aria-labelledby': 'requests-in-tab' }
         = render(partial: 'webui/shared/requests_table', locals: { id: 'requests_in_table', source_url: user_requests_path(User.session!),
                  page_length: 10 })
       .tab-pane.fade#requests-out{ role: 'tabpanel', 'aria-labelledby': 'requests-out-tab' }
@@ -65,7 +65,7 @@
 - if number_of_involved_patchinfos.positive?
   .card.mt-3#patchinfos
     .bg-light
-      %ul.nav.nav-tabs.pt-2.px-3.flex-nowrap.collapsible{ role: 'tablist' }
+      %ul.nav.nav-tabs.pt-2.px-3.flex-nowrap.collapsible.disable-link-generation{ role: 'tablist' }
         %li.nav-item
           %a.nav-link.text-nowrap.active{ href: '#patchinfos-in', title: "Requests that #{User.session!} has to merge" }
             Maintenance Requests


### PR DESCRIPTION
Use the same solution implemented for requests in beta to provide links to show a specific pane of Nav Bootstrap components.

In some cases the pages could be adapted, and the links are generated correctly.

In other cases the pages could not be adapted, so they work as before.

~Still depending on~ Follow up of #13212.

### For reviewers

Here there is a list of links to the review-app pages which are examples of the changes in the Nav Bootstrap components of this PR:
- Request show. Try with beta and without beta: [/request/show/9](http://obs-reviewlab.opensuse.org/eduardoj-request_workflow_redesigngeneralize_tab_links_ii/request/show/9)
- Groups show (The name of the group changes with the deployment):
  - Go to [User profile](http://obs-reviewlab.opensuse.org/eduardoj-request_workflow_redesigngeneralize_tab_links_ii/users/Admin)
  - Click on the Group link, in the section "Member of the group".
- Search: [/search](http://obs-reviewlab.opensuse.org/eduardoj-request_workflow_redesigngeneralize_tab_links_ii/search)
- User profile: [/users/Admin](http://obs-reviewlab.opensuse.org/eduardoj-request_workflow_redesigngeneralize_tab_links_ii/users/Admin)
- User tasks: [/my/tasks](http://obs-reviewlab.opensuse.org/eduardoj-request_workflow_redesigngeneralize_tab_links_ii/my/tasks)
- Project show: [/project/show/linked_project](http://obs-reviewlab.opensuse.org/eduardoj-request_workflow_redesigngeneralize_tab_links_ii/project/show/linked_project)
- Workflow run details: No link can provided with the review-app. Test with the development environment.
- Kiwi images: No link can provided with the review-app. Test with the development environment.