### PR TITLE
Add monitoring for Event::ServiceFail

### DIFF
--- a/src/api/app/models/event/service_fail.rb
+++ b/src/api/app/models/event/service_fail.rb
@@ -21,6 +21,32 @@ module Event
       attribs['error'] = attribs['error'][0..800]
       super(attribs, keys)
     end
+
+    def metric_measurement
+      'service'
+    end
+
+    def metric_tags
+      error = case payload['error']
+              when start_with?('bad link:')
+                'bad_link'
+              when /^ 400 remote error:.*.service  No such file or directory/
+                'service_missing'
+              when /^ 400 remote error:.*service parameter.*is not defined/
+                'unknown_service_parameter'
+              else
+                'unknown'
+              end
+
+      {
+        status: 'fail',
+        error: error
+      }
+    end
+
+    def metric_fields
+      { value: 1 }
+    end
   end
 end
 

--- a/src/api/app/models/event/service_success.rb
+++ b/src/api/app/models/event/service_success.rb
@@ -15,6 +15,20 @@ module Event
       h['X-OBS-Package'] = "#{payload['project']}/#{payload['package']}"
       h
     end
+
+    def metric_measurement
+      'service'
+    end
+
+    def metric_tags
+      {
+        status: 'success'
+      }
+    end
+
+    def metric_fields
+      { value: 1 }
+    end
   end
 end
 


### PR DESCRIPTION
Add monitoring for Event::ServiceFail

Because we need to see in monitoring / be alerted about excessive ServiceFail events
to fix issues before too many users are affected.