### PR TITLE
Handle results other than success and failure in badge

### DIFF
--- a/src/api/app/models/badge.rb
+++ b/src/api/app/models/badge.rb
@@ -21,8 +21,9 @@ class Badge
 
   def status(results)
     return 'failed' if results.any? { |r| r.code == 'failed' }
+    return 'succeeded' if results.all? { |r| r.code == 'succeeded' }
 
-    'succeeded' if results.all? { |r| r.code == 'succeeded' }
+    'unknown'
   end
 
   def process_percent(file)

--- a/src/api/spec/models/badge_spec.rb
+++ b/src/api/spec/models/badge_spec.rb
@@ -57,10 +57,26 @@ RSpec.describe Badge do
           expect(xml).to have_text(expected_success)
         end
       end
+
+      describe 'finished resultlist' do
+        let(:body) do
+          %(<resultlist state="eb0459ee3b000176bb3944a67b7c44fa">
+              <result project="home:tom" repository="openSUSE_Leap_42.1" arch="x86_64" code="finished" state="building">
+                <status package="my_package" code="finished" />
+              </result>
+            </resultlist>)
+        end
+
+        it 'displays the correct unknown state' do
+          xml = Capybara.string(badge.xml)
+          expect(xml).to have_text(expected_unknown)
+        end
+      end
     end
     context 'without type specified' do
       let(:expected_success) { 'succeeded' }
       let(:expected_failure) { 'failed' }
+      let(:expected_unknown) { 'unknown' }
       let(:type) { '' }
 
       include_examples 'tests for badge xml'
@@ -69,6 +85,7 @@ RSpec.describe Badge do
     context 'with percent type specified' do
       let(:expected_success) { '100%' }
       let(:expected_failure) { '50%' }
+      let(:expected_unknown) { '0%' }
       let(:type) { 'percent' }
 
       include_examples 'tests for badge xml'


### PR DESCRIPTION
Fixes #13560

Sometimes final results are different than failed and succeeded, but that wasn't handled by the badge code before. This fixes it

![example](https://user-images.githubusercontent.com/1102934/208671245-25bfaa8b-1741-44c4-ae2f-7722f72ff561.png)