### PR TITLE
Restructure rake tasks

### DIFF
--- a/.circleci/conditional_config.yml
+++ b/.circleci/conditional_config.yml
@@ -173,7 +173,7 @@ jobs:
           name: Run rubocop
           command: |
             cd src/api;
-            bundle exec rake dev:lint:rubocop:all
+            bundle exec rake lint:rubocop:all
       - *save_rubocop_cache
       - when:
           condition: << pipeline.parameters.run-javascripts-linter >>
@@ -198,7 +198,7 @@ jobs:
                 name: Run HAML linter
                 command: |
                   cd src/api
-                  bundle exec rake dev:lint:haml
+                  bundle exec rake lint:haml
       - when:
           condition: << pipeline.parameters.run-apidocs-linter >>
           steps:
@@ -206,7 +206,7 @@ jobs:
                 name: Run Documentation linter
                 command: |
                   cd src/api
-                  bundle exec rake dev:lint:apidocs
+                  bundle exec rake lint:apidocs
 
   rspec:
     parallelism: 3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -277,7 +277,7 @@ You can access the frontend at [localhost:3000](http://localhost:3000). Whatever
 
     ```
     docker-compose run --rm frontend bundle exec rspec
-    docker-compose run --rm frontend bundle exec rake dev:lint
+    docker-compose run --rm frontend bundle exec rake lint:all
     ```
 
 10. Changed something in the backend? Test your changes!

--- a/Rakefile
+++ b/Rakefile
@@ -50,7 +50,7 @@ EOF"
       sh './contrib/rabbitmqadmin declare exchange name=pubsub type=topic durable=true auto_delete=false internal=false'
       # configure the app
       sh 'docker-compose -f docker-compose.sre.yml -f docker-compose.yml up -d db'
-      sh 'docker-compose -f docker-compose.sre.yml -f docker-compose.yml run --no-deps --rm frontend bundle exec rake dev:sre:configure'
+      sh 'docker-compose -f docker-compose.sre.yml -f docker-compose.yml run --no-deps --rm frontend bundle exec rake sre:configure'
     ensure
       sh 'docker-compose -f docker-compose.sre.yml -f docker-compose.yml stop'
     end

--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -987,6 +987,7 @@ Rails/RakeEnvironment:
   Exclude:
     - 'lib/tasks/coverage.rake'
     - 'lib/tasks/dev.rake'
+    - 'lib/tasks/dev/*.rake'
     - 'lib/tasks/migrate_options_yml.rake'
 
 # Offense count: 6

--- a/src/api/lib/tasks/dev.rake
+++ b/src/api/lib/tasks/dev.rake
@@ -60,69 +60,6 @@ namespace :dev do
     Rake::Task['flipper:enable_features_for_group'].invoke
   end
 
-  desc 'Run all linters we use'
-  task :lint do
-    Rake::Task['dev:lint:haml'].invoke
-    Rake::Task['dev:lint:rubocop:all'].invoke
-    sh 'jshint ./app/assets/javascripts/'
-  end
-
-  namespace :lint do
-    namespace :rubocop do
-      desc 'Run the ruby linter in rails and in root'
-      task all: [:root, :rails]
-
-      desc 'Run the ruby linter in rails'
-      task :rails do
-        sh 'rubocop', '--fail-fast', '--display-style-guide', '--fail-level', 'convention', '--ignore_parent_exclusion'
-      end
-
-      desc 'Run the ruby linter in root'
-      task :root do
-        Dir.chdir('../..') do
-          sh 'rubocop', '--fail-fast', '--display-style-guide', '--fail-level', 'convention'
-        end
-      end
-
-      namespace :auto_gen_config do
-        desc 'Autogenerate rubocop config in rails and in root'
-        task all: [:root, :rails]
-
-        desc 'Autogenerate rubocop config in rails'
-        task :rails do
-          # We set `exclude-limit` to 100 (from the default of 15) to make it easier to tackle TODOs one file at a time
-          # A cop will be disabled only if it triggered offenses for more than 100 files
-          sh 'rubocop --auto-gen-config --ignore_parent_exclusion --auto-gen-only-exclude --exclude-limit 100'
-        end
-
-        desc 'Run the ruby linter in root'
-        task :root do
-          Dir.chdir('../..') do
-            # We set `exclude-limit` to 100 (from the default of 15) to make it easier to tackle TODOs one file at a time
-            # A cop will be disabled only if it triggered offenses for more than 100 files
-            sh 'rubocop --auto-gen-config --auto-gen-only-exclude --exclude-limit 100'
-          end
-        end
-      end
-
-      desc 'Autocorrect rubocop offenses in rails and in root'
-      task :autocorrect do
-        sh 'rubocop --autocorrect --ignore_parent_exclusion'
-        Dir.chdir('../..') do
-          sh 'rubocop --autocorrect'
-        end
-      end
-    end
-    desc 'Run the haml linter'
-    task :haml do
-      Rake::Task['haml_lint'].invoke('--parallel')
-    end
-    desc 'Run apidocs linter'
-    task :apidocs do
-      sh 'find public/apidocs-new -name  \'*.yaml\' | xargs -P8 -I % ruby -e "require \'yaml\'; YAML.load_file(\'%\',  permitted_classes: [Time])"'
-    end
-  end
-
   # This is automatically run in Review App or manually in development env.
   namespace :development_testdata do
     desc 'Creates test data to play with in dev and CI environments'

--- a/src/api/lib/tasks/dev.rake
+++ b/src/api/lib/tasks/dev.rake
@@ -170,81 +170,6 @@ namespace :dev do
     end
   end
 
-  # Run this task with: rails "dev:notifications:data[3]"
-  # replacing 3 with any number to indicate how many times you want this code to be executed.
-  namespace :notifications do
-    desc 'Creates a notification and all its dependencies'
-    task :data, [:repetitions] => :environment do |_t, args|
-      unless Rails.env.development?
-        puts "You are running this rake task in #{Rails.env} environment."
-        puts 'Please only run this task with RAILS_ENV=development'
-        puts 'otherwise it will destroy your database data.'
-        return
-      end
-
-      args.with_defaults(repetitions: 1)
-      repetitions = args.repetitions.to_i
-      require 'factory_bot'
-      include FactoryBot::Syntax::Methods
-
-      # Users
-      admin = User.where(login: 'Admin').first || create(:admin_user, login: 'Admin')
-      group = create(:groups_user, user: admin, group: create(:group, title: Faker::Lorem.word)).group
-      subscribe_to_all_notifications(admin)
-      requestor = User.where(login: 'Requestor').first || create(:confirmed_user, login: 'Requestor')
-      User.session = requestor
-
-      # Projects
-      admin_home_project = admin.home_project || create_and_assign_project(admin.home_project_name, admin)
-      requestor_project = Project.find_by(name: 'requestor_project') || create_and_assign_project('requestor_project', requestor)
-
-      repetitions.times do |repetition|
-        package_name = "package_#{Time.now.to_i}_#{repetition}"
-        admin_package = create(:package_with_file, name: package_name, project: admin_home_project)
-        requestor_package = create(:package_with_file, name: admin_package.name, project: requestor_project)
-
-        # Will create a notification (RequestCreate event) for this request.
-        request = create(
-          :bs_request_with_submit_action,
-          creator: requestor,
-          target_project: admin_home_project,
-          target_package: admin_package,
-          source_project: requestor_project,
-          source_package: requestor_package
-        )
-
-        # Will create notifications (ReviewWanted event) for those reviews.
-        # The creation and these two reviews are finally displayed as
-        # one single notification in the UI.
-        request.addreview(by_user: admin, comment: Faker::Lorem.paragraph)
-        request.addreview(by_group: group, comment: Faker::Lorem.paragraph)
-
-        # Will create a notification (CommentForRequest event) for this comment.
-        create(:comment_request, commentable: request, user: requestor)
-        # Will create a notification (CommentForProject event) for this comment.
-        create(:comment_project, commentable: admin_home_project, user: requestor)
-        # Will create a notification (CommentForPackage event) for this comment.
-        create(:comment_package, commentable: admin_package, user: requestor)
-
-        # Admin requests changes to requestor, so a RequestStatechange notification will appear
-        # as soon as the requestor changes the state of the request.
-        request2 = create(
-          :bs_request_with_submit_action,
-          creator: admin,
-          target_project: requestor_project,
-          target_package: requestor_package,
-          source_project: admin_home_project,
-          source_package: admin_package
-        )
-        # Will create a notification (RequestStatechange event) for this request change.
-        request2.change_state(newstate: ['accepted', 'declined'].sample, force: true, user: requestor.login, comment: 'Declined by requestor')
-
-        # Process notifications immediately to see them in the web UI
-        SendEventEmailsJob.new.perform_now
-      end
-    end
-  end
-
   # This is automatically run in Review App or manually in development env.
   namespace :development_testdata do
     desc 'Creates test data to play with in dev and CI environments'
@@ -427,28 +352,4 @@ def request_for_staging(staging_project, maintainer_project, suffix)
   )
 
   request.reviews.each { |review| review.change_state(:accepted, 'Accepted') }
