### PR TITLE
Extract request and action creation to its own file

### DIFF
--- a/src/api/lib/tasks/dev.rake
+++ b/src/api/lib/tasks/dev.rake
@@ -109,12 +109,6 @@ namespace :dev do
         source_package: ruby_iggy
       )
 
-      create(:bs_request_action_submit_with_diff,
-             creator: iggy,
-             source_project_name: home_admin.name,
-             source_package_name: 'package_with_diff',
-             target_package_name: 'package_with_diff')
-
       test_package = create(:package, name: 'hello_world', project: home_admin)
       backend_url = "/source/#{CGI.escape(home_admin.name)}/#{CGI.escape(test_package.name)}"
       Backend::Connection.put("#{backend_url}/hello_world.spec", File.read('../../dist/t/spec/fixtures/hello_world.spec'))
@@ -229,6 +223,9 @@ namespace :dev do
 
       # Create a request with multiple actions
       Rake::Task['dev:requests:multiple_actions_request'].invoke
+
+      # Create a request with a submit action and diff
+      Rake::Task['dev:requests:request_with_submit_action_and_diff'].invoke
     end
   end
 end

--- a/src/api/lib/tasks/dev/requests.rake
+++ b/src/api/lib/tasks/dev/requests.rake
@@ -66,5 +66,35 @@ namespace :dev do
 
       puts "* Request #{request.number} has been created."
     end
+
+    desc 'Creates a  request with submit action and diff'
+    task request_with_submit_action_and_diff: :environment do
+      unless Rails.env.development?
+        puts "You are running this rake task in #{Rails.env} environment."
+        puts 'Please only run this task with RAILS_ENV=development'
+        puts 'otherwise it will destroy your database data.'
+        return
+      end
+
+      require 'factory_bot'
+      include FactoryBot::Syntax::Methods
+
+      puts 'Creating a request with submit action and diff...'
+
+      iggy = User.find_by(login: 'Iggy') || create(:staff_user, login: 'Iggy')
+      User.session = iggy
+      admin = User.get_default_admin
+      iggy_home_project = RakeSupport.find_or_create_project(iggy.home_project_name, iggy)
+      home_admin_project = RakeSupport.find_or_create_project(admin.home_project_name, admin)
+
+      request_action = create(:bs_request_action_submit_with_diff,
+                              creator: iggy,
+                              source_project_name: iggy_home_project.name,
+                              source_package_name: 'package_with_diff',
+                              target_project_name: home_admin_project.name,
+                              target_package_name: 'package_with_diff')
+
+      puts "* Request #{request_action.bs_request.number} has been created."
+    end
   end
 end


### PR DESCRIPTION
To avoid extending the `dev:test_data:create` task too much, we move the code that creates requests and actions to `lib/tasks/requests.rake` (as tasks) and call them from the previous one.

**How to test?**

- Run `rails dev:test_data:create`.
- Run the task independently:  `rails dev:requests:request_with_submit_action_and_diff`.

In both cases, a new `package_with_diff` will be created together with a request associated to that package.