### PR TITLE
Avoid errors when description_extension is nil

### DIFF
--- a/src/api/app/components/bs_request_history_element_component.html.haml
+++ b/src/api/app/components/bs_request_history_element_component.html.haml
@@ -6,7 +6,7 @@
     - if element.instance_of?(HistoryElement::RequestSuperseded)
       superseded this request with
       = link_to("request ##{element.description_extension}", request_show_path(element.description_extension))
-    - elsif element.instance_of?(HistoryElement::RequestReviewAdded)
+    - elsif element.instance_of?(HistoryElement::RequestReviewAdded) && element.review
       = element.user_action_prefix
       %strong
         = element.action_target

--- a/src/api/app/models/history_element/request_review_added.rb
+++ b/src/api/app/models/history_element/request_review_added.rb
@@ -5,6 +5,8 @@ module HistoryElement
     end
 
     def user_action
+      return 'added a reviewer' unless review
+
       "#{user_action_prefix} #{action_target} #{user_action_suffix}"
     end
 
@@ -20,8 +22,10 @@ module HistoryElement
       'as a reviewer'
     end
 
-    # self.description_extension is review id
+    # self.description_extension is review id, but it's not present in old history elements
     def review
+      return if description_extension.blank?
+
       ::Review.find(description_extension)
     end
   end

--- a/src/api/spec/components/bs_request_history_element_component_spec.rb
+++ b/src/api/spec/components/bs_request_history_element_component_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe BsRequestHistoryElementComponent, type: :component do
   context 'when the element provided is not a history element' do
     it_behaves_like 'raising an exception warning the user to provide an history element'
   end
-  # rubocop:enable RSpec/RepeatedExampleGroupBody
 
   context 'when the element provided is a history element superseded' do
     it 'renders the element telling this request was superseded'
@@ -25,4 +24,17 @@ RSpec.describe BsRequestHistoryElementComponent, type: :component do
     it 'renders the element action'
     it 'renders the element comment'
   end
+
+  context 'when the element provided is a history element about review added' do
+    context 'and review is known' do
+      it 'renders the element action'
+      it 'renders the element comment'
+    end
+
+    context 'and review is unknown' do
+      it 'renders the element action'
+      it 'renders the element comment'
+    end
+  end
+  # rubocop:enable RSpec/RepeatedExampleGroupBody
 end


### PR DESCRIPTION
Fixes #13610

The code assumed the `HistoryElement::RequestReviewAdded#description_extension` always contained a review ID, but that's not true for old requests/history_elements.

When the review ID is present:

![Screenshot 2023-01-02 at 11-41-44 Open Build Service](https://user-images.githubusercontent.com/2581944/210220925-db7290fe-03a3-4b24-a957-f5ac35df4c8e.png)

When the review ID is NOT present:

![Screenshot 2023-01-02 at 11-42-16 Open Build Service](https://user-images.githubusercontent.com/2581944/210220932-3b032a0a-f05e-47e2-bc4c-863b1a7fe3fe.png)



