### PR TITLE
Add warning about request auto-acceptance

### DIFF
--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -33,6 +33,10 @@
           - if @bs_request.superseded_by.present?
             by
             = link_to(@bs_request.superseded_by, number: @bs_request.superseded_by)
+
+        - if @bs_request.accept_at.present?
+          %span.badge.alert-warning.ml-1 auto-accept
+
       %p.font-italic
         Created by
         = user_with_realname_and_icon(@bs_request.creator)

--- a/src/api/app/views/webui/request/beta_show_tabs/_conversation.html.haml
+++ b/src/api/app/views/webui/request/beta_show_tabs/_conversation.html.haml
@@ -72,6 +72,28 @@
     .comment_new.mt-3
       = render partial: 'webui/comment/new', locals: { commentable: bs_request }
     %hr
+
+    - if bs_request.accept_at.present?
+      .alert.alert-warning.p-2.mb-3
+        %i.fas.fa-exclamation-triangle
+        %span The current request
+        - if BsRequest::FINAL_REQUEST_STATES.include?(bs_request.state)
+          %span
+            was
+            %strong auto-accepted
+            at
+            %span.fuzzy-time{ title: "#{I18n.l bs_request.accept_at}" }
+            = succeed '.' do
+              = I18n.l bs_request.accept_at, format: :only_date
+        - elsif bs_request.accept_at.past?
+          %span
+            will be
+            %strong auto-accepted
+            after all the reviews are submitted.
+        - else
+          will be
+          %strong auto-accepted
+          in #{time_ago_in_words(bs_request.accept_at)}.
     = render RequestDecisionComponent.new(bs_request: bs_request, action: action,
                                           is_target_maintainer: is_target_maintainer,
                                           is_author: is_author)


### PR DESCRIPTION
To make it clear that this is an "auto-accept" request, I add a badge next to the title.
The details are given in a warning box on top of the decline/accept box.

**Before:**

![before_auto_accept](https://user-images.githubusercontent.com/2581944/203040306-efb13be4-6696-446a-a8de-25bd61db368f.png)

**After**

![badge_and_warning_wo_icon](https://user-images.githubusercontent.com/2581944/203073944-b9cdfdfe-1b55-4458-b943-ba39c608335d.png)
