### PR TITLE
Manage News in a dedicated page

### DIFF
--- a/src/api/app/controllers/webui/status_messages_controller.rb
+++ b/src/api/app/controllers/webui/status_messages_controller.rb
@@ -3,6 +3,18 @@ class Webui::StatusMessagesController < Webui::WebuiController
   before_action :kerberos_auth
   after_action :verify_authorized, except: [:preview]
 
+  def index
+    authorize StatusMessage
+
+    @severity, @communication_scope, @page = index_params.values_at(:severity, :communication_scope, :page)
+    @status_messages = StatusMessage.newest.includes(:user).for_severity(@severity).for_communication_scope(@communication_scope).page(@page)
+
+    respond_to do |format|
+      format.html
+      format.js
+    end
+  end
+
   def new
     authorize StatusMessage
   end
@@ -20,7 +32,7 @@ class Webui::StatusMessagesController < Webui::WebuiController
       flash[:error] = "Could not create status message: #{status_message.errors.full_messages.to_sentence}"
     end
 
-    redirect_to(controller: 'main', action: 'index')
+    redirect_to(action: 'index')
   end
 
   def update
@@ -32,7 +44,7 @@ class Webui::StatusMessagesController < Webui::WebuiController
       flash[:error] = "Could not update status message: #{status_message.errors.full_messages.to_sentence}"
     end
 
-    redirect_to(controller: 'main', action: 'index')
+    redirect_to(action: 'index')
   end
 
   def destroy
@@ -44,7 +56,7 @@ class Webui::StatusMessagesController < Webui::WebuiController
       flash[:error] = "Could not delete status message: #{status_message.errors.full_messages.to_sentence}"
     end
 
-    redirect_to(controller: 'main', action: 'index')
+    redirect_back_or_to({ action: 'index' })
   end
 
   def acknowledge
@@ -76,5 +88,9 @@ class Webui::StatusMessagesController < Webui::WebuiController
 
   def status_message_params
     params.require(:status_message).permit(:message, :severity, :communication_scope).merge(user: User.session)
+  end
+
+  def index_params
+    params.permit(:severity, :communication_scope, :page)
   end
 end

--- a/src/api/app/models/status_message.rb
+++ b/src/api/app/models/status_message.rb
@@ -8,6 +8,8 @@ class StatusMessage < ApplicationRecord
   scope :announcements, -> { order('created_at DESC').where(severity: 'announcement') }
   scope :for_current_user, -> { where(communication_scope: communication_scopes_for_current_user) }
   scope :newest, -> { order('created_at DESC') }
+  scope :for_severity, ->(severity) { where(severity: severity) if severity.present? }
+  scope :for_communication_scope, ->(communication_scope) { where(communication_scope: communication_scope) if communication_scope.present? }
 
   enum severity: { information: 0, green: 1, yellow: 2, red: 3, announcement: 4 }
   enum communication_scope: { all_users: 0, logged_in_users: 1, admin_users: 2, in_beta_users: 3, in_rollout_users: 4 }

--- a/src/api/app/policies/webui/status_message_policy.rb
+++ b/src/api/app/policies/webui/status_message_policy.rb
@@ -7,6 +7,10 @@ class Webui::StatusMessagePolicy < ApplicationPolicy
     user.is_admin? || user.is_staff?
   end
 
+  def index?
+    create?
+  end
+
   def new?
     create?
   end

--- a/src/api/app/views/webui/configuration/_tabs.html.haml
+++ b/src/api/app/views/webui/configuration/_tabs.html.haml
@@ -4,5 +4,6 @@
     = tab_link('Architectures', architectures_path, false, 'scrollable-tab-link')
     = tab_link('Manage Users', users_path, false, 'scrollable-tab-link')
     = tab_link('Manage Groups', groups_path, false, 'scrollable-tab-link')
+    = tab_link('Manage News', status_messages_path, false, 'scrollable-tab-link')
     = tab_link('Notifications', notifications_path, false, 'scrollable-tab-link')
     = tab_link('Interconnect', new_interconnect_path, false, 'scrollable-tab-link')

--- a/src/api/app/views/webui/main/_status_messages.html.haml
+++ b/src/api/app/views/webui/main/_status_messages.html.haml
@@ -5,7 +5,7 @@
 .card.mb-3
   .card-header.d-flex.justify-content-between
     %h5
-      News
+      = link_to_if(status_message_policy.index?, 'News', status_messages_path)
     .float-right
       = link_to(news_feed_path(format: 'rss'), title: 'RSS Feed') do
         %i.fa.fa-rss

--- a/src/api/app/views/webui/status_messages/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui/status_messages/_breadcrumb_items.html.haml
@@ -1,2 +1,4 @@
+= render partial: 'webui/configuration/breadcrumb_items'
+
 %li.breadcrumb-item.active{ 'aria-current' => 'page' }
-  Status Message
+  Manage News

