### PR TITLE
Fix auto-accept badge for requests

### DIFF
--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -34,7 +34,7 @@
             by
             = link_to(@bs_request.superseded_by, number: @bs_request.superseded_by)
         - if @bs_request.accept_at.present?
-          %span.badge.alert-warning.ms-1 auto-accept
+          %span.badge.alert.alert-warning.border-0.ms-1.mb-0.p-2 auto-accept
         - if User.session
           .d-inline.align-bottom.ms-2#watchlist-icon-wrapper
             = render WatchlistIconComponent.new(user: User.session!, bs_request: @bs_request, current_object: @bs_request)


### PR DESCRIPTION
After the upgrade to Bootstrap 5, the `auto-accept` badge was not visible (white on top of white).

![Screenshot 2023-01-13 at 11-37-59 Open Build Service](https://user-images.githubusercontent.com/2581944/212306081-635093e7-9248-46ec-81e2-9a9fa38c23b1.png)

Now we use the classes needed to make it look like a badge but with the alert colors.

![Screenshot 2023-01-13 at 11-37-24 Open Build Service](https://user-images.githubusercontent.com/2581944/212306107-3935e7ee-e32d-4714-80d5-7f5aac236507.png)
