### PR TITLE
Remove use of CSS class details-with-coderay

### DIFF
--- a/src/api/app/assets/javascripts/webui/packages.js
+++ b/src/api/app/assets/javascripts/webui/packages.js
@@ -16,13 +16,13 @@ $(function ($) {
 
   $('body').on('click', '.expand-diffs', function () {
     var forPackage = $(this).data('package');
-    var details = $('details.card.details-with-coderay[data-package="' + forPackage + '"]');
+    var details = $('details.card[data-package="' + forPackage + '"]');
     details.attr('open', 'open');
   });
 
   $('body').on('click', '.collapse-diffs', function () {
     var forPackage = $(this).data('package');
-    var details = $('details.card.details-with-coderay[data-package="' + forPackage + '"]');
+    var details = $('details.card[data-package="' + forPackage + '"]');
     details.attr('open', null);
   });
 });

--- a/src/api/app/views/webui/package/_revision_diff_detail.html.haml
+++ b/src/api/app/views/webui/package/_revision_diff_detail.html.haml
@@ -3,7 +3,7 @@
   = render partial: 'webui/package/revision_diff_detail_buttons',
   locals: { file_view_path: file_view_path, filename: filename, index: index, last: last, has_content: diff_content.present?, linkinfo: linkinfo }
   - if diff_content.present?
-    %details.card.details-with-coderay{ open: expand_diff?(filename, file['state']), id: "revision_details_#{index}", data: { package: package } }
+    %details.card{ open: expand_diff?(filename, file['state']), id: "revision_details_#{index}", data: { package: package } }
       %summary.card-header.py-3
         .diff-card-header
           = calculate_filename(filename, file)


### PR DESCRIPTION
The definition of the CSS class was removed in commit: 433b7d74a5311269281e524f33d10f52beb5b712

The use of this class should have been also removed in that commit.