--- a/src/api/app/views/webui/status_messages/edit.html.haml
+++ b/src/api/app/views/webui/status_messages/edit.html.haml
@@ -26,4 +26,4 @@
                 - options = StatusMessage.communication_scopes.keys.map { |scope| [scope.humanize, scope] }
                 = form.select(:communication_scope, options_for_select(options, @status_message.communication_scope), {}, class: 'custom-select')
               = form.submit 'Update', class: 'btn btn-primary mr-4'
-              = link_to('Back', root_path, class: 'btn btn-outline-secondary', role: 'button')
+              = link_to('Back', request.referer.presence || status_messages_path, class: 'btn btn-outline-secondary', role: 'button')

--- a/src/api/app/views/webui/status_messages/index.html.haml
+++ b/src/api/app/views/webui/status_messages/index.html.haml
@@ -1,0 +1,42 @@
+- @pagetitle = 'Manage News'
+
+.card.mb-3
+  = render partial: 'webui/configuration/tabs'
+  .card-body
+    %h3
+      = @pagetitle
+
+    = form_tag(status_messages_path, method: :get, remote: true) do
+      .row.mt-4
+        .col-auto
+          = label_tag do
+            Severity:
+          - options = StatusMessage.severities.keys.map { |severity| [severity.humanize, severity] }
+          = select_tag('severity', options_for_select(options, @severity), class: 'custom-select',
+                       prompt: 'All severities', onchange: '$(this.form).submit();')
+        .col-auto
+          = label_tag('Communication Scope:')
+          - options = StatusMessage.communication_scopes.keys.map { |scope| [scope.humanize, scope] }
+          = select_tag('communication_scope', options_for_select(options, @communication_scope), class: 'custom-select',
+                       prompt: 'All communication scopes', onchange: '$(this.form).submit();')
+    - if @status_messages.present?
+      .row.justify-content-center.mt-5
+        .col-md-4.col-lg-5
+          .list-group.list-group-flush.border#news-list
+            = render StatusMessageComponent.with_collection(@status_messages)
+      .row.justify-content-center.mt-2
+        .col-auto#news-pagination
+          = paginate @status_messages, remote: true
+    .row.justify-content-center.mt-2
+      .col-auto#news-page-entries-info
+        = page_entries_info @status_messages, entry_name: 'news'
+
+    .pt-4
+      = link_to(new_status_message_path, title: 'Create News') do
+        %i.fas.fa-plus-circle.text-primary
+        Create News
+
+= render DeleteConfirmationDialogComponent.new(modal_id: 'delete-status-message-modal',
+                                                method: :delete,
+                                                options: { modal_title: 'Do you want to remove this status message?',
+                                                          confirmation_text: 'Please confirm the deletion of this status message' })

--- a/src/api/app/views/webui/status_messages/index.js.haml
+++ b/src/api/app/views/webui/status_messages/index.js.haml
@@ -1,0 +1,17 @@
+newsList = '#{escape_javascript(render(StatusMessageComponent.with_collection(@status_messages)))}';
+$('#news-list').html(newsList);
+
+newsPagination ='#{escape_javascript(paginate(@status_messages, remote: true))}';
+$('#news-pagination').html(newsPagination);
+
+newsPageEntriesInfo ='#{escape_javascript(page_entries_info(@status_messages, entry_name: 'news'))}';
+$('#news-page-entries-info').html(newsPageEntriesInfo);
+
+-# Replicate the selected page, severity and communication scope in the URL
+   This doesn't happen since data is fetched through AJAX requests
+url = new URL(window.location);
+url.searchParams.set('page', '#{@page}');
+url.searchParams.set('severity', '#{@severity}');
+url.searchParams.set('communication_scope', '#{@communication_scope}');
+// This won't reload the page like `window.location = url` would
+window.history.pushState({}, '', url);

--- a/src/api/app/views/webui/status_messages/new.html.haml
+++ b/src/api/app/views/webui/status_messages/new.html.haml
@@ -25,3 +25,4 @@
                 - options = StatusMessage.communication_scopes.keys.map { |scope| [scope.humanize, scope] }
                 = f.select(:communication_scope, options_for_select(options), {}, class: 'custom-select')
               = f.submit 'Create', class: 'btn btn-primary'
+              = link_to('Back', request.referer.presence || status_messages_path, class: 'btn btn-outline-secondary', role: 'button')

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -8,7 +8,7 @@ OBSApi::Application.routes.draw do
       mount Flipper::UI.app(Flipper) => '/flipper'
     end
 
-    resources :status_messages, only: [:new, :create, :edit, :update, :destroy], controller: 'webui/status_messages' do
+    resources :status_messages, only: [:index, :new, :create, :edit, :update, :destroy], controller: 'webui/status_messages' do
       collection do
         post 'preview'
       end