-end
-
-def subscribe_to_all_notifications(user)
-  create(:event_subscription_request_created, channel: :web, user: user, receiver_role: 'target_maintainer')
-  create(:event_subscription_review_wanted, channel: 'web', user: user, receiver_role: 'reviewer')
-  create(:event_subscription_request_statechange, channel: :web, user: user, receiver_role: 'target_maintainer')
-  create(:event_subscription_request_statechange, channel: :web, user: user, receiver_role: 'source_maintainer')
-  create(:event_subscription_comment_for_project, channel: :web, user: user, receiver_role: 'maintainer')
-  create(:event_subscription_comment_for_package, channel: :web, user: user, receiver_role: 'maintainer')
-  create(:event_subscription_comment_for_request, channel: :web, user: user, receiver_role: 'target_maintainer')
-  create(:event_subscription_relationship_create, channel: :web, user: user, receiver_role: 'any_role')
-  create(:event_subscription_relationship_delete, channel: :web, user: user, receiver_role: 'any_role')
-
-  user.groups.each do |group|
-    create(:event_subscription_request_created, channel: :web, user: nil, group: group, receiver_role: 'target_maintainer')
-    create(:event_subscription_review_wanted, channel: 'web', user: nil, group: group, receiver_role: 'reviewer')
-    create(:event_subscription_request_statechange, channel: :web, user: nil, group: group, receiver_role: 'target_maintainer')
-    create(:event_subscription_request_statechange, channel: :web, user: nil, group: group, receiver_role: 'source_maintainer')
-    create(:event_subscription_comment_for_project, channel: :web, user: nil, group: group, receiver_role: 'maintainer')
-    create(:event_subscription_comment_for_package, channel: :web, user: nil, group: group, receiver_role: 'maintainer')
-    create(:event_subscription_comment_for_request, channel: :web, user: nil, group: group, receiver_role: 'target_maintainer')
-    create(:event_subscription_relationship_create, channel: :web, user: nil, group: group, receiver_role: 'any_role')
-    create(:event_subscription_relationship_delete, channel: :web, user: nil, group: group, receiver_role: 'any_role')
-  end
 end

