### PR TITLE
Rename dev:development_testdata:create task

### DIFF
--- a/src/api/lib/tasks/dev.rake
+++ b/src/api/lib/tasks/dev.rake
@@ -61,7 +61,7 @@ namespace :dev do
   end
 
   # This is automatically run in Review App or manually in development env.
-  namespace :development_testdata do
+  namespace :test_data do
     desc 'Creates test data to play with in dev and CI environments'
     task create: :environment do
       unless Rails.env.development?


### PR DESCRIPTION
Renamed to `dev:test_data:create`.

Updated in `obs-review-apps` which uses this task. Please review the PR [#22](https://github.com/openSUSE/obs-review-apps/pull/22).

Updated the two appearances in the wiki:

- https://github.com/openSUSE/open-build-service/wiki/Notifications#create-notifications-in-your-development-environment
- https://github.com/openSUSE/open-build-service/wiki/Development-Environment-Tips-&-Tricks#create-data-to-play-with-in-development