### PR TITLE
Prepend file index to the line link

### DIFF
--- a/src/api/app/helpers/application_helper.rb
+++ b/src/api/app/helpers/application_helper.rb
@@ -1,6 +1,6 @@
 # Methods added to this helper will be available to all templates in the application.
 module ApplicationHelper
-  def render_diff(content)
-    sanitize(CodeRay.scan(content, :diff).div(line_numbers: :inline, css: :class))
+  def render_diff(content, file_index:)
+    sanitize(CodeRay.scan(content, :diff).div(css: :class, line_numbers: :inline, line_number_anchors: "diff_#{file_index}_n"))
   end
 end

--- a/src/api/app/views/webui/package/_revision_diff_detail.html.haml
+++ b/src/api/app/views/webui/package/_revision_diff_detail.html.haml
@@ -8,7 +8,7 @@
         .diff-card-header
           = calculate_filename(filename, file)
           %span.badge{ class: "badge-#{file['state']}" }= file['state'].capitalize
-      = render_diff(diff_content)
+      = render_diff(diff_content, file_index: index)
   - else
     .card{ id: "revision_details_#{index}" }
       .card-header

--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -76,3 +76,16 @@
           = render partial: 'webui/request/beta_show_tabs/changes', locals: { bs_request: @bs_request, action: @action, refresh: @refresh }
         .tab-pane.fade.p-2#mentioned-issues{ 'aria-labelledby': 'mentioned-issues-tab', role: 'tabpanel' }
           = render partial: 'webui/request/beta_show_tabs/mentioned_issues'
+
+- content_for :ready_function do
+  :plain
+    var anchor = document.location.hash;
+    var result = [];
+    if (result = anchor.match(/^#diff_([\d]+)_n\d+$/)) {
+      var file_index = result[1];
+      $('.nav-tabs:not(.disable-link-generation) .nav-link[href="#changes"]').tab('show');
+
+      $('#revision_details_' + file_index).attr('open', 'open');
+
+      document.location.hash = anchor;
+    }


### PR DESCRIPTION
Allow to share a URL referring to a line of a file of the Changes section in requests.

### For reviewers

Example of a link pointing to a line of a file in a request, in the [review-app](https://obs-reviewlab.opensuse.org/eduardoj-request_workflow_redesignsharable_urls_for_a_line/request/show/1#diff_0_n4).