### PR TITLE
Mark bs_request_action as seen by user

### DIFF
--- a/src/api/app/components/action_seen_by_user_component.html.haml
+++ b/src/api/app/components/action_seen_by_user_component.html.haml
@@ -1,0 +1,12 @@
+- button_text = 'Action seen'
+
+= link_to(toggle_request_path(action_id: @action.id),
+    class: 'btn btn-sm btn-outline-info',
+    title: 'Wether the action has been marked "as seen" or not yet',
+    method: :put, remote: true,
+    'data-disable-with': tag.i(class: 'fa-solid fa-spinner fa-spin') + button_text) do
+  - if seen_by_user
+    %i.fa-solid.fa-square-check
+  - else
+    %i.fa-regular.fa-square
+  = button_text

--- a/src/api/app/components/action_seen_by_user_component.html.haml
+++ b/src/api/app/components/action_seen_by_user_component.html.haml
@@ -1,12 +1,13 @@
-- button_text = 'Action seen'
+- if @render_only
+  = render_icon_status
 
-= link_to(toggle_request_path(action_id: @action.id),
-    class: 'btn btn-sm btn-outline-info',
-    title: 'Wether the action has been marked "as seen" or not yet',
-    method: :put, remote: true,
-    'data-disable-with': tag.i(class: 'fa-solid fa-spinner fa-spin') + button_text) do
-  - if seen_by_user
-    %i.fa-solid.fa-square-check
-  - else
-    %i.fa-regular.fa-square
-  = button_text
+- else
+  - button_text = 'Action seen'
+
+  = link_to(toggle_request_path(action_id: @action.id),
+      class: 'btn btn-sm btn-outline-info',
+      title: 'Whether the action has been marked "as seen" or not yet',
+      method: :put, remote: true,
+      'data-disable-with': tag.i(class: 'fa-solid fa-spinner fa-spin') + button_text) do
+    = render_icon_status
+    = button_text

--- a/src/api/app/components/action_seen_by_user_component.rb
+++ b/src/api/app/components/action_seen_by_user_component.rb
@@ -1,0 +1,12 @@
+class ActionSeenByUserComponent < ApplicationComponent
+  def initialize(action:, user:)
+    super
+
+    @action = action
+    @user = user
+  end
+
+  def seen_by_user
+    @action.seen_by_users.exists?({ id: @user.id })
+  end
+end

--- a/src/api/app/components/action_seen_by_user_component.rb
+++ b/src/api/app/components/action_seen_by_user_component.rb
@@ -1,12 +1,21 @@
 class ActionSeenByUserComponent < ApplicationComponent
-  def initialize(action:, user:)
+  def initialize(action:, user:, render_only: false)
     super
 
     @action = action
     @user = user
+    @render_only = render_only
   end
 
   def seen_by_user
     @action.seen_by_users.exists?({ id: @user.id })
+  end
+
+  def render_icon_status
+    if seen_by_user
+      tag.i(nil, class: 'fa-regular fa-square-check')
+    else
+      tag.i(nil, class: 'fa-regular fa-square')
+    end
   end
 end

--- a/src/api/app/controllers/webui/action_seen_by_users_controller.rb
+++ b/src/api/app/controllers/webui/action_seen_by_users_controller.rb
@@ -1,0 +1,14 @@
+class Webui::ActionSeenByUsersController < Webui::WebuiController
+  before_action :require_login
+
+  def toggle
+    @action = BsRequestAction.find(params[:action_id])
+    @user = User.session
+
+    @action.toggle_seen_by(@user)
+
+    respond_to do |format|
+      format.js
+    end
+  end
+end

--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -16,6 +16,8 @@ class BsRequestAction < ApplicationRecord
   belongs_to :target_package_object, class_name: 'Package', foreign_key: 'target_package_id', optional: true
   belongs_to :target_project_object, class_name: 'Project', foreign_key: 'target_project_id', optional: true
 
+  has_and_belongs_to_many :seen_by_users, class_name: 'User', join_table: :bs_request_actions_seen_by_users
+
   scope :bs_request_ids_of_involved_projects, ->(project_ids) { where(target_project_id: project_ids).select(:bs_request_id) }
   scope :bs_request_ids_of_involved_packages, ->(package_ids) { where(target_package_id: package_ids).select(:bs_request_id) }
   scope :bs_request_ids_by_source_projects, ->(project_name) { where(source_project: project_name).select(:bs_request_id) }

--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -838,7 +838,7 @@ class BsRequestAction < ApplicationRecord
   end
 
   def toggle_seen_by(user)
