### PR TITLE
Fix issue retrieving building_package

### DIFF
--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -116,8 +116,7 @@ class Webui::RequestController < Webui::WebuiController
       @refresh = @action[:diff_not_cached]
 
       # Handling build results
-      @building_package = building_package
-      @building_project = @bs_request.staged_request? ? @bs_request.staging_project : @building_package.project
+      @staging_project = @bs_request.staging_project.name unless @bs_request.staging_project_id.nil?
 
       if @refresh
         bs_request_action = BsRequestAction.find(@action[:id])
@@ -434,13 +433,5 @@ class Webui::RequestController < Webui::WebuiController
       show_project_maintainer_hint: @show_project_maintainer_hint,
       actions: @actions
     }
-  end
-
-  def building_package
-    @building_package ||= Package.get_by_project_and_name(@active_action.source_project,
-                                                          @active_action.source_package,
-                                                          use_source: false,
-                                                          follow_multibuild: true,
-                                                          follow_project_links: true)
   end
 end

--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -73,12 +73,12 @@
                                                                              is_target_maintainer: @is_target_maintainer, is_author: @is_author }
       - if @action[:sprj] || @action[:spkg]
         .tab-pane.fade.p-2#build-results{ 'aria-labelledby': 'build-results-tab', role: 'tabpanel' }
-          = render partial: 'webui/request/beta_show_tabs/build_results', locals: { project: @building_project,
-                                                                                    package: @building_package,
-                                                                                    bs_request: @bs_request }
+          = render partial: 'webui/request/beta_show_tabs/build_results', locals: { project: @staging_project || @action[:sprj],
+                                                                                    package: @action[:spkg],
+                                                                                    is_staged_request: @staging_project.present? }
         .tab-pane.fade.p-2#rpm-lint-result{ 'aria-labelledby': 'rpm-lint-result-tab', role: 'tabpanel' }
-          = render partial: 'webui/request/beta_show_tabs/rpm_lint_result', locals: { project: @building_project,
-                                                                                      package: @building_package,
+          = render partial: 'webui/request/beta_show_tabs/rpm_lint_result', locals: { project: @action[:sprj],
+                                                                                      package: @action[:spkg],
                                                                                       bs_request: @bs_request }
       - if @action[:type].in?(actions_for_diff)
         .tab-pane.fade.p-2#changes{ 'aria-labelledby': 'changes-tab', role: 'tabpanel' }

--- a/src/api/app/views/webui/request/beta_show_tabs/_build_results.html.haml
+++ b/src/api/app/views/webui/request/beta_show_tabs/_build_results.html.haml
@@ -15,7 +15,7 @@
         Refresh
         %i.fas.fa-sync-alt{ id: 'build-reload' }
     -# For a request staged in a staging project, we display the Build Results / RPM Lint from the staging project instead
-    - if bs_request.staged_request?
+    - if is_staged_request
       %p.font-italic
         From staging project
         = link_to(project, project_show_path(project))

--- a/src/api/app/views/webui/request/beta_show_tabs/_rpm_lint_result.html.haml
+++ b/src/api/app/views/webui/request/beta_show_tabs/_rpm_lint_result.html.haml
@@ -1,7 +1,6 @@
 %p
   The RPM Lint results aren't here yet. For now, you can see them on the request's
-  = link_to('source package', package_show_path(project, package))
-  page. We're working on having them here in the future.
+  source package page. We're working on having them here in the future.
 
 %p
   %i The OBS team


### PR DESCRIPTION
Sometimes the building/source package is not available from the request page because the package was removed.

Co-authored-by: Lukas Krause <lkrause@suse.de>