### PR TITLE
Fix form path when dealing with service tokens

### DIFF
--- a/src/api/app/views/webui/users/tokens/new.html.haml
+++ b/src/api/app/views/webui/users/tokens/new.html.haml
@@ -7,7 +7,8 @@
 
     .row
       .col-12.col-md-10.col-lg-8
-        = form_with(model: @token ||= Token.new, method: :post, local: true) do |f|
+        - url = @token.new_record? ? tokens_path : token_path(@token)
+        = form_with(model: @token, url: url, method: :post, local: true) do |f|
           .row
             .col
               .mb-3


### PR DESCRIPTION
When dealing with errors on the form, the view would crash with an:

	undefined method `token_services_path'

trying to build the form action url, because we don't use tokens but its subclasses (like Token::Service)

Forcing the path ensure we use existing route.

Fixes #13853

## How can you review this PR?

- From [Admin's tokens page in the Review App instance](https://obs-reviewlab.opensuse.org/danidoni-fix-token-service-description-too-large-errors/my/tokens)
- Create a Service token and try to set a description that is longer than 64 characters
- It should not crash. It should flash you an error saying that the `Description is too long (maximum is 64 characters).`