### PR TITLE
Workflow runs show view displays incorrect SCM name in webhook tab 

### DIFF
--- a/src/api/app/models/workflow_run.rb
+++ b/src/api/app/models/workflow_run.rb
@@ -110,12 +110,12 @@ class WorkflowRun < ApplicationRecord
   # together all the behaviour regarding GitHub and all the behaviour regarding
   # GitLab.
   def scm_vendor
-    if parsed_request_headers['HTTP_X_GITHUB_EVENT']
+    if parsed_request_headers['HTTP_X_GITEA_EVENT']
+      :gitea
+    elsif parsed_request_headers['HTTP_X_GITHUB_EVENT']
       :github
     elsif parsed_request_headers['HTTP_X_GITLAB_EVENT']
       :gitlab
-    elsif parsed_request_headers['HTTP_X_GITEA_EVENT']
-      :gitea
     else
       :unknown
     end

--- a/src/api/spec/models/workflow_run_spec.rb
+++ b/src/api/spec/models/workflow_run_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe WorkflowRun, vcr: true do
-  let(:workflow_run) { create(:workflow_run) }
-
   describe '#save_scm_report_success' do
+    let(:workflow_run) { create(:workflow_run) }
+
     subject { workflow_run.save_scm_report_success(options) }
 
     context 'when providing a permitted key' do
@@ -40,6 +40,8 @@ RSpec.describe WorkflowRun, vcr: true do
   end
 
   describe '#save_scm_report_failure' do
+    let(:workflow_run) { create(:workflow_run) }
+
     subject { workflow_run.save_scm_report_failure('oops it failed', options) }
 
     context 'when providing a permitted key' do
@@ -83,6 +85,28 @@ RSpec.describe WorkflowRun, vcr: true do
       it 'marks the workflow run as failed' do
         subject
         expect(workflow_run.reload.status).to eql('fail')
+      end
+    end
+  end
+
+  describe '#scm_vendor' do
+    let(:workflow_run) { create(:workflow_run, request_headers: headers) }
+
+    subject { workflow_run.scm_vendor }
+
+    context 'when event is from GitHub' do
+      let(:headers) { "HTTP_X_GITHUB_EVENT_TYPE: pull_request\nHTTP_X_GITHUB_EVENT: pull_request\nHTTP_ACCEPT: application/xml" }
+
+      it 'identifies GitHub' do
+        expect(subject).to be(:github)
+      end
+    end
+
+    context 'when event is from Gitea' do
+      let(:headers) { "HTTP_X_GITEA_EVENT: pull_request\nHTTP_X_GITHUB_EVENT_TYPE: pull_request\nHTTP_X_GITHUB_EVENT: pull_request\nHTTP_ACCEPT: application/xml" }
+
+      it 'identifies Gitea' do
+        expect(subject).to be(:gitea)
       end
     end
   end


### PR DESCRIPTION
Gitea headers also contain headers of GitHub. To identify GitHub it is important to check the absence of gitea headers.