### PR TITLE
Replace old watchlist code by code under new_watchlist feature in API

### DIFF
--- a/src/api/app/views/models/_user.xml.builder
+++ b/src/api/app/views/models/_user.xml.builder
@@ -19,14 +19,6 @@ else
     xml.ignore_auth_services(my_model.ignore_auth_services) if my_model.is_admin?
 
     # Show the watchlist only to the user for privacy reasons
-    if Flipper.enabled?(:new_watchlist, User.session) && watchlist
-      render partial: 'person/watchlist', locals: { builder: xml, my_model: my_model }
-    elsif watchlist
-      xml.watchlist do
-        my_model.watched_projects.each do |wp|
-          xml.project(name: wp.project.name)
-        end
-      end
-    end
+    render partial: 'person/watchlist', locals: { builder: xml, my_model: my_model } if watchlist
   end
 end

--- a/src/api/app/views/person/userinfo.xml.builder
+++ b/src/api/app/views/person/userinfo.xml.builder
@@ -1,3 +1,4 @@
+# TODO: remove this view, the corresponding action no longer exists
 xml.person do
   xml.login @render_user.login
   xml.email @render_user.email

--- a/src/api/spec/controllers/person_controller_spec.rb
+++ b/src/api/spec/controllers/person_controller_spec.rb
@@ -117,7 +117,6 @@ RSpec.describe PersonController do
 
       before do
         create(:package, project: project, name: 'test-pkg')
-        Flipper.enable_actor(:new_watchlist, admin_user)
         login admin_user
         put :put_userinfo, params: { login: test_user.login, format: :xml }, body: xml
       end
@@ -198,7 +197,6 @@ RSpec.describe PersonController do
       before do
         project = create(:project, name: 'test-proj')
         package = create(:package, project: project, name: 'test-pkg')
-        Flipper.enable_actor(:new_watchlist, user)
         user.watched_items.create(watchable: project)
         user.watched_items.create(watchable: package)
         login user
@@ -227,7 +225,6 @@ RSpec.describe PersonController do
       let!(:package) { create(:package, project: project, name: 'test-pkg') }
 
       before do
-        Flipper.enable_actor(:new_watchlist, user)
         login user
         put :put_watchlist, params: { login: user.login, format: :xml }, body: xml
       end

--- a/src/api/spec/controllers/person_controller_spec.rb
+++ b/src/api/spec/controllers/person_controller_spec.rb
@@ -106,24 +106,27 @@ RSpec.describe PersonController do
           <watchlist>
             <project name="test-proj"/>
             <package name="test-pkg" project="test-proj"/>
+            <request number="#{delete_request.number}"/>
           </watchlist>
         </userinfo>
       XML_DATA
     end
 
+    let(:delete_request) { create(:delete_bs_request) }
+
     context 'when watchlist is available in xml' do
       let(:test_user) { create(:confirmed_user, login: 'test-user', email: 'test-user@email.com') }
       let(:project) { create(:project, name: 'test-proj') }
+      let!(:package) { create(:package, project: project, name: 'test-pkg') }
 
       before do
-        create(:package, project: project, name: 'test-pkg')
         login admin_user
         put :put_userinfo, params: { login: test_user.login, format: :xml }, body: xml
       end
 
-      it "adds projects and packages to user's watchlist" do
-        expect(test_user.watched_items.count).to eq(2)
-        expect(test_user.watched_items.collect(&:watchable)).to include(project)
+      it "adds projects, requests and packages to user's watchlist" do
+        expect(test_user.watched_items.count).to eq(3)
+        expect(test_user.watched_items.collect(&:watchable)).to include(project, package, delete_request)
       end
     end
 
@@ -190,15 +193,19 @@ RSpec.describe PersonController do
           <watchlist>
             <project name="test-proj"/>
             <package name="test-pkg" project="test-proj"/>
+            <request number="#{delete_request.number}"/>
           </watchlist>
         XML_DATA
       end
 
+      let(:project) { create(:project, name: 'test-proj') }
+      let(:package) { create(:package, project: project, name: 'test-pkg') }
+      let(:delete_request) { create(:delete_bs_request) }
+
       before do
-        project = create(:project, name: 'test-proj')
-        package = create(:package, project: project, name: 'test-pkg')
         user.watched_items.create(watchable: project)
         user.watched_items.create(watchable: package)
+        user.watched_items.create(watchable: delete_request)
         login user
       end
 
@@ -217,21 +224,23 @@ RSpec.describe PersonController do
           <watchlist>
             <project name="test-proj"/>
             <package name="test-pkg" project="test-proj"/>
+            <request number="#{delete_request.number}"/>
           </watchlist>
         XML_DATA
       end
 
       let!(:project) { create(:project, name: 'test-proj') }
       let!(:package) { create(:package, project: project, name: 'test-pkg') }
+      let(:delete_request) { create(:delete_bs_request) }
 
       before do
         login user
         put :put_watchlist, params: { login: user.login, format: :xml }, body: xml
       end
 
-      it "adds projects and packages to user's watchlist" do
-        expect(user.watched_items.count).to eq(2)
-        expect(user.watched_items.collect(&:watchable)).to include(project, package)
+      it "adds projects, packages and requests to user's watchlist" do
+        expect(user.watched_items.count).to eq(3)
+        expect(user.watched_items.collect(&:watchable)).to include(project, package, delete_request)
       end
     end
   end


### PR DESCRIPTION
The `new_watchlist` feature has been enabled for all the users for a while now. It's time to replace the old code by the new one.

This PR only replaces the API's watchlist code.

**How to test?**

Play around with these endpoints, they should keep working:
- https://build.opensuse.org/apidocs-new/#/Person/put_person__login__watchlist
- https://build.opensuse.org/apidocs-new/#/Person/get_person__login__watchlist