### PR TITLE
Refactoring "review" side section

### DIFF
--- a/src/api/app/components/add_review_dropdown_component.html.haml
+++ b/src/api/app/components/add_review_dropdown_component.html.haml
@@ -7,10 +7,10 @@
   .dropdown#add-review-dropdown-component
     .btn.btn-success.dropdown-toggle{ type: 'button', data: { toggle: 'dropdown' }, aria: { expanded: 'false' } }
       Review
-    .dropdown-menu.dropdown-menu-right
+    .dropdown-menu.dropdown-menu-left
       %h5.dropdown-header Give a review for...
       - @my_open_reviews.each do |review|
-        = button_tag(type: 'button', class: 'dropdown-item m-2', data: { toggle: 'collapse', target: '#review-form-collapse',
+        = button_tag(type: 'button', class: 'dropdown-item', data: { toggle: 'collapse', target: '#review-form-collapse',
                     review: review.id }, aria: { expanded: 'false', controls: 'review-form-collapse' }) do
           = reviewer_icon_and_text(review: review)
 

--- a/src/api/app/components/bs_request_history_element_component.html.haml
+++ b/src/api/app/components/bs_request_history_element_component.html.haml
@@ -6,6 +6,11 @@
     - if element.instance_of?(HistoryElement::RequestSuperseded)
       superseded this request with
       = link_to("request ##{element.description_extension}", request_show_path(element.description_extension))
+    - elsif element.instance_of?(HistoryElement::RequestReviewAdded)
+      = element.user_action_prefix
+      %strong
+        = element.action_target
+      = element.user_action_suffix
     - else
       = element.user_action
     = link_to("#status-history-#{element.id}", title: l(element.created_at.utc), name: "status-history-#{element.id}") do

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -28,9 +28,7 @@ class Webui::RequestController < Webui::WebuiController
                                           diffs: true, action_id: action_id.to_i, cacheonly: 1).first
       @active_action = @bs_request.bs_request_actions.find(action_id)
 
-      @open_reviews = @bs_request.reviews.opened.for_non_staging_projects
-      @accepted_reviews = @bs_request.reviews.accepted.for_non_staging_projects
-      @declined_reviews = @bs_request.reviews.declined.for_non_staging_projects
+      @request_reviews = @bs_request.reviews.for_non_staging_projects
       @open_reviews_for_staging_projects = @bs_request.reviews.opened.for_staging_projects
       @refresh = @action[:diff_not_cached]
 

--- a/src/api/app/models/history_element/request_review_added.rb
+++ b/src/api/app/models/history_element/request_review_added.rb
@@ -1,12 +1,28 @@
 module HistoryElement
   class RequestReviewAdded < HistoryElement::Request
-    # self.description_extension is review id
     def description
       'Request got a new review request'
     end
 
     def user_action
-      'added a reviewer'
+      "#{user_action_prefix} #{action_target} #{user_action_suffix}"
+    end
+
+    def user_action_prefix
+      'added'
+    end
+
+    def action_target
+      review.reviewed_by
+    end
+
+    def user_action_suffix
+      'as a reviewer'
+    end
+
+    # self.description_extension is review id
+    def review
+      ::Review.find(description_extension)
     end
   end
 end

--- a/src/api/app/models/history_element/request_review_added.rb
+++ b/src/api/app/models/history_element/request_review_added.rb
@@ -6,7 +6,7 @@ module HistoryElement
     end
 
     def user_action
-      'added review'
+      'added a reviewer'
     end
   end
 end

--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -76,8 +76,7 @@
       .tab-pane.fade.p-2#conversation{ 'aria-labelledby': 'conversation-tab', role: 'tabpanel' }
         = render partial: 'webui/request/beta_show_tabs/conversation',
             locals: { bs_request: @bs_request, can_add_reviews: @can_add_reviews,
-                      open_reviews: @open_reviews, accepted_reviews: @accepted_reviews,
-                      declined_reviews: @declined_reviews, open_reviews_for_staging_projects: @open_reviews_for_staging_projects,
+                      request_reviews: @request_reviews, open_reviews_for_staging_projects: @open_reviews_for_staging_projects,
                       my_open_reviews: @my_open_reviews, package_maintainers: @package_maintainers, action: @action,
                       is_target_maintainer: @is_target_maintainer, is_author: @is_author,
                       project_maintainers: @project_maintainers, show_project_maintainer_hint: @show_project_maintainer_hint }

--- a/src/api/app/views/webui/request/beta_show_tabs/_ask_for_review.html.haml
+++ b/src/api/app/views/webui/request/beta_show_tabs/_ask_for_review.html.haml
@@ -1,0 +1,5 @@
+- if can_add_reviews
+  %button.btn.btn-outline-secondary.btn-sm{ data: { toggle: 'modal', target: '#add-reviewer-modal' }, title: 'Add Reviewer' }
+    %i.fas.fa-plus-circle.mr-1.text-outline-secondary
+    %span.nav-item-name Add Reviewer
+  = render partial: 'add_reviewer_dialog'

--- a/src/api/app/views/webui/request/beta_show_tabs/_conversation.html.haml
+++ b/src/api/app/views/webui/request/beta_show_tabs/_conversation.html.haml
@@ -1,18 +1,17 @@
 .row
   .col-md-12
-    .mb-4#description-text
-      - if bs_request.description.present?
-        = render partial: 'webui/shared/collapsible_text', locals: { text: bs_request.description }
-      - else
-        %i No description set
+    .d-flex.justify-content-between.mb-4
+      #description-text
+        - if bs_request.description.present?
+          = render partial: 'webui/shared/collapsible_text', locals: { text: bs_request.description }
+        - else
+          %i No description set
 .row
   = render partial: 'webui/request/beta_show_tabs/conversation_aside',
            locals: { bs_request: bs_request,
              can_add_reviews: can_add_reviews,
              my_open_reviews: my_open_reviews,
-             accepted_reviews: accepted_reviews,
-             declined_reviews: declined_reviews,
-             open_reviews: open_reviews,
+             request_reviews: request_reviews,
              open_reviews_for_staging_projects: open_reviews_for_staging_projects,
              package_maintainers: package_maintainers,
              project_maintainers: project_maintainers,

--- a/src/api/app/views/webui/request/beta_show_tabs/_conversation_aside.html.haml
+++ b/src/api/app/views/webui/request/beta_show_tabs/_conversation_aside.html.haml
@@ -1,23 +1,18 @@
 .col-md-4.order-md-2.order-sm-1.mb-4#side-links
   -# REVIEWERS
-  - if accepted_reviews.present? || declined_reviews.present? || open_reviews.present?
-    .d-flex.justify-content-between
-      %h6
-        Reviews
-      = render AddReviewDropdownComponent.new(bs_request: bs_request, user: User.session,
+  - if request_reviews.present?
+    .mt-4
+      .text-right
+        = render AddReviewDropdownComponent.new(bs_request: bs_request, user: User.session,
                                               can_add_reviews: can_add_reviews,
                                               my_open_reviews: my_open_reviews)
-    = render AddReviewCollapsibleComponent.new
-    .mb-4
-      = render partial: 'webui/request/beta_show_tabs/review_summary', collection: accepted_reviews, as: :review
-      = render partial: 'webui/request/beta_show_tabs/review_summary', collection: declined_reviews, as: :review
-      = render partial: 'webui/request/beta_show_tabs/review_summary', collection: open_reviews, as: :review
-
-  - if can_add_reviews
-    = link_to('#', data: { toggle: 'modal', target: '#add-reviewer-modal' }, title: 'Add a Review', class: 'ml-3') do
-      %i.fas.fa-plus-circle.fa-lg.mr-1
-      %span.nav-item-name Add a Review
-    = render partial: 'add_reviewer_dialog'
+      .mb-2
+        %h6
+          Reviewers
+      = render AddReviewCollapsibleComponent.new
+      .mb-4
+        = render partial: 'webui/request/beta_show_tabs/review_summary', collection: request_reviews, as: :review
+  = render partial: 'webui/request/beta_show_tabs/ask_for_review', locals: { can_add_reviews: can_add_reviews }
 
   - open_reviews_for_staging_projects.each do |review|
     .pl-3


### PR DESCRIPTION
Refactoring:
- do not use a link implementation for an action button, use a proper button instead
- do not group reviews by type (accepted|open|declined), just list them by timeline
 
Rewording:
- `add review` --> `add reviewer`

Additional changes:
- show _who was added_ as a reviewer in the history


## After
![image](https://user-images.githubusercontent.com/7080830/203989981-0d2a5a4f-7933-4c10-995e-27babae46a53.png)