### PR TITLE
Attach line reference anchor to the URL

### DIFF
--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -94,4 +94,5 @@
       var file_index = result[1];
       $('.nav-tabs:not(.disable-link-generation) .nav-link[href="#changes"]').tab('show');
       $('#revision_details_' + file_index).attr('open', 'open');
+      document.location.hash = anchor;
     }


### PR DESCRIPTION
Right now the line number anchor is replaced with a tab anchor if I reload after selecting a diff. This pr fixes that problem and keep the diff reference attached to the URL