### PR TITLE
Update the bundler version in Gemfile.lock

### DIFF
--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -610,4 +610,4 @@ DEPENDENCIES
   yajl-ruby
 
 BUNDLED WITH
-   2.3.7
+   2.3.26

--- a/src/api/Gemfile.next.lock
+++ b/src/api/Gemfile.next.lock
@@ -609,4 +609,4 @@ DEPENDENCIES
   yajl-ruby
 
 BUNDLED WITH
-   2.3.7
+   2.3.26


### PR DESCRIPTION
The builds in OBS are currently failing because the package updated bundler to 2.3.26, and bundler tries to download that version from the internet (which obviously doesn't work). This should fix that issue