### PR TITLE
[backend] support network during (kvm) VM builds

### DIFF
--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -522,10 +522,10 @@ fi
 # drop testcases for now
 rm -rf %{buildroot}%{__obs_api_prefix}/spec
 # only config for CI
-rm %{buildroot}%{__obs_api_prefix}/config/brakeman.ignore
+rm -f %{buildroot}%{__obs_api_prefix}/config/brakeman.ignore
 
 # Remove Gemfile.next and Gemfile.next.lock since they are only for testing the next Rails version in development and test environments
-rm %{buildroot}%{__obs_api_prefix}/Gemfile.next %{buildroot}%{__obs_api_prefix}/Gemfile.next.lock
+rm -f %{buildroot}%{__obs_api_prefix}/Gemfile.next %{buildroot}%{__obs_api_prefix}/Gemfile.next.lock
 
 # fail when Makefiles created a directory
 if ! test -L %{buildroot}%{obs_backend_dir}/build; then

--- a/dist/obsstoragesetup
+++ b/dist/obsstoragesetup
@@ -419,6 +419,7 @@ case "$1" in
 				fi
                         fi
 			# append user presets
+			[ -n "$OBS_VM_ENABLE_NET" ] && echo "OBS_VM_ENABLE_NET=\"$OBS_VM_ENABLE_NET\"" >> /etc/buildhost.config
 			echo "" >> /etc/buildhost.config
 			echo "### preconfigured values from /etc/buildhost.config.presets" >> /etc/buildhost.config
 			if [ -e /etc/buildhost.config.presets ]; then

--- a/dist/obsworker
+++ b/dist/obsworker
@@ -167,6 +167,13 @@ if [ "$OBS_VM_TYPE" = "zvm" ]; then
     fi
 fi
 
+# Only enable network for kvm (now the only one supported)
+if [ "$OBS_VM_TYPE" = "kvm" ]; then
+    if [ "x${OBS_VM_ENABLE_NET}" = "xyes" ]; then
+        OBS_WORKER_OPT="$OBS_WORKER_OPT --vm-network"
+    fi
+fi
+
 if [ "$OBS_VM_TYPE" = "xen" -o "$OBS_VM_TYPE" = "kvm" -o "${OBS_VM_TYPE#qemu:}" != "$OBS_VM_TYPE" -o "${OBS_VM_TYPE#emulator:}" != "$OBS_VM_TYPE" ] ; then
     # we start up in VM mode, check for the worker disk options
     if [ -n "$OBS_VM_DISK_AUTOSETUP_ROOT_FILESIZE" ]; then

--- a/dist/sysconfig.obs-server
+++ b/dist/sysconfig.obs-server
@@ -318,6 +318,16 @@ OBS_VM_USE_TMPFS=""
 OBS_VM_CUSTOM_OPTION=""
 
 ## Path:        Applications/OBS
+## Description: Allow VMs to access the internet.
+## Type:        ("yes" | "")
+## Default:     ""
+## Config:      OBS
+#
+# yes: WARNING: this may not be safe and may prevent build reproductibility.
+#
+OBS_VM_ENABLE_NET=""
+
+## Path:        Applications/OBS
 ## Description: Memory allocated for each VM (512) if not set
 ## Type:        integer
 ## Default:     ""

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -89,6 +89,7 @@ my $vmdisk_filesystem;
 my $vmdisk_filesystem_options;
 my $vmdisk_mount_options;
 my $vmdisk_clean;
+my $vm_network;
 my $emulator_script;
 my $hugetlbfs;
 my $workerid;
@@ -331,6 +332,8 @@ Usage: $0 [OPTION] --root <directory> --statedir <directory>
        --vmdisk-filesystem <none|ext3|ext4>
                    : filesystem to use for autosetup root disk image
 
+       --vm-network: enable network (kvm)
+
        --emulator-script <script>
                    : Define the emulator script 
 
@@ -508,6 +511,11 @@ while (@ARGV) {
   if ($ARGV[0] eq '--vm-worker-nr') {
     shift @ARGV;
     $vm_worker_instance = shift @ARGV;
+    next;
+  }
+  if ($ARGV[0] eq '--vm-network') {
+    shift @ARGV;
+    $vm_network = 1;
     next;
   }
   if ($ARGV[0] eq '--vm-enable-console') {
@@ -3711,6 +3719,7 @@ sub dobuild {
     push @args, '--hugetlbfs', $hugetlbfs if $hugetlbfs;
     push @args, '--vm-worker', $vm_worker_name if $vm_worker_name;
     push @args, '--vm-worker-nr', $vm_worker_instance if $vm_worker_instance;
+    push @args, '--vm-network' if $vm eq 'kvm' && $vm_network;
     push @args, '--vm-enable-console' if $vm_enable_console;
   } elsif ($vm eq 'openstack') {
     mkdir("$buildroot/.mount") unless -d "$buildroot/.mount";


### PR DESCRIPTION
Now that https://github.com/openSUSE/obs-build allows to support network for VMs with `--vm-network` param, offer the possibility to enable this in the worker config using the option:
`OBS_VM_ENABLE_NET=true` in `/etc/sysconfig/obs-server`

Needs an `obs-build` version including https://github.com/openSUSE/obs-build/pull/725

It can be needed to build package relying for example on Maven (as its dependency management is pretty broken), i think that many private instances owners would find it useful, i'm personally running similar patches for years:
- https://github.com/algolia/open-build-service/tree/2.10.1-kvm-net
- https://github.com/algolia/obs-build/tree/20191114-kvm-net


Includes also a small fix of the spec file to prevent build failure if some files do not exists.