### PR TITLE
Add rake task to create request with build results

### DIFF
--- a/src/api/lib/tasks/dev.rake
+++ b/src/api/lib/tasks/dev.rake
@@ -226,6 +226,9 @@ namespace :dev do
 
       # Create a request with a submit action and diff
       Rake::Task['dev:requests:request_with_submit_action_and_diff'].invoke
+
+      # Create a request wich builds and produces build results
+      Rake::Task['dev:requests:request_with_build_results'].invoke
     end
   end
 end

--- a/src/api/lib/tasks/dev/requests.rake
+++ b/src/api/lib/tasks/dev/requests.rake
@@ -96,5 +96,45 @@ namespace :dev do
 
       puts "* Request #{request_action.bs_request.number} has been created."
     end
+
+    desc 'Creates a request which builds and produces build results'
+    task request_with_build_results: :environment do
+      unless Rails.env.development?
+        puts "You are running this rake task in #{Rails.env} environment."
+        puts 'Please only run this task with RAILS_ENV=development'
+        puts 'otherwise it will destroy your database data.'
+        return
+      end
+
+      require 'factory_bot'
+      include FactoryBot::Syntax::Methods
+
+      puts 'Creating a request which builds and produces build results...'
+      admin = User.get_default_admin
+      home_admin_project = RakeSupport.find_or_create_project(admin.home_project_name, admin)
+
+      # Branch the hello_world package
+      iggy = User.find_by(login: 'Iggy') || create(:staff_user, login: 'Iggy')
+      branches_iggy = Project.find_by(name: iggy.branch_project_name(home_admin_project.name)) || create(:project, name: iggy.branch_project_name(home_admin_project.name))
+      hello_world_iggy = create(:package, name: "hello_world_#{Faker::Lorem.word}", project: branches_iggy)
+      backend_url = "/source/#{CGI.escape(branches_iggy.name)}/#{CGI.escape(hello_world_iggy.name)}"
+      hello_world_spec = File.read('../../dist/t/spec/fixtures/hello_world.spec')
+      hello_world_spec.gsub('Most simple RPM package', Faker::Lorem.sentence(word_count: 4))
+      Backend::Connection.put("#{backend_url}/hello_world.spec", hello_world_spec)
+
+      # Create the request
+      request = create(
+        :bs_request_with_submit_action,
+        creator: iggy,
+        target_project: home_admin_project,
+        target_package: 'hello_world',
+        source_project: branches_iggy,
+        source_package: hello_world_iggy
+      )
+      puts "* Request #{request.number} has been created."
+      puts 'To start the builds confirm or perfom the following steps:'
+      puts '- Create the interconnect with openSUSE.org'
+      puts '- Create a couple of repositories in project home:Iggy:branches:home:Admin'
+    end
   end
 end


### PR DESCRIPTION
Try it in the development environment with: `bin/rails dev:requests:request_with_build_results`

Example of running the new task in a Rails console:
```
frontend@45673968231d:/obs/src/api> bin/rails dev:requests:request_with_build_results
Creating a request which builds and produces build results...
* Request 17 has been created.
To start the builds confirm or perfom the following steps:
- Create the interconnect with openSUSE.org
- Create a couple of repositories in project home:Iggy or in project home:Iggy:branches:home:Admin
frontend@45673968231d:/obs/src/api> 
```