### PR TITLE
Write issue trackers to backend after seeding them

### DIFF
--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -498,6 +498,7 @@ class Package < ApplicationRecord
   end
 
   def parse_issues_xml(query, force_state = nil)
+    # The issue trackers should have been written to the backend before this point (IssueTrackerWriteToBackendJob)
     begin
       answer = Backend::Connection.post(source_path(nil, query))
     rescue Backend::Error => e


### PR DESCRIPTION
If the issue trackers are not written to the backend, the issues will never be parsed from the changes files or patchinfos.

The  [IssueTrackerWriteToBackendJob](https://github.com/openSUSE/open-build-service/blob/master/src/api/app/jobs/issue_tracker_write_to_backend_job.rb) is in charge of populating the backend with issue trackers from the database. The job is called in an `IssueTracker` `after_save` [callback](https://github.com/openSUSE/open-build-service/blob/12fdb5db6e3fc67c7d83c2cf804c810552a97f8a/src/api/app/models/issue_tracker.rb#L16).

In the development environment, the Issue Trackers are seeded into the database, so there is no callback and the job is never called. That's why we have to call it manually after seeding the database.

Co-authored-by: Eduardo Navarro <enavarro@suse.com>

**How to test?**

I recommend starting from a clean backend and database, so

```
 docker-compose stop; docker-compose rm db backend; rake docker:build; docker-compose up
 ```
 and run the `test_data` task form the container afterwards
 
 ```
 bundle exec rake dev:test_data:create
 ```
 
 then submit a request that tries to add a `x.changes` file that includes some issues `bsc#1111111`, `CVE-2012-1234` etc.
 
 That request should have content in the `Mentioned Issues` tab.