### PR TITLE
Refactor removing a user

### DIFF
--- a/src/api/app/helpers/webui/user_helper.rb
+++ b/src/api/app/helpers/webui/user_helper.rb
@@ -25,8 +25,7 @@ module Webui::UserHelper
         mail_to(user.email) do
           tag.i(nil, class: 'fas fa-envelope text-secondary pr-1', title: 'Send Email to User')
         end,
-        render(partial: 'webui/users/delete_dialog', formats: [:html], locals: { user: user }),
-        link_to('#', data: { toggle: 'modal', target: "#delete-user-modal-#{user}" }, title: 'Delete User') do
+        link_to('#', title: 'Delete User', data: { toggle: 'modal', target: '#delete-user-modal', 'user-login': user.login, action: user_path(user.login) }) do
           tag.i(nil, class: 'fas fa-times-circle text-danger pr-1')
         end
       ]

--- a/src/api/app/views/webui/users/_delete_dialog.html.haml
+++ b/src/api/app/views/webui/users/_delete_dialog.html.haml
@@ -1,4 +1,4 @@
-.modal.fade{ id: "delete-user-modal-#{user}", tabindex: -1, role: 'dialog',
+.modal.fade{ id: 'delete-user-modal', tabindex: -1, role: 'dialog',
              aria: { labelledby: 'delete-user-modal-label', hidden: true } }
   .modal-dialog.modal-dialog-centered{ role: 'document' }
     .modal-content
@@ -6,9 +6,12 @@
         %h5.modal-title
           Delete User?
       .modal-body
-        %p Please confirm deletion of '#{user}'
+        %p
+          Please confirm deletion of '
+          %span.user-login>
+          '
 
-        = form_tag(user_path(user.login), method: :delete, class: 'delete-user-form') do
+        = form_tag nil, method: :delete do
           .modal-footer
             %button.btn.btn-sm.btn-outline-secondary.px-4{ data: { dismiss: 'modal' } }
               Cancel

--- a/src/api/app/views/webui/users/index.html.haml
+++ b/src/api/app/views/webui/users/index.html.haml
@@ -23,6 +23,13 @@
       = link_to(new_user_path(pagetitle: 'create user', submit_btn_text: 'create', title: 'Create User')) do
         %i.fas.fa-plus-circle.text-primary
         Create User
+    = render partial: 'webui/users/delete_dialog'
 
 - content_for :ready_function do
-  initializeUserConfigurationDatatable("#{Configuration.ldap_enabled?}");
+  :plain
+    initializeUserConfigurationDatatable("#{Configuration.ldap_enabled?}");
+    $('#delete-user-modal').on('show.bs.modal', function (event) {
+      var link = $(event.relatedTarget);
+      $(this).find('.user-login').text(link.data('user-login'));
+      $(this).find('form').attr('action', link.data('action'));
+    });

--- a/src/api/spec/features/webui/users/admin_configuration_spec.rb
+++ b/src/api/spec/features/webui/users/admin_configuration_spec.rb
@@ -26,9 +26,9 @@ RSpec.describe 'Admin user configuration page', js: true do
     within(find('td', text: /#{user.realname}/).ancestor('tr')) do
       expect(page).to have_css('td', text: 'confirmed')
       page.find('a[title="Delete User"]').click
-      # Accept the confirmation dialog
-      click_button('Delete')
     end
+    # Accept the confirmation dialog
+    click_button('Delete')
     expect(page).to have_css('td', text: 'deleted')
   end
 


### PR DESCRIPTION
Instead of generating html code for each modal that asks for removing a user, only one modal is created. Arguments for the modal are passed with "data-*" attributes.

Fixes #13604.