### PR TITLE
[api] fix bugzilla issue owner, when new owner is unknown

### DIFF
--- a/src/api/app/models/issue_tracker.rb
+++ b/src/api/app/models/issue_tracker.rb
@@ -167,6 +167,7 @@ class IssueTracker < ApplicationRecord
     if user
       issue.owner_id = user.id
     else
+      issue.owner_id = nil
       logger.info "Bugzilla user #{bugzilla_response['assigned_to']} is not found in OBS user database"
     end
 


### PR DESCRIPTION
A bugzilla issue might get reassigned to a user who is not registered in OBS. Resetting the owner of the issue in that case to avoid dangling issues for a user.