### PR TITLE
Remove index on updated_at column in packages and projects tables

### DIFF
--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -1440,7 +1440,7 @@ end
 #  title           :string(255)
 #  url             :string(255)
 #  created_at      :datetime
-#  updated_at      :datetime         indexed
+#  updated_at      :datetime
 #  develpackage_id :integer          indexed
 #  kiwi_image_id   :integer          indexed
 #  project_id      :integer          not null, indexed => [name]
@@ -1450,7 +1450,6 @@ end
 #  devel_package_id_index           (develpackage_id)
 #  index_packages_on_kiwi_image_id  (kiwi_image_id)
 #  packages_all_index               (project_id,name) UNIQUE
-#  updated_at_index                 (updated_at)
 #
 # Foreign Keys
 #

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -1542,7 +1542,7 @@ end
 #  title               :string(255)
 #  url                 :string(255)
 #  created_at          :datetime
-#  updated_at          :datetime         indexed
+#  updated_at          :datetime
 #  develproject_id     :integer          indexed
 #  staging_workflow_id :integer          indexed
 #
@@ -1551,5 +1551,4 @@ end
 #  devel_project_id_index                 (develproject_id)
 #  index_projects_on_staging_workflow_id  (staging_workflow_id)
 #  projects_name_index                    (name) UNIQUE
-#  updated_at_index                       (updated_at)
 #

--- a/src/api/app/models/remote_project.rb
+++ b/src/api/app/models/remote_project.rb
@@ -26,7 +26,7 @@ end
 #  title               :string(255)
 #  url                 :string(255)
 #  created_at          :datetime
-#  updated_at          :datetime         indexed
+#  updated_at          :datetime
 #  develproject_id     :integer          indexed
 #  staging_workflow_id :integer          indexed
 #
@@ -35,5 +35,4 @@ end
 #  devel_project_id_index                 (develproject_id)
 #  index_projects_on_staging_workflow_id  (staging_workflow_id)
 #  projects_name_index                    (name) UNIQUE
-#  updated_at_index                       (updated_at)
 #

--- a/src/api/db/migrate/20230109131251_remove_updated_at_index_from_packages_and_projects.rb
+++ b/src/api/db/migrate/20230109131251_remove_updated_at_index_from_packages_and_projects.rb
@@ -1,0 +1,6 @@
+class RemoveUpdatedAtIndexFromPackagesAndProjects < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :packages, column: :updated_at, name: 'updated_at_index'
+    remove_index :projects, column: :updated_at, name: 'updated_at_index'
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_16_234231) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_09_131251) do
   create_table "architectures", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false, collation: "utf8mb3_general_ci"
     t.boolean "available", default: false
@@ -729,7 +729,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_16_234231) do
     t.index ["develpackage_id"], name: "devel_package_id_index"
     t.index ["kiwi_image_id"], name: "index_packages_on_kiwi_image_id"
     t.index ["project_id", "name"], name: "packages_all_index", unique: true
-    t.index ["updated_at"], name: "updated_at_index"
   end
 
   create_table "path_elements", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
@@ -817,7 +816,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_16_234231) do
     t.index ["develproject_id"], name: "devel_project_id_index"
     t.index ["name"], name: "projects_name_index", unique: true
     t.index ["staging_workflow_id"], name: "index_projects_on_staging_workflow_id"
-    t.index ["updated_at"], name: "updated_at_index"
   end
 
   create_table "relationships", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|


### PR DESCRIPTION
This index is super harmful as it allows only one package operation at the same time and generating this index can take a long time. This leads to timeout errors on package operations easily.

I am not aware where this index would be useful atm.