### PR TITLE
Performance of the workflow runs UI 

### DIFF
--- a/src/api/app/queries/workflow_runs_finder.rb
+++ b/src/api/app/queries/workflow_runs_finder.rb
@@ -14,8 +14,8 @@ class WorkflowRunsFinder
   end
 
   def group_by_generic_event_type
-    @relation.all.each_with_object(Hash.new(0)) do |workflow_run, grouped_workflows|
-      grouped_workflows[workflow_run.generic_event_type] += 1
+    EVENT_TYPE_MAPPING.to_h do |key, _value|
+      [key, with_generic_event_type(key).count]
     end
   end
 


### PR DESCRIPTION
WorkflowRun finder was using an iterator to count the number of workflow runs grouped by generic event type. The iterator logic was increasing the page loading time.

With this PR the loading time is reduced. These calculations are based on 20000 records
**Before:** loading time was > 6 seconds
**After:** Loading time is < 1 second (~0.17 seconds) 