### PR TITLE
visually-hidden shim for bootstrap 5 migration

### DIFF
--- a/src/api/app/assets/stylesheets/webui/application.scss
+++ b/src/api/app/assets/stylesheets/webui/application.scss
@@ -17,6 +17,7 @@
 @import 'bootstrap_variables/fonts';
 @import 'bootstrap_variables/sizes';
 @import 'bootstrap';
+@import 'bs5-shims';
 @import 'bootstrap-modal';
 @import 'font-awesome';
 @import 'tokenfield';

--- a/src/api/app/assets/stylesheets/webui/bs5-shims.scss
+++ b/src/api/app/assets/stylesheets/webui/bs5-shims.scss
@@ -1,0 +1,3 @@
+.visually-hidden {
+  @extend .sr-only;
+}

--- a/src/api/app/components/workflow_run_request_action_filter_component.html.haml
+++ b/src/api/app/components/workflow_run_request_action_filter_component.html.haml
@@ -1,6 +1,6 @@
 = form_with(url: token_workflow_runs_path(@token_id), method: :get, local: true, class: 'form-inline') do
   = hidden_field_tag('generic_event_type', @generic_event_type)
-  = label_tag('request_action', 'Action', class: 'sr-only')
+  = label_tag('request_action', 'Action', class: 'visually-hidden')
   .input-group.mr-sm-2
     .input-group-prepend
       .input-group-text

--- a/src/api/app/views/webui/request/show.html.haml
+++ b/src/api/app/views/webui/request/show.html.haml
@@ -38,7 +38,7 @@
   .card-body
     .d-flex.justify-content-center.loading-diff
       .spinner-border{ role: 'status' }
-        %span.sr-only Loading...
+        %span.visually-hidden Loading...
     .tab-content.sourcediff{ data: { diff_limit: @diff_limit } }
 
 .row


### PR DESCRIPTION
This is a part of https://github.com/openSUSE/open-build-service/pull/13602, updating sr-only class to visually-hidden