### PR TITLE
Improving spacing on main page and tables

### DIFF
--- a/src/api/app/components/status_message_component.html.haml
+++ b/src/api/app/components/status_message_component.html.haml
@@ -1,8 +1,8 @@
 .list-group-item
   .row
-    .col-1
-      %i.fa.fa-lg{ helpers.icon_for_severity(@status_message.severity) }
-    .col
+    .col-auto.pe-1
+      %i.fa.fa-lg.fa-fw{ helpers.icon_for_severity(@status_message.severity) }
+    .col.ps-1
       = helpers.user_with_realname_and_icon(@status_message.user, short: true)
       wrote
       %u

--- a/src/api/app/components/status_message_component.html.haml
+++ b/src/api/app/components/status_message_component.html.haml
@@ -8,7 +8,7 @@
       %u
         #{time_ago_in_words(@status_message.created_at)} ago
       - if policy(@status_message).update? && policy(@status_message).destroy?
-        .float-end
+        .float-end<
           = link_to(edit_status_message_path(@status_message), title: 'Edit news item', class: 'me-2') do
             %i.fas.fa-edit.text-secondary
           = link_to('#', title: 'Delete news item', data: { toggle: 'modal',

--- a/src/api/app/views/webui/main/_latest_updates.html.haml
+++ b/src/api/app/views/webui/main/_latest_updates.html.haml
@@ -9,12 +9,12 @@
     - latest_updates.each do |update|
       .list-group-item
         .row
-          .col-1
+          .col-auto.pe-1
             - if update[1] == :package
-              %i.fa.fa-archive.fa-lg.text-warning{ title: 'Package' }
+              %i.fa.fa-archive.fa-lg.fa-fw.text-warning{ title: 'Package' }
             - else
-              %i.fa.fa-cubes.fa-lg.text-secondary{ title: 'Project' }
-          .col.text-truncate
+              %i.fa.fa-cubes.fa-lg.fa-fw.text-secondary{ title: 'Project' }
+          .col.text-truncate.ps-1
             %span
               - if update[1] == :package
                 = link_to(package_show_path(project: update[3], package: update[2])) do

--- a/src/api/app/views/webui/shared/user_or_groups_roles/_list.html.haml
+++ b/src/api/app/views/webui/shared/user_or_groups_roles/_list.html.haml
@@ -19,10 +19,10 @@
             = link_to(project_users_path(project: project)) do
               %i.fa.fa-cubes.text-secondary{ title: 'inherited from project' }
     - if User.session
-      %td.text-nowrap
+      %td.text-nowrap<
         - if mail_subject && record.email
           = mail_to(record.email, subject: mail_subject) do
-            %i.far.fa-envelope{ title: "Send email to #{type}" }
+            %i.far.fa-envelope.me-1{ title: "Send email to #{type}" }
         - if user_is_maintainer
           = link_to('#', class: "remove-#{type}",
             data: { toggle: 'modal',


### PR DESCRIPTION
Discovered while working on bs5, but applies to bs4 as well. It's better to use margins instead of spaces, to avoid issues with link overlap for example