### PR TITLE
Remove ProjectController#toggle_watch method

### DIFF
--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -5,15 +5,14 @@ class Webui::ProjectController < Webui::WebuiController
 
   before_action :lockout_spiders, only: [:requests, :buildresults]
 
-  before_action :require_login, only: [:create, :toggle_watch, :destroy, :new, :release_request,
+  before_action :require_login, only: [:create, :destroy, :new, :release_request,
                                        :new_release_request, :edit_comment]
 
   before_action :set_project, only: [:autocomplete_repositories, :users, :subprojects,
                                      :edit, :release_request,
                                      :show, :buildresult,
                                      :destroy, :remove_path_from_target,
-                                     :requests, :save, :monitor, :toggle_watch,
-                                     :edit_comment,
+                                     :requests, :save, :monitor, :edit_comment,
                                      :unlock, :save_person, :save_group, :remove_role,
                                      :move_path, :clear_failed_comment, :pulse,
                                      :keys_and_certificates]
@@ -27,7 +26,7 @@ class Webui::ProjectController < Webui::WebuiController
   after_action :verify_authorized, except: [:index, :autocomplete_projects, :autocomplete_incidents, :autocomplete_packages,
                                             :autocomplete_repositories, :users, :subprojects, :new, :show,
                                             :buildresult, :requests, :monitor, :new_release_request,
-                                            :remove_target_request, :toggle_watch, :edit_comment, :edit_comment_form,
+                                            :remove_target_request, :edit_comment, :edit_comment_form,
                                             :keys_and_certificates]
 
   def index
@@ -321,22 +320,6 @@ class Webui::ProjectController < Webui::WebuiController
       repohash[repo] = arch_hash.keys.sort!
     end
     @repoarray = repohash.sort
-  end
-
-  def toggle_watch
-    if User.session!.watches?(@project.name)
-      logger.debug "Remove #{@project} from watchlist for #{User.session!}"
-      User.session!.remove_watched_project(@project.name)
-    else
-      logger.debug "Add #{@project} to watchlist for #{User.session!}"
-      User.session!.add_watched_project(@project.name)
-    end
-
-    if request.env['HTTP_REFERER']
-      redirect_back(fallback_location: root_path)
-    else
-      redirect_to action: :show, project: @project
-    end
   end
 
   def clear_failed_comment

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -227,7 +227,6 @@ OBSApi::Application.routes.draw do
         "/project/monitor/#{request.query_parameters[:project]}#{url_string}"
       }, constraints: ->(request) { request.query_parameters['project'].present? }
       # TODO: this should be POST (and the link AJAX)
-      get 'project/toggle_watch/:project' => :toggle_watch, constraints: cons, as: 'project_toggle_watch'
       get 'project/clear_failed_comment/:project' => :clear_failed_comment, constraints: cons, as: :clear_failed_comment
       get 'project/edit_comment_form/:project' => :edit_comment_form, constraints: cons, as: :edit_comment_form
       post 'project/edit_comment/:project' => :edit_comment, constraints: cons

