### PR TITLE
Improve new build results view

### DIFF
--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -181,6 +181,7 @@ Metrics/ClassLength:
     - 'app/models/bs_request_action_maintenance_incident.rb'
     - 'app/models/bs_request_action_maintenance_release.rb'
     - 'app/models/bs_request_permission_check.rb'
+    - 'app/models/buildresult.rb'
     - 'app/models/channel.rb'
     - 'app/models/event/base.rb'
     - 'app/models/event/request.rb'

--- a/src/api/app/assets/javascripts/webui/request_show_redesign/build_results.js
+++ b/src/api/app/assets/javascripts/webui/request_show_redesign/build_results.js
@@ -1,24 +1,9 @@
 // TODO: rename without "Beta" after the rollout of 'request_show_redesign'.
 function updateBuildResultBeta() { // jshint ignore:line
-  var collapsedPackages = [];
-  var collapsedRepositories = {};
-  $('.result div.collapse:not(.show)').map(function(_index, domElement) {
-    var main = $(domElement).data('main') ? $(domElement).data('main') : 'project';
-    if (collapsedRepositories[main] === undefined) { collapsedRepositories[main] = []; }
-    if ($(domElement).data('repository') === undefined) {
-      collapsedPackages.push(main);
-    }
-    else {
-      collapsedRepositories[main].push($(domElement).data('repository'));
-    }
-  });
-
   var ajaxDataShow = $('.build-results-content').data();
   // show_all comes from the buildstatus partial
   ajaxDataShow.show_all = $('#show_all').is(':checked'); // jshint ignore:line
   ajaxDataShow.inRequestShowRedesign = true;
-  ajaxDataShow.collapsedPackages = collapsedPackages;
-  ajaxDataShow.collapsedRepositories = collapsedRepositories;
 
   var buildResultsUrl = $('.build-results-content .build-refresh').data('build-results-url');
 

--- a/src/api/app/assets/stylesheets/request_show_redesign/build_results.scss
+++ b/src/api/app/assets/stylesheets/request_show_redesign/build_results.scss
@@ -1,29 +1,9 @@
 .build-result {
-  // One element per row
-  // The div width is 100% minus the sum of its margins: ml-2 + mr-2 = 0.5rem + 0.5rem = 1rem
-  width: calc(100% - 1rem);
+  width: 220px;
   border-left: thick solid $gray-300;
   cursor: help;
 
   &:hover {
     background-color: $gray-100;
-  }
-
-  @include media-breakpoint-up(sm) {
-    // Up to 2 elements in a row
-    // The div width is 50% minus the sum of its margins: ml-2 + mr-5 = 0.5rem + 3rem = 3.5rem
-    width: calc(50% - 3.5rem);
-  }
-
-  @include media-breakpoint-up(lg) {
-    // Up to 4 elements in a row
-    // The div width is 25% minus the sum of its margins: ml-2 + mr-5 = 0.5rem + 3rem = 3.5rem
-    width: calc(25% - 3.5rem);
-  }
-
-  @include media-breakpoint-up(xxl) {
-    // Up to 5 elements in a row
-    // The div width is 20% minus the sum of its margins: ml-2 + mr-5 = 0.5rem + 3rem = 3.5rem
-    width: calc(20% - 3.5rem);
   }
 }

--- a/src/api/app/assets/stylesheets/request_show_redesign/build_results.scss
+++ b/src/api/app/assets/stylesheets/request_show_redesign/build_results.scss
@@ -1,0 +1,29 @@
+.build-result {
+  // One element per row
+  // The div width is 100% minus the sum of its margins: ml-2 + mr-2 = 0.5rem + 0.5rem = 1rem
+  width: calc(100% - 1rem);
+  border-left: thick solid $gray-300;
+  cursor: help;
+
+  &:hover {
+    background-color: $gray-100;
+  }
+
+  @include media-breakpoint-up(sm) {
+    // Up to 2 elements in a row
+    // The div width is 50% minus the sum of its margins: ml-2 + mr-5 = 0.5rem + 3rem = 3.5rem
+    width: calc(50% - 3.5rem);
+  }
+
+  @include media-breakpoint-up(lg) {
+    // Up to 4 elements in a row
+    // The div width is 25% minus the sum of its margins: ml-2 + mr-5 = 0.5rem + 3rem = 3.5rem
+    width: calc(25% - 3.5rem);
+  }
+
+  @include media-breakpoint-up(xxl) {
+    // Up to 5 elements in a row
+    // The div width is 20% minus the sum of its margins: ml-2 + mr-5 = 0.5rem + 3rem = 3.5rem
+    width: calc(20% - 3.5rem);
+  }
+}

--- a/src/api/app/assets/stylesheets/webui/application.scss
+++ b/src/api/app/assets/stylesheets/webui/application.scss
@@ -70,6 +70,7 @@
 @import 'new_watchlist/watchlist';
 @import 'timeline';
 @import 'request_show_redesign/add_review';
+@import 'request_show_redesign/build_results';
 
 html {
     overflow-y: scroll !important;

--- a/src/api/app/assets/stylesheets/webui/borders.scss
+++ b/src/api/app/assets/stylesheets/webui/borders.scss
@@ -8,3 +8,4 @@
 
 .border-gray-500 { border-color: $gray-500 !important; }
 .border-gray-400 { border-color: $gray-400 !important; }
+.border-gray-300 { border-color: $gray-300 !important; }

--- a/src/api/app/components/build_result_for_architecture_component.html.haml
+++ b/src/api/app/components/build_result_for_architecture_component.html.haml
@@ -1,10 +1,10 @@
-.build-result.p-2.pl-3.my-2.my-sm-4.mx-2.mr-sm-5{ class: "#{status_border_color(result_code)}",
+.build-result.p-1.pl-3.p-sm-2.pl-sm-3.mx-2.mt-2{ class: "#{status_border_color(result_code)}",
                                             data: { placement: 'auto',
                                                     toggle: 'popover',
                                                     html: 'true',
                                                     content: help,
                                                     offset: 50 } }
-  .d-flex.align-items-baseline.mb-2
+  .d-flex.align-items-baseline.mb-sm-2
     %span.font-weight-bold
       = result.architecture
     .build-status.ml-3.d-inline.d-sm-none

--- a/src/api/app/components/build_result_for_architecture_component.html.haml
+++ b/src/api/app/components/build_result_for_architecture_component.html.haml
@@ -1,0 +1,22 @@
+.build-result.p-2.pl-3.my-2.my-sm-4.mx-2.mr-sm-5{ class: "#{status_border_color(result_code)}",
+                                            data: { placement: 'auto',
+                                                    toggle: 'popover',
+                                                    html: 'true',
+                                                    content: help,
+                                                    offset: 50 } }
+  .d-flex.align-items-baseline.mb-2
+    %span.font-weight-bold
+      = result.architecture
+    .build-status.ml-3.d-inline.d-sm-none
+      = build_status_icon_with_link
+    .repository-status.ml-3.d-inline.d-sm-none
+      = repository_status_icon
+    %i.fa-regular.fa-lg.fa-question-circle.text-info.ml-3
+  .build-status.mr-3.d-none.d-sm-block
+    = build_status_icon_with_link
+    %span
+      = build_status
+  .repository-status.d-none.d-sm-block
+    = repository_status_icon
+    %span
+      = result.state

--- a/src/api/app/components/build_result_for_architecture_component.rb
+++ b/src/api/app/components/build_result_for_architecture_component.rb
@@ -1,0 +1,68 @@
+class BuildResultForArchitectureComponent < ApplicationComponent
+  attr_accessor :result, :project, :package
+
+  def initialize(result, project, package)
+    super
+
+    @result = result
+    @project = project
+    @package = package
+  end
+
+  private
+
+  def result_code
+    result.code
+  end
+
+  def help
+    help = "<p><strong>Package build ( #{build_status_icon} #{result_code} ):</strong> #{build_status_help}</p>"
+    help += "<p><u>Details</u>: #{build_status_details}</p>" if build_status_details.present?
+    help += "<p><strong>Repository status ( #{repository_status_icon} #{result.state} ): </strong>#{repository_status_help}</p>"
+    help
+  end
+
+  def build_status_help
+    Buildresult.status_description(result_code)
+  end
+
+  def build_status_details
+    result.details
+  end
+
+  def repository_status_help
+    result.is_repository_in_db ? helpers.repository_info(result.state) : 'This result is outdated'
+  end
+
+  def build_status_icon_with_link
+    return build_status_icon if result_code.in?(['-', 'unresolvable', 'blocked', 'excluded', 'scheduled'])
+
+    link_to(package_live_build_log_path(project: project.to_s, package: package,
+                                        repository: result.repository, arch: result.architecture), rel: 'nofollow') do
+      capture { build_status_icon }
+    end
+  end
+
+  def build_status_icon
+    tag.i(class: "fa #{helpers.build_status_icon(result_code)} text-gray-500")
+  end
+
+  def repository_status_icon
+    helpers.repository_status_icon(status: result.state)
+  end
+
+  def status_border_color(status)
+    build_result = Buildresult.new(status)
+    return 'border-warning' if build_result.in_progress_status?
+    return 'border-success' if build_result.successful_final_status?
+    return 'border-danger' if build_result.unsuccessful_final_status?
+    return 'border-gray-300' if build_result.refused_status?
+  end
+
+  def build_status
+    return result_code if result_code.in?(['-', 'unresolvable', 'blocked', 'excluded', 'scheduled'])
+
+    link_to(result_code, package_live_build_log_path(project: project.to_s, package: package,
+                                                     repository: result.repository, arch: result.architecture), rel: 'nofollow')
+  end
+end

--- a/src/api/app/helpers/webui/buildresult_helper.rb
+++ b/src/api/app/helpers/webui/buildresult_helper.rb
@@ -6,14 +6,15 @@ module Webui::BuildresultHelper
     broken: 'fa-xmark text-danger',
     blocked: 'fa-shield text-warning',
     scheduled: 'fa-hourglass-half text-warning',
-    dispatching: 'fa-plane-departure',
-    building: 'fa-gear',
-    signing: 'fa-signature',
-    finished: 'fa-check',
-    disabled: 'fa-xmark text-warning',
-    excluded: 'fa-xmark text-warning',
+    dispatching: 'fa-plane-departure text-warning',
+    building: 'fa-gear text-warning',
+    signing: 'fa-signature text-warning',
+    finished: 'fa-check text-warning',
+    disabled: 'fa-xmark text-gray-500',
+    excluded: 'fa-xmark text-gray-500',
     locked: 'fa-lock text-warning',
-    unknown: 'fa-question'
+    deleting: 'fa-eraser text-warning',
+    unknown: 'fa-question text-warning'
   }.with_indifferent_access.freeze
 
   def repository_expanded?(collapsed_repositories, repository_name, key = 'project')

--- a/src/api/app/models/buildresult.rb
+++ b/src/api/app/models/buildresult.rb
@@ -1,4 +1,6 @@
 class Buildresult
+  attr_accessor :status
+
   AVAIL_STATUS_VALUES = {
     succeeded: 0,
     failed: 1,
@@ -38,6 +40,10 @@ class Buildresult
     locked: 'The package is frozen',
     unknown: 'The scheduler has not yet evaluated this package. Should be a short intermediate state for new packages.'
   }.with_indifferent_access.freeze
+
+  def initialize(status)
+    @status = status
+  end
 
   def self.find_hashed(opts = {})
     begin
@@ -99,5 +105,21 @@ class Buildresult
     return index if index
 
     raise ArgumentError, "code '#{code}' unknown #{AVAIL_STATUS_VALUES.inspect}"
+  end
+
+  def successful_final_status?
+    status.in?(['succeeded'])
+  end
+
+  def unsuccessful_final_status?
+    status.in?(['failed', 'unresolvable', 'broken'])
+  end
+
+  def in_progress_status?
+    status.in?(['blocked', 'dispatching', 'scheduled', 'building', 'finished', 'signing', 'locked', 'deleting', 'unknown'])
+  end
+
+  def refused_status?
+    status.in?(['disabled', 'excluded'])
   end
 end

--- a/src/api/app/views/webui/request/beta_show_tabs/_build_results.html.haml
+++ b/src/api/app/views/webui/request/beta_show_tabs/_build_results.html.haml
@@ -20,6 +20,7 @@
         From staging project
         = link_to(project, project_show_path(project))
     .result
+      // The content of this div is set by JavaScript which calls the partial ../_build_status.html.haml
 
   :javascript
     updateBuildResultBeta();

--- a/src/api/app/views/webui/request/beta_show_tabs/_build_status.html.haml
+++ b/src/api/app/views/webui/request/beta_show_tabs/_build_status.html.haml
@@ -10,12 +10,12 @@
     = package
   - if results.present?
     - results.group_by(&:repository).each_pair do |repository, results_per_repository|
-      .row.mb-4
-        .col-12
+      .float-left.mb-4
+        %div
           = link_to(word_break(repository, 22),
             package_binaries_path(project: project, package: package, repository: repository),
             title: "Binaries for #{repository}")
-        .col-12.results.d-flex.flex-wrap.p-2
+        .results.d-flex.flex-wrap
           - results_per_repository.sort_by! { |result| Buildresult::AVAIL_STATUS_VALUES[result.code.to_sym] }
           - results_per_repository.each do |result|
             = render BuildResultForArchitectureComponent.new(result, project, package)

--- a/src/api/app/views/webui/request/beta_show_tabs/_build_status.html.haml
+++ b/src/api/app/views/webui/request/beta_show_tabs/_build_status.html.haml
@@ -9,44 +9,16 @@
   %h5.text-primary.mb-3
     = package
   - if results.present?
-    - results_grouped_by_repository = results.group_by(&:repository)
-    - results_grouped_by_repository.each_pair do |repository, results_per_repository|
+    - results.group_by(&:repository).each_pair do |repository, results_per_repository|
       .row.mb-4
         .col-12
           = link_to(word_break(repository, 22),
             package_binaries_path(project: project, package: package, repository: repository),
             title: "Binaries for #{repository}")
-        .col-12
+        .col-12.results.d-flex.flex-wrap.p-2
+          - results_per_repository.sort_by! { |result| Buildresult::AVAIL_STATUS_VALUES[result.code.to_sym] }
           - results_per_repository.each do |result|
-            .row
-              .col-4
-                %p
-                  = result.architecture
-              .col-5
-                = repository_status_icon(status: result.state)
-                %p.d-none.d-sm-inline.d-lg-none
-                  = result.state
-                - result_help = repository_info(result.state) if result.is_repository_in_db
-                - result_help ||= 'This result is outdated'
-                %p.d-none.d-lg-inline
-                  = result_help
-                %i.fa.fa-question-circle.d-lg-none.text-info{ data: { placement: 'top', toggle: 'popover', content: "#{result_help}" } }
-              .col-3
-                - if result.code.in?(['-', 'unresolvable', 'blocked', 'excluded', 'scheduled'])
-                  %i{ class: "fa #{build_status_icon(result.code)}" }
-                - else
-                  = link_to(package_live_build_log_path(project: project.to_s, package: package,
-                      repository: result.repository, arch: result.architecture), rel: 'nofollow') do
-                    %i{ class: "fa #{build_status_icon(result.code)}" }
-                %span.d-none.d-lg-inline
-                  Package build
-                %p.d-none.d-sm-inline
-                  = render(BuildresultStatusLinkComponent.new(repository_name: result.repository, architecture_name: result.architecture,
-                                                              project_name: project.name, package_name: package,
-                                                              build_status: result.code, build_details: result.details))
-                %i.fa.fa-question-circle.text-info{ data: { placement: 'top',
-                                                            toggle: 'popover',
-                                                            content: "#{Buildresult.status_description(result.code)}" } }
+            = render BuildResultForArchitectureComponent.new(result, project, package)
   - else
     All the results have state
     %strong excluded/disabled

--- a/src/api/spec/components/build_result_for_architecture_component_spec.rb
+++ b/src/api/spec/components/build_result_for_architecture_component_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe BuildResultForArchitectureComponent, type: :component do
+  let(:project) { 'fake_project' }
+  let(:package) { 'fake_package' }
+
+  before do
+    render_inline(described_class.new(result, project, package))
+  end
+
+  context 'with succeeded result' do
+    let(:result) do
+      LocalBuildResult.new(
+        repository: '15.4',
+        architecture: 'x86_64',
+        code: 'succeeded',
+        state: 'blocked',
+        is_repository_in_db: 'true'
+      )
+    end
+
+    it { expect(rendered_content).to have_selector('.build-result', class: 'border-success') }
+    it { expect(rendered_content).to have_selector('.build-status i', class: 'fa-check text-success') }
+    it { expect(rendered_content).to have_selector('.build-status span', text: 'succeeded') }
+    it { expect(rendered_content).to have_selector('.repository-status i', class: 'fa-lock') }
+    it { expect(rendered_content).to have_selector('.repository-status span', text: 'blocked') }
+    it { expect(rendered_content).not_to have_selector("div[data-content*='Details']") }
+  end
+
+  context 'with excluded but visible result' do
+    let(:result) do
+      LocalBuildResult.new(
+        repository: '15.4',
+        architecture: 'x86_64',
+        code: 'excluded',
+        state: 'published',
+        is_repository_in_db: 'true',
+        details: 'fake details'
+      )
+    end
+
+    it { expect(rendered_content).to have_selector('.build-result', class: 'border-gray-300') }
+    it { expect(rendered_content).to have_selector('.build-status i', class: 'fa-xmark text-gray-500') }
+    it { expect(rendered_content).to have_selector('.build-status span', text: 'excluded') }
+    it { expect(rendered_content).to have_selector('.repository-status i', class: 'fa-truck') }
+    it { expect(rendered_content).to have_selector('.repository-status span', text: 'published') }
+    it { expect(rendered_content).to have_selector("div[data-content*='fake details']") }
+  end
+end

--- a/src/api/spec/components/previews/build_result_for_architecture_component_preview.rb
+++ b/src/api/spec/components/previews/build_result_for_architecture_component_preview.rb
@@ -1,0 +1,26 @@
+class BuildResultForArchitectureComponentPreview < ViewComponent::Preview
+  # Preview at http://HOST:PORT/rails/view_components/build_result_for_architecture_component/succeeded
+  def succeeded
+    result = LocalBuildResult.new(
+      repository: '15.4',
+      architecture: 'x86_64',
+      code: 'succeeded',
+      state: 'blocked',
+      is_repository_in_db: 'true'
+    )
+    render(BuildResultForArchitectureComponent.new(result, 'fake_project', 'fake_package'))
+  end
+
+  # Preview at http://HOST:PORT/rails/view_components/build_result_for_architecture_component/broken
+  def broken
+    result = LocalBuildResult.new(
+      repository: '15.4',
+      architecture: 'x86_64',
+      code: 'broken',
+      state: 'published',
+      is_repository_in_db: 'true',
+      details: 'fake details'
+    )
+    render(BuildResultForArchitectureComponent.new(result, 'fake_project', 'fake_package'))
+  end
+end


### PR DESCRIPTION
Propose another design for the new build results tab including
- bigger and soberer help icon,
- many results per row in large viewports and minimized content in small ones,
- more descriptive tooltip,

among many other improvements.

![build_results_redesign](https://user-images.githubusercontent.com/2581944/201945129-34a84672-f8ee-461b-9c78-acf7205cd490.gif)

TODO:

- [x] Component specs
- [x] Component preview

**How to test?**

If you already ran the `development_testdata` rake task you'll have a few requests already, you can see them in the Tasks menu.
Add some repositories to the project related to the request you choose. 
Then go to see the build results. For example, request for `home:Admin/package_b`.

In review-app:
https://obs-reviewlab.opensuse.org/saraycp-improve_new_build_results/request/show/9/request_action/9#tab-pane-build-results