### PR TITLE
Ignore GitLab push events for deleted references

### DIFF
--- a/src/api/app/models/scm_webhook.rb
+++ b/src/api/app/models/scm_webhook.rb
@@ -63,7 +63,7 @@ class SCMWebhook
   end
 
   def ignored_push_event?
-    ignored_github_push_event?
+    ignored_github_push_event? || ignored_gitlab_push_event?
   end
 
   private
@@ -126,5 +126,10 @@ class SCMWebhook
 
   def ignored_github_push_event?
     github_push_event? && @payload[:deleted]
+  end
+
+  def ignored_gitlab_push_event?
+    # In Push Hook events to delete a branch, the after field is '0000000000000000000000000000000000000000'
+    gitlab_push_event? && @payload[:commit_sha].match?(/\A0+\z/)
   end
 end

--- a/src/api/spec/models/scm_webhook_spec.rb
+++ b/src/api/spec/models/scm_webhook_spec.rb
@@ -451,5 +451,17 @@ RSpec.describe SCMWebhook do
 
       it { is_expected.to be false }
     end
+
+    context 'with a Push Hook event from Gitlab for a deleted commit reference' do
+      let(:payload) { { scm: 'gitlab', event: 'Push Hook', ref: 'refs/heads/branch_123', commit_sha: '0000000000000000000000000000000000000000' } }
+
+      it { is_expected.to be true }
+    end
+
+    context 'with a Push Hook event from Gitlab without a deleted commit reference' do
+      let(:payload) { { scm: 'gitlab', event: 'Push Hook', ref: 'refs/heads/branch_123', commit_sha: 'd8964263418b3946a6d540a50d09c89c6e13e82d' } }
+
+      it { is_expected.to be false }
+    end
   end
 end


### PR DESCRIPTION
When an upstream branch/commit is deleted, GitLab triggers a Push Hook event.
It makes no sense to try to run a workflow on something removed (i.e. because a merge request was merged or closed and then the branch was removed).

As we do with GitHub [here](https://github.com/openSUSE/open-build-service/pull/13852), we will ignore these kinds of push events.
Unlike GitHub, GitLab doesn't provide a `deleted` field or similar in the payload, so we rely on the `after` field which always contains a commit SHA like this: `0000000000000000000000000000000000000000`.