### PR TITLE
Filter package diff by multiple files

### DIFF
--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -13,6 +13,8 @@ class SourceController < ApplicationController
 
   skip_before_action :extract_user, only: [:lastevents_public, :global_command_orderkiwirepos, :global_command_triggerscmsync]
   skip_before_action :require_login, only: [:lastevents_public, :global_command_orderkiwirepos, :global_command_triggerscmsync]
+  # we use an array for the "file" parameter for: package_command_diff, package_command_linkdiff and package_command_servicediff
+  skip_before_action :validate_params, only: [:package_command]
 
   before_action :require_valid_project_name, except: [:index, :lastevents, :lastevents_public,
                                                       :global_command_orderkiwirepos, :global_command_branch,

--- a/src/api/app/lib/backend/connection.rb
+++ b/src/api/app/lib/backend/connection.rb
@@ -77,9 +77,11 @@ module Backend
 
         if hash[key].nil?
           # just a boolean argument ?
-          [hash[key]].flat_map { key }.join('&')
+          key
+        elsif hash[key].is_a?(Array)
+          hash[key].map { |value| "#{key}=#{CGI.escape(value.to_s)}" }.join('&')
         else
-          [hash[key]].flat_map { "#{key}=#{CGI.escape(hash[key].to_s)}" }.join('&')
+          "#{key}=#{CGI.escape(hash[key].to_s)}"
         end
       end
       query.empty? ? '' : "?#{query.compact.join('&')}"

--- a/src/api/public/apidocs-new/components/parameters/diff_file.yaml
+++ b/src/api/public/apidocs-new/components/parameters/diff_file.yaml
@@ -1,6 +1,8 @@
 in: query
-name: file
+name: file[]
 schema:
-  type: string
-description: Limit diff to the given file name.
-example: hello_world.spec
+  type: array
+  elements:
+    type: string
+description: Limit diff to the given file names.
+example: ['hello_world.spec', 'my_program.c']

--- a/src/api/public/apidocs-new/components/parameters/diff_file_deprecated.yaml
+++ b/src/api/public/apidocs-new/components/parameters/diff_file_deprecated.yaml
@@ -1,0 +1,7 @@
+in: query
+name: file
+schema:
+  type: string
+description: Limit diff to the given file name.
+example: hello_world.spec
+deprecated: true

--- a/src/api/public/apidocs-new/paths/source_project_name_package_name_cmd_diff.yaml
+++ b/src/api/public/apidocs-new/paths/source_project_name_package_name_cmd_diff.yaml
@@ -29,6 +29,7 @@ post:
           - 0
       description: Set to `1` to expand any link before diffing.
       example: 1
+    - $ref: '../components/parameters/diff_file_deprecated.yaml'
     - $ref: '../components/parameters/diff_file.yaml'
     - $ref: '../components/parameters/diff_filelimit.yaml'
     - $ref: '../components/parameters/diff_linkrev.yaml'

--- a/src/api/public/apidocs-new/paths/source_project_name_package_name_cmd_linkdiff.yaml
+++ b/src/api/public/apidocs-new/paths/source_project_name_package_name_cmd_linkdiff.yaml
@@ -9,6 +9,7 @@ post:
   parameters:
     - $ref: '../components/parameters/project_name.yaml'
     - $ref: '../components/parameters/package_name.yaml'
+    - $ref: '../components/parameters/diff_file_deprecated.yaml'
     - $ref: '../components/parameters/diff_file.yaml'
     - $ref: '../components/parameters/diff_filelimit.yaml'
     - $ref: '../components/parameters/diff_linkrev.yaml'

--- a/src/api/public/apidocs-new/paths/source_project_name_package_name_cmd_servicediff.yaml
+++ b/src/api/public/apidocs-new/paths/source_project_name_package_name_cmd_servicediff.yaml
@@ -9,6 +9,7 @@
   parameters:
     - $ref: '../components/parameters/project_name.yaml'
     - $ref: '../components/parameters/package_name.yaml'
+    - $ref: '../components/parameters/diff_file_deprecated.yaml'
     - $ref: '../components/parameters/diff_file.yaml'
     - $ref: '../components/parameters/diff_filelimit.yaml'
     - $ref: '../components/parameters/diff_onlyissues.yaml'


### PR DESCRIPTION
Introduce a new `file[]` query parameter which allows to filter for several files, for these API endpoints:
- `POST /source/{project_name}/{package_name}?cmd=diff`
- `POST /source/{project_name}/{package_name}?cmd=linkdiff`
- `POST /source/{project_name}/{package_name}?cmd=servicediff`

Also, mark the `file` query parameter as deprecated in the documentation.

Fixes #13543.