### PR TITLE
Allow project restoring when package name is invalid

### DIFF
--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -141,6 +141,9 @@ class Project < ApplicationRecord
         # restore all package meta data objects in DB
         backend_packages = Xmlhash.parse(Backend::Api::Search.packages_for_project(project_name))
         backend_packages.elements('package') do |package|
+          # Restoring packages with invalid names can cause issues, we ignore them.
+          next unless Package.valid_name?(package['name'])
+
           package = project.packages.new(name: package['name'])
           package_meta = Xmlhash.parse(package.meta.content)
 


### PR DESCRIPTION
In [this issue](https://github.com/openSUSE/open-build-service/issues/13544), the project we are trying to restore contains one package called `_meta` that makes the restore code crash because `package.meta.content` is nil in [this line](https://github.com/openSUSE/open-build-service/blob/1989d07ba15697ad561fc53a3d66956d0c555ef7/src/api/app/models/project.rb#L145).

Package names like `_meta` are now forbidden in frontend and backend code. The one in the issue was probably created before we introduced the validations.

We should be able to restore the rest of the packages and the project by ignoring packages whose names are invalid.

Fixes #13544

*NOTE:* it's not worth adding a spec as it requires skipping validations from both [the model](https://github.com/openSUSE/open-build-service/blob/ff93a673a346ad5ad9f3e40061031425f4dc59cb/src/api/app/models/package.rb#L108) and [the backend](https://github.com/openSUSE/open-build-service/blob/ff93a673a346ad5ad9f3e40061031425f4dc59cb/src/backend/BSVerify.pm#L43), and then recording a cassette with invalid data. I did it manually and got the expected behaviour (the project was restored with only the valid packages on it).