### PR TITLE
Create a request with multi submit actions, builds and diffs

### DIFF
--- a/src/api/lib/tasks/dev.rake
+++ b/src/api/lib/tasks/dev.rake
@@ -232,7 +232,7 @@ namespace :dev do
       Rake::Task['dev:requests:multiple_actions_request'].invoke
 
       # Create a request with multiple submit actions and diffs
-      Rake::Task['dev:requests:request_with_multiple_submit_actions_and_diffs'].invoke
+      Rake::Task['dev:requests:request_with_multiple_submit_actions_builds_and_diffs'].invoke
 
       # Create news
       Rake::Task['dev:news:data'].invoke


### PR DESCRIPTION
Changed the existing rake task to create a request with multiple submit requests. Those submit requests come from home:Iggy's packages, that push a sample spec to the backend so they build successfully and produce a diff.

For review purposes I added Leap 15.4 under [home:Iggy](https://obs-reviewlab.opensuse.org/danidoni-multi-action-submit-request-with-build-rpmlint-and-diffs-rake-task/project/show/home:Iggy) to kickstart the building process, you can review the sample request [here](https://obs-reviewlab.opensuse.org/danidoni-multi-action-submit-request-with-build-rpmlint-and-diffs-rake-task/request/show/10).

**How to test?**

I recommend starting from a clean backend and database, so

```
 docker-compose stop; docker-compose rm db backend; rake docker:build; docker-compose up
 ```
 
 and run the `test_data` task from the container afterwards
 
 ```
 bundle exec rake dev:test_data:create
 ```
 
The output will give you the request number.
Open that request in your browser and play around with the `Select Action` dropdown, the `Changes` tab, and the `Builds` tab (add repositories first and check after a while).