--- a/src/api/spec/cassettes/Webui_ProjectController/GET_create/with_a_namespace_called_base_/1_14_1_1.yml
+++ b/src/api/spec/cassettes/Webui_ProjectController/GET_create/with_a_namespace_called_base_/1_14_1_1.yml
@@ -1,0 +1,35 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom:my_project/_project/_history?deleted=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Mon, 28 Nov 2022 21:13:56 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Webui_ProjectController/GET_create/with_a_namespace_called_base_/behaves_like_a_valid_project_saved/1_14_1_2_1.yml
+++ b/src/api/spec/cassettes/Webui_ProjectController/GET_create/with_a_namespace_called_base_/behaves_like_a_valid_project_saved/1_14_1_2_1.yml
@@ -1,0 +1,35 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom:my_project/_project/_history?deleted=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Mon, 28 Nov 2022 21:13:56 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Webui_ProjectController/GET_create/with_a_namespace_called_base_/behaves_like_a_valid_project_saved/1_14_1_2_2.yml
+++ b/src/api/spec/cassettes/Webui_ProjectController/GET_create/with_a_namespace_called_base_/behaves_like_a_valid_project_saved/1_14_1_2_2.yml
@@ -1,0 +1,35 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom:my_project/_project/_history?deleted=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Mon, 28 Nov 2022 21:13:56 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Webui_ProjectController/GET_create/with_a_param_called_maintenance_project/1_14_2_1.yml
+++ b/src/api/spec/cassettes/Webui_ProjectController/GET_create/with_a_param_called_maintenance_project/1_14_2_1.yml
@@ -1,0 +1,35 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom:my_project/_project/_history?deleted=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Mon, 28 Nov 2022 21:13:58 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Webui_ProjectController/GET_create/with_a_param_called_maintenance_project/behaves_like_a_valid_project_saved/1_14_2_2_1.yml
+++ b/src/api/spec/cassettes/Webui_ProjectController/GET_create/with_a_param_called_maintenance_project/behaves_like_a_valid_project_saved/1_14_2_2_1.yml
@@ -1,0 +1,35 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom:my_project/_project/_history?deleted=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Mon, 28 Nov 2022 21:13:58 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Webui_ProjectController/GET_create/with_a_param_called_maintenance_project/behaves_like_a_valid_project_saved/1_14_2_2_2.yml
+++ b/src/api/spec/cassettes/Webui_ProjectController/GET_create/with_a_param_called_maintenance_project/behaves_like_a_valid_project_saved/1_14_2_2_2.yml
@@ -1,0 +1,35 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom:my_project/_project/_history?deleted=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Mon, 28 Nov 2022 21:13:58 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Webui_ProjectController/GET_create/with_a_param_that_disables_a_flag/behaves_like_a_param_that_creates_a_disabled_flag/1_14_3_1_1.yml
+++ b/src/api/spec/cassettes/Webui_ProjectController/GET_create/with_a_param_that_disables_a_flag/behaves_like_a_param_that_creates_a_disabled_flag/1_14_3_1_1.yml
@@ -1,0 +1,35 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom:my_project/_project/_history?deleted=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Mon, 28 Nov 2022 21:13:57 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Webui_ProjectController/GET_create/with_a_param_that_disables_a_flag/behaves_like_a_param_that_creates_a_disabled_flag/1_14_3_1_2.yml
+++ b/src/api/spec/cassettes/Webui_ProjectController/GET_create/with_a_param_that_disables_a_flag/behaves_like_a_param_that_creates_a_disabled_flag/1_14_3_1_2.yml
@@ -1,0 +1,35 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom:my_project/_project/_history?deleted=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Mon, 28 Nov 2022 21:13:57 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Webui_ProjectController/GET_create/with_a_param_that_disables_a_flag/behaves_like_a_param_that_creates_a_disabled_flag/1_14_3_2_1.yml
+++ b/src/api/spec/cassettes/Webui_ProjectController/GET_create/with_a_param_that_disables_a_flag/behaves_like_a_param_that_creates_a_disabled_flag/1_14_3_2_1.yml
@@ -1,0 +1,35 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom:my_project/_project/_history?deleted=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Mon, 28 Nov 2022 21:13:57 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Webui_ProjectController/GET_create/with_a_param_that_disables_a_flag/behaves_like_a_param_that_creates_a_disabled_flag/1_14_3_2_2.yml
+++ b/src/api/spec/cassettes/Webui_ProjectController/GET_create/with_a_param_that_disables_a_flag/behaves_like_a_param_that_creates_a_disabled_flag/1_14_3_2_2.yml
@@ -1,0 +1,35 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom:my_project/_project/_history?deleted=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Mon, 28 Nov 2022 21:13:57 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Webui_ProjectController/GET_create/with_a_param_that_disables_a_flag/behaves_like_a_param_that_creates_a_disabled_flag/1_14_3_3_1.yml
+++ b/src/api/spec/cassettes/Webui_ProjectController/GET_create/with_a_param_that_disables_a_flag/behaves_like_a_param_that_creates_a_disabled_flag/1_14_3_3_1.yml
@@ -1,0 +1,35 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom:my_project/_project/_history?deleted=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Mon, 28 Nov 2022 21:13:56 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Webui_ProjectController/GET_create/with_a_param_that_disables_a_flag/behaves_like_a_param_that_creates_a_disabled_flag/1_14_3_3_2.yml
+++ b/src/api/spec/cassettes/Webui_ProjectController/GET_create/with_a_param_that_disables_a_flag/behaves_like_a_param_that_creates_a_disabled_flag/1_14_3_3_2.yml
@@ -1,0 +1,35 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom:my_project/_project/_history?deleted=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Mon, 28 Nov 2022 21:13:56 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Webui_ProjectController/GET_create/with_a_param_that_disables_a_flag/behaves_like_a_param_that_creates_a_disabled_flag/behaves_like_a_valid_project_saved/1_14_3_1_3_1.yml
+++ b/src/api/spec/cassettes/Webui_ProjectController/GET_create/with_a_param_that_disables_a_flag/behaves_like_a_param_that_creates_a_disabled_flag/behaves_like_a_valid_project_saved/1_14_3_1_3_1.yml
@@ -1,0 +1,35 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom:my_project/_project/_history?deleted=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Mon, 28 Nov 2022 21:13:57 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Webui_ProjectController/GET_create/with_a_param_that_disables_a_flag/behaves_like_a_param_that_creates_a_disabled_flag/behaves_like_a_valid_project_saved/1_14_3_1_3_2.yml
+++ b/src/api/spec/cassettes/Webui_ProjectController/GET_create/with_a_param_that_disables_a_flag/behaves_like_a_param_that_creates_a_disabled_flag/behaves_like_a_valid_project_saved/1_14_3_1_3_2.yml
@@ -1,0 +1,35 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom:my_project/_project/_history?deleted=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Mon, 28 Nov 2022 21:13:57 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Webui_ProjectController/GET_create/with_a_param_that_disables_a_flag/behaves_like_a_param_that_creates_a_disabled_flag/behaves_like_a_valid_project_saved/1_14_3_2_3_1.yml
+++ b/src/api/spec/cassettes/Webui_ProjectController/GET_create/with_a_param_that_disables_a_flag/behaves_like_a_param_that_creates_a_disabled_flag/behaves_like_a_valid_project_saved/1_14_3_2_3_1.yml
@@ -1,0 +1,35 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom:my_project/_project/_history?deleted=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Mon, 28 Nov 2022 21:13:58 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Webui_ProjectController/GET_create/with_a_param_that_disables_a_flag/behaves_like_a_param_that_creates_a_disabled_flag/behaves_like_a_valid_project_saved/1_14_3_2_3_2.yml
+++ b/src/api/spec/cassettes/Webui_ProjectController/GET_create/with_a_param_that_disables_a_flag/behaves_like_a_param_that_creates_a_disabled_flag/behaves_like_a_valid_project_saved/1_14_3_2_3_2.yml
@@ -1,0 +1,35 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom:my_project/_project/_history?deleted=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Mon, 28 Nov 2022 21:13:57 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Webui_ProjectController/GET_create/with_a_param_that_disables_a_flag/behaves_like_a_param_that_creates_a_disabled_flag/behaves_like_a_valid_project_saved/1_14_3_3_3_1.yml
+++ b/src/api/spec/cassettes/Webui_ProjectController/GET_create/with_a_param_that_disables_a_flag/behaves_like_a_param_that_creates_a_disabled_flag/behaves_like_a_valid_project_saved/1_14_3_3_3_1.yml
@@ -1,0 +1,35 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom:my_project/_project/_history?deleted=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Mon, 28 Nov 2022 21:13:56 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Webui_ProjectController/GET_create/with_a_param_that_disables_a_flag/behaves_like_a_param_that_creates_a_disabled_flag/behaves_like_a_valid_project_saved/1_14_3_3_3_2.yml
+++ b/src/api/spec/cassettes/Webui_ProjectController/GET_create/with_a_param_that_disables_a_flag/behaves_like_a_param_that_creates_a_disabled_flag/behaves_like_a_valid_project_saved/1_14_3_3_3_2.yml
@@ -1,0 +1,35 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom:my_project/_project/_history?deleted=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Mon, 28 Nov 2022 21:13:57 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Webui_ProjectController/GET_create/with_an_invalid_project_data/1_14_4_1.yml
+++ b/src/api/spec/cassettes/Webui_ProjectController/GET_create/with_an_invalid_project_data/1_14_4_1.yml
@@ -1,0 +1,35 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom:my%20invalid%20project/_project/_history?deleted=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Mon, 28 Nov 2022 21:13:56 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Webui_ProjectController/GET_create/with_an_invalid_project_data/1_14_4_2.yml
+++ b/src/api/spec/cassettes/Webui_ProjectController/GET_create/with_an_invalid_project_data/1_14_4_2.yml
@@ -1,0 +1,35 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom:my%20invalid%20project/_project/_history?deleted=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Mon, 28 Nov 2022 21:13:56 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Webui_ProjectController/GET_monitor/with_a_project/with_buildresult/without_results/1_22_1_4_2_1.yml
+++ b/src/api/spec/cassettes/Webui_ProjectController/GET_monitor/with_a_project/with_buildresult/without_results/1_22_1_4_2_1.yml
@@ -1,0 +1,35 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/build/home:tom/_result?code=deleting&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Mon, 28 Nov 2022 21:14:02 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/controllers/webui/project_controller_spec.rb
+++ b/src/api/spec/controllers/webui/project_controller_spec.rb
@@ -531,34 +531,6 @@ RSpec.describe Webui::ProjectController, vcr: true do
     end
   end
 
