### PR TITLE
Fix RuboCop offense RSpec/Rails/InferredSpecType

### DIFF
--- a/src/api/spec/features/webui/badge_spec.rb
+++ b/src/api/spec/features/webui/badge_spec.rb
@@ -1,6 +1,6 @@
 require 'browser_helper'
 
-RSpec.describe 'Badge', type: :feature do
+RSpec.describe 'Badge' do
   let(:user) { create(:confirmed_user, :with_home, login: 'tom') }
   let(:source_project) { user.home_project }
   let(:source_package) { create(:package, name: 'my_package', project: source_project) }


### PR DESCRIPTION
We can remove the redundant spec type.