### PR TITLE
Add a multiaction submit request

### DIFF
--- a/src/api/lib/tasks/dev.rake
+++ b/src/api/lib/tasks/dev.rake
@@ -224,8 +224,8 @@ namespace :dev do
       # Create a request with multiple actions
       Rake::Task['dev:requests:multiple_actions_request'].invoke
 
-      # Create a request with a submit action and diff
-      Rake::Task['dev:requests:request_with_submit_action_and_diff'].invoke
+      # Create a request with multiple submit actions and diffs
+      Rake::Task['dev:requests:request_with_multiple_submit_actions_and_diffs'].invoke
 
       # Create a request wich builds and produces build results
       Rake::Task['dev:requests:request_with_build_results'].invoke

--- a/src/api/lib/tasks/dev/requests.rake
+++ b/src/api/lib/tasks/dev/requests.rake
@@ -67,8 +67,8 @@ namespace :dev do
       puts "* Request #{request.number} has been created."
     end
 
-    desc 'Creates a  request with submit action and diff'
-    task request_with_submit_action_and_diff: :environment do
+    desc 'Creates several requests with submit actions and diffs'
+    task request_with_multiple_submit_actions_and_diffs: :environment do
       unless Rails.env.development?
         puts "You are running this rake task in #{Rails.env} environment."
         puts 'Please only run this task with RAILS_ENV=development'
@@ -79,22 +79,39 @@ namespace :dev do
       require 'factory_bot'
       include FactoryBot::Syntax::Methods
 
-      puts 'Creating a request with submit action and diff...'
-
       iggy = User.find_by(login: 'Iggy') || create(:staff_user, login: 'Iggy')
       User.session = iggy
       admin = User.get_default_admin
       iggy_home_project = RakeSupport.find_or_create_project(iggy.home_project_name, iggy)
       home_admin_project = RakeSupport.find_or_create_project(admin.home_project_name, admin)
 
-      request_action = create(:bs_request_action_submit_with_diff,
-                              creator: iggy,
-                              source_project_name: iggy_home_project.name,
-                              source_package_name: 'package_with_diff',
-                              target_project_name: home_admin_project.name,
-                              target_package_name: 'package_with_diff')
+      source_package = create(:package_with_file,
+                              project: iggy_home_project,
+                              name: 'source_package_with_multiple_submit_request_and_diff',
+                              file_name: 'somefile.txt',
+                              file_content: '# This will be replaced')
+      target_package = create(:package_with_file,
+                              project: home_admin_project,
+                              name: 'another_package_with_diff',
+                              file_name: 'somefile.txt',
+                              file_content: '# This will be replaced')
 
-      puts "* Request #{request_action.bs_request.number} has been created."
+      bs_request = create(:bs_request_with_submit_action,
+                          creator: iggy,
+                          source_project: iggy_home_project,
+                          source_package: source_package,
+                          target_project: home_admin_project,
+                          target_package: target_package)
+
+      create(:bs_request_action_submit_with_diff,
+             creator: iggy,
+             source_project_name: iggy_home_project.name,
+             source_package_name: 'source_package_with_multiple_submit_request_and_diff',
+             target_project_name: home_admin_project.name,
+             target_package_name: 'package_with_diff',
+             bs_request: bs_request)
+
+      puts "* Request #{bs_request.number} has been created."
     end
 
     desc 'Creates a request which builds and produces build results'

--- a/src/api/lib/tasks/dev/requests.rake
+++ b/src/api/lib/tasks/dev/requests.rake
@@ -87,12 +87,12 @@ namespace :dev do
 
       source_package = create(:package_with_file,
                               project: iggy_home_project,
-                              name: 'source_package_with_multiple_submit_request_and_diff',
+                              name: "source_package_with_multiple_submit_request_and_diff_#{Time.now.to_i}",
                               file_name: 'somefile.txt',
                               file_content: '# This will be replaced')
       target_package = create(:package_with_file,
                               project: home_admin_project,
-                              name: 'another_package_with_diff',
+                              name: "another_package_with_diff_#{Time.now.to_i}",
                               file_name: 'somefile.txt',
                               file_content: '# This will be replaced')
 

--- a/src/api/spec/factories/bs_request_actions.rb
+++ b/src/api/spec/factories/bs_request_actions.rb
@@ -24,7 +24,7 @@ FactoryBot.define do
         end
 
         source_project do |evaluator|
-          Project.find_by_name!(evaluator.source_project_name) ||
+          Project.find_by_name(evaluator.source_project_name) ||
             create(:project, :as_submission_source, name: evaluator.source_project_name)
         end
         source_package do |evaluator|
@@ -49,10 +49,7 @@ FactoryBot.define do
         end
 
         bs_request do |evaluator|
-          create(:bs_request_with_submit_action,
-                 creator: evaluator.creator,
-                 target_package: target_package,
-                 source_package: source_package)
+          evaluator.bs_request || create(:bs_request_with_submit_action)
         end
       end
     end


### PR DESCRIPTION
This PR replaces the call to `request_with_submit_action_and_diff` during the data generation by the this new `request_with_multiple_submit_actions_and_diffs` because the new rake task kind of includes the previous one. 