### PR TITLE
Fix duplicated monitor package headers

### DIFF
--- a/src/api/app/assets/stylesheets/webui/datatables.scss
+++ b/src/api/app/assets/stylesheets/webui/datatables.scss
@@ -9,10 +9,19 @@ table.table-fixed {
 // TODO: Delete when bug is fixed: https://github.com/mkhairi/jquery-datatables/issues/17
 table.dataTable.table-sm {
   min-width: 100%;
+  // This added margin breaks layout
+  margin: 0!important;
 
   td {
     white-space: normal !important;
     @extend .text-break;
+  }
+  // Fixed columns need a solid background to work properly
+  &.DTFC_Cloned {
+    background: $card-bg;
+    thead.header th {
+      &:before, &:after { display: none }
+    }
   }
 }
 


### PR DESCRIPTION
This fixes #13677, displaying the fixed row correctly

![Screenshot from 2023-01-12 12-31-41](https://user-images.githubusercontent.com/114928900/212055895-ef7c0236-b2e5-4973-8bb4-fe5d9887b0fa.png)
