### PR TITLE
Let users save files with spaces in them

### DIFF
--- a/src/api/app/lib/backend/connection_helper.rb
+++ b/src/api/app/lib/backend/connection_helper.rb
@@ -123,7 +123,7 @@ module Backend
         url_base = endpoint
       else
         template = endpoint.shift
-        endpoint.map! { |x| URI.encode_www_form_component(x) }
+        endpoint.map! { |x| ERB::Util.url_encode(x) }
         url_base = template.gsub(/(:\w+)/, '%s') % endpoint
       end
       Addressable::URI.parse(url_base).normalize.to_s

--- a/src/api/spec/lib/backend/connection_helper_spec.rb
+++ b/src/api/spec/lib/backend/connection_helper_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Backend::ConnectionHelper do
     context 'with a template' do
       it { expect(subject.send(:calculate_endpoint, ['string_in_array'])).to eq('string_in_array') }
       it { expect(subject.send(:calculate_endpoint, ['/build/:param', 'my_param'])).to eq('/build/my_param') }
-      it { expect(subject.send(:calculate_endpoint, ['/build/:param', 'my param'])).to eq('/build/my+param') }
+      it { expect(subject.send(:calculate_endpoint, ['/build/:param', 'my param'])).to eq('/build/my%20param') }
       it { expect(subject.send(:calculate_endpoint, ['/build/:param', 'my/param'])).to eq('/build/my%2Fparam') }
       it { expect(subject.send(:calculate_endpoint, ['/build/:param', 'my&param'])).to eq('/build/my&param') }
       it { expect(subject.send(:calculate_endpoint, ['/build/:param', 'my?param'])).to eq('/build/my%3Fparam') }


### PR DESCRIPTION
This caused users that had files with spaces in packages not to be able to modify them in the frontend. Files would instead be saved with a plus instead of space. This is a follow up to #12466, since that wasn't tackled in that PR, this came up with #13281, as the response from the backend was inconsistent with what we were uploading