### PR TITLE
Disallow branch filters for tag push event

### DIFF
--- a/src/api/app/validators/workflow_filters_validator.rb
+++ b/src/api/app/validators/workflow_filters_validator.rb
@@ -27,6 +27,8 @@ class WorkflowFiltersValidator < ActiveModel::Validator
                            "#{unsupported_filters.keys.to_sentence} are unsupported")
     end
 
+    @workflow.errors.add(:filters, 'for branches are not supported for the tag push event') if unsupported_filters_for_event?
+
     return if unsupported_filter_values.blank?
 
     @workflow.errors.add(:filters, "#{unsupported_filter_values.to_sentence} have unsupported values, " \
@@ -55,5 +57,10 @@ class WorkflowFiltersValidator < ActiveModel::Validator
       end
       unsupported_filter_values
     end
+  end
+
+  def unsupported_filters_for_event?
+    # Tags do not have a reference to a branch, they are referring to a commit
+    @workflow_instructions[:filters][:branches].present? && @workflow.scm_webhook.tag_push_event?
   end
 end


### PR DESCRIPTION
We cannot filter branches for a tag push event, since the tag is referring to a certain commit and has no reference to a branch. Therefore the webhook does not contain the information about the branch.

Fixes #13206

I will add a note to the docs