### PR TITLE
Fix 'GPG Key / SSL Certificates' action to show to all users

### DIFF
--- a/src/api/app/views/webui/project/_show_actions.html.haml
+++ b/src/api/app/views/webui/project/_show_actions.html.haml
@@ -13,8 +13,11 @@
       = render partial: 'webui/project/show_actions/delete_project', locals: { project: project }
     - elsif !project.is_locked?
       = render partial: 'webui/project/show_actions/request_role_addition_and_deletion', locals: { project: project }
-  - elsif project.key_info.present?
-    = render partial: 'webui/project/show_actions/gpg_key_ssl_certificate', locals: { project: project }
+    -# Keep `elsif project.key_info.present?` nested under
+    -# `if (bugowners_mail.present? && !CONFIG['bugzilla_host'].nil?) || User.session`
+    -# so every logged user can check up the project's GPG key and SSL certificate.
+    - elsif project.key_info.present?
+      = render partial: 'webui/project/show_actions/gpg_key_ssl_certificate', locals: { project: project }
 
   %li.nav-item
     = link_to(image_templates_path, class: 'nav-link', title: 'New Image') do

--- a/src/api/app/views/webui/project/keys_and_certificates.html.haml
+++ b/src/api/app/views/webui/project/keys_and_certificates.html.haml
@@ -37,6 +37,7 @@
               %dd.col-6.col-sm-9.small
                 = @project.key_info.origin.presence || 'There is no origin for this key'
 
+            %p Download the Project's key
             %p.text-left.m-0
               = link_to(project_public_key_path(project_name: @project.name)) do
                 %i.fas.fa-download.text-primary
@@ -47,10 +48,10 @@
             %h5.card-title SSL Certificate
             %hr
             - if @project.key_info.ssl_certificate.present?
-              %p You can download your certificate here
+              %p Download the Project's certificate
               %p.text-left.m-0
                 = link_to(project_ssl_certificate_path(project_name: @project.name)) do
                   %i.fas.fa-download.text-primary
                   SSL Cert
             - else
-              You do not have any SSL Certificate
+              The Project does not have any SSL Certificate


### PR DESCRIPTION
Howdy folks,

The `GPG Key / SSL Certificates` action link, shown in the sidebar, should be available to be checked by any user, not just project maintainers.

And adjust the syntax of the text shown in the page to use **_Project_** as the subject rather than _**You**_.

Note, however, that I haven't gone through all the hassle of setting up an Open Build Service development environment to test this change. So I'm hoping some veteran with a better judgement than me can attest this change is doing what it's supposed to.

Fixes #4598