--- a/src/api/lib/tasks/dev.rake
+++ b/src/api/lib/tasks/dev.rake
@@ -2,6 +2,7 @@
 
 require 'fileutils'
 require 'yaml'
+require 'tasks/dev/helper_methods'
 
 namespace :dev do
   task :prepare do
@@ -411,16 +412,6 @@ namespace :dev do
   end
 end
 
-def copy_example_file(example_file)
-  if File.exist?(example_file) && !ENV['FORCE_EXAMPLE_FILES']
-    example_file = File.join(File.expand_path(File.dirname(__FILE__) + '/../..'), example_file)
-    puts "WARNING: You already have the config file #{example_file}, make sure it works with docker"
-  else
-    puts "Creating config/#{example_file} from config/#{example_file}.example"
-    FileUtils.copy_file("#{example_file}.example", example_file)
-  end
-end
-
 def request_for_staging(staging_project, maintainer_project, suffix)
   requester = create(:confirmed_user, login: "requester_#{suffix}")
   source_project = create(:project, name: "source_project_#{suffix}")
@@ -436,20 +427,6 @@ def request_for_staging(staging_project, maintainer_project, suffix)
   )
 
   request.reviews.each { |review| review.change_state(:accepted, 'Accepted') }
-end
-
-def create_and_assign_project(project_name, user)
-  create(:project, name: project_name).tap do |project|
-    create(:relationship, project: project, user: user, role: Role.hashed['maintainer'])
-  end
-end
-
-def find_or_create_project(project_name, user)
-  project = Project.joins(:relationships)
-                   .where(projects: { name: project_name }, relationships: { user: user }).first
-  return project if project
-
-  create_and_assign_project(project_name, user)
 end
 
 def subscribe_to_all_notifications(user)

