### PR TITLE
Parse diffs also in Files Changed between revisions

### DIFF
--- a/src/api/app/components/sourcediff_component.rb
+++ b/src/api/app/components/sourcediff_component.rb
@@ -12,7 +12,7 @@ class SourcediffComponent < ApplicationComponent
     @index = index
     @refresh = refresh
 
-    ActionSourcediffParser.new(action_sourcediff: action[:sourcediff]).call
+    SourcediffsParser.new(sourcediffs: action[:sourcediff]).call
   end
 
   def file_view_path(filename, sourcediff)

--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -299,6 +299,8 @@ class Webui::PackageController < Webui::WebuiController
     @not_full_diff = @files.any? { |file| file[1]['diff'].try(:[], 'shown') }
     @filenames = filenames['filenames']
 
+    SourcediffsParser.new(sourcediffs: [filenames]).call if Flipper.enabled?(:request_show_redesign, User.session)
+
     # FIXME: moved from the old view, needs refactoring
     @submit_url_opts = {}
     if @oproject && @opackage && !@oproject.find_attribute('OBS', 'RejectRequests') && !@opackage.find_attribute('OBS', 'RejectRequests')

--- a/src/api/app/services/sourcediffs_parser.rb
+++ b/src/api/app/services/sourcediffs_parser.rb
@@ -1,10 +1,10 @@
-class ActionSourcediffParser
-  def initialize(action_sourcediff:)
-    @action_sourcediff = action_sourcediff
+class SourcediffsParser
+  def initialize(sourcediffs:)
+    @sourcediffs = sourcediffs
   end
 
   def call
-    @action_sourcediff&.each do |sourcediff|
+    @sourcediffs&.each do |sourcediff|
       sourcediff['filenames']&.each do |filename|
         content = sourcediff['files'][filename].dig('diff', '_content')
 


### PR DESCRIPTION
This change was missing when the parser for request diffs was introduced in #13684.

Co-authored-by: Saray Cabrera Padrón <scabrerapadron@suse.de>