### PR TITLE
Clarify Accept header for API requests

### DIFF
--- a/src/api/public/apidocs-new/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs-new/OBS-v2.10.50.yaml
@@ -51,7 +51,7 @@ tags:
 
 info:
   description: |
-    The _Open Build Service API_ is an XML API.
+    The _Open Build Service API_ is an XML API. To make sure you are querying the API and not the Web User Interface, provide the `Accept: application/xml; charset=utf-8` header in your API requests.
 
     To authenticate, use [HTTP basic authentication](https://en.wikipedia.org/wiki/Basic_access_authentication) by passing the _Authorization_ header in the form of `Authorization: Basic <credentials>`.
 


### PR DESCRIPTION
Make it clearer in the description of the API that clients must provide the xml accept header. Otherwise they could access the Web user interface.

### For reviewers
Access the new API documentation page in the review-app through [this link](http://obs-reviewlab.opensuse.org/eduardoj-apidocs_newclarify_xml_headers/apidocs-new/). 