### PR TITLE
Answer with a 400 (bad response) instead of crashing

### DIFF
--- a/src/api/lib/xpath_engine.rb
+++ b/src/api/lib/xpath_engine.rb
@@ -256,6 +256,8 @@ class XpathEngine
       # if the input contains a [ in random place, rexml will throw
       #  undefined method `[]' for nil:NilClass
       raise IllegalXpathError, 'failed to parse xpath expression'
+    rescue REXML::ParseException => e
+      raise IllegalXpathError, e.message
     end
     # logger.debug "starting stack: #{@stack.inspect}"
 

--- a/src/api/spec/controllers/search_controller_spec.rb
+++ b/src/api/spec/controllers/search_controller_spec.rb
@@ -95,12 +95,24 @@ RSpec.describe SearchController, vcr: true do
   end
 
   describe 'illegal predicates' do
-    it 'shows an error', :aggregate_failures do
-      get :bs_request, params: { match: '(' }, format: :xml
+    describe 'non closed parenthesis' do
+      it 'shows an error', :aggregate_failures do
+        get :bs_request, params: { match: '(' }, format: :xml
 
-      expect(response).to have_http_status(:bad_request)
-      expect(Nokogiri::XML(response.body).xpath('//status').attribute('code').value).to eq('illegal_xpath_error')
-      expect(Nokogiri::XML(response.body).xpath('//status/summary').inner_text).to match(/Error found searching elements 'request' with xpath predicate: '\('./)
+        expect(response).to have_http_status(:bad_request)
+        expect(Nokogiri::XML(response.body).xpath('//status').attribute('code').value).to eq('illegal_xpath_error')
+        expect(Nokogiri::XML(response.body).xpath('//status/summary').inner_text).to match(/Error found searching elements 'request' with xpath predicate: '\('./)
+      end
+    end
+
+    describe 'closing parenthesis and closing square brackets' do
+      it 'shows an error', :aggregate_failures do
+        get :bs_request, params: { match: ')]' }, format: :xml
+
+        expect(response).to have_http_status(:bad_request)
+        expect(Nokogiri::XML(response.body).xpath('//status').attribute('code').value).to eq('illegal_xpath_error')
+        expect(Nokogiri::XML(response.body).xpath('//status/summary').inner_text).to match(/Error found searching elements 'request' with xpath predicate: '\)\]'./)
+      end
     end
   end
 end


### PR DESCRIPTION
Parsing XPath string can result in exceptions thrown by the XPath parser.

Catch this exception and answer with a 400 error instead of with a 500.

This PR is a follow up to #13785.

Before:
```sh
> osc api '/search/request?match=)]'
Server returned an error: HTTP Error 500: Internal Server Error
```
After:
```sh
> osc api '/search/request?match=)]'
Server returned an error: HTTP Error 400: Bad Request
Error found searching elements 'request' with xpath predicate: ')]'.

Detailed error message from parser: Garbage component exists at the end: <]>: </request[)]]>
```