### PR TITLE
Clarify when ENABLED_FEATURE_TOGGLES should be changed

### DIFF
--- a/src/api/config/initializers/flipper.rb
+++ b/src/api/config/initializers/flipper.rb
@@ -1,3 +1,6 @@
+# It's completely fine to have rolled out feature toggles in this constant, since we need them in the development
+# environment and review apps to test changes for those features. Rolled-out feature toggles aren't displayed anyway
+# to users in the web UI for beta features.
 ENABLED_FEATURE_TOGGLES = [
   { name: :request_show_redesign, description: 'Redesign of the request pages to improve the collaboration workflow' }
 ].freeze


### PR DESCRIPTION
This is to prevent PRs which are removing rolled-out feature toggles too early, like in #13108 (see this [comment](https://github.com/openSUSE/open-build-service/pull/13108#issuecomment-1346437038)).