### PR TITLE
Remove unneeded variable @namespace in groups#index

### DIFF
--- a/src/api/app/views/webui/groups/index.html.haml
+++ b/src/api/app/views/webui/groups/index.html.haml
@@ -1,7 +1,7 @@
 - @pagetitle = 'Manage Groups'
 
 .card.mb-3
-  = render partial: "webui/configuration/#{@namespace}tabs"
+  = render partial: 'webui/configuration/tabs'
   .card-body
     %h3
       = @pagetitle


### PR DESCRIPTION
This instance variable is not set in Webui::GroupsController and there are no partials beside `_tabs.html.haml` and
`_breadcrumb_items.html.haml` under `app/views/webui/configuration/`, so this can be safely removed.

Co-authored-by: Dario Leidi <dleidi@suse.com>