### PR TITLE
Receive notifications for build failures

### DIFF
--- a/src/api/app/components/notification_action_description_component.rb
+++ b/src/api/app/components/notification_action_description_component.rb
@@ -7,11 +7,9 @@ class NotificationActionDescriptionComponent < ApplicationComponent
     @user = @notification.event_payload['who']
     # If a notification is for a group, the notified user needs to know for which group. Otherwise, the user is simply referred to as 'you'.
     @recipient = @notification.event_payload.fetch('group', 'you')
-    @target_object = if @notification.event_payload['package']
-                       "#{@notification.event_payload['project']} / #{@notification.event_payload['package']}"
-                     else
-                       @notification.event_payload['project']
-                     end
+    project = @notification.event_payload['project']
+    package = @notification.event_payload['package']
+    @target_object = [project, package].compact.join(' / ')
   end
 
   def call
@@ -28,6 +26,8 @@ class NotificationActionDescriptionComponent < ApplicationComponent
         "#{@user} made #{@recipient} #{@role} of #{@target_object}"
       when 'Event::RelationshipDelete'
         "#{@user} removed #{@recipient} as #{@role} of #{@target_object}"
+      when 'Event::BuildFail'
+        "Reason for the build: #{@notification.event_payload['reason']}"
       end
     end
   end

--- a/src/api/app/components/notification_component.rb
+++ b/src/api/app/components/notification_component.rb
@@ -12,12 +12,10 @@ class NotificationComponent < ApplicationComponent
       tag.i(class: ['fas', 'fa-code-pull-request'], title: 'Request notification')
     when 'Comment'
       tag.i(class: ['fas', 'fa-comments'], title: 'Comment notification')
+    when 'Package'
+      tag.i(class: ['fas', helpers.build_status_icon(:failed)], title: 'Package notification')
     else
-      if @notification.event_type == 'Event::BuildFail'
-        tag.i(class: ['fas', helpers.build_status_icon(:failed)], title: 'Package notification')
-      else
-        tag.i(class: ['fas', 'fa-user-tag'], title: 'Relationship notification')
-      end
+      tag.i(class: ['fas', 'fa-user-tag'], title: 'Relationship notification')
     end
   end
 end

--- a/src/api/app/components/notification_component.rb
+++ b/src/api/app/components/notification_component.rb
@@ -13,7 +13,11 @@ class NotificationComponent < ApplicationComponent
     when 'Comment'
       tag.i(class: ['fas', 'fa-comments'], title: 'Comment notification')
     else
-      tag.i(class: ['fas', 'fa-user-tag'], title: 'Relationship notification')
+      if @notification.event_type == 'Event::BuildFail'
+        tag.i(class: ['fas', 'fa-times-circle'], title: 'Package notification')
+      else
+        tag.i(class: ['fas', 'fa-user-tag'], title: 'Relationship notification')
+      end
     end
   end
 end

--- a/src/api/app/components/notification_component.rb
+++ b/src/api/app/components/notification_component.rb
@@ -14,7 +14,7 @@ class NotificationComponent < ApplicationComponent
       tag.i(class: ['fas', 'fa-comments'], title: 'Comment notification')
     else
       if @notification.event_type == 'Event::BuildFail'
-        tag.i(class: ['fas', 'fa-times-circle'], title: 'Package notification')
+        tag.i(class: ['fas', helpers.build_status_icon(:failed)], title: 'Package notification')
       else
         tag.i(class: ['fas', 'fa-user-tag'], title: 'Relationship notification')
       end

--- a/src/api/app/components/notification_notifiable_link_component.rb
+++ b/src/api/app/components/notification_notifiable_link_component.rb
@@ -37,10 +37,17 @@ class NotificationNotifiableLinkComponent < ApplicationComponent
       else
         "Removed as #{role} of a project"
       end
+    when 'Event::BuildFail'
+      project = @notification.event_payload['project']
+      package = @notification.event_payload['package']
+      repository = @notification.event_payload['repository']
+      arch = @notification.event_payload['arch']
+      "Package #{package} on #{project} project failed to build against #{repository} / #{arch}"
     end
   end
   # rubocop:enable Metrics/CyclomaticComplexity
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def notifiable_link_path
     case @notification.event_type
     when 'Event::RequestStatechange', 'Event::RequestCreate', 'Event::ReviewWanted'
@@ -67,6 +74,10 @@ class NotificationNotifiableLinkComponent < ApplicationComponent
       else
         Rails.application.routes.url_helpers.project_users_path(@notification.event_payload['project'])
       end
+    when 'Event::BuildFail'
+      Rails.application.routes.url_helpers.package_live_build_log_path(package: @notification.event_payload['package'], project: @notification.event_payload['project'],
+                                                                       repository: @notification.event_payload['repository'], arch: @notification.event_payload['arch'])
     end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 end

--- a/src/api/app/models/event/build.rb
+++ b/src/api/app/models/event/build.rb
@@ -35,6 +35,11 @@ module Event
       }
     end
 
+    def parameters_for_notification
+      super.merge(notifiable_type: 'Package',
+                  notifiable_id: ::Package.find_by_project_and_name(payload['project'], payload['package'])&.id)
+    end
+
     private
 
     def duration_in_seconds

--- a/src/api/app/services/notification_service/notifier.rb
+++ b/src/api/app/services/notification_service/notifier.rb
@@ -1,6 +1,7 @@
 module NotificationService
   class Notifier
-    EVENTS_TO_NOTIFY = ['Event::RequestStatechange',
+    EVENTS_TO_NOTIFY = ['Event::BuildFail',
+                        'Event::RequestStatechange',
                         'Event::RequestCreate',
                         'Event::ReviewWanted',
                         'Event::CommentForProject',

--- a/src/api/spec/support/shared_contexts/a_user_and_subscriptions_with_defaults.rb
+++ b/src/api/spec/support/shared_contexts/a_user_and_subscriptions_with_defaults.rb
@@ -40,6 +40,15 @@ RSpec.shared_context 'a user and subscriptions with defaults' do
       channel: 'instant_email'
     )
   end
+  let!(:default_subscription3) do
+    create(
+      :event_subscription,
+      eventtype: 'Event::BuildFailure',
+      receiver_role: :source_maintainer,
+      user: user,
+      channel: 'web'
+    )
+  end
 
   let(:subscription_params) do
     {
@@ -48,7 +57,8 @@ RSpec.shared_context 'a user and subscriptions with defaults' do
       '2' => { enabled: 'true', channel: 'instant_email', eventtype: 'Event::RequestStatechange', receiver_role: 'creator' },
       '3' => { enabled: 'true', channel: 'instant_email', eventtype: 'Event::RequestStatechange', receiver_role: 'reviewer' },
       '4' => { enabled: 'true', channel: 'rss', eventtype: 'Event::RequestStatechange', receiver_role: 'creator' },
-      '5' => { enabled: 'true', channel: 'web', eventtype: 'Event::RequestStatechange', receiver_role: 'reviewer' }
+      '5' => { enabled: 'true', channel: 'web', eventtype: 'Event::RequestStatechange', receiver_role: 'reviewer' },
+      '6' => { enabled: 'true', channel: 'web', eventtype: 'Event::BuildFailure', receiver_role: 'source_maintainer' }
     }
   end
 end


### PR DESCRIPTION
This PR allows subscribers to receive notifications when a package fails to build.

This is how a notification for a package build failure looks like:

![image](https://user-images.githubusercontent.com/2650/205321889-96b76ca7-d9dc-4329-856c-505f6d103c10.png)

This is a follow up of #13428 

Edit: Update screenshot