### PR TITLE
Use the correct keys for GitLab in GitlabStatusReporter and SCMExceptionHandler

### DIFF
--- a/src/api/app/services/gitlab_status_reporter.rb
+++ b/src/api/app/services/gitlab_status_reporter.rb
@@ -36,11 +36,13 @@ class GitlabStatusReporter < SCMExceptionHandler
     end
   end
 
-  # TODO: extract to a parent class
+  # TODO: Extract to a parent class, but only the common keys.
+  #       This isn't always the same depending on the SCM.
   def request_context
     {
       api_endpoint: @event_subscription_payload[:api_endpoint],
-      target_repository_full_name: @event_subscription_payload[:target_repository_full_name],
+      project_id: @event_subscription_payload[:project_id],
+      path_with_namespace: @event_subscription_payload[:path_with_namespace],
       commit_sha: @event_subscription_payload[:commit_sha],
       state: @state,
       status_options: status_options

--- a/src/api/app/services/scm_exception_handler.rb
+++ b/src/api/app/services/scm_exception_handler.rb
@@ -67,13 +67,17 @@ class SCMExceptionHandler
     @workflow_run.save_scm_report_failure("Failed to report back to #{scm}: #{SCMExceptionMessage.for(exception: exception, scm: scm)}",
                                           {
                                             api_endpoint: @event_subscription_payload[:api_endpoint],
-                                            target_repository_full_name: @event_subscription_payload[:target_repository_full_name],
                                             commit_sha: @event_subscription_payload[:commit_sha],
                                             state: @state,
                                             status_options: {
                                               context: "OBS: #{@event_payload[:package]} - #{@event_payload[:repository]}/#{@event_payload[:arch]}",
                                               target_url: target_url
-                                            }
+                                            },
+                                            # GitHub / Gitea
+                                            target_repository_full_name: @event_subscription_payload[:target_repository_full_name],
+                                            # GitLab
+                                            project_id: @event_subscription_payload[:project_id],
+                                            path_with_namespace: @event_subscription_payload[:path_with_namespace]
                                           })
   end
 end


### PR DESCRIPTION
I've realized this is wrong after looking into #13377.

The payload of GitLab is defined as such:

https://github.com/openSUSE/open-build-service/blob/29fe2bfa66335797cce355f8f70500685056e507/src/api/app/services/trigger_controller_service/scm_extractor.rb#L16-L17
https://github.com/openSUSE/open-build-service/blob/29fe2bfa66335797cce355f8f70500685056e507/src/api/app/services/trigger_controller_service/scm_extractor.rb#L47-L81

This is where the payload is passed to the event subscription:

https://github.com/openSUSE/open-build-service/blob/29fe2bfa66335797cce355f8f70500685056e507/src/api/app/models/workflow/step.rb#L53