### PR TITLE
Support placeholder variables in workflows

### DIFF
--- a/src/api/app/services/workflows/yaml_to_workflows_service.rb
+++ b/src/api/app/services/workflows/yaml_to_workflows_service.rb
@@ -15,7 +15,7 @@ module Workflows
 
     def create_workflows
       begin
-        parsed_workflows_yaml = YAML.safe_load(File.read(@yaml_file))
+        parsed_workflows_yaml = YAML.safe_load(parse_workflows_file(@yaml_file))
       rescue Psych::SyntaxError => e
         raise Token::Errors::WorkflowsYamlNotParsable, "Unable to parse .obs/workflows.yml: #{e.message}"
       end
@@ -25,6 +25,20 @@ module Workflows
         Workflow.new(workflow_instructions: workflow_instructions, scm_webhook: @scm_webhook, token: @token,
                      workflow_run: @workflow_run)
       end
+    end
+
+    def parse_workflows_file(file_path)
+      target_repository_full_name = @scm_webhook.payload.values_at(:target_repository_full_name, :path_with_namespace).compact.first
+      scm_organization_name, scm_repository_name = target_repository_full_name.split('/')
+
+      # Mapping the placeholder variables to their values from the webhook event payload
+      format(File.read(file_path),
+             SCM_ORGANIZATION_NAME: scm_organization_name,
+             SCM_REPOSITORY_NAME: scm_repository_name,
+             # If someone uses this placeholder variable in a workflow which runs for pull request webhook events, we have a default
+             # value even though this is wrong. Here, we cannot inform users about this since we're processing the whole workflows file
+             SCM_PR_NUMBER: @scm_webhook.payload.fetch(:pr_number, 'NO_PR_NUMBER'),
+             SCM_COMMIT_SHA: @scm_webhook.payload.fetch(:commit_sha))
     end
   end
 end

--- a/src/api/spec/services/workflows/yaml_to_workflows_service_spec.rb
+++ b/src/api/spec/services/workflows/yaml_to_workflows_service_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Workflows::YAMLToWorkflowsService, type: :service do
       source_branch: 'test_branch',
       target_branch: 'master',
       action: 'opened',
-      repository_full_name: 'openSUSE/open-build-service',
+      target_repository_full_name: 'openSUSE/open-build-service',
       event: 'pull_request'
     }
   end
@@ -43,6 +43,20 @@ RSpec.describe Workflows::YAMLToWorkflowsService, type: :service do
       let(:payload) { github_extractor_payload }
 
       it { expect(subject.size).to be(2) }
+    end
+
+    context 'with placeholder variables' do
+      let(:workflows_yml_file) { Rails.root.join('spec/support/files/multiple_workflows.yml').expand_path }
+      let(:payload) { github_extractor_payload }
+
+      it 'maps them to their values from the webhook event payload' do
+        expect(subject.first.workflow_instructions).to include(steps: [{ branch_package: { source_project: 'test-project:openSUSE', source_package: 'open-build-service',
+                                                                                           target_project: 'test-target-project' } }])
+
+        expect(subject.second.workflow_instructions).to include(steps: [{ branch_package: { source_project: 'test-project',
+                                                                                            source_package: 'test-package:387185b7df2b572377712994116c19cd7dd13150',
+                                                                                            target_project: 'test-target-project:PR-123' } }])
+      end
     end
 
     context 'with webhook payload from gitlab' do

--- a/src/api/spec/support/files/multiple_workflows.yml
+++ b/src/api/spec/support/files/multiple_workflows.yml
@@ -1,13 +1,13 @@
 workflow123:
   steps:
     - branch_package:
-        source_project: "test-project"
-        source_package: "test-package"
+        source_project: "test-project:%{SCM_ORGANIZATION_NAME}"
+        source_package: "%{SCM_REPOSITORY_NAME}"
         target_project: 'test-target-project'
 
 workflow124:
   steps:
     - branch_package:
         source_project: "test-project"
-        source_package: "test-package"
-        target_project: 'test-target-project'
+        source_package: "test-package:%{SCM_COMMIT_SHA}"
+        target_project: 'test-target-project:PR-%{SCM_PR_NUMBER}'


### PR DESCRIPTION
See the [developer documentation](https://github.com/openSUSE/open-build-service/wiki/Better-SCM-CI-Integration-Workflows#placeholder-variables) for details on this feature.

Using YAML variables like described [here](https://stackoverflow.com/questions/4150782/use-yaml-with-variables/20467816#20467816) isn't possible. The YAML library errors out with `mapping values are not allowed in this context at line X column Y (Psych::SyntaxError)`. Line _X_ and column _Y_ is wherever there is a YAML variable in a workflows file. This is why we parse the placeholder variables before a workflows file is parsed into YAML.