### PR TITLE
Ignore github push events for deleted refs

### DIFF
--- a/src/api/app/controllers/trigger_workflow_controller.rb
+++ b/src/api/app/controllers/trigger_workflow_controller.rb
@@ -81,8 +81,8 @@ class TriggerWorkflowController < TriggerController
   def extract_scm_webhook
     @scm_webhook = TriggerControllerService::SCMExtractor.new(scm, event, payload).call
 
-    # There are plenty of different pull/merge request action which we don't support.
+    # There are plenty of different pull/merge request and push events which we don't support.
     # Those should not cause an error, we simply ignore them.
-    render_ok if @scm_webhook && @scm_webhook.ignored_pull_request_action?
+    render_ok if @scm_webhook && (@scm_webhook.ignored_pull_request_action? || @scm_webhook.ignored_push_event?)
   end
 end

--- a/src/api/app/models/gitea_payload.rb
+++ b/src/api/app/models/gitea_payload.rb
@@ -1,0 +1,21 @@
+class GiteaPayload < ScmPayload
+  def default_payload
+    {
+      scm: 'gitea',
+      http_url: http_url,
+      api_endpoint: api_endpoint
+    }
+  end
+
+  private
+
+  def http_url
+    webhook_payload.dig(:repository, :clone_url)
+  end
+
+  def api_endpoint
+    url = URI.parse(http_url)
+
+    "#{url.scheme}://#{url.host}"
+  end
+end

--- a/src/api/app/models/gitea_payload/push.rb
+++ b/src/api/app/models/gitea_payload/push.rb
@@ -1,21 +1,28 @@
 # This class is used in TriggerControllerServicve::ScmExtractor to handle push events coming from Gitea.
 # It's basically the same than the pushes coming from Github but with some customizations on top.
-class GiteaPayload::Push < GithubPayload::Push
+class GiteaPayload::Push < GiteaPayload
   def payload
-    super.merge(scm: 'gitea',
-                http_url: http_url,
-                api_endpoint: api_endpoint)
-  end
+    payload_ref = webhook_payload.fetch(:ref, '')
+    payload = default_payload.merge(
+      event: 'push',
+      # We need this for Workflow::Step#branch_request_content_github
+      source_repository_full_name: webhook_payload.dig(:repository, :full_name),
+      # We need this for SCMStatusReporter#call
+      target_repository_full_name: webhook_payload.dig(:repository, :full_name),
+      ref: payload_ref,
+      # We need this for Workflow::Step#branch_request_content_{github,gitlab}
+      commit_sha: webhook_payload[:after],
+      # We need this for Workflows::YAMLDownloader#download_url
+      # when the push event is for commits, we get the branch name from ref.
+      target_branch: payload_ref.sub('refs/heads/', '')
+    )
 
-  private
+    return payload unless payload_ref.start_with?('refs/tags/')
 
-  def http_url
-    webhook_payload.dig(:repository, :clone_url)
-  end
-
-  def api_endpoint
-    url = URI.parse(http_url)
-
-    "#{url.scheme}://#{url.host}"
+    # We need this for Workflow::Step#target_package_name
+    # 'target_branch' will contain a commit SHA
+    payload.merge(tag_name: payload_ref.sub('refs/tags/', ''),
+                  target_branch: webhook_payload.dig(:head_commit, :id),
+                  commit_sha: webhook_payload.dig(:head_commit, :id))
   end
 end

--- a/src/api/app/models/github_payload/push.rb
+++ b/src/api/app/models/github_payload/push.rb
@@ -13,7 +13,8 @@ class GithubPayload::Push < GithubPayload
       commit_sha: webhook_payload[:after],
       # We need this for Workflows::YAMLDownloader#download_url
       # when the push event is for commits, we get the branch name from ref.
-      target_branch: payload_ref.sub('refs/heads/', '')
+      target_branch: payload_ref.sub('refs/heads/', ''),
+      deleted: webhook_payload[:deleted]
     )
 
     return payload unless payload_ref.start_with?('refs/tags/')

--- a/src/api/app/models/scm_webhook.rb
+++ b/src/api/app/models/scm_webhook.rb
@@ -62,6 +62,10 @@ class SCMWebhook
     github_ping? || gitea_ping?
   end
 
+  def ignored_push_event?
+    ignored_github_push_event?
+  end
+
   private
 
   def github_push_event?
@@ -118,5 +122,9 @@ class SCMWebhook
 
   def ignored_gitea_pull_request_action?
     gitea_pull_request? && ALLOWED_PULL_REQUEST_ACTIONS.exclude?(@payload[:action])
+  end
+
+  def ignored_github_push_event?
+    github_push_event? && @payload[:deleted]
   end
 end

--- a/src/api/spec/models/scm_webhook_spec.rb
+++ b/src/api/spec/models/scm_webhook_spec.rb
@@ -436,4 +436,20 @@ RSpec.describe SCMWebhook do
       it { is_expected.to be true }
     end
   end
+
+  describe '#ignored_push_event?' do
+    subject { described_class.new(payload: payload).ignored_push_event? }
+
+    context 'with a push event from GitHub for a deleted commit reference' do
+      let(:payload) { { scm: 'github', event: 'push', ref: 'refs/heads/branch_123', deleted: true } }
+
+      it { is_expected.to be true }
+    end
+
+    context 'with a push event from GitHub without a deleted commit reference' do
+      let(:payload) { { scm: 'github', event: 'push', ref: 'refs/heads/branch_123', deleted: false } }
+
+      it { is_expected.to be false }
+    end
+  end
 end

--- a/src/api/spec/services/trigger_controller_service/scm_extractor_spec.rb
+++ b/src/api/spec/services/trigger_controller_service/scm_extractor_spec.rb
@@ -81,7 +81,8 @@ RSpec.describe TriggerControllerService::SCMExtractor do
             sender: {
               url: 'https://api.github.com'
             },
-            base_ref: nil
+            base_ref: nil,
+            deleted: false
           }
         end
         let(:expected_hash) do
@@ -93,7 +94,8 @@ RSpec.describe TriggerControllerService::SCMExtractor do
             target_branch: 'main/fix-bug',
             source_repository_full_name: 'iggy/repo123',
             target_repository_full_name: 'iggy/repo123',
-            ref: 'refs/heads/main/fix-bug'
+            ref: 'refs/heads/main/fix-bug',
+            deleted: false
           }
         end
 
@@ -118,7 +120,8 @@ RSpec.describe TriggerControllerService::SCMExtractor do
             base_ref: 'refs/heads/main',
             head_commit: {
               id: '8823eec73e46f29082cd343077ee3e97d8da0ec3'
-            }
+            },
+            deleted: false
           }
         end
         let(:expected_hash) do
@@ -131,7 +134,8 @@ RSpec.describe TriggerControllerService::SCMExtractor do
             source_repository_full_name: 'iggy/repo123',
             target_repository_full_name: 'iggy/repo123',
             ref: 'refs/tags/release_abc',
-            tag_name: 'release_abc'
+            tag_name: 'release_abc',
+            deleted: false
           }
         end
 


### PR DESCRIPTION
When the push event is triggered when a branch/commit got deleted, there is nothing to run the workflow for. In those cases we should simply return and do nothing.

We realized that while working on https://github.com/openSUSE/open-build-service/pull/13847 
