### PR TITLE
Redesign UI of the build results tab

### DIFF
--- a/src/api/app/assets/javascripts/webui/request_show_redesign/build_results.js
+++ b/src/api/app/assets/javascripts/webui/request_show_redesign/build_results.js
@@ -16,6 +16,7 @@ function updateBuildResultBeta() { // jshint ignore:line
   var ajaxDataShow = $('.build-results-content').data();
   // show_all comes from the buildstatus partial
   ajaxDataShow.show_all = $('#show_all').is(':checked'); // jshint ignore:line
+  ajaxDataShow.inRequestShowRedesign = true;
   ajaxDataShow.collapsedPackages = collapsedPackages;
   ajaxDataShow.collapsedRepositories = collapsedRepositories;
 
@@ -35,21 +36,5 @@ function updateBuildResultBeta() { // jshint ignore:line
       $('#build-reload').removeClass('fa-spin');
       initializePopovers('[data-toggle="popover"]'); // jshint ignore:line
     }
-  });
-}
-
-function toggleBuildInfoBeta() { // jshint ignore:line
-  $('.toggle-build-info').on('click', function(){
-    var replaceTitle = $(this).attr('title') === 'Click to keep it open' ? 'Click to close it' : 'Click to keep it open';
-    var infoContainer = $(this).parents('.toggle-build-info-parent').next();
-    $(infoContainer).toggleClass('collapsed');
-    $(infoContainer).removeClass('hover');
-    $('.toggle-build-info').attr('title', replaceTitle);
-  });
-  $('.toggle-build-info').on('mouseover', function(){
-    $(this).parents('.toggle-build-info-parent').next().addClass('hover');
-  });
-  $('.toggle-build-info').on('mouseout', function(){
-    $(this).parents('.toggle-build-info-parent').next().removeClass('hover');
   });
 }

--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -543,17 +543,14 @@ class Webui::PackageController < Webui::WebuiController
       @index = params[:index]
       @buildresults = @package.buildresult(@project, show_all)
 
-      partial_name = if Flipper.enabled?(:request_show_redesign, User.session)
-                       'webui/request/beta_show_tabs/build_status'
-                     else
-                       'buildstatus'
-                     end
+      # TODO: this is part of the temporary changes done for 'request_show_redesign'.
+      request_show_redesign_partial = 'webui/request/beta_show_tabs/build_status' if params.fetch(:inRequestShowRedesign, false)
 
-      render partial: partial_name, locals: { buildresults: @buildresults,
-                                              index: @index,
-                                              project: @project,
-                                              collapsed_packages: params.fetch(:collapsedPackages, []),
-                                              collapsed_repositories: params.fetch(:collapsedRepositories, {}) }
+      render partial: (request_show_redesign_partial || 'buildstatus'), locals: { buildresults: @buildresults,
+                                                                                  index: @index,
+                                                                                  project: @project,
+                                                                                  collapsed_packages: params.fetch(:collapsedPackages, []),
+                                                                                  collapsed_repositories: params.fetch(:collapsedRepositories, {}) }
     else
       render partial: 'no_repositories', locals: { project: @project }
     end

--- a/src/api/app/helpers/webui/buildresult_helper.rb
+++ b/src/api/app/helpers/webui/buildresult_helper.rb
@@ -1,4 +1,21 @@
 module Webui::BuildresultHelper
+  STATUS_ICON = {
+    succeeded: 'fa-check text-success',
+    failed: 'fa-xmark text-danger',
+    unresolvable: 'fa-xmark text-danger',
+    broken: 'fa-xmark text-danger',
+    blocked: 'fa-shield text-warning',
+    scheduled: 'fa-hourglass-half text-warning',
+    dispatching: 'fa-plane-departure',
+    building: 'fa-gear',
+    signing: 'fa-signature',
+    finished: 'fa-check',
+    disabled: 'fa-xmark text-warning',
+    excluded: 'fa-xmark text-warning',
+    locked: 'fa-lock text-warning',
+    unknown: 'fa-question'
+  }.with_indifferent_access.freeze
+
   # NOTE: There is a JavaScript version of this method in project_monitor.js
   # TODO: Refactor this! A good start would be to never ever use an instance variable in a helper method... please!
   def arch_repo_table_cell(repo, arch, package_name, status = nil)
@@ -55,5 +72,9 @@ module Webui::BuildresultHelper
     else
       line.strip
     end
+  end
+
+  def build_status_icon(state)
+    STATUS_ICON[state]
   end
 end

--- a/src/api/app/views/webui/request/beta_show_tabs/_build_status.html.haml
+++ b/src/api/app/views/webui/request/beta_show_tabs/_build_status.html.haml
@@ -7,61 +7,46 @@
       %u.custom-label #{label_message} excluded/disabled results
 
 - buildresults.results.each_pair do |package, results|
-  :ruby
-    package_name = package.tr('.:', '_')
-    expanded = collapsed_packages.exclude?(package_name)
-  %h5.d-flex.flex-row.text-primary.mt-3.mb-3
+  %h5.text-primary.mb-3
     = package
