### PR TITLE
Use news_item route on the update form

### DIFF
--- a/src/api/app/views/webui/status_messages/edit.html.haml
+++ b/src/api/app/views/webui/status_messages/edit.html.haml
@@ -8,7 +8,7 @@
           .col-12
             %h3= @pagetitle
           .col-12.col-md-9.col-lg-6
-            = form_for(@status_message) do |form|
+            = form_for(@status_message, url: news_item_path) do |form|
               .mb-3
                 = form.label(:message) do
                   Message:


### PR DESCRIPTION
This is a follow-up of https://github.com/openSUSE/open-build-service/pull/13649, there was a form adaptation missing.

While renaming the routes from status_message to news_item, this form should've been adapted too.
We need to specify the URL to avoid it taking the default [PATCH] "/status/messages/:id".

**Test**

Try to update a News item (a.k.a status message). It was not possible before this change.

![Screenshot 2023-01-12 at 12-41-46 Open Build Service](https://user-images.githubusercontent.com/2581944/212057910-4898070c-776f-4efd-825e-3be0f8830840.png)
