### PR TITLE
[backend] fix caching when using with obs_scm_bridge

### DIFF
--- a/src/backend/call-service-in-container
+++ b/src/backend/call-service-in-container
@@ -176,7 +176,7 @@ CONTAINER_VOLUMES="-v $OUTEROUTDIR:$INNEROUTDIR -v $OUTERSRCDIR:$INNERSRCDIR -v 
 JAILED=""
 
 if [ $SCM_COMMAND -eq 1 ];then
-  URL_HASH=`echo $PARAM_URL|sha256sum|cut -f1 -d\ `
+  URL_HASH=`echo ${PARAM_URL%\?*}|sha256sum|cut -f1 -d\ `
   OUTERSCMCACHE="$SERVICES_DIR/scm-cache/$URL_HASH"
   INNERSCMCACHE="$INNERBASEDIR/scm-cache"
   create_dir "$OUTERSCMCACHE"


### PR DESCRIPTION
It is always the same cache independ of any used subdir cgi parameter