### PR TITLE
Prevent warnings involving Struct::StatusCount from appearing

### DIFF
--- a/src/api/app/models/buildresult.rb
+++ b/src/api/app/models/buildresult.rb
@@ -41,6 +41,8 @@ class Buildresult
     unknown: 'The scheduler has not yet evaluated this package. Should be a short intermediate state for new packages.'
   }.with_indifferent_access.freeze
 
+  StatusCount = Struct.new(:code, :count)
+
   def initialize(status)
     @status = status
   end
@@ -86,10 +88,9 @@ class Buildresult
         state: state
       )
 
-      Struct.new('StatusCount', :code, :count)
       build.summary = []
       result['summary'].elements('statuscount').each do |count|
-        build.summary << Struct::StatusCount.new(count['code'], count['count'])
+        build.summary << StatusCount.new(count['code'], count['count'])
       end
 
       build.summary.sort! { |a, b| code2index(a.code) <=> code2index(b.code) }


### PR DESCRIPTION
The exact literal from the warning is:
```
/root/project/src/api/app/models/buildresult.rb:89: warning: redefining constant Struct::StatusCount
```