### PR TITLE
Rearrange exceptions for xpath parser and search controller

### DIFF
--- a/src/api/app/controllers/search_controller.rb
+++ b/src/api/app/controllers/search_controller.rb
@@ -1,6 +1,10 @@
 class SearchController < ApplicationController
   require 'xpath_engine'
 
+  class IllegalXpathError < APIError
+    setup 'illegal_xpath_error', 400
+  end
+
   def project
     search(:project, true)
   end
@@ -253,5 +257,8 @@ class SearchController < ApplicationController
 
   def find_items(what, predicate)
     XpathEngine.new.find("/#{what}[#{predicate}]")
+  rescue XpathEngine::IllegalXpathError => e
+    raise IllegalXpathError, "Error found searching elements '#{what}' with xpath predicate: '#{predicate}'.\n\n" \
+                             "Detailed error message from parser: #{e.message}"
   end
 end

--- a/src/api/lib/xpath_engine.rb
+++ b/src/api/lib/xpath_engine.rb
@@ -3,9 +3,7 @@
 class XpathEngine
   require 'rexml/parsers/xpathparser'
 
-  class IllegalXpathError < APIError
-    setup 'illegal_xpath_error', 400
-  end
+  class IllegalXpathError < ArgumentError; end
 
   def initialize
     @lexer = REXML::Parsers::XPathParser.new
@@ -254,10 +252,10 @@ class XpathEngine
 
     begin
       @stack = @lexer.parse xpath
-    rescue NoMethodError => e
+    rescue NoMethodError
       # if the input contains a [ in random place, rexml will throw
       #  undefined method `[]' for nil:NilClass
-      raise IllegalXpathError, "failed to parse #{e.inspect}"
+      raise IllegalXpathError, 'failed to parse xpath expression'
     end
     # logger.debug "starting stack: #{@stack.inspect}"
 

--- a/src/api/spec/controllers/search_controller_spec.rb
+++ b/src/api/spec/controllers/search_controller_spec.rb
@@ -88,9 +88,19 @@ RSpec.describe SearchController, vcr: true do
       let(:project) { create(:project, name: 'Foo') }
       let!(:attrib) { create(:maintained_attrib, project: project) }
 
-      subject! { get :project, params: { match: "[attribute/@name='OBS:Maintained']" } }
+      subject! { get :project, params: { match: "attribute/@name='OBS:Maintained'" } }
 
       it_behaves_like 'find project'
+    end
+  end
+
+  describe 'illegal predicates' do
+    it 'shows an error', :aggregate_failures do
+      get :bs_request, params: { match: '(' }, format: :xml
+
+      expect(response).to have_http_status(:bad_request)
+      expect(Nokogiri::XML(response.body).xpath('//status').attribute('code').value).to eq('illegal_xpath_error')
+      expect(Nokogiri::XML(response.body).xpath('//status/summary').inner_text).to match(/Error found searching elements 'request' with xpath predicate: '\('./)
     end
   end
 end


### PR DESCRIPTION
Don't use the APIError exception in the XpathEngine parser. Instead, make the search controller throw an APIError exception when an exception is found in XpathEngine.

Prevent from showing detailed Ruby error messages.

Fixes #13657.

Before:
```sh
> osc api '/search/request?match=('
Server returned an error: HTTP Error 400: Bad Request
failed to parse #<NoMethodError: undefined method `[]' for nil:NilClass

          contents = contents[1..-2]
                             ^^^^^^^>
```
After:
```sh
> osc api '/search/request?match=('
Server returned an error: HTTP Error 400: Bad Request
Error found searching elements 'request' with xpath predicate: '('.

Detailed error message from parser: failed to parse xpath expression
```