### PR TITLE
[api] allow to reopen a declined review

### DIFF
--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -681,7 +681,7 @@ class BsRequest < ApplicationRecord
     with_lock do
       new_review_state = new_review_state.to_sym
 
-      raise InvalidStateError, 'request is not in review state' unless state == :review || (state == :new && new_review_state == :new)
+      raise InvalidStateError, 'request is not in a changeable state (new, review or declined)' unless state == :review || (state.in?([:new, :declined]) && new_review_state == :new)
 
       check_if_valid_review!(opts)
       raise InvalidStateError, "review state must be new, accepted, declined or superseded, was #{new_review_state}" unless new_review_state.in?([:new, :accepted, :declined, :superseded])


### PR DESCRIPTION
A user who declined a review should also be able to revert it by setting it to new again.

This solves #2923