### PR TITLE
Fix warnings in project feature tests

### DIFF
--- a/src/api/spec/features/webui/projects_spec.rb
+++ b/src/api/spec/features/webui/projects_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe 'Projects', js: true do
   let(:broken_package_with_error) { create(:package, project: project, name: 'broken_package') }
 
   it 'project show' do
+    project.update(description: 'Original description')
+
     login user
     visit project_show_path(project: project)
     expect(page).to have_text(/Packages .*0/)
@@ -37,6 +39,10 @@ RSpec.describe 'Projects', js: true do
     end
 
     context 'when cancelling the changes' do
+      before do
+        project.update(title: 'Original title', description: 'Original description')
+      end
+
       it "renders back the original project's details" do
         login user
         visit project_show_path(project: project)


### PR DESCRIPTION
Provide a title and a description for the project which is tested. Otherwise tests compare against nil, throwing this warning:
```
Checking for expected text of nil is confusing and/or pointless since it will always match. Please specify a string or regexp instead. /root/project/src/api/spec/features/webui/projects_spec.rb:14
```