-    return unless user
+    return unless user.is_a?(User)
 
     if seen_by_users.exists?({ id: user.id })
       seen_by_users.destroy(user)

--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -837,6 +837,16 @@ class BsRequestAction < ApplicationRecord
     package.commit(source_rev) || package.commit
   end
 
+  def toggle_seen_by(user)
+    return unless user
+
+    if seen_by_users.exists?({ id: user.id })
+      seen_by_users.destroy(user)
+    else
+      seen_by_users << user
+    end
+  end
+
   private
 
   def cache_diffs

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -45,6 +45,9 @@ class User < ApplicationRecord
   has_and_belongs_to_many :groups, -> { distinct }
   # users have a n:m relation to roles
   has_and_belongs_to_many :roles, -> { distinct }
+
+  has_and_belongs_to_many :bs_request_actions_seen, class_name: 'BsRequestAction', join_table: :bs_request_actions_seen_by_users
+
   # users have 0..1 user_registration records assigned to them
   has_one :user_registration
 

--- a/src/api/app/views/webui/action_seen_by_users/toggle.js.erb
+++ b/src/api/app/views/webui/action_seen_by_users/toggle.js.erb
@@ -1,1 +1,7 @@
-$('#action-seen-by-user-wrapper').html("<%= escape_javascript(render ActionSeenByUserComponent.new(action: @action, user: @user)) %>");
+$('#action-seen-by-user-wrapper').html(
+  "<%= escape_javascript(render ActionSeenByUserComponent.new(action: @action, user: @user)) %>"
+);
+
+$('#action-seen-by-user-wrapper-in-select-<%= @action.id %>').html(
+  "<%= escape_javascript(render ActionSeenByUserComponent.new(action: @action, user: @user, render_only: true)) %>"
+);

--- a/src/api/app/views/webui/action_seen_by_users/toggle.js.erb
+++ b/src/api/app/views/webui/action_seen_by_users/toggle.js.erb
@@ -1,0 +1,1 @@
+$('#action-seen-by-user-wrapper').html("<%= escape_javascript(render ActionSeenByUserComponent.new(action: @action, user: @user)) %>");

--- a/src/api/app/views/webui/request/_action_text.html.haml
+++ b/src/api/app/views/webui/request/_action_text.html.haml
@@ -1,31 +1,37 @@
-- details = action.commit_details
-- if details
-  - if details.key?('comment')
-    %p.mt-0.mb-0.fw-normal
-      %span.me-2 ##{action_index + 1}
-      = details['comment'].truncate(50)
-    %p.mb-0.mt-0.small
-      = action.name
-  - else
-    %p.mt-0.mb-0.fw-normal
-      %span.me-2 ##{action_index + 1}
-      = action.name
-  %span.float-end.ms-5
-    = details['rev']
-- else
-  %p.mt-0.mb-0.fw-normal
-    %span.me-2 ##{action_index + 1}
-    = action.name
--# add_role, delete and set_bugowner are actions on the target repo, so they don't need to mention where they are coming from
-- unless %w[add_role delete set_bugowner].include?(action.type)
-  %p.mb-0.mt-0.small
-    from
-    = action.source_project
-    - if action.source_package
-      \/
-      = action.source_package
-- if details
-  %p.mb-0.mt-0.small
-    by
-    = details['user']
-    #{ApplicationController.helpers.time_ago_in_words(details['time'].to_i)} ago
+.d-flex.align-items-center
+  - if (user = User.session)
+    .ms-1.me-3{ id: "action-seen-by-user-wrapper-in-select-#{action.id}" }
+      = render ActionSeenByUserComponent.new(action: action, user: user, render_only: true)
+
+  .d-block
+    - details = action.commit_details
+    - if details
+      - if details.key?('comment')
+        %p.mt-0.mb-0.fw-normal
+          %span.me-2 ##{action_index + 1}
+          = details['comment'].truncate(50)
+        %p.mb-0.mt-0.small
+          = action.name
+      - else
+        %p.mt-0.mb-0.fw-normal
+          %span.me-2 ##{action_index + 1}
+          = action.name
+      %span.float-end.ms-5
+        = details['rev']
+    - else
+      %p.mt-0.mb-0.fw-normal
+        %span.me-2 ##{action_index + 1}
+        = action.name
+    -# add_role, delete and set_bugowner are actions on the target repo, so they don't need to mention where they are coming from
+    - unless %w[add_role delete set_bugowner].include?(action.type)
+      %p.mb-0.mt-0.small
+        from
+        = action.source_project
+        - if action.source_package
+          \/
+          = action.source_package
+    - if details
+      %p.mb-0.mt-0.small
+        by
+        = details['user']
+        #{ApplicationController.helpers.time_ago_in_words(details['time'].to_i)} ago

