### PR TITLE
Fix warning in notification spec

### DIFF
--- a/src/api/spec/components/notification_action_description_component_spec.rb
+++ b/src/api/spec/components/notification_action_description_component_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe NotificationActionDescriptionComponent, type: :component do
     end
 
     it 'renders a div containing only the target project' do
-      expect(rendered_content).to have_selector('div.smart-overflow', text: 'project_12345', exact: true)
+      expect(rendered_content).to have_selector('div.smart-overflow', exact_text: 'project_12345')
     end
   end
 


### PR DESCRIPTION
Prevent this warning to be thrown in the test suite:
```
The :exact option only has an effect on queries using the XPath#is method. Using it with the query "div.smart-overflow" has no effect.
```