--- a/src/api/lib/tasks/dev.rake
+++ b/src/api/lib/tasks/dev.rake
@@ -123,26 +123,6 @@ namespace :dev do
     end
   end
 
-  namespace :sre do
-    desc 'Configure the rails app to publish application health monitoring stats'
-    task :configure do
-      unless Rails.env.development?
-        puts "You are running this rake task in #{Rails.env} environment."
-        puts 'Please only run this task with RAILS_ENV=development'
-        return
-      end
-
-      copy_example_file('config/options.yml')
-      options_yml = YAML.load_file('config/options.yml') || {}
-      options_yml['development']['influxdb_hosts'] = ['influx']
-      options_yml['development']['amqp_namespace'] = 'opensuse.obs'
-      options_yml['development']['amqp_options'] = { host: 'rabbit', port: '5672', user: 'guest', pass: 'guest', vhost: '/' }
-      options_yml['development']['amqp_exchange_name'] = 'pubsub'
-      options_yml['development']['amqp_exchange_options'] = { type: :topic, persistent: 'true', passive: 'true' }
-      File.write('config/options.yml', YAML.dump(options_yml))
-    end
-  end
-
   # This is automatically run in Review App or manually in development env.
   namespace :development_testdata do
     desc 'Creates test data to play with in dev and CI environments'

--- a/src/api/lib/tasks/dev.rake
+++ b/src/api/lib/tasks/dev.rake
@@ -143,33 +143,6 @@ namespace :dev do
     end
   end
 
-  namespace :staging do
-    desc 'Creates a staging workflow with a project and a confirmed user'
-    task data: :environment do
-      unless Rails.env.development?
-        puts "You are running this rake task in #{Rails.env} environment."
-        puts 'Please only run this task with RAILS_ENV=development'
-        puts 'otherwise it will destroy your database data.'
-        return
-      end
-
-      require 'factory_bot'
-      include FactoryBot::Syntax::Methods
-      timestamp = Time.now.to_i
-      maintainer = create(:confirmed_user, login: "maintainer_#{timestamp}")
-      User.session = maintainer
-      managers_group = create(:group, title: "managers_group_#{timestamp}")
-      staging_workflow = create(:staging_workflow_with_staging_projects, project: maintainer.home_project, managers_group: managers_group)
-      staging_workflow.managers_group.add_user(maintainer)
-
-      staging_workflow.staging_projects.each do |staging_project|
-        2.times { |i| request_for_staging(staging_project, maintainer.home_project, "#{staging_project.id}_#{timestamp}_#{i}") }
-      end
-
-      puts "**** Created staging workflow project: /staging_workflows/#{staging_workflow.project} ****"
-    end
-  end
-
   # This is automatically run in Review App or manually in development env.
   namespace :development_testdata do
     desc 'Creates test data to play with in dev and CI environments'
