### PR TITLE
Trigger workflow cleanup

### DIFF
--- a/src/api/app/controllers/person/token_controller.rb
+++ b/src/api/app/controllers/person/token_controller.rb
@@ -12,10 +12,6 @@ module Person
 
     # POST /person/<login>/token
     def create
-      # TODO: remove when `trigger_workflow` feature is rolled out
-      raise(NoPermission, 'You are not allowed to create a workflow token. You need to join the Beta program for that.') if params[:operation] == 'workflow' &&
-                                                                                                                            !Flipper.enabled?(:trigger_workflow, @user)
-
       authorize @user, :update?
 
       pkg = (Package.get_by_project_and_name(params[:project], params[:package]) if params[:project] || params[:package])

--- a/src/api/app/policies/token/rss_policy.rb
+++ b/src/api/app/policies/token/rss_policy.rb
@@ -1,6 +1,1 @@
-class Token::RssPolicy < TokenPolicy
-  # TODO: when trigger_workflow is rolled out, remove the create? method
-  def create?
-    user == record.executor
-  end
-end
+class Token::RssPolicy < TokenPolicy; end

--- a/src/api/app/policies/token/workflow_policy.rb
+++ b/src/api/app/policies/token/workflow_policy.rb
@@ -1,7 +1,6 @@
 class Token::WorkflowPolicy < TokenPolicy
-  # TODO: remove the second half of the condition when `trigger_workflow` feature is rolled out
   def trigger?
-    user.is_active? && Flipper.enabled?(:trigger_workflow, user)
+    user.is_active?
   end
 
   def rebuild?
@@ -14,9 +13,6 @@ class Token::WorkflowPolicy < TokenPolicy
   end
 
   def create?
-    # TODO: when trigger_workflow is rolled out, remove the Flipper check
-    return false unless Flipper.enabled?(:trigger_workflow, user)
-
     record.owned_by?(user)
   end
 

--- a/src/api/app/policies/token_policy.rb
+++ b/src/api/app/policies/token_policy.rb
@@ -18,9 +18,7 @@ class TokenPolicy < ApplicationPolicy
   end
 
   def new?
-    # TODO: when trigger_workflow is rolled out, uncomment the next line and remove the Flipper check
-    # true
-    Flipper.enabled?(:trigger_workflow, user)
+    true
   end
 
   def edit?
@@ -28,14 +26,10 @@ class TokenPolicy < ApplicationPolicy
   end
 
   def update?
-    record.executor == user && Flipper.enabled?(:trigger_workflow, user)
+    create?
   end
 
   def create?
-    # TODO: when trigger_workflow is rolled out, remove the Flipper check
-    return false unless Flipper.enabled?(:trigger_workflow, user)
-    return false unless record.type != 'Token::Rss'
-
     record.executor == user
   end
 

--- a/src/api/app/views/webui/user/_index_actions.html.haml
+++ b/src/api/app/views/webui/user/_index_actions.html.haml
@@ -2,6 +2,5 @@
   - if configuration.passwords_changable?(user)
     = render partial: 'webui/user/index_actions/change_password'
   = render partial: 'webui/user/index_actions/change_notifications'
-  - if feature_enabled?('trigger_workflow')
-    = render partial: 'webui/user/index_actions/manage_tokens'
+  = render partial: 'webui/user/index_actions/manage_tokens'
   = render partial: 'webui/user/index_actions/manage_beta_features'

--- a/src/api/spec/components/token_card_component_spec.rb
+++ b/src/api/spec/components/token_card_component_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe TokenCardComponent, type: :component do
   let(:user) { build_stubbed(:confirmed_user) }
 
   before do
-    Flipper.enable(:trigger_workflow)
     User.session = user
     render_inline(described_class.new(token: token))
   end

--- a/src/api/spec/controllers/person/token_controller_spec.rb
+++ b/src/api/spec/controllers/person/token_controller_spec.rb
@@ -71,7 +71,6 @@ RSpec.describe Person::TokenController, vcr: false do
       let!(:package) { create(:package, project: user.home_project) }
 
       before do
-        Flipper[:trigger_workflow].enable
         login user
       end
 

--- a/src/api/spec/controllers/trigger_workflow_controller_spec.rb
+++ b/src/api/spec/controllers/trigger_workflow_controller_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
-RSpec.describe TriggerWorkflowController, beta: true do
+RSpec.describe TriggerWorkflowController do
   render_views
 
   describe 'POST :create' do
     context 'workflows.yml do not exist' do
       let(:octokit_client) { instance_double(Octokit::Client) }
       let(:token_extractor_instance) { instance_double(TriggerControllerService::TokenExtractor) }
