### PR TITLE
Use new receiver role name `project_watcher` for newly created event subscriptions

### DIFF
--- a/src/api/app/models/event/base.rb
+++ b/src/api/app/models/event/base.rb
@@ -242,7 +242,12 @@ module Event
       ret
     end
 
+    # TODO: Remove this method after all event subscriptions are migrated to use the receiver role `project_watchers`
     def watchers
+      project_watchers
+    end
+
+    def project_watchers
       project = ::Project.find_by_name(payload['project'])
       return [] if project.blank?
 

--- a/src/api/app/models/event/build_fail.rb
+++ b/src/api/app/models/event/build_fail.rb
@@ -4,7 +4,7 @@ module Event
 
     self.message_bus_routing_key = 'package.build_fail'
     self.description = 'Package has failed to build'
-    receiver_roles :maintainer, :bugowner, :reader, :watcher, :package_watcher, :request_watcher
+    receiver_roles :maintainer, :bugowner, :reader, :watcher, :project_watcher, :package_watcher, :request_watcher
 
     create_jobs :report_to_scm_job
 

--- a/src/api/app/models/event/comment_for_package.rb
+++ b/src/api/app/models/event/comment_for_package.rb
@@ -3,7 +3,7 @@ module Event
     include CommentEvent
     self.message_bus_routing_key = 'package.comment'
     self.description = 'New comment for package created'
-    receiver_roles :maintainer, :bugowner, :watcher, :package_watcher
+    receiver_roles :maintainer, :bugowner, :watcher, :project_watcher, :package_watcher
     payload_keys :project, :package, :sender
 
     def subject

--- a/src/api/app/models/event/comment_for_project.rb
+++ b/src/api/app/models/event/comment_for_project.rb
@@ -4,7 +4,7 @@ module Event
     self.message_bus_routing_key = 'project.comment'
     self.description = 'New comment for project created'
     payload_keys :project
-    receiver_roles :maintainer, :bugowner, :watcher
+    receiver_roles :maintainer, :bugowner, :watcher, :project_watcher
 
     def subject
       "New comment in project #{payload['project']} by #{payload['commenter']}"

--- a/src/api/app/models/event/comment_for_request.rb
+++ b/src/api/app/models/event/comment_for_request.rb
@@ -5,6 +5,7 @@ module Event
     self.description = 'New comment for request created'
     payload_keys :request_number
     receiver_roles :source_maintainer, :target_maintainer, :creator, :reviewer, :source_watcher, :target_watcher,
+                   :source_project_watcher, :target_project_watcher,
                    :source_package_watcher, :target_package_watcher, :request_watcher
 
     def subject

--- a/src/api/app/models/event/request.rb
+++ b/src/api/app/models/event/request.rb
@@ -84,11 +84,21 @@ module Event
       action_maintainers('sourceproject', 'sourcepackage')
     end
 
+    # TODO: Remove this method after all event subscriptions are migrated to use the new receiver role `source_project_watchers`
     def source_watchers
+      source_project_watchers
+    end
+
+    # TODO: Remove this method after all event subscriptions are migrated to use the new receiver role `target_project_watchers`
+    def target_watchers
+      target_project_watchers
+    end
+
+    def source_project_watchers
       source_or_target_project_watchers(project_type: 'sourceproject')
     end
 
-    def target_watchers
+    def target_project_watchers
       source_or_target_project_watchers(project_type: 'targetproject')
     end
 

--- a/src/api/app/models/event/request_create.rb
+++ b/src/api/app/models/event/request_create.rb
@@ -3,6 +3,7 @@ module Event
     self.message_bus_routing_key = 'request.create'
     self.description = 'Request created'
     receiver_roles :source_maintainer, :target_maintainer, :source_watcher, :target_watcher,
+                   :source_project_watcher, :target_project_watcher,
                    :source_package_watcher, :target_package_watcher
 
     def custom_headers

--- a/src/api/app/models/event/request_statechange.rb
+++ b/src/api/app/models/event/request_statechange.rb
@@ -4,6 +4,7 @@ module Event
     self.description = 'Request state was changed'
     payload_keys :oldstate, :duration
     receiver_roles :source_maintainer, :target_maintainer, :creator, :reviewer, :source_watcher, :target_watcher,
+                   :source_project_watcher, :target_project_watcher,
                    :source_package_watcher, :target_package_watcher, :request_watcher
 
     def subject

