### PR TITLE
Bring back AJAX calls to request changes in beta

### DIFF
--- a/src/api/app/assets/javascripts/webui/request.js
+++ b/src/api/app/assets/javascripts/webui/request.js
@@ -166,3 +166,17 @@ function loadDiffs(element){
     }
   });
 }
+
+function loadChanges() { // jshint ignore:line
+  $('.loading-diff').removeClass('invisible');
+  var element = $('#changes-item');
+  // Always retrieve the changes of the first request action, by now
+  // TODO: request-action-id should be retrieved from the select component, when it is introduced
+  var url = '/request/' + element.data('request-number') + '/request_action/' + element.data('request-action-id') + '/changes';
+  $.ajax({
+    url: url,
+    success: function() {
+      $('.loading-diff').addClass('invisible');
+    }
+  });
+}

--- a/src/api/app/assets/javascripts/webui/request.js
+++ b/src/api/app/assets/javascripts/webui/request.js
@@ -169,9 +169,7 @@ function loadDiffs(element){
 
 function loadChanges() { // jshint ignore:line
   $('.loading-diff').removeClass('invisible');
-  var element = $('#changes-item');
-  // Always retrieve the changes of the first request action, by now
-  // TODO: request-action-id should be retrieved from the select component, when it is introduced
+  var element = $('#changes-tab');
   var url = '/request/' + element.data('request-number') + '/request_action/' + element.data('request-action-id') + '/changes';
   $.ajax({
     url: url,

--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -52,22 +52,23 @@
     .border-bottom
       %ul.nav.nav-tabs.scrollable-tabs.border-0#request-tabs{ role: 'tablist' }
         %li.nav-item.scrollable-tab-link{ role: 'presentation' }
-          = link_to('Conversation', '#conversation', class: 'nav-link text-nowrap', 'aria-controls': 'conversation',
+          = link_to('Conversation', '#conversation', id: 'conversation-tab', class: 'nav-link text-nowrap', 'aria-controls': 'conversation',
                     'aria-selected': 'false', 'data-toggle': 'tab', role: 'tab')
         - if @action[:sprj] || @action[:spkg]
           %li.nav-item.scrollable-tab-link{ role: 'presentation' }
-            = link_to('Build Results', '#build-results', class: 'nav-link text-nowrap', 'aria-controls': 'build-results',
+            = link_to('Build Results', '#build-results', id: 'build-results-tab', class: 'nav-link text-nowrap', 'aria-controls': 'build-results',
                       'aria-selected': 'false', 'data-toggle': 'tab', role: 'tab')
           %li.nav-item.scrollable-tab-link{ role: 'presentation' }
-            = link_to('RPM Lint', '#rpm-lint', class: 'nav-link text-nowrap', 'aria-controls': 'rpm-lint',
-                      'aria-selected': 'false', 'data-toggle': 'tab', role: 'tab')
-        - if @action[:type].in?(actions_for_diff)
-          %li.nav-item.scrollable-tab-link{ role: 'presentation', 'data-request-number': @bs_request.number, 'data-request-action-id': @action[:id] }
-            = link_to('Changes', '#changes', class: 'nav-link text-nowrap', 'aria-controls': 'changes',
+            = link_to('RPM Lint', '#rpm-lint', id: 'rpm-lint-tab', class: 'nav-link text-nowrap', 'aria-controls': 'rpm-lint',
                       'aria-selected': 'false', 'data-toggle': 'tab', role: 'tab')
         - if @action[:type].in?(actions_for_diff)
           %li.nav-item.scrollable-tab-link{ role: 'presentation' }
-            = link_to('#mentioned-issues', class: 'nav-link text-nowrap', 'aria-controls': 'mentioned-issues',
+            = link_to('Changes', '#changes', id: 'changes-tab', class: 'nav-link text-nowrap', 'aria-controls': 'changes',
+                      'data-request-number': @bs_request.number, 'data-request-action-id': @action[:id],
+                      'aria-selected': 'false', 'data-toggle': 'tab', role: 'tab')
+        - if @action[:type].in?(actions_for_diff)
+          %li.nav-item.scrollable-tab-link{ role: 'presentation' }
+            = link_to('#mentioned-issues', id: 'mentioned-issues-tab', class: 'nav-link text-nowrap', 'aria-controls': 'mentioned-issues',
                       'aria-selected': 'false', 'data-toggle': 'tab', role: 'tab') do
               Mentioned Issues
               %span.badge.badge-primary.align-text-top= @issues.size

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -298,6 +298,7 @@ OBSApi::Application.routes.draw do
       get 'request/list_small' => :list_small, as: 'request_list_small'
       post 'request/set_bugowner_request' => :set_bugowner_request
       get 'request/:number/request_action/:id' => :request_action, as: 'request_action'
+      get 'request/:number/request_action/:id/changes' => :request_action_changes, as: 'request_action_changes'
     end
 
     resources :requests, only: [], param: :number, controller: 'webui/bs_requests' do


### PR DESCRIPTION
Fixes issue #13443 only for beta, more concretely what refers to this sentence of [this comment](https://github.com/openSUSE/open-build-service/issues/13443#issuecomment-1329586992): 

> With the beta, the [button](https://github.com/openSUSE/open-build-service/blob/b07306d87baffd72a1ba7e51a64b1978a348ddfc/src/api/app/components/sourcediff_component.html.haml#L5) calls the loadChanges() JS function, but this function was removed in https://github.com/openSUSE/open-build-service/commit/2f23bedd1f100e6dcd7ac1ab23f3153982755b29 as part of https://github.com/openSUSE/open-build-service/pull/13029.