### PR TITLE
[api] support search for release project in requests

### DIFF
--- a/src/api/lib/xpath_engine.rb
+++ b/src/api/lib/xpath_engine.rb
@@ -212,6 +212,7 @@ class XpathEngine
         'action/target/@package' => { cpart: 'a.target_package', joins: 'LEFT JOIN bs_request_actions a ON a.bs_request_id = bs_requests.id' },
         'action/source/@project' => { cpart: 'a.source_project', joins: 'LEFT JOIN bs_request_actions a ON a.bs_request_id = bs_requests.id' },
         'action/source/@package' => { cpart: 'a.source_package', joins: 'LEFT JOIN bs_request_actions a ON a.bs_request_id = bs_requests.id' },
+        'target/@releaseproject' => { cpart: 'a.target_releaseproject', joins: 'LEFT JOIN bs_request_actions a ON a.bs_request_id = bs_requests.id' },
         # osc is doing these 4 kinds of searches during submit
         'target/@project' => { cpart: 'a.target_project', joins: 'LEFT JOIN bs_request_actions a ON a.bs_request_id = bs_requests.id' },
         'target/@package' => { cpart: 'a.target_package', joins: 'LEFT JOIN bs_request_actions a ON a.bs_request_id = bs_requests.id' },

--- a/src/api/test/functional/search_controller_test.rb
+++ b/src/api/test/functional/search_controller_test.rb
@@ -332,6 +332,10 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     get '/search/request', params: { match: "state/@name='review' and review[@by_group='maintenance-team' and @state='new']" }
     assert_response :success
 
+    # osc supersede check for maintenance requests
+    get '/search/request', params: { match: "(target/@releaseproject='Apache' and action/@type='maintenance_incident')" }
+    assert_response :success
+
     get '/search/request', params: { match: "(action/target/@project='Apache' and action/@type='submit' and state/@name='review' ) or (action/target/@project='Apache' and action/@type='maintenance_release' and state/@name='review' )" }
     assert_response :success
     assert_xml_tag tag: 'collection', attributes: { 'matches' => '1' }


### PR DESCRIPTION
Required for osc supersede check, this patch/submission seem to have lost in last two years somewhere.