### PR TITLE
Implement filters for build fail events

### DIFF
--- a/src/api/app/components/notification_action_description_component.rb
+++ b/src/api/app/components/notification_action_description_component.rb
@@ -27,7 +27,7 @@ class NotificationActionDescriptionComponent < ApplicationComponent
       when 'Event::RelationshipDelete'
         "#{@user} removed #{@recipient} as #{@role} of #{@target_object}"
       when 'Event::BuildFail'
-        "Reason for the build: #{@notification.event_payload['reason']}"
+        "Build was triggered because of #{@notification.event_payload['reason']}"
       end
     end
   end

--- a/src/api/app/components/notification_filter_component.html.haml
+++ b/src/api/app/components/notification_filter_component.html.haml
@@ -17,6 +17,8 @@
                                                filter_item: { type: 'relationships_created' }, selected_filter: @selected_filter)
   = render NotificationFilterLinkComponent.new(text: 'Roles Revoked', amount: @count['relationships_deleted'],
                                                filter_item: { type: 'relationships_deleted' }, selected_filter: @selected_filter)
+  = render NotificationFilterLinkComponent.new(text: 'Build Failures', amount: @count['build_failures'],
+                                               filter_item: { type: 'build_failures' }, selected_filter: @selected_filter)
 
 - unless @projects_for_filter.empty?
   .list-group.list-group-flush.mt-5.mb-2

--- a/src/api/app/components/notification_filter_component.rb
+++ b/src/api/app/components/notification_filter_component.rb
@@ -17,6 +17,7 @@ class NotificationFilterComponent < ApplicationComponent
     counted_notifications['outgoing_requests'] = finder.for_outgoing_requests.count
     counted_notifications['relationships_created'] = finder.for_relationships_created.count
     counted_notifications['relationships_deleted'] = finder.for_relationships_deleted.count
+    counted_notifications['build_failures'] = finder.for_failed_builds.count
     counted_notifications.merge!('unread' => User.session.unread_notifications)
   end
 end

--- a/src/api/app/controllers/webui/users/notifications_controller.rb
+++ b/src/api/app/controllers/webui/users/notifications_controller.rb
@@ -1,5 +1,6 @@
 class Webui::Users::NotificationsController < Webui::WebuiController
-  VALID_NOTIFICATION_TYPES = ['read', 'reviews', 'comments', 'requests', 'unread', 'incoming_requests', 'outgoing_requests', 'relationships_created', 'relationships_deleted'].freeze
+  VALID_NOTIFICATION_TYPES = ['read', 'reviews', 'comments', 'requests', 'unread', 'incoming_requests', 'outgoing_requests', 'relationships_created', 'relationships_deleted',
+                              'build_failures'].freeze
 
   # TODO: Remove this when we'll refactor kerberos_auth
   before_action :kerberos_auth

--- a/src/api/app/queries/notifications_finder.rb
+++ b/src/api/app/queries/notifications_finder.rb
@@ -35,6 +35,10 @@ class NotificationsFinder
     @relation.where(event_type: 'Event::RelationshipDelete', delivered: false)
   end
 
+  def for_failed_builds
+    @relation.where(event_type: 'Event::BuildFail', delivered: false)
+  end
+
   # rubocop:disable Metrics/CyclomaticComplexity
   # We need to refactor this method, the `case` statement is way too big
   def for_notifiable_type(type = 'unread')
@@ -55,6 +59,8 @@ class NotificationsFinder
       notifications.for_relationships_created
     when 'relationships_deleted'
       notifications.for_relationships_deleted
+    when 'build_failures'
+      notifications.for_failed_builds
     else
       notifications.unread
     end

--- a/src/api/spec/components/notification_filter_component_spec.rb
+++ b/src/api/spec/components/notification_filter_component_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe NotificationFilterComponent, type: :component do
       render_inline(described_class.new(selected_filter: { type: 'unread' }))
     end
 
-    ['Unread', 'Read', 'Comments', 'Requests', 'Incoming Requests', 'Outgoing Requests'].each do |filter_name|
+    ['Unread', 'Read', 'Comments', 'Requests', 'Incoming Requests', 'Outgoing Requests', 'Build Failures'].each do |filter_name|
       it "displays a '#{filter_name}' filter" do
         expect(rendered_content).to have_link(filter_name)
       end
@@ -38,7 +38,7 @@ RSpec.describe NotificationFilterComponent, type: :component do
       render_inline(described_class.new(selected_filter: { type: 'unread' }))
     end
 
-    ['Unread', 'Read', 'Comments', 'Requests', 'Incoming Requests', 'Outgoing Requests'].each do |filter_name|
+    ['Unread', 'Read', 'Comments', 'Requests', 'Incoming Requests', 'Outgoing Requests', 'Build Failures'].each do |filter_name|
       it "displays a '#{filter_name}' filter" do
         expect(rendered_content).to have_link(filter_name)
       end

--- a/src/api/spec/controllers/webui/users/notifications_controller_spec.rb
+++ b/src/api/spec/controllers/webui/users/notifications_controller_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Webui::Users::NotificationsController do
   let(:comment_for_request_notification) { create(:web_notification, :comment_for_request, subscriber: user) }
   let(:read_notification) { create(:web_notification, :request_state_change, subscriber: user, delivered: true) }
   let(:notifications_for_other_users) { create(:web_notification, :request_state_change, subscriber: other_user) }
+  let(:build_failure) { create(:web_notification, :build_failure, subscriber: user) }
 
   shared_examples 'returning success' do
     it 'returns ok status' do
@@ -62,6 +63,20 @@ RSpec.describe Webui::Users::NotificationsController do
 
       it 'sets @notifications to all delivered notifications regardless of type' do
         expect(assigns[:notifications]).to include(read_notification)
+      end
+    end
+
+    context "when param type is 'build_failures'" do
+      let(:params) { default_params.merge(type: 'build_failures') }
+
+      before do
+        subject
+      end
+
+      it_behaves_like 'returning success'
+
+      it "sets @notifications to all undelivered notifications of 'build_failures' type" do
+        expect(assigns[:notifications]).to include(build_failure)
       end
     end
 

--- a/src/api/spec/factories/notification.rb
+++ b/src/api/spec/factories/notification.rb
@@ -63,6 +63,11 @@ FactoryBot.define do
       event_type { 'Event::RelationshipDelete' }
       association :notifiable, factory: :project
     end
+
+    trait :build_failure do
+      event_type { 'Event::BuildFail' }
+      association :notifiable, factory: :package
+    end
   end
 
   factory :rss_notification, parent: :notification do


### PR DESCRIPTION
Now that we can receive notifications for build failure events, we
need a way to filter them from the rest.

This is how it looks like:

![image](https://user-images.githubusercontent.com/2650/204838967-9491637e-b862-42d9-92ce-1bc13e2f6f27.png)

This is a follow up of #13447 