### PR TITLE
Extract linters tasks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -277,7 +277,7 @@ You can access the frontend at [localhost:3000](http://localhost:3000). Whatever
 
     ```
     docker-compose run --rm frontend bundle exec rspec
-    docker-compose run --rm frontend bundle exec rake dev:lint
+    docker-compose run --rm frontend bundle exec rake dev:lint:all
     ```
 
 10. Changed something in the backend? Test your changes!

--- a/src/api/lib/tasks/dev.rake
+++ b/src/api/lib/tasks/dev.rake
@@ -60,69 +60,6 @@ namespace :dev do
     Rake::Task['flipper:enable_features_for_group'].invoke
   end
 
-  desc 'Run all linters we use'
-  task :lint do
-    Rake::Task['dev:lint:haml'].invoke
-    Rake::Task['dev:lint:rubocop:all'].invoke
-    sh 'jshint ./app/assets/javascripts/'
-  end
-
-  namespace :lint do
-    namespace :rubocop do
-      desc 'Run the ruby linter in rails and in root'
-      task all: [:root, :rails]
-
-      desc 'Run the ruby linter in rails'
-      task :rails do
-        sh 'rubocop', '--fail-fast', '--display-style-guide', '--fail-level', 'convention', '--ignore_parent_exclusion'
-      end
-
-      desc 'Run the ruby linter in root'
-      task :root do
-        Dir.chdir('../..') do
-          sh 'rubocop', '--fail-fast', '--display-style-guide', '--fail-level', 'convention'
-        end
-      end
-
-      namespace :auto_gen_config do
-        desc 'Autogenerate rubocop config in rails and in root'
-        task all: [:root, :rails]
-
-        desc 'Autogenerate rubocop config in rails'
-        task :rails do
-          # We set `exclude-limit` to 100 (from the default of 15) to make it easier to tackle TODOs one file at a time
-          # A cop will be disabled only if it triggered offenses for more than 100 files
-          sh 'rubocop --auto-gen-config --ignore_parent_exclusion --auto-gen-only-exclude --exclude-limit 100'
-        end
-
-        desc 'Run the ruby linter in root'
-        task :root do
-          Dir.chdir('../..') do
-            # We set `exclude-limit` to 100 (from the default of 15) to make it easier to tackle TODOs one file at a time
-            # A cop will be disabled only if it triggered offenses for more than 100 files
-            sh 'rubocop --auto-gen-config --auto-gen-only-exclude --exclude-limit 100'
-          end
-        end
-      end
-
-      desc 'Autocorrect rubocop offenses in rails and in root'
-      task :autocorrect do
-        sh 'rubocop --autocorrect --ignore_parent_exclusion'
-        Dir.chdir('../..') do
-          sh 'rubocop --autocorrect'
-        end
-      end
-    end
-    desc 'Run the haml linter'
-    task :haml do
-      Rake::Task['haml_lint'].invoke('--parallel')
-    end
-    desc 'Run apidocs linter'
-    task :apidocs do
-      sh 'find public/apidocs-new -name  \'*.yaml\' | xargs -P8 -I % ruby -e "require \'yaml\'; YAML.load_file(\'%\',  permitted_classes: [Time])"'
-    end
-  end
-
   # This is automatically run in Review App or manually in development env.
   namespace :development_testdata do
     desc 'Creates test data to play with in dev and CI environments'

--- a/src/api/lib/tasks/dev/lint.rake
+++ b/src/api/lib/tasks/dev/lint.rake
@@ -1,0 +1,67 @@
+namespace :dev do
+  namespace :lint do
+    # Run this task with: rails dev:lint:all
+    desc 'Run all linters we use'
+    task :all do
+      Rake::Task['dev:lint:haml'].invoke
+      Rake::Task['dev:lint:rubocop:all'].invoke
+      sh 'jshint ./app/assets/javascripts/'
+    end
+
+    desc 'Run the haml linter'
+    task :haml do
+      Rake::Task['haml_lint'].invoke('--parallel')
+    end
+
+    desc 'Run apidocs linter'
+    task :apidocs do
+      sh 'find public/apidocs-new -name  \'*.yaml\' | xargs -P8 -I % ruby -e "require \'yaml\'; YAML.load_file(\'%\',  permitted_classes: [Time])"'
+    end
+
+    namespace :rubocop do
+      desc 'Run the ruby linter in rails and in root'
+      task all: [:root, :rails]
+
+      desc 'Run the ruby linter in rails'
+      task :rails do
+        sh 'rubocop', '--fail-fast', '--display-style-guide', '--fail-level', 'convention', '--ignore_parent_exclusion'
+      end
+
+      desc 'Run the ruby linter in root'
+      task :root do
+        Dir.chdir('../..') do
+          sh 'rubocop', '--fail-fast', '--display-style-guide', '--fail-level', 'convention'
+        end
+      end
+
+      namespace :auto_gen_config do
+        desc 'Autogenerate rubocop config in rails and in root'
+        task all: [:root, :rails]
+
+        desc 'Autogenerate rubocop config in rails'
+        task :rails do
+          # We set `exclude-limit` to 100 (from the default of 15) to make it easier to tackle TODOs one file at a time
+          # A cop will be disabled only if it triggered offenses for more than 100 files
+          sh 'rubocop --auto-gen-config --ignore_parent_exclusion --auto-gen-only-exclude --exclude-limit 100'
+        end
+
+        desc 'Run the ruby linter in root'
+        task :root do
+          Dir.chdir('../..') do
+            # We set `exclude-limit` to 100 (from the default of 15) to make it easier to tackle TODOs one file at a time
+            # A cop will be disabled only if it triggered offenses for more than 100 files
+            sh 'rubocop --auto-gen-config --auto-gen-only-exclude --exclude-limit 100'
+          end
+        end
+      end
+
+      desc 'Autocorrect rubocop offenses in rails and in root'
+      task :autocorrect do
+        sh 'rubocop --autocorrect --ignore_parent_exclusion'
+        Dir.chdir('../..') do
+          sh 'rubocop --autocorrect'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is the 7th and last in a series of PRs refactoring the dev tasks. The plan is to move some tasks from `dev.rake` to different individual files. They will be placed in the `lib/tasks/dev` directory.

In this PR, I move the tasks related to linters to an individual file in `lib/tasks/dev`.

Developer, bear in mind that the commonly used rake task `rails dev:lint` is renamed to `rails dev:lint:all`.