### PR TITLE
Overwrite the badge colours in staging workflows

### DIFF
--- a/src/api/app/assets/stylesheets/webui/staging-workflow.scss
+++ b/src/api/app/assets/stylesheets/webui/staging-workflow.scss
@@ -134,17 +134,17 @@ ul .table-list-group-item {
       }
 
       &.state-ready {
-        @extend .bg-success;
+        color: white;
         background-color: $request-ready-color;
       }
 
       &.state-review {
-        @extend .bg-warning;
+        color: white;
         background-color: $request-review-color;
       }
 
       &.state-obsolete {
-        @extend .bg-info;
+        color: white;
         background-color: $request-obsolete-color;
       }
 


### PR DESCRIPTION
This fixes #13665, the background colour was overwritten by the .bg-warning class extends otherwise