### PR TITLE
Fix N+1 queries when fetching users of a watched package/request

### DIFF
--- a/src/api/app/models/event/base.rb
+++ b/src/api/app/models/event/base.rb
@@ -253,7 +253,7 @@ module Event
       package = Package.get_by_project_and_name(payload['project'], payload['package'], { follow_multibuild: true, follow_project_links: false, use_source: false })
       return [] if package.blank?
 
-      package.watched_items.map(&:user)
+      package.watched_items.includes(:user).map(&:user)
     rescue Package::Errors::UnknownObjectError, Project::Errors::UnknownObjectError
       []
     end
@@ -262,7 +262,7 @@ module Event
       bs_request = BsRequest.find_by(number: payload['number'])
       return [] if bs_request.blank?
 
-      bs_request.watched_items.map(&:user)
+      bs_request.watched_items.includes(:user).map(&:user)
     end
 
     def _roles(role, project, package = nil)


### PR DESCRIPTION
Before, a database query was sent for each user watching a package/request. Now, it's a single database query for all users watching a package/request, no matter how many users are involved.

I realized that this can be improved after commenting on #13438. See the [discussion](https://github.com/openSUSE/open-build-service/pull/13438#discussion_r1033527555).