@@ -335,21 +308,4 @@ namespace :dev do
       Rake::Task['requests:multiple_actions_request'].invoke
     end
   end
-end
-
-def request_for_staging(staging_project, maintainer_project, suffix)
-  requester = create(:confirmed_user, login: "requester_#{suffix}")
-  source_project = create(:project, name: "source_project_#{suffix}")
-  target_package = create(:package, name: "target_package_#{suffix}", project: maintainer_project)
-  source_package = create(:package, name: "source_package_#{suffix}", project: source_project)
-  request = create(
-    :bs_request_with_submit_action,
-    state: :new,
-    creator: requester,
-    target_package: target_package,
-    source_package: source_package,
-    staging_project: staging_project
-  )
-
-  request.reviews.each { |review| review.change_state(:accepted, 'Accepted') }
 end

--- a/src/api/lib/tasks/dev/helper_methods.rb
+++ b/src/api/lib/tasks/dev/helper_methods.rb
@@ -1,0 +1,23 @@
+def create_and_assign_project(project_name, user)
+  create(:project, name: project_name).tap do |project|
+    create(:relationship, project: project, user: user, role: Role.hashed['maintainer'])
+  end
+end
+
+def find_or_create_project(project_name, user)
+  project = Project.joins(:relationships)
+                   .where(projects: { name: project_name }, relationships: { user: user }).first
+  return project if project
+
+  create_and_assign_project(project_name, user)
+end
+
+def copy_example_file(example_file)
+  if File.exist?(example_file) && !ENV['FORCE_EXAMPLE_FILES']
+    example_file = File.join(File.expand_path(File.dirname(__FILE__) + '/../..'), example_file)
+    puts "WARNING: You already have the config file #{example_file}, make sure it works with docker"
+  else
+    puts "Creating config/#{example_file} from config/#{example_file}.example"
+    FileUtils.copy_file("#{example_file}.example", example_file)
+  end
+end

--- a/src/api/lib/tasks/dev/lint.rake
+++ b/src/api/lib/tasks/dev/lint.rake
@@ -16,6 +16,11 @@ namespace :lint do
     sh 'find public/apidocs-new -name  \'*.yaml\' | xargs -P8 -I % ruby -e "require \'yaml\'; YAML.load_file(\'%\',  permitted_classes: [Time])"'
   end
 
+  desc 'Run the JavaScript linter'
+  task :javascript do
+    sh 'jshint ./app/assets/javascripts/'
+  end
+
   namespace :rubocop do
     desc 'Run the ruby linter in rails and in root'
     task all: [:root, :rails]

