### PR TITLE
Create a new component for a Card

### DIFF
--- a/src/api/app/components/card_component.html.haml
+++ b/src/api/app/components/card_component.html.haml
@@ -1,0 +1,14 @@
+.card
+  .card-header.d-flex.justify-content-between
+    %div
+      = header
+    - if delete_button?
+      %div
+        = delete_button
+  .card-body
+    = content
+    - if actions?
+      %ul.nav.justify-content-end
+        - actions.each do |action|
+          %li.nav-item
+            = action

--- a/src/api/app/components/card_component.html.haml
+++ b/src/api/app/components/card_component.html.haml
@@ -3,7 +3,7 @@
     %div
       = header
     - if delete_button?
-      %div
+      .ms-4
         = delete_button
   .card-body
     = content

--- a/src/api/app/components/card_component.rb
+++ b/src/api/app/components/card_component.rb
@@ -1,0 +1,8 @@
+# The card component is shaping the card style only, it does not set anything about the width
+# of the card itself because it depends on the occurrence where it is used for.
+# I.e: look at the src/api/app/views/webui/repositories/_repository_entry.html.haml
+class CardComponent < ApplicationComponent
+  renders_one :header
+  renders_one :delete_button
+  renders_many :actions
+end

--- a/src/api/spec/components/previews/card_component_preview.rb
+++ b/src/api/spec/components/previews/card_component_preview.rb
@@ -1,0 +1,88 @@
+class CardComponentPreview < ViewComponent::Preview
+  def with_header
+    render(CardComponent.new) do |component|
+      component.with_header do
+        tag.a('openSUSE_Factory', href: '#').concat(
+          tag.span('tag-1', class: 'badge bg-primary ms-1')
+        ).concat(
+          tag.span('tag-2', class: 'badge bg-primary ms-1')
+        ).concat(
+          tag.span('tag-3', class: 'badge bg-primary ms-1')
+        ).concat(
+          tag.span('tag-4', class: 'badge bg-primary ms-1')
+        )
+      end
+      tag.strong('Repository paths:').concat(
+        content_tag(
+          :ol,
+          content_tag(
+            :li,
+            tag.span('SUSE:SLE-15-SP4:GA/standard').concat(
+              content_tag(
+                :a,
+                tag.i(class: 'fas fa-sm fa-times-circle text-danger'),
+                href: '#',
+                title: 'Delete',
+                class: 'ms-2'
+              )
+            )
+          ),
+          class: 'list-unstyled ms-3'
+        )
+      )
+    end
+  end
+
+  def with_delete_button
+    render(CardComponent.new) do |component|
+      component.with_delete_button do
+        content_tag(
+          :a,
+          tag.i(class: 'fas fa-sm fa-times-circle text-danger'),
+          href: '#',
+          title: 'Delete'
+        )
+      end
+      content_tag(
+        :div,
+        tag.input(
+          type: 'checkbox',
+          name: '',
+          id: 'input-id',
+          value: 'true',
+          class: 'form-check-input group-maintainership'
+        ).concat(
+          tag.label(
+            'Maintainer',
+            class: 'form-check-label',
+            for: 'input-id'
+          )
+        ),
+        class: 'form-check mt-2'
+      )
+    end
+  end
+
+  def with_actions
+    render(CardComponent.new) do |component|
+      component.with_header do
+        content_tag(:a, tag.h5('Run our OBS Workflow', class: 'card-title font-italic'), href: '#')
+      end
+      component.with_action do
+        content_tag(:a, tag.i(class: 'fas fa-edit'), href: '#', title: 'Edit Token', class: 'nav-link p-1')
+      end
+      component.with_action do
+        content_tag(:a, tag.i(class: 'fas fa-project-diagram'), href: '#', title: 'Trigger Token', class: 'nav-link p-1')
+      end
+      tag.p('Id: 4763', class: 'card-text').concat(
+        tag.p('Operation: Rebuild', class: 'card-text')
+      ).concat(
+        content_tag(
+          :p,
+          tag.span('Runs as: ').concat(tag.a('user', href: '#')),
+          class: 'card-text'
+        )
+      )
+    end
+  end
+end


### PR DESCRIPTION
The new **Card** is a [View Component](https://viewcomponent.org/) meant to unify usages of the [Boostrap card](https://getbootstrap.com/docs/5.0/components/card/) when it is a simple element with a title, few actions and a custom content. The implementation uses advantages of [View Component Slots](https://viewcomponent.org/guide/slots.html) and it comes with some [View Component Previews](https://viewcomponent.org/guide/previews.html).

The previews to check out how the component can look like are available [here](https://obs-reviewlab.opensuse.org/ncounter-card-component/rails/view_components/card_component/)