### PR TITLE
Display information about the staging workflow in request

### DIFF
--- a/src/api/app/assets/stylesheets/webui/requests.scss
+++ b/src/api/app/assets/stylesheets/webui/requests.scss
@@ -13,6 +13,14 @@
   background-color: $cyan;
 }
 
+.badge-staging {
+  color: $white;
+  background-color: $pink;
+  &:hover {
+    color: $gray-100;
+  }
+}
+
 .req-description-box {
   word-break: break-all;
   white-space: pre-line;

--- a/src/api/app/models/history_element/request_review_added.rb
+++ b/src/api/app/models/history_element/request_review_added.rb
@@ -11,6 +11,8 @@ module HistoryElement
     end
 
     def user_action_prefix
+      return 'set' if review&.staging_project?
+
       'added'
     end
 
@@ -19,6 +21,8 @@ module HistoryElement
     end
 
     def user_action_suffix
+      return 'as a staging project' if review&.staging_project?
+
       'as a reviewer'
     end
 

--- a/src/api/app/models/review.rb
+++ b/src/api/app/models/review.rb
@@ -295,6 +295,10 @@ class Review < ApplicationRecord
     by_project? && by_package?
   end
 
+  def staging_project?
+    for_project? && !project.staging_workflow_id.nil?
+  end
+
   private
 
   def matches_maintainers?(user)

--- a/src/api/app/models/review.rb
+++ b/src/api/app/models/review.rb
@@ -63,6 +63,8 @@ class Review < ApplicationRecord
   scope :for_staging_projects, -> { includes(:project).where.not(projects: { staging_workflow_id: nil }) }
   scope :for_non_staging_projects, -> { includes(:project).where(projects: { staging_workflow_id: nil }) }
 
+  scope :staging, ->(project) { for_staging_projects.or(where(group: Staging::Workflow.find_by(project:)&.managers_group)) }
+
   before_validation(on: :create) do
     self.state = :new if self[:state].nil?
   end

--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -26,21 +26,21 @@
 .card
   .card-body.p-0
     .card-title.p-4.mb-0
-      %h3
+      %h3<>
         Request #{@bs_request.number}
-        %span.badge.ms-1{ class: "bg-#{request_badge_color(@bs_request.state)}" }
+        %span.badge.ms-2{ class: "bg-#{request_badge_color(@bs_request.state)}" }>
           = @bs_request.state
           - if @bs_request.superseded_by.present?
             by
             = link_to(@bs_request.superseded_by, number: @bs_request.superseded_by)
         - if @staging_status
-          - staging_title = @staging_status[:title].capitalize
+          - staging_title = @staging_status[:title]
           - staging_title[0].capitalize
-          = link_to @staging_status[:name], @staging_status[:url], title: staging_title, class: 'badge text-bg-primary'
+          = link_to @staging_status[:name], @staging_status[:url], title: staging_title, class: 'badge badge-staging ms-2'
         - if @bs_request.accept_at.present?
-          %span.badge.alert.alert-warning.border-0.ms-1.mb-0.p-2 auto-accept
+          %span.badge.alert.alert-warning.border-0.ms-2.mb-0.p-2 auto-accept
         - if User.session
-          .d-inline.align-bottom.ms-2#watchlist-icon-wrapper
+          .d-inline.align-bottom.ms-1#watchlist-icon-wrapper
             = render WatchlistIconComponent.new(user: User.session!, bs_request: @bs_request, current_object: @bs_request)
 
       %p.font-italic

--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -33,6 +33,10 @@
           - if @bs_request.superseded_by.present?
             by
             = link_to(@bs_request.superseded_by, number: @bs_request.superseded_by)
+        - if @staging_status
+          - staging_title = @staging_status[:title].capitalize
+          - staging_title[0].capitalize
+          = link_to @staging_status[:name], @staging_status[:url], title: staging_title, class: 'badge text-bg-primary'
         - if @bs_request.accept_at.present?
           %span.badge.alert.alert-warning.border-0.ms-1.mb-0.p-2 auto-accept
         - if User.session
@@ -50,6 +54,9 @@
 
         = render partial: 'actions_details', locals: { bs_request: @bs_request, action: @action, active_action: @active_action,
                                                        diff_to_superseded_id: @diff_to_superseded_id, diff_limit: @diff_limit }
+        - if @staging_status
+          This request is currently
+          = link_to @staging_status[:title], @staging_status[:url]
 
     .border-bottom
       %ul.nav.nav-tabs.scrollable-tabs.border-0#request-tabs{ role: 'tablist' }
@@ -78,7 +85,7 @@
       .tab-pane.fade.p-2#conversation{ 'aria-labelledby': 'conversation-tab', role: 'tabpanel' }
         = render partial: 'webui/request/beta_show_tabs/conversation',
             locals: { bs_request: @bs_request, can_add_reviews: @can_add_reviews,
-                      request_reviews: @request_reviews, open_reviews_for_staging_projects: @open_reviews_for_staging_projects,
+                      request_reviews: @request_reviews,
                       my_open_reviews: @my_open_reviews, package_maintainers: @package_maintainers, action: @action,
                       is_target_maintainer: @is_target_maintainer, is_author: @is_author,
                       project_maintainers: @project_maintainers, show_project_maintainer_hint: @show_project_maintainer_hint }

--- a/src/api/app/views/webui/request/beta_show_tabs/_conversation.html.haml
+++ b/src/api/app/views/webui/request/beta_show_tabs/_conversation.html.haml
@@ -12,7 +12,6 @@
              can_add_reviews: can_add_reviews,
              my_open_reviews: my_open_reviews,
              request_reviews: request_reviews,
-             open_reviews_for_staging_projects: open_reviews_for_staging_projects,
              package_maintainers: package_maintainers,
              project_maintainers: project_maintainers,
              show_project_maintainer_hint: show_project_maintainer_hint }

--- a/src/api/app/views/webui/request/beta_show_tabs/_conversation_aside.html.haml
+++ b/src/api/app/views/webui/request/beta_show_tabs/_conversation_aside.html.haml
@@ -14,13 +14,6 @@
         = render partial: 'webui/request/beta_show_tabs/review_summary', collection: request_reviews, as: :review
   = render partial: 'webui/request/beta_show_tabs/ask_for_review', locals: { can_add_reviews: can_add_reviews }
 
-  - open_reviews_for_staging_projects.each do |review|
-    .ps-3
-      %i.fas.fa-info-circle.text-info
-      - staging_project = review.project
-      Is staged in
-      = link_to(review.by_project, staging_workflow_staging_project_path(staging_project.staging_workflow.project, staging_project.name))
-
   -# PACKAGE MAINTAINERS
   - unless package_maintainers.empty?
     .mt-4


### PR DESCRIPTION
Currently when a request gets a review for a staging workflow project, a note is displayed saying that the request is staged in that staging workflow project. This PR expands that a little bit, by displaying that the request is unstaged at first, when submitted to a staging project, staged when the staging manager group accepts the review and staged to a staging workflow project when there's a review for that project.

![Staging](https://user-images.githubusercontent.com/114928900/212093498-864e0fe7-0bbe-4ca6-9dcd-cca27a5a572a.png)
![Staged](https://user-images.githubusercontent.com/114928900/212093504-f2714ec2-864c-46bf-8d8f-21880607f7a1.png)
![Unstaged](https://user-images.githubusercontent.com/114928900/212093508-591134fb-df6a-41da-9177-4a0d988151d4.png)