### PR TITLE
Extract methods used by many tasks to a file

### DIFF
--- a/src/api/lib/tasks/dev/rake_support.rb
+++ b/src/api/lib/tasks/dev/rake_support.rb
@@ -1,0 +1,25 @@
+module RakeSupport
+  def self.create_and_assign_project(project_name, user)
+    create(:project, name: project_name).tap do |project|
+      create(:relationship, project: project, user: user, role: Role.hashed['maintainer'])
+    end
+  end
+
+  def self.find_or_create_project(project_name, user)
+    project = Project.joins(:relationships)
+                     .where(projects: { name: project_name }, relationships: { user: user }).first
+    return project if project
+
+    create_and_assign_project(project_name, user)
+  end
+
+  def self.copy_example_file(example_file)
+    if File.exist?(example_file) && !ENV['FORCE_EXAMPLE_FILES']
+      example_file = File.join(File.expand_path(File.dirname(__FILE__) + '/../..'), example_file)
+      puts "WARNING: You already have the config file #{example_file}, make sure it works with docker"
+    else
+      puts "Creating config/#{example_file} from config/#{example_file}.example"
+      FileUtils.copy_file("#{example_file}.example", example_file)
+    end
+  end
+end

--- a/src/api/lib/tasks/multiple_actions_request.rake
+++ b/src/api/lib/tasks/multiple_actions_request.rake
@@ -18,7 +18,7 @@ namespace :requests do
     User.session = requestor
 
     # Set source project, packages and files
-    source_project = find_or_create_project(requestor.home_project_name, requestor) # home:Admin
+    source_project = RakeSupport.find_or_create_project(requestor.home_project_name, requestor) # home:Admin
     source_package_a = Package.where(name: 'package_a', project: source_project).first || create(:package, name: 'package_a', project: source_project)
     source_package_b = Package.where(name: 'package_b', project: source_project).first || create(:package, name: 'package_b', project: source_project)
     # Add files to the newly created source package A

--- a/src/api/lib/tasks/workflows.rake
+++ b/src/api/lib/tasks/workflows.rake
@@ -16,7 +16,7 @@ namespace :workflows do
 
     admin = User.get_default_admin
     User.session = admin
-    project = find_or_create_project(admin.home_project_name, admin)
+    project = RakeSupport.find_or_create_project(admin.home_project_name, admin)
 
     workflow_token = Token::Workflow.find_by(description: 'Testing token') || create(:workflow_token, executor: admin, description: 'Testing token')
 


### PR DESCRIPTION
This is the first in a series of PRs refactoring the dev tasks. The plan is to move some tasks from `dev.rake` to different individual files. They will be placed in the `lib/tasks/dev` directory.

In this first PR, I extract methods that are going to be used by different tasks to a file we can require later.
