### PR TITLE
Display file list in the binary view

### DIFF
--- a/src/api/app/views/webui/package/_deps.html.haml
+++ b/src/api/app/views/webui/package/_deps.html.haml
@@ -85,3 +85,16 @@
           %tr
             %td{ colspan: '2' }
               %em No recommends
+
+  .table-responsive.col-sm-12.col-md-6.mt-4
+    %h4 Files
+    - if fileinfo['filelist']
+      %table.table.table-bordered.table-hover.table-sm
+        %thead
+          %tr
+            %th Filename
+        - fileinfo.elements('filelist') do |package_file|
+          %tr
+            %td.text-word-break-all= package_file
+    - else
+      %i No files

--- a/src/backend/BSXML.pm
+++ b/src/backend/BSXML.pm
@@ -476,6 +476,7 @@ our $fileinfo = [
       [ 'supplements' ],
       [ 'suggests' ],
       [ 'enhances' ],
+      [ 'filelist' ],
 
      [[ 'provides_ext' =>
 	    'dep',

--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -1283,7 +1283,7 @@ sub getbinary_info {
   }
   my @s = stat($path);
   die("404 $bin: $!\n") unless @s;
-  my $res = Build::query($path, 'evra' => 1, 'description' => 1, 'weakdeps' => 1) || {};
+  my $res = Build::query($path, 'evra' => 1, 'description' => 1, 'weakdeps' => 1, 'filelist' => 1) || {};
   if (!%$res && $path =~ /\/updateinfo\.xml$/) {
     my $updateinfos = readxml($path, $BSXML::updateinfo, 1);
     if ($updateinfos && @{$updateinfos->{'update'} || []} == 1) {


### PR DESCRIPTION
This adds displaying file list in the binary view

To verify:
1. Create a package that builds some binaries (I think obs-build only supports file lists in rpm and deb?, so build one of those)
2. Open binary view
3. See list of files in the package

![image](https://user-images.githubusercontent.com/114928900/203541937-05e6d519-55b3-44db-af60-8b5f298b2ca6.png)

Fixes #613