### PR TITLE
Remove the user parameter from the documentation

### DIFF
--- a/src/api/public/apidocs-new/paths/source_project_name_cmd_freezelink.yaml
+++ b/src/api/public/apidocs-new/paths/source_project_name_cmd_freezelink.yaml
@@ -7,12 +7,6 @@ post:
   parameters:
     - $ref: '../components/parameters/project_name.yaml'
     - in: query
-      name: user
-      schema:
-        type: string
-      description: A username
-      example: Admin
-    - in: query
       name: comment
       schema:
         type: string

--- a/src/api/public/apidocs-new/paths/source_project_name_package_name_cmd_copy.yaml
+++ b/src/api/public/apidocs-new/paths/source_project_name_package_name_cmd_copy.yaml
@@ -79,12 +79,6 @@ post:
     - in: query
       name: comment
       description: Comment for the new revision.
-    - in: query
-      name: user
-      schema:
-        type: string
-      description: Set the user who triggers the services.
-      example: Iggy
   responses:
     '200':
       description: OK

--- a/src/api/public/apidocs-new/paths/source_project_name_package_name_cmd_mergeservice.yaml
+++ b/src/api/public/apidocs-new/paths/source_project_name_package_name_cmd_mergeservice.yaml
@@ -46,12 +46,6 @@ post:
         type: string
       description: Set a comment.
       example: Merge services.
-    - in: query
-      name: user
-      schema:
-        type: string
-      description: Set the user who merge the services.
-      example: Iggy
   responses:
     '200':
       description: Revision of the merge of the service file.

--- a/src/api/public/apidocs-new/paths/source_project_name_package_name_cmd_undelete.yaml
+++ b/src/api/public/apidocs-new/paths/source_project_name_package_name_cmd_undelete.yaml
@@ -26,12 +26,6 @@ post:
           value: 1664912989
         Same as Delete Time:
           value: 1
-    - in: query
-      name: user
-      schema:
-        type: string
-      description: Set the user of the undelete operation.
-      example: Iggy
   responses:
     '200':
       $ref: '../components/responses/succeeded.yaml'


### PR DESCRIPTION
The `user` parameter passed to the backend is always the authorized user in the frontend.

There is no way of changing the `user` parameter for the backend endpoints.