### PR TITLE
Revert "Remove redundant logger method"

### DIFF
--- a/src/api/app/models/branch_package.rb
+++ b/src/api/app/models/branch_package.rb
@@ -35,6 +35,10 @@ class BranchPackage
     @update_path_elements = true
   end
 
+  def logger
+    Rails.logger
+  end
+
   def branch
     #
     # 1) BaseProject <-- 2) UpdateProject <-- 3) DevelProject/Package

--- a/src/api/test/test_helper.rb
+++ b/src/api/test/test_helper.rb
@@ -107,10 +107,6 @@ def inject_build_job(project, package, repo, arch, extrabinary = nil)
   system("echo \"#{verifymd5}  #{package}\" > #{jobfile}:dir/meta")
 end
 
-def logger
-  Rails.logger
-end
-
 module Minitest
   def self.__run(reporter, options)
     # there is no way to avoid the randomization of used suites, so we overload this method.


### PR DESCRIPTION
Reverts openSUSE/open-build-service#13761

https://errbit.opensuse.org/apps/5620ca2bdc71fa00b1000000/problems/63e4d91184bf460565f2de6e

My guess is that this there is a problem with this change and auto loading in production...