### PR TITLE
Remove redundant logger method

### DIFF
--- a/src/api/app/models/branch_package.rb
+++ b/src/api/app/models/branch_package.rb
@@ -35,10 +35,6 @@ class BranchPackage
     @update_path_elements = true
   end
 
-  def logger
-    Rails.logger
-  end
-
   def branch
     #
     # 1) BaseProject <-- 2) UpdateProject <-- 3) DevelProject/Package

--- a/src/api/test/test_helper.rb
+++ b/src/api/test/test_helper.rb
@@ -107,6 +107,10 @@ def inject_build_job(project, package, repo, arch, extrabinary = nil)
   system("echo \"#{verifymd5}  #{package}\" > #{jobfile}:dir/meta")
 end
 
+def logger
+  Rails.logger
+end
+
 module Minitest
   def self.__run(reporter, options)
     # there is no way to avoid the randomization of used suites, so we overload this method.


### PR DESCRIPTION
The logger method can be called from any model. There is no need to redefine it in a model.

From the [official guide](https://guides.rubyonrails.org/debugging_rails_applications.html#sending-messages):

_To write in the current log use the logger.(debug|info|warn|error|fatal|unknown) method from within a controller, model, or mailer._