--- a/src/api/lib/tasks/dev/lint.rake
+++ b/src/api/lib/tasks/dev/lint.rake
@@ -1,0 +1,64 @@
+namespace :lint do
+  desc 'Run all linters we use'
+  task :all do
+    Rake::Task['lint:haml'].invoke
+    Rake::Task['lint:rubocop:all'].invoke
+    sh 'jshint ./app/assets/javascripts/'
+  end
+
+  desc 'Run the haml linter'
+  task :haml do
+    Rake::Task['haml_lint'].invoke('--parallel')
+  end
+
+  desc 'Run apidocs linter'
+  task :apidocs do
+    sh 'find public/apidocs-new -name  \'*.yaml\' | xargs -P8 -I % ruby -e "require \'yaml\'; YAML.load_file(\'%\',  permitted_classes: [Time])"'
+  end
+
+  namespace :rubocop do
+    desc 'Run the ruby linter in rails and in root'
+    task all: [:root, :rails]
+
+    desc 'Run the ruby linter in rails'
+    task :rails do
+      sh 'rubocop', '--fail-fast', '--display-style-guide', '--fail-level', 'convention', '--ignore_parent_exclusion'
+    end
+
+    desc 'Run the ruby linter in root'
+    task :root do
+      Dir.chdir('../..') do
+        sh 'rubocop', '--fail-fast', '--display-style-guide', '--fail-level', 'convention'
+      end
+    end
+
+    namespace :auto_gen_config do
+      desc 'Autogenerate rubocop config in rails and in root'
+      task all: [:root, :rails]
+
+      desc 'Autogenerate rubocop config in rails'
+      task :rails do
+        # We set `exclude-limit` to 100 (from the default of 15) to make it easier to tackle TODOs one file at a time
+        # A cop will be disabled only if it triggered offenses for more than 100 files
+        sh 'rubocop --auto-gen-config --ignore_parent_exclusion --auto-gen-only-exclude --exclude-limit 100'
+      end
+
+      desc 'Run the ruby linter in root'
+      task :root do
+        Dir.chdir('../..') do
+          # We set `exclude-limit` to 100 (from the default of 15) to make it easier to tackle TODOs one file at a time
+          # A cop will be disabled only if it triggered offenses for more than 100 files
+          sh 'rubocop --auto-gen-config --auto-gen-only-exclude --exclude-limit 100'
+        end
+      end
+    end
+
+    desc 'Autocorrect rubocop offenses in rails and in root'
+    task :autocorrect do
+      sh 'rubocop --autocorrect --ignore_parent_exclusion'
+      Dir.chdir('../..') do
+        sh 'rubocop --autocorrect'
+      end
+    end
+  end
+end

--- a/src/api/lib/tasks/dev/multiple_actions_request.rake
+++ b/src/api/lib/tasks/dev/multiple_actions_request.rake
@@ -1,3 +1,5 @@
+require 'tasks/dev/helper_methods'
+
 namespace :requests do
   # Run this task with: rails requests:multiple_actions_request
   desc 'Creates a request with multiple actions'

