### PR TITLE
Add table shim for bootstrap 5 migration

### DIFF
--- a/src/api/app/assets/stylesheets/webui/bs5-shims.scss
+++ b/src/api/app/assets/stylesheets/webui/bs5-shims.scss
@@ -1,3 +1,5 @@
 .visually-hidden {
   @extend .sr-only;
 }
+
+.table-light { @extend .thead-light; }

--- a/src/api/app/views/webui/shared/_repositories_flag_table.html.haml
+++ b/src/api/app/views/webui/shared/_repositories_flag_table.html.haml
@@ -1,6 +1,6 @@
 .table-responsive
   %table.table.table-hover.table-sm{ id: table_id }
-    %thead.thead-light
+    %thead.table-light
       %tr
         %th.w-auto Repository
         %th.w-auto.text-center All


### PR DESCRIPTION
This is a part of https://github.com/openSUSE/open-build-service/pull/13602, updating table classes