### PR TITLE
[api] Add information about autoaccept in notifications

### DIFF
--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -836,6 +836,7 @@ class BsRequest < ApplicationRecord
 
     params[:oldstate] = state_was if state_changed?
     params[:who] = commenter if commenter.present?
+    params[:accept_at] = accept_at if accept_at.present?
 
     # Use a nested data structure to support multiple actions in one request
     params[:actions] = []

--- a/src/api/app/views/event_mailer/request_create.text.erb
+++ b/src/api/app/views/event_mailer/request_create.text.erb
@@ -1,5 +1,9 @@
 Visit <%= url_for(controller: 'webui/request', action: :show, number: event['number'], host: @host, only_path: false) %>
 
+<% if event['accept_at']-%>
+*** This request will get accepted automatically at <%= event['accept_at']%>, except it gets declined ***
+<%-end-%>
+
 <% if event['description']-%>
 Description:
 <%= event['description']%>


### PR DESCRIPTION
The mails hide the fact that auto-accept requests will get accept when no reaction happens.