### PR TITLE
Skip iteration in `FindForEvent#subscriptions` when there are no receivers for the role

### DIFF
--- a/src/api/app/models/event_subscription/find_for_event.rb
+++ b/src/api/app/models/event_subscription/find_for_event.rb
@@ -12,6 +12,8 @@ class EventSubscription
       event.class.receiver_roles.each do |receiver_role|
         # Find the users/groups who are receivers for this event
         receivers = event.send("#{receiver_role}s")
+        next if receivers.blank?
+
         receivers = expand_receivers(receivers, channel)
 
         options = { eventtype: event.eventtype, receiver_role: receiver_role, channel: channel }


### PR DESCRIPTION
There is no reason to proceed in the method when there are no receivers for the event for the given role. We can skip and continue with the next receiver_role.