### PR TITLE
Revert "[backend] forbid _project as package name in verify_pack()"

### DIFF
--- a/src/backend/BSVerify.pm
+++ b/src/backend/BSVerify.pm
@@ -306,7 +306,6 @@ sub verify_proj {
 sub verify_pack {
   my ($pack, $packid) = @_;
   if (defined($packid)) {
-    die("illegal package name '$packid'\n") if $packid eq '_project';
     die("name does not match data\n") unless $packid eq $pack->{'name'};
   }
   verify_projid($pack->{'project'}) if exists $pack->{'project'};


### PR DESCRIPTION
This reverts commit bd705eb378855c231d7901b70274f9258c1293cf.

We found out that it breaks workflows code in https://github.com/openSUSE/open-build-service/blob/master/src/api/app/models/workflow/step/link_package_step.rb#L70-L75 and we don't currently have a better workaround