### PR TITLE
Avoid failing packtrack jobs

### DIFF
--- a/src/api/app/jobs/update_released_binaries_job.rb
+++ b/src/api/app/jobs/update_released_binaries_job.rb
@@ -9,4 +9,9 @@ class UpdateReleasedBinariesJob < CreateJob
 
     BinaryRelease.update_binary_releases(repo, pl['payload'], event.created_at)
   end
+
+  def max_run_time
+    # twice the time of the default (8 hours now)
+    28800
+  end
 end


### PR DESCRIPTION
Due to large amount of content in single registry release repositories.