### PR TITLE
Allow users to remove themselves from a group

### DIFF
--- a/src/api/app/controllers/webui/groups/users_controller.rb
+++ b/src/api/app/controllers/webui/groups/users_controller.rb
@@ -48,7 +48,8 @@ module Webui
       end
 
       def destroy
-        authorize @group, :update?
+        groups_user = GroupsUser.find_by(group: @group, user: @user)
+        authorize groups_user, :destroy?
 
         if @group.remove_user(@user)
           flash[:success] = "Removed user '#{@user}' from group '#{@group}'"

--- a/src/api/app/policies/groups_user_policy.rb
+++ b/src/api/app/policies/groups_user_policy.rb
@@ -1,0 +1,6 @@
+class GroupsUserPolicy < ApplicationPolicy
+  def destroy?
+    # An admin, a group maintainer or the user themselves can remove themselves from a group
+    user.is_admin? || record.group.group_maintainers.exists?(user: user) || user.id == record.user_id
+  end
+end

--- a/src/api/app/views/webui/groups/_group_members.html.haml
+++ b/src/api/app/views/webui/groups/_group_members.html.haml
@@ -8,13 +8,13 @@
     .d-flex.flex-wrap
       - group.users.each do |user|
         .card.m-1.p-2.group-user
-          - if write_access
+          - if policy(GroupsUser.new(group: group, user: user)).destroy?
             = link_to('#',
-                       title: 'Remove member from group',
-                       data: { toggle: 'modal',
-                               target: '#delete-group-members-modal',
-                               confirmation_text: "Please confirm deletion of '#{user}' from this group",
-                               action: group_user_path(group_title: group.title, user_login: user.login) }) do
+                      title: 'Remove member from group',
+                      data: { toggle: 'modal',
+                              target: '#delete-group-members-modal',
+                              confirmation_text: "Please confirm deletion of '#{user}' from this group",
+                              action: group_user_path(group_title: group.title, user_login: user.login) }) do
               .float-end
                 %i.fas.fa-sm.fa-times-circle.text-danger
           .row.no-gutters
@@ -42,9 +42,9 @@
           Add Member
   = render partial: 'add_group_user_modal', locals: { group: group }
 
-  = render DeleteConfirmationDialogComponent.new(modal_id: 'delete-group-members-modal',
-                                                 method: :delete,
-                                                 options: { modal_title: 'Do you want to remove this group member?' })
+= render DeleteConfirmationDialogComponent.new(modal_id: 'delete-group-members-modal',
+                                               method: :delete,
+                                               options: { modal_title: 'Do you want to remove this group member?' })
 
 - content_for :ready_function do
   :plain

--- a/src/api/spec/controllers/webui/groups_controller_spec.rb
+++ b/src/api/spec/controllers/webui/groups_controller_spec.rb
@@ -7,8 +7,6 @@ RSpec.describe Webui::GroupsController do
 
   # except [:show, :tokens, :autocomplete]
   it { is_expected.to use_before_action(:require_login) }
-  # only: [:show, :update, :edit]
-  it { is_expected.to use_before_action(:set_group) }
   # except: [:show, :autocomplete, :tokens]
   it { is_expected.to use_after_action(:verify_authorized) }
 

--- a/src/api/spec/policies/groups_user_policy_spec.rb
+++ b/src/api/spec/policies/groups_user_policy_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe GroupsUserPolicy do
+  subject { described_class }
+
+  permissions :destroy? do
+    let(:group) { create(:group) }
+
+    context 'as an admin' do
+      let(:admin) { create(:admin_user) }
+      let(:groups_user) { create(:groups_user, group: group) }
+
+      it { is_expected.to permit(admin, groups_user) }
+    end
+
+    context 'as a group maintainer' do
+      let(:group_maintainer) { create(:group_maintainer, group: group).user }
+      let(:groups_user) { create(:groups_user, group: group) }
+
+      it { is_expected.to permit(group_maintainer, groups_user) }
+    end
+
+    context 'as a group member' do
+      let(:group_member) { create(:confirmed_user) }
+
+      context 'when removing themselves from a group' do
+        let(:groups_user) { create(:groups_user, group: group, user: group_member) }
+
+        it { is_expected.to permit(group_member, groups_user) }
+      end
+
+      context 'when removing someone else from a group' do
+        let(:groups_user) { create(:groups_user, group: group) }
+
+        it { is_expected.not_to permit(group_member, groups_user) }
+      end
+    end
+
+    context 'as a user which is not a group member' do
+      let(:groups_user) { create(:groups_user, group: group) }
+      let(:other_user) { create(:confirmed_user) }
+
+      it { is_expected.not_to permit(other_user, groups_user) }
+    end
+  end
+end


### PR DESCRIPTION
Even if they aren't an admin or a maintainer of the group.

Closes #13406

Example - While logged in as _Iggy_, I can remove myself from the group. The alignment is a bit off in this case, but I didn't want to tackle this in this PR. 
![preview](https://user-images.githubusercontent.com/1102934/210581461-48a30772-f81f-4fab-a85b-689675549862.png)