### PR TITLE
Restrict .alert-* classes to alert elements

### DIFF
--- a/src/api/app/assets/stylesheets/webui/flash.scss
+++ b/src/api/app/assets/stylesheets/webui/flash.scss
@@ -6,34 +6,36 @@
   }
 }
 
-.alert-success i.fas {
-  @extend .fa-check-circle;
-}
-
-.alert-error {
-  @extend .alert-danger;
-
-  i.fas {
-    @extend .fa-exclamation-circle;
+.alert {
+  &.alert-success i.fas {
+    @extend .fa-check-circle;
   }
-}
 
-.alert-alert {
-  @extend .alert-warning;
+  &.alert-error {
+    @extend .alert-danger;
 
-  i.fas {
-    @extend .fa-exclamation-triangle;
+    i.fas {
+      @extend .fa-exclamation-circle;
+    }
   }
-}
 
-.alert-notice {
-  @extend .alert-info;
+  &.alert-alert {
+    @extend .alert-warning;
 
-  i.fas {
-    @extend .fa-info-circle;
+    i.fas {
+      @extend .fa-exclamation-triangle;
+    }
   }
-}
 
-.alert-dismissible {
-  padding-right: 3rem;
+  &.alert-notice {
+    @extend .alert-info;
+
+    i.fas {
+      @extend .fa-info-circle;
+    }
+  }
+
+  &.alert-dismissible {
+    padding-right: 3rem;
+  }
 }


### PR DESCRIPTION
Those classes are sometimes extending rules (like with `@extend .alert-warning`) and the rules from `flash.scss` affect those extended rules. This should only be the case for alert elements, which is what we have now with this PR.

Nothing changes visually for the flash messages.