### PR TITLE
Extend notifications primary and foreign keys capacity

### DIFF
--- a/src/api/app/models/notification.rb
+++ b/src/api/app/models/notification.rb
@@ -66,7 +66,7 @@ end
 #
 # Table name: notifications
 #
-#  id                         :integer          not null, primary key
+#  id                         :bigint           not null, primary key
 #  bs_request_oldstate        :string(255)
 #  bs_request_state           :string(255)
 #  delivered                  :boolean          default(FALSE)

--- a/src/api/app/models/notified_project.rb
+++ b/src/api/app/models/notified_project.rb
@@ -9,9 +9,9 @@ end
 #
 # Table name: notified_projects
 #
-#  id              :integer          not null, primary key
+#  id              :bigint           not null, primary key
 #  created_at      :datetime         not null
-#  notification_id :integer          not null, indexed, indexed => [project_id]
+#  notification_id :bigint           not null, indexed, indexed => [project_id]
 #  project_id      :integer          not null, indexed => [notification_id]
 #
 # Indexes

--- a/src/api/db/migrate/20221123163119_change_notifications_primary_and_foreign_keys_to_bigint.rb
+++ b/src/api/db/migrate/20221123163119_change_notifications_primary_and_foreign_keys_to_bigint.rb
@@ -1,0 +1,16 @@
+class ChangeNotificationsPrimaryAndForeignKeysToBigint < ActiveRecord::Migration[7.0]
+  def up
+    # This migration blocks the table, we are running it during Maintenance Window.
+    safety_assured do
+      # Foreign key
+      change_column :notified_projects, :notification_id, :bigint
+      # Primary key
+      change_column :notified_projects, :id, :bigint, auto_increment: true
+      change_column :notifications, :id, :bigint, auto_increment: true
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_06_22_135133) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_23_163119) do
   create_table "architectures", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false, collation: "utf8mb3_general_ci"
     t.boolean "available", default: false
@@ -668,7 +668,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_22_135133) do
     t.index ["maintenance_db_project_id"], name: "index_maintenance_incidents_on_maintenance_db_project_id"
   end
 
-  create_table "notifications", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "notifications", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "event_type", null: false, collation: "utf8mb3_general_ci"
     t.text "event_payload", null: false
     t.string "subscription_receiver_role", null: false, collation: "utf8mb3_general_ci"
@@ -689,8 +689,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_22_135133) do
     t.index ["subscriber_type", "subscriber_id"], name: "index_notifications_on_subscriber_type_and_subscriber_id"
   end
 
-  create_table "notified_projects", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.integer "notification_id", null: false
+  create_table "notified_projects", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "notification_id", null: false
     t.integer "project_id", null: false
     t.datetime "created_at", null: false
     t.index ["notification_id", "project_id"], name: "index_notified_projects_on_notification_id_and_project_id", unique: true


### PR DESCRIPTION
We are adding new notification types which could increase the number of notifications considerably, so we extend the capacity of the primary key (from `int` to `bigint`) to avoid future overflow.

Not only do we extend the `Notification#id` and `NotifiedProject#id` but also the `NotifiedProject#notification_id`.

After running the migration these should be the results (from `int(11)` to `bigint(20)`):


```
MariaDB [api_development]> DESCRIBE notifications id;
+-------+------------+------+-----+---------+----------------+
| Field | Type       | Null | Key | Default | Extra          |
+-------+------------+------+-----+---------+----------------+
| id    | bigint(20) | NO   | PRI | NULL    | auto_increment |
+-------+------------+------+-----+---------+----------------+
```

```
MariaDB [api_development]> DESCRIBE notified_projects ;
+-----------------+-------------+------+-----+---------+----------------+
| Field           | Type        | Null | Key | Default | Extra          |
+-----------------+-------------+------+-----+---------+----------------+
| id              | bigint(20)  | NO   | PRI | NULL    | auto_increment |
| notification_id | bigint(20)  | NO   | MUL | NULL    |                |
...
+-----------------+-------------+------+-----+---------+----------------+
 ```
~**DO NOT MERGE**: this migration should be run during the next maintenance window.~