-      let(:token) { create(:workflow_token, executor: create(:confirmed_user, :in_beta)) }
+      let(:token) { create(:workflow_token, executor: create(:confirmed_user)) }
       let(:github_payload) do
         {
           action: 'opened',
@@ -51,7 +51,7 @@ RSpec.describe TriggerWorkflowController, beta: true do
 
     context 'token different type' do
       let(:token_extractor_instance) { instance_double(TriggerControllerService::TokenExtractor) }
-      let(:token) { create(:service_token, executor: create(:confirmed_user, :in_beta)) }
+      let(:token) { create(:service_token, executor: create(:confirmed_user)) }
 
       let(:github_payload) do
         {
@@ -98,7 +98,7 @@ RSpec.describe TriggerWorkflowController, beta: true do
 
     context 'scm event is invalid' do
       let(:token_extractor_instance) { instance_double(TriggerControllerService::TokenExtractor) }
-      let(:token) { build_stubbed(:workflow_token, executor: build_stubbed(:confirmed_user, :in_beta)) }
+      let(:token) { build_stubbed(:workflow_token, executor: build_stubbed(:confirmed_user)) }
 
       before do
         allow(TriggerControllerService::TokenExtractor).to receive(:new).and_return(token_extractor_instance)
@@ -114,7 +114,7 @@ RSpec.describe TriggerWorkflowController, beta: true do
     context 'scm action is invalid' do
       let(:octokit_client) { instance_double(Octokit::Client) }
       let(:token_extractor_instance) { instance_double(TriggerControllerService::TokenExtractor) }
-      let(:token) { build_stubbed(:workflow_token, executor: build_stubbed(:confirmed_user, :in_beta)) }
+      let(:token) { build_stubbed(:workflow_token, executor: build_stubbed(:confirmed_user)) }
       let(:github_payload) do
         {
           action: 'assigned',
@@ -150,7 +150,7 @@ RSpec.describe TriggerWorkflowController, beta: true do
 
     context 'scm payload is invalid' do
       let(:token_extractor_instance) { instance_double(TriggerControllerService::TokenExtractor) }
-      let(:token) { create(:workflow_token, executor: create(:confirmed_user, :in_beta)) }
+      let(:token) { create(:workflow_token, executor: create(:confirmed_user)) }
 
       before do
         allow(TriggerControllerService::TokenExtractor).to receive(:new).and_return(token_extractor_instance)
@@ -179,7 +179,7 @@ RSpec.describe TriggerWorkflowController, beta: true do
 
     context 'validation errors happening when triggering the token' do
       let(:token_extractor_instance) { instance_double(TriggerControllerService::TokenExtractor) }
-      let(:token) { build_stubbed(:workflow_token, executor: build_stubbed(:confirmed_user, :in_beta)) }
+      let(:token) { build_stubbed(:workflow_token, executor: build_stubbed(:confirmed_user)) }
       let(:github_payload) do
         {
           action: 'opened',
@@ -223,7 +223,7 @@ RSpec.describe TriggerWorkflowController, beta: true do
 
     context 'no validation errors' do
       let(:token_extractor_instance) { instance_double(TriggerControllerService::TokenExtractor) }
-      let(:token) { build_stubbed(:workflow_token, executor: build_stubbed(:confirmed_user, :in_beta)) }
+      let(:token) { build_stubbed(:workflow_token, executor: build_stubbed(:confirmed_user)) }
       let(:github_payload) do
         {
           action: 'opened',
@@ -264,7 +264,7 @@ RSpec.describe TriggerWorkflowController, beta: true do
 
     context 'the SCM is unsupported' do
       let(:token_extractor_instance) { instance_double(TriggerControllerService::TokenExtractor) }
-      let(:token) { build_stubbed(:workflow_token, executor: build_stubbed(:confirmed_user, :in_beta)) }
+      let(:token) { build_stubbed(:workflow_token, executor: build_stubbed(:confirmed_user)) }
       let(:scm_payload) do
         { super: 'duper' }
       end

--- a/src/api/spec/controllers/webui/users/tokens_controller_spec.rb
+++ b/src/api/spec/controllers/webui/users/tokens_controller_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe Webui::Users::TokensController do
   let(:other_user) { create(:confirmed_user, login: 'bar') }
 
   before do
-    Flipper[:trigger_workflow].enable
     login user
   end
 

--- a/src/api/spec/policies/token/workflow_policy_spec.rb
+++ b/src/api/spec/policies/token/workflow_policy_spec.rb
@@ -8,11 +8,6 @@ RSpec.describe Token::WorkflowPolicy do
 
   subject { described_class }
 
-  before do
-    Flipper.enable(:trigger_workflow, user)
-    Flipper.enable(:trigger_workflow, other_user)
-  end
-
   describe '#trigger' do
     context 'user inactive' do
       include_examples 'non-active users cannot trigger a token'
@@ -29,72 +24,56 @@ RSpec.describe Token::WorkflowPolicy do
   end
 
   permissions :create? do
-    context 'when the user has the feature enabled' do
-      context 'when the user is the owner of the token' do
-        it { is_expected.to permit(user, user_token) }
-      end
-
-      context 'when the user belongs to a group which owns the token' do
-        let(:group_token) { create(:workflow_token, executor: user) }
-
-        before { group.shared_workflow_tokens << group_token }
-
-        it { is_expected.to permit(other_user, group_token) }
-      end
-
-      context 'when the user is not the owner of the token' do
-        context 'and the token has not been shared with that user' do
-          it { is_expected.not_to permit(other_user, user_token) }
-        end
-
-        context 'but the token has been shared with that user' do
-          before do
-            other_user.shared_workflow_tokens << user_token
-          end
-
-          it { is_expected.to permit(other_user, user_token) }
-        end
-
-        context "but the token has been shared with that users's group" do
-          before do
-            group.shared_workflow_tokens << user_token
-          end
-
-          it { is_expected.to permit(other_user, user_token) }
-        end
-      end
+    context 'when the user is the owner of the token' do
+      it { is_expected.to permit(user, user_token) }
     end
 
-    context 'when the user does not have the feature enabled' do
-      before { Flipper.disable(:trigger_workflow, user) }
+    context 'when the user belongs to a group which owns the token' do
+      let(:group_token) { create(:workflow_token, executor: user) }
 
-      it { is_expected.not_to permit(user, user_token) }
+      before { group.shared_workflow_tokens << group_token }
+
+      it { is_expected.to permit(other_user, group_token) }
+    end
+
+    context 'when the user is not the owner of the token' do
+      context 'and the token has not been shared with that user' do
+        it { is_expected.not_to permit(other_user, user_token) }
+      end
+
+      context 'but the token has been shared with that user' do
+        before do
+          other_user.shared_workflow_tokens << user_token
+        end
+
+        it { is_expected.to permit(other_user, user_token) }
+      end
+
+      context "but the token has been shared with that users's group" do
+        before do
+          group.shared_workflow_tokens << user_token
+        end
+
+        it { is_expected.to permit(other_user, user_token) }
+      end
     end
   end
 
   permissions :destroy? do
-    context 'when the user has the feature enabled' do
-      context 'when the user is the owner of the token' do
-        it { is_expected.to permit(user, user_token) }
-      end
-
-      context 'when the user belongs to a group which owns the token' do
-        let(:group_token) { create(:workflow_token, executor: user) }
-
-        before { group.shared_workflow_tokens << group_token }
-
-        it { is_expected.to permit(other_user, group_token) }
-      end
-
-      context 'when the user does not own the token' do
-        it { is_expected.not_to(permit(other_user, user_token)) }
-      end
+    context 'when the user is the owner of the token' do
+      it { is_expected.to permit(user, user_token) }
     end
 
-    context 'when the user does not have the feature enabled' do
-      before { Flipper.disable(:trigger_workflow, user) }
+    context 'when the user belongs to a group which owns the token' do
+      let(:group_token) { create(:workflow_token, executor: user) }
 
-      it { is_expected.not_to permit(user, user_token) }
+      before { group.shared_workflow_tokens << group_token }
+
+      it { is_expected.to permit(other_user, group_token) }
+    end
+
+    context 'when the user does not own the token' do
+      it { is_expected.not_to(permit(other_user, user_token)) }
     end
   end
 end

--- a/src/api/spec/policies/token_policy_spec.rb
+++ b/src/api/spec/policies/token_policy_spec.rb
@@ -20,13 +20,25 @@ RSpec.describe TokenPolicy, type: :policy do
     it { is_expected.to permit(token_user, user_token) }
   end
 
-  permissions :show? do
+  permissions :show?, :create?, :update? do
     it { is_expected.to permit(token_user, workflow_token) }
   end
 
   permissions :webui_trigger? do
     it { is_expected.not_to permit(token_user, workflow_token) }
     it { is_expected.not_to permit(unconfirmed_user, token_of_unconfirmed_user) }
+  end
+
+  # New action is permitted on any kind of token and user
+  permissions :new? do
+    it { is_expected.to permit(token_user, Token.new) }
+    it { is_expected.to permit(unconfirmed_user, Token.new) }
+  end
+
+  # Create and update are permitted when the user and the executor are the same
+  permissions :create?, :update? do
+    it { is_expected.to permit(token_user, rss_token) }
+    it { is_expected.not_to permit(other_user, rss_token) }
   end
 
   describe TokenPolicy::Scope do

--- a/src/api/spec/support/beta.rb
+++ b/src/api/spec/support/beta.rb
@@ -1,5 +1,6 @@
 RSpec.configure do |config|
   config.before(:example, beta: true) do
-    Flipper.enable(:trigger_workflow)
+    # Add here the feature flags you want to enable on your beta features' tests
+    # Example: Flipper.enable(:foo)
   end
 end


### PR DESCRIPTION
After rolling out the `trigger_workflow` feature more than 4 months ago, it's time to clean up the code to remove all the feature flag checks.

**How to test?**

Make sure your user is [out of beta](http://localhost:3000/my/beta_features) and try to create/edit/update a workflow token [from the UI](http://localhost:3000/my/tokens) and also trigger one.