--- a/src/api/app/views/webui/request/_actions_details.html.haml
+++ b/src/api/app/views/webui/request/_actions_details.html.haml
@@ -25,11 +25,16 @@
                                                       'aria-current': 'true')
 %p
   - if submit_actions_count > 1
+    - if User.session
+      .d-inline#action-seen-by-user-wrapper
+        = render ActionSeenByUserComponent.new(action: active_action, user: User.session!)
+
     - active_action_index = submit_actions.find_index(active_action) + 1
-    Showing
-    %em action ##{active_action_index}
-    \-
-  %span.font-italic= request_action_header(action, bs_request.creator)
+    %span.ms-2.align-middle
+      Showing
+      %em action ##{active_action_index}
+      \-
+  %span.font-italic.align-middle= request_action_header(action, bs_request.creator)
 
 - content_for :ready_function do
   :plain

--- a/src/api/app/views/webui/request/_actions_details.html.haml
+++ b/src/api/app/views/webui/request/_actions_details.html.haml
@@ -12,6 +12,8 @@
       %ul.dropdown-menu.dropdown-menu-start.scrollable-dropdown
         %li
           %h6.dropdown-header
+            - if User.session
+              %span Seen
             %span Action
             %span.float-end Revision
         - submit_actions.each_with_index do |action_item, action_index|

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -302,6 +302,7 @@ OBSApi::Application.routes.draw do
     resources :requests, only: [], param: :number, controller: 'webui/bs_requests' do
       member do
         put :toggle_watched_item, controller: 'webui/watched_items'
+        put :toggle, controller: 'webui/action_seen_by_users'
       end
     end
 

--- a/src/api/db/migrate/20230116143207_create_bs_request_actions_seen_by_users.rb
+++ b/src/api/db/migrate/20230116143207_create_bs_request_actions_seen_by_users.rb
@@ -1,0 +1,7 @@
+class CreateBsRequestActionsSeenByUsers < ActiveRecord::Migration[7.0]
+  def change
+    create_join_table :bs_request_actions, :users, table_name: :bs_request_actions_seen_by_users do |t|
+      t.index [:bs_request_action_id, :user_id], name: :bs_request_actions_seen_by_users_index
+    end
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_09_131251) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_16_143207) do
   create_table "architectures", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false, collation: "utf8mb3_general_ci"
     t.boolean "available", default: false
@@ -188,6 +188,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_09_131251) do
     t.index ["target_package_id"], name: "index_bs_request_actions_on_target_package_id"
     t.index ["target_project"], name: "index_bs_request_actions_on_target_project"
     t.index ["target_project_id"], name: "index_bs_request_actions_on_target_project_id"
+  end
+
+  create_table "bs_request_actions_seen_by_users", id: false, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "bs_request_action_id", null: false
+    t.bigint "user_id", null: false
+    t.index ["bs_request_action_id", "user_id"], name: "bs_request_actions_seen_by_users_index"
   end
 
   create_table "bs_request_counter", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|

--- a/src/api/spec/models/bs_request_action_spec.rb
+++ b/src/api/spec/models/bs_request_action_spec.rb
@@ -396,4 +396,39 @@ RSpec.describe BsRequestAction do
       end
     end
   end
+
+  describe '#toggle_seen_by' do
+    let(:bs_request) { create(:bs_request_with_submit_action, creator: user) }
+    let(:bs_request_action) { bs_request.bs_request_actions.first }
+
+    subject do
+      bs_request_action.toggle_seen_by(user)
+      bs_request_action.seen_by_users
+    end
+
+    context 'mark the action as seen by the user' do
+      it 'adds the user to the seen_by_users association' do
+        expect(subject).to include(user)
+      end
+    end
+
+    context 'mark the action as not seen by the user' do
+      before do
+        # prepare the data with the association
+        bs_request_action.seen_by_users << user
+      end
+
+      it 'removes the user from the seen_by_users association' do
+        expect(subject).not_to include(user)
+      end
+    end
+
+    context 'mark the action as seen by a nil user' do
+      before do
+        bs_request_action.toggle_seen_by(nil)
+      end
+
+      it { expect(bs_request_action.seen_by_users).not_to include(user) }
+    end
+  end
 end


### PR DESCRIPTION
https://trello.com/c/OVu6ybaT

Let the user mark an action request as seen or not in order to be able to not load it back if he already viewed it.

![action-as-seen-in-select-checkbox-improved](https://user-images.githubusercontent.com/7080830/214000396-b303db1d-c36d-4adc-adb5-16a0d57d4560.gif)
