### PR TITLE
Use the group subscription settings for Event::Relationship*

### DIFF
--- a/src/api/app/models/event_subscription/find_for_event.rb
+++ b/src/api/app/models/event_subscription/find_for_event.rb
@@ -65,6 +65,8 @@ class EventSubscription
       receivers_and_subscriptions.values.flatten
     end
 
+    private
+
     def expand_receivers(receivers, channel)
       receivers.inject([]) do |new_receivers, receiver|
         case receiver
@@ -72,17 +74,14 @@ class EventSubscription
           new_receivers << receiver if receiver.is_active?
           puts "Skipped receiver #{receiver} because it's inactive" if @debug && !receiver.is_active?
         when Group
-          new_receivers += expand_receivers_for_groups(new_receivers, receiver, channel)
+          new_receivers += expand_receivers_for_groups(receiver, channel)
         end
 
         new_receivers
       end
     end
 
-    def expand_receivers_for_groups(_new_receivers, receiver, channel)
-      # We don't subscribe Groups so we have to get the group's users to get the subscriptions
-      return receiver.users if event.instance_of?(Event::RelationshipCreate) || event.instance_of?(Event::RelationshipDelete)
-
+    def expand_receivers_for_groups(receiver, channel)
       # We don't split events which come through the web channel, for a group subscriber.
       # They are split in the NotificationService::WebChannel service, if needed.
       return [receiver] if channel == :web || receiver.email.present?

--- a/src/api/spec/mailers/event_mailer_spec.rb
+++ b/src/api/spec/mailers/event_mailer_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe EventMailer, vcr: true do
     context 'for an event of type Event::RelationshipCreate' do
       let(:who) { create(:confirmed_user) }
       let(:project) { create(:project) }
-      let(:group) { create(:group_with_user, user: receiver) }
+      let(:group) { create(:group_with_user, user: receiver, email: nil) }
       let!(:subscription) { create(:event_subscription_relationship_create, user: receiver) }
       let(:mail) { EventMailer.with(subscribers: Event::RelationshipCreate.last.subscribers, event: Event::RelationshipCreate.last).notification_email.deliver_now }
 
@@ -187,7 +187,7 @@ RSpec.describe EventMailer, vcr: true do
     context 'for an event of type Event::RelationshipDelete' do
       let(:who) { create(:confirmed_user) }
       let(:project) { create(:project) }
-      let(:group) { create(:group_with_user, user: receiver) }
+      let(:group) { create(:group_with_user, user: receiver, email: nil) }
       let!(:subscription) { create(:event_subscription_relationship_delete, user: receiver) }
       let(:mail) { EventMailer.with(subscribers: Event::RelationshipDelete.last.subscribers, event: Event::RelationshipDelete.last).notification_email.deliver_now }
 

--- a/src/api/spec/models/event_subscription/find_for_event_spec.rb
+++ b/src/api/spec/models/event_subscription/find_for_event_spec.rb
@@ -332,8 +332,8 @@ RSpec.describe EventSubscription::FindForEvent do
             event_subscription.payload = { project: project.name }
           end
 
-          it 'includes the target user' do
-            expect(subject.map(&:subscriber)).to include(user)
+          it 'includes the target group' do
+            expect(subject.map(&:subscriber)).to include(group)
           end
         end
 
@@ -391,8 +391,8 @@ RSpec.describe EventSubscription::FindForEvent do
             event_subscription.payload = { package: package.name }
           end
 
-          it 'includes the target user' do
-            expect(subject.map(&:subscriber)).to include(user)
+          it 'includes the target group' do
+            expect(subject.map(&:subscriber)).to include(group)
           end
         end
 
@@ -462,8 +462,8 @@ RSpec.describe EventSubscription::FindForEvent do
             event_subscription.payload = { project: project.name }
           end
 
-          it 'includes the target user' do
-            expect(subject.map(&:subscriber)).to include(user)
+          it 'includes the target group' do
+            expect(subject.map(&:subscriber)).to include(group)
           end
         end
 
@@ -522,8 +522,8 @@ RSpec.describe EventSubscription::FindForEvent do
             event_subscription.payload = { package: package.name }
           end
 
-          it 'includes the target user' do
-            expect(subject.map(&:subscriber)).to include(user)
+          it 'includes the target group' do
+            expect(subject.map(&:subscriber)).to include(group)
           end
         end
 


### PR DESCRIPTION
This enables filtering of the `Event::Relationship*` event types based on the type of subscription. This should have been included originally, because as it is, the notification avoids being filtered with the subscription settings for groups, and instead sends mails to all the members of the group.

Fixes #12588