### PR TITLE
Drop unused 'find attribute' shared example

### DIFF
--- a/src/api/spec/controllers/search_controller_spec.rb
+++ b/src/api/spec/controllers/search_controller_spec.rb
@@ -11,12 +11,6 @@ RSpec.describe SearchController, vcr: true do
     login user
   end
 
-  shared_examples 'find attribute' do
-    it { expect(response).to have_http_status(:success) }
-    it { expect(Xmlhash.parse(response.body)).to include('namespace' => namespace) }
-    it { expect(Xmlhash.parse(response.body)).to include('name' => name) }
-  end
-
   shared_examples 'find project' do
     it { expect(response).to have_http_status(:success) }
     it { expect(Xmlhash.parse(response.body)['project']['name']).to eq(project.name) }


### PR DESCRIPTION
This should have been removed in commit: a946785979e30d966fd0071e602f573b7b5fe32f.