### PR TITLE
Extract the correct reference to the YAML file for GitHub/Gitea events

### DIFF
--- a/src/api/app/models/gitea_payload/push.rb
+++ b/src/api/app/models/gitea_payload/push.rb
@@ -4,7 +4,8 @@ class GiteaPayload::Push < GithubPayload::Push
   def payload
     super.merge(scm: 'gitea',
                 http_url: http_url,
-                api_endpoint: api_endpoint)
+                api_endpoint: api_endpoint,
+                workflow_configuration_ref: webhook_payload[:after])
   end
 
   private

--- a/src/api/app/models/github_payload/pull_request.rb
+++ b/src/api/app/models/github_payload/pull_request.rb
@@ -9,7 +9,8 @@ class GithubPayload::PullRequest < GithubPayload
       target_branch: webhook_payload.dig(:pull_request, :base, :ref),
       action: webhook_payload[:action],
       source_repository_full_name: webhook_payload.dig(:pull_request, :head, :repo, :full_name),
-      target_repository_full_name: webhook_payload.dig(:pull_request, :base, :repo, :full_name)
+      target_repository_full_name: webhook_payload.dig(:pull_request, :base, :repo, :full_name),
+      workflow_configuration_ref: webhook_payload.dig(:pull_request, :base, :sha)
     )
   end
 end

--- a/src/api/app/services/workflows/yaml_downloader.rb
+++ b/src/api/app/services/workflows/yaml_downloader.rb
@@ -32,7 +32,7 @@ module Workflows
       when 'github'
         client = Octokit::Client.new(access_token: @token.scm_token, api_endpoint: @scm_payload[:api_endpoint])
         # :ref can be the name of the commit, branch or tag.
-        client.content("#{@scm_payload[:target_repository_full_name]}", path: "/#{@token.workflow_configuration_path}", ref: @scm_payload[:target_branch])[:download_url]
+        client.content("#{@scm_payload[:target_repository_full_name]}", path: "/#{@token.workflow_configuration_path}", ref: @scm_payload[:workflow_configuration_ref])[:download_url]
       when 'gitlab'
         # This GitLab URL admits both a branch name and a commit sha.
         "#{@scm_payload[:api_endpoint]}/#{@scm_payload[:path_with_namespace]}/-/raw/#{@scm_payload[:target_branch]}/#{@token.workflow_configuration_path}"
@@ -51,7 +51,7 @@ module Workflows
       if @scm_payload[:tag_name].present?
         "#{@scm_payload[:api_endpoint]}/#{@scm_payload[:target_repository_full_name]}/raw/tag/#{@scm_payload[:tag_name]}/#{@token.workflow_configuration_path}"
       else
-        "#{@scm_payload[:api_endpoint]}/#{@scm_payload[:target_repository_full_name]}/raw/branch/#{@scm_payload[:target_branch]}/#{@token.workflow_configuration_path}"
+        "#{@scm_payload[:api_endpoint]}/#{@scm_payload[:target_repository_full_name]}/raw/commit/#{@scm_payload[:workflow_configuration_ref]}/#{@token.workflow_configuration_path}"
       end
     end
   end

--- a/src/api/spec/services/workflows/yaml_downloader_spec.rb
+++ b/src/api/spec/services/workflows/yaml_downloader_spec.rb
@@ -29,11 +29,12 @@ RSpec.describe Workflows::YAMLDownloader, type: :service do
             source_repository_full_name: 'rubhanazeem/hello_world',
             target_repository_full_name: 'rubhanazeem/hello_world',
             event: 'pull_request',
-            api_endpoint: 'https://api.github.com'
+            api_endpoint: 'https://api.github.com',
+            workflow_configuration_ref: '4d175d7f4c58d06907bba188fe9a4c8b6bd723d0'
           }
         end
         let(:octokit_client) { instance_double(Octokit::Client) }
-        let(:url) { "https://raw.githubusercontent.com/#{payload[:target_repository_full_name]}/#{payload[:target_branch]}/.obs/workflows.yml" }
+        let(:url) { "https://raw.githubusercontent.com/#{payload[:target_repository_full_name]}/#{payload[:workflow_configuration_ref]}/.obs/workflows.yml" }
 
         it { expect(Down).to have_received(:download).with(url, max_size: max_size) }
       end

--- a/src/api/spec/services/workflows/yaml_downloader_spec.rb
+++ b/src/api/spec/services/workflows/yaml_downloader_spec.rb
@@ -74,10 +74,11 @@ RSpec.describe Workflows::YAMLDownloader, type: :service do
               scm: 'gitea',
               target_branch: 'main',
               target_repository_full_name: 'iggy/target_repo',
-              api_endpoint: 'https://gitea.opensuse.org'
+              api_endpoint: 'https://gitea.opensuse.org',
+              workflow_configuration_ref: '4d175d7f4c58d06907bba188fe9a4c8b6bd723d0'
             }
           end
-          let(:url) { "https://gitea.opensuse.org/#{payload[:target_repository_full_name]}/raw/branch/#{payload[:target_branch]}/.obs/workflows.yml" }
+          let(:url) { "https://gitea.opensuse.org/#{payload[:target_repository_full_name]}/raw/commit/#{payload[:workflow_configuration_ref]}/.obs/workflows.yml" }
 
           it { expect(Down).to have_received(:download).with(url, max_size: max_size) }
         end


### PR DESCRIPTION
**NOTE:** This PR focuses on GitHub/Gitea events only.

The YAML file should be downloaded from the target branch or commit, not the source one.

We want to rely on the head commit SHA of the target branch. In case of a push event that deletes the ref, we need to take the commit SHA from the "after" key comming from the original payload.

A new key is added to the SCMWebhook payload: yaml_reference.