### PR TITLE
Use correct commit sha on tag push in scm/ci integration for github

### DIFF
--- a/src/api/app/services/trigger_controller_service/scm_extractor.rb
+++ b/src/api/app/services/trigger_controller_service/scm_extractor.rb
@@ -150,7 +150,7 @@ module TriggerControllerService
       # We need this for Workflow::Step#target_package_name
       # 'target_branch' will contain a commit SHA
       payload.merge!({ tag_name: payload_ref.sub('refs/tags/', ''),
-                       target_branch: @payload[:after] })
+                       target_branch: @payload.dig(:head_commit, :id) })
     end
 
     def gitlab_payload_tag(payload)

--- a/src/api/app/services/trigger_controller_service/scm_extractor.rb
+++ b/src/api/app/services/trigger_controller_service/scm_extractor.rb
@@ -150,7 +150,8 @@ module TriggerControllerService
       # We need this for Workflow::Step#target_package_name
       # 'target_branch' will contain a commit SHA
       payload.merge!({ tag_name: payload_ref.sub('refs/tags/', ''),
-                       target_branch: @payload.dig(:head_commit, :id) })
+                       target_branch: @payload.dig(:head_commit, :id),
+                       commit_sha: @payload.dig(:head_commit, :id) })
     end
 
     def gitlab_payload_tag(payload)

--- a/src/api/spec/services/trigger_controller_service/scm_extractor_spec.rb
+++ b/src/api/spec/services/trigger_controller_service/scm_extractor_spec.rb
@@ -115,7 +115,10 @@ RSpec.describe TriggerControllerService::SCMExtractor do
             sender: {
               url: 'https://api.github.com'
             },
-            base_ref: 'refs/heads/main'
+            base_ref: 'refs/heads/main',
+            head_commit: {
+              id: '8823eec73e46f29082cd343077ee3e97d8da0ec3'
+            }
           }
         end
         let(:expected_hash) do
@@ -123,8 +126,8 @@ RSpec.describe TriggerControllerService::SCMExtractor do
             scm: 'github',
             event: 'push',
             api_endpoint: 'https://api.github.com',
-            commit_sha: '9e0ea1fd99c9000cbb8b8c9d28763d0ddace0b65',
-            target_branch: '9e0ea1fd99c9000cbb8b8c9d28763d0ddace0b65',
+            commit_sha: '8823eec73e46f29082cd343077ee3e97d8da0ec3',
+            target_branch: '8823eec73e46f29082cd343077ee3e97d8da0ec3',
             source_repository_full_name: 'iggy/repo123',
             target_repository_full_name: 'iggy/repo123',
             ref: 'refs/tags/release_abc',


### PR DESCRIPTION
The json payload key `:after` in the webhook of a push event from GitHub contains the sha of the tag itself. Instead we need to use the commit sha the tag is refering to. This is part of `:head_commit => :id`.

Fixes #13206

![image](https://user-images.githubusercontent.com/22001671/206465998-a77fa5e2-66a2-49a8-b970-17878aa02486.png)
