### PR TITLE
Fix scm integration for tag push to gitea

### DIFF
--- a/src/api/app/services/trigger_controller_service/scm_extractor.rb
+++ b/src/api/app/services/trigger_controller_service/scm_extractor.rb
@@ -188,7 +188,8 @@ module TriggerControllerService
       # We need this for Workflow::Step#target_package_name
       # 'target_branch' will contain a commit SHA
       payload.merge!({ tag_name: payload_ref.sub('refs/tags/', ''),
-                       target_branch: @payload[:after] })
+                       target_branch: @payload.dig(:head_commit, :id),
+                       commit_sha: @payload.dig(:head_commit, :id) })
     end
   end
 end

--- a/src/api/app/services/workflows/yaml_downloader.rb
+++ b/src/api/app/services/workflows/yaml_downloader.rb
@@ -32,7 +32,7 @@ module Workflows
         # This GitLab URL admits both a branch name and a commit sha.
         "#{@scm_payload[:api_endpoint]}/#{@scm_payload[:path_with_namespace]}/-/raw/#{@scm_payload[:target_branch]}/#{@token.workflow_configuration_path}"
       when 'gitea'
-        "#{@scm_payload[:api_endpoint]}/#{@scm_payload[:target_repository_full_name]}/raw/branch/#{@scm_payload[:target_branch]}/#{@token.workflow_configuration_path}"
+        gitea_download_url
       end
     rescue Octokit::InvalidRepository => e
       raise Token::Errors::NonExistentRepository, e.message
@@ -40,6 +40,14 @@ module Workflows
       # 'target_branch' can contain a commit sha (when tag push) instead of a branch name
       raise Token::Errors::NonExistentWorkflowsFile,
             "#{@token.workflow_configuration_path} could not be downloaded from the SCM branch/commit #{@scm_payload[:target_branch]}: #{e.message}"
+    end
+
+    def gitea_download_url
+      if @scm_payload[:tag_name].present?
+        "#{@scm_payload[:api_endpoint]}/#{@scm_payload[:target_repository_full_name]}/raw/tag/#{@scm_payload[:tag_name]}/#{@token.workflow_configuration_path}"
+      else
+        "#{@scm_payload[:api_endpoint]}/#{@scm_payload[:target_repository_full_name]}/raw/branch/#{@scm_payload[:target_branch]}/#{@token.workflow_configuration_path}"
+      end
     end
   end
 end

--- a/src/api/spec/services/trigger_controller_service/scm_extractor_spec.rb
+++ b/src/api/spec/services/trigger_controller_service/scm_extractor_spec.rb
@@ -384,7 +384,10 @@ RSpec.describe TriggerControllerService::SCMExtractor do
               full_name: 'iggy/repo123',
               clone_url: 'https://gitea.opensuse.org/krauselukas/test.git'
             },
-            base_ref: 'refs/heads/main'
+            base_ref: 'refs/heads/main',
+            head_commit: {
+              id: '8823eec73e46f29082cd343077ee3e97d8da0ec3'
+            }
           }
         end
         let(:expected_hash) do
@@ -392,8 +395,8 @@ RSpec.describe TriggerControllerService::SCMExtractor do
             scm: 'gitea',
             event: 'push',
             api_endpoint: 'https://gitea.opensuse.org',
-            commit_sha: '9e0ea1fd99c9000cbb8b8c9d28763d0ddace0b65',
-            target_branch: '9e0ea1fd99c9000cbb8b8c9d28763d0ddace0b65',
+            commit_sha: '8823eec73e46f29082cd343077ee3e97d8da0ec3',
+            target_branch: '8823eec73e46f29082cd343077ee3e97d8da0ec3',
             source_repository_full_name: 'iggy/repo123',
             target_repository_full_name: 'iggy/repo123',
             ref: 'refs/tags/release_abc',

--- a/src/api/spec/services/workflows/yaml_downloader_spec.rb
+++ b/src/api/spec/services/workflows/yaml_downloader_spec.rb
@@ -48,21 +48,37 @@ RSpec.describe Workflows::YAMLDownloader, type: :service do
     end
 
     context 'gitea' do
-      let(:payload) do
-        {
-          scm: 'gitea',
-          target_branch: 'main',
-          target_repository_full_name: 'iggy/target_repo',
-          api_endpoint: 'https://gitea.opensuse.org'
-        }
-      end
-      let(:url) { "https://gitea.opensuse.org/#{payload[:target_repository_full_name]}/raw/branch/#{payload[:target_branch]}/.obs/workflows.yml" }
-
       before do
         yaml_downloader.call
       end
 
-      it { expect(Down).to have_received(:download).with(url, max_size: max_size) }
+      context 'for a tag push event' do
+        let(:payload) do
+          {
+            scm: 'gitea',
+            target_repository_full_name: 'iggy/target_repo',
+            api_endpoint: 'https://gitea.opensuse.org',
+            tag_name: '3.0'
+          }
+        end
+        let(:url) { "https://gitea.opensuse.org/#{payload[:target_repository_full_name]}/raw/tag/#{payload[:tag_name]}/.obs/workflows.yml" }
+
+        it { expect(Down).to have_received(:download).with(url, max_size: max_size) }
+      end
+
+      context 'for a push or pull request event' do
+        let(:payload) do
+          {
+            scm: 'gitea',
+            target_branch: 'main',
+            target_repository_full_name: 'iggy/target_repo',
+            api_endpoint: 'https://gitea.opensuse.org'
+          }
+        end
+        let(:url) { "https://gitea.opensuse.org/#{payload[:target_repository_full_name]}/raw/branch/#{payload[:target_branch]}/.obs/workflows.yml" }
+
+        it { expect(Down).to have_received(:download).with(url, max_size: max_size) }
+      end
     end
   end
 end


### PR DESCRIPTION
Similar to github, we have to use the `:head_commit => :id` attribute
from the webhook payload on a tag push in order to point to
commit the tag is refering to, not the sha of the tag itself.
Otherwise we are not able to pull the workflow configuration and the obs_scm service
won't pull the correct sources since the wrong commit_sha is used in the branch_request
file.
The download url for a tag push is different to the one for
a regular push/pull_request event. In order to pull the
workflow configuration file the tag version is refering to
we have to adapt the url. Example of a valid download url for a tag: https://gitea.opensuse.org/krauselukas/hello_world/raw/tag/4.0/.obs/workflows.yml

Related to https://github.com/openSUSE/open-build-service/pull/13500

How to test:
Follow our testing guide here https://github.com/openSUSE/open-build-service/wiki/Better-SCM-CI-Integration-Testing and simulate a tag push to a Gitea repo. You could use the openSUSE instance https://gitea.opensuse.org/
See my test repo for reference https://gitea.opensuse.org/krauselukas/hello_world

