### PR TITLE
Reject set_flags step when deleting projects after a PR was closed

### DIFF
--- a/src/api/app/models/workflow.rb
+++ b/src/api/app/models/workflow.rb
@@ -114,7 +114,9 @@ class Workflow
   # TODO: Extract this into a service
   def destroy_target_projects
     # Do not process steps for which there's nothing to do
-    processable_steps = steps.reject { |step| step.instance_of?(::Workflow::Step::ConfigureRepositories) || step.instance_of?(::Workflow::Step::RebuildPackage) }
+    processable_steps = steps.reject do |step|
+      step.instance_of?(::Workflow::Step::ConfigureRepositories) || step.instance_of?(::Workflow::Step::RebuildPackage) || step.instance_of?(::Workflow::Step::SetFlags)
+    end
     target_packages = processable_steps.map(&:target_package).uniq.compact
     EventSubscription.where(channel: 'scm', token: token, package: target_packages).delete_all
 


### PR DESCRIPTION
There is no project that should be deleted for the set_flags step in a workflow, when a PR is closed on the SCM. There for it should be one of the steps that gets rejected when we clean up. This will also fix an issue, since the `target_project_name` method of the `SetFlags` expects to get passed a keyword argument, which all other steps don't.

Fixes #12637