### PR TITLE
Use card component for repository card

### DIFF
--- a/src/api/app/assets/stylesheets/webui/repositories.scss
+++ b/src/api/app/assets/stylesheets/webui/repositories.scss
@@ -10,9 +10,3 @@ details[open].repository-path {
   .less{ display: inline; }
   .more{ display: none; }
 }
-
-// Ensure repository footer has same height when being empty
-.repository-card .card-footer .row {
-  min-height: 24px;
-}
-

--- a/src/api/app/views/webui/repositories/_dod_repository_card_content.html.haml
+++ b/src/api/app/views/webui/repositories/_dod_repository_card_content.html.haml
@@ -1,39 +1,22 @@
-.card-body
-  Download on demand sources:
-  %ul.list-unstyled.ms-3
-    - repository.download_repositories.each do |dod_element|
-      %li
-        %small.fw-bold
-          = dod_element.arch
-          = link_to("#{dod_element.url}", target: '_blank', rel: 'noopener', title: 'Go to the repository') do
-            = dod_element.url
-          (#{dod_element.repotype})
-        - if User.possibly_nobody.can_modify?(project)
-          = link_to('#', title: 'Edit Download on Demand Source', data: { 'bs-toggle': 'modal',
-                                                                          'bs-target': "#edit-dod-source-modal-#{dod_element.id}" }) do
-            %i.fas.fa-edit.text-secondary
-          = link_to('#', title: 'Delete Download on Demand Source',
-                         data: { 'bs-toggle': 'modal', 'bs-target': "#delete-dod-source-modal-#{dod_element.id}" }) do
-            %i.fas.fa-times-circle.text-danger
-          = render partial: 'edit_dod_source_modal', locals: { repository: repository, project: project,
-                   download_on_demand: dod_element, available_architectures: available_architectures }
-          = render partial: 'delete_dod_source_modal', locals: { repository: repository, project: project, download_on_demand: dod_element }
-.card-footer.text-center
-  .row
-    - if User.possibly_nobody.can_modify?(project)
-      .col
-        = link_to('#', title: 'Add Download on Demand Source', data: { 'bs-toggle': 'modal',
-                                                                       'bs-target': "#add-dod-source-modal-#{repository.id}" }) do
-          %i.fas.fa-plus-circle.text-primary
-      .col
-        = link_to('#', title: 'Delete Repository', data: { 'bs-toggle': 'modal', 'bs-target': '#delete-repository',
-          action: destroy_repository_path(project: project, target: repository.name), repository: repository.name }) do
+Download on demand sources:
+%ul.list-unstyled.ms-3
+  - repository.download_repositories.each do |dod_element|
+    %li
+      %small.fw-bold
+        = dod_element.arch
+        = link_to("#{dod_element.url}", target: '_blank', rel: 'noopener', title: 'Go to the repository') do
+          = dod_element.url
+        (#{dod_element.repotype})
+      - if User.possibly_nobody.can_modify?(project)
+        = link_to('#', title: 'Edit Download on Demand Source', data: { 'bs-toggle': 'modal',
+                                                                        'bs-target': "#edit-dod-source-modal-#{dod_element.id}" }) do
+          %i.fas.fa-edit.text-secondary
+        = link_to('#', title: 'Delete Download on Demand Source',
+                        data: { 'bs-toggle': 'modal', 'bs-target': "#delete-dod-source-modal-#{dod_element.id}" }) do
           %i.fas.fa-times-circle.text-danger
-    - elsif User.session
-      .col
-        = link_to('#', title: 'Request Delete Repository', data: { 'bs-toggle': 'modal', 'bs-target': '#request-delete-repository',
-          action: project_remove_target_request_path(project: project, target: repository), repository: repository.name }) do
-          %i.fas.fa-user-times.text-danger
+        = render partial: 'edit_dod_source_modal', locals: { repository: repository, project: project,
+                  download_on_demand: dod_element, available_architectures: available_architectures }
+        = render partial: 'delete_dod_source_modal', locals: { repository: repository, project: project, download_on_demand: dod_element }
 
 = render partial: 'add_dod_source_modal', locals: { repository: repository,
                                                     project: project,

--- a/src/api/app/views/webui/repositories/_project_repositories.html.haml
+++ b/src/api/app/views/webui/repositories/_project_repositories.html.haml
@@ -3,7 +3,7 @@
   .card-body
     %h3.pb-2= pagetitle
 
-    .row.pt-2
+    .d-flex.flex-wrap.gap-4
       - repositories.each do |repository|
         = render partial: 'repository_entry', locals: { repository: repository, project: project, download_url: configuration['download_url'],
                     user_can_modify: user_can_modify, available_architectures: available_architectures }

--- a/src/api/app/views/webui/repositories/_repository_card_content.html.haml
+++ b/src/api/app/views/webui/repositories/_repository_card_content.html.haml
@@ -1,49 +1,22 @@
 - number_paths = 3
-.card-body
-  - if repository.path_elements.present?
-    %strong Repository paths:
-    %ol.list-unstyled.ms-3
-      - repository.path_elements.each_with_index do |path, index|
-        - if index < number_paths
+
+- if repository.path_elements.present?
+  %strong Repository paths:
+  %ol.list-unstyled.ms-3
+    - repository.path_elements.each_with_index do |path, index|
+      - if index < number_paths
+        = render partial: 'repository_path_item', locals: { project: project, repository: repository, path: path,
+                                                            user_can_modify: user_can_modify }
+      - else
+        - content_for :repository_path_item do
           = render partial: 'repository_path_item', locals: { project: project, repository: repository, path: path,
                                                               user_can_modify: user_can_modify }
-        - else
-          - content_for :repository_path_item do
-            = render partial: 'repository_path_item', locals: { project: project, repository: repository, path: path,
-                                                                user_can_modify: user_can_modify }
-      - if repository.path_elements.size > number_paths
-        %details.repository-path
-          %summary.small
-            %span.more More
-            %span.less Less
-          = yield :repository_path_item
-
-.card-footer.text-center
-  .row
-    - if user_can_modify
-      .col
-        = link_to('#', title: 'Edit Repository',
-                       data: { 'bs-toggle': 'modal', 'bs-target': "#edit-repository-#{repository.id}" }) do
-          %i.fas.fa-edit.text-secondary
-      .col
-        = link_to('#', title: 'Add Repository Path',
-                       data: { 'bs-toggle': 'modal', 'bs-target': "#add-repository-path-#{repository.id}" }) do
-          %i.fas.fa-plus-circle.text-primary
-    .col
-      - url = "#{download_url}/#{project.to_s.gsub(/:/, ':/')}/#{repository}"
-      = link_to(url, title: 'Download Repository') do
-        %i.fas.fa-download.text-secondary
-
-    - if user_can_modify
-      .col
-        = link_to('#', title: 'Delete Repository', data: { 'bs-toggle': 'modal', 'bs-target': '#delete-repository',
-          action: destroy_repository_path(project: project, target: repository.name), repository: repository.name }) do
-          %i.fas.fa-times-circle.text-danger
-    - elsif User.session
-      .col
-        = link_to('#', title: 'Request Delete Repository', data: { 'bs-toggle': 'modal', 'bs-target': '#request-delete-repository',
-          action: project_remove_target_request_path(project: project, repository: repository.name), repository: repository.name }) do
-          %i.fas.fa-user-times.text-danger
+    - if repository.path_elements.size > number_paths
+      %details.repository-path
+        %summary.small
+          %span.more More
+          %span.less Less
+        = yield :repository_path_item
 
 = render partial: 'edit_repository_modal', locals: { repository: repository, project: project, available_architectures: available_architectures }
 = render partial: 'add_repository_path_modal', locals: { repository: repository, project: project, user_can_modify: user_can_modify }

--- a/src/api/app/views/webui/repositories/_repository_entry.html.haml
+++ b/src/api/app/views/webui/repositories/_repository_entry.html.haml
@@ -1,16 +1,54 @@
-.col-12.col-md-6.col-lg-4
-  .card.mb-3.repository-card
-    .card-header
+.col-11.col-md-5.col-lg-3.flex-fill.repository-card
+  = render(CardComponent.new) do |component|
+    - if repository.is_dod_repository?
+      = render partial: 'dod_repository_card_content', locals: { project: project, repository: repository,
+                  available_architectures: available_architectures }
+      - component.with_delete_button do
+        - if user_can_modify
+          = link_to('#', title: 'Delete Repository', data: { 'bs-toggle': 'modal', 'bs-target': '#delete-repository',
+            action: destroy_repository_path(project: project, target: repository.name), repository: repository.name }) do
+            %i.fas.fa-times-circle.text-danger
+        - elsif User.session
+          .col
+            = link_to('#', title: 'Request Delete Repository', data: { 'bs-toggle': 'modal', 'bs-target': '#request-delete-repository',
+              action: project_remove_target_request_path(project: project, target: repository), repository: repository.name }) do
+              %i.fas.fa-user-times.text-danger
+      - if user_can_modify
+        - component.with_action do
+          = link_to('#', title: 'Add Download on Demand Source', class: 'nav-link p-1', data: { 'bs-toggle': 'modal',
+                                                                        'bs-target': "#add-dod-source-modal-#{repository.id}" }) do
+            %i.fas.fa-plus-circle.text-primary
+    - else
+      = render partial: 'repository_card_content', locals: { project: project, repository: repository,
+                  download_url: download_url, user_can_modify: user_can_modify,
+                  available_architectures: available_architectures }
+      - component.with_delete_button do
+        - if user_can_modify
+          = link_to('#', title: 'Delete Repository', data: { 'bs-toggle': 'modal', 'bs-target': '#delete-repository',
+            action: destroy_repository_path(project: project, target: repository.name), repository: repository.name }) do
+            %i.fas.fa-times-circle.text-danger
+        - elsif User.session
+          = link_to('#', title: 'Request Delete Repository', data: { 'bs-toggle': 'modal', 'bs-target': '#request-delete-repository',
+            action: project_remove_target_request_path(project: project, repository: repository.name), repository: repository.name }) do
+            %i.fas.fa-user-times.text-danger
+      - if user_can_modify
+        - component.with_action do
+          = link_to('#', title: 'Edit Repository', class: 'nav-link p-1',
+                        data: { 'bs-toggle': 'modal', 'bs-target': "#edit-repository-#{repository.id}" }) do
+            %i.fas.fa-edit.text-secondary
+        - component.with_action do
+          = link_to('#', title: 'Add Repository Path', class: 'nav-link p-1',
+                        data: { 'bs-toggle': 'modal', 'bs-target': "#add-repository-path-#{repository.id}" }) do
+            %i.fas.fa-plus-circle.text-primary
+      - component.with_action do
+        - url = "#{download_url}/#{project.to_s.gsub(/:/, ':/')}/#{repository}"
+        = link_to(url, title: 'Download Repository', class: 'nav-link p-1') do
+          %i.fas.fa-download.text-secondary
+
+    - component.with_header do
       = link_to(repository, project_repository_state_path(project: project, repository: repository.name), class: 'fw-bold')
       - if repository.architectures.empty?
         %i No architecture selected
       - else
         - repository.architectures.pluck(:name).each do |architecture|
           %span.badge.bg-primary= architecture
-    - if repository.is_dod_repository?
-      = render partial: 'dod_repository_card_content', locals: { project: project, repository: repository,
-                 available_architectures: available_architectures }
-    - else
-      = render partial: 'repository_card_content', locals: { project: project, repository: repository,
-                 download_url: download_url, user_can_modify: user_can_modify,
-                 available_architectures: available_architectures }


### PR DESCRIPTION
Based on top of https://github.com/openSUSE/open-build-service/pull/13809 to make use of the new default component in the repository instances

A preview is available [here](https://obs-reviewlab.opensuse.org/ncounter-repository-card/repositories/home:Admin)

## Before
![repository-card-before](https://user-images.githubusercontent.com/7080830/218064317-f241bc29-2c13-4486-91f4-3b1a033a22c1.png)

## After
![repository-card-after](https://user-images.githubusercontent.com/7080830/218064321-c2beae1e-9c1d-4dfe-a848-cfa88a2ceb28.png)
