### PR TITLE
[api] fix incomplete releases via token

### DIFF
--- a/src/api/app/controllers/concerns/rescue_authorization_handler.rb
+++ b/src/api/app/controllers/concerns/rescue_authorization_handler.rb
@@ -53,6 +53,8 @@ module RescueAuthorizationHandler
         'Please login to access the resource'
       when :request_state_change
         "Request #{exception.record.number} would not be acceptable by you"
+      when :unsufficient_permission_on_release_target
+        "You don't have permission to release into project #{exception.record.name}."
       else
         "Sorry, you are not authorized to #{action_for_exception(exception)} this #{ActiveSupport::Inflector.underscore(exception.record.class.to_s).humanize(capitalize: false)}."
       end

--- a/src/api/app/models/token/release.rb
+++ b/src/api/app/models/token/release.rb
@@ -10,6 +10,7 @@ class Token::Release < Token
     manual_release_targets = package_to_release.project.release_targets.where(trigger: 'manual')
     raise NoReleaseTargetFound, "#{package_to_release.project} has no release targets that are triggered manually" unless manual_release_targets.any?
 
+    # releasing ...
     manual_release_targets.each do |release_target|
       opts = { filter_source_repository: release_target.repository,
                manual: true,

--- a/src/api/app/policies/token/release_policy.rb
+++ b/src/api/app/policies/token/release_policy.rb
@@ -1,7 +1,19 @@
 class Token::ReleasePolicy < TokenPolicy
   def trigger?
     return false unless user.is_active?
+    return false unless sufficient_permission_on_all_release_targets?
 
     PackagePolicy.new(user, record.object_to_authorize).update?
+  end
+
+  private
+
+  # we need to check all release targets upfront to avoid incomplete releases
+  def sufficient_permission_on_all_release_targets?
+    record.object_to_authorize.project.release_targets.where(trigger: 'manual').each do |release_target|
+      unless ProjectPolicy.new(user, release_target.target_repository.project).update?
+        raise Pundit::NotAuthorizedError, query: :trigger?, record: release_target.target_repository.project, reason: :unsufficient_permission_on_release_target
+      end
+    end
   end
 end

--- a/src/api/spec/controllers/trigger_controller_spec.rb
+++ b/src/api/spec/controllers/trigger_controller_spec.rb
@@ -92,6 +92,13 @@ RSpec.describe TriggerController, vcr: true do
       let(:other_user) { create(:confirmed_user, login: 'mrfluffy') }
       let(:token) { Token::Release.create(executor: other_user, package: package) }
       let!(:relationship_package_user) { create(:relationship_package_user, user: other_user, package: package) }
+      let(:expected_response_body) do
+        <<~XML
+          <status code="trigger_project_not_authorized">
+            <summary>You don't have permission to release into project target_project.</summary>
+          </status>
+        XML
+      end
 
       before do
         release_target
@@ -99,7 +106,7 @@ RSpec.describe TriggerController, vcr: true do
       end
 
       it { expect(response).to have_http_status(:forbidden) }
-      it { expect(response.body).to include("No permission to modify project 'target_project' for user 'mrfluffy'") }
+      it { expect(response.body).to include(expected_response_body) }
     end
 
     context 'when there are no release targets' do


### PR DESCRIPTION
It failed with an absurd error in the middle of a release when another
releasetarget lacked the permissions.

The `release_package` method of the `MaintenanceHelper` mixin checks
for permission on the given release target/project. But to avoid
incomplete releases, we need to check all release targets of the
collection upfront, before we start to release them one by one.