### PR TITLE
Rescue format errors when parsing workflows yaml

### DIFF
--- a/src/api/app/models/token/errors.rb
+++ b/src/api/app/models/token/errors.rb
@@ -24,4 +24,8 @@ module Token::Errors
   class WorkflowsYamlNotParsable < APIError
     setup 400
   end
+
+  class WorkflowsYamlFormatError < APIError
+    setup 400
+  end
 end

--- a/src/api/spec/services/workflows/yaml_to_workflows_service_spec.rb
+++ b/src/api/spec/services/workflows/yaml_to_workflows_service_spec.rb
@@ -83,5 +83,14 @@ RSpec.describe Workflows::YAMLToWorkflowsService, type: :service do
         expect { subject }.to raise_error(Token::Errors::WorkflowsYamlNotParsable)
       end
     end
+
+    context 'with invalid placeholder variables' do
+      let(:workflows_yml_file) { Rails.root.join('spec/support/files/unparsable_workflows_placeholders.yml').expand_path }
+      let(:payload) { github_extractor_payload }
+
+      it 'raises a user-friendly error' do
+        expect { subject }.to raise_error(Token::Errors::WorkflowsYamlNotParsable, 'Unable to parse .obs/workflows.yml: malformed format string - %S')
+      end
+    end
   end
 end

--- a/src/api/spec/support/files/unparsable_workflows_placeholders.yml
+++ b/src/api/spec/support/files/unparsable_workflows_placeholders.yml
@@ -1,0 +1,12 @@
+workflow123:
+  steps:
+    - branch_package:
+        source_project: "test-project:%SCM_ORGANIZATION_NAME"
+        source_package: "test-package:%u"
+        target_project: "test-target-project"
+  filters:
+    branches:
+      only:
+        - 'main'
+        - 'master'
+        - 'source'


### PR DESCRIPTION
This shows a nicer error when formatting of the workflows yaml fails due to non existent placeholder variable

In order to verify this:
1. Create a workflow
2. Set a workflows.yml containing random invalid placeholder variables (starting with `%`) around the file
3. Trigger a workflow run
4. See it show a nice error telling you what's wrong