-  describe 'GET #toggle_watch' do
-    before do
-      login user
-    end
-
-    it 'with a project already whatched' do
-      create(:watched_project, project: user.home_project, user: user)
-      get :toggle_watch, params: { project: user.home_project }
-      expect(user.watched_project_names).not_to include(user.home_project_name)
-    end
-
-    it 'with a project not whatched' do
-      get :toggle_watch, params: { project: user.home_project }
-      expect(user.watched_project_names).to include(user.home_project_name)
-    end
-
-    it 'redirects to back if a referer is there' do
-      request.env['HTTP_REFERER'] = root_url # Needed for the redirect_to :back
-      get :toggle_watch, params: { project: user.home_project }
-      expect(subject).to redirect_to(root_url)
-    end
-
-    it 'redirects to project#show' do
-      get :toggle_watch, params: { project: user.home_project }
-      expect(subject).to redirect_to(project_show_path(user.home_project))
-    end
-  end
-
   describe 'POST #unlock' do
     before do
       login user

--- a/src/api/spec/controllers/webui/watched_items_controller_spec.rb
+++ b/src/api/spec/controllers/webui/watched_items_controller_spec.rb
@@ -2,48 +2,46 @@ require 'rails_helper'
 
 RSpec.describe Webui::WatchedItemsController do
   describe '#toggle_watched_item' do
