### PR TITLE
Add action_id to rdiff

### DIFF
--- a/src/api/app/views/webui/package/rdiff.html.haml
+++ b/src/api/app/views/webui/package/rdiff.html.haml
@@ -39,7 +39,8 @@
                 index: index,
                 last: @filenames.last == filename,
                 package: @package,
-                linkinfo: @linkinfo }
+                linkinfo: @linkinfo,
+                action_id: nil }
         - else
           .mb-2
             %p.lead No source changes.


### PR DESCRIPTION
`rdiff` renders `_revision_diff_details` which requires `action_id`
 