### PR TITLE
Deliver web notification to group members

### DIFF
--- a/src/api/app/models/event_subscription/find_for_event.rb
+++ b/src/api/app/models/event_subscription/find_for_event.rb
@@ -52,6 +52,9 @@ class EventSubscription
               channel: default_subscription.channel,
               subscriber: receiver
             )
+          elsif channel == :web && receiver.instance_of?(Group) && receiver.web_users.any? { |u| EventSubscription.for_subscriber(u).find_by(options).present? }
+            # There is no default subscription for groups, so we are using the existing details
+            receivers_and_subscriptions[receiver] = EventSubscription.new(options.merge({ subscriber: receiver }))
           elsif @debug && default_subscription.present? && !default_subscription.enabled?
             puts "Skipped receiver #{receiver} because of a disabled default subscription"
           end


### PR DESCRIPTION
`receivers_and_subscriptions` hash did not end up with any groups whatsoever, so the delivery of web notifications about groups wasn't working. This should fix that

# To verify:
1. Create a group and join a user to it
2. Have the group have a role in a project
3. Perform an action that would result in a notification in that project (except for `Event::Relationship*` one, that's addressed in another PR)
4. See if the user got notified about it