### PR TITLE
[api] fix whitespace in error message

### DIFF
--- a/src/api/app/models/bs_request_permission_check.rb
+++ b/src/api/app/models/bs_request_permission_check.rb
@@ -261,8 +261,8 @@ class BsRequestPermissionCheck
       c = Backend::Api::Sources::Package.files(action.source_project, action.source_package, expand: 1)
       data = REXML::Document.new(c)
       unless action.source_rev == data.elements['directory'].attributes['srcmd5']
-        raise SourceChanged, "The current source revision in #{action.source_project}/#{action.source_package}" \
-                             "are not on revision #{action.source_rev} anymore."
+        raise SourceChanged, "The current source revision in #{action.source_project}/#{action.source_package} " \
+                             "is not on revision #{action.source_rev} anymore."
       end
     end
 


### PR DESCRIPTION
example: The current source revision in SUSE:Maintenance:26696/tar.SUSE_SLE-15_Updateare not on revision e56083b71a6732bddb9cf68337b8bdcd anymore.