### PR TITLE
[backend] forbid _project as package name in verify_pack()

### DIFF
--- a/src/backend/BSVerify.pm
+++ b/src/backend/BSVerify.pm
@@ -306,6 +306,7 @@ sub verify_proj {
 sub verify_pack {
   my ($pack, $packid) = @_;
   if (defined($packid)) {
+    die("illegal package name '$packid'\n") if $packid eq '_project';
     die("name does not match data\n") unless $packid eq $pack->{'name'};
   }
   verify_projid($pack->{'project'}) if exists $pack->{'project'};


### PR DESCRIPTION
A project is not a package.