### PR TITLE
Enable build failure subscriptions for web channel

### DIFF
--- a/src/api/app/models/event_subscription/for_channel_form.rb
+++ b/src/api/app/models/event_subscription/for_channel_form.rb
@@ -1,6 +1,6 @@
 class EventSubscription
   class ForChannelForm
-    DISABLE_FOR_EVENTS = ['Event::BuildFail', 'Event::ServiceFail'].freeze
+    DISABLE_FOR_EVENTS = ['Event::ServiceFail'].freeze
 
     attr_reader :name, :subscription
 


### PR DESCRIPTION
This PR enables the subscription to build failure events.

![image](https://user-images.githubusercontent.com/2650/204571332-06e38928-fa00-461f-a40e-d89262c29d5b.png)

It does not actually delivers the notifications. That is covered in #13447 