### PR TITLE
Make index of the diff fit within the column

### DIFF
--- a/src/api/app/assets/stylesheets/webui/diff.scss
+++ b/src/api/app/assets/stylesheets/webui/diff.scss
@@ -11,6 +11,13 @@
 }
 
 .pre.scroll {
+  --line-index-digits: 6ch;
+  @for $i from 1 through 10 {
+    .digits-#{$i} {
+      --line-index-digits: #{$i}ch;
+    }
+    
+  }
   overflow: auto;
   border-bottom-left-radius: calc(#{$card-border-radius} - #{$card-border-width});
   border-bottom-right-radius: calc(#{$card-border-radius} - #{$card-border-width});
@@ -31,7 +38,8 @@
         left: 0;
         .number {
           color: $text-muted;
-          width: 4rem;
+          font-family: monospace;
+          width: calc(var(--line-index-digits) + 2rem + #{$card-border-width});
           text-align: right;
           padding: 0 1rem;
           border-right: $card-border-width solid $card-border-color;
@@ -49,7 +57,8 @@
         border-bottom: $card-border-width solid $card-border-color;
         border-top: $card-border-width solid $card-border-color;
         .offset {
-          padding-left: calc(8rem - #{$card-border-width});
+          font-family: monospace;
+          padding-left: calc(4rem + (2 * var(--line-index-digits)) + #{$card-border-width});
           position: sticky;
           left: 0;
           .text {

--- a/src/api/app/views/webui/package/_revision_diff_detail.html.haml
+++ b/src/api/app/views/webui/package/_revision_diff_detail.html.haml
@@ -11,8 +11,12 @@
       -# TODO: Remove this `if` condition, and the `else` clause once request_show_redesign is rolled out
       - if Flipper.enabled?(:request_show_redesign, User.session)
         .pre.scroll
-          .diff>
-            - diff_parsed_lines = file.dig('diff', 'parsed_lines')
+          :ruby
+            diff_parsed_lines = file.dig('diff', 'parsed_lines') || []
+            last_line = diff_parsed_lines.reverse.find { |l| l.original_index || l.changed_index }
+            max_index = [last_line.original_index, last_line.changed_index].compact.max if last_line
+            index_width = max_index&.digits&.count || 6
+          .diff{ class: "digits-#{index_width}" }>
             - diff_parsed_lines&.each do |line|
               - id = "diff_#{index}_n#{line.index}"
               %div{ class: "line #{line.state}", id: }>


### PR DESCRIPTION
This could technically support any number of digits, but I didn't want to use `style` in haml, to use the exact number, so this PR only supports up to 10 digits. That should be more than enough for most cases.
|Before|After|
|:---|:---|
|![Screenshot from 2023-01-18 15-35-33](https://user-images.githubusercontent.com/114928900/213199462-ec6d7e58-44a5-4b1f-9b81-57bc9067d7b7.png)|![Screenshot from 2023-01-18 15-36-21](https://user-images.githubusercontent.com/114928900/213199467-3d372d56-43b2-4893-a114-6f4076a171f2.png)|