### PR TITLE
Reject set_flags step when restoring projects after a PR was reopend

### DIFF
--- a/src/api/app/models/workflow.rb
+++ b/src/api/app/models/workflow.rb
@@ -130,7 +130,9 @@ class Workflow
     token_user_login = token.executor.login
 
     # Do not process steps for which there's nothing to do
-    processable_steps = steps.reject { |step| step.instance_of?(::Workflow::Step::ConfigureRepositories) || step.instance_of?(::Workflow::Step::RebuildPackage) }
+    processable_steps = steps.reject do |step|
+      step.instance_of?(::Workflow::Step::ConfigureRepositories) || step.instance_of?(::Workflow::Step::RebuildPackage) || step.instance_of?(::Workflow::Step::SetFlags)
+    end
     target_project_names = processable_steps.map(&:target_project_name).uniq.compact
     target_project_names.each do |target_project_name|
       Project.restore(target_project_name, user: token_user_login)

--- a/src/api/app/models/workflow.rb
+++ b/src/api/app/models/workflow.rb
@@ -11,6 +11,8 @@ class Workflow
   }.freeze
 
   SUPPORTED_FILTERS = [:branches, :event].freeze
+  STEPS_WITH_NO_TARGET_PROJECT_TO_RESTORE_OR_DESTROY = [Workflow::Step::ConfigureRepositories, Workflow::Step::RebuildPackage,
+                                                        Workflow::Step::SetFlags].freeze
 
   attr_accessor :workflow_instructions, :scm_webhook, :token, :workflow_run
 
@@ -114,9 +116,7 @@ class Workflow
   # TODO: Extract this into a service
   def destroy_target_projects
     # Do not process steps for which there's nothing to do
-    processable_steps = steps.reject do |step|
-      step.instance_of?(::Workflow::Step::ConfigureRepositories) || step.instance_of?(::Workflow::Step::RebuildPackage) || step.instance_of?(::Workflow::Step::SetFlags)
-    end
+    processable_steps = steps.reject { |step| step.class.in?(STEPS_WITH_NO_TARGET_PROJECT_TO_RESTORE_OR_DESTROY) }
     target_packages = processable_steps.map(&:target_package).uniq.compact
     EventSubscription.where(channel: 'scm', token: token, package: target_packages).delete_all
 
@@ -130,9 +130,7 @@ class Workflow
     token_user_login = token.executor.login
 
     # Do not process steps for which there's nothing to do
-    processable_steps = steps.reject do |step|
-      step.instance_of?(::Workflow::Step::ConfigureRepositories) || step.instance_of?(::Workflow::Step::RebuildPackage) || step.instance_of?(::Workflow::Step::SetFlags)
-    end
+    processable_steps = steps.reject { |step| step.class.in?(STEPS_WITH_NO_TARGET_PROJECT_TO_RESTORE_OR_DESTROY) }
     target_project_names = processable_steps.map(&:target_project_name).uniq.compact
     target_project_names.each do |target_project_name|
       Project.restore(target_project_name, user: token_user_login)


### PR DESCRIPTION
There is no project that should be restored for the set_flags step in a workflow, when a PR is reopened on the SCM. There for it should be one of the steps that gets rejected when restoring. This will also fix an issue, since the target_project_name method of the SetFlags is private and expects to get passed a keyword argument, which all other steps don't.

Fixes #13338

Very similar to https://github.com/openSUSE/open-build-service/pull/13538