### PR TITLE
Show comments and activity from superseded requests

### DIFF
--- a/src/api/app/assets/stylesheets/webui/collapse-component.scss
+++ b/src/api/app/assets/stylesheets/webui/collapse-component.scss
@@ -1,13 +1,13 @@
 [data-toggle="collapse"] {
   &[aria-expanded="false"] {
     .collapser {
-      display: none;
+      display: none !important;
     }
   }
 
   &[aria-expanded="true"] {
     .expander {
-      display: none;
+      display: none !important;
     }
   }
 }

--- a/src/api/app/assets/stylesheets/webui/timeline.scss
+++ b/src/api/app/assets/stylesheets/webui/timeline.scss
@@ -1,11 +1,12 @@
 // This stylesheet defines styles for use in the comments and request history merged timeline
 .timeline {
     $timeline-border-width: 0.125rem;
+    $timeline-offset: -(($avatars-counter-size / 2) + $timeline-border-width);
     border-left: $timeline-border-width solid $gray-400;
 
     .timeline-item {
         position: relative;
-        left: -(($avatars-counter-size / 2) + $timeline-border-width); // The avatars of users involved in timeline items will be displayed on the timeline border
+        left: $timeline-offset; // The avatars of users involved in timeline items will be displayed on the timeline border
 
         $timeline-item-avatar-margin: 0.5rem;
         img.avatars-counter {
@@ -14,6 +15,32 @@
 
         .timeline-item-comment {
             margin-left: $avatars-counter-size + $timeline-border-width + $timeline-item-avatar-margin;
+        }
+
+        i.timeline-break, i.timeline-offset {
+            @extend .py-2;
+            @extend .mr-2;
+            @extend .fas;
+            @extend .fa-ellipsis-vertical;
+            margin-left: 0.66rem;
+        }
+        i.timeline-break {
+            @extend .bg-white;
+            @extend .text-dark;
+        }
+        a:hover i.timeline-break {
+            filter: none;
+        }
+        i.timeline-offset {
+            color: transparent;
+        }
+    }
+
+    .collapse, .collapsing {
+        position: relative;
+        left: $timeline-offset;
+        .timeline-item {
+            left: 0;
         }
     }
 }

--- a/src/api/app/components/bs_request_activity_timeline_component.html.haml
+++ b/src/api/app/components/bs_request_activity_timeline_component.html.haml
@@ -1,17 +1,3 @@
-.timeline-item
-  .d-inline-flex
-    = helpers.image_tag_for(creator, size: 35, custom_class: 'rounded-circle bg-light border border-gray-400 avatars-counter')
-    %p
-      %i.fas.fa-code-commit.text-dark
-      = link_to(helpers.realname_with_login(creator), user_path(creator))
-      created request
-      = link_to('#request-creation', title: l(bs_request.created_at.utc), name: 'request-creation') do
-        #{time_ago_in_words(bs_request.created_at)} ago
-      - if bs_request.superseding.any?
-        superseding
-        - bs_request.superseding.each do |superseded_request|
-          = link_to("request ##{superseded_request.number}", request_show_path(superseded_request.number, anchor: 'overview'))
-
 - timeline.each do |comment_or_history_element|
   .timeline-item
     - if comment_or_history_element.is_a?(Comment)

--- a/src/api/app/views/webui/request/beta_show_tabs/_conversation.html.haml
+++ b/src/api/app/views/webui/request/beta_show_tabs/_conversation.html.haml
@@ -35,7 +35,40 @@
   .col-md-8.order-md-1.order-sm-2
     %h4.list-group.mb-4 Comments & Request History
     .timeline{ data: { comment_counter: local_assigns[:comment_counter_id] } }
+      .timeline-item
+        .d-inline-flex
+          - creator = User.find_by_login(bs_request.creator) || User.nobody
+          = image_tag_for(creator, size: 35, custom_class: 'rounded-circle bg-light border border-gray-400 avatars-counter')
+          %p
+            %i.fas.fa-code-commit.text-dark
+            = link_to(realname_with_login(creator), user_path(creator))
+            created this request
+            = link_to('#request-creation', title: l(bs_request.created_at.utc), name: 'request-creation') do
+              #{time_ago_in_words(bs_request.created_at)} ago
+            - if bs_request.superseding.any?
+              superseding
+              - bs_request.superseding.each do |superseded_request|
+                = link_to("request ##{superseded_request.number}", request_show_path(superseded_request.number, anchor: 'overview'))
+
+      - bs_request.superseding.each do |superseding_request|
+        .timeline-item.pb-4
+          = link_to('#collapse-superseding', class: 'd-flex align-items-center',
+              data: { toggle: 'collapse' },
+              aria: { expanded: false, controls: 'collapse-superseding' }) do
+            %i.timeline-break.expander>
+            %i.timeline-offset.collapser>
+
+            %i.fas.fa-fw.fa-chevron-right.expander.mr-1{ title: 'Show history' }>
+            %i.fas.fa-fw.fa-chevron-down.collapser.mr-1{ title: 'Hide history' }>
+            %span.expander
+              Expand history from superseded request ##{superseding_request.number}
+            %span.collapser
+              Collapse history from superseded request ##{superseding_request.number}
+        .collapse.mb-4#collapse-superseding
+          = render BsRequestActivityTimelineComponent.new(bs_request: superseding_request)
+
       = render BsRequestActivityTimelineComponent.new(bs_request: bs_request)
+
     .comment_new.mt-3
       = render partial: 'webui/comment/new', locals: { commentable: bs_request }
     %hr


### PR DESCRIPTION
This PR adds an expander/collapser link to toggle visibility of superseded comments and request history.

**Before**
![image](https://user-images.githubusercontent.com/2650/195857835-22d748de-9e00-4e11-9771-4e999fdcb6a3.png)

**After**
_Collapsed_

![image](https://user-images.githubusercontent.com/2650/196451682-a48f9996-39df-4d2d-a6f8-3977e82dbf6c.png)

_Expanded_

![image](https://user-images.githubusercontent.com/2650/196471961-6b334ce7-76d8-45f7-b9bf-6584edf1b45f.png)

