### PR TITLE
Use Marcel:Magic instead of hardcoded binary extensions

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -385,7 +385,7 @@ class Webui::PackageController < Webui::WebuiController
 
   def view_file
     @filename = params[:filename] || params[:file] || ''
-    if Package.is_binary_file?(@filename) # We don't want to display binary files
+    if binary_file?(@filename) # We don't want to display binary files
       flash[:error] = "Unable to display binary file #{@filename}"
       redirect_back(fallback_location: { action: :show, project: @project, package: @package })
       return
@@ -695,7 +695,7 @@ class Webui::PackageController < Webui::WebuiController
     files = []
     dir.elements('entry') do |entry|
       file = Hash[*[:name, :size, :mtime, :md5].map! { |x| [x, entry.value(x.to_s)] }.flatten]
-      file[:viewable] = !Package.is_binary_file?(file[:name]) && file[:size].to_i < 2**20 # max. 1 MB
+      file[:viewable] = !binary_file?(file[:name]) && file[:size].to_i < 2**20 # max. 1 MB
       file[:editable] = file[:viewable] && !file[:name].match?(/^_service[_:]/)
       file[:srcmd5] = dir.value('srcmd5')
       files << file

--- a/src/api/app/helpers/webui/package_helper.rb
+++ b/src/api/app/helpers/webui/package_helper.rb
@@ -76,7 +76,13 @@ module Webui::PackageHelper
   end
 
   def viewable_file?(filename)
-    !Package.is_binary_file?(filename) && filename.exclude?('/')
+    !binary_file?(filename) && filename.exclude?('/')
+  end
+
+  def binary_file?(filename)
+    return false unless (mime = Marcel::Magic.by_path(filename))
+
+    !mime.text?
   end
 
   def calculate_revision_on_state(revision, state)

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -1186,12 +1186,6 @@ class Package < ApplicationRecord
     store if update_needed
   end
 
-  def self.is_binary_file?(filename)
-    return false unless (mime = Marcel::Magic.by_path(filename))
-
-    !mime.text?
-  end
-
   def serviceinfo
     begin
       dir = Directory.hashed(project: project.name, package: name)

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -13,13 +13,6 @@ class Package < ApplicationRecord
   include PackageSphinx
   include MultibuildPackage
 
-  BINARY_EXTENSIONS = ['.0', '.bin', '.bin_mid', '.bz', '.bz2', '.ccf', '.cert',
-                       '.chk', '.der', '.dll', '.exe', '.fw', '.gem', '.gif', '.gz',
-                       '.jar', '.jpeg', '.jpg', '.lzma', '.ogg', '.otf', '.oxt',
-                       '.pdf', '.pk3', '.png', '.ps', '.rpm', '.sig', '.svgz', '.tar',
-                       '.taz', '.tb2', '.tbz', '.tbz2', '.tgz', '.tlz', '.txz', '.ucode',
-                       '.xpm', '.xz', '.z', '.zip', '.ttf'].freeze
-
   has_many :relationships, dependent: :destroy, inverse_of: :package
   belongs_to :kiwi_image, class_name: 'Kiwi::Image', inverse_of: :package, optional: true
   accepts_nested_attributes_for :kiwi_image
@@ -1194,7 +1187,9 @@ class Package < ApplicationRecord
   end
 
   def self.is_binary_file?(filename)
-    BINARY_EXTENSIONS.include?(File.extname(filename).downcase)
+    return false unless (mime = Marcel::Magic.by_path(filename))
+
+    !mime.text?
   end
 
   def serviceinfo

--- a/src/api/config/initializers/marcel.rb
+++ b/src/api/config/initializers/marcel.rb
@@ -1,0 +1,9 @@
+require 'marcel'
+require 'marcel/mime_type'
+
+Marcel::MimeType.extend "application/x-tar", extensions: %w[gem]
+Marcel::MimeType.extend "application/x-x509-ca-cert", extensions: %w[cert]
+Marcel::MimeType.extend "image/svg+xml-compressed", parents: "application/gzip", extensions: %w[svgz]
+Marcel::MimeType.extend "application/x-tarz", parents: "application/x-compress", extensions: %w[taz]
+Marcel::MimeType.extend "application/x-lzma-compressed-tar", parents: "application/x-lzma", extensions: %w[tlz]
+Marcel::MimeType.extend "application/zstd", extensions: %w[zst]

--- a/src/api/spec/helpers/webui/package_helper_spec.rb
+++ b/src/api/spec/helpers/webui/package_helper_spec.rb
@@ -260,4 +260,34 @@ RSpec.describe Webui::PackageHelper do
     it { expect(viewable_file?('some_file.rb')).to be(true) }
     it { expect(viewable_file?('some_file.bin')).to be(false) }
   end
