### PR TITLE
Prevent null bytes in API status messages from throwing an exception

### DIFF
--- a/src/api/app/views/status.xml.builder
+++ b/src/api/app/views/status.xml.builder
@@ -1,5 +1,5 @@
 xml.status('code' => @errorcode) do
-  xml.summary @summary
+  xml.summary @summary.gsub("\u0000", '\u0000')
   if @exception
     xml.exception do
       xml.type(@exception.class.name)

--- a/src/api/spec/controllers/search_controller_spec.rb
+++ b/src/api/spec/controllers/search_controller_spec.rb
@@ -114,5 +114,15 @@ RSpec.describe SearchController, vcr: true do
         expect(Nokogiri::XML(response.body).xpath('//status/summary').inner_text).to match(/Error found searching elements 'request' with xpath predicate: '\)\]'./)
       end
     end
+
+    describe 'invalid predicate with null byte' do
+      it 'shows an error', :aggregate_failures do
+        get :bs_request, params: { match: "/e\u0000" }, format: :xml
+
+        expect(response).to have_http_status(:bad_request)
+        expect(Nokogiri::XML(response.body).xpath('//status').attribute('code').value).to eq('illegal_xpath_error')
+        expect(Nokogiri::XML(response.body).xpath('//status/summary').inner_text).to match(%r{Error found searching elements 'request' with xpath predicate: '/e\\u0000'.})
+      end
+    end
   end
 end


### PR DESCRIPTION
Before, when a null byte had to be shown in an API status message, an exception was thrown. XML doesn't allow rendering null bytes (\u0000).

Now, the string '\u0000' is shown instead, allowing error status messages to be rendered.

This PR is a follow up to #13786.

Before:
```sh
> osc api "/search/request?match=/e%00"
Server returned an error: HTTP Error 500: Internal Server Error
```
After:
```sh
> osc api "/search/request?match=/e%00"
Server returned an error: HTTP Error 400: Bad Request
Error found searching elements 'request' with xpath predicate: '/e\u0000'.

Detailed error message from parser: illegal token X ':document'
```