### PR TITLE
Move review request action button closer to context area

### DIFF
--- a/src/api/app/views/webui/request/_actions.html.haml
+++ b/src/api/app/views/webui/request/_actions.html.haml
@@ -1,3 +1,4 @@
+-# TODO: drop this partial when `request_show_redesign` feature is rolled out
 - content_for :actions do
   %li.nav-item
     = link_to('#', data: { toggle: 'modal', target: '#add-reviewer-modal' }, class: 'nav-link', title: 'Add a Review') do

--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -3,10 +3,6 @@
   @pagetitle += ": #{@action[:name]}"
   actions_for_diff = [:submit, :delete, :maintenance_incident, :maintenance_release]
 
-- if @can_add_reviews
-  = render partial: 'actions'
-  = render partial: 'add_reviewer_dialog'
-
 .alert.alert-info{ role: 'alert' }
   As part of the
   = succeed ',' do

--- a/src/api/app/views/webui/request/beta_show_tabs/_conversation.html.haml
+++ b/src/api/app/views/webui/request/beta_show_tabs/_conversation.html.haml
@@ -19,6 +19,10 @@
         = render partial: 'webui/request/beta_show_tabs/review_summary', collection: accepted_reviews, as: :review
         = render partial: 'webui/request/beta_show_tabs/review_summary', collection: declined_reviews, as: :review
         = render partial: 'webui/request/beta_show_tabs/review_summary', collection: open_reviews, as: :review
+      = link_to('#', data: { toggle: 'modal', target: '#add-reviewer-modal' }, title: 'Add a Review') do
+        %i.fas.fa-plus-circle.fa-lg.mr-1
+        %span.nav-item-name Add a Review
+      = render partial: 'add_reviewer_dialog'
 
     - open_reviews_for_staging_projects.each do |review|
       .pl-3


### PR DESCRIPTION
Moving the `Add a request` button within the conversation page, closer to the side link area related to the review section.

Note: the `_actions.html.haml` has been marked `TODO - to drop` because after the roll out of the beta feature redesign, it will be no longer needed.

## After
![feature-after](https://user-images.githubusercontent.com/7080830/196173881-0336b17d-9dc0-4ee6-ac66-61318c1d6d80.png)



Fixes https://trello.com/c/p313TsCI