### PR TITLE
Support the GitHub ping event

### DIFF
--- a/src/api/app/models/scm_webhook.rb
+++ b/src/api/app/models/scm_webhook.rb
@@ -58,6 +58,10 @@ class SCMWebhook
     ignored_github_pull_request_action? || ignored_gitlab_merge_request_action? || ignored_gitea_pull_request_action?
   end
 
+  def ping_event?
+    github_ping? || gitea_ping?
+  end
+
   private
 
   def github_push_event?
@@ -94,6 +98,14 @@ class SCMWebhook
 
   def gitea_pull_request?
     @payload[:scm] == 'gitea' && @payload[:event] == 'pull_request'
+  end
+
+  def github_ping?
+    @payload[:scm] == 'github' && @payload[:event] == 'ping'
+  end
+
+  def gitea_ping?
+    @payload[:scm] == 'gitea' && @payload[:event] == 'ping'
   end
 
   def ignored_github_pull_request_action?

--- a/src/api/app/validators/scm_webhook_event_validator.rb
+++ b/src/api/app/validators/scm_webhook_event_validator.rb
@@ -1,5 +1,5 @@
 class SCMWebhookEventValidator < ActiveModel::Validator
-  ALLOWED_GITHUB_AND_GITEA_EVENTS = ['pull_request', 'push'].freeze
+  ALLOWED_GITHUB_AND_GITEA_EVENTS = ['pull_request', 'push', 'ping'].freeze
   ALLOWED_GITLAB_EVENTS = ['Merge Request Hook', 'Push Hook', 'Tag Push Hook'].freeze
 
   def validate(record)

--- a/src/api/spec/models/token/workflow_spec.rb
+++ b/src/api/spec/models/token/workflow_spec.rb
@@ -159,5 +159,47 @@ RSpec.describe Token::Workflow do
 
       it { expect { subject }.to change(workflow_token, :triggered_at) & change(workflow_run, :response_url).to('https://api.github.com') }
     end
+
+    context 'with a ping event' do
+      let(:scm) { 'github' }
+      let(:event) { 'ping' }
+      let(:github_payload) { { sender: { url: 'https://api.github.com' } } }
+      let(:github_extractor_payload) do
+        {
+          scm: 'github',
+          event: 'ping',
+          api_endpoint: 'https://api.github.com'
+        }
+      end
+      let(:scm_extractor) { TriggerControllerService::SCMExtractor.new(scm, event, github_payload) }
+      let(:scm_webhook) { SCMWebhook.new(payload: github_extractor_payload) }
+      let(:workflow) do
+        Workflow.new(scm_webhook: scm_webhook, token: workflow_token,
+                     workflow_instructions: { steps: [branch_package: { source_project: 'home:Admin', source_package: 'ctris', target_project: 'dev:tools' }] })
+      end
+      let(:workflows) { [workflow] }
+
+      before do
+        # Skipping call since it's tested in the Workflow model
+        allow(workflow).to receive(:call).and_return(true)
+
+        allow(TriggerControllerService::SCMExtractor).to receive(:new).with(scm, event, github_payload).and_return(scm_extractor)
+        allow(scm_extractor).to receive(:call).and_return(scm_webhook)
+        allow(SCMStatusReporter).to receive(:new).and_return(proc { true })
+      end
+
+      subject { workflow_token.call(workflow_run: workflow_run, scm_webhook: scm_extractor.call) }
+
+      it 'returns before checking for validation errors' do
+        expect(subject).to be_empty
+      end
+
+      it { expect { subject }.to change(workflow_token, :triggered_at).and(change(workflow_run, :response_url).to('https://api.github.com')) }
+
+      it 'returns early with one report' do
+        subject
+        expect(SCMStatusReporter).to have_received(:new).once
+      end
+    end
   end
 end


### PR DESCRIPTION
This should make GitHub display a green status next to ping events when first creating webhooks in repos.

# To verify:
1. Set up testing according to [instructions on the wiki](https://github.com/openSUSE/open-build-service/wiki/Better-SCM-CI-Integration-Testing)
2. Send out a ping request
3. See a green response in OBS (and/or GitHub depending on the setup)