### PR TITLE
Isolate and slightly refactor build results' code

### DIFF
--- a/src/api/app/assets/javascripts/webui/application.js
+++ b/src/api/app/assets/javascripts/webui/application.js
@@ -57,5 +57,6 @@
 //= require webui/long_text.js
 //= require webui/new_watchlist/collapsible_tooltip.js
 //= require webui/request_show_redesign/add_review.js
+//= require webui/request_show_redesign/build_results.js
 //= require webui/delete_confirmation_dialog.js
 //= require webui/nav_tabs.js

--- a/src/api/app/assets/javascripts/webui/buildresult.js
+++ b/src/api/app/assets/javascripts/webui/buildresult.js
@@ -1,3 +1,7 @@
+// TODO: replace with the content of
+// app/assets/javascripts/webui/request_show_redesign/build_results.js
+// after the rollout of 'request_show_redesign'.
+
 function updateRpmlintResult(index) { // jshint ignore:line
   $('#rpm'+index+'-reload').addClass('fa-spin');
   $.ajax({

--- a/src/api/app/assets/javascripts/webui/request_show_redesign/build_results.js
+++ b/src/api/app/assets/javascripts/webui/request_show_redesign/build_results.js
@@ -1,0 +1,55 @@
+// TODO: rename without "Beta" after the rollout of 'request_show_redesign'.
+function updateBuildResultBeta() { // jshint ignore:line
+  var collapsedPackages = [];
+  var collapsedRepositories = {};
+  $('.result div.collapse:not(.show)').map(function(_index, domElement) {
+    var main = $(domElement).data('main') ? $(domElement).data('main') : 'project';
+    if (collapsedRepositories[main] === undefined) { collapsedRepositories[main] = []; }
+    if ($(domElement).data('repository') === undefined) {
+      collapsedPackages.push(main);
+    }
+    else {
+      collapsedRepositories[main].push($(domElement).data('repository'));
+    }
+  });
+
+  var ajaxDataShow = $('.build-results-content').data();
+  // show_all comes from the buildstatus partial
+  ajaxDataShow.show_all = $('#show_all').is(':checked'); // jshint ignore:line
+  ajaxDataShow.collapsedPackages = collapsedPackages;
+  ajaxDataShow.collapsedRepositories = collapsedRepositories;
+
+  var buildResultsUrl = $('.build-results-content .build-refresh').data('build-results-url');
+
+  $('#build-reload').addClass('fa-spin');
+  $.ajax({
+    url: buildResultsUrl,
+    data: ajaxDataShow,
+    success: function(data) {
+      $('.build-results-content .result').html(data);
+    },
+    error: function() {
+      $('.build-results-content .result').html('<p>No build results available</p>');
+    },
+    complete: function() {
+      $('#build-reload').removeClass('fa-spin');
+      initializePopovers('[data-toggle="popover"]'); // jshint ignore:line
+    }
+  });
+}
+
+function toggleBuildInfoBeta() { // jshint ignore:line
+  $('.toggle-build-info').on('click', function(){
+    var replaceTitle = $(this).attr('title') === 'Click to keep it open' ? 'Click to close it' : 'Click to keep it open';
+    var infoContainer = $(this).parents('.toggle-build-info-parent').next();
+    $(infoContainer).toggleClass('collapsed');
+    $(infoContainer).removeClass('hover');
+    $('.toggle-build-info').attr('title', replaceTitle);
+  });
+  $('.toggle-build-info').on('mouseover', function(){
+    $(this).parents('.toggle-build-info-parent').next().addClass('hover');
+  });
+  $('.toggle-build-info').on('mouseout', function(){
+    $(this).parents('.toggle-build-info-parent').next().removeClass('hover');
+  });
+}

--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -542,11 +542,18 @@ class Webui::PackageController < Webui::WebuiController
       show_all = params[:show_all].to_s.casecmp?('true')
       @index = params[:index]
       @buildresults = @package.buildresult(@project, show_all)
-      render partial: 'buildstatus', locals: { buildresults: @buildresults,
-                                               index: @index,
-                                               project: @project,
-                                               collapsed_packages: params.fetch(:collapsedPackages, []),
-                                               collapsed_repositories: params.fetch(:collapsedRepositories, {}) }
+
+      partial_name = if Flipper.enabled?(:request_show_redesign, User.session)
+                       'webui/request/beta_show_tabs/build_status'
+                     else
+                       'buildstatus'
+                     end
+
+      render partial: partial_name, locals: { buildresults: @buildresults,
+                                              index: @index,
+                                              project: @project,
+                                              collapsed_packages: params.fetch(:collapsedPackages, []),
+                                              collapsed_repositories: params.fetch(:collapsedRepositories, {}) }
     else
       render partial: 'no_repositories', locals: { project: @project }
     end

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -115,6 +115,10 @@ class Webui::RequestController < Webui::WebuiController
       @not_full_diff = BsRequest.truncated_diffs?([@action])
       @refresh = @action[:diff_not_cached]
 
+      # Handling build results
+      @building_package = building_package
+      @building_project = @bs_request.staged_request? ? @bs_request.staging_project : @building_package.project
+
       if @refresh
         bs_request_action = BsRequestAction.find(@action[:id])
         job = Delayed::Job.where("handler LIKE '%job_class: BsRequestActionWebuiInfosJob%#{bs_request_action.to_global_id.uri}%'").count
@@ -430,5 +434,13 @@ class Webui::RequestController < Webui::WebuiController
       show_project_maintainer_hint: @show_project_maintainer_hint,
       actions: @actions
     }
+  end
+
+  def building_package
+    @building_package ||= Package.get_by_project_and_name(@active_action.source_project,
+                                                          @active_action.source_package,
+                                                          use_source: false,
+                                                          follow_multibuild: true,
+                                                          follow_project_links: true)
   end
 end

--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -1008,6 +1008,10 @@ class BsRequest < ApplicationRecord
     target_project_objects.pluck(:required_checks).flatten.uniq
   end
 
+  def staged_request?
+    !staging_project_id.nil?
+  end
+
   private
 
   # returns true if we have reached a state that we can't get out anymore

--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -73,11 +73,13 @@
                                                                              is_target_maintainer: @is_target_maintainer, is_author: @is_author }
       - if @action[:sprj] || @action[:spkg]
         .tab-pane.fade.p-2#build-results{ 'aria-labelledby': 'build-results-tab', role: 'tabpanel' }
-          = render partial: 'webui/request/beta_show_tabs/build_results', locals: { project: @action[:sprj], package: @action[:spkg] }
+          = render partial: 'webui/request/beta_show_tabs/build_results', locals: { project: @building_project,
+                                                                                    package: @building_package,
+                                                                                    bs_request: @bs_request }
         .tab-pane.fade.p-2#rpm-lint-result{ 'aria-labelledby': 'rpm-lint-result-tab', role: 'tabpanel' }
-          = render partial: 'webui/request/beta_show_tabs/rpm_lint_result', locals: { project: @action[:sprj],
-                                                                                      package: @action[:spkg],
-                                                                                      action: @action }
+          = render partial: 'webui/request/beta_show_tabs/rpm_lint_result', locals: { project: @building_project,
+                                                                                      package: @building_package,
+                                                                                      bs_request: @bs_request }
       - if @action[:type].in?(actions_for_diff)
         .tab-pane.fade.p-2#changes{ 'aria-labelledby': 'changes-tab', role: 'tabpanel' }
           = render partial: 'webui/request/beta_show_tabs/changes', locals: { bs_request: @bs_request, action: @action, refresh: @refresh }

--- a/src/api/app/views/webui/request/beta_show_tabs/_build_results.html.haml
+++ b/src/api/app/views/webui/request/beta_show_tabs/_build_results.html.haml
@@ -1,7 +1,30 @@
-%p
-  The build results aren't here yet. For now, you can see them on the request's
-  = link_to('source package', package_show_path(project, package))
-  page. We're working on having them here in the future.
+:ruby
+  buildable = package || project
 
-%p
-  %i The OBS team
+- if buildable
+  :ruby
+    ajax_data = {}
+    ajax_data['project'] = h(project) if project
+    ajax_data['package'] = h(package) if package
+
+  .build-results-content{ data: ajax_data }
+    .d-flex.justify-content-end
+      .btn.btn-outline-primary.build-refresh{ onclick: 'updateBuildResultBeta()',
+                                              accesskey: 'r', title: 'Refresh Build Results',
+                                              data: { build_results_url: package_buildresult_path } }
+        Refresh
+        %i.fas.fa-sync-alt{ id: 'build-reload' }
+    -# For a request staged in a staging project, we display the Build Results / RPM Lint from the staging project instead
+    - if bs_request.staged_request?
+      %p.font-italic
+        From staging project
+        = link_to(project, project_show_path(project))
+    .result
+
+  :javascript
+    updateBuildResultBeta();
+
+- else
+  .build-results-content
+    .result
+      %i No build results available

--- a/src/api/app/views/webui/request/beta_show_tabs/_build_status.html.haml
+++ b/src/api/app/views/webui/request/beta_show_tabs/_build_status.html.haml
@@ -1,0 +1,67 @@
+- unless buildresults.excluded_counter.zero? && !buildresults.show_all
+  .mt-3.custom-control-checkbox
+    = check_box_tag('show_all', true, buildresults.show_all, class: 'custom-control-input d-none',
+                    onchange: 'updateBuildResultBeta()')
+    - label_message = buildresults.excluded_counter.zero? ? 'Hide' : "Show #{buildresults.excluded_counter}"
+    = label_tag 'show_all' do
+      %u.custom-label #{label_message} excluded/disabled results
+
+- buildresults.results.each_pair do |package, results|
+  :ruby
+    package_name = package.tr('.:', '_')
+    expanded = collapsed_packages.exclude?(package_name)
+  %h5.d-flex.flex-row.text-primary.mt-3.mb-3
+    = package
+    - if buildresults.results.count > 1
+      = collapse_link(expanded, package_name)
+  .collapse#package-buildstatus{ class: "collapse-#{package_name}#{expanded ? ' show' : ''}", data: { main: package_name } }
+    - if results.present?
+      - previous_repo = nil
+      - results.each do |result|
+        :ruby
+          repository_name = result.repository.tr('.', '_')
+          expanded = repository_expanded?(collapsed_repositories, repository_name, package_name)
+        - if result.repository != previous_repo
+          .d-flex.flex-row.py-1.bg-light.pl-1.pl-sm-2
+            = link_to(word_break(result.repository, 22),
+              package_binaries_path(project: project, package: package, repository: result.repository),
+              title: "Binaries for #{result.repository}")
+            = collapse_link(expanded, package_name, repository_name)
+
+        .collapse{ class: "collapse-#{package_name}-#{repository_name}#{expanded ? ' show' : ''}",
+                   data: { repository: repository_name, main: package_name } }
+          .d-flex.flex-row.flex-wrap.pt-1
+            .repository-state
+              - if result.is_repository_in_db
+                = repository_status_icon(status: result.state)
+              - else
+                %i.fas.fa-clock.text-warning{ title: 'This result is outdated' }
+              %span.ml-1
+                = result.architecture
+            .build-state.toggle-build-info-parent
+              %i.fa.fa-question-circle.text-info.px-2.pl-lg-1.toggle-build-info{ title: 'Click to keep it open' }
+              = arch_repo_table_cell(result.repository, result.architecture, package, 'code' => result.code, 'details' => result.details)
+            .build-info.mt-1.ml-3.mb-3.mr-3.collapsed
+              .triangle.center
+              .build-info-content
+                %p.py-1= Buildresult.status_description(result.code)
+                %div
+                  - if result.is_repository_in_db
+                    = repository_status_icon(status: result.state)
+                    %span.pl-1= repository_info(result.state)
+                  - else
+                    %i.fas.fa-clock.text-warning
+                    This result is outdated
+                - if result.details
+                  .pt-1.mt-3
+                    %strong{ class: "build-state-#{result.code}" } #{result.code}:
+                    %span.text-word-break-all= result.details
+
+        - previous_repo = result.repository
+    - else
+      All the results have state
+      %strong excluded/disabled
+
+:javascript
+  // TODO: call toggleCollapsibleTooltip() as soon as the new_watchlist fature is rolled out. Changing the classes in the view is also needed.
+  toggleBuildInfoBeta();


### PR DESCRIPTION
Refactor the bare minimum to make Build Results work in the new request redesigned page, in the new Build Results tab. 

Main changes:

- Extract the code of the build results to their own files, to make it independent of the rpm lint code. 
- Remove previously existing _Build Results_ and _RPM Lint_ tabs.
- Adapt JavaScript accordingly.
- Stop using `index` to identify the different actions in one request.
 
 This is how it looks so far: 
 
![Screenshot 2022-10-19 at 11-03-56 Open Build Service](https://user-images.githubusercontent.com/2581944/196647270-f7881687-0005-4be1-8505-cff05ee1586d.png)

`codeclimate` complains about the long `RequestController#show` action, we are ignoring it during the implementation of `request_show_redesign`.

**How to test?**

I'd compare each case with and without the feature flag enabled.

Check different cases:
- When the request contains multiple actions (make sure the source project has working repositories set). Switch between actions. Example [here](https://obs-reviewlab.opensuse.org/saraycp-redesign_build_results_i/request/show/9/request_action/9#tab-pane-build-results).
- When the source project has no repositories set. Example [here](https://obs-reviewlab.opensuse.org/saraycp-redesign_build_results_i/request/show/7#tab-pane-build-results).
- When there are no build results. Example [here](https://obs-reviewlab.opensuse.org/saraycp-redesign_build_results_i/request/show/2#tab-pane-build-results).
- When all the results are excluded and hidden. Example [here](https://obs-reviewlab.opensuse.org/saraycp-redesign_build_results_i/request/show/8#tab-pane-build-results).
