### PR TITLE
Fix broken diffs

### DIFF
--- a/src/api/app/assets/stylesheets/webui/diff.scss
+++ b/src/api/app/assets/stylesheets/webui/diff.scss
@@ -41,7 +41,7 @@
           font-family: monospace;
           width: calc(var(--line-index-digits) + 2rem + #{$card-border-width});
           text-align: right;
-          padding: 0 1rem;
+          padding: 0 1rem 0 0;
           border-right: $card-border-width solid $card-border-color;
           user-select: none;
           background-color: $card-bg;


### PR DESCRIPTION
We correctly calculate the max digits but for some reason the line index digits needs a +1 to correctly display diffs

Example of broken diffs: ![image](https://user-images.githubusercontent.com/6298234/220337232-7d8969f0-88b0-4c8f-8106-cc5fd9aa56b9.png)
