### PR TITLE
Add markdown preview to status message

### DIFF
--- a/src/api/app/assets/javascripts/webui/application.js
+++ b/src/api/app/assets/javascripts/webui/application.js
@@ -60,3 +60,4 @@
 //= require webui/request_show_redesign/build_results.js
 //= require webui/delete_confirmation_dialog.js
 //= require webui/nav_tabs.js
+//= require webui/write_and_preview.js

--- a/src/api/app/assets/javascripts/webui/write_and_preview.js
+++ b/src/api/app/assets/javascripts/webui/write_and_preview.js
@@ -1,0 +1,23 @@
+$(document).ready(function(){
+  $('.write-and-preview').on('click', '.preview-message-tab:not(.active)', function (e) {
+      var messageContainer = $(e.target).closest('.write-and-preview');
+      var messageText = messageContainer.find('.message-field').val();
+      var messagePreview = messageContainer.find('.message-preview');
+      if (messageText) {
+        $.ajax({
+          method: 'POST',
+          url: $(this).data('previewMessageUrl'),
+          dataType: 'json',
+          data: { 'status_message[message]': messageText },
+          success: function(data) {
+            messagePreview.html(data.markdown);
+          },
+          error: function() {
+            messagePreview.html('Error loading markdown preview');
+          }
+        });
+      } else {
+        messagePreview.html('Nothing to preview');
+      }
+  });
+});

--- a/src/api/app/components/write_and_preview_component.html.haml
+++ b/src/api/app/components/write_and_preview_component.html.haml
@@ -1,0 +1,16 @@
+.card.write-and-preview
+  %ul.nav.nav-tabs.px-3.pt-2.disable-link-generation{ role: 'tablist' }
+    %li.nav-item
+      = link_to('Write', '#write_message', class: 'nav-link active', data: { toggle: 'tab' }, role: 'tab',
+      aria: { controls: 'write-message-tab', selected: 'true' })
+    %li.nav-item
+      = link_to('Preview', '#preview_message', class: 'nav-link preview-message-tab',
+      data: { toggle: 'tab', preview_message_url: preview_message_url },
+      role: 'tab', aria: { controls: 'preview-message-tab', selected: 'false' })
+  .tab-content.px-3
+    .tab-pane.fade.show.active.my-3{ id: 'write_message', role: 'tabpanel', 'aria-labelledby': 'write-message-tab' }
+      ~ form.text_area(:message, rows: '4', required: true,
+        placeholder: 'Write your message here... (Markdown markup is supported)',
+        class: 'w-100 form-control message-field')
+    .tab-pane.fade{ id: 'preview_message', role: 'tabpanel', 'aria-labelledby': 'preview-message-tab' }
+      .message-preview.my-3

--- a/src/api/app/components/write_and_preview_component.rb
+++ b/src/api/app/components/write_and_preview_component.rb
@@ -1,0 +1,10 @@
+class WriteAndPreviewComponent < ApplicationComponent
+  attr_reader :form, :preview_message_url
+
+  def initialize(form, preview_message_url)
+    super
+
+    @form = form
+    @preview_message_url = preview_message_url
+  end
+end

--- a/src/api/app/controllers/webui/status_messages_controller.rb
+++ b/src/api/app/controllers/webui/status_messages_controller.rb
@@ -1,7 +1,7 @@
 class Webui::StatusMessagesController < Webui::WebuiController
   # TODO: Remove this when we'll refactor kerberos_auth
   before_action :kerberos_auth
-  after_action :verify_authorized
+  after_action :verify_authorized, except: [:preview]
 
   def new
     authorize StatusMessage
@@ -54,6 +54,13 @@ class Webui::StatusMessagesController < Webui::WebuiController
 
     respond_to do |format|
       format.js { render controller: 'status_message', action: 'acknowledge' }
+    end
+  end
+
+  def preview
+    markdown = helpers.render_as_markdown(status_message_params[:message])
+    respond_to do |format|
+      format.json { render json: { markdown: markdown } }
     end
   end
 

--- a/src/api/app/views/webui/status_messages/edit.html.haml
+++ b/src/api/app/views/webui/status_messages/edit.html.haml
@@ -13,7 +13,7 @@
                 = form.label(:message) do
                   Message:
                   %abbr.text-danger{ title: 'required' } *
-                = form.text_area(:message, rows: 3, required: true, class: 'form-control')
+                = render WriteAndPreviewComponent.new(form, preview_status_messages_path)
               .form-group
                 = form.label(:severity) do
                   Severity:

--- a/src/api/app/views/webui/status_messages/new.html.haml
+++ b/src/api/app/views/webui/status_messages/new.html.haml
@@ -12,7 +12,7 @@
                 = f.label(:message) do
                   Message:
                   %abbr.text-danger{ title: 'required' } *
-                = f.text_area(:message, rows: 3, required: true, class: 'form-control')
+                = render WriteAndPreviewComponent.new(f, preview_status_messages_path)
               .form-group
                 = f.label(:severity) do
                   Severity:

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -8,7 +8,11 @@ OBSApi::Application.routes.draw do
       mount Flipper::UI.app(Flipper) => '/flipper'
     end
 
-    resources :status_messages, only: [:new, :create, :edit, :update, :destroy], controller: 'webui/status_messages'
+    resources :status_messages, only: [:new, :create, :edit, :update, :destroy], controller: 'webui/status_messages' do
+      collection do
+        post 'preview'
+      end
+    end
 
     controller 'webui/feeds' do
       get 'main/news' => :news, constraints: ->(req) { req.format == :rss }, as: :news_feed


### PR DESCRIPTION
The status messages accept markdown. We find it helpful to see a preview before we save it.

![write_preview_status](https://user-images.githubusercontent.com/2581944/200316704-bf4fdf2c-1df2-4066-9719-c5ccbd1d52fb.gif)

**How to test in review-app?**

- Log in as Admin.
- Go to the OBS home page.
- Click on "Create Status Message"
- Add some text applying markdown.
- Click on the _Preview_ tab and check if the markdown is applied correctly.
- Save the status message and check the message is displaying, with the correct markdown applied, in the News section.