### PR TITLE
Launch workers with systemd unit templates instead of using screen buffers

### DIFF
--- a/dist/obs_worker_manager
+++ b/dist/obs_worker_manager
@@ -1,0 +1,488 @@
+#! /bin/sh
+
+# Is the worker running on Fedora >= 17 ?
+# It lacks the complete path to build other distros then
+bash_bin=`type -p bash`
+if [ "$bash_bin" != "${bash_bin#/usr}" ]; then
+    export PATH="/bin:$PATH"
+fi
+
+if test -e /etc/sysconfig/proxy; then
+  . /etc/sysconfig/proxy
+  if [ "$PROXY_ENABLED" != "no" ]; then
+    export http_proxy="$HTTP_PROXY"
+    export HTTPS_PROXY
+    export NO_PROXY
+  fi
+fi
+if test -e /etc/sysconfig/obs-server; then
+    # optional on workers
+    . /etc/sysconfig/obs-server
+fi
+# This file may still exist from OBS 2.1 and before.
+if test -e /etc/sysconfig/obs-worker; then
+    . /etc/sysconfig/obs-worker
+fi
+
+# Determine the base and follow a runlevel link name.
+base=${0##*/}
+link=${base#*[SK][0-9][0-9]}
+
+# Preconfigured by obsstoragesetup runlevel setup script
+if [ -f /etc/buildhost.config ];then
+    . /etc/buildhost.config
+fi
+
+if [ -z "$OBS_WORKER_DIRECTORY" ]; then
+    OBS_WORKER_DIRECTORY="/var/cache/obs/worker"
+fi
+mkdir -p "$OBS_WORKER_DIRECTORY"
+
+if [ -z "$OBS_RUN_DIR" ]; then
+    OBS_RUN_DIR="/var/run/obs"
+fi
+if [ -z "$OBS_LOG_DIR" ]; then
+    OBS_LOG_DIR="/srv/obs/log"
+fi
+if [ -z "$OBS_REPO_SERVERS" ]; then
+    OBS_REPO_SERVERS="localhost:5252"
+fi
+
+if [ -n "$OBS_WORKER_TEST_MODE" ]; then
+    OBS_TEST="--test"
+fi
+if [ -n "$OBS_WORKER_JOBS" ]; then
+    OBS_JOBS="--jobs $OBS_WORKER_JOBS"
+fi
+if [ -n "$OBS_WORKER_THREADS" ]; then
+    OBS_THREADS="--threads $OBS_WORKER_THREADS"
+fi
+if [ -n "$OBS_WORKER_NICE_LEVEL" ]; then
+    OBS_NICE=$OBS_WORKER_NICE_LEVEL
+else
+    OBS_NICE=18
+fi
+if [ -n "$OBS_WORKER_CLEANUP_CHROOT" ]; then
+    OBS_CLEANUP_CHROOT="--cleanup-chroot"
+fi
+if [ -n "$OBS_WORKER_WIPE_AFTER_BUILD" ]; then
+    OBS_WIPE_AFTER_BUILD="--wipeafterbuild"
+fi
+if [ -n "$OBS_WORKER_USE_MKFS_COPYIN" ]; then
+    OBS_WORKER_USE_MKFS_COPYIN="--vm-use-mkfs-copyin"
+fi
+
+if [ -n "$OBS_WORKER_SECURITY_LEVEL" ]; then
+    OBS_WORKER_HOSTLABELS="OBS_WORKER_SECURITY_LEVEL_${OBS_WORKER_SECURITY_LEVEL} $OBS_WORKER_HOSTLABELS"
+fi
+
+REPO_PARAM=
+for i in $OBS_REPO_SERVERS; do
+    case $i in
+       http://*|https://*) ;;
+       *) i="http://$i";;
+    esac
+    REPO_PARAM="$REPO_PARAM --reposerver $i"
+    WORKER_CODE="$i"
+done
+
+obsrundir="$OBS_RUN_DIR"         # /var/run/obs
+workerdir="$obsrundir"/worker    # /var/run/obs/worker
+workerbootdir="$workerdir"/boot  # /var/run/obs/worker/boot
+OBS_WORKER_OPT=""
+
+if [ -n "$OBS_CACHE_SIZE" -a -n "$OBS_CACHE_DIR" ]; then
+    OBS_WORKER_OPT="--cachedir $OBS_CACHE_DIR"
+    mkdir -p $OBS_CACHE_DIR
+    OBS_WORKER_OPT="$OBS_WORKER_OPT --cachesize $OBS_CACHE_SIZE"
+fi
+
+if [ -n "$OBS_VM_KERNEL" -a "$OBS_VM_KERNEL" != "none" -a "$OBS_VM_TYPE" != "openstack" ] ; then
+    OBS_WORKER_OPT="$OBS_WORKER_OPT --vm-kernel $OBS_VM_KERNEL"
+fi
+
+if [ -n "$OBS_VM_INITRD" -a "$OBS_VM_INITRD" != "none" ] ; then
+    OBS_WORKER_OPT="$OBS_WORKER_OPT --vm-initrd $OBS_VM_INITRD"
+fi
+
+if [ -n "$OBS_VM_CUSTOM_OPTION" -a "$OBS_VM_CUSTOM_OPTION" != "none" ] ; then
+    OBS_WORKER_OPT="$OBS_WORKER_OPT --vm-custom-option \"$OBS_VM_CUSTOM_OPTION\""
+fi
+
+if [ -n "$OBS_WORKER_LOCALKIWI_DIRECTORY" ]; then
+    OBS_WORKER_OPT="$OBS_WORKER_OPT --localkiwi $OBS_WORKER_LOCALKIWI_DIRECTORY --arch local"
+fi
+
+if [ -n "$OBS_WORKER_BINARIES_PROXY" ]; then
+    OBS_WORKER_OPT="$OBS_WORKER_OPT --getbinariesproxy $OBS_WORKER_BINARIES_PROXY"
+fi
+
+if [ -n "$OBS_VM_ENABLE_CONSOLE" ]; then
+    OBS_WORKER_OPT="$OBS_WORKER_OPT --vm-enable-console"
+fi
+
+[ -z "$OBS_INSTANCE_MEMORY" ] && OBS_INSTANCE_MEMORY=512
+
+vmopt=
+
+ARCH=""
+EMULATOR=""
+if [ -n "$OBS_VM_TYPE" -a "$OBS_VM_TYPE" != "auto" ] ; then
+    if [ "${OBS_VM_TYPE#emulator:}" != "$OBS_VM_TYPE" ] ; then
+        vmopt="--emulator"
+        options=(${OBS_VM_TYPE//:/ })
+        ARCH="--arch ${options[1]}"
+        [ -n "${options[2]}" ] && EMULATOR="--emulator-script ${options[2]}"
+    elif [ "${OBS_VM_TYPE#qemu:}" != "$OBS_VM_TYPE" ] ; then
+        vmopt="--vm-type qemu"
+        options=(${OBS_VM_TYPE//:/ })
+        ARCH="--arch ${options[1]}"
+    elif [ "$OBS_VM_TYPE" != "none" ] ; then
+        vmopt="--$OBS_VM_TYPE"
+    fi
+elif [ -e /dev/kvm -a -x /usr/bin/qemu-kvm ] ; then
+    vmopt=--kvm
+    OBS_VM_TYPE="kvm"
+elif [ -e /sys/hypervisor/type ] && [ -x /usr/sbin/xl -o -x /usr/sbin/xm ] && grep -q xen /sys/hypervisor/type; then
+    vmopt=--xen
+    OBS_VM_TYPE="xen"
+fi
+
+if [ "$OBS_VM_TYPE" = "zvm" ]; then
+    # for z/VM, the disks are already setup with the workers.
+    if [ -n "$OBS_VM_DISK_AUTOSETUP_FILESYSTEM" ]; then
+        VMDISK_FILESYSTEM="--vmdisk-filesystem ${OBS_VM_DISK_AUTOSETUP_FILESYSTEM}"
+    fi
+    if [ -n "$OBS_VM_DISK_AUTOSETUP_MOUNT_OPTIONS" ]; then
+        VMDISK_MOUNT_OPTIONS="--vmdisk-mount-options ${OBS_VM_DISK_AUTOSETUP_MOUNT_OPTIONS}"
+    fi
+    if [ -n "$OBS_VM_DISK_CLEAN" ];then
+        VMDISK_CLEAN="--vmdisk-clean"
+    fi
+fi
+
+# Only enable network for kvm (now the only one supported)
+if [ "$OBS_VM_TYPE" = "kvm" ]; then
+    if [ "x${OBS_VM_ENABLE_NET}" = "xyes" ]; then
+        OBS_WORKER_OPT="$OBS_WORKER_OPT --vm-network"
+    fi
+fi
+
+if [ "$OBS_VM_TYPE" = "xen" -o "$OBS_VM_TYPE" = "kvm" -o "${OBS_VM_TYPE#qemu:}" != "$OBS_VM_TYPE" -o "${OBS_VM_TYPE#emulator:}" != "$OBS_VM_TYPE" ] ; then
+    # we start up in VM mode, check for the worker disk options
+    if [ -n "$OBS_VM_DISK_AUTOSETUP_ROOT_FILESIZE" ]; then
+        VMDISK_ROOT_FILESIZE="--vmdisk-rootsize ${OBS_VM_DISK_AUTOSETUP_ROOT_FILESIZE}"
+        if [ -n "$OBS_VM_DISK_AUTOSETUP_SWAP_FILESIZE" ]; then
+            VMDISK_SWAP_FILESIZE="--vmdisk-swapsize ${OBS_VM_DISK_AUTOSETUP_SWAP_FILESIZE}"
+        fi
+        if [ -n "$OBS_VM_DISK_AUTOSETUP_FILESYSTEM" ]; then
+            VMDISK_FILESYSTEM="--vmdisk-filesystem ${OBS_VM_DISK_AUTOSETUP_FILESYSTEM}"
+        fi
+        if [ -n "$OBS_VM_DISK_AUTOSETUP_MOUNT_OPTIONS" ]; then
+            VMDISK_MOUNT_OPTIONS="--vmdisk-mount-options ${OBS_VM_DISK_AUTOSETUP_MOUNT_OPTIONS}"
+        fi
+        if [ -n "$OBS_VM_DISK_CLEAN" ];then
+            VMDISK_CLEAN="--vmdisk-clean"
+        fi
+    fi
+fi
+
+if [ "$OBS_VM_TYPE" = "openstack" ]; then
+    if [ -z "$OBS_WORKER_CONTROL_INSTANCE" ];then
+        echo "Please specify OBS_WORKER_CONTROL_INSTANCE in /etc/sysconfig/obs-server!"
+        exit 1
+    fi
+
+    if [ -z "$OBS_WORKER_OS_FLAVOR" ];then
+        echo "Please specify OBS_WORKER_OS_FLAVOR in /etc/sysconfig/obs-server!"
+        exit 1
+    fi
+
+    if [ "$OBS_WORKER_INSTANCES" -lt 1 ]; then
+        OBS_WORKER_INSTANCES=1
+    fi
+
+    # ENVIRONMENT variables for openstack clients
+    # like nova, cinder, glance, etc.
+
+    # Checking, setting and exporting of defaults
+
+    # * OS_INTERFACE
+    if [ -z "$OS_INTERFACE" ];then
+        OS_INTERFACE=public
+    fi
+    export OS_INTERFACE
+
+    # * OS_IDENTITY_API_VERSION
+    if [ -z "$OS_IDENTITY_API_VERSION" ];then
+        OS_IDENTITY_API_VERSION=3
+    fi
+    export OS_IDENTITY_API_VERSION
+
+    # Checking and exporting of required variables
+    # * OS_AUTH_URL
+    if [ -z "$OS_AUTH_URL" ];then
+        echo "ERROR: OBS_VM_TYPE=openstack needs OS_AUTH_URL to be set! Exiting"
+        exit 1
+    else
+        export OS_AUTH_URL
+    fi
+
+    # * OS_PROJECT_ID
+    if [ -z "$OS_PROJECT_ID" ];then
+        echo "ERROR: OBS_VM_TYPE=openstack needs OS_PROJECT_ID to be set! Exiting"
+        exit 1
+    else
+        export OS_PROJECT_ID
+    fi
+
+    # * OS_PROJECT_NAME
+    if [ -z "$OS_PROJECT_NAME" ];then
+        echo "ERROR: OBS_VM_TYPE=openstack needs OS_PROJECT_NAME to be set! Exiting"
+        exit 1
+    else
+        export OS_PROJECT_NAME
+    fi
+
+    # * OS_USER_DOMAIN_NAME
+    if [ -z "$OS_USER_DOMAIN_NAME" ];then
+        echo "ERROR: OBS_VM_TYPE=openstack needs OS_USER_DOMAIN_NAME to be set! Exiting"
+        exit 1
+    else
+        export OS_USER_DOMAIN_NAME
+    fi
+
+    # * OS_USERNAME
+    if [ -z "$OS_USERNAME" ];then
+        echo "ERROR: OBS_VM_TYPE=openstack needs OS_USERNAME to be set! Exiting"
+        exit 1
+    else
+        export OS_USERNAME
+    fi
+
+    # * OS_PASSWORD
+    if [ -z "$OS_PASSWORD" ];then
+        echo "ERROR: OBS_VM_TYPE=openstack needs OS_PASSWORD to be set! Exiting"
+        exit 1
+    else
+        export OS_PASSWORD
+    fi
+
+    if [ -n "$OBS_OPENSTACK_DISK_SIZE" ];then
+        VMDISK_ROOT_FILESIZE="--vmdisk-rootsize ${OBS_OPENSTACK_DISK_SIZE}"
+    fi
+
+    if [ -n "$OBS_OPENSTACK_SWAP_SIZE" ];then
+        VMDISK_SWAP_FILESIZE="--vmdisk-swapsize ${OBS_OPENSTACK_SWAP_SIZE}"
+    fi
+
+    if [ -n "$OBS_OPENSTACK_MEMORY_SIZE" ];then
+        MEMORY="--vm-memory ${OBS_OPENSTACK_MEMORY_SIZE}"
+    fi
+fi
+
+check_vmcp()
+{
+    # try to load the kernel module
+    modprobe vmcp 2> /dev/null || :
+    # run a vmcp command that always works from within z/VM
+    vmcp q privclass
+    # transport zVM console messages over iucv
+    vmcp set smsg iucv
+    vmcp set cpconio iucv
+    modprobe smsgiucv_app
+}
+
+create_initrd()
+{
+    # $1 name of kernel
+    # $2 name of initrd
+    # 0150 is already included from the local guest
+    ZVM_VOLUME_SWAP=${ZVM_VOLUME_SWAP:-0200}
+    if test -z "$2" ; then
+        echo "Please define a name for the new initrd in /etc/sysconfig/obs-server"
+        return 1
+    else
+        # create initrd with system scripts
+        mkinitrd -k ${1}-$(get_kernel_version ${1}) -i $2 -m "xfs reiserfs fat vfat" -B
+        TEMPDIR=$(mktemp -d /tmp/initrd.XXX)
+        pushd $TEMPDIR
+        # unpack initrd to add some extra files
+        xzcat $2 | cpio -i
+        cat - > etc/udev/rules.d/51-dasd-0.0.${ZVM_VOLUME_SWAP}.rules <<EOF
+ACTION=="add", SUBSYSTEM=="ccw", KERNEL=="0.0.${ZVM_VOLUME_SWAP}", DRIVER=="dasd-eckd", GOTO="cfg_dasd_eckd_0.0.${ZVM_VOLUME_SWAP}"
+ACTION=="add", SUBSYSTEM=="drivers", KERNEL=="dasd-eckd", TEST=="[ccw/0.0.${ZVM_VOLUME_SWAP}]", GOTO="cfg_dasd_eckd_0.0.${ZVM_VOLUME_SWAP}"
+GOTO="end_dasd_eckd_0.0.${ZVM_VOLUME_SWAP}"
+
+LABEL="cfg_dasd_eckd_0.0.${ZVM_VOLUME_SWAP}"
+ATTR{[ccw/0.0.${ZVM_VOLUME_SWAP}]use_diag}="0"
+ATTR{[ccw/0.0.${ZVM_VOLUME_SWAP}]online}="1"
+
+LABEL="end_dasd_eckd_0.0.${ZVM_VOLUME_SWAP}"
+EOF
+        cp -a /usr/sbin/xfs_db sbin/
+        # create new initrd:
+        find . | cpio -H newc -o | xz -9 --format=lzma > $2
+        popd
+        rm -rf $TEMPDIR
+    fi
+}
+
+case "$1" in
+    start|run)
+        mkdir -p "$obsrundir"
+        chown obsrun:obsrun "$obsrundir"
+        rm -rf "$workerdir"
+        mkdir -p "$workerbootdir"
+
+        if [ 0"$OBS_WORKER_INSTANCES" -gt 0 ]; then
+            NUM="$OBS_WORKER_INSTANCES"
+        else
+            # start one build backend per CPU
+            NUM=`ls -d /sys/devices/system/cpu/cpu[0-9]* | wc -l`
+        fi
+        if [ "--zvm" == "$vmopt" ]; then
+            check_vmcp || exit 1
+            create_initrd $OBS_VM_KERNEL $OBS_VM_INITRD || exit 1
+            if [ -n "$OBS_WORKER_INSTANCE_NAMES" ]; then
+                WORKERS=($OBS_WORKER_INSTANCE_NAMES)
+                NUM=${#WORKERS[*]}
+            fi
+        fi
+
+        if [ -n "$OBS_WORKER_OWNER" ]; then
+            HOSTOWNER="--owner $OBS_WORKER_OWNER"
+        fi
+
+        # print some config data
+        echo "Run $NUM obsworker using $OBS_WORKER_DIRECTORY"
+        echo -n "Type of obsworker is "
+        if [ "--kvm" == "$vmopt" ]; then echo "KVM virtual machine"
+        elif [ "--xen" == "$vmopt" ]; then echo "XEN virtual machine"
+        elif [ "--zvm" == "$vmopt" ]; then echo "z/VM virtual machine"
+        elif [ "--pvm" == "$vmopt" ]; then echo "PowerVM LPAR"
+        elif [ "--emulator" == "$vmopt" ]; then echo "System emulated virtual machine"
+        elif [ "--vm-type qemu" == "$vmopt" ]; then echo "System emulated virtual machine via QEMU"
+        elif [ "--lxc" == "$vmopt" ]; then echo "LXC container"
+        elif [ "openstack" == "$OBS_VM_TYPE" ]; then echo "OpenStack virtual machine"
+        else  echo "chroot"
+        fi
+
+        # find SLP announced OBS servers
+        if [ "$OBS_USE_SLP" == "yes" ]; then
+            for i in `slptool findsrvs service:obs.repo_server | sed -n 's/service:obs.repo_server:\([^,]*\),.*/\1/p'`; do
+                [ "${i#http://localhost}" != "$i" ] && continue
+                [ "${i#http://127.}" != "$i" ] && continue
+                REPO_PARAM="$REPO_PARAM --reposerver $i"
+                # any of them should be okay
+                WORKER_CODE="$i"
+            done
+        fi
+
+        # fetch worker sources from server
+        echo "Fetching initial worker code from $WORKER_CODE/getworkercode"
+        pushd "$workerbootdir" > /dev/null
+        I=0
+        while ! curl -s "$WORKER_CODE"/getworkercode | cpio --quiet --extract ; do
+            # we need to wait for rep server maybe
+            echo >&2 "WARNING: Could not reach rep server $WORKER_CODE. Trying again."
+            I=$(( $I + 1 ))
+            if test "10" -lt "$I"; then
+                 echo >&2 "ERROR: Unable to reach rep server $WORKER_CODE!"
+                 exit 1
+            fi
+            sleep 10
+        done
+        ln -s . XML
+        chmod 755 bs_worker
+        popd > /dev/null
+
+        for i in $OBS_WORKER_HOSTLABELS; do
+            HOSTLABELS="$HOSTLABELS --hostlabel $i"
+        done
+        OBS_WORKER_OPT1="$OBS_WORKER_OPT"
+        I=0
+        [ -z "$OBS_WORKER_PREFIX" ] && OBS_WORKER_PREFIX=worker
+        while test "$NUM" -gt "$I"; do
+            if [ 0"$OBS_WORKER_PORTBASE" -gt 0 ]; then
+                port="--port $((OBS_WORKER_PORTBASE + I))"
+            else
+                port=""
+            fi
+            proto=
+            if [ -n "$OBS_WORKER_PROTO" ] ; then
+                proto="--proto $OBS_WORKER_PROTO"
+            fi
+            I_INDEX=$I
+            I=$(( $I + 1 ))
+            if [ "$OBS_VM_TYPE" = 'zvm' ]; then
+                WORKERID="${HOSTNAME}:${WORKERS[$I_INDEX]}"
+            else
+                WORKERID="${HOSTNAME}:$I"
+            fi
+            R=$OBS_WORKER_DIRECTORY/root_$I
+            mkdir -p $R
+            TMPFS=
+            if [ "$OBS_VM_TYPE" = "xen" -o "$OBS_VM_TYPE" = "kvm" -o "${OBS_VM_TYPE#qemu:}" != "$OBS_VM_TYPE" -o "${OBS_VM_TYPE#emulator:}" != "$OBS_VM_TYPE" ] ; then
+                DEVICE="$OBS_WORKER_DIRECTORY/root_$I/root"
+                SWAP="$OBS_WORKER_DIRECTORY/root_$I/swap"
+                if [ -n "$OBS_VM_DISK_AUTOSETUP_ROOT_FILESIZE" ]; then
+                    OBS_WORKER_OPT="$OBS_WORKER_OPT1 $VMDISK_AUTOSETUP $VMDISK_ROOT_FILESIZE $VMDISK_SWAP_FILESIZE $VMDISK_FILESYSTEM $VMDISK_MOUNT_OPTIONS $VMDISK_CLEAN"
+                elif [ ! -e "$DEVICE" ]; then
+                    echo "ERROR: worker is configured to use a VM, but the root device do not exist: $DEVICE"
+                    exit 1
+                fi
+                if [ -n "$OBS_VM_USE_TMPFS" ]; then
+                    TMPFS="--tmpfs"
+                fi
+                DEVICE="--device $DEVICE"
+                SWAP="--swap $SWAP"
+                MEMORY="--vm-memory $OBS_INSTANCE_MEMORY"
+                if [ -n "$OBS_VM_USE_HUGETLBFS" ]; then
+                    HUGETLBFS="--hugetlbfs $OBS_VM_USE_HUGETLBFS"
+                fi
+            elif [ "$OBS_VM_TYPE" = 'openstack' ]; then
+                # Without a worker being defined, we would not be in this loop.
+                VM_SERVER="--vm-server $OBS_WORKER_CONTROL_INSTANCE"
+                VM_FLAVOR="--openstack-flavor $OBS_WORKER_OS_FLAVOR"
+                WORKER="--vm-worker $OBS_WORKER_PREFIX$I"
+                VM_KERNEL="--vm-kernel $OBS_WORKER_PREFIX$I-grub-image"
+                VM_DISK="--device $OBS_WORKER_PREFIX$I-root"
+                VM_SWAP="--swap $OBS_WORKER_PREFIX$I-swap"
+                OBS_WORKER_OPT="$OBS_WORKER_OPT1 $WORKER $VM_KERNEL $VM_DISK $VM_SWAP $VM_SERVER $VM_FLAVOR $VMDISK_ROOT_FILESIZE $VMDISK_SWAP_FILESIZE "
+            elif [ -n "$vmopt" -a "$OBS_VM_TYPE" = 'zvm' ]; then
+                # Without a worker being defined, we would not be in this loop.
+                WORKER="--vm-worker ${WORKERS[$I_INDEX]}"
+                WORKER_NR="--vm-worker-nr $I"
+                OBS_WORKER_OPT="$OBS_WORKER_OPT1 $WORKER $WORKER_NR $VMDISK_FILESYSTEM $VMDISK_MOUNT_OPTIONS $VMDISK_CLEAN"
+            elif [ -n "$vmopt" -a "$OBS_VM_TYPE" = 'lxc' ]; then
+                DEVICE=
+                SWAP=
+                if [ -n "$OBS_INSTANCE_MEMORY" ]; then
+                    MEMORY="--vm-memory $OBS_INSTANCE_MEMORY"
+                fi
+            else
+                DEVICE=
+                SWAP=
+                MEMORY=
+            fi
+            mkdir -p $workerdir/$I
+            OBS_WORKER_PARAMETERS="--hardstatus $vmopt $port $proto --root $R \
+--statedir $workerdir/$I --id $WORKERID $REPO_PARAM $HUGETLBFS $HOSTLABELS \
+$HOSTOWNER $OBS_JOBS $OBS_THREADS $OBS_TEST $OBS_WORKER_OPT $TMPFS $DEVICE $SWAP $MEMORY \
+$OBS_CLEANUP_CHROOT $OBS_WIPE_AFTER_BUILD $OBS_WORKER_USE_MKFS_COPYIN $ARCH $EMULATOR"
+            cat << EOT > "$workerdir/$I/parameters.txt"
+OBS_NICE=$OBS_NICE
+OBS_WORKER_PARAMETERS=$OBS_WORKER_PARAMETERS
+EOT
+            systemctl start obsworker@$I.service &
+        done
+    ;;
+    stop)
+        systemctl stop obsworker@*.service
+    ;;
+    *)
+        echo "Usage: $0 {start|stop|run}"
+        exit 1
+    ;;
+esac

--- a/dist/systemd/obsworker@.service
+++ b/dist/systemd/obsworker@.service
@@ -1,17 +1,12 @@
 [Unit]   
-Description=OBS worker for %i
-After=network-online.target
+Description=OBS worker, instance %i
+After=network-online.target obsstoragesetup.service obssrcserver.service obsrepserver.service xendomains.service
          
 [Service]
 OOMPolicy=continue
-EnvironmentFile=/etc/sysconfig/obs-server
-ExecStartPre=/bin/sh -c "/bin/systemctl set-environment HOSTNAME=`hostname`"
-ExecStartPre=/bin/mkdir -p /var/cache/build/root_%i
-ExecStartPre=/bin/mkdir -p /var/cache/build/state_%i
-ExecStartPre=/bin/chmod 755 /var/cache/build/root_%i
-ExecStartPre=/bin/chmod 755 /var/cache/build/state_%i
-ExecStart=/usr/lib/obs/server/bs_worker --hardstatus --root /var/cache/build/root_%i --statedir /var/cache/build/state_%i --id ${HOSTNAME}:%i --reposerver http://${OBS_REPO_SERVERS} --jobs $OBS_WORKER_JOBS &
-ExecReload=/bin/kill -HUP $MAINPID
+EnvironmentFile=/srv/obs/run/worker/%i/parameters.txt
+ExecStart=nice -n $OBS_NICE /srv/obs/run/worker/boot/bs_worker $OBS_WORKER_PARAMETERS
+ExecStop=nice -n $OBS_NICE /srv/obs/run/worker/boot/bs_worker --statedir /srv/obs/run/worker/%i --exit
          
 [Install]
-WantedBy=multi-user.target  
+WantedBy=multi-user.target


### PR DESCRIPTION
OBS workers are managed with the `obsworker.service` systemd unit service.

This pull request introduces the `obs-worker-manager.service` systemd service unit, which internallly will make use of the `obsworker@.service` systemd unit template to launch each worker in an independent systemd service unit.

This PR does not substitute `obsworker.service`. The new systemd service unit has been introduced in the codebase to first be tested and run in non-production environments.

## How to test the new service unit

Setup an (or use an existing) OBS instance in production mode. I used and tested this pull request with an OBS appliance QCow2 image, available [here](https://openbuildservice.org/download/other/).

### Stop and disable `obsworker.service`

```
systemctl stop obsworker.service
systemctl disable obsworker.service
```

### Install `obs-worker-manager.service`

```                                                                                                                                                                                     
cp $GITHUB_REPO/dist/obs_worker_manager                 /usr/sbin/                                                                                                                      
cp $GITHUB_REPO/dist/systemd/obsworker@.service         /etc/systemd/system/                                                                                                            
cp $GITHUB_REPO/dist/systemd/obs-worker-manager.service /etc/systemd/system/                                                                                                            
systemctl daemon-reload                                                                                                                                                                 
```                             

### Enable and start `obs-worker-manager.service`

```
systemctl enable obs-worker-manager.service
systemctl start obs-worker-manager.service
```

### Check the logs

```
journalctl -f -u obs-worker-manager.service -u obsworker@*.service
```

<details><summary>Example of log output with 4 workers, for <code>systemctl start obs-worker-manager.service</code></summary>

```
Feb 03 17:25:07 obs-unstable-25-13 systemd[1]: Starting OBS worker...
Feb 03 17:25:07 obs-unstable-25-13 obs_worker_manager[5214]: Run 4 obsworker using /var/cache/obs/worker
Feb 03 17:25:07 obs-unstable-25-13 obs_worker_manager[5214]: Type of obsworker is KVM virtual machine
Feb 03 17:25:09 obs-unstable-25-13 obs_worker_manager[5214]: Fetching initial worker code from http://localhost:5252/getworkercode
Feb 03 17:25:09 obs-unstable-25-13 systemd[1]: Started OBS worker, instance 1.
Feb 03 17:25:09 obs-unstable-25-13 systemd[1]: Started OBS worker, instance 2.
Feb 03 17:25:09 obs-unstable-25-13 systemd[1]: Started OBS worker, instance 3.
Feb 03 17:25:09 obs-unstable-25-13 systemd[1]: Finished OBS worker.
Feb 03 17:25:09 obs-unstable-25-13 systemd[1]: Started OBS worker, instance 4.
Feb 03 17:25:09 obs-unstable-25-13 nice[5252]: Name "BSConfig::reposervers" used only once: possible typo at /srv/obs/run/worker/boot/bs_worker line 725.
Feb 03 17:25:09 obs-unstable-25-13 nice[5247]: Name "BSConfig::reposervers" used only once: possible typo at /srv/obs/run/worker/boot/bs_worker line 725.
Feb 03 17:25:09 obs-unstable-25-13 nice[5252]: worker started on port 45109 code ? build ?
Feb 03 17:25:09 obs-unstable-25-13 nice[5247]: worker started on port 35323 code ? build ?
Feb 03 17:25:09 obs-unstable-25-13 nice[5244]: Name "BSConfig::reposervers" used only once: possible typo at /srv/obs/run/worker/boot/bs_worker line 725.
Feb 03 17:25:09 obs-unstable-25-13 nice[5244]: worker started on port 35805 code ? build ?
Feb 03 17:25:09 obs-unstable-25-13 nice[5250]: Name "BSConfig::reposervers" used only once: possible typo at /srv/obs/run/worker/boot/bs_worker line 725.
Feb 03 17:25:10 obs-unstable-25-13 nice[5250]: worker started on port 39679 code ? build ?
```
</details>

<details><summary>Example of log output with 4 workers, for <code>systemctl stop obs-worker-manager.service</code></summary>

```
Feb 03 17:28:24 obs-unstable-25-13 systemd[1]: Stopping OBS worker...
Feb 03 17:28:24 obs-unstable-25-13 systemd[1]: Stopping OBS worker, instance 4...
Feb 03 17:28:24 obs-unstable-25-13 systemd[1]: Stopping OBS worker, instance 3...
Feb 03 17:28:24 obs-unstable-25-13 systemd[1]: Stopping OBS worker, instance 1...
Feb 03 17:28:24 obs-unstable-25-13 systemd[1]: Stopping OBS worker, instance 2...
Feb 03 17:28:24 obs-unstable-25-13 nice[5397]: Name "BSConfig::reposervers" used only once: possible typo at /srv/obs/run/worker/boot/bs_worker line 725.
Feb 03 17:28:24 obs-unstable-25-13 nice[5396]: Name "BSConfig::reposervers" used only once: possible typo at /srv/obs/run/worker/boot/bs_worker line 725.
Feb 03 17:28:24 obs-unstable-25-13 nice[5395]: Name "BSConfig::reposervers" used only once: possible typo at /srv/obs/run/worker/boot/bs_worker line 725.
Feb 03 17:28:24 obs-unstable-25-13 nice[5394]: Name "BSConfig::reposervers" used only once: possible typo at /srv/obs/run/worker/boot/bs_worker line 725.
Feb 03 17:28:29 obs-unstable-25-13 nice[5244]: [8B blob data]
Feb 03 17:28:29 obs-unstable-25-13 systemd[1]: obsworker@1.service: Deactivated successfully.
Feb 03 17:28:29 obs-unstable-25-13 systemd[1]: Stopped OBS worker, instance 1.
Feb 03 17:28:29 obs-unstable-25-13 nice[5247]: [8B blob data]
Feb 03 17:28:29 obs-unstable-25-13 systemd[1]: obsworker@2.service: Deactivated successfully.
Feb 03 17:28:29 obs-unstable-25-13 systemd[1]: Stopped OBS worker, instance 2.
Feb 03 17:28:30 obs-unstable-25-13 nice[5252]: [8B blob data]
Feb 03 17:28:30 obs-unstable-25-13 systemd[1]: obsworker@4.service: Deactivated successfully.
Feb 03 17:28:30 obs-unstable-25-13 systemd[1]: Stopped OBS worker, instance 4.
Feb 03 17:28:30 obs-unstable-25-13 nice[5250]: [8B blob data]
Feb 03 17:28:30 obs-unstable-25-13 systemd[1]: obsworker@3.service: Deactivated successfully.
Feb 03 17:28:30 obs-unstable-25-13 systemd[1]: Stopped OBS worker, instance 3.
Feb 03 17:28:30 obs-unstable-25-13 systemd[1]: obs-worker-manager.service: Deactivated successfully.
Feb 03 17:28:30 obs-unstable-25-13 systemd[1]: Stopped OBS worker.
```
</details>
