### PR TITLE
Log special characters to `backend_access.log`

### DIFF
--- a/src/api/app/lib/backend/logger.rb
+++ b/src/api/app/lib/backend/logger.rb
@@ -26,7 +26,9 @@ module Backend
       if data.nil?
         @backend_logger.info '(no data)'
       elsif data.instance_of?(String) && data[0, 1] == '<'
-        @backend_logger.info data
+        # Reencode the data replacing invalid UTF-8 characters with the default unicode replacement character: '\ufffd'
+        # source: https://stackoverflow.com/a/24493972
+        @backend_logger.info data.encode('UTF-8', 'UTF-8', invalid: :replace)
       else
         @backend_logger.info "(non-XML data) #{data.class}"
       end


### PR DESCRIPTION
Prevent this messages from appearing in our test suite:

```
log writing failed. "\xE5" from ASCII-8BIT to UTF-8
```