-    context 'when the user belongs to the beta group' do
-      context 'when the package is not already watched' do
-        let(:user) { create(:confirmed_user) }
-        let(:package) { create(:package) }
+    context 'when the package is not already watched' do
+      let(:user) { create(:confirmed_user) }
+      let(:package) { create(:package) }
 
-        before do
-          login user
-          put :toggle_watched_item, params: { package_name: package, project_name: package.project }, xhr: true
-        end
-
-        it 'adds the package to the watchlist' do
-          expect(user.watched_items).to exist(watchable: package)
-        end
+      before do
+        login user
+        put :toggle_watched_item, params: { package_name: package, project_name: package.project }, xhr: true
       end
 
-      context 'when the request is not already watched' do
-        let(:user) { create(:confirmed_user) }
-        let(:bs_request) { create(:bs_request_with_submit_action) }
+      it 'adds the package to the watchlist' do
+        expect(user.watched_items).to exist(watchable: package)
+      end
+    end
 
-        before do
-          login user
-          put :toggle_watched_item, params: { number: bs_request.number }, xhr: true
-        end
+    context 'when the request is not already watched' do
+      let(:user) { create(:confirmed_user) }
+      let(:bs_request) { create(:bs_request_with_submit_action) }
 
-        it 'adds the request to the watchlist' do
-          expect(user.watched_items).to exist(watchable: bs_request)
-        end
+      before do
+        login user
+        put :toggle_watched_item, params: { number: bs_request.number }, xhr: true
       end
 
-      context 'when the item is already watched' do
-        let(:user) { create(:confirmed_user) }
-        let(:package) { create(:package) }
+      it 'adds the request to the watchlist' do
+        expect(user.watched_items).to exist(watchable: bs_request)
+      end
+    end
 
-        before do
-          login user
-          user.watched_items.create(watchable: package)
-          put :toggle_watched_item, params: { package_name: package, project_name: package.project }, xhr: true
-        end
+    context 'when the item is already watched' do
+      let(:user) { create(:confirmed_user) }
+      let(:package) { create(:package) }
 
-        it 'removes the item from the watchlist' do
-          expect(user.watched_items).not_to exist(watchable: package)
-        end
+      before do
+        login user
+        user.watched_items.create(watchable: package)
+        put :toggle_watched_item, params: { package_name: package, project_name: package.project }, xhr: true
+      end
+
+      it 'removes the item from the watchlist' do
+        expect(user.watched_items).not_to exist(watchable: package)
       end
     end
   end


### PR DESCRIPTION
We are replacing the old watchlist code with the new one step by step.

In this case, we focus on removing `ProjectController#toggle_watch` which is now replaced by `Webui::WatchedItemsController#toggle_watched_item`.