-    - if buildresults.results.count > 1
-      = collapse_link(expanded, package_name)
-  .collapse#package-buildstatus{ class: "collapse-#{package_name}#{expanded ? ' show' : ''}", data: { main: package_name } }
-    - if results.present?
-      - previous_repo = nil
-      - results.each do |result|
-        :ruby
-          repository_name = result.repository.tr('.', '_')
-          expanded = repository_expanded?(collapsed_repositories, repository_name, package_name)
-        - if result.repository != previous_repo
-          .d-flex.flex-row.py-1.bg-light.pl-1.pl-sm-2
-            = link_to(word_break(result.repository, 22),
-              package_binaries_path(project: project, package: package, repository: result.repository),
-              title: "Binaries for #{result.repository}")
-            = collapse_link(expanded, package_name, repository_name)
-
-        .collapse{ class: "collapse-#{package_name}-#{repository_name}#{expanded ? ' show' : ''}",
-                   data: { repository: repository_name, main: package_name } }
-          .d-flex.flex-row.flex-wrap.pt-1
-            .repository-state
-              - if result.is_repository_in_db
+  - if results.present?
+    - results_grouped_by_repository = results.group_by(&:repository)
+    - results_grouped_by_repository.each_pair do |repository, results_per_repository|
+      .row.mb-4
+        .col-12
+          = link_to(word_break(repository, 22),
+            package_binaries_path(project: project, package: package, repository: repository),
+            title: "Binaries for #{repository}")
+        .col-12
+          - results_per_repository.each do |result|
+            .row
+              .col-4
+                %p
+                  = result.architecture
+              .col-5
                 = repository_status_icon(status: result.state)
-              - else
-                %i.fas.fa-clock.text-warning{ title: 'This result is outdated' }
-              %span.ml-1
-                = result.architecture
-            .build-state.toggle-build-info-parent
-              %i.fa.fa-question-circle.text-info.px-2.pl-lg-1.toggle-build-info{ title: 'Click to keep it open' }
-              = arch_repo_table_cell(result.repository, result.architecture, package, 'code' => result.code, 'details' => result.details)
-            .build-info.mt-1.ml-3.mb-3.mr-3.collapsed
-              .triangle.center
-              .build-info-content
-                %p.py-1= Buildresult.status_description(result.code)
-                %div
-                  - if result.is_repository_in_db
-                    = repository_status_icon(status: result.state)
-                    %span.pl-1= repository_info(result.state)
-                  - else
-                    %i.fas.fa-clock.text-warning
-                    This result is outdated
-                - if result.details
-                  .pt-1.mt-3
-                    %strong{ class: "build-state-#{result.code}" } #{result.code}:
-                    %span.text-word-break-all= result.details
-
-        - previous_repo = result.repository
-    - else
-      All the results have state
-      %strong excluded/disabled
-
-:javascript
-  // TODO: call toggleCollapsibleTooltip() as soon as the new_watchlist fature is rolled out. Changing the classes in the view is also needed.
-  toggleBuildInfoBeta();
+                %p.d-none.d-sm-inline.d-lg-none
+                  = result.state
+                - result_help = repository_info(result.state) if result.is_repository_in_db
+                - result_help ||= 'This result is outdated'
+                %p.d-none.d-lg-inline
+                  = result_help
+                %i.fa.fa-question-circle.d-lg-none.text-info{ data: { placement: 'top', toggle: 'popover', content: "#{result_help}" } }
+              .col-3
+                - if result.code.in?(['-', 'unresolvable', 'blocked', 'excluded', 'scheduled'])
+                  %i{ class: "fa #{build_status_icon(result.code)}" }
+                - else
+                  = link_to(package_live_build_log_path(project: project.to_s, package: package,
+                      repository: result.repository, arch: result.architecture), rel: 'nofollow') do
+                    %i{ class: "fa #{build_status_icon(result.code)}" }
+                %span.d-none.d-lg-inline
+                  Package build
+                %p.d-none.d-sm-inline
+                  = arch_repo_table_cell(result.repository, result.architecture,
+                      package, 'code' => result.code, 'details' => result.details)
+                %i.fa.fa-question-circle.text-info{ data: { placement: 'top',
+                                                            toggle: 'popover',
+                                                            content: "#{Buildresult.status_description(result.code)}" } }
+  - else
+    All the results have state
+    %strong excluded/disabled


### PR DESCRIPTION
On the redesigned request show page, we have a wide area to display the build results, not a small column as we had before.

Please, bear in mind that the code needs a lot of refactoring, but I've just done minimal changes to make it work and fit the new area. A proper refactoring will come soonish.

**How to test?**

- Make sure your user has the feature flag `request_show_page` enabled.
- Go to a request page.
- Add many repositories and architectures to the project of the package associated with the request.
- Use the refresh button to see different states of the build results.
- Play around with the question mark icon, the collapse arrow, etc.


`codeclimate` complains about the long `RequestController#show` action, we are ignoring it during the implementation of `request_show_redesign`.

~**DO NOT MERGE** until #13236 is reviewed and merged.~