### PR TITLE
Log reason for request decline during auto_accept

### DIFF
--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -887,8 +887,9 @@ class BsRequest < ApplicationRecord
           change_state(newstate: 'revoked', comment: 'Target disappeared')
         rescue PostRequestNoPermission
           change_state(newstate: 'revoked', comment: 'Permission problem')
-        rescue APIError
-          change_state(newstate: 'declined', comment: 'Unhandled error during accept')
+        rescue APIError => e
+          logger.info("Failed to accept BsRequest #{number} with #{auto_accept_user.login}. #{e.class.name}: #{e}")
+          change_state(newstate: 'declined', comment: 'Unhandled error during accept, contact your admin.')
         end
       end
     end


### PR DESCRIPTION
If there is an error at least log it so we can think of how we can get out of this situation.