### PR TITLE
Correctly merge default options in policies

### DIFF
--- a/src/api/app/policies/cloud/azure/configuration_policy.rb
+++ b/src/api/app/policies/cloud/azure/configuration_policy.rb
@@ -2,7 +2,7 @@ module Cloud
   module Azure
     class ConfigurationPolicy < ApplicationPolicy
       def initialize(user, record, opts = {})
-        super(user, record, opts.merge(ensure_logged_in: true))
+        super(user, record, { ensure_logged_in: true }.merge(opts))
       end
 
       def show?

--- a/src/api/app/policies/event_subscription/form_policy.rb
+++ b/src/api/app/policies/event_subscription/form_policy.rb
@@ -1,7 +1,7 @@
 class EventSubscription
   class FormPolicy < ApplicationPolicy
     def initialize(user, record, opts = {})
-      super(user, record, opts.merge(ensure_logged_in: true))
+      super(user, record, { ensure_logged_in: true }.merge(opts))
     end
 
     def index?

--- a/src/api/app/policies/staging/workflow_policy.rb
+++ b/src/api/app/policies/staging/workflow_policy.rb
@@ -1,6 +1,6 @@
 class Staging::WorkflowPolicy < ApplicationPolicy
   def initialize(user, record, opts = {})
-    super(user, record, opts.reverse_merge(ensure_logged_in: true))
+    super(user, record, { ensure_logged_in: true }.merge(opts))
   end
 
   def new?

--- a/src/api/app/policies/token_policy.rb
+++ b/src/api/app/policies/token_policy.rb
@@ -1,6 +1,6 @@
 class TokenPolicy < ApplicationPolicy
   def initialize(user, record, opts = {})
-    super(user, record, opts.merge(ensure_logged_in: true))
+    super(user, record, { ensure_logged_in: true }.merge(opts))
   end
 
   class Scope < Scope

--- a/src/api/app/policies/users/patchinfos_policy.rb
+++ b/src/api/app/policies/users/patchinfos_policy.rb
@@ -1,7 +1,7 @@
 module Users
   class PatchinfosPolicy < ApplicationPolicy
     def initialize(user, record, opts = {})
-      super(user, record, opts.merge(ensure_logged_in: true))
+      super(user, record, { ensure_logged_in: true }.merge(opts))
     end
 
     def index?

--- a/src/api/app/policies/users/task_policy.rb
+++ b/src/api/app/policies/users/task_policy.rb
@@ -1,7 +1,7 @@
 module Users
   class TaskPolicy < ApplicationPolicy
     def initialize(user, record, opts = {})
-      super(user, record, opts.merge(ensure_logged_in: true))
+      super(user, record, { ensure_logged_in: true }.merge(opts))
     end
 
     def index?

--- a/src/api/app/policies/webui/status_message_policy.rb
+++ b/src/api/app/policies/webui/status_message_policy.rb
@@ -1,6 +1,6 @@
 class Webui::StatusMessagePolicy < ApplicationPolicy
   def initialize(user, record, opts = {})
-    super(user, record, opts.merge(ensure_logged_in: true))
+    super(user, record, { ensure_logged_in: true }.merge(opts))
   end
 
   def create?

--- a/src/api/app/policies/webui/user_policy.rb
+++ b/src/api/app/policies/webui/user_policy.rb
@@ -1,6 +1,6 @@
 class Webui::UserPolicy < ApplicationPolicy
   def initialize(user, record, opts = {})
-    super(user, record, opts.merge(ensure_logged_in: true))
+    super(user, record, { ensure_logged_in: true }.merge(opts))
   end
 
   # This is a stub: right now the authorization logic lives in Webui::UsersController.

--- a/src/api/app/views/webui/main/_status_messages.html.haml
+++ b/src/api/app/views/webui/main/_status_messages.html.haml
@@ -1,3 +1,7 @@
+-# This is needed since inferring the policy class with `policy(StatusMessage.new)` would use StatusMessagePolicy which is for the API
+  Anonymous users can see this view, so we need to set `ensure_logged_in` to `false`
+- status_message_policy = Webui::StatusMessagePolicy.new(User.possibly_nobody, StatusMessage.new, ensure_logged_in: false)
+
 .card.mb-3
   .card-header.d-flex.justify-content-between
     %h5
@@ -7,13 +11,13 @@
         %i.fa.fa-rss
   .list-group.list-group-flush
     = render StatusMessageComponent.with_collection(status_messages)
-  - if policy(StatusMessage.new).create?
+  - if status_message_policy.create?
     .card-footer
       = link_to(new_status_message_path, class: 'nav-link') do
         %i.fas.fa-plus-circle.text-primary
         Create Status Message
 
-- if policy(StatusMessage.new).destroy?
+- if status_message_policy.destroy?
   = render DeleteConfirmationDialogComponent.new(modal_id: 'delete-status-message-modal',
                                                  method: :delete,
                                                  options: { modal_title: 'Do you want to remove this status message?',


### PR DESCRIPTION
Before, options passed to the policies were simply ignored and the default values were always taken. Only `Staging::WorkflowPolicy` was correct.

I realized this was wrong while pairing with @ncounter as we worked on a feature.