### PR TITLE
Fix overflow in revision diff view

### DIFF
--- a/src/api/app/views/webui/package/_revision_diff_detail.html.haml
+++ b/src/api/app/views/webui/package/_revision_diff_detail.html.haml
@@ -36,7 +36,7 @@
         = render_diff(diff_content, file_index: index)
   - else
     .card{ id: "revision_details_#{index}" }
-      .card-header
+      .card-header.py-3
         .div.w-75
           = calculate_filename(filename, file)
           %span.badge{ class: "badge-#{file['state']}" }= file['state'].capitalize


### PR DESCRIPTION
Aftermath from bs5 migration
|Before|After|
|:---|:---|
|![Screenshot from 2023-01-17 13-25-53](https://user-images.githubusercontent.com/114928900/212898953-7413e351-ce62-47d7-8061-4b71fe8404c3.png)|![Screenshot from 2023-01-17 13-26-17](https://user-images.githubusercontent.com/114928900/212898960-da6823bf-31cd-4696-930f-01ee086f20e2.png)|

This happens with files that don't have a diff, like binaries