### PR TITLE
Fix live build log after bootstrap 5 migration

### DIFF
--- a/src/api/app/assets/stylesheets/webui/application.scss
+++ b/src/api/app/assets/stylesheets/webui/application.scss
@@ -16,6 +16,7 @@
 @import 'bootstrap_variables/spacers';
 @import 'bootstrap_variables/fonts';
 @import 'bootstrap_variables/sizes';
+@import 'bootstrap_variables/options';
 @import 'bootstrap';
 @import 'bootstrap-modal';
 @import 'font-awesome';

--- a/src/api/app/assets/stylesheets/webui/bootstrap_variables/options.scss
+++ b/src/api/app/assets/stylesheets/webui/bootstrap_variables/options.scss
@@ -1,0 +1,1 @@
+$enable-smooth-scroll: false;

--- a/src/api/app/views/webui/package/live_build_log.html.haml
+++ b/src/api/app/views/webui/package/live_build_log.html.haml
@@ -25,18 +25,18 @@
     #log-space-wrapper{ data: { url: package_update_build_log_path(package: @package_name, project: @project,
                                                                    status: @status, arch: @arch, repository: @repo) } }
       .d-block.text-center.shadow-sm.position-sticky.w-100#log-info
-        .running.stop_refresh.py-2.alert-info
+        .running.stop_refresh.py-2.text-bg-info
           %i.fas.fa-spinner.fa-pulse
           Running...
-        .paused.start_refresh.py-2.alert-dark
+        .paused.start_refresh.py-2.text-bg-dark
           %i.far.fa-pause-circle
           Paused
-        .finished.py-2.alert-warning
+        .finished.py-2.text-bg-warning
           Build #{@status}
-        .succeeded.py-2.alert-success
+        .succeeded.py-2.text-bg-success
           %i.fa.fa-check-circle
           Build succeeded
-        .failed.py-2.alert-danger
+        .failed.py-2.text-bg-danger
           %i.fa.fa-times-circle
           Build failed
       %pre.p-4.bg-light.text-pre-wrap#log-space


### PR DESCRIPTION
This fixes #13689, as well as lacking background in live build log header
![Screenshot from 2023-01-13 09-14-12](https://user-images.githubusercontent.com/114928900/212271030-0380e758-faf1-458f-94b9-09a88c7d23b3.png)