--- a/src/api/lib/tasks/dev/notifications.rake
+++ b/src/api/lib/tasks/dev/notifications.rake
@@ -1,0 +1,100 @@
+require 'tasks/dev/helper_methods'
+
+# Run this task with: rails "notifications:data[3]"
+# replacing 3 with any number to indicate how many times you want this code to be executed.
+namespace :notifications do
+  desc 'Creates a notification and all its dependencies'
+  task :data, [:repetitions] => :environment do |_t, args|
+    unless Rails.env.development?
+      puts "You are running this rake task in #{Rails.env} environment."
+      puts 'Please only run this task with RAILS_ENV=development'
+      puts 'otherwise it will destroy your database data.'
+      return
+    end
+
+    args.with_defaults(repetitions: 1)
+    repetitions = args.repetitions.to_i
+    require 'factory_bot'
+    include FactoryBot::Syntax::Methods
+
+    # Users
+    admin = User.where(login: 'Admin').first || create(:admin_user, login: 'Admin')
+    group = create(:groups_user, user: admin, group: create(:group, title: Faker::Lorem.word)).group
+    subscribe_to_all_notifications(admin)
+    requestor = User.where(login: 'Requestor').first || create(:confirmed_user, login: 'Requestor')
+    User.session = requestor
+
+    # Projects
+    admin_home_project = admin.home_project || create_and_assign_project(admin.home_project_name, admin)
+    requestor_project = Project.find_by(name: 'requestor_project') || create_and_assign_project('requestor_project', requestor)
+
+    repetitions.times do |repetition|
+      package_name = "package_#{Time.now.to_i}_#{repetition}"
+      admin_package = create(:package_with_file, name: package_name, project: admin_home_project)
+      requestor_package = create(:package_with_file, name: admin_package.name, project: requestor_project)
+
+      # Will create a notification (RequestCreate event) for this request.
+      request = create(
+        :bs_request_with_submit_action,
+        creator: requestor,
+        target_project: admin_home_project,
+        target_package: admin_package,
+        source_project: requestor_project,
+        source_package: requestor_package
+      )
+
+      # Will create notifications (ReviewWanted event) for those reviews.
+      # The creation and these two reviews are finally displayed as
+      # one single notification in the UI.
+      request.addreview(by_user: admin, comment: Faker::Lorem.paragraph)
+      request.addreview(by_group: group, comment: Faker::Lorem.paragraph)
+
+      # Will create a notification (CommentForRequest event) for this comment.
+      create(:comment_request, commentable: request, user: requestor)
+      # Will create a notification (CommentForProject event) for this comment.
+      create(:comment_project, commentable: admin_home_project, user: requestor)
+      # Will create a notification (CommentForPackage event) for this comment.
+      create(:comment_package, commentable: admin_package, user: requestor)
+
+      # Admin requests changes to requestor, so a RequestStatechange notification will appear
+      # as soon as the requestor changes the state of the request.
+      request2 = create(
+        :bs_request_with_submit_action,
+        creator: admin,
+        target_project: requestor_project,
+        target_package: requestor_package,
+        source_project: admin_home_project,
+        source_package: admin_package
+      )
+      # Will create a notification (RequestStatechange event) for this request change.
+      request2.change_state(newstate: ['accepted', 'declined'].sample, force: true, user: requestor.login, comment: 'Declined by requestor')
+
+      # Process notifications immediately to see them in the web UI
+      SendEventEmailsJob.new.perform_now
+    end
+  end
+end
+
+def subscribe_to_all_notifications(user)
+  create(:event_subscription_request_created, channel: :web, user: user, receiver_role: 'target_maintainer')
+  create(:event_subscription_review_wanted, channel: 'web', user: user, receiver_role: 'reviewer')
+  create(:event_subscription_request_statechange, channel: :web, user: user, receiver_role: 'target_maintainer')
+  create(:event_subscription_request_statechange, channel: :web, user: user, receiver_role: 'source_maintainer')
+  create(:event_subscription_comment_for_project, channel: :web, user: user, receiver_role: 'maintainer')
+  create(:event_subscription_comment_for_package, channel: :web, user: user, receiver_role: 'maintainer')
+  create(:event_subscription_comment_for_request, channel: :web, user: user, receiver_role: 'target_maintainer')
+  create(:event_subscription_relationship_create, channel: :web, user: user, receiver_role: 'any_role')
+  create(:event_subscription_relationship_delete, channel: :web, user: user, receiver_role: 'any_role')
+
+  user.groups.each do |group|
+    create(:event_subscription_request_created, channel: :web, user: nil, group: group, receiver_role: 'target_maintainer')
+    create(:event_subscription_review_wanted, channel: 'web', user: nil, group: group, receiver_role: 'reviewer')
+    create(:event_subscription_request_statechange, channel: :web, user: nil, group: group, receiver_role: 'target_maintainer')
+    create(:event_subscription_request_statechange, channel: :web, user: nil, group: group, receiver_role: 'source_maintainer')
+    create(:event_subscription_comment_for_project, channel: :web, user: nil, group: group, receiver_role: 'maintainer')
+    create(:event_subscription_comment_for_package, channel: :web, user: nil, group: group, receiver_role: 'maintainer')
+    create(:event_subscription_comment_for_request, channel: :web, user: nil, group: group, receiver_role: 'target_maintainer')
+    create(:event_subscription_relationship_create, channel: :web, user: nil, group: group, receiver_role: 'any_role')
+    create(:event_subscription_relationship_delete, channel: :web, user: nil, group: group, receiver_role: 'any_role')
+  end
+end

