### PR TITLE
Prevent sending large token descriptions

### DIFF
--- a/src/api/app/views/webui/users/tokens/new.html.haml
+++ b/src/api/app/views/webui/users/tokens/new.html.haml
@@ -23,7 +23,7 @@
             .col-sm
               .mb-3.ui-front
                 = f.label(:description, 'Description:')
-                = f.text_field(:description, class: 'form-control', placeholder: 'Eg: Rebuild vim package')
+                = f.text_field(:description, class: 'form-control', placeholder: 'Eg: Rebuild vim package', maxlength: 64)
                 .form-text.text-muted
                   Optional: provide a description to your token.
 


### PR DESCRIPTION
This is an improvement on top of #13854, but it can be shipped alone by itself.

## How can you review this PR?

- From [Admin's tokens page in the Review App instance](https://obs-reviewlab.opensuse.org/danidoni-prevent-sending-large-token-descriptions/my/tokens)
- Try to create a Service token and try to set a description that is longer than 64 characters
- You should not be able to, as the input field stops at 64 characters preventing you to enter anything else.
