### PR TITLE
Make the workflow runs status icon take less space in the list

### DIFF
--- a/src/api/app/components/workflow_run_row_component.html.haml
+++ b/src/api/app/components/workflow_run_row_component.html.haml
@@ -1,4 +1,4 @@
-.col-1.text-start
+.col-auto.text-start
   %i{ title: status_title, class: status_icon }
 .col.text-start
   = link_to "#{hook_event.humanize} event", token_workflow_run_path(workflow_run.token, workflow_run)


### PR DESCRIPTION
On wider viewports, using col-1 ends up taking up 1/12 of the width of the container, while an icon might not need that much space. col-auto adjusts the container to fit the icon inside instead
|Before|After|
|:---|:---|
|![Screenshot from 2023-02-09 13-49-38](https://user-images.githubusercontent.com/114928900/217817467-636b8a6f-c676-4df2-8a87-73e2f321557c.png)|![Screenshot from 2023-02-09 13-49-33](https://user-images.githubusercontent.com/114928900/217817462-fb6c293f-294f-4f7d-a438-3de983e6b0c2.png)|
