### PR TITLE
Show old file name for renamed files in diffs

### DIFF
--- a/src/api/app/helpers/webui/request_helper.rb
+++ b/src/api/app/helpers/webui/request_helper.rb
@@ -97,7 +97,7 @@ module Webui::RequestHelper
   end
 
   def calculate_filename(filename, file_element)
-    return filename unless file_element['state'] == 'changed'
+    return filename unless ['changed', 'renamed'].include?(file_element['state'])
     return filename if file_element['old']['name'] == filename
 
     "#{file_element['old']['name']} -> #{filename}"

--- a/src/api/spec/helpers/webui/request_helper_spec.rb
+++ b/src/api/spec/helpers/webui/request_helper_spec.rb
@@ -70,6 +70,15 @@ RSpec.describe Webui::RequestHelper do
       it { expect(calculate_filename(filename, file_element)).to eq(filename) }
       it { expect(calculate_filename(new_filename, file_element)).to eq("#{filename} -> #{new_filename}") }
     end
+
+    context 'for renamed files' do
+      let(:file_element) do
+        { state: 'renamed', old: { name: filename } }.with_indifferent_access
+      end
+      let(:new_filename) { 'apache3' }
+
+      it { expect(calculate_filename(new_filename, file_element)).to eq("#{filename} -> #{new_filename}") }
+    end
   end
 
   context 'source diffs' do


### PR DESCRIPTION
After working in #13720, it showed up that rendering the file name for renamed files in diffs was missing or not rendered correctly: the old file name was missing.

This fix applies for both, beta program and non-beta.

**Before:**

![Screenshot from 2023-01-18 10-09-44](https://user-images.githubusercontent.com/24919/213130055-84e812d3-988f-4581-bc20-72fb2696440f.png)

**After:**

![Screenshot from 2023-01-18 10-09-10](https://user-images.githubusercontent.com/24919/213130099-a4979b49-9d06-4ac7-94ec-a3343728f1b6.png)

The issue with the badge style will be fixed as soon as #13720 is merged.