--- a/src/api/app/models/event/review_changed.rb
+++ b/src/api/app/models/event/review_changed.rb
@@ -3,7 +3,8 @@ module Event
     self.message_bus_routing_key = 'request.review_changed'
     self.description = 'Request was reviewed'
     payload_keys :reviewers, :by_user, :by_group, :by_project, :by_package
-    receiver_roles :source_maintainer, :target_maintainer, :creator, :source_watcher, :target_watcher
+    receiver_roles :source_maintainer, :target_maintainer, :creator, :source_watcher, :target_watcher,
+                   :source_project_watcher, :target_project_watcher
 
     def subject
       "Request #{payload['number']} was reviewed (#{actions_summary})"

--- a/src/api/app/models/event_subscription.rb
+++ b/src/api/app/models/event_subscription.rb
@@ -9,9 +9,9 @@ class EventSubscription < ApplicationRecord
     reviewer: 'Reviewer',
     commenter: 'Commenter',
     creator: 'Creator',
-    watcher: 'Watching the project',
-    source_watcher: 'Watching the source project',
-    target_watcher: 'Watching the target project',
+    project_watcher: 'Watching the project',
+    source_project_watcher: 'Watching the source project',
+    target_project_watcher: 'Watching the target project',
     any_role: 'Any role',
     package_watcher: 'Watching the package',
     source_package_watcher: 'Watching the source package',
@@ -41,6 +41,7 @@ class EventSubscription < ApplicationRecord
   validates :receiver_role, inclusion: {
     in: [:maintainer, :bugowner, :reader, :source_maintainer, :target_maintainer,
          :reviewer, :commenter, :creator, :watcher, :source_watcher, :target_watcher,
+         :project_watcher, :source_project_watcher, :target_project_watcher,
          :package_watcher, :target_package_watcher, :source_package_watcher, :request_watcher, :any_role]
   }
 

--- a/src/api/app/models/event_subscription/for_role_form.rb
+++ b/src/api/app/models/event_subscription/for_role_form.rb
@@ -2,6 +2,14 @@ class EventSubscription
   class ForRoleForm
     attr_reader :name, :channels, :subscriber
 
+    # TODO: Remove this constant after successfully migrating all event subscriptions to the new receiver_role
+    # name `project_watcher`
+    RECEIVER_ROLE_MAPPING = {
+      'project_watcher' => 'watcher',
+      'source_project_watcher' => 'source_watcher',
+      'target_project_watcher' => 'target_watcher'
+    }.freeze
+
     def initialize(role_name, event, subscriber)
       @subscriber = subscriber
       @name = role_name
@@ -35,10 +43,20 @@ class EventSubscription
     end
 
     def find_subscription_for_subscriber(event_class, role, channel)
+      # TODO: remove this if clause after we finish renaming *watcher to *project_watcher
+      # We have to do this in order to still render the checkboxes correctly for the 'old'
+      # existing subscription for the `watcher` role
+      role = RECEIVER_ROLE_MAPPING[role] if role.in?(RECEIVER_ROLE_MAPPING.keys)
+
       subscriber_subscriptions.find { |s| s.event_class == event_class && s.receiver_role == role && s.channel == channel }
     end
 
     def find_default_subscription(event_class, role, channel)
+      # TODO: remove this if clause after we finish renaming *watcher to *project_watcher
+      # We have to do this in order to still render the checkboxes correctly for the 'old'
+      # existing subscription for the `watcher` role
+      role = RECEIVER_ROLE_MAPPING[role] if role.in?(RECEIVER_ROLE_MAPPING.keys)
+
       default_subscriptions.find { |s| s.event_class == event_class && s.receiver_role == role && s.channel == channel }
     end
 

--- a/src/api/spec/db/data/generate_web_notifications_spec.rb
+++ b/src/api/spec/db/data/generate_web_notifications_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe GenerateWebNotifications, type: :migration do
     let!(:event_subscription_3) { create(:event_subscription_comment_for_project, user: owner, receiver_role: 'bugowner') }
     let!(:disabled_event_for_web_and_rss) { create(:event_subscription, eventtype: 'Event::BuildFail', user: owner, receiver_role: 'maintainer') }
     let!(:default_subscription) { create(:event_subscription_comment_for_project_without_subscriber, receiver_role: 'bugowner') }
