### PR TITLE
Document the rest of parameters for `POST /source/{project_name}?cmd=copy`

### DIFF
--- a/src/api/public/apidocs-new/paths/source_project_name_cmd_copy.yaml
+++ b/src/api/public/apidocs-new/paths/source_project_name_cmd_copy.yaml
@@ -1,21 +1,26 @@
 post:
-  summary: Copy the entire project.
-  description: |
-    The `copy` command copies the entire project from the source project provided by `oproject` to the target project provided by `project`.
-
-    The params `makeolder` and `makeoriginolder` update the relevant vrev.
-    The param `withbinaries` ensures we copy also the binaries.
+  summary: Copy an entire project.
+  description: Copy the source project provided by the required parameter `oproject` to the target project provided by the path parameter `project_name`.
   security:
     - basic_authentication: []
   parameters:
-    - $ref: '../components/parameters/project_name.yaml'
+    - in: path
+      name: project_name
+      schema:
+        type: string
+      required: true
+      description: |
+        Target project name
+
+        The target project must exist. Otherwise, the copy is not performed and a not found error (404) is returned.
+      example: home:Iggy:target
     - in: query
       name: oproject
       schema:
         type: string
       required: true
       description: Origin project name
-      example: "home:Admin"
+      example: home:Iggy:source
     - in: query
       name: opackage
       schema:
@@ -33,13 +38,21 @@ post:
       name: makeolder
       schema:
         type: string
-      description: Make target older, the source vrev is bumped by two numbers and target by one. This parameter is interpreted as `true` if present, `false` otherwise.
+        enum:
+          - 1
+          - 0
+      default: 0
+      description: Make target older. Set to `1` to bump the source vrev by two numbers and the target by one.
       example: 1
     - in: query
       name: makeoriginolder
       schema:
         type: string
-      description: Make origin older, the source vrev is extended and target is guaranteed to be newer. This parameter is interpreted as `true` if present, `false` otherwise.
+        enum:
+          - 1
+          - 0
+      default: 0
+      description: Make origin older. Set to `1` to extend the source vrev.
       example: 1
     - in: query
       name: noservice
@@ -55,13 +68,21 @@ post:
       name: withbinaries
       schema:
         type: string
-      description: Copies also binaries on copy command. This parameter is interpreted as `true` if present, `false` otherwise.
+        enum:
+          - 1
+          - 0
+      default: 0
+      description: Set to `1` to also copy binaries.
       example: 1
     - in: query
       name: nodelay
       schema:
         type: string
-      description: If the parameter is present, the copying is done right away. If not present, the copying is done as a deferred job.
+        enum:
+          - 1
+          - 0
+      default: 0
+      description: By default the copying is done as a deferred job. Set to `1` to perform the copy right away.
       example: 1
     - in: query
       name: withhistory
@@ -75,21 +96,40 @@ post:
       example: 1
   responses:
     '200':
-      $ref: '../components/responses/succeeded.yaml'
-    '401':
-      $ref: '../components/responses/unauthorized.yaml'
-    '403':
       description: |
-        Forbidden.
+        OK. The request has succeeded.
 
-        no permission to execute command 'copy'.
+        XML Schema used for body validation: [about.xsd](../schema/about.xsd)
       content:
         application/xml; charset=utf-8:
           schema:
             $ref: '../components/schemas/api_response.yaml'
-          example:
-            code: no_permission_to_change
-            summary: no permission to execute command 'copy' ...
+          examples:
+            job_invoked:
+              summary: Job Invoked
+              value:
+                code: invoked
+                summary: Job invoked
+            ok:
+              summary: Ok
+              description: Response given when `nodelay` is set to `1`.
+              value:
+                code: ok
+                summary: Ok
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '403':
+      description: Forbidden.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          examples:
+            cmd_execution_no_permission:
+              summary: No Permission to Execute Command
+              value:
+                code: cmd_execution_no_permission
+                summary: no permission to execute command 'copy'
     '404':
       $ref: '../components/responses/unknown_project.yaml'
   tags:

--- a/src/api/public/apidocs-new/paths/source_project_name_cmd_copy.yaml
+++ b/src/api/public/apidocs-new/paths/source_project_name_cmd_copy.yaml
@@ -24,6 +24,12 @@ post:
       description: Origin package name
       example: "ctris"
     - in: query
+      name: comment
+      schema:
+        type: string
+      description: Comment to be added in the revision history.
+      example: Copy project for testing.
+    - in: query
       name: makeolder
       schema:
         type: string
@@ -36,6 +42,16 @@ post:
       description: Make origin older, the source vrev is extended and target is guaranteed to be newer. This parameter is interpreted as `true` if present, `false` otherwise.
       example: 1
     - in: query
+      name: noservice
+      schema:
+        type: string
+        enum:
+          - 1
+          - 0
+      default: 0
+      description: Set to `1` not to run source services.
+      example: 1
+    - in: query
       name: withbinaries
       schema:
         type: string
@@ -46,6 +62,16 @@ post:
       schema:
         type: string
       description: If the parameter is present, the copying is done right away. If not present, the copying is done as a deferred job.
+      example: 1
+    - in: query
+      name: withhistory
+      schema:
+        type: string
+        enum:
+          - 1
+          - 0
+      default: 0
+      description: Set to `1` to also copy the revision history.
       example: 1
   responses:
     '200':


### PR DESCRIPTION
Document parameters `comment`, `noservice` and `withhistory` for the `POST /source/{project_name}?cmd=copy` endpoint.

Also improve the documentation of this same endpoint.