### PR TITLE
Enhance the BsRequestAction factory

### DIFF
--- a/src/api/lib/tasks/dev.rake
+++ b/src/api/lib/tasks/dev.rake
@@ -109,6 +109,12 @@ namespace :dev do
         source_package: ruby_iggy
       )
 
+      create(:bs_request_action_submit_with_diff,
+             creator: iggy,
+             source_project_name: home_admin.name,
+             source_package_name: 'package_with_diff',
+             target_package_name: 'package_with_diff')
+
       test_package = create(:package, name: 'hello_world', project: home_admin)
       backend_url = "/source/#{CGI.escape(home_admin.name)}/#{CGI.escape(test_package.name)}"
       Backend::Connection.put("#{backend_url}/hello_world.spec", File.read('../../dist/t/spec/fixtures/hello_world.spec'))

--- a/src/api/spec/factories/bs_request_actions.rb
+++ b/src/api/spec/factories/bs_request_actions.rb
@@ -12,6 +12,49 @@ FactoryBot.define do
     end
     factory :bs_request_action_submit, class: 'BsRequestActionSubmit' do
       type { 'submit' }
+
+      # This is used by the dev.rake task to create a BsRequestAction with a diff
+      factory :bs_request_action_submit_with_diff, class: 'BsRequestActionSubmit' do
+        transient do
+          source_project_name { 'source_project' }
+          source_package_name { 'source_package' }
+          target_project_name { 'target_project' }
+          target_package_name { 'target_package' }
+          creator { create(:confirmed_user) }
+        end
+
+        source_project do |evaluator|
+          Project.find_by_name!(evaluator.source_project_name) ||
+            create(:project, :as_submission_source, name: evaluator.source_project_name)
+        end
+        source_package do |evaluator|
+          Package.find_by_project_and_name(source_project.name, evaluator.source_package_name) ||
+            create(:package_with_file,
+                   project: source_project,
+                   name: evaluator.source_package_name,
+                   file_name: 'somefile.txt',
+                   file_content: '# This is the new text')
+        end
+        target_project do |evaluator|
+          Project.find_by_name(evaluator.target_project_name) ||
+            create(:project, name: target_project_name)
+        end
+        target_package do |evaluator|
+          Package.find_by_project_and_name(target_project.name, evaluator.target_package_name) ||
+            create(:package_with_file,
+                   project: target_project,
+                   name: target_package_name,
+                   file_name: 'somefile.txt',
+                   file_content: '# This will be replaced')
+        end
+
+        bs_request do |evaluator|
+          create(:bs_request_with_submit_action,
+                 creator: evaluator.creator,
+                 target_package: target_package,
+                 source_package: source_package)
+        end
+      end
     end
     factory :bs_request_action_delete, class: 'BsRequestActionDelete' do
       type { 'delete' }


### PR DESCRIPTION
Provides a BsRequest submit action with a file diff.

## How To Test It

- Run the `dev:development_testdata:create` rake task on a local OBS instance.
- Once it finishes, boot up the local instance [as usual](https://github.com/openSUSE/open-build-service/wiki/Development-Environment-Tips-&-Tricks#control-services).
- http://localhost:3000/package/show/home:Admin/package_with_diff is the created package with the file diff.
- Navigate to [its open requests](http://localhost:3000/package/requests/home:Admin/package_with_diff) 
![image](https://user-images.githubusercontent.com/2650/202402684-da401782-97c6-41b7-a231-3bc058c627e4.png)
- And check the Changes tab of that request. There you'll find the file diff
![image](https://user-images.githubusercontent.com/2650/202402931-9d4bf9a4-64f5-472d-ae1d-b33eac3f2fd0.png)
