### PR TITLE
Correctly check for the current page in request breadcrumbs

### DIFF
--- a/src/api/app/views/webui/request/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui/request/_breadcrumb_items.html.haml
@@ -1,3 +1,3 @@
-- if current_page?(request_show_path)
+- if current_page?(controller: 'webui/request', action: 'show', request_action_id: params[:request_action_id])
   %li.breadcrumb-item.active{ 'aria-current' => 'page' }
     Request #{@bs_request.number}


### PR DESCRIPTION
Previously, it would only match on URLs like `/request/show/14`, but not on `/request/show/14/request_action/26`. The second URL example is what we get whenever selecting an action in the `Select Action` dropdown of the request#show page with the `request_show_redesign` feature toggle.

Now, breadcrumbs are displayed for both URLs.