### PR TITLE
Correct the usage of list-group in notifications

### DIFF
--- a/src/api/app/components/notification_filter_component.html.haml
+++ b/src/api/app/components/notification_filter_component.html.haml
@@ -1,9 +1,9 @@
-.row.list-group-flush
+.list-group.list-group-flush.my-2
   = render NotificationFilterLinkComponent.new(text: 'Unread', amount: @count['unread'],
                                                filter_item: { type: 'unread' }, selected_filter: @selected_filter)
   = render NotificationFilterLinkComponent.new(text: 'Read', filter_item: { type: 'read' },
                                                selected_filter: @selected_filter)
-.row.list-group-flush.mt-5
+.list-group.list-group-flush.mt-5.mb-2
   %h5.ml-3 Filter
   = render NotificationFilterLinkComponent.new(text: 'Comments', amount: @count['Comment'],
                                                filter_item: { type: 'comments' }, selected_filter: @selected_filter)
@@ -19,13 +19,13 @@
                                                filter_item: { type: 'relationships_deleted' }, selected_filter: @selected_filter)
 
 - unless @projects_for_filter.empty?
-  .row.list-group-flush.mt-5
+  .list-group.list-group-flush.mt-5.mb-2
     %h5.ml-3 Projects
     - @projects_for_filter.each_pair do |project_name, amount|
       = render NotificationFilterLinkComponent.new(text: project_name, amount: amount, filter_item: { project: project_name },
                                                    selected_filter: @selected_filter)
 - unless @groups_for_filter.empty?
-  .row.list-group-flush.mt-5
+  .list-group.list-group-flush.mt-5.mb-2
     %h5.ml-3 Groups
     - @groups_for_filter.each_pair do |group_title, amount|
       = render NotificationFilterLinkComponent.new(text: group_title, amount: amount, filter_item: { group: group_title },

--- a/src/api/app/views/webui/users/notifications/index.html.haml
+++ b/src/api/app/views/webui/users/notifications/index.html.haml
@@ -9,7 +9,7 @@
                                   aria: { expanded: true, controls: 'filters' } }
         Filtered by: #{params[:type]&.humanize || @filtered_project || 'Unread'}
         %i.float-right.mt-1.fa.fa-chevron-down#notifications-dropdown-trigger
-      .card-body.collapse#filters
+      .collapse#filters
         = render NotificationFilterComponent.new(selected_filter: @selected_filter)
 
   .col-md-8.col-lg-9.px-0.px-md-3#notifications-list


### PR DESCRIPTION
This caused the list of filters to be displayed incorrectly:

![Screenshot from 2022-11-23 13-48-33](https://user-images.githubusercontent.com/114928900/203550884-f5ada5b7-698f-4f28-9efd-8b257bb35b41.png)

A small adjustment in the way list-group is used corrects it:
![Screenshot from 2022-11-23 13-48-39](https://user-images.githubusercontent.com/114928900/203550889-1f74ca2d-f3d4-4c13-ab58-2d265c505a69.png)
