### PR TITLE
Add new tab RPM Lint in request page

### DIFF
--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -54,6 +54,9 @@
         %li.nav-item.scrollable-tab-link{ role: 'presentation' }
           = link_to('Build Results', '#build-results', class: 'nav-link text-nowrap', 'aria-controls': 'build-results',
                     'aria-selected': 'false', 'data-toggle': 'tab', role: 'tab')
+        %li.nav-item.scrollable-tab-link{ role: 'presentation' }
+          = link_to('RPM Lint', '#rpm-lint-result', class: 'nav-link text-nowrap', 'aria-controls': 'rpm-lint-result',
+                    'aria-selected': 'false', 'data-toggle': 'tab', role: 'tab')
       - if @action[:type].in?(actions_for_diff)
         %li.nav-item.scrollable-tab-link{ role: 'presentation', 'data-request-number': @bs_request.number, 'data-request-action-id': @action[:id] }
           = link_to('Changes', '#changes', class: 'nav-link text-nowrap', 'aria-controls': 'changes',
@@ -75,6 +78,10 @@
       - if @action[:sprj] || @action[:spkg]
         .tab-pane.fade.p-2#build-results{ 'aria-labelledby': 'build-results-tab', role: 'tabpanel' }
           = render partial: 'webui/request/beta_show_tabs/build_results', locals: { project: @action[:sprj], package: @action[:spkg] }
+        .tab-pane.fade.p-2#rpm-lint-result{ 'aria-labelledby': 'rpm-lint-result-tab', role: 'tabpanel' }
+          = render partial: 'webui/request/beta_show_tabs/rpm_lint_result', locals: { project: @action[:sprj],
+                                                                                      package: @action[:spkg],
+                                                                                      action: @action }
       - if @action[:type].in?(actions_for_diff)
         .tab-pane.fade.p-2#changes{ 'aria-labelledby': 'changes-tab', role: 'tabpanel' }
           = render partial: 'webui/request/beta_show_tabs/changes', locals: { bs_request: @bs_request, action: @action, refresh: @refresh }

--- a/src/api/app/views/webui/request/beta_show_tabs/_rpm_lint_result.html.haml
+++ b/src/api/app/views/webui/request/beta_show_tabs/_rpm_lint_result.html.haml
@@ -1,0 +1,7 @@
+%p
+  The RPM Lint results aren't here yet. For now, you can see them on the request's
+  = link_to('source package', package_show_path(project, package))
+  page. We're working on having them here in the future.
+
+%p
+  %i The OBS team


### PR DESCRIPTION
This is the first of a series of PRs which implement the Build Results and the RPM Lint sections in the redesigned request page.

In this case, the sections are split into two independent tabs. They don't have actual content yet.


**How to test?**

- Enable the beta feature `request_show_redesing` for your user.
- Open a request page.
- Check that the two tabs are there and you can switch tabs without problems.