### PR TITLE
Move review request action button closer to context area

### DIFF
--- a/src/api/app/components/add_review_dropdown_component.html.haml
+++ b/src/api/app/components/add_review_dropdown_component.html.haml
@@ -8,10 +8,10 @@
   .dropdown#add-review-dropdown-component
     .btn.btn-success.dropdown-toggle{ type: 'button', data: { toggle: 'dropdown' }, aria: { expanded: 'false' } }
       Review as
-    .dropdown-menu.dropdown-menu-right
+    .dropdown-menu.dropdown-menu-left
       %h5.dropdown-header Give a review for...
       - @my_open_reviews.each do |review|
-        = button_tag(type: 'button', class: 'dropdown-item m-2', data: { toggle: 'collapse', target: '#review-form-collapse',
+        = button_tag(type: 'button', class: 'dropdown-item', data: { toggle: 'collapse', target: '#review-form-collapse',
                     review: review.id }, aria: { expanded: 'false', controls: 'review-form-collapse' }) do
           = reviewer_icon_and_text(review: review)
 

--- a/src/api/app/components/add_review_dropdown_component.html.haml
+++ b/src/api/app/components/add_review_dropdown_component.html.haml
@@ -2,11 +2,12 @@
   .btn.btn-success.toggle-review-form{ type: 'button', data: { toggle: 'collapse', target: '#review-form-collapse',
                                        review: @my_open_reviews.first.id, reviewer_icon: reviewer_icon_and_text(review: @my_open_reviews.first) },
                                        aria: { expanded: 'false', controls: 'review-form-collapse' } }
-    Review
+    Review as
+    = @my_open_reviews.first.reviewer
 - else
   .dropdown#add-review-dropdown-component
     .btn.btn-success.dropdown-toggle{ type: 'button', data: { toggle: 'dropdown' }, aria: { expanded: 'false' } }
-      Review
+      Review as
     .dropdown-menu.dropdown-menu-right
       %h5.dropdown-header Give a review for...
       - @my_open_reviews.each do |review|

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -108,9 +108,7 @@ class Webui::RequestController < Webui::WebuiController
                                           diffs: true, action_id: action_id.to_i, cacheonly: 1).first
       @active_action = @bs_request.bs_request_actions.find(action_id)
 
-      @open_reviews = @bs_request.reviews.opened.for_non_staging_projects
-      @accepted_reviews = @bs_request.reviews.accepted.for_non_staging_projects
-      @declined_reviews = @bs_request.reviews.declined.for_non_staging_projects
+      @request_reviews = @bs_request.reviews.for_non_staging_projects
       @open_reviews_for_staging_projects = @bs_request.reviews.opened.for_staging_projects
       @not_full_diff = BsRequest.truncated_diffs?([@action])
       @refresh = @action[:diff_not_cached]

--- a/src/api/app/models/history_element/request_review_added.rb
+++ b/src/api/app/models/history_element/request_review_added.rb
@@ -6,7 +6,7 @@ module HistoryElement
     end
 
     def user_action
-      'added review'
+      'asked for a review'
     end
   end
 end

--- a/src/api/app/models/history_element/review_accepted.rb
+++ b/src/api/app/models/history_element/review_accepted.rb
@@ -5,7 +5,7 @@ module HistoryElement
     end
 
     def user_action
-      'accepted review'
+      'accepted the request'
     end
   end
 end

--- a/src/api/app/views/webui/request/_actions.html.haml
+++ b/src/api/app/views/webui/request/_actions.html.haml
@@ -1,3 +1,4 @@
+-# TODO: drop this partial when `request_show_redesign` feature is rolled out
 - content_for :actions do
   %li.nav-item
     = link_to('#', data: { toggle: 'modal', target: '#add-reviewer-modal' }, class: 'nav-link', title: 'Add a Review') do

--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -3,9 +3,6 @@
   @pagetitle += ": #{@action[:name]}"
   actions_for_diff = [:submit, :delete, :maintenance_incident, :maintenance_release]
 
-- if @can_add_reviews
-  = render partial: 'actions'
-
 .alert.alert-info{ role: 'alert' }
   As part of the
   = succeed ',' do

--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -5,7 +5,6 @@
 
 - if @can_add_reviews
   = render partial: 'actions'
-  = render partial: 'add_reviewer_dialog'
 
 .alert.alert-info{ role: 'alert' }
   As part of the

--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -61,9 +61,7 @@
     .tab-content.p-4#request-tabs-content
       .tab-pane.fade.p-2#conversation{ 'aria-labelledby': 'conversation-tab', role: 'tabpanel' }
         = render partial: 'webui/request/beta_show_tabs/conversation', locals: { bs_request: @bs_request, can_add_reviews: @can_add_reviews,
-                                                                             open_reviews: @open_reviews,
-                                                                             accepted_reviews: @accepted_reviews,
-                                                                             declined_reviews: @declined_reviews,
+                                                                             request_reviews: @request_reviews,
                                                                              open_reviews_for_staging_projects: @open_reviews_for_staging_projects,
                                                                              my_open_reviews: @my_open_reviews,
                                                                              action: @action,

--- a/src/api/app/views/webui/request/beta_show_tabs/_conversation.html.haml
+++ b/src/api/app/views/webui/request/beta_show_tabs/_conversation.html.haml
@@ -10,10 +10,10 @@
     - if accepted_reviews.present? || declined_reviews.present? || open_reviews.present?
       .d-flex.justify-content-between
         %h4
-          Reviews
-        = link_to('#', data: { toggle: 'modal', target: '#add-reviewer-modal' }, title: 'Add a Review') do
+          Reviewers
+        = link_to('#', data: { toggle: 'modal', target: '#add-reviewer-modal' }, title: 'Ask for Review') do
           %i.fas.fa-plus-circle.fa-lg.mr-1
-          %span.nav-item-name Add a Review
+          %span.nav-item-name Ask for a Review
         = render partial: 'add_reviewer_dialog'
       = render AddReviewCollapsibleComponent.new
       .mb-4

--- a/src/api/app/views/webui/request/beta_show_tabs/_conversation.html.haml
+++ b/src/api/app/views/webui/request/beta_show_tabs/_conversation.html.haml
@@ -11,18 +11,18 @@
       .d-flex.justify-content-between
         %h4
           Reviews
-        = render AddReviewDropdownComponent.new(bs_request: bs_request, user: User.session,
-                                                can_add_reviews: can_add_reviews,
-                                                my_open_reviews: my_open_reviews)
+        = link_to('#', data: { toggle: 'modal', target: '#add-reviewer-modal' }, title: 'Add a Review') do
+          %i.fas.fa-plus-circle.fa-lg.mr-1
+          %span.nav-item-name Add a Review
+        = render partial: 'add_reviewer_dialog'
       = render AddReviewCollapsibleComponent.new
       .mb-4
         = render partial: 'webui/request/beta_show_tabs/review_summary', collection: accepted_reviews, as: :review
         = render partial: 'webui/request/beta_show_tabs/review_summary', collection: declined_reviews, as: :review
         = render partial: 'webui/request/beta_show_tabs/review_summary', collection: open_reviews, as: :review
-      = link_to('#', data: { toggle: 'modal', target: '#add-reviewer-modal' }, title: 'Add a Review') do
-        %i.fas.fa-plus-circle.fa-lg.mr-1
-        %span.nav-item-name Add a Review
-      = render partial: 'add_reviewer_dialog'
+      = render AddReviewDropdownComponent.new(bs_request: bs_request, user: User.session,
+                                              can_add_reviews: can_add_reviews,
+                                              my_open_reviews: my_open_reviews)
 
     - open_reviews_for_staging_projects.each do |review|
       .pl-3

--- a/src/api/app/views/webui/request/beta_show_tabs/_conversation.html.haml
+++ b/src/api/app/views/webui/request/beta_show_tabs/_conversation.html.haml
@@ -7,7 +7,7 @@
         %i No description set
 .row
   .col-md-4.order-md-2.order-sm-1.mb-4#side-links
-    - if accepted_reviews.present? || declined_reviews.present? || open_reviews.present?
+    - if request_reviews.present?
       .d-flex.justify-content-between
         %h4
           Reviewers
@@ -16,9 +16,7 @@
         = render partial: 'add_reviewer_dialog'
       = render AddReviewCollapsibleComponent.new
       .mb-4
-        = render partial: 'webui/request/beta_show_tabs/review_summary', collection: accepted_reviews, as: :review
-        = render partial: 'webui/request/beta_show_tabs/review_summary', collection: declined_reviews, as: :review
-        = render partial: 'webui/request/beta_show_tabs/review_summary', collection: open_reviews, as: :review
+        = render partial: 'webui/request/beta_show_tabs/review_summary', collection: request_reviews, as: :review
       = render AddReviewDropdownComponent.new(bs_request: bs_request, user: User.session,
                                               can_add_reviews: can_add_reviews,
                                               my_open_reviews: my_open_reviews)

--- a/src/api/app/views/webui/request/beta_show_tabs/_conversation.html.haml
+++ b/src/api/app/views/webui/request/beta_show_tabs/_conversation.html.haml
@@ -13,7 +13,6 @@
           Reviewers
         %button.btn.btn-link{ data: { toggle: 'modal', target: '#add-reviewer-modal' }, title: 'Ask for a Review' }
           %i.fas.fa-plus-circle.fa-lg.mr-1.text-secondary
-          %span.nav-item-name Ask for a Review
         = render partial: 'add_reviewer_dialog'
       = render AddReviewCollapsibleComponent.new
       .mb-4

--- a/src/api/app/views/webui/request/beta_show_tabs/_conversation.html.haml
+++ b/src/api/app/views/webui/request/beta_show_tabs/_conversation.html.haml
@@ -19,6 +19,10 @@
         = render partial: 'webui/request/beta_show_tabs/review_summary', collection: accepted_reviews, as: :review
         = render partial: 'webui/request/beta_show_tabs/review_summary', collection: declined_reviews, as: :review
         = render partial: 'webui/request/beta_show_tabs/review_summary', collection: open_reviews, as: :review
+      = link_to('#', data: { toggle: 'modal', target: '#add-reviewer-modal' }, title: 'Add a Review') do
+        %i.fas.fa-plus-circle.fa-lg.mr-1
+        %span.nav-item-name Add a Review
+      = render partial: 'add_reviewer_dialog'
 
     - open_reviews_for_staging_projects.each do |review|
       .pl-3

--- a/src/api/app/views/webui/request/beta_show_tabs/_conversation.html.haml
+++ b/src/api/app/views/webui/request/beta_show_tabs/_conversation.html.haml
@@ -11,8 +11,8 @@
       .d-flex.justify-content-between
         %h4
           Reviewers
-        = link_to('#', data: { toggle: 'modal', target: '#add-reviewer-modal' }, title: 'Ask for Review') do
-          %i.fas.fa-plus-circle.fa-lg.mr-1
+        %button.btn.btn-link{ data: { toggle: 'modal', target: '#add-reviewer-modal' }, title: 'Ask for a Review' }
+          %i.fas.fa-plus-circle.fa-lg.mr-1.text-secondary
           %span.nav-item-name Ask for a Review
         = render partial: 'add_reviewer_dialog'
       = render AddReviewCollapsibleComponent.new


### PR DESCRIPTION
Moving the `Add a request` button within the conversation page, closer to the side link area related to the review section.

Some refactoring included:
- do not use a link implementation for an action button, use a proper button instead
- do not group reviews by type (accepted|open|declined), just list them by timeline
 
Some rewording included, such as:
- `add review` --> `ask for a review`
- `accepted review` --> `accepted the request`
- and more (see pictures)

Note: the `_actions.html.haml` has been marked `TODO - to drop` because after the roll out of the beta feature redesign, it will be no longer needed.


Before:
![conversation-reviewers-side-before](https://user-images.githubusercontent.com/7080830/195874069-a129eb6c-9d60-45d2-aa1a-8a7cc07a4ff8.png)

After:
![conversation-reviewers-side-after](https://user-images.githubusercontent.com/7080830/195874092-441b1e7a-0d20-4d5c-9e20-0930eb551387.png)


Fixes https://trello.com/c/p313TsCI