+
+  describe '#binary_file?' do
+    it { expect(binary_file?('anNhbG.exe')).to be(true) }
+    it { expect(binary_file?('ZramE7b2.bin')).to be(true) }
+    it { expect(binary_file?('g3cWhqem.tar')).to be(true) }
+    it { expect(binary_file?('x3ZXVqaDg.tar.bz')).to be(true) }
+    it { expect(binary_file?('zNDd1NDU5O.tar.bz2')).to be(true) }
+    it { expect(binary_file?('Dd5MnE0Ly.tar.zst')).to be(true) }
+    it { expect(binary_file?('4vLi8uNTMvN.gem')).to be(true) }
+    it { expect(binary_file?('S40LjUzOV.gif')).to be(true) }
+    it { expect(binary_file?('BISTs7U.jpg')).to be(true) }
+    it { expect(binary_file?('RGVUpF.jpeg')).to be(true) }
+    it { expect(binary_file?('U0hLSl.ttf')).to be(true) }
+    it { expect(binary_file?('ERgo.zip')).to be(true) }
+    it { expect(binary_file?('NDg3Mj/UyMDg3U.tar.gz')).to be(true) }
+    it { expect(binary_file?('kZJVUhWSk.png')).to be(true) }
+    it { expect(binary_file?('tIRkdJREta.gem')).to be(true) }
+    it { expect(binary_file?('WFk5V1dXV.cert')).to be(true) }
+    it { expect(binary_file?('MzQ1OHI3OGZ5ZW.svgz')).to be(true) }
+    it { expect(binary_file?('hzeml5OTc2e.taz')).to be(true) }
+    it { expect(binary_file?('WZ6OTdneXJqa.tlz')).to be(true) }
+    it { expect(binary_file?('3c0ZWdha.diff')).to be(false) }
+    it { expect(binary_file?('GpyNWpoc.txt')).to be(false) }
+    it { expect(binary_file?('0ZLREpoCg.csv')).to be(false) }
+    it { expect(binary_file?('YWprd2Fqb.pm')).to be(false) }
+    it { expect(binary_file?('GtqbWttLG.c')).to be(false) }
+    it { expect(binary_file?('ZuYW5tIGJ0.rb')).to be(false) }
+    it { expect(binary_file?('NGkzNzV5.h')).to be(false) }
+    it { expect(binary_file?('Jmc2hiCg.spec')).to be(false) }
+  end
 end

--- a/src/api/test/unit/package_test.rb
+++ b/src/api/test/unit/package_test.rb
@@ -312,50 +312,8 @@ class PackageTest < ActiveSupport::TestCase
     end
   end
 
-  test 'is_binary_file?' do
-    file_paths = [
-      '/tmp/some/file',
-      '/srv/www/another_file_',
-      '/var/lib/cache/file with spaces'
-    ]
-
-    filename = ''
-
-    # binary files
-    generate_suffixes(['exe', 'bin', 'bz', 'bz2', 'gem', 'gif', 'jpg', 'jpeg', 'ttf', 'zip', 'gz', 'png']).each do |suffix|
-      file_paths.each do |file_path|
-        filename = file_path + '.' + suffix
-        assert Package.is_binary_file?(filename), "File #{filename} should be treated as binary"
-      end
-    end
-
-    # these aren't binary
-    generate_suffixes(['diff', 'txt', 'csv', 'pm', 'c', 'rb', 'h']).each do |suffix|
-      file_paths.each do |file_path|
-        filename = file_path + '.' + suffix
-        assert_not Package.is_binary_file?(filename), "File #{filename} should not be treated as binary"
-      end
-    end
-  end
-
   test 'fixtures name' do
     assert_equal 'home_Iggy_TestPack', packages(:home_Iggy_TestPack).fixtures_name
-  end
-
-  private
-
-  # gets list of strings and tries to generate another longer list
-  # with some letters up/down-cased, based on the original list
-  def generate_suffixes(suffixes_in)
-    suffixes_out = suffixes_in.dup
-    # some lower-cased suffixes
-    suffixes_out.collect!(&:downcase)
-    # the same ones capitalized
-    suffixes_out.concat(suffixes_in.collect(&:capitalize))
-    # the same ones upper-cased
-    suffixes_out.concat(suffixes_in.collect(&:upcase))
-    # the same ones swap-cased
-    suffixes_out.concat(suffixes_in.collect { |i| i.capitalize.swapcase })
   end
 
   test 'default scope does not include forbidden projects' do


### PR DESCRIPTION
Since we don't get enough information from the backend about the files, we don't know what their mime types are, but we can use Marcel, which is built into Rails nowadays, to guess the mimetypes from the extensions. We could use file content, but that seems inefficient. Sadly due to its license, Marcel uses Apache Tika database for mime information, instead of Freedesktop one, which is more complete, so we need to append some mime configuration in the initializer

This is intended to fix #13613