### PR TITLE
Scroll towards the current action in the dropdown

### DIFF
--- a/src/api/app/views/webui/request/_actions_details.html.haml
+++ b/src/api/app/views/webui/request/_actions_details.html.haml
@@ -36,6 +36,11 @@
     var hashRegexp = new RegExp(`\#${HASH_PREFIX}.+`);
 
     $('#request-actions').on('shown.bs.dropdown', function () {
+      // Scrolls towards the current request action
+      var currentAction = $('a.dropdown-item.active');
+      currentAction[0].scrollIntoView({behavior: "smooth", block: "center"});
+
+      // Adapts Href according to seleted tab
       $.each($('#request-actions .dropdown-item'), function () {
         var href = $(this).attr('href');
         if (document.location.hash.search('#diff_') != -1 && href.search('#') == -1) {


### PR DESCRIPTION
Especially in dropdowns with a lot of request actions, it's helpful to have the dropdown centred on the current action (the one we are currently displaying on the page).

![scroll_to_active_request_action](https://user-images.githubusercontent.com/2581944/212336409-337c432d-ba5e-40ad-8921-a7d59987994c.gif)