--- a/src/api/lib/tasks/dev/sre.rake
+++ b/src/api/lib/tasks/dev/sre.rake
@@ -1,0 +1,23 @@
+require 'fileutils'
+require 'yaml'
+
+# Run this task with: rails sre:configure
+namespace :sre do
+  desc 'Configure the rails app to publish application health monitoring stats'
+  task :configure do
+    unless Rails.env.development?
+      puts "You are running this rake task in #{Rails.env} environment."
+      puts 'Please only run this task with RAILS_ENV=development'
+      return
+    end
+
+    copy_example_file('config/options.yml')
+    options_yml = YAML.load_file('config/options.yml') || {}
+    options_yml['development']['influxdb_hosts'] = ['influx']
+    options_yml['development']['amqp_namespace'] = 'opensuse.obs'
+    options_yml['development']['amqp_options'] = { host: 'rabbit', port: '5672', user: 'guest', pass: 'guest', vhost: '/' }
+    options_yml['development']['amqp_exchange_name'] = 'pubsub'
+    options_yml['development']['amqp_exchange_options'] = { type: :topic, persistent: 'true', passive: 'true' }
+    File.write('config/options.yml', YAML.dump(options_yml))
+  end
+end

--- a/src/api/lib/tasks/dev/staging.rake
+++ b/src/api/lib/tasks/dev/staging.rake
@@ -1,0 +1,44 @@
+# Run this task with: rails staging:data
+namespace :staging do
+  desc 'Creates a staging workflow with a project and a confirmed user'
+  task data: :environment do
+    unless Rails.env.development?
+      puts "You are running this rake task in #{Rails.env} environment."
+      puts 'Please only run this task with RAILS_ENV=development'
+      puts 'otherwise it will destroy your database data.'
+      return
+    end
+
+    require 'factory_bot'
+    include FactoryBot::Syntax::Methods
+    timestamp = Time.now.to_i
+    maintainer = create(:confirmed_user, login: "maintainer_#{timestamp}")
+    User.session = maintainer
+    managers_group = create(:group, title: "managers_group_#{timestamp}")
+    staging_workflow = create(:staging_workflow_with_staging_projects, project: maintainer.home_project, managers_group: managers_group)
+    staging_workflow.managers_group.add_user(maintainer)
+
+    staging_workflow.staging_projects.each do |staging_project|
+      2.times { |i| request_for_staging(staging_project, maintainer.home_project, "#{staging_project.id}_#{timestamp}_#{i}") }
+    end
+
+    puts "**** Created staging workflow project: /staging_workflows/#{staging_workflow.project} ****"
+  end
+end
+
+def request_for_staging(staging_project, maintainer_project, suffix)
+  requester = create(:confirmed_user, login: "requester_#{suffix}")
+  source_project = create(:project, name: "source_project_#{suffix}")
+  target_package = create(:package, name: "target_package_#{suffix}", project: maintainer_project)
+  source_package = create(:package, name: "source_package_#{suffix}", project: source_project)
+  request = create(
+    :bs_request_with_submit_action,
+    state: :new,
+    creator: requester,
+    target_package: target_package,
+    source_package: source_package,
+    staging_project: staging_project
+  )
+
+  request.reviews.each { |review| review.change_state(:accepted, 'Accepted') }
+end

--- a/src/api/lib/tasks/dev/workflows.rake
+++ b/src/api/lib/tasks/dev/workflows.rake
@@ -1,3 +1,5 @@
+require 'tasks/dev/helper_methods'
+
 namespace :workflows do
   # Run this task with: rails workflows:create_workflow_runs
   desc 'Creates a workflow token, workflow runs, artifacts and some of their dependencies'

--- a/src/api/spec/support/shared_contexts/rake.rb
+++ b/src/api/spec/support/shared_contexts/rake.rb
@@ -6,7 +6,7 @@ RSpec.shared_context 'rake' do
     Rake.application = Rake::Application.new
     Rake.application.rake_require(
       self.class.top_level_description,
-      [Rails.root.join('lib', 'tasks').to_s]
+      [Rails.root.join('lib', 'tasks').to_s, Rails.root.join('lib', 'tasks', 'dev').to_s]
     )
     Rake::Task.define_task(:environment)
   end


### PR DESCRIPTION
Instead of having all the development-related tasks inside the same file, `dev.rake`, they are moved to independent files.