### PR TITLE
Fix delivery of emails to groups

### DIFF
--- a/src/api/app/models/event_subscription/find_for_event.rb
+++ b/src/api/app/models/event_subscription/find_for_event.rb
@@ -52,7 +52,7 @@ class EventSubscription
               channel: default_subscription.channel,
               subscriber: receiver
             )
-          elsif channel == :web && receiver.instance_of?(Group) && receiver.web_users.any? { |u| EventSubscription.for_subscriber(u).find_by(options).present? }
+          elsif receiver.instance_of?(Group) && (receiver.web_users.any? { |u| EventSubscription.for_subscriber(u).find_by(options).present? } || receiver.email.present?)
             # There is no default subscription for groups, so we are using the existing details
             receivers_and_subscriptions[receiver] = EventSubscription.new(options.merge({ subscriber: receiver }))
           elsif @debug && default_subscription.present? && !default_subscription.enabled?


### PR DESCRIPTION
It seems this was broken for a while, now it should be fixed. I noticed it when working on my card.

# To verify:
1. Create a group and give it email address in console (there's no frontend for this)
2. Create an action that would trigger an event for the group
3. See the email

It may cause a huge amount of unexpected messages from obs (more than 0 from before at least), so we should probably think about giving groups ability to choose which events they want to get emails for. Currently it is technically possible to stop the mails from being sent out by creating event_subscriptions for groups and/or creating default event_subscriptions, but users don't get that ability in the frontend.