### PR TITLE
[backend] report x86-64 architecture level as well via cpu flags

### DIFF
--- a/docs/api/api/constraints.rng
+++ b/docs/api/api/constraints.rng
@@ -100,6 +100,10 @@
                       </attribute>
                     </optional>
                     <text />
+                    <a:documentation>
+                     All cpu flags from /proc/cpuinfo can required here. In addition also pseudo helper
+                     flags for an architecture level: power7, power8, power9, EL0, x86-64-v2, x86-64-v3, x86-64-v4
+                    </a:documentation>
                   </element>
                 </oneOrMore> 
               </element>

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -838,6 +838,15 @@ if (open(FILE, "<", "/proc/cpuinfo")) {
     $hw->{'nativeonly'} = undef unless $supports_aarch32;
     push @{$hw->{'cpu'}->{'flag'}}, 'EL0' if $require_aarch64_kernel;
   }
+
+  # Extend flags with architecture level for x86_64
+  if ($hostarch eq 'x86_64') {
+    my %flags = map {$_ => 1} @{$hw->{'cpu'}->{'flag'}};
+    push @{$hw->{'cpu'}->{'flag'}}, 'x86-64-v2' unless grep {!$flags{$_}} qw{cx16 lahf_lm popcnt pni sse4_1 sse4_2 ssse3};
+    push @{$hw->{'cpu'}->{'flag'}}, 'x86-64-v3' unless grep {!$flags{$_}} qw{avx2 bmi1 bmi2 f16c fma}; # linux is not offering flags for LZCNT, MOVBE and OSXSAVE
+    # FIXME: I was unable to test x86-64-v4 due to lack of hardware... please remove this comment once this happened.
+    push @{$hw->{'cpu'}->{'flag'}}, 'x86-64-v4' unless grep {!$flags{$_}} qw{avx512f avx512dq avx512cd avx512bw avx512vl};
+  }
 }
 $hw->{'jobs'} = $jobs if $jobs;
 $hw->{'memory'} = $vm_memory if $vm_memory;


### PR DESCRIPTION
No own element as we don't do this for other archs like power neither