### PR TITLE
Remove reference to the user.rng schema in the GET watchlist endpoint documentation

### DIFF
--- a/src/api/public/apidocs-new/paths/watchlist.yaml
+++ b/src/api/public/apidocs-new/paths/watchlist.yaml
@@ -6,10 +6,7 @@ get:
     - $ref: '../components/parameters/login.yaml'
   responses:
     '200':
-      description: >
-        OK. The request has succeeded.
-
-        XML Schema used for body validation: [user.rng](../schema/user.rng)
+      description: OK. The request has succeeded.
       content:
         application/xml; charset=utf-8:
           schema:


### PR DESCRIPTION
No validation schema is used in this endpoint.