--- a/src/api/lib/tasks/dev.rake
+++ b/src/api/lib/tasks/dev.rake
@@ -229,6 +229,9 @@ namespace :dev do
 
       # Create a request wich builds and produces build results
       Rake::Task['dev:requests:request_with_build_results'].invoke
+
+      # Create news
+      Rake::Task['dev:news:data'].invoke
     end
   end
 end

--- a/src/api/lib/tasks/dev/news.rake
+++ b/src/api/lib/tasks/dev/news.rake
@@ -1,0 +1,35 @@
+namespace :dev do
+  namespace :news do
+    # Run this task with: rails "dev:news:data[3]"
+    # replacing 3 with any number to indicate how many times you want this code to be executed.
+    desc 'Creates a notification and all its dependencies'
+    task :data, [:repetitions] => :environment do |_t, args|
+      unless Rails.env.development?
+        puts "You are running this rake task in #{Rails.env} environment."
+        puts 'Please only run this task with RAILS_ENV=development'
+        puts 'otherwise it will destroy your database data.'
+        return
+      end
+
+      args.with_defaults(repetitions: 1)
+      repetitions = args.repetitions.to_i
+      require 'factory_bot'
+      include FactoryBot::Syntax::Methods
+
+      # Users
+      admin = User.where(login: 'Admin').first || create(:admin_user, login: 'Admin')
+
+      repetitions.times do
+        puts('Creating news for each combination of severity and communication scope')
+        StatusMessage.severities.each do |severity_name, _severity_index|
+          StatusMessage.communication_scopes.each do |communication_scope_name, _severity_index|
+            create(:status_message, message: "#{communication_scope_name} - #{Faker::Lorem.paragraph}",
+                                    severity: severity_name,
+                                    communication_scope: communication_scope_name,
+                                    user: admin)
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/api/spec/controllers/webui/status_messages_controller_spec.rb
+++ b/src/api/spec/controllers/webui/status_messages_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Webui::StatusMessagesController do
       login(admin_user)
 
       post :create, params: { status_message: { message: 'Some message', severity: 'green' } }
-      expect(response).to redirect_to(root_path)
+      expect(response).to redirect_to(status_messages_path)
       message = StatusMessage.where(user: admin_user, message: 'Some message', severity: 'green')
       expect(message).to exist
     end
@@ -26,13 +26,13 @@ RSpec.describe Webui::StatusMessagesController do
       expect do
         post :create, params: { status_message: { message: 'Some message' } }
       end.not_to change(StatusMessage, :count)
-      expect(response).to redirect_to(root_path)
+      expect(response).to redirect_to(status_messages_path)
       expect(flash[:error]).to eq("Could not create status message: Severity can't be blank")
 
       expect do
         post :create, params: { status_message: { severity: 'green' } }
       end.not_to change(StatusMessage, :count)
-      expect(response).to redirect_to(root_path)
+      expect(response).to redirect_to(status_messages_path)
       expect(flash[:error]).to eq("Could not create status message: Message can't be blank")
     end
 
@@ -43,8 +43,9 @@ RSpec.describe Webui::StatusMessagesController do
         post :create, params: { status_message: { message: 'Some message', severity: 'green' } }
       end
 
-      it 'does not create a status message' do
+      it 'is not authorized to create a status message' do
         expect(response).to redirect_to(root_path)
+        expect(flash[:error]).to eq('Sorry, you are not authorized to create this status message.')
         message = StatusMessage.where(user: admin_user, message: 'Some message', severity: 'green')
         expect(message).not_to exist
       end
@@ -91,7 +92,7 @@ RSpec.describe Webui::StatusMessagesController do
 
       subject { delete :destroy, params: { id: message.id } }
 
-      it { is_expected.to redirect_to(root_path) }
+      it { is_expected.to redirect_to(status_messages_path) }
       it { expect { subject }.to change(StatusMessage, :count).by(-1) }
     end
 
@@ -102,7 +103,11 @@ RSpec.describe Webui::StatusMessagesController do
 
       subject { delete :destroy, params: { id: message.id } }
 
-      it { is_expected.to redirect_to(root_path) }
+      it 'is not authorized to delete a status message' do
+        expect(subject).to redirect_to(root_path)
+        expect(flash[:error]).to eq('Sorry, you are not authorized to delete this status message.')
+      end
+
       it { expect { subject }.not_to(change(StatusMessage, :count)) }
     end
   end


### PR DESCRIPTION
`Manage News` is a new page to you guessed it, manage news / status messages!!! We went with `News` to be consistent with the UI on the homepage which refers to status messages as news. This confusion naming will be aligned in #13574.

The page works with AJAX, we didn't implement a full-text search since this would have increased the scope of the changes. It's accessible from the homepage by clicking on `News` and also from a tab under the `Configuration` page.

Preview:
![preview](https://user-images.githubusercontent.com/1102934/209174347-9ed94fb4-d9ff-4af6-9520-72c2d49d8315.gif)

Closes #13458