### PR TITLE
Don't underline urls

### DIFF
--- a/src/api/app/assets/stylesheets/webui/links.scss
+++ b/src/api/app/assets/stylesheets/webui/links.scss
@@ -1,4 +1,6 @@
 a {
+  text-decoration: none;
+
   &:hover {
     i.fa, i.fas, i.fal {
       filter: brightness(0.7);


### PR DESCRIPTION
For consistency with how it used to be prior to the move to Bootstrap 5.