### PR TITLE
Re-introduce forgotten `resign` parameter

### DIFF
--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -702,7 +702,7 @@ class SourceController < ApplicationController
     end
 
     job_params = params.slice(
-      :cmd, :user, :comment, :oproject, :withbinaries, :withhistory, :makeolder, :makeoriginolder, :noservice
+      :cmd, :user, :comment, :oproject, :withbinaries, :withhistory, :makeolder, :makeoriginolder, :noservice, :resign
     ).permit!.to_h
     job_params[:user] = User.session!.login
 


### PR DESCRIPTION
... for the `POST /source/{project_name}?cmd=copy API` endpoint

This parameter should have been included in this commit: a19f13e96b1f8f3c405b5062c591640586119e2e