### PR TITLE
Add debug mode to EventSubscription::FindForEvent#subscription

### DIFF
--- a/src/api/.rubocop.yml
+++ b/src/api/.rubocop.yml
@@ -243,6 +243,7 @@ Metrics/BlockLength:
     - 'app/models/branch_package.rb'
     - 'app/models/bs_request.rb'
     - 'app/models/bs_request_action.rb'
+    - 'app/models/event_subscription/find_for_event.rb'
     - 'app/models/patchinfo.rb'
     - 'app/models/product.rb'
     - 'app/models/user_ldap_strategy.rb'

--- a/src/api/app/models/event_subscription/find_for_event.rb
+++ b/src/api/app/models/event_subscription/find_for_event.rb
@@ -2,19 +2,23 @@ class EventSubscription
   class FindForEvent
     attr_reader :event
 
-    def initialize(event)
+    def initialize(event, debug: false)
       @event = event
+      @debug = debug
     end
 
+    # rubocop: disable Rails/Output
     def subscriptions(channel = :instant_email)
       receivers_and_subscriptions = {}
 
       event.class.receiver_roles.each do |receiver_role|
         # Find the users/groups who are receivers for this event
-        receivers = event.send("#{receiver_role}s")
-        next if receivers.blank?
+        receivers_before_expand = event.send("#{receiver_role}s")
+        next if receivers_before_expand.blank?
 
-        receivers = expand_receivers(receivers, channel)
+        puts "Looking at #{receivers_before_expand.map(&:to_s).join(', ')} for '#{receiver_role}' and channel '#{channel}'" if @debug
+        receivers = expand_receivers(receivers_before_expand, channel)
+        puts "Looking at #{receivers.map(&:to_s).join(', ')} for '#{receiver_role}' and channel '#{channel}'" if @debug && (receivers_before_expand - receivers).any?
 
         options = { eventtype: event.eventtype, receiver_role: receiver_role, channel: channel }
         # Find the default subscription for this eventtype and receiver_role
@@ -22,16 +26,23 @@ class EventSubscription
 
         receivers.each do |receiver|
           # Prevent multiple enabled subscriptions for the same subscriber & eventtype
-          # Also skip if the receiver is the originator of this event
-          next if receivers_and_subscriptions[receiver].present? || receiver == event.originator
+          if receivers_and_subscriptions[receiver].present?
+            puts "Skipped receiver #{receiver}, since it is already in the list..." if @debug
+            next
+          end
+
+          # Skip if the receiver is the originator of this event
+          if receiver == event.originator
+            puts "Skipped receiver #{receiver}, since it is the originator of the event..." if @debug
+            next
+          end
 
           # Try to find the subscription for this receiver
           receiver_subscription = EventSubscription.for_subscriber(receiver).find_by(options)
-
           if receiver_subscription.present?
             # Use the receiver's subscription if it exists
             receivers_and_subscriptions[receiver] = receiver_subscription if receiver_subscription.enabled?
-
+            puts "Skipped receiver #{receiver} because they have a disabled user subscription" if @debug && !receiver_subscription.enabled?
           # Only check the default_subscription if there is no receiver's subscription
           elsif default_subscription.present? && default_subscription.enabled?
             # Add a new subscription for the receiver based on the default subscription
@@ -41,8 +52,11 @@ class EventSubscription
               channel: default_subscription.channel,
               subscriber: receiver
             )
+          elsif @debug && default_subscription.present? && !default_subscription.enabled?
+            puts "Skipped receiver #{receiver} because of a disabled default subscription"
           end
         end
+        puts "People to receive something: #{receivers_and_subscriptions.values.flatten.map { |subscription| subscription.subscriber.to_s }}\n\n" if @debug
       end
 
       receivers_and_subscriptions.values.flatten
@@ -53,7 +67,7 @@ class EventSubscription
         case receiver
         when User
           new_receivers << receiver if receiver.is_active?
-
+          puts "Skipped receiver #{receiver} because it's inactive" if @debug && !receiver.is_active?
         when Group
           new_receivers += expand_receivers_for_groups(new_receivers, receiver, channel)
         end
@@ -65,11 +79,14 @@ class EventSubscription
     def expand_receivers_for_groups(_new_receivers, receiver, channel)
       # We don't subscribe Groups so we have to get the group's users to get the subscriptions
       return receiver.users if event.instance_of?(Event::RelationshipCreate) || event.instance_of?(Event::RelationshipDelete)
+
       # We don't split events which come through the web channel, for a group subscriber.
       # They are split in the NotificationService::WebChannel service, if needed.
       return [receiver] if channel == :web || receiver.email.present?
 
+      puts "Expanding group #{receiver}..." if @debug
       receiver.email_users
     end
+    # rubocop: enable Rails/Output
   end
 end


### PR DESCRIPTION
We recently faced an issue where a user received notifications
for events without subscription. In order to identify the source/cause,
debugging output will help to follow the connections between Event,
Subscription and Receiver.

*Example output:*

```
Looking at Admin for 'commenter' and channel 'instant_email'
Skipped receiver Admin, since it is the originator of the event...
People to receive something: []

Looking at Admin for 'source_maintainer' and channel 'instant_email'
Skipped receiver Admin, since it is the originator of the event...
People to receive something: []

Looking at foo, bar for 'target_maintainer' and channel 'instant_email'
Expanding group bar...
Looking at foo, foo for 'target_maintainer' and channel 'instant_email'
Skipped receiver foo, since it is already in the list...
People to receive something: ["foo"]

Looking at Admin for 'creator' and channel 'instant_email'
Skipped receiver Admin, since it is the originator of the event...
People to receive something: ["foo"]

Looking at Admin, bar for 'reviewer' and channel 'instant_email'
Expanding group bar...
Looking at Admin, foo for 'reviewer' and channel 'instant_email'
Skipped receiver Admin, since it is the originator of the event...
Skipped receiver foo, since it is already in the list...
People to receive something: ["foo"]

```
