### PR TITLE
Don't use uninitialized values

### DIFF
--- a/src/backend/BSSched/Remote.pm
+++ b/src/backend/BSSched/Remote.pm
@@ -93,16 +93,17 @@ sub setup_watches {
       next if $projpacks->{$projid} && !$projpacks->{$projid}->{'remoteurl'};
       my $rproj = remoteprojid($gctx, $projid);
       next unless $rproj;			# not remote, so nothing to watch
-      my $remoteurl = $rproj->{'partition'} ? $BSConfig::srcserver : $rproj->{'remoteurl'};
+      my $remoteurl = $rproj->{'partition'} ? $BSConfig::srcserver : ($rproj->{'remoteurl'} // '');
+      my $rproj_remoteproject = $rproj->{'remoteproject'} // '';
 
       $needremoteproj{$projid} = $rproj if $rproj->{'partition'};	# we need to keep partition entries so we know where to watch
       my %packids = map {$_->{'package'} => 1} @{$projpacks_linked->{$projid}};
       if ($packids{':*'}) {
 	# we watch all packages
-        $watchremote->{$remoteurl}->{"package/$rproj->{'remoteproject'}"} = $projid;
+        $watchremote->{$remoteurl}->{"package/$rproj_remoteproject"} = $projid;
       } else {
         for my $packid (sort keys %packids) {
-          $watchremote->{$remoteurl}->{"package/$rproj->{'remoteproject'}/$packid"} = $projid;
+          $watchremote->{$remoteurl}->{"package/$rproj_remoteproject/$packid"} = $projid;
 	}
       }
     }
@@ -156,17 +157,18 @@ sub setup_watches {
     next if $projpacks->{$projid} && !$projpacks->{$projid}->{'remoteurl'};
     my $rproj = remoteprojid($gctx, $projid);
     next unless $rproj;		# not remote, so nothing to watch
-    my $remoteurl = $rproj->{'partition'} ? $BSConfig::srcserver : $rproj->{'remoteurl'};
+    my $remoteurl = $rproj->{'partition'} ? $BSConfig::srcserver : ($rproj->{'remoteurl'} // '');
+    my $rproj_remoteproject = $rproj->{'remoteproject'} // '';
 
     # we need the config for all path elements, so we also add a project watch
     # XXX: should make this implicit with the repository watch
     $needremoteproj{$projid} = $rproj;	# we need this one in remoteprojs
-    $watchremote->{$remoteurl}->{"project/$rproj->{'remoteproject'}"} = $projid;
+    $watchremote->{$remoteurl}->{"project/$rproj_remoteproject"} = $projid;
 
     # add watches for the repositories
     for my $repoidarch (sort @{$projdeps{$projid}}) {
       $needremoterepo{"$projid/$repoidarch"} = 1;
-      $watchremote->{$remoteurl}->{"repository/$rproj->{'remoteproject'}/$repoidarch"} = $projid;
+      $watchremote->{$remoteurl}->{"repository/$rproj_remoteproject/$repoidarch"} = $projid;
     }
   }
 

--- a/src/backend/BSSrcServer/Remote.pm
+++ b/src/backend/BSSrcServer/Remote.pm
@@ -396,12 +396,14 @@ sub getrev_remote {
     die("collect_remote_getrev\n");
   }
   my $dir;
+  my $proj_remoteurl = $proj->{'remoteurl'} // '';
+  my $proj_remoteproject = $proj->{'remoteproject'} // '';
   eval {
-    $dir = BSRPC::rpc({'uri' => "$proj->{'remoteurl'}/source/$proj->{'remoteproject'}/$packid", 'proxy' => $proj->{'remoteproxy'}}, $BSXML::dir, @args, 'withlinked') if $linked;
+    $dir = BSRPC::rpc({'uri' => "($proj_remoteurl/source/$proj_remoteproject/$packid", 'proxy' => $proj->{'remoteproxy'}}, $BSXML::dir, @args, 'withlinked') if $linked;
   };
   if (!$dir || $@) {
     eval {
-      $dir = BSRPC::rpc({'uri' => "$proj->{'remoteurl'}/source/$proj->{'remoteproject'}/$packid", 'proxy' => $proj->{'remoteproxy'}}, $BSXML::dir, @args);
+      $dir = BSRPC::rpc({'uri' => "$proj_remoteurl/source/$proj_remoteproject/$packid", 'proxy' => $proj->{'remoteproxy'}}, $BSXML::dir, @args);
     };
     if ($@) {
       return {'project' => $projid, 'package' => $packid, 'srcmd5' => $BSSrcrep::emptysrcmd5} if $missingok && $@ =~ /^404[^\d]/;
@@ -439,7 +441,7 @@ sub getrev_remote {
     }
     mkdir_p($uploaddir);
     my $param = {
-      'uri' => "$proj->{'remoteurl'}/source/$proj->{'remoteproject'}/$packid/$entry->{'name'}",
+      'uri' => "$proj_remoteurl/source/$proj_remoteproject/$packid/$entry->{'name'}",
       'filename' => "$uploaddir/$$",
       'withmd5' => 1,
       'receiver' => \&BSHTTP::file_receiver,
@@ -482,7 +484,7 @@ sub getrev_remote {
         last unless $li->{'srcmd5'} && !$li->{'error'};
         my $ldir;
         eval {
-          $ldir = BSRPC::rpc({'uri' => "$proj->{'remoteurl'}/source/$lprojid/$lpackid", 'proxy' => $proj->{'remoteproxy'}}, $BSXML::dir, "rev=$li->{'srcmd5'}");
+          $ldir = BSRPC::rpc({'uri' => "$proj_remoteurl/source/$lprojid/$lpackid", 'proxy' => $proj->{'remoteproxy'}}, $BSXML::dir, "rev=$li->{'srcmd5'}");
         };
         last if $@ || !$ldir;
         $li = $ldir->{'linkinfo'};


### PR DESCRIPTION
Prevent these warnings from happening:

```
Use of uninitialized value in concatenation (.) or string at /obs/src/backend/BSSrcServer/Remote.pm line 386.
Use of uninitialized value in concatenation (.) or string at /obs/src/backend/BSSrcServer/Remote.pm line 390.
Use of uninitialized value $remoteurl in hash element at /obs/src/backend/BSSched/Remote.pm line 104.
Use of uninitialized value in concatenation (.) or string at /obs/src/backend/BSSched/Remote.pm line 104.
Use of uninitialized value $remoteurl in hash element at /obs/src/backend/BSSched/Remote.pm line 163.
Use of uninitialized value in concatenation (.) or string at /obs/src/backend/BSSched/Remote.pm line 163.
Use of uninitialized value $remoteurl in hash element at /obs/src/backend/BSSched/Remote.pm line 168.
Use of uninitialized value in concatenation (.) or string at /obs/src/backend/BSSched/Remote.pm line 168.
```

Follow up to #12739.