### PR TITLE
Stop using concerns where they are not needed

### DIFF
--- a/src/api/app/controllers/concerns/triggerable.rb
+++ b/src/api/app/controllers/concerns/triggerable.rb
@@ -1,6 +1,4 @@
 module Triggerable
-  extend ActiveSupport::Concern
-
   def set_project
     # By default we operate on the package association
     @project = @token.package.try(:project)

--- a/src/api/app/controllers/source/errors.rb
+++ b/src/api/app/controllers/source/errors.rb
@@ -1,6 +1,4 @@
 module Source::Errors
-  extend ActiveSupport::Concern
-
   class IllegalRequest < APIError
     setup 404, 'Illegal request'
   end

--- a/src/api/app/controllers/staging/errors.rb
+++ b/src/api/app/controllers/staging/errors.rb
@@ -1,6 +1,4 @@
 module Staging::Errors
-  extend ActiveSupport::Concern
-
   class StagingProjectNotAcceptable < APIError; end
 
   class StagingWorkflowNotFound < APIError

--- a/src/api/app/controllers/trigger/errors.rb
+++ b/src/api/app/controllers/trigger/errors.rb
@@ -1,6 +1,4 @@
 module Trigger::Errors
-  extend ActiveSupport::Concern
-
   class InvalidToken < APIError
     setup 'permission_denied',
           403,

--- a/src/api/app/models/bs_request/errors.rb
+++ b/src/api/app/models/bs_request/errors.rb
@@ -1,6 +1,4 @@
 module BsRequest::Errors
-  extend ActiveSupport::Concern
-
   class InvalidStateError < APIError
     setup 'request_not_modifiable', 404
   end

--- a/src/api/app/models/bs_request_action/errors.rb
+++ b/src/api/app/models/bs_request_action/errors.rb
@@ -1,6 +1,4 @@
 module BsRequestAction::Errors
-  extend ActiveSupport::Concern
-
   # a diff error can have many reasons, but most likely something within us
   class DiffError < APIError; setup 404; end
 

--- a/src/api/app/models/bs_request_action_maintenance_release/errors.rb
+++ b/src/api/app/models/bs_request_action_maintenance_release/errors.rb
@@ -1,5 +1,4 @@
 module BsRequestActionMaintenanceRelease::Errors
-  extend ActiveSupport::Concern
   class LackingReleaseMaintainership < APIError; setup 'lacking_maintainership', 403; end
 
   class RepositoryWithoutReleaseTarget < APIError; setup 'repository_without_releasetarget'; end

--- a/src/api/app/models/concerns/project_distribution.rb
+++ b/src/api/app/models/concerns/project_distribution.rb
@@ -1,6 +1,4 @@
 module ProjectDistribution
-  extend ActiveSupport::Concern
-
   # Check if the project has a path_element matching project and repository
   def has_distribution(project_name, repository)
     has_local_distribution(project_name, repository) || has_remote_distribution(project_name, repository)

--- a/src/api/app/models/concerns/scm_sync_enabled_step.rb
+++ b/src/api/app/models/concerns/scm_sync_enabled_step.rb
@@ -1,6 +1,4 @@
 module ScmSyncEnabledStep
-  extend ActiveSupport::Concern
-
   def set_scmsync_on_target_package
     # only change the fragment here and leave the query alone!
     parsed_scmsync_url = Addressable::URI.parse(scmsync_url)

--- a/src/api/app/models/issue/errors.rb
+++ b/src/api/app/models/issue/errors.rb
@@ -1,6 +1,4 @@
 module Issue::Errors
-  extend ActiveSupport::Concern
-
   class NotFoundError < APIError
     setup 'issue_not_found', 404, 'Issue not found'
   end

--- a/src/api/app/models/package/errors.rb
+++ b/src/api/app/models/package/errors.rb
@@ -1,6 +1,4 @@
 module Package::Errors
-  extend ActiveSupport::Concern
-
   class PackageError < StandardError; end
 
   class CycleError < APIError

--- a/src/api/app/models/project/errors.rb
+++ b/src/api/app/models/project/errors.rb
@@ -1,6 +1,4 @@
 module Project::Errors
-  extend ActiveSupport::Concern
-
   class CycleError < APIError
     setup 'project_cycle'
   end

--- a/src/api/app/models/token/errors.rb
+++ b/src/api/app/models/token/errors.rb
@@ -1,8 +1,6 @@
 require 'api_error'
 
 module Token::Errors
-  extend ActiveSupport::Concern
-
   class NoReleaseTargetFound < APIError
     setup 404
   end

--- a/src/api/app/models/workflow/step/errors.rb
+++ b/src/api/app/models/workflow/step/errors.rb
@@ -1,6 +1,4 @@
 module Workflow::Step::Errors
-  extend ActiveSupport::Concern
-
   class NoSourceServiceDefined < APIError
     setup 404
   end

--- a/src/api/config/initializers/logging.rb
+++ b/src/api/config/initializers/logging.rb
@@ -1,7 +1,5 @@
 module APIInstrumentation
   module ControllerRuntime
-    extend ActiveSupport::Concern
-
     protected
 
     def append_info_to_payload(payload)


### PR DESCRIPTION
If we don't make use of `included`, `prepended` or `class_methods` in these modules, we can get rid of using a concern.

Take as a reference the [ActiveSupport::Concern](https://api.rubyonrails.org/classes/ActiveSupport/Concern.html) documentation.