### PR TITLE
Fix actions' hrefs when the url contains a line diff

### DIFF
--- a/src/api/app/components/sourcediff_component.html.haml
+++ b/src/api/app/components/sourcediff_component.html.haml
@@ -31,8 +31,7 @@
                                                                                   index: file_index,
                                                                                   last: sourcediff['filenames'].last == filename,
                                                                                   package: @action[:spkg],
-                                                                                  linkinfo: nil,
-                                                                                  action_id: @action[:id] }
+                                                                                  linkinfo: nil }
           - else
             .mb-2
               %p.lead

--- a/src/api/app/components/sourcediff_tab_component.html.haml
+++ b/src/api/app/components/sourcediff_tab_component.html.haml
@@ -40,8 +40,7 @@
                                                                                           index: file_index,
                                                                                           last: sourcediff['filenames'].last == filename,
                                                                                           package: @action[:spkg],
-                                                                                          linkinfo: nil,
-                                                                                          action_id: @action[:id] }
+                                                                                          linkinfo: nil }
             - else
               .mb-2
                 %p.lead

--- a/src/api/app/helpers/application_helper.rb
+++ b/src/api/app/helpers/application_helper.rb
@@ -1,6 +1,6 @@
 # Methods added to this helper will be available to all templates in the application.
 module ApplicationHelper
-  def render_diff(content, file_index:, action_id:)
-    sanitize(CodeRay.scan(content, :diff).div(css: :class, line_numbers: :inline, line_number_anchors: "diff_#{action_id}_#{file_index}_n"))
+  def render_diff(content, file_index:)
+    sanitize(CodeRay.scan(content, :diff).div(css: :class, line_numbers: :inline, line_number_anchors: "diff_#{file_index}_n"))
   end
 end

--- a/src/api/app/views/webui/package/_revision_diff_detail.html.haml
+++ b/src/api/app/views/webui/package/_revision_diff_detail.html.haml
@@ -8,7 +8,7 @@
         .diff-card-header
           = calculate_filename(filename, file)
           %span.badge{ class: "badge-#{file['state']}" }= file['state'].capitalize
-      = render_diff(diff_content, file_index: index, action_id: action_id)
+      = render_diff(diff_content, file_index: index)
   - else
     .card{ id: "revision_details_#{index}" }
       .card-header

--- a/src/api/app/views/webui/package/rdiff.html.haml
+++ b/src/api/app/views/webui/package/rdiff.html.haml
@@ -39,8 +39,7 @@
                 index: index,
                 last: @filenames.last == filename,
                 package: @package,
-                linkinfo: @linkinfo,
-                action_id: nil }
+                linkinfo: @linkinfo }
         - else
           .mb-2
             %p.lead No source changes.

--- a/src/api/app/views/webui/request/_actions_details.html.haml
+++ b/src/api/app/views/webui/request/_actions_details.html.haml
@@ -31,10 +31,13 @@
     $('#request-actions').on('shown.bs.dropdown', function () {
       $.each($('#request-actions .dropdown-item'), function () {
         var href = $(this).attr('href');
-        if (href.search('#') == -1) {
-           href = href + document.location.hash;
+        if (document.location.hash.search('#diff_') != -1 && href.search('#') == -1) {
+          href = href + '#' + HASH_PREFIX + 'changes';
         }
-        else {
+        else if (href.search('#') == -1) {
+          href = href + document.location.hash;
+        }
+        else if (document.location.hash.search('#diff_') == -1) {
           href = href.replace(hashRegexp, document.location.hash);
         }
         $(this).attr('href', href);

--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -90,8 +90,11 @@
   :plain
     var anchor = document.location.hash;
     var result = [];
-    if (result = anchor.match(/^#diff_([\d]+)_([\d]+)_n\d+$/)) {
+    if (result = anchor.match(/^#diff_([\d]+)_n\d+$/)) {
       var file_index = result[1];
       $('.nav-tabs:not(.disable-link-generation) .nav-link[href="#changes"]').tab('show');
+
       $('#revision_details_' + file_index).attr('open', 'open');
+
+      document.location.hash = anchor;
     }

--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -94,5 +94,4 @@
       var file_index = result[1];
       $('.nav-tabs:not(.disable-link-generation) .nav-link[href="#changes"]').tab('show');
       $('#revision_details_' + file_index).attr('open', 'open');
-      document.location.hash = anchor;
     }


### PR DESCRIPTION
There is no need to include the `action_id` in the fraction identifier (anchor) of the URL. In case of browsing an action, that same action is already included in the URL. Therefore, I reverted the three commits related to this change.

In case we browse a diff line, change `href` attributes of other actions' links to point to the Changes tab.