-    let!(:default_subscription_1) { create(:event_subscription_comment_for_project_without_subscriber, receiver_role: 'watcher') }
+    let!(:default_subscription_1) { create(:event_subscription_comment_for_project_without_subscriber, receiver_role: 'project_watcher') }
     let!(:default_subscription_2) do
       create(:event_subscription_comment_for_project_without_subscriber,
              receiver_role: 'maintainer',

--- a/src/api/spec/features/webui/subscriptions_spec.rb
+++ b/src/api/spec/features/webui/subscriptions_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Subscriptions', js: true do
 
       expect(page).to have_content(title)
       notification_field = find('.card-body h5', text: 'Package has failed to build').sibling('.list-group')
-      ['maintainer', 'bugowner', 'reader', 'watcher'].each do |role|
+      ['maintainer', 'bugowner', 'reader', 'project_watcher'].each do |role|
         subscription_by_role = notification_field.find(".#{role}")
         subscription_by_role.check('email')
         expect(page).to have_css('#flash', text: 'Notifications settings updated')
@@ -18,7 +18,7 @@ RSpec.describe 'Subscriptions', js: true do
       visit path
 
       notification_field = find('.card-body h5', text: 'Package has failed to build').sibling('.list-group')
-      ['maintainer', 'bugowner', 'reader', 'watcher'].each do |role|
+      ['maintainer', 'bugowner', 'reader', 'project_watcher'].each do |role|
         subscription_by_role = notification_field.find(".#{role}")
         expect(subscription_by_role.find_field('email', visible: false)).to be_checked
       end

--- a/src/api/spec/models/event_subscription/find_for_event_spec.rb
+++ b/src/api/spec/models/event_subscription/find_for_event_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe EventSubscription::FindForEvent do
         create(
           :event_subscription,
           eventtype: 'Event::RequestCreate',
-          receiver_role: 'source_watcher',
+          receiver_role: 'source_project_watcher',
           user: nil,
           group: nil,
           channel: :instant_email
@@ -160,7 +160,7 @@ RSpec.describe EventSubscription::FindForEvent do
         let!(:comment) { create(:comment_project, commentable: project) }
 
         let!(:default_subscription) do
-          create(:event_subscription_comment_for_project, receiver_role: 'watcher', user: nil, group: nil)
+          create(:event_subscription_comment_for_project, receiver_role: 'project_watcher', user: nil, group: nil)
         end
 
         before do

--- a/src/api/spec/models/event_subscription/for_event_form_spec.rb
+++ b/src/api/spec/models/event_subscription/for_event_form_spec.rb
@@ -7,13 +7,15 @@ RSpec.describe EventSubscription::ForEventForm do
 
   describe '#call' do
     let(:roles) { subject.roles }
+    # TODO: Remove this after all event subscriptions are migrated to the new receiver role name `project_watcher`
+    let(:deprecated_roles) { [:watcher, :source_watcher, :target_watcher] }
 
     subject { EventSubscription::ForEventForm.new(event_class, subscriber).call }
 
     context 'for Event::CommentForProject' do
       let(:event_class) { Event::CommentForProject }
       let(:expected_receiver_roles) do
-        event_class.receiver_roles
+        event_class.receiver_roles - deprecated_roles
       end
 
       it { expect(subject.event_class).to eq(event_class) }
@@ -23,7 +25,7 @@ RSpec.describe EventSubscription::ForEventForm do
     context 'for Event::CommentForRequest' do
       let(:event_class) { Event::CommentForRequest }
       let(:expected_receiver_roles) do
-        event_class.receiver_roles
+        event_class.receiver_roles - deprecated_roles
       end
 
       it { expect(subject.event_class).to eq(event_class) }


### PR DESCRIPTION
In order to migrate the receiver role names from `watcher` to `project_watcher` we have to first use the new receiver role names for all newly created subscriptions. For now we still support the old naming by keeping the old receiver role names for the events, so we can still match them against each other. So we going to support both until we migrated all existing event subscriptions in a further step.

In order to support both the new and old naming for the receiver_role
`watcher` and `project_watcher` we need to update the old existing
records by just switching the `enabled` field while keeping the old
naming scheme for the receiver_role `watcher`. For non existing
subscriptions we create a new record with the new naming scheme
`project_watcher`

In order to render the checkboxes correctly for the old role names, we have to check for the old role names
when rendering the event subscription form and have to take them in to account. Otherwise we simply going with the 
new role names.

